### PR TITLE
[ImageCapture] Add runtime logging

### DIFF
--- a/Source/WebCore/Modules/mediastream/ImageCapture.h
+++ b/Source/WebCore/Modules/mediastream/ImageCapture.h
@@ -34,6 +34,7 @@
 #include "MediaStreamTrack.h"
 #include "PhotoCapabilities.h"
 #include "PhotoSettings.h"
+#include <wtf/LoggerHelper.h>
 
 namespace WebCore {
 
@@ -57,10 +58,21 @@ public:
 private:
     ImageCapture(Document&, Ref<MediaStreamTrack>);
 
+#if !RELEASE_LOG_DISABLED
+    const Logger& logger() const { return m_logger.get(); }
+    const void* logIdentifier() const { return m_logIdentifier; }
+    const char* logClassName() const { return "ImageCapture"; }
+    WTFLogChannel& logChannel() const;
+#endif
+
     // ActiveDOMObject API.
     const char* activeDOMObjectName() const final;
 
     Ref<MediaStreamTrack> m_track;
+#if !RELEASE_LOG_DISABLED
+    Ref<const Logger> m_logger;
+    const void* m_logIdentifier;
+#endif
 };
 
 }

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
@@ -130,8 +130,8 @@ public:
 
     using TakePhotoPromise = NativePromise<std::pair<Vector<uint8_t>, String>, Exception>;
     Ref<TakePhotoPromise> takePhoto(PhotoSettings&&);
-    void getPhotoCapabilities(DOMPromiseDeferred<IDLDictionary<PhotoCapabilities>>&&) const;
-    void getPhotoSettings(DOMPromiseDeferred<IDLDictionary<PhotoSettings>>&&) const;
+    void getPhotoCapabilities(DOMPromiseDeferred<IDLDictionary<PhotoCapabilities>>&&);
+    void getPhotoSettings(DOMPromiseDeferred<IDLDictionary<PhotoSettings>>&&);
 
     const MediaTrackConstraints& getConstraints() const { return m_constraints; }
     void setConstraints(MediaTrackConstraints&& constraints) { m_constraints = WTFMove(constraints); }


### PR DESCRIPTION
#### 82bd651c8ed19eb8c7db8152f9a9d1990305d638
<pre>
[ImageCapture] Add runtime logging
<a href="https://bugs.webkit.org/show_bug.cgi?id=265452">https://bugs.webkit.org/show_bug.cgi?id=265452</a>
<a href="https://rdar.apple.com/118879100">rdar://118879100</a>

Reviewed by Youenn Fablet.

Add runtime logging to help diagnose future errors and failures.

* Source/WebCore/Modules/mediastream/ImageCapture.cpp:
(WebCore::ImageCapture::ImageCapture):
(WebCore::ImageCapture::takePhoto):
(WebCore::ImageCapture::getPhotoCapabilities):
(WebCore::ImageCapture::getPhotoSettings):
(WebCore::ImageCapture::logChannel const):
* Source/WebCore/Modules/mediastream/ImageCapture.h:
(WebCore::ImageCapture::logger const):
(WebCore::ImageCapture::logIdentifier const):
(WebCore::ImageCapture::logClassName const):
* Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp:
(WebCore::MediaStreamTrack::getPhotoCapabilities const):
(WebCore::MediaStreamTrack::getPhotoSettings const):

Canonical link: <a href="https://commits.webkit.org/271229@main">https://commits.webkit.org/271229@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3be6fab656f6f1f5d796794ac425d30fad1b5b9c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27721 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6358 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28966 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29937 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25331 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28196 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8306 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3752 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/25091 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27986 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5114 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23784 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4433 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4605 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24794 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30577 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25316 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25222 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30762 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/4627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2775 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28688 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6128 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6662 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/5075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5059 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->