### PR TITLE
Fix race condition in ARM64 disassembler initialization

### DIFF
--- a/Source/JavaScriptCore/disassembler/ARM64/A64DOpcode.cpp
+++ b/Source/JavaScriptCore/disassembler/ARM64/A64DOpcode.cpp
@@ -129,13 +129,8 @@ static const OpcodeGroupInitializer opcodeGroupList[] = {
     OPCODE_GROUP_ENTRY(0x1e, A64DOpcodeFloatingPointIntegerConversions),
 };
 
-bool A64DOpcode::s_initialized = false;
-
 void A64DOpcode::init()
 {
-    if (s_initialized)
-        return;
-
     OpcodeGroup* lastGroups[32];
 
     for (unsigned i = 0; i < 32; i++) {
@@ -153,8 +148,6 @@ void A64DOpcode::init()
             lastGroups[opcodeGroupNumber]->setNext(newOpcodeGroup);
         lastGroups[opcodeGroupNumber] = newOpcodeGroup;
     }
-
-    s_initialized = true;
 }
 
 void A64DOpcode::setPCAndOpcode(uint32_t* newPC, uint32_t newOpcode)

--- a/Source/JavaScriptCore/disassembler/ARM64/A64DOpcode.h
+++ b/Source/JavaScriptCore/disassembler/ARM64/A64DOpcode.h
@@ -81,7 +81,8 @@ public:
         , m_opcode(0)
         , m_bufferOffset(0)
     {
-        init();
+        static std::once_flag once;
+        std::call_once(once, init);
         m_formatBuffer[0] = '\0';
     }
 
@@ -243,8 +244,6 @@ protected:
 
 private:
     static OpcodeGroup* opcodeTable[32];
-
-    static bool s_initialized;
 };
 
 #define DEFINE_STATIC_FORMAT(klass, thisObj) \


### PR DESCRIPTION
#### 48684d06eb78b8546fd78bd554eeb87d1c921289
<pre>
Fix race condition in ARM64 disassembler initialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=265469">https://bugs.webkit.org/show_bug.cgi?id=265469</a>
<a href="https://rdar.apple.com/118890976">rdar://118890976</a>

Reviewed by Mark Lam and Yusuke Suzuki.

Moves A64DOpcode::init() inside a std::call_once to ensure it is
not called simultaneously from more than one thread.

* Source/JavaScriptCore/disassembler/ARM64/A64DOpcode.h:
(JSC::ARM64Disassembler::A64DOpcode::A64DOpcode):

Canonical link: <a href="https://commits.webkit.org/271350@main">https://commits.webkit.org/271350@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e28972348d053b7c1d789c19808010c24847e5fd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27943 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6581 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29241 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30472 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25495 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8571 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3975 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/25266 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28209 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5339 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23999 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4597 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4784 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25004 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31161 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/24211 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25549 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25446 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31037 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/27089 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4791 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2951 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28850 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6320 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/34570 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5237 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7473 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3634 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5268 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->