### PR TITLE
getDisplayMedia frameRate always 30 regardless of constraints

### DIFF
--- a/LayoutTests/fast/mediastream/getDisplayMedia-frame-rate.html
+++ b/LayoutTests/fast/mediastream/getDisplayMedia-frame-rate.html
@@ -23,9 +23,6 @@ promise_test(async () => {
 }, "Ensure getDisplayMedia generate frames");
 
 promise_test(async () => {
-    if (!window.internals)
-        return;
-
     const stream = await callGetDisplayMedia({ video: { frameRate : 30 } });
     assert_equals(stream.getVideoTracks()[0].getSettings().frameRate, 30, "before cloning");
     assert_equals(stream.getVideoTracks()[0].getSettings().width, 1920, "before cloning");
@@ -45,15 +42,30 @@ promise_test(async () => {
     assert_equals(video2.videoWidth, 320);
     assert_equals(video2.videoHeight, 320 * 1080 / 1920);
 
-    internals.observeMediaStreamTrack(stream.getVideoTracks()[0]);
-    let currentCount = internals.trackVideoSampleCount;
-    while (!currentCount) {
-        await new Promise(resolve => setTimeout(resolve, 50));
-        currentCount = internals.trackVideoSampleCount;
-    }
+    let counter = 0;
+    while (counter++ < 10) {
+        const metadata1Promise = new Promise(resolve => video1.requestVideoFrameCallback((now, metadata) => resolve(metadata)));
+        const metadata2Promise = new Promise(resolve => video2.requestVideoFrameCallback((now, metadata) => resolve(metadata)));
 
-    await new Promise(resolve => setTimeout(resolve, 500));
-    assert_true(internals.trackVideoSampleCount - currentCount > 1);
+        await new Promise(resolve => setTimeout(resolve, 2000));
+
+        const m1 = await metadata1Promise;
+        const m2 = await metadata2Promise;
+
+        const metadata3Promise = new Promise(resolve => video1.requestVideoFrameCallback((now, metadata) => resolve(metadata)));
+        const metadata4Promise = new Promise(resolve => video2.requestVideoFrameCallback((now, metadata) => resolve(metadata)));
+        const m3 = await metadata3Promise;
+        const m4 = await metadata4Promise;
+
+        const frames1Count = m3.presentedFrames - m1.presentedFrames;
+        const frames2Count = m4.presentedFrames - m2.presentedFrames;
+
+        if (frames2Count && frames1Count / frames2Count >= 2)
+            return;
+        if (frames1Count > 5)
+            return;
+    };
+    assert_not_equals(counter, 10);
 }, "Ensure getDisplayMedia generate frames with valid frame rate and size in case of clones");
         </script>
     </body>

--- a/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp
@@ -311,6 +311,11 @@ void DisplayCaptureSourceCocoa::emitFrame()
     videoFrameAvailable(*videoFrame.get(), metadata);
 }
 
+double DisplayCaptureSourceCocoa::observedFrameRate() const
+{
+    return frameRate();
+}
+
 void DisplayCaptureSourceCocoa::capturerConfigurationChanged()
 {
     m_currentSettings = { };

--- a/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.h
+++ b/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.h
@@ -139,6 +139,7 @@ private:
     void endApplyingConstraints() final { commitConfiguration(); }
     IntSize computeResizedVideoFrameSize(IntSize desiredSize, IntSize actualSize) final;
     void setSizeFrameRateAndZoom(std::optional<int> width, std::optional<int> height, std::optional<double>, std::optional<double>) final;
+    double observedFrameRate() const final;
 
     const char* logClassName() const final { return "DisplayCaptureSourceCocoa"; }
     void setLogger(const Logger&, const void*) final;


### PR DESCRIPTION
#### fb659ad0308bd57d7bc57ef1e52cbbf1a14220a8
<pre>
getDisplayMedia frameRate always 30 regardless of constraints
<a href="https://bugs.webkit.org/show_bug.cgi?id=265305">https://bugs.webkit.org/show_bug.cgi?id=265305</a>
<a href="https://rdar.apple.com/118874132">rdar://118874132</a>

Reviewed by Eric Carlson.

Our frame decimator is based on knowing the observed frame rate.
DisplayCaptureSourceCocoa was not implementing observedFrameRate so the frame rate decimator was not kicking in.
We implement observedFrameRate by using the frame rate used by the timer that generates frames.
We beef up the existing test and use rvfc instead of the internals API.

* LayoutTests/fast/mediastream/getDisplayMedia-frame-rate.html:
* Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp:
(WebCore::DisplayCaptureSourceCocoa::observedFrameRate const):
* Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.h:

Canonical link: <a href="https://commits.webkit.org/271233@main">https://commits.webkit.org/271233@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2572f7a2fb13465e920de9d07df7969ead9d469

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27731 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6368 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28976 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29947 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25339 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28206 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8318 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3762 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/25099 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27996 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5128 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23795 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4442 "Found 1 new API test failure: /WPE/TestWebKitWebView:/webkit/WebKitWebView/notification (failure)") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/4617 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24805 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30587 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25329 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25233 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30777 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4636 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2783 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28697 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6138 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/24539 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6663 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/5083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5070 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->