### PR TITLE
Add logic to determine hasUAVisualTransition value

### DIFF
--- a/LayoutTests/swipe/pushState-back-swipe-verify-ua-transition-expected.txt
+++ b/LayoutTests/swipe/pushState-back-swipe-verify-ua-transition-expected.txt
@@ -1,0 +1,8 @@
+startSwipeGesture
+didBeginSwipe
+completeSwipeGesture
+willEndSwipe
+hasUAVisualTransition true
+didEndSwipe
+didRemoveSwipeSnapshot
+

--- a/LayoutTests/swipe/pushState-back-swipe-verify-ua-transition.html
+++ b/LayoutTests/swipe/pushState-back-swipe-verify-ua-transition.html
@@ -1,0 +1,87 @@
+<!-- webkit-test-runner [ NavigationAPIEnabled=true ] -->
+<head>
+<style>
+html {
+    font-size: 32pt;
+}
+</style>
+<script src="resources/swipe-test.js"></script>
+<script src="../resources/ui-helper.js"></script>
+
+<script>
+
+function didBeginSwipeCallback()
+{
+    log("didBeginSwipe");
+
+    completeSwipeGesture();
+}
+
+function willEndSwipeCallback()
+{
+    log("willEndSwipe");
+
+    shouldBe(false, isFirstPage(), "The swipe should not yet have navigated away from the second page.");
+}
+
+function didEndSwipeCallback()
+{
+    log("didEndSwipe");
+
+    startMeasuringDuration("snapshotRemoval");
+}
+
+function didRemoveSwipeSnapshotCallback()
+{
+    log("didRemoveSwipeSnapshot");
+
+    shouldBe(true, isFirstPage(), "The swipe should have navigated back to the first page.");
+
+    testComplete();
+}
+
+function isFirstPage()
+{
+    return window.location.href.indexOf("second") == -1;
+}
+
+function updateContent()
+{
+    document.body.innerHTML = isFirstPage() ? "first" : "second";
+}
+
+window.onload = async function () {
+    if (!window.eventSender || !window.testRunner) {
+        document.body.innerHTML = "This test must be run in WebKitTestRunner.";
+        return;
+    }
+
+    updateContent();
+
+    initializeSwipeTest();
+
+    testRunner.installDidBeginSwipeCallback(didBeginSwipeCallback);
+    testRunner.installWillEndSwipeCallback(willEndSwipeCallback);
+    testRunner.installDidEndSwipeCallback(didEndSwipeCallback);
+    testRunner.installDidRemoveSwipeSnapshotCallback(didRemoveSwipeSnapshotCallback);
+
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+
+    window.addEventListener("popstate", function(e) {
+        log("hasUAVisualTransition " + e.hasUAVisualTransition);
+        updateContent();
+    });
+
+    await UIHelper.delayFor(0);
+
+    history.pushState(null, null, "#second");
+    updateContent();
+
+    await UIHelper.delayFor(0);
+    await startSwipeGesture();
+};
+</script>
+</head>
+<body>
+</body>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -7905,7 +7905,9 @@ void Document::enqueueHashchangeEvent(const String& oldURL, const String& newURL
 
 void Document::dispatchPopstateEvent(RefPtr<SerializedScriptValue>&& stateObject)
 {
-    dispatchWindowEvent(PopStateEvent::create(WTFMove(stateObject), m_domWindow ? &m_domWindow->history() : nullptr));
+    auto event = PopStateEvent::create(WTFMove(stateObject), m_domWindow ? &m_domWindow->history() : nullptr);
+    event->setHasUAVisualTransition(page() && page()->isInSwipeAnimation());
+    dispatchWindowEvent(event);
 }
 
 void Document::addMediaCanStartListener(MediaCanStartListener& listener)

--- a/Source/WebCore/dom/PopStateEvent.h
+++ b/Source/WebCore/dom/PopStateEvent.h
@@ -55,8 +55,8 @@ public:
     
     History* history() const { return m_history.get(); }
 
-    // FIXME(https://bugs.webkit.org/show_bug.cgi?id=264748): add logic to determine hasUAVisualTransition value.
     bool hasUAVisualTransition() const { return m_hasUAVisualTransition; }
+    void setHasUAVisualTransition(bool hasUAVisualTransition) { m_hasUAVisualTransition = hasUAVisualTransition; }
 
 private:
     PopStateEvent();

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1098,6 +1098,9 @@ public:
     WEBCORE_EXPORT bool hasActiveImmersiveSession() const;
 #endif
 
+    void setIsInSwipeAnimation(bool inSwipeAnimation) { m_inSwipeAnimation = inSwipeAnimation; }
+    bool isInSwipeAnimation() const { return m_inSwipeAnimation; }
+
 private:
     explicit Page(PageConfiguration&&);
 
@@ -1360,6 +1363,8 @@ private:
 #if ENABLE(EDITABLE_REGION)
     bool m_isEditableRegionEnabled { false };
 #endif
+
+    bool m_inSwipeAnimation { false };
 
     Vector<OptionSet<RenderingUpdateStep>, 2> m_renderingUpdateRemainingSteps;
     OptionSet<RenderingUpdateStep> m_unfulfilledRequestedSteps;

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -244,7 +244,7 @@ void ProvisionalPageProxy::initializeWebPage(RefPtr<API::WebsitePolicies>&& webs
     }
 
     if (m_page->isLayerTreeFrozenDueToSwipeAnimation())
-        send(Messages::WebPage::FreezeLayerTreeDueToSwipeAnimation());
+        send(Messages::WebPage::SwipeAnimationDidStart());
 
     if (registerWithInspectorController)
         m_page->inspectorController().didCreateProvisionalPage(*this);
@@ -590,9 +590,9 @@ void ProvisionalPageProxy::didCreateContextInModelProcessForVisibilityPropagatio
 #endif // ENABLE(MODEL_PROCESS)
 #endif // HAVE(VISIBILITY_PROPAGATION_VIEW)
 
-void ProvisionalPageProxy::unfreezeLayerTreeDueToSwipeAnimation()
+void ProvisionalPageProxy::swipeAnimationDidEnd()
 {
-    send(Messages::WebPage::UnfreezeLayerTreeDueToSwipeAnimation());
+    send(Messages::WebPage::SwipeAnimationDidEnd());
 }
 
 void ProvisionalPageProxy::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.h
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.h
@@ -130,7 +130,7 @@ public:
     void goToBackForwardItem(API::Navigation&, WebBackForwardListItem&, RefPtr<API::WebsitePolicies>&&, WebCore::ShouldTreatAsContinuingLoad, std::optional<NetworkResourceLoadIdentifier> existingNetworkResourceLoadIdentifierToResume = std::nullopt);
     void cancel();
 
-    void unfreezeLayerTreeDueToSwipeAnimation();
+    void swipeAnimationDidEnd();
 
     void processDidTerminate();
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -4505,7 +4505,7 @@ void WebPageProxy::commitProvisionalPage(FrameIdentifier frameID, FrameInfoData&
 #endif
 
     if (m_isLayerTreeFrozenDueToSwipeAnimation)
-        send(Messages::WebPage::UnfreezeLayerTreeDueToSwipeAnimation());
+        send(Messages::WebPage::SwipeAnimationDidEnd());
 
     resetStateAfterProcessTermination(ProcessTerminationReason::NavigationSwap);
 
@@ -11404,7 +11404,7 @@ void WebPageProxy::navigationGestureWillEnd(bool willNavigate, WebBackForwardLis
     Ref protectedPageClient { pageClient() };
     if (willNavigate) {
         m_isLayerTreeFrozenDueToSwipeAnimation = true;
-        send(Messages::WebPage::FreezeLayerTreeDueToSwipeAnimation());
+        send(Messages::WebPage::SwipeAnimationDidStart());
     }
 
     protectedPageClient->navigationGestureWillEnd(willNavigate, item);
@@ -11422,10 +11422,10 @@ void WebPageProxy::navigationGestureDidEnd(bool willNavigate, WebBackForwardList
 
     if (m_isLayerTreeFrozenDueToSwipeAnimation) {
         m_isLayerTreeFrozenDueToSwipeAnimation = false;
-        send(Messages::WebPage::UnfreezeLayerTreeDueToSwipeAnimation());
+        send(Messages::WebPage::SwipeAnimationDidEnd());
 
         if (m_provisionalPage)
-            m_provisionalPage->unfreezeLayerTreeDueToSwipeAnimation();
+            m_provisionalPage->swipeAnimationDidEnd();
     }
 }
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -6201,14 +6201,16 @@ void WebPage::effectiveAppearanceDidChange(bool useDarkAppearance, bool useEleva
         m_inspectorUI->effectiveAppearanceDidChange(useDarkAppearance ? WebCore::InspectorFrontendClient::Appearance::Dark : WebCore::InspectorFrontendClient::Appearance::Light);
 }
 
-void WebPage::freezeLayerTreeDueToSwipeAnimation()
+void WebPage::swipeAnimationDidStart()
 {
     freezeLayerTree(LayerTreeFreezeReason::SwipeAnimation);
+    corePage()->setIsInSwipeAnimation(true);
 }
 
-void WebPage::unfreezeLayerTreeDueToSwipeAnimation()
+void WebPage::swipeAnimationDidEnd()
 {
     unfreezeLayerTree(LayerTreeFreezeReason::SwipeAnimation);
+    corePage()->setIsInSwipeAnimation(false);
 }
 
 void WebPage::beginPrinting(FrameIdentifier frameID, const PrintInfo& printInfo)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -986,8 +986,8 @@ public:
     void markLayersVolatile(CompletionHandler<void(bool)>&& completionHandler = { });
     void cancelMarkLayersVolatile();
 
-    void freezeLayerTreeDueToSwipeAnimation();
-    void unfreezeLayerTreeDueToSwipeAnimation();
+    void swipeAnimationDidStart();
+    void swipeAnimationDidEnd();
 
     NotificationPermissionRequestManager* notificationPermissionRequestManager();
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -441,8 +441,9 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
     SuspendAllMediaPlayback() -> ()
     ResumeAllMediaPlayback() -> ()
 
-    FreezeLayerTreeDueToSwipeAnimation()
-    UnfreezeLayerTreeDueToSwipeAnimation()
+    SwipeAnimationDidStart()
+    SwipeAnimationDidEnd()
+
     IsLayerTreeFrozen() -> (bool isFrozen)
 
     # Printing.


### PR DESCRIPTION
#### 44a5e909d5d7fc8de0c7aa834670a5c5e1a3a33a
<pre>
Add logic to determine hasUAVisualTransition value
<a href="https://bugs.webkit.org/show_bug.cgi?id=264748">https://bugs.webkit.org/show_bug.cgi?id=264748</a>

Reviewed by Simon Fraser.

Add logic to determine hasUAVisualTransition value for PopStateEvent when swiping on navigation and add a test to verify this.

Rename FreezeLayerTreeDueToSwipeAnimation/UnfreezeLayerTreeDueToSwipeAnimation messages to the more generic
SwipeAnimationDidStart/swipeAnimationDidEnd, since now it needs to handle both layer tree freezing as well
as detecting the swipe on the Page for hasUAVisualTransition determination.

* LayoutTests/swipe/pushState-back-swipe-verify-ua-transition-expected.txt: Added.
* LayoutTests/swipe/pushState-back-swipe-verify-ua-transition.html: Added.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::dispatchPopstateEvent):
* Source/WebCore/dom/PopStateEvent.h:
* Source/WebCore/page/Page.h:
(WebCore::Page::setIsInSwipeAnimation):
(WebCore::Page::isInSwipeAnimation const):
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::initializeWebPage):
(WebKit::ProvisionalPageProxy::swipeAnimationDidEnd):
(WebKit::ProvisionalPageProxy::unfreezeLayerTreeDueToSwipeAnimation): Deleted.
* Source/WebKit/UIProcess/ProvisionalPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::commitProvisionalPage):
(WebKit::WebPageProxy::navigationGestureWillEnd):
(WebKit::WebPageProxy::navigationGestureDidEnd):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::swipeAnimationDidStart):
(WebKit::WebPage::swipeAnimationDidEnd):
(WebKit::WebPage::freezeLayerTreeDueToSwipeAnimation): Deleted.
(WebKit::WebPage::unfreezeLayerTreeDueToSwipeAnimation): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:

Canonical link: <a href="https://commits.webkit.org/275438@main">https://commits.webkit.org/275438@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a71b7363f6b1eb66367d68c08c397397c6ed92d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41712 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/20726 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/44093 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44286 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37805 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/44019 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/23858 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/18057 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/34474 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/42286 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/17652 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35920 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/15146 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/15344 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36941 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/45673 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37896 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/37263 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/41016 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/16527 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/13566 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/39445 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/18146 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/36220 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9373 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/18203 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/17790 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->