### PR TITLE
Remove redundant Cocoa-specific EnumTraits specializations under WebCore/platform

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h
@@ -389,15 +389,6 @@ namespace WTF {
 template<typename Type>
 struct LogArgument;
 
-template<> struct EnumTraits<WebCore::MediaPlayerPrivateAVFoundation::MediaRenderingMode> {
-using values = EnumValues<
-    WebCore::MediaPlayerPrivateAVFoundation::MediaRenderingMode,
-    WebCore::MediaPlayerPrivateAVFoundation::MediaRenderingMode::MediaRenderingNone,
-    WebCore::MediaPlayerPrivateAVFoundation::MediaRenderingMode::MediaRenderingToContext,
-    WebCore::MediaPlayerPrivateAVFoundation::MediaRenderingMode::MediaRenderingToLayer
-    >;
-};
-
 }; // namespace WTF
 
 #endif // ENABLE(VIDEO) && USE(AVFOUNDATION)

--- a/Source/WebCore/platform/ios/SelectionGeometry.h
+++ b/Source/WebCore/platform/ios/SelectionGeometry.h
@@ -115,15 +115,3 @@ private:
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const SelectionGeometry&);
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::SelectionRenderingBehavior> {
-    using values = EnumValues<
-        WebCore::SelectionRenderingBehavior,
-        WebCore::SelectionRenderingBehavior::CoalesceBoundingRects,
-        WebCore::SelectionRenderingBehavior::UseIndividualQuads
-    >;
-};
-
-} // namespace WTF


### PR DESCRIPTION
#### 94ac298a5aff06bc81c7eb4395875f857991b3c5
<pre>
Remove redundant Cocoa-specific EnumTraits specializations under WebCore/platform
<a href="https://bugs.webkit.org/show_bug.cgi?id=265448">https://bugs.webkit.org/show_bug.cgi?id=265448</a>

Reviewed by Chris Dumez.

Remove the EnumTraits specializations for MediaPlayerPrivateAVFoundation::MediaRenderingMode
and SelectionRenderingBehavior enumerations. The former is not needed and the
latter already has an IPC serialization specification available.

* Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h:
* Source/WebCore/platform/ios/SelectionGeometry.h:

Canonical link: <a href="https://commits.webkit.org/271476@main">https://commits.webkit.org/271476@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55f7bb3987c5403f9b083f76afd747c458a1bc96

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28493 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7138 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29879 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31020 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25948 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28990 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9295 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4507 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28762 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5941 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24516 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5154 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/5317 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25516 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31706 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26141 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25959 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31558 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5235 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3412 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29327 "Found 1 new API test failure: /TestWTF:WTF_ParkingLot.UnparkOneOneFast (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6836 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6829 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5692 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5755 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->