### PR TITLE
Change include per 271197@main post-review

### DIFF
--- a/Source/WebCore/bindings/js/JSWorkerGlobalScopeBase.h
+++ b/Source/WebCore/bindings/js/JSWorkerGlobalScopeBase.h
@@ -28,7 +28,7 @@
 
 #include "JSDOMGlobalObject.h"
 #include "JSDOMWrapper.h"
-#include "ServiceWorkerGlobalScope.h"
+#include "WorkerGlobalScope.h"
 
 namespace WebCore {
 


### PR DESCRIPTION
#### febb74bac55fa680d1214f3601f421dbd3a9f930
<pre>
Change include per 271197@main post-review
<a href="https://bugs.webkit.org/show_bug.cgi?id=265454">https://bugs.webkit.org/show_bug.cgi?id=265454</a>

Reviewed by NOBODY (OOPS!).

* Source/WebCore/bindings/js/JSWorkerGlobalScopeBase.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/febb74bac55fa680d1214f3601f421dbd3a9f930

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27695 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6333 "Hash febb74ba for PR 20993 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28941 "Hash febb74ba for PR 20993 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29915 "Hash febb74ba for PR 20993 does not build (failure)") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/25315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28170 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8281 "Hash febb74ba for PR 20993 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3726 "Hash febb74ba for PR 20993 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/29915 "Hash febb74ba for PR 20993 does not build (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27961 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/8281 "Hash febb74ba for PR 20993 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/28941 "Hash febb74ba for PR 20993 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/29915 "Hash febb74ba for PR 20993 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/8281 "Hash febb74ba for PR 20993 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/28941 "Hash febb74ba for PR 20993 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30555 "Hash febb74ba for PR 20993 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/8281 "Hash febb74ba for PR 20993 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/28941 "Hash febb74ba for PR 20993 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/30555 "Hash febb74ba for PR 20993 does not build (failure)") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4609 "Hash febb74ba for PR 20993 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/51/builds/3726 "Hash febb74ba for PR 20993 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/30555 "Hash febb74ba for PR 20993 does not build (failure)") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6106 "Hash febb74ba for PR 20993 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/28941 "Hash febb74ba for PR 20993 does not build (failure)") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/5060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5037 "Hash febb74ba for PR 20993 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->