### PR TITLE
[JSC] Use synchronous GCActivityCallback GC with RunLoopObserver

### DIFF
--- a/Source/JavaScriptCore/heap/EdenGCActivityCallback.cpp
+++ b/Source/JavaScriptCore/heap/EdenGCActivityCallback.cpp
@@ -30,8 +30,8 @@
 
 namespace JSC {
 
-EdenGCActivityCallback::EdenGCActivityCallback(Heap& heap)
-    : GCActivityCallback(heap)
+EdenGCActivityCallback::EdenGCActivityCallback(Heap& heap, Synchronousness synchronousness)
+    : GCActivityCallback(heap, synchronousness)
 {
 }
 
@@ -40,7 +40,7 @@ EdenGCActivityCallback::~EdenGCActivityCallback() = default;
 void EdenGCActivityCallback::doCollection(VM& vm)
 {
     setDidGCRecently(false);
-    vm.heap.collectAsync(CollectionScope::Eden);
+    vm.heap.collect(m_synchronousness, CollectionScope::Eden);
 }
 
 Seconds EdenGCActivityCallback::lastGCLength(Heap& heap)

--- a/Source/JavaScriptCore/heap/EdenGCActivityCallback.h
+++ b/Source/JavaScriptCore/heap/EdenGCActivityCallback.h
@@ -31,14 +31,14 @@ namespace JSC {
 
 class EdenGCActivityCallback : public GCActivityCallback {
 public:
-    static RefPtr<EdenGCActivityCallback> tryCreate(Heap& heap)
+    static RefPtr<EdenGCActivityCallback> tryCreate(Heap& heap, Synchronousness synchronousness = Synchronousness::Async)
     {
-        return s_shouldCreateGCTimer ? adoptRef(new EdenGCActivityCallback(heap)) : nullptr;
+        return s_shouldCreateGCTimer ? adoptRef(new EdenGCActivityCallback(heap, synchronousness)) : nullptr;
     }
 
     JS_EXPORT_PRIVATE void doCollection(VM&) override;
 
-    JS_EXPORT_PRIVATE EdenGCActivityCallback(Heap&);
+    JS_EXPORT_PRIVATE EdenGCActivityCallback(Heap&, Synchronousness);
     JS_EXPORT_PRIVATE ~EdenGCActivityCallback();
 
 private:

--- a/Source/JavaScriptCore/heap/FullGCActivityCallback.cpp
+++ b/Source/JavaScriptCore/heap/FullGCActivityCallback.cpp
@@ -31,8 +31,8 @@
 
 namespace JSC {
 
-FullGCActivityCallback::FullGCActivityCallback(Heap& heap)
-    : GCActivityCallback(heap)
+FullGCActivityCallback::FullGCActivityCallback(Heap& heap, Synchronousness synchronousness)
+    : GCActivityCallback(heap, synchronousness)
 {
 }
 
@@ -52,7 +52,7 @@ void FullGCActivityCallback::doCollection(VM& vm)
     }
 #endif
 
-    heap.collectAsync(CollectionScope::Full);
+    heap.collect(m_synchronousness, CollectionScope::Full);
 }
 
 Seconds FullGCActivityCallback::lastGCLength(Heap& heap)

--- a/Source/JavaScriptCore/heap/FullGCActivityCallback.h
+++ b/Source/JavaScriptCore/heap/FullGCActivityCallback.h
@@ -31,14 +31,14 @@ namespace JSC {
 
 class FullGCActivityCallback : public GCActivityCallback {
 public:
-    static RefPtr<FullGCActivityCallback> tryCreate(Heap& heap)
+    static RefPtr<FullGCActivityCallback> tryCreate(Heap& heap, Synchronousness synchronousness = Synchronousness::Async)
     {
-        return s_shouldCreateGCTimer ? adoptRef(new FullGCActivityCallback(heap)) : nullptr;
+        return s_shouldCreateGCTimer ? adoptRef(new FullGCActivityCallback(heap, synchronousness)) : nullptr;
     }
 
     JS_EXPORT_PRIVATE void doCollection(VM&) override;
 
-    JS_EXPORT_PRIVATE FullGCActivityCallback(Heap&);
+    JS_EXPORT_PRIVATE FullGCActivityCallback(Heap&, Synchronousness);
     JS_EXPORT_PRIVATE ~FullGCActivityCallback();
 
 private:

--- a/Source/JavaScriptCore/heap/GCActivityCallback.cpp
+++ b/Source/JavaScriptCore/heap/GCActivityCallback.cpp
@@ -38,13 +38,14 @@ bool GCActivityCallback::s_shouldCreateGCTimer = true;
 
 const double timerSlop = 2.0; // Fudge factor to avoid performance cost of resetting timer.
 
-GCActivityCallback::GCActivityCallback(Heap& heap)
-    : GCActivityCallback(heap.vm())
+GCActivityCallback::GCActivityCallback(Heap& heap, Synchronousness synchronousness)
+    : GCActivityCallback(heap.vm(), synchronousness)
 {
 }
 
-GCActivityCallback::GCActivityCallback(VM& vm)
+GCActivityCallback::GCActivityCallback(VM& vm, Synchronousness synchronousness)
     : Base(vm)
+    , m_synchronousness(synchronousness)
 {
 }
 

--- a/Source/JavaScriptCore/heap/GCActivityCallback.h
+++ b/Source/JavaScriptCore/heap/GCActivityCallback.h
@@ -29,6 +29,7 @@
 #pragma once
 
 #include "JSRunLoopTimer.h"
+#include "Synchronousness.h"
 #include <wtf/RefPtr.h>
 
 namespace JSC {
@@ -40,7 +41,7 @@ class GCActivityCallback : public JSRunLoopTimer {
 public:
     using Base = JSRunLoopTimer;
 
-    JS_EXPORT_PRIVATE GCActivityCallback(Heap&);
+    JS_EXPORT_PRIVATE GCActivityCallback(Heap&, Synchronousness);
     JS_EXPORT_PRIVATE ~GCActivityCallback();
 
     JS_EXPORT_PRIVATE void doWork(VM&) override;
@@ -63,8 +64,9 @@ protected:
     virtual double deathRate(Heap&) = 0;
     JS_EXPORT_PRIVATE void scheduleTimer(Seconds);
 
-    GCActivityCallback(VM&);
+    GCActivityCallback(VM&, Synchronousness);
 
+    Synchronousness m_synchronousness { Synchronousness::Async };
     bool m_enabled { true };
     bool m_didGCRecently { false };
     Seconds m_delay { s_decade };

--- a/Source/JavaScriptCore/heap/Synchronousness.h
+++ b/Source/JavaScriptCore/heap/Synchronousness.h
@@ -27,7 +27,7 @@
 
 namespace JSC {
 
-enum Synchronousness {
+enum Synchronousness : uint8_t {
     Async,
     Sync
 };

--- a/Source/WebCore/page/OpportunisticTaskScheduler.h
+++ b/Source/WebCore/page/OpportunisticTaskScheduler.h
@@ -82,10 +82,10 @@ public:
         void doCollection(JSC::VM&) final;
 
     private:
-        FullGCActivityCallback(JSC::Heap& heap)
-            : Base(heap)
-        { }
+        FullGCActivityCallback(JSC::Heap&);
 
+        JSC::VM& m_vm;
+        std::unique_ptr<RunLoopObserver> m_runLoopObserver;
         JSC::HeapVersion m_version { 0 };
         unsigned m_deferCount { 0 };
     };
@@ -102,10 +102,10 @@ public:
         void doCollection(JSC::VM&) final;
 
     private:
-        EdenGCActivityCallback(JSC::Heap& heap)
-            : Base(heap)
-        { }
+        EdenGCActivityCallback(JSC::Heap&);
 
+        JSC::VM& m_vm;
+        std::unique_ptr<RunLoopObserver> m_runLoopObserver;
         JSC::HeapVersion m_version { 0 };
         unsigned m_deferCount { 0 };
     };


### PR DESCRIPTION
#### e0c479c2e8bdc4473d872db99d4c3dcefa81e87d
<pre>
[JSC] Use synchronous GCActivityCallback GC with RunLoopObserver
<a href="https://bugs.webkit.org/show_bug.cgi?id=265515">https://bugs.webkit.org/show_bug.cgi?id=265515</a>
<a href="https://rdar.apple.com/118930139">rdar://118930139</a>

Reviewed by Wenson Hsieh.

Now we can schedule GC only when we are idle from GCActivityCallback. So we do not need to run async version.
This patch changes two things.

1. We set up RunLoopObserver and run GC when RunLoop gets idle state after GCActivityCallback detects GC opportunities.
2. We use sync GC instead of async GC since we now run this only when we are idle. We do not need to run async version.

* Source/JavaScriptCore/heap/EdenGCActivityCallback.cpp:
(JSC::EdenGCActivityCallback::EdenGCActivityCallback):
(JSC::EdenGCActivityCallback::doCollection):
* Source/JavaScriptCore/heap/EdenGCActivityCallback.h:
(JSC::EdenGCActivityCallback::tryCreate):
* Source/JavaScriptCore/heap/FullGCActivityCallback.cpp:
(JSC::FullGCActivityCallback::FullGCActivityCallback):
(JSC::FullGCActivityCallback::doCollection):
* Source/JavaScriptCore/heap/FullGCActivityCallback.h:
(JSC::FullGCActivityCallback::tryCreate):
* Source/JavaScriptCore/heap/GCActivityCallback.cpp:
(JSC::GCActivityCallback::GCActivityCallback):
* Source/JavaScriptCore/heap/GCActivityCallback.h:
* Source/JavaScriptCore/heap/Synchronousness.h:
* Source/WebCore/page/OpportunisticTaskScheduler.cpp:
(WebCore::OpportunisticTaskScheduler::FullGCActivityCallback::FullGCActivityCallback):
(WebCore::OpportunisticTaskScheduler::FullGCActivityCallback::doCollection):
(WebCore::OpportunisticTaskScheduler::EdenGCActivityCallback::EdenGCActivityCallback):
(WebCore::OpportunisticTaskScheduler::EdenGCActivityCallback::doCollection):
* Source/WebCore/page/OpportunisticTaskScheduler.h:

Canonical link: <a href="https://commits.webkit.org/271324@main">https://commits.webkit.org/271324@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e9f357380d4a551e37bfdd4d5feb9456d09fcb3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27938 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6576 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29236 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30467 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25490 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28433 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8565 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3970 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/25265 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28204 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5335 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24002 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4596 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4781 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25007 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31156 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/24207 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25544 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25449 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31038 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/27084 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4787 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2948 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28851 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6315 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/34565 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5233 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7471 "Found 4077 new JSC stress test failures: wasm.yaml/wasm/branch-hints/branchHintsSection.js.default-wasm, wasm.yaml/wasm/branch-hints/branchHintsSection.js.wasm-collect-continuously, wasm.yaml/wasm/branch-hints/branchHintsSection.js.wasm-eager, wasm.yaml/wasm/branch-hints/branchHintsSection.js.wasm-eager-jettison, wasm.yaml/wasm/branch-hints/branchHintsSection.js.wasm-no-cjit, wasm.yaml/wasm/branch-hints/branchHintsSection.js.wasm-slow-memory, wasm.yaml/wasm/extended-const-spec-tests/data.wast.js.default-wasm, wasm.yaml/wasm/extended-const-spec-tests/data.wast.js.wasm-collect-continuously, wasm.yaml/wasm/extended-const-spec-tests/data.wast.js.wasm-eager-jettison, wasm.yaml/wasm/extended-const-spec-tests/data.wast.js.wasm-no-cjit ... (failure)") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3623 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5263 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->