### PR TITLE
[MediaStream] Cleanup getPhotoSettings and getPhotoCapabilities

### DIFF
--- a/Source/WebCore/Modules/mediastream/ImageCapture.h
+++ b/Source/WebCore/Modules/mediastream/ImageCapture.h
@@ -34,7 +34,10 @@
 #include "MediaStreamTrack.h"
 #include "PhotoCapabilities.h"
 #include "PhotoSettings.h"
-#include <wtf/LoggerHelper.h>
+
+namespace WTF {
+class Logger;
+}
 
 namespace WebCore {
 
@@ -46,24 +49,18 @@ public:
     ~ImageCapture();
 
     void takePhoto(PhotoSettings&&, DOMPromiseDeferred<IDLInterface<Blob>>&&);
-
-    using PhotoCapabilitiesPromise = DOMPromiseDeferred<IDLDictionary<PhotoCapabilities>>;
-    void getPhotoCapabilities(PhotoCapabilitiesPromise&&);
-
-    using PhotoSettingsPromise = DOMPromiseDeferred<IDLDictionary<PhotoSettings>>;
-    void getPhotoSettings(PhotoSettingsPromise&&);
+    void getPhotoCapabilities(DOMPromiseDeferred<IDLDictionary<PhotoCapabilities>>&&);
+    void getPhotoSettings(DOMPromiseDeferred<IDLDictionary<PhotoSettings>>&&);
 
     Ref<MediaStreamTrack> track() const { return m_track; }
 
 private:
     ImageCapture(Document&, Ref<MediaStreamTrack>);
 
-#if !RELEASE_LOG_DISABLED
     const Logger& logger() const { return m_logger.get(); }
     const void* logIdentifier() const { return m_logIdentifier; }
     const char* logClassName() const { return "ImageCapture"; }
     WTFLogChannel& logChannel() const;
-#endif
 
     // ActiveDOMObject API.
     const char* activeDOMObjectName() const final;

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
@@ -130,8 +130,12 @@ public:
 
     using TakePhotoPromise = NativePromise<std::pair<Vector<uint8_t>, String>, Exception>;
     Ref<TakePhotoPromise> takePhoto(PhotoSettings&&);
-    void getPhotoCapabilities(DOMPromiseDeferred<IDLDictionary<PhotoCapabilities>>&&);
-    void getPhotoSettings(DOMPromiseDeferred<IDLDictionary<PhotoSettings>>&&);
+
+    using PhotoCapabilitiesPromise = NativePromise<PhotoCapabilities, Exception>;
+    Ref<PhotoCapabilitiesPromise> getPhotoCapabilities();
+
+    using PhotoSettingsPromise = NativePromise<PhotoSettings, Exception>;
+    Ref<PhotoSettingsPromise> getPhotoSettings();
 
     const MediaTrackConstraints& getConstraints() const { return m_constraints; }
     void setConstraints(MediaTrackConstraints&& constraints) { m_constraints = WTFMove(constraints); }

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp
@@ -189,9 +189,9 @@ const RealtimeMediaSourceCapabilities& MediaStreamTrackPrivate::capabilities() c
     return m_source->capabilities();
 }
 
-void MediaStreamTrackPrivate::getPhotoCapabilities(RealtimeMediaSource::PhotoCapabilitiesHandler&& completion)
+Ref<RealtimeMediaSource::PhotoCapabilitiesNativePromise> MediaStreamTrackPrivate::getPhotoCapabilities()
 {
-    m_source->getPhotoCapabilities(WTFMove(completion));
+    return m_source->getPhotoCapabilities();
 }
 
 Ref<RealtimeMediaSource::PhotoSettingsNativePromise> MediaStreamTrackPrivate::getPhotoSettings()

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h
@@ -112,7 +112,7 @@ public:
     const RealtimeMediaSourceCapabilities& capabilities() const;
 
     Ref<RealtimeMediaSource::TakePhotoNativePromise> takePhoto(PhotoSettings&&);
-    void getPhotoCapabilities(RealtimeMediaSource::PhotoCapabilitiesHandler&&);
+    Ref<RealtimeMediaSource::PhotoCapabilitiesNativePromise> getPhotoCapabilities();
     Ref<RealtimeMediaSource::PhotoSettingsNativePromise> getPhotoSettings();
 
     void applyConstraints(const MediaConstraints&, RealtimeMediaSource::ApplyConstraintsHandler&&);

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
@@ -1461,9 +1461,9 @@ auto RealtimeMediaSource::takePhoto(PhotoSettings&&) -> Ref<TakePhotoNativePromi
     return TakePhotoNativePromise::createAndReject("Not supported"_s);
 }
 
-void RealtimeMediaSource::getPhotoCapabilities(PhotoCapabilitiesHandler&& completion)
+auto RealtimeMediaSource::getPhotoCapabilities() -> Ref<PhotoCapabilitiesNativePromise>
 {
-    completion(PhotoCapabilitiesOrError("Not supported"_s));
+    return PhotoCapabilitiesNativePromise::createAndReject("Not supported"_s);
 }
 
 auto RealtimeMediaSource::getPhotoSettings() -> Ref<PhotoSettingsNativePromise>

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
@@ -82,7 +82,6 @@ enum class VideoFrameRotation : uint16_t;
 
 struct CaptureSourceError;
 struct CaptureSourceOrError;
-struct PhotoCapabilitiesOrError;
 struct VideoFrameAdaptor;
 
 class WEBCORE_EXPORT RealtimeMediaSource
@@ -215,8 +214,8 @@ public:
     using TakePhotoNativePromise = NativePromise<std::pair<Vector<uint8_t>, String>, String>;
     virtual Ref<TakePhotoNativePromise> takePhoto(PhotoSettings&&);
 
-    using PhotoCapabilitiesHandler = CompletionHandler<void(PhotoCapabilitiesOrError&&)>;
-    virtual void getPhotoCapabilities(PhotoCapabilitiesHandler&&);
+    using PhotoCapabilitiesNativePromise = NativePromise<PhotoCapabilities, String>;
+    virtual Ref<PhotoCapabilitiesNativePromise> getPhotoCapabilities();
 
     using PhotoSettingsNativePromise = NativePromise<PhotoSettings, String>;
     virtual Ref<PhotoSettingsNativePromise> getPhotoSettings();
@@ -404,25 +403,6 @@ struct CaptureSourceOrError {
 
     RefPtr<RealtimeMediaSource> captureSource;
     CaptureSourceError error;
-};
-
-struct PhotoCapabilitiesOrError {
-    PhotoCapabilitiesOrError() = default;
-    PhotoCapabilitiesOrError(std::optional<PhotoCapabilities>&& capabilities, String&& errorMessage)
-        : capabilities(WTFMove(capabilities))
-        , errorMessage(WTFMove(errorMessage))
-    { }
-    PhotoCapabilitiesOrError(PhotoCapabilities& capabilities)
-        : capabilities({ capabilities })
-    { }
-    explicit PhotoCapabilitiesOrError(String&& errorMessage)
-        : errorMessage(WTFMove(errorMessage))
-    { }
-
-    operator bool() const { return capabilities.has_value(); }
-
-    std::optional<PhotoCapabilities> capabilities;
-    String errorMessage;
 };
 
 String convertEnumerationToString(RealtimeMediaSource::Type);

--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h
@@ -90,7 +90,7 @@ private:
     const RealtimeMediaSourceCapabilities& capabilities() final;
     const RealtimeMediaSourceSettings& settings() final;
     Ref<TakePhotoNativePromise> takePhotoInternal(PhotoSettings&&) final;
-    void getPhotoCapabilities(PhotoCapabilitiesHandler&&) final;
+    Ref<PhotoCapabilitiesNativePromise> getPhotoCapabilities() final;
     Ref<PhotoSettingsNativePromise> getPhotoSettings() final;
     double facingModeFitnessScoreAdjustment() const final;
     void startProducingData() final;

--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
@@ -672,12 +672,10 @@ auto AVVideoCaptureSource::takePhotoInternal(PhotoSettings&& photoSettings) -> R
     return promise.releaseNonNull();
 }
 
-void AVVideoCaptureSource::getPhotoCapabilities(PhotoCapabilitiesHandler&& completion)
+auto AVVideoCaptureSource::getPhotoCapabilities() -> Ref<PhotoCapabilitiesNativePromise>
 {
-    if (m_photoCapabilities) {
-        completion({ *m_photoCapabilities });
-        return;
-    }
+    if (m_photoCapabilities)
+        return PhotoCapabilitiesNativePromise::createAndResolve(*m_photoCapabilities);
 
     auto capabilities = this->capabilities();
     PhotoCapabilities photoCapabilities;
@@ -690,7 +688,7 @@ void AVVideoCaptureSource::getPhotoCapabilities(PhotoCapabilitiesHandler&& compl
 
     m_photoCapabilities = WTFMove(photoCapabilities);
 
-    completion({ *m_photoCapabilities });
+    return PhotoCapabilitiesNativePromise::createAndResolve(*m_photoCapabilities);
 }
 
 auto AVVideoCaptureSource::getPhotoSettings() -> Ref<PhotoSettingsNativePromise>

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
@@ -257,12 +257,10 @@ auto MockRealtimeVideoSource::takePhotoInternal(PhotoSettings&&) -> Ref<TakePhot
     });
 }
 
-void MockRealtimeVideoSource::getPhotoCapabilities(PhotoCapabilitiesHandler&& completion)
+auto MockRealtimeVideoSource::getPhotoCapabilities() -> Ref<PhotoCapabilitiesNativePromise>
 {
-    if (m_photoCapabilities) {
-        completion({ *m_photoCapabilities });
-        return;
-    }
+    if (m_photoCapabilities)
+        return PhotoCapabilitiesNativePromise::createAndResolve(*m_photoCapabilities);
 
     auto capabilities = this->capabilities();
     PhotoCapabilities photoCapabilities;
@@ -275,7 +273,7 @@ void MockRealtimeVideoSource::getPhotoCapabilities(PhotoCapabilitiesHandler&& co
 
     m_photoCapabilities = WTFMove(photoCapabilities);
 
-    completion({ *m_photoCapabilities });
+    return PhotoCapabilitiesNativePromise::createAndResolve(*m_photoCapabilities);
 }
 
 auto MockRealtimeVideoSource::getPhotoSettings() -> Ref<PhotoSettingsNativePromise>

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.h
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.h
@@ -78,7 +78,7 @@ private:
     const RealtimeMediaSourceCapabilities& capabilities() final;
     const RealtimeMediaSourceSettings& settings() final;
     Ref<TakePhotoNativePromise> takePhotoInternal(PhotoSettings&&) final;
-    void getPhotoCapabilities(PhotoCapabilitiesHandler&&) final;
+    Ref<PhotoCapabilitiesNativePromise> getPhotoCapabilities() final;
     Ref<PhotoSettingsNativePromise> getPhotoSettings() final;
 
     void startProducingData() override;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6013,12 +6013,6 @@ header: <WebCore/PhotoSettings.h>
     std::optional<double> imageWidth;
     std::optional<bool> redEyeReduction;
 };
-
-header: <WebCore/RealtimeMediaSource.h>
-[CustomHeader] struct WebCore::PhotoCapabilitiesOrError {
-    std::optional<WebCore::PhotoCapabilities> capabilities;
-    String errorMessage;
-};
 #endif
 
 header: <WebCore/WebGPUTextureAspect.h>

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
@@ -257,9 +257,9 @@ public:
         return takePhotoPromise;
     }
 
-    void getPhotoCapabilities(GetPhotoCapabilitiesCallback&& handler)
+    Ref<RealtimeMediaSource::PhotoCapabilitiesNativePromise> getPhotoCapabilities()
     {
-        m_source->getPhotoCapabilities(WTFMove(handler));
+        return m_source->getPhotoCapabilities();
     }
 
     Ref<RealtimeMediaSource::PhotoSettingsNativePromise> getPhotoSettings()
@@ -647,12 +647,13 @@ void UserMediaCaptureManagerProxy::takePhoto(RealtimeMediaSourceIdentifier sourc
 
 void UserMediaCaptureManagerProxy::getPhotoCapabilities(RealtimeMediaSourceIdentifier sourceID, GetPhotoCapabilitiesCallback&& handler)
 {
-    if (auto* proxy = m_proxies.get(sourceID)) {
-        proxy->getPhotoCapabilities(WTFMove(handler));
+    auto* proxy = m_proxies.get(sourceID);
+    if (!proxy) {
+        handler(Unexpected<String>("Device not available"_s));
         return;
     }
 
-    handler(PhotoCapabilitiesOrError("Device not available"_s));
+    proxy->getPhotoCapabilities()->whenSettled(RunLoop::main(), WTFMove(handler));
 }
 
 void UserMediaCaptureManagerProxy::getPhotoSettings(RealtimeMediaSourceIdentifier sourceID, GetPhotoSettingsCallback&& handler)

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.h
@@ -100,7 +100,7 @@ private:
     using TakePhotoCallback = CompletionHandler<void(Expected<std::pair<Vector<uint8_t>, String>, String>&&)>;
     void takePhoto(WebCore::RealtimeMediaSourceIdentifier, WebCore::PhotoSettings&&, TakePhotoCallback&&);
 
-    using GetPhotoCapabilitiesCallback = CompletionHandler<void(WebCore::PhotoCapabilitiesOrError&&)>;
+    using GetPhotoCapabilitiesCallback = CompletionHandler<void(Expected<WebCore::PhotoCapabilities, String>&&)>;
     void getPhotoCapabilities(WebCore::RealtimeMediaSourceIdentifier, GetPhotoCapabilitiesCallback&&);
 
     using GetPhotoSettingsCallback = CompletionHandler<void(Expected<WebCore::PhotoSettings, String>&&)>;

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.messages.in
@@ -30,7 +30,7 @@ messages -> UserMediaCaptureManagerProxy NotRefCounted {
     RemoveSource(WebCore::RealtimeMediaSourceIdentifier id)
     ApplyConstraints(WebCore::RealtimeMediaSourceIdentifier id, struct WebCore::MediaConstraints constraints)
     TakePhoto(WebCore::RealtimeMediaSourceIdentifier sourceID, struct WebCore::PhotoSettings settings) -> (Expected<std::pair<Vector<uint8_t>, String>, String> result);
-    GetPhotoCapabilities(WebCore::RealtimeMediaSourceIdentifier sourceID) -> (struct WebCore::PhotoCapabilitiesOrError result) Async
+    GetPhotoCapabilities(WebCore::RealtimeMediaSourceIdentifier sourceID) -> (Expected<WebCore::PhotoCapabilities, String> result) Async
     GetPhotoSettings(WebCore::RealtimeMediaSourceIdentifier sourceID) -> (Expected<WebCore::PhotoSettings, String> result) Async
     Clone(WebCore::RealtimeMediaSourceIdentifier clonedID, WebCore::RealtimeMediaSourceIdentifier cloneID, WebCore::PageIdentifier pageIdentifier)
     EndProducingData(WebCore::RealtimeMediaSourceIdentifier sourceID)

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.cpp
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.cpp
@@ -85,9 +85,9 @@ Ref<RealtimeMediaSource::TakePhotoNativePromise> RemoteRealtimeMediaSource::take
     return m_proxy.takePhoto(WTFMove(settings));
 }
 
-void RemoteRealtimeMediaSource::getPhotoCapabilities(PhotoCapabilitiesHandler&& callback)
+Ref<RealtimeMediaSource::PhotoCapabilitiesNativePromise> RemoteRealtimeMediaSource::getPhotoCapabilities()
 {
-    m_proxy.getPhotoCapabilities(WTFMove(callback));
+    return m_proxy.getPhotoCapabilities();
 }
 
 Ref<RealtimeMediaSource::PhotoSettingsNativePromise> RemoteRealtimeMediaSource::getPhotoSettings()

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.h
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.h
@@ -75,7 +75,7 @@ protected:
     const WebCore::RealtimeMediaSourceCapabilities& capabilities() final { return m_capabilities; }
 
     Ref<TakePhotoNativePromise> takePhoto(WebCore::PhotoSettings&&) final;
-    void getPhotoCapabilities(PhotoCapabilitiesHandler&&) final;
+    Ref<PhotoCapabilitiesNativePromise> getPhotoCapabilities() final;
     Ref<PhotoSettingsNativePromise> getPhotoSettings() final;
 
 private:

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.cpp
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.cpp
@@ -123,9 +123,15 @@ Ref<WebCore::RealtimeMediaSource::TakePhotoNativePromise> RemoteRealtimeMediaSou
     });
 }
 
-void RemoteRealtimeMediaSourceProxy::getPhotoCapabilities(WebCore::RealtimeMediaSource::PhotoCapabilitiesHandler&& handler)
+Ref<WebCore::RealtimeMediaSource::PhotoCapabilitiesNativePromise> RemoteRealtimeMediaSourceProxy::getPhotoCapabilities()
 {
-    m_connection->sendWithAsyncReply(Messages::UserMediaCaptureManagerProxy::GetPhotoCapabilities(identifier()), WTFMove(handler));
+    return m_connection->sendWithPromisedReply(Messages::UserMediaCaptureManagerProxy::GetPhotoCapabilities(identifier()))
+    ->whenSettled(RunLoop::current(), [](Messages::UserMediaCaptureManagerProxy::GetPhotoCapabilities::Promise::Result&& result) {
+        if (result)
+            return WebCore::RealtimeMediaSource::PhotoCapabilitiesNativePromise::createAndSettle(WTFMove(result.value()));
+
+        return WebCore::RealtimeMediaSource::PhotoCapabilitiesNativePromise::createAndReject(String("IPC Connection closed"_s));
+    });
 }
 
 Ref<WebCore::RealtimeMediaSource::PhotoSettingsNativePromise> RemoteRealtimeMediaSourceProxy::getPhotoSettings()

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.h
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.h
@@ -75,7 +75,7 @@ public:
     void applyConstraints(const WebCore::MediaConstraints&, WebCore::RealtimeMediaSource::ApplyConstraintsHandler&&);
 
     Ref<WebCore::RealtimeMediaSource::TakePhotoNativePromise> takePhoto(WebCore::PhotoSettings&&);
-    void getPhotoCapabilities(WebCore::RealtimeMediaSource::PhotoCapabilitiesHandler&&);
+    Ref<WebCore::RealtimeMediaSource::PhotoCapabilitiesNativePromise> getPhotoCapabilities();
     Ref<WebCore::RealtimeMediaSource::PhotoSettingsNativePromise> getPhotoSettings();
 
     void whenReady(CompletionHandler<void(WebCore::CaptureSourceError&&)>&&);


### PR DESCRIPTION
#### 8607642c71c8943b9f85a77e2dbafcde87a79414
<pre>
[MediaStream] Cleanup getPhotoSettings and getPhotoCapabilities
<a href="https://bugs.webkit.org/show_bug.cgi?id=265497">https://bugs.webkit.org/show_bug.cgi?id=265497</a>
<a href="https://rdar.apple.com/118909014">rdar://118909014</a>

Reviewed by Jean-Yves Avenard.

Don&apos;t pass the DOMPromise outside of ImageCapture, have MediaStreamTrack and below
pass and return a NativePromise.

* Source/WebCore/Modules/mediastream/ImageCapture.cpp:
(WebCore::ImageCapture::getPhotoCapabilities):
(WebCore::ImageCapture::getPhotoSettings):
* Source/WebCore/Modules/mediastream/ImageCapture.h:
* Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp:
(WebCore::MediaStreamTrack::getPhotoCapabilities):
(WebCore::MediaStreamTrack::getPhotoSettings):
* Source/WebCore/Modules/mediastream/MediaStreamTrack.h:
* Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp:
(WebCore::MediaStreamTrackPrivate::getPhotoCapabilities):
* Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h:
* Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp:
(WebCore::RealtimeMediaSource::getPhotoCapabilities):
* Source/WebCore/platform/mediastream/RealtimeMediaSource.h:
(WebCore::PhotoCapabilitiesOrError::PhotoCapabilitiesOrError): Deleted.
(WebCore::PhotoCapabilitiesOrError::operator bool const): Deleted.
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h:
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm:
(WebCore::AVVideoCaptureSource::getPhotoCapabilities):
* Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp:
(WebCore::MockRealtimeVideoSource::getPhotoCapabilities):
* Source/WebCore/platform/mock/MockRealtimeVideoSource.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp:
(WebKit::UserMediaCaptureManagerProxy::SourceProxy::getPhotoCapabilities):
(WebKit::UserMediaCaptureManagerProxy::getPhotoCapabilities):
* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.messages.in:
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.cpp:
(WebKit::RemoteRealtimeMediaSource::getPhotoCapabilities):
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.h:
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.cpp:
(WebKit::RemoteRealtimeMediaSourceProxy::getPhotoCapabilities):
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.h:

Canonical link: <a href="https://commits.webkit.org/271314@main">https://commits.webkit.org/271314@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c73da2afb31e346324007a36b94dad24a839a14d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27976 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6614 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29278 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30506 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25518 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28471 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8609 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4005 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/25282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28243 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5370 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24031 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4624 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/4807 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25038 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31195 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25582 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25474 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31062 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/4811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2974 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28873 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6346 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6715 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/5256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5297 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->