### PR TITLE
Followup to 270854@main: remove some hard-coded default colors in `WKExtendedTextInputTraits`

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKExtendedTextInputTraits.mm
+++ b/Source/WebKit/UIProcess/ios/WKExtendedTextInputTraits.mm
@@ -30,34 +30,6 @@
 
 #import <wtf/RetainPtr.h>
 
-namespace WebKit {
-
-static constexpr auto selectionHighlightAlphaComponent = 0.2;
-
-static UIColor *defaultInsertionPointColor()
-{
-#if PLATFORM(MACCATALYST)
-    return UIColor.systemBlueColor;
-#else
-    static NeverDestroyed<RetainPtr<UIColor>> color = [UIColor colorWithRed:0.26 green:0.42 blue:0.95 alpha:1];
-    return color->get();
-#endif
-}
-
-static UIColor *defaultSelectionGrabberColor()
-{
-    static NeverDestroyed<RetainPtr<UIColor>> color = [UIColor colorWithRed:0.078 green:0.435 blue:0.882 alpha:1];
-    return color->get();
-}
-
-static UIColor *defaultSelectionHighlightColor()
-{
-    static NeverDestroyed<RetainPtr<UIColor>> color = [UIColor colorWithRed:0.33 green:0.65 blue:0.2 alpha:1];
-    return color->get();
-}
-
-} // namespace WebKit
-
 @implementation WKExtendedTextInputTraits {
     RetainPtr<UITextContentType> _textContentType;
     RetainPtr<UIColor> _insertionPointColor;
@@ -107,10 +79,11 @@ static UIColor *defaultSelectionHighlightColor()
 
 - (void)setSelectionColorsToMatchTintColor:(UIColor *)tintColor
 {
+    static constexpr auto selectionHighlightAlphaComponent = 0.2;
     BOOL shouldUseTintColor = tintColor && tintColor != UIColor.systemBlueColor;
-    self.insertionPointColor = shouldUseTintColor ? tintColor : WebKit::defaultInsertionPointColor();
-    self.selectionBarColor = shouldUseTintColor ? tintColor : WebKit::defaultSelectionGrabberColor();
-    self.selectionHighlightColor = shouldUseTintColor ? [tintColor colorWithAlphaComponent:WebKit::selectionHighlightAlphaComponent] : WebKit::defaultSelectionHighlightColor();
+    self.insertionPointColor = shouldUseTintColor ? tintColor : nil;
+    self.selectionBarColor = shouldUseTintColor ? tintColor : nil;
+    self.selectionHighlightColor = shouldUseTintColor ? [tintColor colorWithAlphaComponent:selectionHighlightAlphaComponent] : nil;
 }
 
 @end


### PR DESCRIPTION
#### 9265f759cab1cf9af2572363ef399153eeede692
<pre>
Followup to 270854@main: remove some hard-coded default colors in `WKExtendedTextInputTraits`
<a href="https://bugs.webkit.org/show_bug.cgi?id=264977">https://bugs.webkit.org/show_bug.cgi?id=264977</a>
<a href="https://rdar.apple.com/118526529">rdar://118526529</a>

Reviewed by Richard Robinson.

The following three properties:

```
-insertionPointColor
-selectionBarColor
-selectionHighlightColor
```

...are actually nullable on `UIExtendedTextInputTraits`, and setting them to `nil` allows UIKit to
fall back to default colors. As such, we can avoid hard-coding default values here and just set
these properties to `nil`.

* Source/WebKit/UIProcess/ios/WKExtendedTextInputTraits.mm:
(-[WKExtendedTextInputTraits setSelectionColorsToMatchTintColor:]):
(WebKit::defaultInsertionPointColor): Deleted.
(WebKit::defaultSelectionGrabberColor): Deleted.
(WebKit::defaultSelectionHighlightColor): Deleted.

Canonical link: <a href="https://commits.webkit.org/271257@main">https://commits.webkit.org/271257@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7cf3c732125b32656056df8b64f803ac6d9279e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27804 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6441 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29050 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30020 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25388 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8398 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3833 "Built successfully") | [💥 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/25147 "An unexpected error occured. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28069 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5187 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23850 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4499 "Found 1 new API test failure: /WPE/TestWebKitWebView:/webkit/WebKitWebView/notification (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4663 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30660 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25391 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25295 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30852 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/4684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2834 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28752 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6199 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6681 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/5130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5141 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->