### PR TITLE
[JSC] Suppress coverage_sanitizer on Fuzzilli::initializeCoverage()

### DIFF
--- a/Source/JavaScriptCore/fuzzilli/Fuzzilli.cpp
+++ b/Source/JavaScriptCore/fuzzilli/Fuzzilli.cpp
@@ -23,6 +23,7 @@
 
 #include <mutex>
 #include <wtf/Assertions.h>
+#include <wtf/Compiler.h>
 #include <wtf/DataLog.h>
 #include <wtf/NeverDestroyed.h>
 
@@ -77,6 +78,7 @@ void Fuzzilli::waitForCommand()
     RELEASE_ASSERT_WITH_MESSAGE(action == 'cexe', "[REPRL] Unknown action: %u", action);
 }
 
+SUPPRESS_COVERAGE
 void Fuzzilli::initializeCoverage(uint32_t* start, uint32_t* stop)
 {
     RELEASE_ASSERT_WITH_MESSAGE(!edgesStart && !edgesStop, "Coverage instrumentation is only supported for a single module");

--- a/Source/WTF/wtf/Compiler.h
+++ b/Source/WTF/wtf/Compiler.h
@@ -170,6 +170,16 @@
 #define SUPPRESS_TSAN
 #endif
 
+/* COVERAGE_ENABLED and SUPPRESS_COVERAGE */
+
+#define COVERAGE_ENABLED COMPILER_HAS_CLANG_FEATURE(coverage_sanitizer)
+
+#if COVERAGE_ENABLED
+#define SUPPRESS_COVERAGE __attribute__((no_sanitize("coverage")))
+#else
+#define SUPPRESS_COVERAGE
+#endif
+
 /* ==== Compiler-independent macros for various compiler features, in alphabetical order ==== */
 
 /* ALWAYS_INLINE */


### PR DESCRIPTION
#### df1c826fa3da7556a3de840845bee6d3b6e1fb70
<pre>
[JSC] Suppress coverage_sanitizer on Fuzzilli::initializeCoverage()
<a href="https://bugs.webkit.org/show_bug.cgi?id=265507">https://bugs.webkit.org/show_bug.cgi?id=265507</a>
&lt;<a href="https://rdar.apple.com/118908398">rdar://118908398</a>&gt;

Reviewed by Yusuke Suzuki.

* Source/JavaScriptCore/fuzzilli/Fuzzilli.cpp:
(Fuzzilli::initializeCoverage):
- Suppress coverage sanitizer when initializing coverage.

* Source/WTF/wtf/Compiler.h:
(COVERAGE_ENABLED): Add.
(SUPPRESS_COVERAGE): Add.
- Add macros used with -fsanitize-coverage.

Canonical link: <a href="https://commits.webkit.org/271277@main">https://commits.webkit.org/271277@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6cbd6543d4d9c29c6d47c522a0886fca59e91c63

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27858 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6497 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29115 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30392 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25429 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8466 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3891 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/25199 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28124 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5248 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23896 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4535 "Found 1 new API test failure: /WPE/TestWebKitWebView:/webkit/WebKitWebView/notification (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4714 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24919 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31081 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/24150 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25455 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25361 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30920 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/27014 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4725 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2879 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28788 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6245 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/34489 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5172 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7450 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3604 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5191 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->