### PR TITLE
Ignore the "alg" member in JWK import operation

### DIFF
--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey.https.any-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey.https.any-expected.txt
@@ -1,22 +1,22 @@
 
 PASS Good parameters: Ed25519 bits (spki, buffer(44), {name: Ed25519}, true, [verify])
 PASS Good parameters: Ed25519 bits (jwk, object(kty, crv, x), {name: Ed25519}, true, [verify])
-FAIL Good parameters with ignored JWK alg: Ed25519 (jwk, object(kty, crv, x), {name: Ed25519}, true, [verify]) assert_unreached: Threw an unexpected error: DataError: Data provided to an operation does not meet requirements Reached unreachable code
+PASS Good parameters with ignored JWK alg: Ed25519 (jwk, object(kty, crv, x), {name: Ed25519}, true, [verify])
 PASS Good parameters: Ed25519 bits (raw, buffer(32), {name: Ed25519}, true, [verify])
 PASS Good parameters: Ed25519 bits (spki, buffer(44), {name: Ed25519}, true, [])
 PASS Good parameters: Ed25519 bits (jwk, object(kty, crv, x), {name: Ed25519}, true, [])
-FAIL Good parameters with ignored JWK alg: Ed25519 (jwk, object(kty, crv, x), {name: Ed25519}, true, []) assert_unreached: Threw an unexpected error: DataError: Data provided to an operation does not meet requirements Reached unreachable code
+PASS Good parameters with ignored JWK alg: Ed25519 (jwk, object(kty, crv, x), {name: Ed25519}, true, [])
 PASS Good parameters: Ed25519 bits (raw, buffer(32), {name: Ed25519}, true, [])
 PASS Good parameters: Ed25519 bits (spki, buffer(44), {name: Ed25519}, true, [verify, verify])
 PASS Good parameters: Ed25519 bits (jwk, object(kty, crv, x), {name: Ed25519}, true, [verify, verify])
-FAIL Good parameters with ignored JWK alg: Ed25519 (jwk, object(kty, crv, x), {name: Ed25519}, true, [verify, verify]) assert_unreached: Threw an unexpected error: DataError: Data provided to an operation does not meet requirements Reached unreachable code
+PASS Good parameters with ignored JWK alg: Ed25519 (jwk, object(kty, crv, x), {name: Ed25519}, true, [verify, verify])
 PASS Good parameters: Ed25519 bits (raw, buffer(32), {name: Ed25519}, true, [verify, verify])
 PASS Good parameters: Ed25519 bits (pkcs8, buffer(48), {name: Ed25519}, true, [sign])
 PASS Good parameters: Ed25519 bits (jwk, object(crv, d, x, kty), {name: Ed25519}, true, [sign])
-FAIL Good parameters with ignored JWK alg: Ed25519 (jwk, object(crv, d, x, kty), {name: Ed25519}, true, [sign]) assert_unreached: Threw an unexpected error: DataError: Data provided to an operation does not meet requirements Reached unreachable code
+PASS Good parameters with ignored JWK alg: Ed25519 (jwk, object(crv, d, x, kty), {name: Ed25519}, true, [sign])
 PASS Good parameters: Ed25519 bits (pkcs8, buffer(48), {name: Ed25519}, true, [sign, sign])
 PASS Good parameters: Ed25519 bits (jwk, object(crv, d, x, kty), {name: Ed25519}, true, [sign, sign])
-FAIL Good parameters with ignored JWK alg: Ed25519 (jwk, object(crv, d, x, kty), {name: Ed25519}, true, [sign, sign]) assert_unreached: Threw an unexpected error: DataError: Data provided to an operation does not meet requirements Reached unreachable code
+PASS Good parameters with ignored JWK alg: Ed25519 (jwk, object(crv, d, x, kty), {name: Ed25519}, true, [sign, sign])
 PASS Good parameters: Ed25519 bits (spki, buffer(44), {name: Ed25519}, false, [verify])
 PASS Good parameters: Ed25519 bits (jwk, object(kty, crv, x), {name: Ed25519}, false, [verify])
 PASS Good parameters: Ed25519 bits (raw, buffer(32), {name: Ed25519}, false, [verify])

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey.https.any.worker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey.https.any.worker-expected.txt
@@ -1,22 +1,22 @@
 
 PASS Good parameters: Ed25519 bits (spki, buffer(44), {name: Ed25519}, true, [verify])
 PASS Good parameters: Ed25519 bits (jwk, object(kty, crv, x), {name: Ed25519}, true, [verify])
-FAIL Good parameters with ignored JWK alg: Ed25519 (jwk, object(kty, crv, x), {name: Ed25519}, true, [verify]) assert_unreached: Threw an unexpected error: DataError: Data provided to an operation does not meet requirements Reached unreachable code
+PASS Good parameters with ignored JWK alg: Ed25519 (jwk, object(kty, crv, x), {name: Ed25519}, true, [verify])
 PASS Good parameters: Ed25519 bits (raw, buffer(32), {name: Ed25519}, true, [verify])
 PASS Good parameters: Ed25519 bits (spki, buffer(44), {name: Ed25519}, true, [])
 PASS Good parameters: Ed25519 bits (jwk, object(kty, crv, x), {name: Ed25519}, true, [])
-FAIL Good parameters with ignored JWK alg: Ed25519 (jwk, object(kty, crv, x), {name: Ed25519}, true, []) assert_unreached: Threw an unexpected error: DataError: Data provided to an operation does not meet requirements Reached unreachable code
+PASS Good parameters with ignored JWK alg: Ed25519 (jwk, object(kty, crv, x), {name: Ed25519}, true, [])
 PASS Good parameters: Ed25519 bits (raw, buffer(32), {name: Ed25519}, true, [])
 PASS Good parameters: Ed25519 bits (spki, buffer(44), {name: Ed25519}, true, [verify, verify])
 PASS Good parameters: Ed25519 bits (jwk, object(kty, crv, x), {name: Ed25519}, true, [verify, verify])
-FAIL Good parameters with ignored JWK alg: Ed25519 (jwk, object(kty, crv, x), {name: Ed25519}, true, [verify, verify]) assert_unreached: Threw an unexpected error: DataError: Data provided to an operation does not meet requirements Reached unreachable code
+PASS Good parameters with ignored JWK alg: Ed25519 (jwk, object(kty, crv, x), {name: Ed25519}, true, [verify, verify])
 PASS Good parameters: Ed25519 bits (raw, buffer(32), {name: Ed25519}, true, [verify, verify])
 PASS Good parameters: Ed25519 bits (pkcs8, buffer(48), {name: Ed25519}, true, [sign])
 PASS Good parameters: Ed25519 bits (jwk, object(crv, d, x, kty), {name: Ed25519}, true, [sign])
-FAIL Good parameters with ignored JWK alg: Ed25519 (jwk, object(crv, d, x, kty), {name: Ed25519}, true, [sign]) assert_unreached: Threw an unexpected error: DataError: Data provided to an operation does not meet requirements Reached unreachable code
+PASS Good parameters with ignored JWK alg: Ed25519 (jwk, object(crv, d, x, kty), {name: Ed25519}, true, [sign])
 PASS Good parameters: Ed25519 bits (pkcs8, buffer(48), {name: Ed25519}, true, [sign, sign])
 PASS Good parameters: Ed25519 bits (jwk, object(crv, d, x, kty), {name: Ed25519}, true, [sign, sign])
-FAIL Good parameters with ignored JWK alg: Ed25519 (jwk, object(crv, d, x, kty), {name: Ed25519}, true, [sign, sign]) assert_unreached: Threw an unexpected error: DataError: Data provided to an operation does not meet requirements Reached unreachable code
+PASS Good parameters with ignored JWK alg: Ed25519 (jwk, object(crv, d, x, kty), {name: Ed25519}, true, [sign, sign])
 PASS Good parameters: Ed25519 bits (spki, buffer(44), {name: Ed25519}, false, [verify])
 PASS Good parameters: Ed25519 bits (jwk, object(kty, crv, x), {name: Ed25519}, false, [verify])
 PASS Good parameters: Ed25519 bits (raw, buffer(32), {name: Ed25519}, false, [verify])

--- a/Source/WebCore/crypto/keys/CryptoKeyOKP.cpp
+++ b/Source/WebCore/crypto/keys/CryptoKeyOKP.cpp
@@ -100,8 +100,6 @@ RefPtr<CryptoKeyOKP> CryptoKeyOKP::importJwk(CryptoAlgorithmIdentifier identifie
         if (keyData.crv != "Ed25519"_s)
             return nullptr;
         // FIXME: Do we have tests for these checks ?
-        if (!keyData.alg.isEmpty() && keyData.alg != "EdDSA"_s)
-            return nullptr;
         if (usages && !keyData.use.isEmpty() && keyData.use != "sign"_s)
             return nullptr;
         if (keyData.key_ops && ((keyData.usages & usages) != usages))


### PR DESCRIPTION
#### 6d42d9786b3a41fc63d8bf24cf98aec25371a6fd
<pre>
Ignore the &quot;alg&quot; member in JWK import operation
<a href="https://bugs.webkit.org/show_bug.cgi?id=262613">https://bugs.webkit.org/show_bug.cgi?id=262613</a>

Reviewed by NOBODY (OOPS!).

The old (EdDSA) value is going to be DEPRECATED soon (the draft is
going to be adopted after the JOSE WG recharter goes through). The
Curve25519 spec draft has been already updated accordingly, so this
patch updates our implementation to ignore the &apos;alg&apos; field of the
JWK data when importing the keys.

The export operaton doesn&apos;t add this field, so the round-trip check
still passes with this change.

* LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey.https.any-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey.https.any.worker-expected.txt:
* Source/WebCore/crypto/keys/CryptoKeyOKP.cpp:
(WebCore::CryptoKeyOKP::importJwk):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d42d9786b3a41fc63d8bf24cf98aec25371a6fd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27744 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6382 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28989 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29960 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25349 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28219 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8334 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3775 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/25108 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28009 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5150 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23800 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4452 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4637 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24810 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30600 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25353 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25239 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30785 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4646 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2792 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28707 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6149 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5093 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5083 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->