### PR TITLE
Set kCACornerCurveCircular for CALayers with corner radius

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h
@@ -142,7 +142,6 @@ typedef struct _CARenderContext CARenderContext;
 - (CGSize)size;
 - (void *)regionBeingDrawn;
 - (void)reloadValueForKeyPath:(NSString *)keyPath;
-- (void)setCornerRadius:(CGFloat)cornerRadius;
 - (void)addPresentationModifier:(CAPresentationModifier *)modifier;
 - (void)removePresentationModifier:(CAPresentationModifier *)modifier;
 @property BOOL allowsGroupBlending;

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
@@ -956,6 +956,8 @@ void PlatformCALayerCocoa::setCornerRadius(float value)
 {
     BEGIN_BLOCK_OBJC_EXCEPTIONS
     [m_layer setCornerRadius:value];
+    if (value)
+        [m_layer setCornerCurve:kCACornerCurveCircular];
     END_BLOCK_OBJC_EXCEPTIONS
 }
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
@@ -204,8 +204,11 @@ void RemoteLayerTreePropertyApplier::applyPropertiesToLayer(CALayer *layer, Remo
     if (properties.changedProperties & LayerChange::ContentsRectChanged)
         layer.contentsRect = properties.contentsRect;
 
-    if (properties.changedProperties & LayerChange::CornerRadiusChanged)
+    if (properties.changedProperties & LayerChange::CornerRadiusChanged) {
         layer.cornerRadius = properties.cornerRadius;
+        if (properties.cornerRadius)
+            layer.cornerCurve = kCACornerCurveCircular;
+    }
 
     if (properties.changedProperties & LayerChange::ShapeRoundedRectChanged) {
         Path path;

--- a/Source/WebKit/UIProcess/PDF/WKPDFHUDView.mm
+++ b/Source/WebKit/UIProcess/PDF/WKPDFHUDView.mm
@@ -271,7 +271,8 @@ static NSArray<NSString *> *controlArray()
 {
     _layer = adoptNS([[CALayer alloc] init]);
     [_layer setCornerRadius:layerCornerRadius];
-    
+    [_layer setCornerCurve:kCACornerCurveCircular];
+
     [_layer setBackgroundColor:WebCore::cachedCGColor({ WebCore::SRGBA<float>(layerGrayComponent, layerGrayComponent, layerGrayComponent) }).get()];
     [self _setLayerOpacity:layerAlpha];
     

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm
@@ -276,6 +276,9 @@ void updateLayersForInteractionRegions(RemoteLayerTreeNode& node)
 
         if (region.type == InteractionRegion::Type::Interaction) {
             [regionLayer setCornerRadius:region.borderRadius];
+            if (region.borderRadius)
+                [regionLayer setCornerCurve:kCACornerCurveCircular];
+
             constexpr CACornerMask allCorners = kCALayerMinXMinYCorner | kCALayerMaxXMinYCorner | kCALayerMinXMaxYCorner | kCALayerMaxXMaxYCorner;
             if (region.maskedCorners.isEmpty())
                 [regionLayer setMaskedCorners:allCorners];

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullscreenStackView.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullscreenStackView.mm
@@ -72,6 +72,7 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     [_backgroundView.get().layer setContinuousCorners:YES];
 ALLOW_DEPRECATED_DECLARATIONS_END
     [_backgroundView.get().layer setCornerRadius:16];
+    [_backgroundView.get().layer setCornerCurve:kCACornerCurveCircular];
 #endif
     [self addSubview:_backgroundView.get()];
     return self;

--- a/WebKitLibraries/SDKs/watchos10.0-additions.sdk/System/Library/Frameworks/QuartzCore.framework/QuartzCore.tbd
+++ b/WebKitLibraries/SDKs/watchos10.0-additions.sdk/System/Library/Frameworks/QuartzCore.framework/QuartzCore.tbd
@@ -19,7 +19,7 @@ exports:
                 _kCAGravityCenter, _kCAGravityResizeAspect, _kCAGravityTopLeft, _kCAMediaTimingFunctionEaseInEaseOut, _kCAMediaTimingFunctionLinear,
                 _kCAValueFunctionRotateX, _kCAValueFunctionRotateY, _kCAValueFunctionRotateZ, _kCAValueFunctionScale, _kCAValueFunctionScaleX,
                 _kCAValueFunctionScaleY, _kCAValueFunctionScaleZ, _kCAValueFunctionTranslate, _kCAValueFunctionTranslateX,
-                _kCAValueFunctionTranslateY, _kCAValueFunctionTranslateZ]
+                _kCAValueFunctionTranslateY, _kCAValueFunctionTranslateZ, _kCACornerCurveCircular]
         objc-classes: [CAAnimationGroup, CABackdropLayer, CABasicAnimation, CAContext, CADisplayLink, CAEAGLLayer, CAFilter,
                 CAKeyframeAnimation, CALayer, CALayerHost, CAMediaTimingFunction, CAMetalLayer, CAPropertyAnimation, CAShapeLayer,
                 CASpringAnimation, CATiledLayer, CATransaction, CATransformLayer, CAValueFunction]

--- a/WebKitLibraries/SDKs/watchos9.0-additions.sdk/System/Library/Frameworks/QuartzCore.framework/QuartzCore.tbd
+++ b/WebKitLibraries/SDKs/watchos9.0-additions.sdk/System/Library/Frameworks/QuartzCore.framework/QuartzCore.tbd
@@ -19,7 +19,7 @@ exports:
                 _kCAGravityCenter, _kCAGravityResizeAspect, _kCAGravityTopLeft, _kCAMediaTimingFunctionEaseInEaseOut, _kCAMediaTimingFunctionLinear,
                 _kCAValueFunctionRotateX, _kCAValueFunctionRotateY, _kCAValueFunctionRotateZ, _kCAValueFunctionScale, _kCAValueFunctionScaleX,
                 _kCAValueFunctionScaleY, _kCAValueFunctionScaleZ, _kCAValueFunctionTranslate, _kCAValueFunctionTranslateX,
-                _kCAValueFunctionTranslateY, _kCAValueFunctionTranslateZ]
+                _kCAValueFunctionTranslateY, _kCAValueFunctionTranslateZ, _kCACornerCurveCircular]
         objc-classes: [CAAnimationGroup, CABackdropLayer, CABasicAnimation, CAContext, CADisplayLink, CAEAGLLayer, CAFilter,
                 CAKeyframeAnimation, CALayer, CALayerHost, CAMediaTimingFunction, CAMetalLayer, CAPropertyAnimation, CAShapeLayer,
                 CASpringAnimation, CATiledLayer, CATransaction, CATransformLayer, CAValueFunction]

--- a/WebKitLibraries/SDKs/watchsimulator10.0-additions.sdk/System/Library/Frameworks/QuartzCore.framework/QuartzCore.tbd
+++ b/WebKitLibraries/SDKs/watchsimulator10.0-additions.sdk/System/Library/Frameworks/QuartzCore.framework/QuartzCore.tbd
@@ -19,7 +19,7 @@ exports:
                 _kCAGravityTopLeft, _kCAMediaTimingFunctionEaseInEaseOut, _kCAMediaTimingFunctionLinear, _kCAValueFunctionRotateX,
                 _kCAValueFunctionRotateY, _kCAValueFunctionRotateZ, _kCAValueFunctionScale, _kCAValueFunctionScaleX, _kCAValueFunctionScaleY,
                 _kCAValueFunctionScaleZ, _kCAValueFunctionTranslate, _kCAValueFunctionTranslateX, _kCAValueFunctionTranslateY,
-                _kCAValueFunctionTranslateZ]
+                _kCAValueFunctionTranslateZ, _kCACornerCurveCircular]
         objc-classes: [CAAnimationGroup, CABackdropLayer, CABasicAnimation, CAContext, CADisplayLink, CAEAGLLayer, CAFilter,
                 CAKeyframeAnimation, CALayer, CALayerHost, CAMediaTimingFunction, CAMetalLayer, CAPropertyAnimation, CAShapeLayer,
                 CASpringAnimation, CATiledLayer, CATransaction, CATransformLayer, CAValueFunction]

--- a/WebKitLibraries/SDKs/watchsimulator9.0-additions.sdk/System/Library/Frameworks/QuartzCore.framework/QuartzCore.tbd
+++ b/WebKitLibraries/SDKs/watchsimulator9.0-additions.sdk/System/Library/Frameworks/QuartzCore.framework/QuartzCore.tbd
@@ -19,7 +19,7 @@ exports:
                 _kCAGravityTopLeft, _kCAMediaTimingFunctionEaseInEaseOut, _kCAMediaTimingFunctionLinear, _kCAValueFunctionRotateX,
                 _kCAValueFunctionRotateY, _kCAValueFunctionRotateZ, _kCAValueFunctionScale, _kCAValueFunctionScaleX, _kCAValueFunctionScaleY,
                 _kCAValueFunctionScaleZ, _kCAValueFunctionTranslate, _kCAValueFunctionTranslateX, _kCAValueFunctionTranslateY,
-                _kCAValueFunctionTranslateZ]
+                _kCAValueFunctionTranslateZ, _kCACornerCurveCircular]
         objc-classes: [CAAnimationGroup, CABackdropLayer, CABasicAnimation, CAContext, CADisplayLink, CAEAGLLayer, CAFilter,
                 CAKeyframeAnimation, CALayer, CALayerHost, CAMediaTimingFunction, CAMetalLayer, CAPropertyAnimation, CAShapeLayer,
                 CASpringAnimation, CATiledLayer, CATransaction, CATransformLayer, CAValueFunction]


### PR DESCRIPTION
#### 59046b46f4f8bd12cb89e767fedd5d7b1d965bb5
<pre>
Set kCACornerCurveCircular for CALayers with corner radius
<a href="https://bugs.webkit.org/show_bug.cgi?id=265492">https://bugs.webkit.org/show_bug.cgi?id=265492</a>
<a href="https://rdar.apple.com/113292205">rdar://113292205</a>

Reviewed by Tim Horton.

Make sure corner radii on CALayers use circular corner radius, rather than continuous corner radius.

* Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h: setCornerRadius: is API now.
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm:
(WebCore::PlatformCALayerCocoa::setCornerRadius):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(WebKit::RemoteLayerTreePropertyApplier::applyPropertiesToLayer):
* Source/WebKit/UIProcess/PDF/WKPDFHUDView.mm:
(-[WKPDFHUDView _setupLayer:]):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm:
(WebKit::updateLayersForInteractionRegions):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullscreenStackView.mm:
(-[WKFullscreenStackView init]):
* WebKitLibraries/SDKs/watchos10.0-additions.sdk/System/Library/Frameworks/QuartzCore.framework/QuartzCore.tbd: QuartzCore is SPI on watchOS so we have to add the symbol here.
* WebKitLibraries/SDKs/watchos9.0-additions.sdk/System/Library/Frameworks/QuartzCore.framework/QuartzCore.tbd:
* WebKitLibraries/SDKs/watchsimulator10.0-additions.sdk/System/Library/Frameworks/QuartzCore.framework/QuartzCore.tbd:
* WebKitLibraries/SDKs/watchsimulator9.0-additions.sdk/System/Library/Frameworks/QuartzCore.framework/QuartzCore.tbd:

Canonical link: <a href="https://commits.webkit.org/271301@main">https://commits.webkit.org/271301@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3560c3ce99487b5e9e8aa8e7b9468357e8f26eca

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27936 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6574 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29234 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30465 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25489 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28431 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8617 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3968 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/25262 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28202 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/5372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24006 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4592 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/4809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25011 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31154 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/25584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25453 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31033 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4786 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2945 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28846 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6314 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6708 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5232 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5261 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->