### PR TITLE
Second div within a rotated and overflow:hidden parent div does not render.

### DIFF
--- a/LayoutTests/compositing/layer-creation/overlap-transformed-clip-expected.html
+++ b/LayoutTests/compositing/layer-creation/overlap-transformed-clip-expected.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+  .container {
+    width: 80px;
+    height: 80px;
+    background-color: green;
+    overflow: hidden;
+  }
+</style>
+</head>
+<body>
+
+<div class="container"></div>
+
+</body>
+</html>
+

--- a/LayoutTests/compositing/layer-creation/overlap-transformed-clip.html
+++ b/LayoutTests/compositing/layer-creation/overlap-transformed-clip.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+  .container {
+    width: 80px;
+    height: 80px;
+    transform: rotateZ(270deg);
+    overflow: hidden;
+  }
+
+  .composited {
+    position: absolute;
+    transform: rotateY(0deg);
+    width: 151px;
+    height: 151px;
+    background-color: red;
+  }
+
+  .overlap {
+    position: absolute;
+    width: 114px;
+    height: 114px;
+    background-color: green;
+  }
+</style>
+</head>
+<body>
+
+<div class="container">
+  <div class="composited"></div>
+  <div class="overlap"></div>
+</div>
+
+</body>
+</html>
+

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -601,6 +601,7 @@ public:
     bool hasAncestorWithFilterOutsets() const;
 
     inline bool canUseOffsetFromAncestor() const;
+    bool canUseOffsetFromAncestor(const RenderLayer& ancestor) const;
 
     // FIXME: adjustForColumns allows us to position compositing layers in columns correctly, but eventually they need to be split across columns too.
     enum ColumnOffsetAdjustment { DontAdjustForColumns, AdjustForColumns };

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -3015,10 +3015,8 @@ static std::optional<bool> intersectsWithAncestor(const RenderLayer& child, cons
 {
     // If any layers between child and ancestor are transformed, then adjusting the offset is
     // insufficient to convert coordinates into ancestor's coordinate space.
-    for (auto* layer = &child; layer != &ancestor; layer = layer->parent()) {
-        if (!layer->canUseOffsetFromAncestor())
+    if (!child.canUseOffsetFromAncestor(ancestor))
             return std::nullopt;
-    }
 
     auto overlap = child.boundingBox(&ancestor, child.offsetFromAncestor(&ancestor), RenderLayer::UseFragmentBoxesExcludingCompositing);
     return overlap.intersects(ancestorCompositedBounds);


### PR DESCRIPTION
#### cc12d007e2e9ea083b66ce8d6cc42b9fd8c9a389
<pre>
Second div within a rotated and overflow:hidden parent div does not render.
<a href="https://bugs.webkit.org/show_bug.cgi?id=265480">https://bugs.webkit.org/show_bug.cgi?id=265480</a>
&lt;<a href="https://rdar.apple.com/118901069">rdar://118901069</a>&gt;

Reviewed by Simon Fraser.

RenderLayerCompositor::addToOverlapMap takes layer overlap bounds in the root coordinate space, computes
the clip in the root coordinate space and intersect them.

RenderLayer::calculateClipRects was only ever applying an offset when converting clips to an ancestor coordinate
space, which is incorrect if there is a non-tranlation transform (like the rotation in the testcase).

The incorrect clip resulted in an empty overlap area, and us drawing the green div into the backing store behind
the composited (3d transformed) div.

This makes calculateClipRects transform the clip quad, not just the top-left point.

* LayoutTests/compositing/layer-creation/overlap-transformed-clip-expected.html: Added.
* LayoutTests/compositing/layer-creation/overlap-transformed-clip.html: Added.
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::intersectsWithAncestor):

Canonical link: <a href="https://commits.webkit.org/271894@main">https://commits.webkit.org/271894@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6cce3f81f00733922261cd1d5d5b4c41d0e008b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29863 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8528 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31179 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32376 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27005 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30521 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10711 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5789 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27080 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30156 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7150 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25478 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6098 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6271 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26566 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33721 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27246 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26991 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32448 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6183 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4374 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30233 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7925 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/26364 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7102 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6931 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6711 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->