### PR TITLE
Add support for web extension registered content scripts

### DIFF
--- a/Source/WebKit/Shared/Extensions/WebExtensionDynamicScripts.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionDynamicScripts.serialization.in
@@ -50,15 +50,15 @@ struct WebKit::WebExtensionRegisteredScriptParameters {
     std::optional<Vector<String>> js;
 
     String identifier;
-    WebKit::WebExtension::InjectionTime injectionTime;
+    std::optional<WebKit::WebExtension::InjectionTime> injectionTime;
 
-    std::optional<Vector<String>> excludedMatchPatterns;
+    std::optional<Vector<String>> excludeMatchPatterns;
     std::optional<Vector<String>> matchPatterns;
 
-    bool allFrames;
-    bool persistAcrossSessions;
+    std::optional<bool> allFrames;
+    std::optional<bool> persistent;
 
-    WebKit::WebExtensionContentWorldType world;
+    std::optional<WebKit::WebExtensionContentWorldType> world;
 }
 
 [Nested] enum class WebKit::WebExtension::InjectionTime : uint8_t {

--- a/Source/WebKit/Shared/Extensions/WebExtensionRegisteredScriptParameters.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionRegisteredScriptParameters.h
@@ -37,15 +37,15 @@ struct WebExtensionRegisteredScriptParameters {
     std::optional<Vector<String>> js;
 
     String identifier;
-    WebExtension::InjectionTime injectionTime { WebExtension::InjectionTime::DocumentIdle };
+    std::optional<WebExtension::InjectionTime> injectionTime;
 
-    std::optional<Vector<String>> excludedMatchPatterns;
+    std::optional<Vector<String>> excludeMatchPatterns;
     std::optional<Vector<String>> matchPatterns;
 
-    bool allFrames { false };
-    bool persistAcrossSessions { true };
+    std::optional<bool> allFrames;
+    std::optional<bool> persistent;
 
-    WebExtensionContentWorldType world { WebExtensionContentWorldType::ContentScript };
+    std::optional<WebExtensionContentWorldType> world;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
@@ -1850,7 +1850,19 @@ void WebExtension::populateContentScriptPropertiesIfNeeded()
         else
             recordError(createError(Error::InvalidContentScripts, WEB_UI_STRING("Manifest `content_scripts` entry has unknown `run_at` value.", "WKWebExtensionErrorInvalidContentScripts description for unknown 'run_at' value")));
 
-        m_staticInjectedContents.append({ WTFMove(includeMatchPatterns), WTFMove(excludeMatchPatterns), injectionTime, matchesAboutBlank, injectsIntoAllFrames, false, scriptPaths, styleSheetPaths, includeGlobPatternStrings, excludeGlobPatternStrings });
+        InjectedContentData injectedContentData;
+        injectedContentData.includeMatchPatterns = WTFMove(includeMatchPatterns);
+        injectedContentData.excludeMatchPatterns = WTFMove(excludeMatchPatterns);
+        injectedContentData.injectionTime = injectionTime;
+        injectedContentData.matchesAboutBlank = matchesAboutBlank;
+        injectedContentData.injectsIntoAllFrames = injectsIntoAllFrames;
+        injectedContentData.forMainWorld = false;
+        injectedContentData.scriptPaths = scriptPaths;
+        injectedContentData.styleSheetPaths = styleSheetPaths;
+        injectedContentData.includeGlobPatternStrings = includeGlobPatternStrings;
+        injectedContentData.excludeGlobPatternStrings = excludeGlobPatternStrings;
+
+        m_staticInjectedContents.append(WTFMove(injectedContentData));
     };
 
     for (NSDictionary<NSString *, id> *contentScriptsManifestEntry in contentScriptsManifestArray)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
@@ -39,7 +39,6 @@
 #import "WebExtensionContext.h"
 #import "WebExtensionFrameIdentifier.h"
 #import "WebExtensionScriptInjectionParameters.h"
-#import "WebExtensionScriptInjectionResultParameters.h"
 #import "WebExtensionUtilities.h"
 #import "WebPageProxy.h"
 #import "WebUserContentControllerProxy.h"
@@ -52,8 +51,6 @@
 namespace WebKit {
 
 namespace WebExtensionDynamicScripts {
-
-using UserStyleSheetVector = WebExtensionContext::UserStyleSheetVector;
 
 static bool userStyleSheetMatchesContent(Ref<API::UserStyleSheet> userStyleSheet, SourcePair styleSheetContent, WebCore::UserContentInjectedFrames injectedFrames)
 {
@@ -194,6 +191,89 @@ WebExtensionScriptInjectionResultParameters toInjectionResultParameters(id resul
         parameters.error = errorMessage;
 
     return parameters;
+}
+
+WebExtensionRegisteredScript::WebExtensionRegisteredScript(WebExtensionContext& extensionContext, const WebExtensionRegisteredScriptParameters& parameters)
+    : m_extensionContext(extensionContext)
+    , m_parameters(parameters)
+{
+
+}
+
+void WebExtensionRegisteredScript::updateParameters(const WebExtensionRegisteredScriptParameters& parameters)
+{
+    m_parameters = parameters;
+}
+
+void WebExtensionRegisteredScript::merge(WebExtensionRegisteredScriptParameters& parameters)
+{
+    if (!parameters.css && m_parameters.css)
+        parameters.css = m_parameters.css.value();
+
+    if (!parameters.js && m_parameters.js)
+        parameters.js = m_parameters.js.value();
+
+    if (!parameters.injectionTime)
+        parameters.injectionTime = m_parameters.injectionTime.value();
+
+    if (!parameters.excludeMatchPatterns && m_parameters.excludeMatchPatterns)
+        parameters.excludeMatchPatterns = m_parameters.excludeMatchPatterns.value();
+
+    if (!parameters.matchPatterns)
+        parameters.matchPatterns = m_parameters.matchPatterns.value();
+
+    if (!parameters.allFrames)
+        parameters.allFrames = m_parameters.allFrames.value();
+
+    if (!parameters.persistent)
+        parameters.persistent = m_parameters.persistent.value();
+
+    if (!parameters.world)
+        parameters.world = m_parameters.world.value();
+}
+
+void WebExtensionRegisteredScript::addUserScript(const String& identifier, API::UserScript& userScript)
+{
+    auto& userScripts = m_userScriptsMap.ensure(identifier, [&] {
+        return UserScriptVector { };
+    }).iterator->value;
+    userScripts.append(userScript);
+}
+
+void WebExtensionRegisteredScript::addUserStyleSheet(const String& identifier, API::UserStyleSheet& userStyleSheet)
+{
+    auto& userStyleSheets = m_userStyleSheetsMap.ensure(identifier, [&] {
+        return UserStyleSheetVector { };
+    }).iterator->value;
+    userStyleSheets.append(userStyleSheet);
+}
+
+void WebExtensionRegisteredScript::removeUserScriptsAndStyleSheets(const String& identifier)
+{
+    removeUserScripts(identifier);
+    removeUserStyleSheets(identifier);
+}
+
+void WebExtensionRegisteredScript::removeUserScripts(const String& identifier)
+{
+    auto userScripts = m_userScriptsMap.take(identifier);
+    auto allUserContentControllers = m_extensionContext->extensionController()->allUserContentControllers();
+
+    for (auto& userScript : userScripts) {
+        for (auto& userContentController : allUserContentControllers)
+            userContentController.removeUserScript(userScript);
+    }
+}
+
+void WebExtensionRegisteredScript::removeUserStyleSheets(const String& identifier)
+{
+    auto userStyleSheets = m_userStyleSheetsMap.take(identifier);
+    auto allUserContentControllers = m_extensionContext->extensionController()->allUserContentControllers();
+
+    for (auto& userStyleSheet : userStyleSheets) {
+        for (auto& userContentController : allUserContentControllers)
+            userContentController.removeUserStyleSheet(userStyleSheet);
+    }
 }
 
 } // namespace WebExtensionDynamicScripts

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -151,6 +151,8 @@ public:
 
         InjectionTime injectionTime = InjectionTime::DocumentIdle;
 
+        String identifier { ""_s };
+
         bool matchesAboutBlank { false };
         bool injectsIntoAllFrames { false };
         bool forMainWorld { false };

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -508,10 +508,11 @@ private:
     void scriptingExecuteScript(const WebExtensionScriptInjectionParameters&, CompletionHandler<void(std::optional<Vector<WebExtensionScriptInjectionResultParameters>>, WebExtensionDynamicScripts::Error)>&&);
     void scriptingInsertCSS(const WebExtensionScriptInjectionParameters&, CompletionHandler<void(WebExtensionDynamicScripts::Error)>&&);
     void scriptingRemoveCSS(const WebExtensionScriptInjectionParameters&, CompletionHandler<void(WebExtensionDynamicScripts::Error)>&&);
-    void scriptingRegisterScripts(const Vector<WebExtensionRegisteredScriptParameters>& scripts, CompletionHandler<void(WebExtensionDynamicScripts::Error)>&&);
+    void scriptingRegisterContentScripts(const Vector<WebExtensionRegisteredScriptParameters>& scripts, CompletionHandler<void(WebExtensionDynamicScripts::Error)>&&);
     void scriptingUpdateRegisteredScripts(const Vector<WebExtensionRegisteredScriptParameters>& scripts, CompletionHandler<void(WebExtensionDynamicScripts::Error)>&&);
-    void scriptingGetRegisteredScripts(const Vector<String>&, CompletionHandler<void(std::optional<Vector<WebExtensionRegisteredScriptParameters>> scripts, WebExtensionDynamicScripts::Error)>&&);
-    void scriptingUnregisterScripts(const Vector<String>&, CompletionHandler<void(std::optional<Vector<WebExtensionRegisteredScriptParameters>> scripts, WebExtensionDynamicScripts::Error)>&&);
+    void scriptingGetRegisteredScripts(const Vector<String>&, CompletionHandler<void(Vector<WebExtensionRegisteredScriptParameters> scripts)>&&);
+    void scriptingUnregisterContentScripts(const Vector<String>&, CompletionHandler<void(WebExtensionDynamicScripts::Error)>&&);
+    bool parseRegisteredContentScripts(const Vector<WebExtensionRegisteredScriptParameters>&, WebExtensionDynamicScripts::WebExtensionRegisteredScript::FirstTimeRegistration, InjectedContentVector&, NSString *callingAPIName, NSString **errorMessage);
 
     // Tabs APIs
     void tabsCreate(WebPageProxyIdentifier, const WebExtensionTabParameters&, CompletionHandler<void(std::optional<WebExtensionTabParameters>, WebExtensionTab::Error)>&&);
@@ -624,6 +625,8 @@ private:
 
     HashMap<Ref<WebExtensionMatchPattern>, UserScriptVector> m_injectedScriptsPerPatternMap;
     HashMap<Ref<WebExtensionMatchPattern>, UserStyleSheetVector> m_injectedStyleSheetsPerPatternMap;
+
+    HashMap<String, Ref<WebExtensionDynamicScripts::WebExtensionRegisteredScript>> m_registeredScriptsMap;
 
     UserStyleSheetVector m_dynamicallyInjectedUserStyleSheets;
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
@@ -87,10 +87,10 @@ messages -> WebExtensionContext {
     ScriptingExecuteScript(WebKit::WebExtensionScriptInjectionParameters parameters) -> (std::optional<Vector<WebKit::WebExtensionScriptInjectionResultParameters>> results, WebKit::WebExtensionDynamicScripts::Error error);
     ScriptingInsertCSS(WebKit::WebExtensionScriptInjectionParameters parameters) -> (WebKit::WebExtensionDynamicScripts::Error error);
     ScriptingRemoveCSS(WebKit::WebExtensionScriptInjectionParameters parameters) -> (WebKit::WebExtensionDynamicScripts::Error error);
-    ScriptingRegisterScripts(Vector<WebKit::WebExtensionRegisteredScriptParameters> scripts) -> (WebKit::WebExtensionDynamicScripts::Error error);
+    ScriptingRegisterContentScripts(Vector<WebKit::WebExtensionRegisteredScriptParameters> scripts) -> (WebKit::WebExtensionDynamicScripts::Error error);
     ScriptingUpdateRegisteredScripts(Vector<WebKit::WebExtensionRegisteredScriptParameters> scripts) -> (WebKit::WebExtensionDynamicScripts::Error error);
-    ScriptingGetRegisteredScripts(Vector<String> scriptIDs) -> (std::optional<Vector<WebKit::WebExtensionRegisteredScriptParameters>> scripts, WebKit::WebExtensionDynamicScripts::Error error);
-    ScriptingUnregisterScripts(Vector<String> scriptIDs) -> (std::optional<Vector<WebKit::WebExtensionRegisteredScriptParameters>> scripts, WebKit::WebExtensionDynamicScripts::Error error);
+    ScriptingGetRegisteredScripts(Vector<String> scriptIDs) -> (Vector<WebKit::WebExtensionRegisteredScriptParameters> scripts);
+    ScriptingUnregisterContentScripts(Vector<String> scriptIDs) -> (WebKit::WebExtensionDynamicScripts::Error error);
 
     // Tabs APIs
     TabsCreate(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, WebKit::WebExtensionTabParameters creationParameters) -> (std::optional<WebKit::WebExtensionTabParameters> tabParameters, WebKit::WebExtensionTab::Error error);

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIScripting.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIScripting.h
@@ -36,6 +36,10 @@ OBJC_CLASS NSString;
 
 namespace WebKit {
 
+using FirstTimeRegistration = WebExtensionDynamicScripts::WebExtensionRegisteredScript::FirstTimeRegistration;
+
+class WebExtension;
+
 class WebExtensionAPIScripting : public WebExtensionAPIObject, public JSWebExtensionWrappable {
     WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIScripting, scripting);
 
@@ -57,18 +61,20 @@ private:
     bool validateTarget(NSDictionary *, NSString **outExceptionString);
     bool validateCSS(NSDictionary *, NSString **outExceptionString);
 
-    bool validateRegisteredScripts(NSArray *, bool isRegisteringScript, NSString **outExceptionString);
+    bool validateRegisteredScripts(NSArray *, FirstTimeRegistration, NSString **outExceptionString);
     bool validateFilter(NSDictionary *filter, NSString **outExceptionString);
 
     void parseCSSInjectionOptions(NSDictionary *, WebExtensionScriptInjectionParameters&);
     void parseTargetInjectionOptions(NSDictionary *, WebExtensionScriptInjectionParameters&, NSString **outExceptionString);
     void parseScriptInjectionOptions(NSDictionary *, WebExtensionScriptInjectionParameters&);
-    void parseRegisteredContentScripts(NSArray *, Vector<WebExtensionRegisteredScriptParameters>&);
+    void parseRegisteredContentScripts(NSArray *, FirstTimeRegistration, Vector<WebExtensionRegisteredScriptParameters>&);
 
 #endif
 };
 
 NSArray *toWebAPI(const Vector<WebExtensionScriptInjectionResultParameters>&, bool returnExecutionResultOnly);
+NSArray *toWebAPI(const Vector<WebExtensionRegisteredScriptParameters>&);
+NSString *toWebAPI(WebExtension::InjectionTime);
 
 } // namespace WebKit
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIScripting.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIScripting.mm
@@ -421,6 +421,331 @@ TEST(WKWebExtensionAPIScripting, InsertAndRemoveCSSWithFrameIds)
     [manager loadAndRun];
 }
 
+TEST(WKWebExtensionAPIScripting, RegisterContentScripts)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } }
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"function getBackgroundColor() { return window.getComputedStyle(document.body).getPropertyValue('background-color') }",
+
+        @"function getFontSize() { return window.getComputedStyle(document.body).getPropertyValue('font-size') }",
+
+        @"  const pinkValue = 'rgb(255, 192, 203)'",
+
+        @"browser.webNavigation.onCompleted.addListener(async (details) => {",
+        @"  const tabId = details.tabId",
+
+        @"  var expectedResults = [{",
+        @"    allFrames: false,",
+        @"    id: '1',",
+        @"    js: ['changeBackgroundColorScript.js', 'changeBackgroundFontScript.js'],",
+        @"    matches: ['*://localhost/*'],",
+        @"    persistAcrossSessions: true,",
+        @"    runAt: 'document_idle',",
+        @"    world: 'ISOLATED'",
+        @"  }]",
+
+        @"  var results",
+        @"  var resultsPassingIds",
+
+        @"  await browser.scripting.registerContentScripts([{ id: '1', matches: ['*://localhost/*'], js: ['changeBackgroundColorScript.js', 'changeBackgroundFontScript.js'] }])",
+        @"  results = await browser.scripting.getRegisteredContentScripts()",
+        @"  resultsPassingIds = await browser.scripting.getRegisteredContentScripts({ ids: ['1'] })",
+
+        @"  browser.test.assertDeepEq(results, resultsPassingIds)",
+        @"  browser.test.assertDeepEq(results, expectedResults)",
+
+        // Verify scripts injected.
+
+        @"  results = await browser.scripting.executeScript({ target: { tabId: tabId }, func: getBackgroundColor })",
+        @"  browser.test.assertEq(results[0].result, pinkValue)",
+
+        @"  results = await browser.scripting.executeScript({ target: { tabId: tabId }, func: getFontSize })",
+        @"  browser.test.assertEq(results[0].result, '555px')",
+
+        @"  await browser.scripting.unregisterContentScripts()",
+
+        @"  browser.test.notifyPass()",
+        @"})",
+
+        @"browser.test.yield('Load Tab')",
+    ]);
+
+    static auto *changeBackgroundColorScript = @"document.body.style.background = 'pink'";
+    static auto *changeBackgroundFontScript = @"document.body.style.fontSize = '555px'";
+
+    static auto *resources = @{
+        @"background.js": backgroundScript,
+        @"changeBackgroundColorScript.js": changeBackgroundColorScript,
+        @"changeBackgroundFontScript.js": changeBackgroundFontScript,
+    };
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:scriptingManifest resources:resources]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    auto *urlRequest = server.requestWithLocalhost();
+    auto *url = urlRequest.URL;
+
+    auto *matchPattern = [_WKWebExtensionMatchPattern matchPatternWithScheme:url.scheme host:url.host path:@"/*"];
+    [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:_WKWebExtensionPermissionWebNavigation];
+    [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:matchPattern];
+
+    [manager loadAndRun];
+
+    EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
+
+    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+
+    [manager run];
+}
+
+TEST(WKWebExtensionAPIScripting, UpdateContentScripts)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<iframe src='/frame.html'></iframe>"_s } },
+        { "/frame.html"_s, { { { "Content-Type"_s, "text/html"_s } }, "<body style='background-color: blue'></body>"_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"function getBackgroundColor() { return window.getComputedStyle(document.body).getPropertyValue('background-color') }",
+
+        @"function getFontSize() { return window.getComputedStyle(document.body).getPropertyValue('font-size') }",
+
+        @"  const pinkValue = 'rgb(255, 192, 203)'",
+
+        @"browser.webNavigation.onCompleted.addListener(async (details) => {",
+        @"  const tabId = details.tabId",
+
+        @"  var expectedResults = [{",
+        @"    allFrames: false,",
+        @"    id: '1',",
+        @"    js: ['changeBackgroundColorScript.js'],",
+        @"    matches: ['*://localhost/*'],",
+        @"    persistAcrossSessions: true,",
+        @"    runAt: 'document_idle',",
+        @"    world: 'ISOLATED'",
+        @"  }]",
+
+        @"  var results",
+
+        @"  await browser.scripting.registerContentScripts([{ id: '1', matches: ['*://localhost/*'], js: ['changeBackgroundColorScript.js'] }])",
+
+        @"  await browser.scripting.updateContentScripts([{ id: '1', allFrames: true, persistAcrossSessions: false, runAt: 'document_start', world: 'MAIN' }])",
+        @"  results = await browser.scripting.getRegisteredContentScripts()",
+        @"  expectedResults[0].allFrames = true",
+        @"  expectedResults[0].persistAcrossSessions = false",
+        @"  expectedResults[0].runAt = 'document_start'",
+        @"  expectedResults[0].world = 'MAIN'",
+
+        @"  browser.test.assertDeepEq(results, expectedResults)",
+
+        @"  await browser.scripting.updateContentScripts([{ id: '1', js: ['changeBackgroundColorScript.js', 'changeBackgroundFontScript.js'] }])",
+        @"  expectedResults[0].js = ['changeBackgroundColorScript.js', 'changeBackgroundFontScript.js']",
+        @"  results = await browser.scripting.getRegisteredContentScripts()",
+
+        @"  browser.test.assertDeepEq(results, expectedResults)",
+
+        // Verify scripts injected.
+
+        @"  results = await browser.scripting.executeScript({ target: { tabId: tabId, allFrames:true }, func: getBackgroundColor })",
+        @"  browser.test.assertEq(results[0].result, pinkValue)",
+        @"  browser.test.assertEq(results[1].result, pinkValue)",
+
+        @"  results = await browser.scripting.executeScript({ target: { tabId: tabId, allFrames:true }, func: getFontSize })",
+        @"  browser.test.assertEq(results[0].result, '555px')",
+        @"  browser.test.assertEq(results[1].result, '555px')",
+
+        @"  await browser.scripting.unregisterContentScripts()",
+
+        @"  browser.test.notifyPass()",
+        @"})",
+
+        @"browser.test.yield('Load Tab')",
+    ]);
+
+    static auto *changeBackgroundColorScript = @"document.body.style.background = 'pink'";
+    static auto *changeBackgroundFontScript = @"document.body.style.fontSize = '555px'";
+
+    static auto *resources = @{
+        @"background.js": backgroundScript,
+        @"changeBackgroundColorScript.js": changeBackgroundColorScript,
+        @"changeBackgroundFontScript.js": changeBackgroundFontScript,
+    };
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:scriptingManifest resources:resources]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    auto *urlRequest = server.requestWithLocalhost();
+    auto *url = urlRequest.URL;
+
+    auto *matchPattern = [_WKWebExtensionMatchPattern matchPatternWithScheme:url.scheme host:url.host path:@"/*"];
+    [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:_WKWebExtensionPermissionWebNavigation];
+    [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:matchPattern];
+
+    [manager loadAndRun];
+
+    EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
+
+    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+
+    [manager run];
+}
+
+TEST(WKWebExtensionAPIScripting, GetContentScripts)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } }
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.webNavigation.onCompleted.addListener(async () => {",
+
+        @"  var expectedResults = [{",
+        @"    allFrames: false,",
+        @"    id: '1',",
+        @"    js: ['changeBackgroundColorScript.js'],",
+        @"    matches: ['*://localhost/*'],",
+        @"    persistAcrossSessions: true,",
+        @"    runAt: 'document_idle',",
+        @"    world: 'ISOLATED'",
+        @"  }]",
+
+        @"  var results",
+
+        @"  await browser.scripting.registerContentScripts([{ id: '1', matches: ['*://localhost/*'], js: ['changeBackgroundColorScript.js'] }])",
+
+        @"  results = await browser.scripting.getRegisteredContentScripts()",
+        @"  browser.test.assertDeepEq(results, expectedResults)",
+
+        @"  results = await browser.scripting.getRegisteredContentScripts({ 'ids': ['1'] })",
+        @"  browser.test.assertDeepEq(results, expectedResults)",
+
+        // Unrecognized ids should be ignored.
+        @"  results = await browser.scripting.getRegisteredContentScripts({ 'ids': ['1', '2'] })",
+        @"  browser.test.assertDeepEq(results, expectedResults)",
+
+        @"  await browser.scripting.registerContentScripts([{ id: '2', matches: ['*://localhost/*'], js: ['changeBackgroundFontScript.js'], runAt: 'document_start', world: 'MAIN' }])",
+
+        @"  results = await browser.scripting.getRegisteredContentScripts({ 'ids': ['1', '2'] })",
+        @"  expectedResults.push({ allFrames: false, id: '2', js: ['changeBackgroundFontScript.js'], matches: ['*://localhost/*'], persistAcrossSessions: true, runAt: 'document_start', world: 'MAIN' })",
+        @"  browser.test.assertDeepEq(results, expectedResults)",
+
+        @"  await browser.scripting.unregisterContentScripts()",
+
+        @"  browser.test.notifyPass()",
+        @"})",
+
+        @"browser.test.yield('Load Tab')",
+    ]);
+
+    static auto *changeBackgroundColorScript = @"document.body.style.background = 'pink'";
+    static auto *changeBackgroundFontScript = @"document.body.style.fontSize = '555px'";
+
+    static auto *resources = @{
+        @"background.js": backgroundScript,
+        @"changeBackgroundColorScript.js": changeBackgroundColorScript,
+        @"changeBackgroundFontScript.js": changeBackgroundFontScript,
+    };
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:scriptingManifest resources:resources]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    auto *urlRequest = server.requestWithLocalhost();
+    auto *url = urlRequest.URL;
+
+    auto *matchPattern = [_WKWebExtensionMatchPattern matchPatternWithScheme:url.scheme host:url.host path:@"/*"];
+    [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:_WKWebExtensionPermissionWebNavigation];
+    [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:matchPattern];
+
+    [manager loadAndRun];
+
+    EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
+
+    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+
+    [manager run];
+}
+
+TEST(WKWebExtensionAPIScripting, UnregisterContentScripts)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } }
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"function getBackgroundColor() { return window.getComputedStyle(document.body).getPropertyValue('background-color') }",
+
+        @"  const pinkValue = 'rgb(255, 192, 203)'",
+        @"  const transparentValue = 'rgba(0, 0, 0, 0)'",
+
+        @"  browser.webNavigation.onCompleted.addListener(async (details) => {",
+        @"    const tabId = details.tabId",
+
+        @"    await browser.scripting.registerContentScripts([{ id: '1', matches: ['*://localhost/*'], js: ['changeBackgroundColorScript.js'] }])",
+
+        @"    var results",
+        @"    results = await browser.scripting.getRegisteredContentScripts()",
+
+        @"    browser.test.assertEq(results.length, 1)",
+
+        @"    await browser.scripting.unregisterContentScripts()",
+        @"    results = await browser.scripting.getRegisteredContentScripts()",
+        @"    browser.test.assertEq(results.length, 0)",
+
+        // Unrecognized ids should return an error and result in a no-op.
+
+        @"    await browser.scripting.registerContentScripts([{ id: '1', matches: ['*://localhost/*'], js: ['changeBackgroundColorScript.js'] }])",
+        @"    browser.test.assertRejects(browser.scripting.unregisterContentScripts({ 'ids': ['1', '2'] }))",
+
+        @"    results = await browser.scripting.executeScript({ target: { tabId: tabId }, func: getBackgroundColor })",
+        @"    browser.test.assertEq(results[0].result, pinkValue)",
+
+        // Tests removal with multiple ids.
+
+        @"    await browser.scripting.registerContentScripts([{ id: '2', matches: ['*://localhost/*'], js: ['changeBackgroundFontScript.js'] }])",
+        @"    results = await browser.scripting.getRegisteredContentScripts()",
+        @"    browser.test.assertEq(results.length, 2)",
+
+        @"    await browser.scripting.unregisterContentScripts({ 'ids': ['1', '2'] })",
+        @"    results = await browser.scripting.getRegisteredContentScripts()",
+        @"    browser.test.assertEq(results.length, 0)",
+
+        @"    browser.test.notifyPass()",
+        @"})",
+
+        @"browser.test.yield('Load Tab')",
+    ]);
+
+    static auto *changeBackgroundColorScript = @"document.body.style.background = 'pink'";
+    static auto *changeBackgroundFontScript = @"document.body.style.fontSize = '555px'";
+
+    static auto *resources = @{
+        @"background.js": backgroundScript,
+        @"changeBackgroundColorScript.js": changeBackgroundColorScript,
+        @"changeBackgroundFontScript.js": changeBackgroundFontScript,
+    };
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:scriptingManifest resources:resources]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    auto *urlRequest = server.requestWithLocalhost();
+    auto *url = urlRequest.URL;
+
+    auto *matchPattern = [_WKWebExtensionMatchPattern matchPatternWithScheme:url.scheme host:url.host path:@"/*"];
+    [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:_WKWebExtensionPermissionWebNavigation];
+    [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:matchPattern];
+
+    [manager loadAndRun];
+
+    EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
+
+    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+
+    [manager run];
+}
+
 } // namespace TestWebKitAPI
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)


### PR DESCRIPTION
#### 309fb63df40fb69a38444e281ab03d02073832c0
<pre>
Add support for web extension registered content scripts
<a href="https://bugs.webkit.org/show_bug.cgi?id=261769">https://bugs.webkit.org/show_bug.cgi?id=261769</a>

Reviewed by Timothy Hatcher.

This patch adds support for registered web extension content scripts with the scriptingAPI. To do this,
expand the WebExtensionDynamicScripts namespace to include a new WebExtensionRegisteredScript class
that will keep track of the scripts added with the API. This class will also keep track of the
user scripts and stylesheets added, and removes them when a script is either updated or unregistered.

To do: Allow the scripts to persist across browser sessions if &apos;persistAcrossSessions&apos; is true.
In order to do this, we first need to add support for web extension storage, which is being tracked
in <a href="https://bugs.webkit.org/show_bug.cgi?id=264892.">https://bugs.webkit.org/show_bug.cgi?id=264892.</a>

* Source/WebKit/Shared/Extensions/WebExtensionDynamicScripts.serialization.in:
* Source/WebKit/Shared/Extensions/WebExtensionRegisteredScriptParameters.h:
(): Deleted.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm:
(WebKit::WebExtensionContext::scriptingRegisterScripts):
(WebKit::WebExtensionContext::scriptingUpdateRegisteredScripts):
(WebKit::WebExtensionContext::scriptingGetRegisteredScripts):
(WebKit::WebExtensionContext::scriptingUnregisterContentScripts):
(WebKit::WebExtensionContext::parseRegisteredContentScripts):
Validate scripts and create InjectedContentData for each one.

(WebKit::WebExtensionContext::scriptingUnregisterScripts): Deleted.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::populateContentScriptPropertiesIfNeeded):

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::addInjectedContent):
Keep track of user scripts and style sheets for registered scripts.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm:
(WebKit::WebExtensionDynamicScripts::WebExtensionRegisteredScript::updateParameters):
(WebKit::WebExtensionDynamicScripts::WebExtensionRegisteredScript::merge):
Take the existing properties if they&apos;re not specified in the update parameters.

(WebKit::WebExtensionDynamicScripts::WebExtensionRegisteredScript::addUserScript):
(WebKit::WebExtensionDynamicScripts::WebExtensionRegisteredScript::addUserStyleSheet):
Keep track of user scripts and style sheets for registered scripts.

(WebKit::WebExtensionDynamicScripts::WebExtensionRegisteredScript::removeUserScriptsAndStyleSheets):
(WebKit::WebExtensionDynamicScripts::WebExtensionRegisteredScript::removeUserScripts):
(WebKit::WebExtensionDynamicScripts::WebExtensionRegisteredScript::removeUserStyleSheets):
Iterate through all user content controllers and remove all the user scripts and stylesheets for the
given script ID.

* Source/WebKit/UIProcess/Extensions/WebExtension.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in:
* Source/WebKit/UIProcess/Extensions/WebExtensionDynamicScripts.h:
(WebKit::WebExtensionDynamicScripts::WebExtensionRegisteredScript::create):
(WebKit::WebExtensionDynamicScripts::WebExtensionRegisteredScript::WebExtensionRegisteredScript):
(WebKit::WebExtensionDynamicScripts::WebExtensionRegisteredScript::parameters const):

* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIScriptingCocoa.mm:
(WebKit::toWebAPI):
(WebKit::WebExtensionAPIScripting::registerContentScripts):
(WebKit::WebExtensionAPIScripting::getRegisteredContentScripts):
(WebKit::WebExtensionAPIScripting::updateContentScripts):
(WebKit::WebExtensionAPIScripting::unregisterContentScripts):

(WebKit::WebExtensionAPIScripting::validateRegisteredScripts):
Fix bug caused by how we check for the the injectionTime.

(WebKit::WebExtensionAPIScripting::parseRegisteredContentScripts):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIScripting.h:

Canonical link: <a href="https://commits.webkit.org/271318@main">https://commits.webkit.org/271318@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/86dc3fcd53e364b52d20b03674e6fc0156b2d997

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27994 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6632 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29298 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30524 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25530 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28489 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8630 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4022 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/25293 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28261 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5383 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24046 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4638 "Found 1 new API test failure: /WPE/TestWebKitWebView:/webkit/WebKitWebView/notification (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4816 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25054 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31213 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25594 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25489 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31078 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4823 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2989 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28889 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6360 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/5267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3621 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5313 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->