### PR TITLE
REGRESSION (271261@main): Some tests in inspector/layers are flaky failures.

### DIFF
--- a/LayoutTests/inspector/layers/layers-blending-compositing-reasons.html
+++ b/LayoutTests/inspector/layers/layers-blending-compositing-reasons.html
@@ -10,7 +10,7 @@ function test()
  
     InspectorProtocol.eventHandler["DOM.setChildNodes"] = setChildNodes;
 
-    enableLayerTreeAgent();
+    requestAnimationFrame(() => setTimeout(enableLayerTreeAgent, 0));
     
     function enableLayerTreeAgent(result)
     {

--- a/LayoutTests/inspector/layers/layers-compositing-reasons.html
+++ b/LayoutTests/inspector/layers/layers-compositing-reasons.html
@@ -10,7 +10,7 @@ function test()
  
     InspectorProtocol.eventHandler["DOM.setChildNodes"] = setChildNodes;
 
-    enableLayerTreeAgent();
+    requestAnimationFrame(() => setTimeout(enableLayerTreeAgent, 0));
     
     function enableLayerTreeAgent(result)
     {

--- a/LayoutTests/inspector/layers/layers-for-node.html
+++ b/LayoutTests/inspector/layers/layers-for-node.html
@@ -9,7 +9,7 @@ function addCompositedLayer()
     element.className = "composited";
     element.id = "last-element";
     document.body.appendChild(element);
-    return new Promise(resolve => requestAnimationFrame(resolve));
+    return new Promise(resolve => requestAnimationFrame(() => setTimeout(resolve, 0)));
 };
 
 function test()
@@ -17,14 +17,17 @@ function test()
     let documentNode;
     let initialLayers;
 
-    step({
-        name: "Enable the LayerTree agent",
-        command: "LayerTree.enable",
-        parameters: {},
-        callback: () => {}
-    });
+    requestAnimationFrame(() => setTimeout(enableLayerTreeAgent, 0));
 
-    InspectorProtocol.awaitEvent({event: "LayerTree.layerTreeDidChange"}).then(getDocument);
+    function enableLayerTreeAgent(result)
+    {
+	step({
+	    name: "Enable the LayerTree agent",
+	    command: "LayerTree.enable",
+	    parameters: {},
+	    callback: getDocument
+	});
+    };
 
     function getDocument()
     {

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2718,5 +2718,3 @@ imported/w3c/web-platform-tests/css/css-backgrounds/background-size/background-s
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-timeline-snapshotting.html [ Skip ]
 
 fast/css/transform-function-perspective-crash.html [ Failure ]
-
-webkit.org/b/265535 inspector/layers/layers-for-node.html [ Pass Timeout ]

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2606,7 +2606,3 @@ webkit.org/b/264177 requestidlecallback/requestidlecallback-deadline-shortened-b
 webkit.org/b/264527 imported/w3c/web-platform-tests/css/css-cascade/idlharness.html [ Pass Failure ]
 
 webkit.org/b/264607 [ Sonoma+ ] css1/box_properties/acid_test.html [ Pass Timeout ]
-
-# webkit.org/b/265536 ([ macOS ] 2 tests in inspector/layers are flaky failures)
-inspector/layers/layers-compositing-reasons.html [ Pass Failure ]
-inspector/layers/layers-blending-compositing-reasons.html [ Pass Failure ]


### PR DESCRIPTION
#### 8df321e4ca5415ec0a39f8e25d8ea16fa6878527
<pre>
REGRESSION (271261@main): Some tests in inspector/layers are flaky failures.
<a href="https://bugs.webkit.org/show_bug.cgi?id=265536">https://bugs.webkit.org/show_bug.cgi?id=265536</a>
&lt;<a href="https://rdar.apple.com/118943342">rdar://118943342</a>&gt;

Reviewed by NOBODY (OOPS!).

These inspector tests are querying the layer tree state during DOMContentLoaded and expecting compositing
decisions to have been made.

This adds a delay until afer the first paint before checking the layers.

* LayoutTests/inspector/layers/layers-blending-compositing-reasons.html:
* LayoutTests/inspector/layers/layers-compositing-reasons.html:
* LayoutTests/inspector/layers/layers-for-node.html:
* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8df321e4ca5415ec0a39f8e25d8ea16fa6878527

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28023 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6662 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29329 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30554 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25550 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8661 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4050 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/25310 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28290 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5409 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24073 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4661 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4834 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25081 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31243 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25619 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25515 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31134 "Found 1 new test failure: inspector/layers/layers-for-node.html (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4843 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3008 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28908 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6384 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/24857 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5286 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5338 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->