### PR TITLE
REGRESSION(270890@main): Animation doesn't trigger when custom property initial value matches the first frame

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-css-variable-dependent-property-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-css-variable-dependent-property-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Dependent property updates correctly
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-css-variable-dependent-property.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-css-variable-dependent-property.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Animations: Dependent property updates correctly when animating a declared custom property</title>
+<link rel="help" href="https://drafts.csswg.org/css-animations/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/testcommon.js"></script>
+<style>
+@property --c {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: black;
+}
+@keyframes color-shift {
+    0% {
+        --c: black;
+    }
+    100% {
+        --c: white;
+    }
+}
+#target {
+    color: var(--c);
+    animation: color-shift 1s linear 1 forwards paused
+}
+</style>
+<div id=target></div>
+<div id="log"></div>
+<script>
+
+test(t => {
+  const animation = target.getAnimations()[0];
+
+  assert_equals(
+    getComputedStyle(target).color,
+    'rgb(0, 0, 0)'
+  );
+
+  animation.currentTime = 500;
+
+  assert_equals(
+    getComputedStyle(target).color,
+    'rgb(128, 128, 128)'
+  );
+
+  animation.currentTime = 1000;
+
+  assert_equals(
+    getComputedStyle(target).color,
+    'rgb(255, 255, 255)'
+  );
+
+}, 'Dependent property updates correctly');
+
+</script>

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -619,7 +619,7 @@ ElementUpdate TreeResolver::createAnimatedElementUpdate(ResolvedStyle&& resolved
 
         auto animationImpact = styleable.applyKeyframeEffects(*animatedStyle, animatedProperties, previousLastStyleChangeEventStyle.get(), resolutionContext);
 
-        if (*resolvedStyle.style == *animatedStyle && animationImpact.isEmpty())
+        if (*resolvedStyle.style == *animatedStyle && animationImpact.isEmpty() && previousLastStyleChangeEventStyle)
             return { WTFMove(resolvedStyle.style), animationImpact };
 
         if (resolvedStyle.matchResult) {


### PR DESCRIPTION
#### 7687d03911da56a6689087f88c4812174ef2febe
<pre>
REGRESSION(270890@main): Animation doesn&apos;t trigger when custom property initial value matches the first frame
<a href="https://bugs.webkit.org/show_bug.cgi?id=265160">https://bugs.webkit.org/show_bug.cgi?id=265160</a>
<a href="https://rdar.apple.com/118697176">rdar://118697176</a>

Reviewed by Antoine Quint.

If the initial value of a declared custom property is the same as the first frame we would bail out before
computing the cascade effect (since nothing changes). Because of this we would fail to set hasPropertiesOverridenAfterAnimation
bit and then proceed to optimize away the cascade updates for future frames too.

* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-css-variable-dependent-property-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-css-variable-dependent-property.html: Added.
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::createAnimatedElementUpdate):

Ensure that we apply the cascade when computing the first frame of animation so we know to not optimize away style
updates for the subsequent frames.

Canonical link: <a href="https://commits.webkit.org/271268@main">https://commits.webkit.org/271268@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0498d103cf5921d87dc53c1708cbffb62a1f1167

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27871 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6510 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29142 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30403 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25439 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28365 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8485 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3904 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/25212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28137 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5267 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23920 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4541 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/4729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24937 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31091 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25473 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25381 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/30929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4736 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2891 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/28793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6257 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/24677 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6689 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5182 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5204 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->