### PR TITLE
[webkitscmpy] Optionally include commit message in diff

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/scm.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/scm.py
@@ -135,3 +135,6 @@ class Scm(ScmBase):
 
     def pull(self):
         raise NotImplementedError()
+
+    def diff(self, head='HEAD', base=None, include_log=False):
+        raise NotImplementedError()

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
@@ -614,7 +614,32 @@ nothing to commit, working tree clean
                     returncode=0,
                     stdout='\n'.join([
                         '--- a/ChangeLog\n+++ b/ChangeLog\n@@ -1,0 +1,0 @@\n{}'.format(
-                            '\n'.join(['+ {}'.format(line) for line in commit.message.splitlines()])
+                            '\n'.join(['+{}'.format(line) for line in commit.message.splitlines()])
+                        ) for commit in list(self.rev_list(args[2] if '..' in args[2] else '{}..HEAD'.format(args[2])))
+                    ])
+                )
+            ), mocks.Subprocess.Route(
+                self.executable, 'format-patch', re.compile(r'.+'),
+                cwd=self.path,
+                generator=lambda *args, **kwargs: mocks.ProcessCompletion(
+                    returncode=0,
+                    stdout='\n'.join([
+                        'From {hash}\n'
+                        'From: {author} <{email}>\n'
+                        'Date: {date}\n'
+                        'Subject: [PATCH] {message}\n'
+                        '---\n'
+                        'diff --git a/ChangeLog b/ChangeLog\n'
+                        '--- a/ChangeLog\n'
+                        '+++ b/ChangeLog\n'
+                        '@@ -1,0 +1,0 @@\n'
+                        '{content}'.format(
+                            hash=commit.hash,
+                            author=commit.author.name,
+                            email=commit.author.email,
+                            date=datetime.utcfromtimestamp(commit.timestamp + time.timezone).strftime('%a %b %d %H:%M:%S %Y +0000'),
+                            message=commit.message.rstrip(),
+                            content='\n'.join(['+{}'.format(line) for line in commit.message.splitlines()]),
                         ) for commit in list(self.rev_list(args[2] if '..' in args[2] else '{}..HEAD'.format(args[2])))
                     ])
                 )

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/land.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/land.py
@@ -247,7 +247,7 @@ class Land(Command):
             return 1
 
         if not args.oops:
-            for line in repository.diff_lines(branch_point.hash, source_branch):
+            for line in repository.diff(base=branch_point.hash, head=source_branch):
                 if cls.OOPS_RE.search(line):
                     sys.stderr.write("Found '(OOPS!)' in commit diff, please resolve before committing\n")
                     return 1

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py
@@ -491,20 +491,40 @@ CommitDate: {time_c}
             self.assertEqual(repo.rebase(target='main', base='main', head='branch-a', recommit=False), 0)
             self.assertEqual(str(repo.commit(branch='branch-a')), '5.2@branch-a')
 
-    def test_diff_lines(self):
+    def test_diff(self):
         with mocks.local.Git(self.path), OutputCapture():
             repo = local.Git(self.path)
             self.assertEqual(
-                ['--- a/ChangeLog', '+++ b/ChangeLog', '@@ -1,0 +1,0 @@', '+ Patch Series'],
-                list(repo.diff_lines(base='bae5d1e90999d4f916a8a15810ccfa43f37a2fd6'))
+                ['--- a/ChangeLog', '+++ b/ChangeLog', '@@ -1,0 +1,0 @@', '+Patch Series'],
+                list(repo.diff(base='bae5d1e90999d4f916a8a15810ccfa43f37a2fd6'))
             )
 
-    def test_diff_lines_identifier(self):
+    def test_diff_identifier(self):
+        with mocks.local.Git(self.path):
+            repo = local.Git(self.path)
+            self.assertEqual(
+                ['--- a/ChangeLog', '+++ b/ChangeLog', '@@ -1,0 +1,0 @@', '+8th commit'],
+                list(repo.diff(base='3@main', head='4@main'))
+            )
+
+    def test_diff_with_commit_message(self):
+        self.maxDiff = None
         with mocks.local.Git(self.path), OutputCapture():
             repo = local.Git(self.path)
             self.assertEqual(
-                ['--- a/ChangeLog', '+++ b/ChangeLog', '@@ -1,0 +1,0 @@', '+ 8th commit'],
-                list(repo.diff_lines(base='3@main', head='4@main'))
+                [
+                    'From bae5d1e90999d4f916a8a15810ccfa43f37a2fd6',
+                    'From: Jonathan Bedard <jbedard@apple.com>',
+                    'Date: {} +0000'.format(datetime.utcfromtimestamp(1601668000 + time.timezone).strftime('%a %b %d %H:%M:%S %Y')),
+                    'Subject: [PATCH] 8th commit',
+                    '---',
+                    'diff --git a/ChangeLog b/ChangeLog',
+                    '--- a/ChangeLog',
+                    '+++ b/ChangeLog',
+                    '@@ -1,0 +1,0 @@',
+                    '+8th commit',
+                ],
+                list(repo.diff(base='3@main', head='4@main', include_log=True))
             )
 
     def test_pull(self):


### PR DESCRIPTION
#### 3608a480f43913f177f2d854077e7cb0586d1c52
<pre>
[webkitscmpy] Optionally include commit message in diff
<a href="https://bugs.webkit.org/show_bug.cgi?id=265481">https://bugs.webkit.org/show_bug.cgi?id=265481</a>
<a href="https://rdar.apple.com/118901053">rdar://118901053</a>

Reviewed by Dewei Zhu.

Programs generating diffs may want to include commit messages
in patch format.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py:
(Git.diff): Return lines in a diff, use format-patch if caller
requests commit message be included.
(Git.diff_lines): Renamed &apos;diff&apos;.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/scm.py:
(Scm.diff): Added.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/land.py:
(Land.main): Call &apos;diff&apos; instead of &apos;diff_lines&apos;
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py:

Canonical link: <a href="https://commits.webkit.org/277213@main">https://commits.webkit.org/277213@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/10fe0f861c2d4846542cac2782f1af3e4d06f9ce

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46993 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26160 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49626 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49675 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43041 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49300 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31293 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23627 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38273 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47574 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23603 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40491 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19581 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/46859 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/20980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41638 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5039 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/43375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42030 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51549 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22013 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18370 "Found 1 new test failure: media/video-pause-immediately.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45565 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/47032 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23295 "Built successfully") | | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44554 "Found 3 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state-changed, /TestWTF:WTF_ParkingLot.UnparkOneOneFast (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24070 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6594 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23006 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->