### PR TITLE
Stop outputting JSONP for layout tests results

### DIFF
--- a/Tools/Scripts/webkitpy/layout_tests/controllers/manager.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/manager.py
@@ -703,7 +703,7 @@ class Manager(object):
 
         full_results_path = self._filesystem.join(self._results_directory, "full_results.json")
         # We write full_results.json out as jsonp because we need to load it from a file url and WebKit doesn't allow that.
-        json_results_generator.write_json(self._filesystem, summarized_results, full_results_path, callback="ADD_RESULTS")
+        json_results_generator.write_json(self._filesystem, summarized_results, full_results_path)
 
         generator = json_layout_results_generator.JSONLayoutResultsGenerator(
             self._port, self._results_directory,

--- a/Tools/Scripts/webkitpy/layout_tests/layout_package/json_results_generator.py
+++ b/Tools/Scripts/webkitpy/layout_tests/layout_package/json_results_generator.py
@@ -62,11 +62,9 @@ def load_json(filesystem, file_path):
     return json.loads(content)
 
 
-def write_json(filesystem, json_object, file_path, callback=None):
+def write_json(filesystem, json_object, file_path):
     # Specify separators in order to get compact encoding.
     json_string = json.dumps(json_object, separators=(',', ':'))
-    if callback:
-        json_string = callback + "(" + json_string + ");"
     filesystem.write_text_file(file_path, json_string)
 
 


### PR DESCRIPTION
#### 7862a0946a2d
<pre>
Stop outputting JSONP for layout tests results
<a href="https://bugs.webkit.org/show_bug.cgi?id=265468">https://bugs.webkit.org/show_bug.cgi?id=265468</a>

Reviewed by NOBODY (OOPS!).

Now everywhere handles raw JSON output for layout tests results, we
should stop outputting JSONP.

Note we maintain support for *reading* JSONP files, as we want to be
able to read older test results.

* Tools/Scripts/webkitpy/layout_tests/controllers/manager.py:
(Manager._save_json_files):
* Tools/Scripts/webkitpy/layout_tests/layout_package/json_results_generator.py:
(write_json):
* Tools/Scripts/webkitpy/layout_tests/run_webkit_tests_integrationtest.py:
(parse_full_results):
(RunTest.serial_test_basic):
(RunTest.test_missing_and_unexpected_results):
(RunTest.test_crash_with_stderr):
(RunTest.test_wpt_tests):
(RunTest.test_wpt_tests_rebaseline):
(RunTest.test_output_diffs):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7862a0946a2dda521dedfe8de3c94e695eb3cdc2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27776 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6413 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/29461 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30393 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25370 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28253 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8763 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3877 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/25196 "Found unexpected failure with change (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28041 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/5509 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24175 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4534 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/27937 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/4925 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/25171 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30632 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/25716 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/25609 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30817 "layout-tests (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4667 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2869 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28732 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6174 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5113 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5114 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->