### PR TITLE
Match multiple feature flags in a single line

### DIFF
--- a/Tools/Scripts/webkitpy/featuredefines/matcher.py
+++ b/Tools/Scripts/webkitpy/featuredefines/matcher.py
@@ -58,19 +58,18 @@ class _FeatureDefineMatcher:
         self._prefix = prefix
 
     def __call__(self, line):
-        match = self._regex.search(line)
+        feature_defines = []
 
-        if not match:
-            return None
+        for match in self._regex.finditer(line):
+            groups = match.groupdict()
 
-        groups = match.groupdict()
+            flag = self._prefix + groups['flag']
+            description = groups.get('description', '')
+            value = groups.get('value', '') in ['1', 'ON']
 
-        flag = self._prefix + groups['flag']
-        description = groups.get('description', '')
-        value = groups.get('value', '') in ['1', 'ON']
+            feature_defines.append(FeatureDefine(flag, value=value, description=description))
 
-        return FeatureDefine(flag, value=value, description=description)
-
+        return feature_defines
 
 def usage_matcher(macro='ENABLE'):
     """ Matches MACRO(FLAG) """

--- a/Tools/Scripts/webkitpy/featuredefines/matcher_unittest.py
+++ b/Tools/Scripts/webkitpy/featuredefines/matcher_unittest.py
@@ -46,6 +46,8 @@ class TestFeatureDefineMatcher(unittest.TestCase):
         self._is_a_match(matcher, 'ENABLE(FOO)', 'ENABLE_FOO')
         self._is_a_match(matcher, 'ENABLE(BAR)', 'ENABLE_BAR')
 
+        self._multiple_matches(matcher, 'ENABLE(FOO) || ENABLE(BAR)', ['ENABLE_FOO', 'ENABLE_BAR'])
+
         # Test with different prefix
         matcher = usage_matcher('USE')
 
@@ -87,6 +89,8 @@ class TestFeatureDefineMatcher(unittest.TestCase):
 
         self._is_a_match(matcher, 'ENABLE_FOO', 'ENABLE_FOO')
         self._is_a_match(matcher, 'ENABLE_BAR', 'ENABLE_BAR')
+
+        self._multiple_matches(matcher, 'ENABLE_FOO OR ENABLE_BAR', ['ENABLE_FOO', 'ENABLE_BAR'])
 
         # Still would match these
         self._is_a_match(matcher, '#define ENABLE_FOO 1', 'ENABLE_FOO')
@@ -140,15 +144,31 @@ class TestFeatureDefineMatcher(unittest.TestCase):
         self._is_a_match(matcher, 'WEBKIT_OPTION_DEFINE(USE_BAR "Mesg" PRIVATE OFF)', 'USE_BAR', value=False, description='Mesg')
 
     def _not_a_match(self, matcher, line):
-        self.assertIsNone(matcher(line))
+        self.assertFalse(matcher(line))
 
     def _is_a_match(self, matcher, line, flag, value=False, description=""):
-        match = matcher(line)
+        matches = matcher(line)
 
-        self.assertIsNotNone(match)
-        self.assertEqual(match.flag, flag)
-        self.assertEqual(match.value, value)
-        self.assertEqual(match.description, description)
+        self.assertTrue(matches)
+        self.assertEqual(len(matches), 1)
+        self.assertEqual(matches[0].flag, flag)
+        self.assertEqual(matches[0].value, value)
+        self.assertEqual(matches[0].description, description)
+
+    def _multiple_matches(self, matcher, line, flags):
+        matches = matcher(line)
+
+        self.assertTrue(matches)
+        self.assertEqual(len(matches), len(flags))
+
+        for flag in flags:
+            found = False
+
+            for match in matches:
+                if match.flag == flag:
+                    found = True
+
+            self.assertTrue(found)
 
 
 if __name__ == '__main__':

--- a/Tools/Scripts/webkitpy/featuredefines/search.py
+++ b/Tools/Scripts/webkitpy/featuredefines/search.py
@@ -58,9 +58,7 @@ class FeatureDefinesSearch(object):
     def _search_file(self, matcher, path):
         with open(path, encoding="latin-1") as contents:
             for line in contents:
-                value = matcher(line)
-
-                if value:
+                for value in matcher(line):
                     flag = value.flag
 
                     if flag not in self._defines:
@@ -71,8 +69,8 @@ class FeatureDefinesSearch(object):
     def _search_directory(self, matcher, path, patterns):
         for root, __, files in os.walk(path):
             for file in files:
-                for patten in patterns:
-                    if fnmatch.fnmatch(file, patten):
+                for pattern in patterns:
+                    if fnmatch.fnmatch(file, pattern):
                         self._search_file(matcher, os.path.join(root, file))
 
     @classmethod


### PR DESCRIPTION
#### cc9b0d88747e0d321660345a2d1235240e72d94a
<pre>
Match multiple feature flags in a single line
<a href="https://bugs.webkit.org/show_bug.cgi?id=265488">https://bugs.webkit.org/show_bug.cgi?id=265488</a>

Reviewed by Jonathan Bedard.

When searching through a line of source code use `finditer` instead of
`search` so multiple feature flags can be found on the same line.

Fix a typo while modifying the file.

* Tools/Scripts/webkitpy/featuredefines/matcher.py:
* Tools/Scripts/webkitpy/featuredefines/matcher_unittest.py:
* Tools/Scripts/webkitpy/featuredefines/search.py:

Canonical link: <a href="https://commits.webkit.org/271299@main">https://commits.webkit.org/271299@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f2de58f51dd3266cc79bb7c88a2b97b54bd8229

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27953 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6591 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29251 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30482 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/25503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28448 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8581 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3983 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/25272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28219 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5344 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24007 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4604 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/28112 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/4789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25012 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31171 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25555 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/25454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/31045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/4798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/2956 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/28857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6328 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6706 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/5244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5276 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->