### PR TITLE
[run-webkit-tests] Include test configuration in full_results.json

### DIFF
--- a/Tools/Scripts/webkitpy/layout_tests/models/test_run_results.py
+++ b/Tools/Scripts/webkitpy/layout_tests/models/test_run_results.py
@@ -32,9 +32,7 @@ import logging
 import signal
 
 from webkitpy.common.iteration_compatibility import iteritems
-from webkitpy.layout_tests.models import test_expectations
-from webkitpy.layout_tests.models import test_failures
-
+from webkitpy.layout_tests.models import test_expectations, test_failures
 
 _log = logging.getLogger(__name__)
 
@@ -390,6 +388,12 @@ def summarize_results(port_obj, expectations_by_type, initial_results, retry_res
     results['pixel_tests_enabled'] = port_obj.get_option('pixel_tests')
     results['other_crashes'] = other_crashes_dict
     results['date'] = datetime.datetime.now().strftime("%I:%M%p on %B %d, %Y")
+    results['port_name'] = port_obj.name()
+    results['test_configuration'] = dict(port_obj.test_configuration().items())
+    results['baseline_search_path'] = [
+        port_obj.host.filesystem.relpath(p, port_obj.layout_tests_dir())
+        for p in port_obj.baseline_search_path()
+    ]
 
     try:
         # We only use the svn revision for using trac links in the results.html file,

--- a/Tools/Scripts/webkitpy/layout_tests/models/test_run_results_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/models/test_run_results_unittest.py
@@ -183,3 +183,16 @@ class SummarizedResultsTest(unittest.TestCase):
         self.port._options.builder_name = 'dummy builder'
         summary = summarized_results(self.port, expected=False, passing=True, flaky=False, include_passes=True)
         self.assertEqual(summary['tests']['failures']['expected']['leak.html']['expected'], 'PASS')
+
+    def test_summarized_run_metadata(self):
+        self.port._options.builder_name = 'dummy builder'
+        summary = summarized_results(self.port, expected=False, passing=True, flaky=False, include_passes=True)
+        self.assertEqual(summary['port_name'], 'test-mac-leopard')
+        self.assertEqual(
+            summary['test_configuration'],
+            {'version': 'leopard', 'architecture': 'x86', 'build_type': 'release'},
+        )
+        self.assertEqual(
+            summary['baseline_search_path'],
+            ['platform/test-mac-leopard', 'platform/test-mac-snowleopard'],
+        )


### PR DESCRIPTION
#### 647c89210b17d2f0e009bf51737077879c19c769
<pre>
[run-webkit-tests] Include test configuration in full_results.json
<a href="https://bugs.webkit.org/show_bug.cgi?id=265491">https://bugs.webkit.org/show_bug.cgi?id=265491</a>

Reviewed by Jonathan Bedard.

It&apos;s often useful to be able to determine what we were actually running
when looking at results, especially for scripts such as
update-test-expectations-from-bugzilla (which currently guessing the
port based on the bot name).

To acheieve this, add a small amount of metadata to full_results.json
about the run.

Pedantically, this doesn&apos;t suffice as we might run tests in a variety of
different configurations (e.g., we might run some on an iPhone and some
on an iPad), but this is relatively rare, and we don&apos;t believe this will
often cause problems.

* Tools/Scripts/webkitpy/layout_tests/models/test_run_results.py:
(summarize_results):
* Tools/Scripts/webkitpy/layout_tests/models/test_run_results_unittest.py:
(SummarizedResultsTest.test_summarized_results_world_leaks_disabled):
(SummarizedResultsTest):
(SummarizedResultsTest.test_summarized_run_metadata):

Canonical link: <a href="https://commits.webkit.org/271396@main">https://commits.webkit.org/271396@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d76f4cc5e88e77e33fd3ee609e23a2e61f0c31d1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28019 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6658 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29324 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30550 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25546 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28515 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8656 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4046 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/25306 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28286 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5403 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24063 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4657 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/28178 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4829 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25071 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31239 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25613 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25504 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31096 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4839 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3006 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28905 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6380 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5282 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3649 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5334 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->