### PR TITLE
Add protocol handlers to _WKApplicationManifest

### DIFF
--- a/Source/WebCore/Modules/applicationmanifest/ApplicationManifest.h
+++ b/Source/WebCore/Modules/applicationmanifest/ApplicationManifest.h
@@ -63,6 +63,11 @@ struct ApplicationManifest {
         Vector<Icon> icons;
     };
 
+    struct ProtocolHandler {
+        String protocol;
+        URL url;
+    };
+
     String rawJSON;
     String name;
     String shortName;
@@ -79,6 +84,7 @@ struct ApplicationManifest {
     Vector<String> categories;
     Vector<Icon> icons;
     Vector<Shortcut> shortcuts;
+    Vector<ProtocolHandler> protocolHandlers;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.h
+++ b/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.h
@@ -56,6 +56,7 @@ private:
     Vector<ApplicationManifest::Icon> parseIcons(const JSON::Object&);
     Vector<ApplicationManifest::Shortcut> parseShortcuts(const JSON::Object&);
     URL parseId(const JSON::Object&, const URL&);
+    Vector<ApplicationManifest::ProtocolHandler> parseProtocolHandlers(const JSON::Object&, const URL&);
 
     Color parseColor(const JSON::Object&, const String& propertyName);
     String parseGenericString(const JSON::Object&, const String&);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1251,6 +1251,11 @@ enum class WebCore::ScreenOrientationLockType : uint8_t {
     Vector<WebCore::ApplicationManifest::Icon> icons
 }
 
+[Nested] struct WebCore::ApplicationManifest::ProtocolHandler {
+     String protocol
+     URL url
+ }
+
 struct WebCore::ApplicationManifest {
     String rawJSON
     String name
@@ -1268,6 +1273,7 @@ struct WebCore::ApplicationManifest {
     Vector<String> categories
     Vector<WebCore::ApplicationManifest::Icon> icons
     Vector<WebCore::ApplicationManifest::Shortcut> shortcuts
+    Vector<WebCore::ApplicationManifest::ProtocolHandler> protocolHandlers
 }
 #endif // ENABLE(APPLICATION_MANIFEST)
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.h
@@ -33,6 +33,7 @@
 #endif
 @class _WKApplicationManifestIcon;
 @class _WKApplicationManifestShortcut;
+@class _WKApplicationManifestProtocolHandler;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -76,6 +77,7 @@ WK_CLASS_AVAILABLE(macos(10.13.4), ios(11.3))
 @property (nonatomic, readonly, copy) NSArray<NSString *> *categories WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 @property (nonatomic, readonly, copy) NSArray<_WKApplicationManifestIcon *> *icons WK_API_AVAILABLE(macos(13.0), ios(16.0));
 @property (nonatomic, readonly, copy) NSArray<_WKApplicationManifestShortcut *> *shortcuts WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+@property (nonatomic, readonly, copy) NSArray<_WKApplicationManifestProtocolHandler *> *protocolHandlers WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 #if TARGET_OS_IPHONE
 @property (nonatomic, readonly, nullable, copy) UIColor *backgroundColor WK_API_AVAILABLE(ios(17.0));
@@ -109,6 +111,14 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 @property (nonatomic, readonly, copy) NSString *name;
 @property (nonatomic, readonly, copy) NSURL *url;
 @property (nonatomic, readonly, copy) NSArray<_WKApplicationManifestIcon *> *icons;
+
+@end
+
+WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+@interface _WKApplicationManifestProtocolHandler : NSObject <NSSecureCoding>
+
+@property (nonatomic, readonly, copy) NSString *protocol;
+@property (nonatomic, readonly, copy) NSString *url;
 
 @end
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ApplicationManifest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ApplicationManifest.mm
@@ -42,7 +42,7 @@ namespace TestWebKitAPI {
 
 TEST(ApplicationManifest, Coding)
 {
-    auto jsonString = @"{ \"name\": \"TestName\", \"short_name\": \"TestShortName\", \"description\": \"TestDescription\", \"scope\": \"https://test.com/app\", \"start_url\": \"https://test.com/app/index.html\", \"display\": \"minimal-ui\", \"theme_color\": \"red\" }";
+    auto jsonString = @"{ \"name\": \"TestName\", \"short_name\": \"TestShortName\", \"description\": \"TestDescription\", \"scope\": \"https://test.com/app\", \"start_url\": \"https://test.com/app/index.html\", \"display\": \"minimal-ui\", \"theme_color\": \"red\", \"protocol_handlers\": [{ \"protocol\": \"mailto\", \"url\": \"/app/mail?id=%s\" }] }";
     RetainPtr<_WKApplicationManifest> manifest { [_WKApplicationManifest applicationManifestFromJSON:jsonString manifestURL:[NSURL URLWithString:@"https://test.com/manifest.json"] documentURL:[NSURL URLWithString:@"https://test.com/"]] };
 
     NSData *data = [NSKeyedArchiver archivedDataWithRootObject:manifest.get() requiringSecureCoding:YES error:nullptr];
@@ -55,6 +55,11 @@ TEST(ApplicationManifest, Coding)
     EXPECT_STREQ("https://test.com/app", manifest.get().scope.absoluteString.UTF8String);
     EXPECT_STREQ("https://test.com/app/index.html", manifest.get().startURL.absoluteString.UTF8String);
     EXPECT_EQ(_WKApplicationManifestDisplayModeMinimalUI,  manifest.get().displayMode);
+    EXPECT_EQ(1llu, manifest.get().protocolHandlers.count);
+    for (_WKApplicationManifestProtocolHandler *protocolHandler in manifest.get().protocolHandlers) {
+        EXPECT_WK_STREQ(@"mailto", protocolHandler.protocol);
+        EXPECT_WK_STREQ(@"https://test.com/app/mail?id=%s", protocolHandler.url);
+    }
 
     auto sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
     auto redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));


### PR DESCRIPTION
#### 6a56145baf5a3ef3752d3766353cd8638ab93c07
<pre>
Add protocol handlers to _WKApplicationManifest
<a href="https://bugs.webkit.org/show_bug.cgi?id=265486">https://bugs.webkit.org/show_bug.cgi?id=265486</a>
<a href="https://rdar.apple.com/106139265">rdar://106139265</a>

Reviewed by NOBODY (OOPS!).

Parse protocol handlers from Web Application Manifest and pass it to WebKit clients.
Spec: <a href="https://wicg.github.io/manifest-incubations/#protocol_handlers-member">https://wicg.github.io/manifest-incubations/#protocol_handlers-member</a>
Test: ApplicationManifestParserTest.ProtocolHandlers
      ApplicationManifest.Coding

* Source/WebCore/Modules/applicationmanifest/ApplicationManifest.h:
* Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp:
(WebCore::supportedSchemes): We currently only support &quot;mailto&quot; as we have concern on other schemes, see discussion in
radar.
(WebCore::normalizedParametersAndCreateProtocolHandler):
(WebCore::isInScope):
(WebCore::ApplicationManifestParser::parseManifest):
(WebCore::ApplicationManifestParser::parseProtocolHandlers):
* Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.h: We use NSString for url because NSURL encodes characters,
(&quot;%s&quot; token will become &quot;%25s&quot;) which might be confusing for clients when constructing URL for request (by replacing
&quot;%s&quot; token with actual identifier).
* Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm:
(makeVectorElement):
(+[_WKApplicationManifestProtocolHandler supportsSecureCoding]):
(-[_WKApplicationManifestProtocolHandler initWithCoder:]):
(-[_WKApplicationManifestProtocolHandler protocol]):
(-[_WKApplicationManifestProtocolHandler url]):
(-[_WKApplicationManifestProtocolHandler initWithCoreProtocolHandler:]):
(-[_WKApplicationManifestProtocolHandler encodeWithCoder:]):
(-[_WKApplicationManifestProtocolHandler dealloc]):
(-[_WKApplicationManifest initWithCoder:]):
(-[_WKApplicationManifest encodeWithCoder:]):
(-[_WKApplicationManifest protocolHandlers]):
* Tools/TestWebKitAPI/Tests/WebCore/ApplicationManifestParser.cpp:
(ApplicationManifestParserTest::testProtocolHandlers):
(TEST_F):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ApplicationManifest.mm:
(TestWebKitAPI::TEST):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a56145baf5a3ef3752d3766353cd8638ab93c07

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28264 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6907 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29622 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30794 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25755 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28761 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8949 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4287 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26048 "Build was cancelled. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests (exception)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28532 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5683 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24329 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4945 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5076 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25327 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31483 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25886 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25761 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31376 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5046 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3227 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29130 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6627 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5483 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5564 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->