### PR TITLE
[iOS] Image analysis menu items for images with machine-readable codes sometimes fail to appear

### DIFF
--- a/LayoutTests/fast/events/touch/ios/long-press-on-image-with-machine-readable-code-menu-items-expected.txt
+++ b/LayoutTests/fast/events/touch/ios/long-press-on-image-with-machine-readable-code-menu-items-expected.txt
@@ -1,0 +1,11 @@
+Verifies that dynamically-inserted image analysis context menu items show up after long-pressing on an image. This test requires WebKitTestRunner.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Found QR code menu item
+PASS Finished dismissing context menu
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/events/touch/ios/long-press-on-image-with-machine-readable-code-menu-items.html
+++ b/LayoutTests/fast/events/touch/ios/long-press-on-image-with-machine-readable-code-menu-items.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<meta charset="utf-8">
+<html>
+<head>
+<meta name="viewport" content="initial-scale=1">
+<script src="../../../../resources/ui-helper.js"></script>
+<script src="../../../../resources/js-test.js"></script>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("Verifies that dynamically-inserted image analysis context menu items show up after long-pressing on an image. This test requires WebKitTestRunner.");
+
+    if (!window.testRunner || !testRunner.runUIScript)
+        return;
+
+    await UIHelper.installFakeMachineReadableCodeResultsForImageAnalysis();
+    await UIHelper.longPressElement(document.querySelector("img"));
+
+    let foundQRCodeItem = false;
+    do {
+        await UIHelper.delayFor(200);
+        let contextMenu = await UIHelper.contextMenuItems();
+        if (contextMenu?.items?.includes("QR Code"))
+            foundQRCodeItem = true;
+    } while (!foundQRCodeItem);
+
+    testPassed("Found QR code menu item");
+    await UIHelper.activateAt(0, 0);
+    await UIHelper.waitForContextMenuToHide();
+    testPassed("Finished dismissing context menu");
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+<img src="../../../images/resources/dice.png" width="320" height="240" alt="Dice">
+</body>
+</html>

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -1079,6 +1079,15 @@ window.UIHelper = class UIHelper {
         });
     }
 
+    static contextMenuItems()
+    {
+        return new Promise(resolve => {
+            testRunner.runUIScript(`(() => {
+                uiController.uiScriptComplete(JSON.stringify(uiController.contentsOfUserInterfaceItem('contextMenu')))
+            })()`, result => resolve(result ? JSON.parse(result).contextMenu : null));
+        });
+    }
+
     static setSelectedColorForColorPicker(red, green, blue)
     {
         const selectColorScript = `uiController.setSelectedColorForColorPicker(${red}, ${green}, ${blue})`;
@@ -1927,6 +1936,16 @@ window.UIHelper = class UIHelper {
 
         return new Promise(resolve => {
             testRunner.runUIScript("uiController.uiScriptComplete(uiController.currentImageAnalysisRequestID)", result => resolve(result));
+        });
+    }
+
+    static installFakeMachineReadableCodeResultsForImageAnalysis()
+    {
+        if (!this.isWebKit2())
+            return Promise.resolve();
+
+        return new Promise(resolve => {
+            testRunner.runUIScript("uiController.installFakeMachineReadableCodeResultsForImageAnalysis()", resolve);
         });
     }
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -272,6 +272,12 @@ struct RemoveBackgroundData {
 
 enum class ProceedWithTextSelectionInImage : bool { No, Yes };
 
+enum class DynamicImageAnalysisContextMenuState : uint8_t {
+    NotWaiting,
+    WaitingForImageAnalysis,
+    WaitingForVisibleMenu,
+};
+
 enum class ImageAnalysisRequestIdentifierType { };
 using ImageAnalysisRequestIdentifier = ObjectIdentifier<ImageAnalysisRequestIdentifierType>;
 
@@ -565,7 +571,7 @@ struct ImageAnalysisContextMenuActionData {
     RetainPtr<NSString> _visualSearchPreviewTitle;
     CGRect _visualSearchPreviewImageBounds;
 #endif // USE(QUICK_LOOK)
-    BOOL _waitingForDynamicImageAnalysisContextMenuActions;
+    WebKit::DynamicImageAnalysisContextMenuState _dynamicImageAnalysisContextMenuState;
     std::optional<WebKit::ImageAnalysisContextMenuActionData> _imageAnalysisContextMenuActionData;
 #endif // ENABLE(IMAGE_ANALYSIS)
     uint32_t _fullscreenVideoImageAnalysisRequestIdentifier;

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -396,4 +396,5 @@ interface UIScriptController {
     readonly attribute unsigned long countOfUpdatesWithLayerChanges;
 
     readonly attribute unsigned long long currentImageAnalysisRequestID;
+    undefined installFakeMachineReadableCodeResultsForImageAnalysis();
 };

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -392,6 +392,7 @@ public:
     // Image Analysis
 
     virtual uint64_t currentImageAnalysisRequestID() const { return 0; }
+    virtual void installFakeMachineReadableCodeResultsForImageAnalysis() { }
 
 protected:
     explicit UIScriptController(UIScriptContext&);

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -423,6 +423,8 @@ public:
 
 #if ENABLE(IMAGE_ANALYSIS)
     static uint64_t currentImageAnalysisRequestID();
+    void installFakeMachineReadableCodeResultsForImageAnalysis();
+    bool shouldUseFakeMachineReadableCodeResultsForImageAnalysis() const;
 #endif
 
 private:
@@ -652,6 +654,10 @@ private:
     RetainPtr<UIPasteboardConsistencyEnforcer> m_pasteboardConsistencyEnforcer;
     RetainPtr<UIKeyboardInputMode> m_overriddenKeyboardInputMode;
     Vector<std::unique_ptr<InstanceMethodSwizzler>> m_presentPopoverSwizzlers;
+#endif
+
+#if ENABLE(IMAGE_ANALYSIS)
+    bool m_useFakeMachineReadableCodeResultsForImageAnalysis { false };
 #endif
 
     enum State {

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h
@@ -83,6 +83,7 @@ private:
 
 #if ENABLE(IMAGE_ANALYSIS)
     uint64_t currentImageAnalysisRequestID() const final;
+    void installFakeMachineReadableCodeResultsForImageAnalysis() final;
 #endif
 
     void setSpellCheckerResults(JSValueRef) final;

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
@@ -311,6 +311,11 @@ uint64_t UIScriptControllerCocoa::currentImageAnalysisRequestID() const
     return TestController::currentImageAnalysisRequestID();
 }
 
+void UIScriptControllerCocoa::installFakeMachineReadableCodeResultsForImageAnalysis()
+{
+    TestController::singleton().installFakeMachineReadableCodeResultsForImageAnalysis();
+}
+
 #endif // ENABLE(IMAGE_ANALYSIS)
 
 void UIScriptControllerCocoa::setSpellCheckerResults(JSValueRef results)


### PR DESCRIPTION
#### 48c8c316241e1519cd2deb1dcdda00788fa629a6
<pre>
[iOS] Image analysis menu items for images with machine-readable codes sometimes fail to appear
<a href="https://bugs.webkit.org/show_bug.cgi?id=265544">https://bugs.webkit.org/show_bug.cgi?id=265544</a>
<a href="https://rdar.apple.com/118540193">rdar://118540193</a>

Reviewed by Megan Gardner.

Our current logic for dynamically inserting image analysis menu items (such as &quot;Look Up&quot; and any
menu items for machine-readable codes) works like this:

1.  We kick off image analysis for machine-readable codes and visual search when the context menu is
    about to be presented. The menu is presented with a hidden placeholder menu item, which
    represents the set of dynamically-inserted image analysis items we might insert in the future.

2.  When the image analysis started by (1) is done, we use `-updateVisibleMenuWithBlock:` on the
    context menu interaction to replace the placeholder item above with the final set of image
    analysis items (only if the WebKit client didn&apos;t remove the placeholder menu item).

However, there&apos;s a subtle race here, where image analysis may complete before the context menu has a
visible menu. In this scenario, the call to `-updateVisibleMenuWithBlock:` returns early without
calling the update block, and we end up missing our only chance to swap out the placeholder item for
the actual image analysis items.

To fix this, we detect the case where our image analysis completes before the menu is visible, and
try again in `-contextMenuInteraction:willDisplayMenuForConfiguration:animator:`, after the menu
is guaranteed to be visible.

Test: fast/events/touch/ios/long-press-on-image-with-machine-readable-code-menu-items.html

* LayoutTests/fast/events/touch/ios/long-press-on-image-with-machine-readable-code-menu-items-expected.txt: Added.
* LayoutTests/fast/events/touch/ios/long-press-on-image-with-machine-readable-code-menu-items.html: Added.

Add a new layout test, along with some additional test infrastructure to exercise this fix.

* LayoutTests/resources/ui-helper.js:

Add a way to simulate MRC menu item results when long-pressing on an image in layout tests, on iOS.

(window.UIHelper.contextMenuItems):
(window.UIHelper.installFakeMachineReadableCodeResultsForImageAnalysis):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _setUpImageAnalysis]):
(-[WKContentView _tearDownImageAnalysis]):
(-[WKContentView imageAnalysisGestureDidBegin:]):

Replace the extant boolean flag `_waitingForDynamicImageAnalysisContextMenuActions` with a tri-state
enum type, `_dynamicImageAnalysisContextMenuState`, which allows us to appropriately deal with the
corner case where image analysis completes before the context menu has any visible items. See above
for more details.

(-[WKContentView _completeImageAnalysisRequestForContextMenu:requestIdentifier:hasTextResults:]):
(-[WKContentView _insertDynamicImageAnalysisContextMenuItemsIfPossible]):

Pull the existing logic for updating visible context menu items to include the dynamically-inserted
image analysis items into a separate helper method, so that we can invoke it after the context menu
is done presenting.

If the update block runs successfully (i.e. the menu is visible), then we transition directly to the
`NotWaiting` state and we&apos;re done. However, if the update block never runs when calling into
`-updateVisibleMenuWithBlock:`, we instead transition to `WaitingForVisibleMenu` and wait until the
menu is done presenting, before trying to perform the update again.

(-[WKContentView placeholderForDynamicallyInsertedImageAnalysisActions]):
(-[WKContentView contextMenuInteraction:willDisplayMenuForConfiguration:animator:]):

Update the menu to include MRC menu items (and other dynamically-inserted image analysis items) if
needed — note that we&apos;ll only perform the update here, in the case where we failed to run the update
block at all, in `-_completeImageAnalysisRequestForContextMenu:requestIdentifier:hasTextResults:`.

* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
(WTR::UIScriptController::installFakeMachineReadableCodeResultsForImageAnalysis):
* Tools/WebKitTestRunner/TestController.h:
* Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm:
(fakeMachineReadableCodeMenuForTesting):
(-[FakeMachineReadableCodeImageAnalysis allLines]):
(-[FakeMachineReadableCodeImageAnalysis hasResultsForAnalysisTypes:]):
(-[FakeMachineReadableCodeImageAnalysis mrcMenu]):

Add a helper class that represents a fake VisionKit image analysis result that contains MRC menu
items (for simplicity, there&apos;s only one hard-coded item titled &quot;QR code&quot;).

(swizzledProcessImageAnalysisRequest):
(WTR::TestController::installFakeMachineReadableCodeResultsForImageAnalysis):
(WTR::TestController::shouldUseFakeMachineReadableCodeResultsForImageAnalysis const):
(WTR::TestController::cocoaResetStateToConsistentValues):
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h:
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm:
(WTR::UIScriptControllerCocoa::installFakeMachineReadableCodeResultsForImageAnalysis):

Canonical link: <a href="https://commits.webkit.org/271317@main">https://commits.webkit.org/271317@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/86ac200a10c78f7b00fb453de35f313396fbf734

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27977 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6615 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29279 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30507 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25519 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28472 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8610 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4006 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/25280 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28244 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5365 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24036 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4622 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4802 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25043 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31196 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25577 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25480 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31065 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4812 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2973 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28875 "Found 1 new API test failure: /WebKitGTK/TestResources:/webkit/WebKitWebView/sync-request-on-max-conns (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6347 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/24811 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6717 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/5257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5298 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->