### PR TITLE
Have VTTCue use LoggerHelper

### DIFF
--- a/Source/WebCore/html/track/VTTCue.h
+++ b/Source/WebCore/html/track/VTTCue.h
@@ -37,6 +37,7 @@
 #include "SpeechSynthesisUtterance.h"
 #include "TextTrackCue.h"
 #include "VTTRegion.h"
+#include <wtf/LoggerHelper.h>
 #include <wtf/TypeCasts.h>
 
 namespace WebCore {
@@ -107,7 +108,12 @@ private:
 
 // ----------------------------
 
-class VTTCue : public TextTrackCue {
+class VTTCue
+    : public TextTrackCue
+#if !RELEASE_LOG_DISABLED
+    , private LoggerHelper
+#endif
+{
     WTF_MAKE_ISO_ALLOCATED(VTTCue);
 public:
     static Ref<VTTCue> create(Document&, double start, double end, String&& content);
@@ -252,6 +258,13 @@ private:
     void pauseSpeaking() final;
     void cancelSpeaking() final;
 
+#if !RELEASE_LOG_DISABLED
+    const Logger& logger() const final { return *m_logger; }
+    const void* logIdentifier() const final;
+    WTFLogChannel& logChannel() const final;
+    const char* logClassName() const final { return "VTTCue"; }
+#endif
+
     String m_content;
     String m_settings;
     std::optional<double> m_linePosition;
@@ -294,6 +307,11 @@ private:
     LineAndPositionSetting m_top { Auto };
     LineAndPositionSetting m_width { Auto };
     LineAndPositionSetting m_height { Auto };
+
+#if !RELEASE_LOG_DISABLED
+    mutable RefPtr<Logger> m_logger;
+    mutable const void* m_logIdentifier { nullptr };
+#endif
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 7d887fc6d028bb20f3499c9169ff7057292600d5
<pre>
Have VTTCue use LoggerHelper
<a href="https://bugs.webkit.org/show_bug.cgi?id=265466">https://bugs.webkit.org/show_bug.cgi?id=265466</a>
<a href="https://rdar.apple.com/118889015">rdar://118889015</a>

Reviewed by Richard Robinson and Jer Noble.

Bring VTTCue&apos;s logging up to date by using INFO_LOG() and ERROR_LOG() instead of LOG().

* Source/WebCore/html/track/VTTCue.cpp:
(WebCore::VTTCue::VTTCue):
(WebCore::VTTCue::setTrack):
(WebCore::VTTCue::setCueSettings):
(WebCore::VTTCue::logIdentifier const):
(WebCore::VTTCue::logChannel const):
(WebCore::VTTCue::logger const):
* Source/WebCore/html/track/VTTCue.h:

Canonical link: <a href="https://commits.webkit.org/271498@main">https://commits.webkit.org/271498@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36772159925c74965051220c2baa961d2b2a01ac

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28116 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6757 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29471 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30647 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25629 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28613 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8777 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4143 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/25941 "Build was cancelled. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests (exception)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28384 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5514 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24193 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4762 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4937 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25188 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31336 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25721 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25619 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31237 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4922 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3090 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28994 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6466 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6843 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5360 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5425 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->