### PR TITLE
Fix some incorrect adoptNS() usage in tests

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm
@@ -639,7 +639,7 @@ TEST(IPCTestingAPI, CGColorInNSSecureCoding)
     EXPECT_TRUE([key isEqual:resultKey]);
     CGColorRef resultValue = static_cast<CGColorRef>(result.allValues[0]);
     ASSERT_EQ(CFGetTypeID(resultValue), CGColorGetTypeID());
-    auto resultValueColorSpace = adoptCF(CGColorGetColorSpace(resultValue));
+    RetainPtr resultValueColorSpace = CGColorGetColorSpace(resultValue);
     auto resultValueColorSpaceName = adoptCF(CGColorSpaceCopyName(resultValueColorSpace.get()));
     EXPECT_NE(CFStringFind(resultValueColorSpaceName.get(), CFSTR("SRGB"), 0).location, kCFNotFound);
     ASSERT_EQ(CGColorGetNumberOfComponents(resultValue), CGColorGetNumberOfComponents(value.get()));

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm
@@ -1363,7 +1363,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedSAML)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClass());
 
-    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    RetainPtr testURL = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
 
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[@"SAML"]]);
@@ -1374,7 +1374,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedSAML)
     configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
 
     // Add a http body to the request to mimic a SAML request.
-    auto request = adoptNS([NSMutableURLRequest requestWithURL:testURL.get()]);
+    RetainPtr request = [NSMutableURLRequest requestWithURL:testURL.get()];
     [request setHTTPBody:adoptNS([[NSData alloc] init]).get()];
     haveHttpBody = true;
 
@@ -2382,7 +2382,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedSuppressActiveSession)
 
     navigationCompleted = false;
     [webView evaluateJavaScript: @"newWindow" completionHandler:^(id result, NSError *) {
-        EXPECT_TRUE(result == adoptNS([NSNull null]).get());
+        EXPECT_TRUE(result == [NSNull null]);
         navigationCompleted = true;
     }];
     Util::run(&navigationCompleted);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm
@@ -1586,11 +1586,11 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMaximum1)
     auto options = adoptNS([[_WKPublicKeyCredentialCreationOptions alloc] initWithRelyingParty:rp.get() user:user.get() publicKeyCredentialParamaters:publicKeyCredentialParamaters]);
     [options setTimeout:@120];
 
-    auto usb = adoptNS([NSNumber numberWithInt:_WKWebAuthenticationTransportUSB]);
-    auto nfc = adoptNS([NSNumber numberWithInt:_WKWebAuthenticationTransportNFC]);
-    auto internal = adoptNS([NSNumber numberWithInt:_WKWebAuthenticationTransportInternal]);
-    auto hybrid = adoptNS([NSNumber numberWithInt:_WKWebAuthenticationTransportHybrid]);
-    auto credential = adoptNS([[_WKPublicKeyCredentialDescriptor alloc] initWithIdentifier:nsIdentifier]);
+    RetainPtr usb = [NSNumber numberWithInt:_WKWebAuthenticationTransportUSB];
+    RetainPtr nfc = [NSNumber numberWithInt:_WKWebAuthenticationTransportNFC];
+    RetainPtr internal = [NSNumber numberWithInt:_WKWebAuthenticationTransportInternal];
+    RetainPtr hybrid = [NSNumber numberWithInt:_WKWebAuthenticationTransportHybrid];
+    RetainPtr credential = adoptNS([[_WKPublicKeyCredentialDescriptor alloc] initWithIdentifier:nsIdentifier]);
     [credential setTransports:@[ usb.get(), nfc.get(), internal.get(), hybrid.get() ]];
     [options setExcludeCredentials:@[ credential.get(), credential.get() ]];
 
@@ -1658,10 +1658,10 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMaximum2)
     auto options = adoptNS([[_WKPublicKeyCredentialCreationOptions alloc] initWithRelyingParty:rp.get() user:user.get() publicKeyCredentialParamaters:publicKeyCredentialParamaters]);
     [options setTimeout:@120];
 
-    auto usb = adoptNS([NSNumber numberWithInt:_WKWebAuthenticationTransportUSB]);
-    auto nfc = adoptNS([NSNumber numberWithInt:_WKWebAuthenticationTransportNFC]);
-    auto internal = adoptNS([NSNumber numberWithInt:_WKWebAuthenticationTransportInternal]);
-    auto credential = adoptNS([[_WKPublicKeyCredentialDescriptor alloc] initWithIdentifier:nsIdentifier]);
+    RetainPtr usb = [NSNumber numberWithInt:_WKWebAuthenticationTransportUSB];
+    RetainPtr nfc = [NSNumber numberWithInt:_WKWebAuthenticationTransportNFC];
+    RetainPtr internal = [NSNumber numberWithInt:_WKWebAuthenticationTransportInternal];
+    RetainPtr credential = adoptNS([[_WKPublicKeyCredentialDescriptor alloc] initWithIdentifier:nsIdentifier]);
     [credential setTransports:@[ usb.get(), nfc.get(), internal.get() ]];
     [options setExcludeCredentials:@[ credential.get(), credential.get() ]];
 
@@ -1893,16 +1893,16 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialRequestOptionsMaximum)
     auto options = adoptNS([[_WKPublicKeyCredentialRequestOptions alloc] init]);
     [options setTimeout:@120];
 
-    auto usb = adoptNS([NSNumber numberWithInt:_WKWebAuthenticationTransportUSB]);
-    auto nfc = adoptNS([NSNumber numberWithInt:_WKWebAuthenticationTransportNFC]);
-    auto internal = adoptNS([NSNumber numberWithInt:_WKWebAuthenticationTransportInternal]);
-    auto credential = adoptNS([[_WKPublicKeyCredentialDescriptor alloc] initWithIdentifier:nsIdentifier]);
+    RetainPtr usb = [NSNumber numberWithInt:_WKWebAuthenticationTransportUSB];
+    RetainPtr nfc = [NSNumber numberWithInt:_WKWebAuthenticationTransportNFC];
+    RetainPtr internal = [NSNumber numberWithInt:_WKWebAuthenticationTransportInternal];
+    RetainPtr credential = adoptNS([[_WKPublicKeyCredentialDescriptor alloc] initWithIdentifier:nsIdentifier]);
     [credential setTransports:@[ usb.get(), nfc.get(), internal.get() ]];
     [options setAllowCredentials:@[ credential.get(), credential.get() ]];
 
     [options setUserVerification:_WKUserVerificationRequirementRequired];
 
-    auto extensions = adoptNS([[_WKAuthenticationExtensionsClientInputs alloc] init]);
+    RetainPtr extensions = adoptNS([[_WKAuthenticationExtensionsClientInputs alloc] init]);
     [extensions setAppid:@"https//www.example.com/fido"];
     [options setExtensions:extensions.get()];
 


### PR DESCRIPTION
#### 4e5d8928f4798bb1a78734997e52292e9ae8cff7
<pre>
Fix some incorrect adoptNS() usage in tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=265496">https://bugs.webkit.org/show_bug.cgi?id=265496</a>
<a href="https://rdar.apple.com/118908203">rdar://118908203</a>

Reviewed by Chris Dumez.

Don&apos;t use adoptNS/adoptCF() with expressions that don&apos;t return a retained value.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/271287@main">https://commits.webkit.org/271287@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/83ea89255d669afdfbd7aabcdb46fc579c69c468

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27832 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6470 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29080 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30050 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25408 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28325 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8505 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3863 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/25165 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28097 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5285 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23870 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4519 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4742 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24892 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30689 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25491 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25332 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30871 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4704 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2855 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28772 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6221 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6702 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5150 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5166 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->