### PR TITLE
Make setting overridable by defaults

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3986,6 +3986,7 @@ ManageCaptureStatusBarInGPUProcessEnabled:
 ManageWebKitProcessesAsExtensions:
   type: bool
   status: internal
+  defaultsOverridable: true
   humanReadableName: "Manage WebKit processes as extensions"
   humanReadableDescription: "Manage WebKit processes as extensions"
   condition: USE(EXTENSIONKIT)


### PR DESCRIPTION
#### f0d5016081822a9c2342c2be0c4370d7504b49f6
<pre>
Make setting overridable by defaults
<a href="https://bugs.webkit.org/show_bug.cgi?id=265555">https://bugs.webkit.org/show_bug.cgi?id=265555</a>
<a href="https://rdar.apple.com/118951719">rdar://118951719</a>

Reviewed by Brent Fulgham.

Make setting for WebKit process management overridable by defaults.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:

Canonical link: <a href="https://commits.webkit.org/271348@main">https://commits.webkit.org/271348@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba9bb349f65ff40a5c0268865e4652707a024710

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28011 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6649 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29315 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30541 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25542 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8647 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4038 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/25303 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28278 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5397 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24060 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4652 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4826 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25068 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31230 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/24254 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25607 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25501 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31087 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/27144 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4835 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2999 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28900 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6374 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/34637 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6735 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5278 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7488 "Found 4077 new JSC stress test failures: wasm.yaml/wasm/branch-hints/branchHintsSection.js.default-wasm, wasm.yaml/wasm/branch-hints/branchHintsSection.js.wasm-collect-continuously, wasm.yaml/wasm/branch-hints/branchHintsSection.js.wasm-eager, wasm.yaml/wasm/branch-hints/branchHintsSection.js.wasm-eager-jettison, wasm.yaml/wasm/branch-hints/branchHintsSection.js.wasm-no-cjit, wasm.yaml/wasm/branch-hints/branchHintsSection.js.wasm-slow-memory, wasm.yaml/wasm/extended-const-spec-tests/data.wast.js.default-wasm, wasm.yaml/wasm/extended-const-spec-tests/data.wast.js.wasm-collect-continuously, wasm.yaml/wasm/extended-const-spec-tests/data.wast.js.wasm-eager-jettison, wasm.yaml/wasm/extended-const-spec-tests/data.wast.js.wasm-no-cjit ... (failure)") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5328 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->