### PR TITLE
Don't fall back to legacy event handling logic in -_interpretKeyEvent:isCharEvent: when using async text input

### DIFF
--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -1263,7 +1263,7 @@ typedef struct {
 
 @protocol UIAsyncTextInputDelegate_Staging<UIAsyncTextInputDelegate>
 - (void)invalidateTextEntryContext; // Added in rdar://118536368.
-- (void)replaceText:(id)sender; // Added in rdar://118307558.
+- (void)deferReplaceTextActionToSystem:(id)sender; // Added in rdar://118307558.
 - (void)provideCandidateUISuggestions:(NSArray<UITextSuggestion*> *)suggestions; // Added in rdar://117914235.
 @end
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -4142,7 +4142,7 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(FORWARD_ACTION_TO_WKWEBVIEW)
 {
 #if HAVE(UI_ASYNC_TEXT_INTERACTION)
     if (self.shouldUseAsyncInteractions)
-        [_asyncSystemInputDelegate replaceText:sender];
+        [_asyncSystemInputDelegate deferReplaceTextActionToSystem:sender];
     else
 #endif
         [[UIKeyboardImpl sharedInstance] replaceText:sender];
@@ -5899,7 +5899,7 @@ static void logTextInteractionAssistantSelectionChange(const char* methodName, U
     [self _updateInternalStateBeforeSelectionChange];
 
 #if HAVE(UI_ASYNC_TEXT_INPUT_DELEGATE)
-    if (_asyncSystemInputDelegate)
+    if (self.shouldUseAsyncInteractions)
         [_asyncSystemInputDelegate selectionWillChange:self];
     else
 #endif
@@ -5922,7 +5922,7 @@ static void logTextInteractionAssistantSelectionChange(const char* methodName, U
 - (void)_internalEndSelectionChange
 {
 #if HAVE(UI_ASYNC_TEXT_INPUT_DELEGATE)
-    if (_asyncSystemInputDelegate)
+    if (self.shouldUseAsyncInteractions)
         [_asyncSystemInputDelegate selectionDidChange:self];
     else
 #endif
@@ -7122,7 +7122,11 @@ inline static UIShiftKeyState shiftKeyState(UIKeyModifierFlags flags)
         return YES;
 
 #if HAVE(UI_ASYNC_TEXT_INTERACTION)
-    if (auto systemDelegate = retainPtr(_asyncSystemInputDelegate)) {
+    if (self.shouldUseAsyncInteractions) {
+        RetainPtr systemDelegate = _asyncSystemInputDelegate;
+        if (!systemDelegate)
+            return NO;
+
         auto context = adoptNS([allocUIKeyEventContextInstance() initWithKeyEvent:event.originalUIKeyEvent]);
         [context setDocumentIsEditable:_page->editorState().isContentEditable];
         [context setShouldInsertChar:isCharEvent];


### PR DESCRIPTION
#### cabc6752c8386048f2ae8ce3ef739c98a5910543
<pre>
Don&apos;t fall back to legacy event handling logic in -_interpretKeyEvent:isCharEvent: when using async text input
<a href="https://bugs.webkit.org/show_bug.cgi?id=265461">https://bugs.webkit.org/show_bug.cgi?id=265461</a>

Reviewed by Megan Gardner.

Instead of using the nullity of `_asyncSystemInputDelegate` to guard async text input codepaths, we
should instead be using the feature flag (`self.shouldUseAsyncInteractions`). This should prevent us
from unintentionally falling back to legacy UIKit SPI codepaths in a handful of places below.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView replaceForWebView:]):

Drive-by fix: rename this again, to reflect the final name that was merged in &lt;<a href="https://rdar.apple.com/118307558">rdar://118307558</a>&gt;.

(-[WKContentView _internalBeginSelectionChange]):
(-[WKContentView _internalEndSelectionChange]):
(-[WKContentView _interpretKeyEvent:isCharEvent:]):

Canonical link: <a href="https://commits.webkit.org/271226@main">https://commits.webkit.org/271226@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20d954debd73a5cc74c67102be9da5035277e32e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27728 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6365 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28973 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29944 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/25336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8315 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3759 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/25097 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27993 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5126 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23790 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4440 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/4615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30584 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25327 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25228 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/30773 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/4633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2780 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/28693 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6135 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6660 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/5080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5067 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->