### PR TITLE
[IFC][Ruby] Don't inherit text decorations through annotation box

### DIFF
--- a/Source/WebCore/rendering/TextDecorationPainter.cpp
+++ b/Source/WebCore/rendering/TextDecorationPainter.cpp
@@ -362,7 +362,7 @@ static void collectStylesForRenderer(TextDecorationPainter::Styles& result, cons
         const auto& style = styleForRenderer(*current);
         extractDecorations(style, style.textDecorationLine());
 
-        if (current->isRenderRubyText())
+        if (current->isRenderRubyText() || current->style().display() == DisplayType::RubyAnnotation)
             return;
 
         current = current->parent();


### PR DESCRIPTION
#### 9da902cdac2f71df13d9abd5fa67ddb328d56393
<pre>
[IFC][Ruby] Don&apos;t inherit text decorations through annotation box
<a href="https://bugs.webkit.org/show_bug.cgi?id=265523">https://bugs.webkit.org/show_bug.cgi?id=265523</a>
<a href="https://rdar.apple.com/118934032">rdar://118934032</a>

Reviewed by Alan Baradlay.

&quot;Text decoration does not propagate from the base text to the annotations.&quot;

<a href="https://www.w3.org/TR/css-ruby-1/#ruby-text-decoration">https://www.w3.org/TR/css-ruby-1/#ruby-text-decoration</a>

Tested by fast/ruby/text-decoration-in-descendants-ruby.html with style-based ruby enabled.

* Source/WebCore/rendering/TextDecorationPainter.cpp:
(WebCore::collectStylesForRenderer):

Canonical link: <a href="https://commits.webkit.org/271288@main">https://commits.webkit.org/271288@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/682dc54eab6f2bf6fadf6474af6b463fef615f3b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27902 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6541 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29199 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30433 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25467 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28397 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8525 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3935 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/25235 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28168 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5305 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23972 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4567 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4758 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24979 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31121 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25512 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25418 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/31012 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4763 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2919 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28822 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6287 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6698 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5209 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5234 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->