### PR TITLE
Use faster alternatives to Vector::resize() when possible

### DIFF
--- a/Source/JavaScriptCore/b3/B3EliminateDeadCode.cpp
+++ b/Source/JavaScriptCore/b3/B3EliminateDeadCode.cpp
@@ -97,7 +97,7 @@ bool eliminateDeadCodeImpl(Procedure& proc)
                 changed = true;
             }
         }
-        block->values().resize(targetIndex);
+        block->values().shrink(targetIndex);
     }
 
     for (Variable* variable : proc.variables()) {

--- a/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
+++ b/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
@@ -3099,7 +3099,7 @@ private:
         cloneValue(m_value);
 
         // Remove the values from the predecessor.
-        predecessor->values().resize(startIndex);
+        predecessor->values().shrink(startIndex);
         
         predecessor->appendNew<Value>(m_proc, Branch, source->origin(), predicate);
         predecessor->setSuccessors(FrequentedBlock(cases[0]), FrequentedBlock(cases[1]));

--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGraphColoring.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGraphColoring.cpp
@@ -75,8 +75,8 @@ public:
             dataLogLn("]");
         }
 
-        m_adjacencyList.resize(tmpArraySize);
-        m_moveList.resize(tmpArraySize);
+        m_adjacencyList.grow(tmpArraySize);
+        m_moveList.grow(tmpArraySize);
         m_isOnSelectStack.ensureSize(tmpArraySize);
         m_spillWorklist.ensureSize(tmpArraySize);
     }

--- a/Source/JavaScriptCore/bytecode/BytecodeDumper.cpp
+++ b/Source/JavaScriptCore/bytecode/BytecodeDumper.cpp
@@ -279,8 +279,7 @@ void CodeBlockBytecodeDumper<Block>::dumpGraph(Block* block, const JSInstruction
 
     out.printf("\n");
 
-    Vector<Vector<unsigned>> predecessors;
-    predecessors.resize(graph.size());
+    Vector<Vector<unsigned>> predecessors(graph.size());
     for (auto& block : graph) {
         if (block.isEntryBlock() || block.isExitBlock())
             continue;

--- a/Source/JavaScriptCore/bytecode/BytecodeGeneratorification.cpp
+++ b/Source/JavaScriptCore/bytecode/BytecodeGeneratorification.cpp
@@ -78,7 +78,7 @@ public:
                 auto bytecode = instruction->as<OpYield>();
                 unsigned liveCalleeLocalsIndex = bytecode.m_yieldPoint;
                 if (liveCalleeLocalsIndex >= m_yields.size())
-                    m_yields.resize(liveCalleeLocalsIndex + 1);
+                    m_yields.grow(liveCalleeLocalsIndex + 1);
                 YieldData& data = m_yields[liveCalleeLocalsIndex];
                 data.point = instruction.offset();
                 data.argument = bytecode.m_argument;
@@ -147,7 +147,7 @@ private:
         // It means that, the register can be retrieved even if the immediate previous op_save does not save it.
 
         if (m_storages.size() <= index)
-            m_storages.resize(index + 1);
+            m_storages.grow(index + 1);
         if (std::optional<Storage> storage = m_storages[index])
             return *storage;
 

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -3682,7 +3682,7 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
         if (isGenerated)
             poly.m_list[dstIndex++] = WTFMove(someCase);
     }
-    poly.m_list.resize(dstIndex);
+    poly.m_list.shrink(dstIndex);
 
     bool generatedMegamorphicCode = false;
 

--- a/Source/JavaScriptCore/dfg/DFGCPSRethreadingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGCPSRethreadingPhase.cpp
@@ -117,7 +117,7 @@ private:
             
             for (unsigned phiIndex = block->phis.size(); phiIndex--;)
                 m_graph.deleteNode(block->phis[phiIndex]);
-            block->phis.resize(0);
+            block->phis.shrink(0);
         }
     }
     

--- a/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
@@ -1562,8 +1562,7 @@ private:
         // Nodes without remaining unmaterialized fields will be
         // materialized first - amongst the remaining unmaterialized
         // nodes
-        Vector<Allocation> toMaterialize;
-        toMaterialize.resize(escapees.size());
+        Vector<Allocation> toMaterialize(escapees.size());
         size_t firstIndex = 0;
         size_t lastIndex = toMaterialize.size();
         auto materializeFirst = [&] (Allocation&& allocation) {

--- a/Source/JavaScriptCore/interpreter/ShadowChicken.cpp
+++ b/Source/JavaScriptCore/interpreter/ShadowChicken.cpp
@@ -213,7 +213,7 @@ void ShadowChicken::update(VM& vm, CallFrame* callFrame)
             }
             break;
         }
-        m_stack.resize(shadowIndex);
+        m_stack.shrink(shadowIndex);
         
         if (ShadowChickenInternal::verbose)
             dataLog("    Revised stack: ", listDump(m_stack), "\n");

--- a/Source/JavaScriptCore/jit/CallFrameShuffleData.cpp
+++ b/Source/JavaScriptCore/jit/CallFrameShuffleData.cpp
@@ -93,7 +93,7 @@ CallFrameShuffleData CallFrameShuffleData::createForBaselineOrLLIntTailCall(cons
     shuffleData.numberTagRegister = GPRInfo::numberTagRegister;
 #endif
     shuffleData.numLocals = bytecode.m_argv - sizeof(CallerFrameAndPC) / sizeof(Register);
-    shuffleData.args.resize(bytecode.m_argc);
+    shuffleData.args.grow(bytecode.m_argc);
     for (unsigned i = 0; i < bytecode.m_argc; ++i) {
         shuffleData.args[i] =
             ValueRecovery::displacedInJSStack(

--- a/Source/JavaScriptCore/jit/CallFrameShuffler.h
+++ b/Source/JavaScriptCore/jit/CallFrameShuffler.h
@@ -110,7 +110,7 @@ public:
         data.numPassedArgs = m_numPassedArgs;
         data.numParameters = m_numParameters;
         data.callee = getNew(VirtualRegister { CallFrameSlot::callee })->recovery();
-        data.args.resize(argCount());
+        data.args.grow(argCount());
         for (size_t i = 0; i < argCount(); ++i)
             data.args[i] = getNew(virtualRegisterForArgumentIncludingThis(i))->recovery();
         for (Reg reg = Reg::first(); reg <= Reg::last(); reg = reg.next()) {

--- a/Source/JavaScriptCore/runtime/ISO8601.cpp
+++ b/Source/JavaScriptCore/runtime/ISO8601.cpp
@@ -1311,7 +1311,7 @@ String formatTimeZoneOffsetString(int64_t offset)
             }
         }
         if (validLength)
-            fraction.resize(validLength.value());
+            fraction.shrink(validLength.value());
         else
             fraction.clear();
         return makeString(negative ? '-' : '+', pad('0', 2, hours), ':', pad('0', 2, minutes), ':', pad('0', 2, seconds), '.', pad('0', paddingLength, emptyString()), fraction);
@@ -1346,7 +1346,7 @@ String temporalTimeToString(PlainTime plainTime, std::tuple<Precision, unsigned>
             }
         }
         if (validLength)
-            fraction.resize(validLength.value());
+            fraction.shrink(validLength.value());
         else
             fraction.clear();
         return makeString(pad('0', 2, plainTime.hour()), ':', pad('0', 2, plainTime.minute()), ':', pad('0', 2, plainTime.second()), '.', pad('0', paddingLength, emptyString()), fraction);

--- a/Source/JavaScriptCore/runtime/IntlObject.cpp
+++ b/Source/JavaScriptCore/runtime/IntlObject.cpp
@@ -1726,7 +1726,7 @@ static JSArray* availableCollations(JSGlobalObject* globalObject)
             return WTF::codePointCompare(a, b) < 0;
         });
     auto end = std::unique(elements.begin(), elements.end());
-    elements.resize(elements.size() - (elements.end() - end));
+    elements.shrink(elements.size() - (elements.end() - end));
 
     RELEASE_AND_RETURN(scope, createArrayFromStringVector(globalObject, WTFMove(elements)));
 }
@@ -1782,7 +1782,7 @@ static JSArray* availableCurrencies(JSGlobalObject* globalObject)
             return WTF::codePointCompare(a, b) < 0;
         });
     auto end = std::unique(elements.begin(), elements.end());
-    elements.resize(elements.size() - (elements.end() - end));
+    elements.shrink(elements.size() - (elements.end() - end));
 
     RELEASE_AND_RETURN(scope, createArrayFromStringVector(globalObject, WTFMove(elements)));
 }

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
@@ -870,7 +870,7 @@ template<typename Adaptor> inline bool JSGenericTypedArrayView<Adaptor>::sort()
     ElementType* originalArray = typedVector();
     ElementType* array = originalArray;
     if (isShared()) {
-        forShared.resize(length);
+        forShared.grow(length);
         WTF::copyElements(forShared.data(), originalArray, length);
         array = forShared.data();
     }

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
@@ -779,10 +779,8 @@ static ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncSortImpl(VM& v
 
     auto* originalArray = thisObject->typedVector();
 
-    Vector<typename ViewClass::ElementType, 16> src;
-    Vector<typename ViewClass::ElementType, 16> dst;
-    src.resize(length);
-    dst.resize(length);
+    Vector<typename ViewClass::ElementType, 16> src(length);
+    Vector<typename ViewClass::ElementType, 16> dst(length);
     WTF::copyElements(src.data(), originalArray, length);
 
     typename ViewClass::ElementType* result = nullptr;

--- a/Source/JavaScriptCore/runtime/ObjectConstructorInlines.h
+++ b/Source/JavaScriptCore/runtime/ObjectConstructorInlines.h
@@ -81,7 +81,7 @@ ALWAYS_INLINE bool objectAssignFast(JSGlobalObject* globalObject, JSObject* targ
     // Do not clear since Vector::clear shrinks the backing store.
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    properties.resize(0);
+    properties.shrink(0);
     values.clear();
 
     if (source->canHaveExistingOwnIndexedGetterSetterProperties())

--- a/Source/JavaScriptCore/runtime/RegExp.cpp
+++ b/Source/JavaScriptCore/runtime/RegExp.cpp
@@ -373,8 +373,7 @@ void RegExp::deleteCode()
 void RegExp::matchCompareWithInterpreter(const String& s, int startOffset, int* offsetVector, int jitResult)
 {
     int offsetVectorSize = (m_numSubpatterns + 1) * 2;
-    Vector<int> interpreterOvector;
-    interpreterOvector.resize(offsetVectorSize);
+    Vector<int> interpreterOvector(offsetVectorSize);
     int* interpreterOffsetVector = interpreterOvector.data();
     int interpreterResult = 0;
     int differences = 0;

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -1275,7 +1275,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncSplitFast, (JSGlobalObject* globalObject
     }
 
     auto& result = vm.stringSplitIndice;
-    result.resize(0);
+    result.shrink(0);
 
     auto cacheAndCreateArray = [&]() -> JSArray* {
         if (result.isEmpty())

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -9884,7 +9884,7 @@ private:
             m_locals[value.asLocal()] = loc;
         else if (value.isTemp()) {
             if (m_temps.size() <= value.asTemp())
-                m_temps.resize(value.asTemp() + 1);
+                m_temps.grow(value.asTemp() + 1);
             m_temps[value.asTemp()] = loc;
         }
 

--- a/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.cpp
@@ -44,27 +44,27 @@ unsigned FunctionIPIntMetadataGenerator::addSignature(const TypeDefinition& sign
 
 void FunctionIPIntMetadataGenerator::addBlankSpace(uint32_t size)
 {
-    m_metadata.resize(m_metadata.size() + size);
+    m_metadata.grow(m_metadata.size() + size);
 }
 
 void FunctionIPIntMetadataGenerator::addRawValue(uint64_t value)
 {
     auto size = m_metadata.size();
-    m_metadata.resize(m_metadata.size() + 8);
+    m_metadata.grow(m_metadata.size() + 8);
     WRITE_TO_METADATA(m_metadata.data() + size, value, uint64_t);
 }
 
 void FunctionIPIntMetadataGenerator::addLength(uint32_t length)
 {
     size_t size = m_metadata.size();
-    m_metadata.resize(size + 1);
+    m_metadata.grow(size + 1);
     WRITE_TO_METADATA(m_metadata.data() + size, length, uint8_t);
 }
 
 void FunctionIPIntMetadataGenerator::addLEB128ConstantInt32AndLength(uint32_t value, uint32_t length)
 {
     size_t size = m_metadata.size();
-    m_metadata.resize(size + 5);
+    m_metadata.grow(size + 5);
     WRITE_TO_METADATA(m_metadata.data() + size, length, uint8_t);
     WRITE_TO_METADATA(m_metadata.data() + size + 1, value, uint32_t);
 }
@@ -73,10 +73,10 @@ void FunctionIPIntMetadataGenerator::addCondensedLocalIndexAndLength(uint32_t in
 {
     size_t size = m_metadata.size();
     if (length == 2) {
-        m_metadata.resize(size + 1);
+        m_metadata.grow(size + 1);
         WRITE_TO_METADATA(m_metadata.data() + size, 0, uint8_t);
     } else {
-        m_metadata.resize(size + 5);
+        m_metadata.grow(size + 5);
         WRITE_TO_METADATA(m_metadata.data() + size, length, uint8_t);
         WRITE_TO_METADATA(m_metadata.data() + size + 1, index, uint32_t);
     }
@@ -87,21 +87,21 @@ void FunctionIPIntMetadataGenerator::addLEB128ConstantAndLengthForType(Type type
     if (type.isI32()) {
         size_t size = m_metadata.size();
         if (length == 2) {
-            m_metadata.resize(size + 1);
+            m_metadata.grow(size + 1);
             WRITE_TO_METADATA(m_metadata.data() + size, (value >> 7) & 1, uint8_t);
         } else {
-            m_metadata.resize(size + 5);
+            m_metadata.grow(size + 5);
             WRITE_TO_METADATA(m_metadata.data() + size, static_cast<uint8_t>(length), uint8_t);
             WRITE_TO_METADATA(m_metadata.data() + size + 1, static_cast<uint32_t>(value), uint32_t);
         }
     } else if (type.isI64()) {
         size_t size = m_metadata.size();
-        m_metadata.resize(size + 9);
+        m_metadata.grow(size + 9);
         WRITE_TO_METADATA(m_metadata.data() + size, static_cast<uint8_t>(length), uint8_t);
         WRITE_TO_METADATA(m_metadata.data() + size + 1, static_cast<uint64_t>(value), uint64_t);
     }  else if (type.isFuncref()) {
         size_t size = m_metadata.size();
-        m_metadata.resize(size + 5);
+        m_metadata.grow(size + 5);
         WRITE_TO_METADATA(m_metadata.data() + size, static_cast<uint8_t>(length), uint8_t);
         WRITE_TO_METADATA(m_metadata.data() + size + 1, static_cast<uint32_t>(value), uint32_t);
     } else if (!type.isF32() && !type.isF64())
@@ -111,7 +111,7 @@ void FunctionIPIntMetadataGenerator::addLEB128ConstantAndLengthForType(Type type
 void FunctionIPIntMetadataGenerator::addLEB128V128Constant(v128_t value, uint32_t length)
 {
     size_t size = m_metadata.size();
-    m_metadata.resize(size + 17);
+    m_metadata.grow(size + 17);
     WRITE_TO_METADATA(m_metadata.data() + size, static_cast<uint8_t>(length), uint8_t);
     WRITE_TO_METADATA(m_metadata.data() + size + 1, value, v128_t);
 }

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -2086,7 +2086,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             Vector<ExpressionType> args;
             size_t firstArgumentIndex = m_expressionStack.size() - argc;
             WASM_PARSER_FAIL_IF(!args.tryReserveInitialCapacity(argc), "can't allocate enough memory for array.new_fixed ", argc, " values");
-            args.resize(argc);
+            args.grow(argc);
 
             // Start parsing arguments; the expected type for each one is the unpacked version of the array element type
             for (size_t i = 0; i < argc; ++i) {
@@ -2293,7 +2293,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             Vector<ExpressionType> args;
             size_t firstArgumentIndex = m_expressionStack.size() - structType->fieldCount();
             WASM_PARSER_FAIL_IF(!args.tryReserveInitialCapacity(structType->fieldCount()), "can't allocate enough memory for struct.new ", structType->fieldCount(), " values");
-            args.resize(structType->fieldCount());
+            args.grow(structType->fieldCount());
 
             for (size_t i = 0; i < structType->fieldCount(); ++i) {
                 TypedExpression arg = m_expressionStack.at(m_expressionStack.size() - i - 1);
@@ -2659,7 +2659,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         size_t firstArgumentIndex = m_expressionStack.size() - calleeSignature.argumentCount();
         Vector<ExpressionType> args;
         WASM_PARSER_FAIL_IF(!args.tryReserveInitialCapacity(calleeSignature.argumentCount()), "can't allocate enough memory for call's ", calleeSignature.argumentCount(), " arguments");
-        args.resize(calleeSignature.argumentCount());
+        args.grow(calleeSignature.argumentCount());
         for (size_t i = 0; i < calleeSignature.argumentCount(); ++i) {
             size_t stackIndex = m_expressionStack.size() - i - 1;
             TypedExpression arg = m_expressionStack.at(stackIndex);
@@ -2728,7 +2728,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
         Vector<ExpressionType> args;
         WASM_PARSER_FAIL_IF(!args.tryReserveInitialCapacity(argumentCount), "can't allocate enough memory for ", argumentCount, " call_indirect arguments");
-        args.resize(argumentCount);
+        args.grow(argumentCount);
         size_t firstArgumentIndex = m_expressionStack.size() - argumentCount;
         for (size_t i = 0; i < argumentCount; ++i) {
             size_t stackIndex = m_expressionStack.size() - i - 1;
@@ -2793,7 +2793,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
         Vector<ExpressionType> args;
         WASM_PARSER_FAIL_IF(!args.tryReserveInitialCapacity(argumentCount), "can't allocate enough memory for ", argumentCount, " call_indirect arguments");
-        args.resize(argumentCount);
+        args.grow(argumentCount);
         size_t firstArgumentIndex = m_expressionStack.size() - argumentCount;
         for (size_t i = 0; i < argumentCount; ++i) {
             size_t stackIndex = m_expressionStack.size() - i - 1;
@@ -3008,7 +3008,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         unsigned offset = m_expressionStack.size() - exceptionSignature.argumentCount();
         Vector<ExpressionType> args;
         WASM_PARSER_FAIL_IF(!args.tryReserveInitialCapacity(exceptionSignature.argumentCount()), "can't allocate enough memory for throw's ", exceptionSignature.argumentCount(), " arguments");
-        args.resize(exceptionSignature.argumentCount());
+        args.grow(exceptionSignature.argumentCount());
         for (unsigned i = 0; i < exceptionSignature.argumentCount(); ++i) {
             TypedExpression arg = m_expressionStack.at(m_expressionStack.size() - i - 1);
             WASM_VALIDATOR_FAIL_IF(arg.type() != exceptionSignature.argumentType(exceptionSignature.argumentCount() - i - 1), "The exception being thrown expects the argument at index ", i, " to be ", exceptionSignature.argumentType(exceptionSignature.argumentCount() - i - 1), " but argument has type ", arg.type());

--- a/Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp
@@ -626,7 +626,7 @@ std::unique_ptr<FunctionCodeBlockGenerator> LLIntGenerator::finalize()
     Buffer usedBuffer;
     m_codeBlock->setInstructions(m_writer.finalize(usedBuffer));
     size_t oldCapacity = usedBuffer.capacity();
-    usedBuffer.resize(0);
+    usedBuffer.shrink(0);
     RELEASE_ASSERT(usedBuffer.capacity() == oldCapacity);
     *threadSpecific = WTFMove(usedBuffer);
 

--- a/Source/WTF/wtf/Liveness.h
+++ b/Source/WTF/wtf/Liveness.h
@@ -338,7 +338,7 @@ protected:
                             liveAtTail.begin(), liveAtTail.end(),
                             m_workset.begin(), m_workset.end(),
                             mergeBuffer.begin());
-                        mergeBuffer.resize(iter - mergeBuffer.begin());
+                        mergeBuffer.shrink(iter - mergeBuffer.begin());
                         
                         if (mergeBuffer.size() == liveAtTail.size())
                             continue;

--- a/Source/WTF/wtf/NativePromise.h
+++ b/Source/WTF/wtf/NativePromise.h
@@ -546,7 +546,7 @@ private:
         {
             ASSERT(dependentPromisesCount);
             if constexpr (!std::is_void_v<ResolveValueT>)
-                m_resolveValues.resize(dependentPromisesCount);
+                m_resolveValues.grow(dependentPromisesCount);
         }
 
         template<typename ResolveValueType_>
@@ -609,7 +609,7 @@ private:
             , m_outstandingPromises(dependentPromisesCount)
         {
             ASSERT(dependentPromisesCount);
-            m_results.resize(dependentPromisesCount);
+            m_results.grow(dependentPromisesCount);
         }
 
         void settle(size_t index, ResultParam result)

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -624,7 +624,7 @@ inline StringView::UpconvertedCharacters::UpconvertedCharacters(StringView strin
     }
     const LChar* characters8 = string.characters8();
     unsigned length = string.m_length;
-    m_upconvertedCharacters.resize(length);
+    m_upconvertedCharacters.grow(length);
     StringImpl::copyCharacters(m_upconvertedCharacters.data(), characters8, length);
     m_characters = m_upconvertedCharacters.data();
 }


### PR DESCRIPTION
#### 26626e84d8b3a6247cf57bc28be26d0ff4750291
<pre>
Use faster alternatives to Vector::resize() when possible
<a href="https://bugs.webkit.org/show_bug.cgi?id=265423">https://bugs.webkit.org/show_bug.cgi?id=265423</a>

Reviewed by NOBODY (OOPS!).

Use faster alternatives to Vector::resize() when possible. It involves calling
directly Vector::shrink(), Vector::grow() or a Vector constructor.

* Source/JavaScriptCore/b3/B3EliminateDeadCode.cpp:
(JSC::B3::eliminateDeadCodeImpl):
* Source/JavaScriptCore/b3/B3ReduceStrength.cpp:
* Source/JavaScriptCore/b3/air/AirAllocateRegistersByGraphColoring.cpp:
* Source/JavaScriptCore/bytecode/BytecodeDumper.cpp:
(JSC::CodeBlockBytecodeDumper&lt;Block&gt;::dumpGraph):
* Source/JavaScriptCore/bytecode/BytecodeGeneratorification.cpp:
(JSC::BytecodeGeneratorification::BytecodeGeneratorification):
(JSC::BytecodeGeneratorification::storageForGeneratorLocal):
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheCompiler::regenerate):
* Source/JavaScriptCore/dfg/DFGCPSRethreadingPhase.cpp:
(JSC::DFG::CPSRethreadingPhase::freeUnnecessaryNodes):
* Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp:
* Source/JavaScriptCore/interpreter/ShadowChicken.cpp:
(JSC::ShadowChicken::update):
* Source/JavaScriptCore/jit/CallFrameShuffleData.cpp:
(JSC::CallFrameShuffleData::createForBaselineOrLLIntTailCall):
* Source/JavaScriptCore/jit/CallFrameShuffler.h:
(JSC::CallFrameShuffler::snapshot const):
* Source/JavaScriptCore/runtime/ISO8601.cpp:
(JSC::ISO8601::formatTimeZoneOffsetString):
(JSC::ISO8601::temporalTimeToString):
* Source/JavaScriptCore/runtime/IntlObject.cpp:
(JSC::availableCollations):
(JSC::availableCurrencies):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h:
(JSC::JSGenericTypedArrayView&lt;Adaptor&gt;::sort):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h:
(JSC::genericTypedArrayViewProtoFuncSortImpl):
* Source/JavaScriptCore/runtime/ObjectConstructorInlines.h:
(JSC::objectAssignFast):
* Source/JavaScriptCore/runtime/RegExp.cpp:
(JSC::RegExp::matchCompareWithInterpreter):
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJIT::bind):
* Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.cpp:
(JSC::Wasm::FunctionIPIntMetadataGenerator::addBlankSpace):
(JSC::Wasm::FunctionIPIntMetadataGenerator::addRawValue):
(JSC::Wasm::FunctionIPIntMetadataGenerator::addLength):
(JSC::Wasm::FunctionIPIntMetadataGenerator::addLEB128ConstantInt32AndLength):
(JSC::Wasm::FunctionIPIntMetadataGenerator::addCondensedLocalIndexAndLength):
(JSC::Wasm::FunctionIPIntMetadataGenerator::addLEB128ConstantAndLengthForType):
(JSC::Wasm::FunctionIPIntMetadataGenerator::addLEB128V128Constant):
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseExpression):
* Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp:
(JSC::Wasm::LLIntGenerator::finalize):
* Source/WTF/wtf/Liveness.h:
(WTF::Liveness::compute):
* Source/WTF/wtf/NativePromise.h:
* Source/WTF/wtf/text/StringView.h:
(WTF::StringView::UpconvertedCharacters::UpconvertedCharacters):
* Source/WebCore/Modules/compression/CompressionStreamEncoder.cpp:
(WebCore::CompressionStreamEncoder::compress):
* Source/WebCore/Modules/compression/DecompressionStreamDecoder.cpp:
(WebCore::DecompressionStreamDecoder::decompressZlib):
(WebCore::DecompressionStreamDecoder::decompressAppleCompressionFramework):
* Source/WebCore/Modules/fetch/FetchHeaders.cpp:
(WebCore::FetchHeaders::Iterator::next):
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformer.cpp:
(WebCore::RTCRtpSFrameTransformer::encryptFrame):
* Source/WebCore/Modules/mediastream/SFrameUtils.cpp:
(WebCore::computeH264PrefixBuffer):
* Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp:
(WebCore::AudioWorkletNode::AudioWorkletNode):
* Source/WebCore/PAL/pal/crypto/commoncrypto/CryptoDigestCommonCrypto.cpp:
(PAL::CryptoDigest::computeHash):
* Source/WebCore/contentextensions/DFABytecodeCompiler.cpp:
(WebCore::ContentExtensions::DFABytecodeCompiler::compile):
* Source/WebCore/contentextensions/NFAToDFA.cpp:
(WebCore::ContentExtensions::resolveEpsilonClosures):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::initializeContextState):
* Source/WebCore/html/canvas/WebGLTransformFeedback.cpp:
(WebCore::WebGLTransformFeedback::WebGLTransformFeedback):
* Source/WebCore/html/canvas/WebGLVertexArrayObjectBase.cpp:
(WebCore::WebGLVertexArrayObjectBase::WebGLVertexArrayObjectBase):
* Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp:
(WebCore::HTMLFastPathParser::scanEscapedText):
(WebCore::HTMLFastPathParser::scanTagName):
(WebCore::HTMLFastPathParser::scanAttributeName):
(WebCore::HTMLFastPathParser::scanEscapedAttributeValue):
(WebCore::HTMLFastPathParser::parseAttributes):
* Source/WebCore/layout/formattingContexts/flex/FlexLayout.cpp:
(WebCore::Layout::FlexLayout::computeMainSizeForFlexItems const):
* Source/WebCore/platform/audio/Biquad.cpp:
(WebCore::Biquad::Biquad):
* Source/WebCore/platform/audio/ReverbConvolverStage.cpp:
(WebCore::ReverbConvolverStage::ReverbConvolverStage):
* Source/WebCore/platform/graphics/FloatPolygon.cpp:
(WebCore::FloatPolygon::FloatPolygon):
* Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp:
* Source/WebCore/platform/graphics/opentype/OpenTypeUtilities.cpp:
(WebCore::EOTHeader::EOTHeader):
(WebCore::EOTHeader::appendBigEndianString):
* Source/WebCore/platform/image-decoders/bmp/BMPImageReader.cpp:
(WebCore::BMPImageReader::processColorTable):
* Source/WebCore/platform/image-decoders/jpegxl/JPEGXLImageDecoder.cpp:
(WebCore::JPEGXLImageDecoder::processInput):
* Source/WebCore/platform/mediarecorder/cocoa/AudioSampleBufferCompressor.mm:
(WebCore::AudioSampleBufferCompressor::initAudioConverterForSourceFormatDescription):
(WebCore::AudioSampleBufferCompressor::sampleBufferWithNumPackets):
(WebCore::AudioSampleBufferCompressor::provideSourceDataNumOutputPackets):
* Source/WebCore/rendering/GridMasonryLayout.cpp:
(WebCore::GridMasonryLayout::collectMasonryItems):
* Source/WebCore/rendering/RenderTableSection.cpp:
(WebCore::RenderTableSection::removeRedundantColumns):
* Source/WebCore/rendering/shapes/RasterShape.cpp:
(WebCore::MarginIntervalGenerator::MarginIntervalGenerator):
* Source/WebCore/rendering/shapes/RasterShape.h:
(WebCore::RasterShapeIntervals::RasterShapeIntervals):
* Source/WebDriver/socket/HTTPParser.cpp:
(WebDriver::HTTPParser::abortProcess):
* Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp:
(WebKit::NetworkNotificationManager::NetworkNotificationManager):
* Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm:
(WebKit::fileContents):
* Source/WebKit/UIProcess/Gamepad/UIGamepad.cpp:
(WebKit::UIGamepad::UIGamepad):
* Source/WebKit/UIProcess/UserMediaProcessManager.cpp:
(WebKit::UserMediaProcessManager::willCreateMediaStream):
* Source/WebKit/UIProcess/mac/WKTextFinderClient.mm:
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::prepareBuffersForDisplay):
* Source/WebKit/WebProcess/Gamepad/WebGamepad.cpp:
(WebKit::WebGamepad::WebGamepad):
* Source/WebKit/WebProcess/Gamepad/WebGamepadProvider.cpp:
(WebKit::WebGamepadProvider::gamepadConnected):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62e495586d642f221959a3e304cc6f9df3ee42c5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28127 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6768 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29481 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30656 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25636 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8787 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4152 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/25618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28395 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5525 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24207 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4780 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4939 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25199 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31345 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/24340 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25732 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25630 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31251 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/27242 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4929 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3099 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29008 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6474 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/34748 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5366 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7530 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5433 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->