### PR TITLE
Remove unused "previousSkippingChildrenPostOrder" from NodeTraversal.cpp|h

### DIFF
--- a/Source/WebCore/dom/NodeTraversal.cpp
+++ b/Source/WebCore/dom/NodeTraversal.cpp
@@ -174,14 +174,5 @@ Node* previousPostOrder(const Node& current, const Node* stayWithin)
     return previousAncestorSiblingPostOrder(current, stayWithin);
 }
 
-Node* previousSkippingChildrenPostOrder(const Node& current, const Node* stayWithin)
-{
-    if (&current == stayWithin)
-        return nullptr;
-    if (current.previousSibling())
-        return current.previousSibling();
-    return previousAncestorSiblingPostOrder(current, stayWithin);
-}
-
 }
 }

--- a/Source/WebCore/dom/NodeTraversal.h
+++ b/Source/WebCore/dom/NodeTraversal.h
@@ -55,9 +55,8 @@ Node* previousSkippingChildren(const Node&, const Node* stayWithin = nullptr);
 // Like next, but visits parents after their children.
 Node* nextPostOrder(const Node&, const Node* stayWithin = nullptr);
 
-// Like previous/previousSkippingChildren, but visits parents before their children.
+// Like previous, but visits parents before their children.
 Node* previousPostOrder(const Node&, const Node* stayWithin = nullptr);
-Node* previousSkippingChildrenPostOrder(const Node&, const Node* stayWithin = nullptr);
 
 // Pre-order traversal including the pseudo-elements.
 Node* previousIncludingPseudo(const Node&, const Node* = nullptr);


### PR DESCRIPTION
<pre>
Remove unused "previousSkippingChildrenPostOrder" from NodeTraversal.cpp|h
<a href="https://bugs.webkit.org/show_bug.cgi?id=265517">https://bugs.webkit.org/show_bug.cgi?id=265517</a>

Reviewed by NOBODY (OOPS!).

This PR is to remove unused function "previousSkippingChildrenPostOrder" from NodeTraversal.cpp & NodeTraversal.h.

* Source/WebCore/dom/NodeTraversal.cpp:
(previousSkippingChildrenPostOrder): Deleted
* Source/WebCore/dom/NodeTraversal.h:
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c4c98bc7fbc3b10260c7cfd8714c230829a794a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27892 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6531 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29185 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30423 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25458 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28387 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8513 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3925 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/25227 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28158 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5293 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23961 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4559 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4761 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24969 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31111 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25499 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25420 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31010 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4754 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2911 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28821 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6277 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5200 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5224 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->