### PR TITLE
Use dynamicDowncast<T> more in display/

### DIFF
--- a/Source/WebCore/display/css/DisplayBoxPainter.cpp
+++ b/Source/WebCore/display/css/DisplayBoxPainter.cpp
@@ -53,11 +53,9 @@ void BoxPainter::paintBoxDecorations(const BoxModelBox& box, PaintingContext& pa
 
 void BoxPainter::paintBoxContent(const Box& box, PaintingContext& paintingContext)
 {
-    if (is<ImageBox>(box)) {
-        auto& imageBox = downcast<ImageBox>(box);
-        
-        auto* image = imageBox.image();
-        auto imageRect = imageBox.replacedContentRect();
+    if (auto* imageBox = dynamicDowncast<ImageBox>(box)) {
+        auto* image = imageBox->image();
+        auto imageRect = imageBox->replacedContentRect();
 
         if (image)
             paintingContext.context.drawImage(*image, imageRect);
@@ -65,9 +63,7 @@ void BoxPainter::paintBoxContent(const Box& box, PaintingContext& paintingContex
         return;
     }
     
-    if (is<TextBox>(box)) {
-        auto& textBox = downcast<TextBox>(box);
-
+    if (auto* textBox = dynamicDowncast<TextBox>(box)) {
         auto& style = box.style();
         auto textRect = box.absoluteBoxRect();
 
@@ -76,9 +72,9 @@ void BoxPainter::paintBoxContent(const Box& box, PaintingContext& paintingContex
 
         // FIXME: Add non-baseline align painting
         auto baseline = textRect.y() + style.metricsOfPrimaryFont().ascent();
-        auto expansion = textBox.expansion();
+        auto expansion = textBox->expansion();
 
-        auto textRun = TextRun { textBox.text().originalContent(), textRect.x(), expansion.horizontalExpansion, expansion.behavior };
+        auto textRun = TextRun { textBox->text().originalContent(), textRect.x(), expansion.horizontalExpansion, expansion.behavior };
         textRun.setTabSize(!style.collapseWhiteSpace(), style.tabSize());
         paintingContext.context.drawText(style.fontCascade(), textRun, { textRect.x(), baseline });
         return;
@@ -92,8 +88,8 @@ void BoxPainter::paintBox(const Box& box, PaintingContext& paintingContext, cons
     if (!dirtyRect.intersects(enclosingIntRect(absoluteRect)))
         return;
 
-    if (is<BoxModelBox>(box))
-        paintBoxDecorations(downcast<BoxModelBox>(box), paintingContext);
+    if (auto* boxModelBox = dynamicDowncast<BoxModelBox>(box))
+        paintBoxDecorations(*boxModelBox, paintingContext);
 
     paintBoxContent(box, paintingContext);
 }


### PR DESCRIPTION
#### 0e506e8c4bce9c3aee935a95395a07f99a0cfee0
<pre>
Use dynamicDowncast&lt;T&gt; more in display/
<a href="https://bugs.webkit.org/show_bug.cgi?id=265502">https://bugs.webkit.org/show_bug.cgi?id=265502</a>

Reviewed by NOBODY (OOPS!).

* Source/WebCore/display/DisplayTreeBuilder.cpp:
(WebCore::Display::TreeBuilder::insertIntoTree):
(WebCore::Display::TreeBuilder::recursiveBuildDisplayTree):
(WebCore::Display::outputDisplayTree):
* Source/WebCore/display/css/DisplayBoxFactory.cpp:
(WebCore::Display::BoxFactory::displayBoxForLayoutBox const):
(WebCore::Display::BoxFactory::setupBoxGeometry const):
(WebCore::Display::BoxFactory::documentElementBoxFromRootBox):
(WebCore::Display::BoxFactory::bodyBoxFromRootBox):
* Source/WebCore/display/css/DisplayBoxPainter.cpp:
(WebCore::Display::BoxPainter::paintBoxContent):
(WebCore::Display::BoxPainter::paintBox):
* Source/WebCore/display/css/DisplayCSSPainter.cpp:
(WebCore::Display::applyClipIfNecessary):
(WebCore::Display::CSSPainter::recursivePaintDescendantsForPhase):
(WebCore::Display::CSSPainter::paintAtomicallyPaintedBox):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e506e8c4bce9c3aee935a95395a07f99a0cfee0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27843 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6481 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29094 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30354 "Failed to checkout and rebase branch from PR 21040") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25419 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28336 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8444 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3874 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/30354 "Failed to checkout and rebase branch from PR 21040") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28108 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5230 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23880 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/30354 "Failed to checkout and rebase branch from PR 21040") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4700 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24903 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30749 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25437 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25345 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31255 "layout-tests (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4715 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2865 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28781 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6232 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5161 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5177 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->