### PR TITLE
[UnifiedPDF] UnifiedPDFPlugin should start producing cursor updates

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -30,14 +30,28 @@
 #include "PDFDocumentLayout.h"
 #include "PDFPluginBase.h"
 #include <WebCore/GraphicsLayer.h>
+#include <wtf/OptionSet.h>
 
 namespace WebKit {
-
 class WebFrame;
+class WebMouseEvent;
 
 class UnifiedPDFPlugin final : public PDFPluginBase, public WebCore::GraphicsLayerClient {
 public:
     static Ref<UnifiedPDFPlugin> create(WebCore::HTMLPlugInElement&);
+
+    enum class PDFElementType : uint16_t {
+        Page       = 1 << 0,
+        Text       = 1 << 1,
+        Annotation = 1 << 2,
+        Link       = 1 << 3,
+        Control    = 1 << 4,
+        TextField  = 1 << 5,
+        Icon       = 1 << 6,
+        Popup      = 1 << 7,
+        Image      = 1 << 8,
+    };
+    using PDFElementTypes = OptionSet<PDFElementType>;
 
 private:
     explicit UnifiedPDFPlugin(WebCore::HTMLPlugInElement&);
@@ -118,6 +132,8 @@ private:
 #endif
 
     RefPtr<WebCore::GraphicsLayer> createGraphicsLayer(const String& name, GraphicsLayer::Type);
+
+    PDFElementTypes pdfElementTypesForPluginPoint(const WebCore::IntPoint&) const;
 
     PDFDocumentLayout m_documentLayout;
     RefPtr<WebCore::GraphicsLayer> m_rootLayer;


### PR DESCRIPTION
#### 907be252d130e3290d0876282300061f0051f2e7
<pre>
[UnifiedPDF] UnifiedPDFPlugin should start producing cursor updates
<a href="https://bugs.webkit.org/show_bug.cgi?id=265512">https://bugs.webkit.org/show_bug.cgi?id=265512</a>
<a href="https://rdar.apple.com/118925385">rdar://118925385</a>

Reviewed by Simon Fraser.

This commit lays down the plumbing required to start generating cursor
updates from UnifiedPDFPlugin, and is written in anticipation of correct
hit testing to identify areas of interest under the mouse -- see
<a href="https://rdar.apple.com/118550951.">rdar://118550951.</a> Note that this commit is not involved in actually
notifying the web page about cursor updates, since that was already
hooked up in 270863@main.

We introduce the `PDFElementTypes` option set to indicate the presence
of interesting PDF elements under a given point. This mirrors the
`PDFAreaOfInterest` enumeration from PDFKit.

Furthermore, we update `UnifiedPDFPlugin::handleMouseEvent()` to reason
about mouseMove events by passing the event in question to
`UnifiedPDFPlugin::pdfElementTypesForPluginPoint()`. This function is not
implemented yet, but will be done soon, as mentioned above.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::toWebCoreCursorType):
(WebKit::UnifiedPDFPlugin::pdfElementTypesForPluginPoint const):
(WebKit::UnifiedPDFPlugin::handleMouseEvent):

Canonical link: <a href="https://commits.webkit.org/271319@main">https://commits.webkit.org/271319@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b64e3cd61e145def50229c705b6fdfe553b91230

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27995 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6633 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29299 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30525 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25531 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8631 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4023 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/25294 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28262 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5385 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24052 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4642 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4818 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31214 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25596 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25495 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31077 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4824 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2988 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28888 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/notification (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6361 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6716 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/5268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5314 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->