### PR TITLE
Sync 'SVGFESpecularLightingElement' with WebIDL Specification

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/idlharness.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/idlharness.any-expected.txt
@@ -437,8 +437,8 @@ PASS SVGFESpecularLightingElement interface: attribute in1
 PASS SVGFESpecularLightingElement interface: attribute surfaceScale
 PASS SVGFESpecularLightingElement interface: attribute specularConstant
 PASS SVGFESpecularLightingElement interface: attribute specularExponent
-FAIL SVGFESpecularLightingElement interface: attribute kernelUnitLengthX assert_true: The prototype object must have a property "kernelUnitLengthX" expected true got false
-FAIL SVGFESpecularLightingElement interface: attribute kernelUnitLengthY assert_true: The prototype object must have a property "kernelUnitLengthY" expected true got false
+PASS SVGFESpecularLightingElement interface: attribute kernelUnitLengthX
+PASS SVGFESpecularLightingElement interface: attribute kernelUnitLengthY
 PASS SVGFESpecularLightingElement interface: attribute x
 PASS SVGFESpecularLightingElement interface: attribute y
 PASS SVGFESpecularLightingElement interface: attribute width

--- a/Source/WebCore/svg/SVGFESpecularLightingElement.idl
+++ b/Source/WebCore/svg/SVGFESpecularLightingElement.idl
@@ -23,6 +23,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
+// https://drafts.fxtf.org/filter-effects/#InterfaceSVGFESpecularLightingElement
+
 [
     Exposed=Window
 ] interface SVGFESpecularLightingElement : SVGElement {
@@ -30,6 +32,8 @@
     readonly attribute SVGAnimatedNumber surfaceScale;
     readonly attribute SVGAnimatedNumber specularConstant;
     readonly attribute SVGAnimatedNumber specularExponent;
+    readonly attribute SVGAnimatedNumber kernelUnitLengthX;
+    readonly attribute SVGAnimatedNumber kernelUnitLengthY;
 };
 
 SVGFESpecularLightingElement includes SVGFilterPrimitiveStandardAttributes;


### PR DESCRIPTION
#### 1531d41a4ef64103835343c7ca448db7defee9de
<pre>
Sync &apos;SVGFESpecularLightingElement&apos; with WebIDL Specification

<a href="https://bugs.webkit.org/show_bug.cgi?id=265019">https://bugs.webkit.org/show_bug.cgi?id=265019</a>
<a href="https://rdar.apple.com/problem/118768259">rdar://problem/118768259</a>

Reviewed by Said Abou-Hallawa.

This patch is to align WebKit with Gecko / Firefox, Blink / Chromium and Web-Specification [1]:

[1] <a href="https://drafts.fxtf.org/filter-effects/#InterfaceSVGFESpecularLightingElement">https://drafts.fxtf.org/filter-effects/#InterfaceSVGFESpecularLightingElement</a>

This patch adds missing &apos;kernelUnitLengthX&apos; and &apos;kernelUnitLengthY&apos; in IDL file.

* Source/WebCore/svg/SVGFESpecularLightingElement.idl:
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/idlharness.any-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/271329@main">https://commits.webkit.org/271329@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/838ecbc5883c120ee5dcad46ea1fc8124f4b6f71

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28021 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6660 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29326 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30552 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25548 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28517 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8658 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4048 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/25308 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28288 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5404 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24068 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4660 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4830 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25076 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31241 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25614 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25509 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31129 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4841 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3007 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28906 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6382 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6723 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5284 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5336 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->