### PR TITLE
"Async UIKit Interactions" enablement should default to the corresponding system feature flag

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -6660,7 +6660,7 @@ UseAsyncUIKitInteractions:
     WebKitLegacy:
       default: false
     WebKit:
-      default: false
+      default: WebKit::defaultUseAsyncUIKitInteractions()
     WebCore:
       default: false
 

--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.h
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.h
@@ -41,6 +41,7 @@ bool defaultCSSOMViewScrollingAPIEnabled();
 bool defaultShouldPrintBackgrounds();
 bool defaultAlternateFormControlDesignEnabled();
 bool defaultVideoFullscreenRequiresElementFullscreen();
+bool defaultUseAsyncUIKitInteractions();
 #if ENABLE(TEXT_AUTOSIZING)
 bool defaultTextAutosizingUsesIdempotentMode();
 #endif

--- a/Source/WebKit/Shared/ios/WebPreferencesDefaultValuesIOS.mm
+++ b/Source/WebKit/Shared/ios/WebPreferencesDefaultValuesIOS.mm
@@ -28,6 +28,7 @@
 
 #if PLATFORM(IOS_FAMILY)
 
+#import <pal/spi/cocoa/FeatureFlagsSPI.h>
 #import <pal/spi/ios/ManagedConfigurationSPI.h>
 #import <pal/system/ios/Device.h>
 #import <pal/system/ios/UserInterfaceIdiom.h>
@@ -73,6 +74,18 @@ bool defaultMediaSourceEnabled()
 }
 
 #endif
+
+bool defaultUseAsyncUIKitInteractions()
+{
+    static bool enabled = false;
+#if HAVE(UI_ASYNC_TEXT_INTERACTION)
+    static std::once_flag flag;
+    std::call_once(flag, [] {
+        enabled = os_feature_enabled(UIKit, async_text_input);
+    });
+#endif
+    return enabled;
+}
 
 } // namespace WebKit
 

--- a/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
+++ b/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
@@ -354,8 +354,8 @@ def parse_args(args):
             "--no-use-gpu-process", action="store_true", default=False,
             help=("Disable GPU process for DOM rendering.")),
         optparse.make_option(
-            "--use-async-uikit-interactions", action="store_true", default=False,
-            help=("Opt into async UIKit interactions (iOS-family WebKit2 ports only)")),
+            "--no-use-async-uikit-interactions", action="store_true", default=False,
+            help=("Opt out of async UIKit interactions (iOS-family WebKit2 ports only)")),
         optparse.make_option(
             "--prefer-integrated-gpu", action="store_true", default=False,
             help=("Prefer using the lower-power integrated GPU on a dual-GPU system. Note that other running applications and the tests themselves can override this request.")),
@@ -415,12 +415,12 @@ def parse_args(args):
             raise RuntimeError('--accessibility-isolated-tree implicitly sets the result flavor, this should not be overridden')
         options.result_report_flavor = 'accessibility-isolated-tree'
 
-    if options.use_async_uikit_interactions:
+    if options.no_use_async_uikit_interactions:
         host = Host()
         host.initialize_scm()
         if not options.internal_feature:
             options.internal_feature = []
-        options.internal_feature.append('UseAsyncUIKitInteractions')
+        options.internal_feature.append('UseAsyncUIKitInteractions=0')
 
     return options, args
 


### PR DESCRIPTION
#### 94f99d6f5bb3fc5b69116cf0c2297eb3b69b13f5
<pre>
&quot;Async UIKit Interactions&quot; enablement should default to the corresponding system feature flag
<a href="https://bugs.webkit.org/show_bug.cgi?id=265548">https://bugs.webkit.org/show_bug.cgi?id=265548</a>
<a href="https://rdar.apple.com/118945616">rdar://118945616</a>

Reviewed by Megan Gardner and Abrar Rahman Protyasha.

Make the default value of this internal feature flag match the closely-related system feature flag,
`UIKit/async_text_input`.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebKit/Shared/WebPreferencesDefaultValues.h:
* Source/WebKit/Shared/ios/WebPreferencesDefaultValuesIOS.mm:
(WebKit::defaultUseAsyncUIKitInteractions):
* Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py:

Also, adjust the corresponding `run-webkit-tests` argument to make it possible to run layout tests
with the WebKit feature flag off, even if `UIKit/async_text_input` is enabled in the simulator.

(parse_args):

Canonical link: <a href="https://commits.webkit.org/271321@main">https://commits.webkit.org/271321@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c0584e0293d715e7e39d5b32313c6314b46d229

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28010 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6648 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29314 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30540 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25541 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28505 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8646 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4037 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/25301 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28277 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5398 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24061 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4651 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/28169 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/4827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25069 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31229 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/24253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25608 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25502 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31086 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/27143 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/4834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2997 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28899 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6373 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/34636 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6718 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/5277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7487 "Found 4077 new JSC stress test failures: wasm.yaml/wasm/branch-hints/branchHintsSection.js.default-wasm, wasm.yaml/wasm/branch-hints/branchHintsSection.js.wasm-collect-continuously, wasm.yaml/wasm/branch-hints/branchHintsSection.js.wasm-eager, wasm.yaml/wasm/branch-hints/branchHintsSection.js.wasm-eager-jettison, wasm.yaml/wasm/branch-hints/branchHintsSection.js.wasm-no-cjit, wasm.yaml/wasm/branch-hints/branchHintsSection.js.wasm-slow-memory, wasm.yaml/wasm/extended-const-spec-tests/data.wast.js.default-wasm, wasm.yaml/wasm/extended-const-spec-tests/data.wast.js.wasm-collect-continuously, wasm.yaml/wasm/extended-const-spec-tests/data.wast.js.wasm-eager-jettison, wasm.yaml/wasm/extended-const-spec-tests/data.wast.js.wasm-no-cjit ... (failure)") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5327 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->