### PR TITLE
Add a script to count places we skip code on site isolated frames

### DIFF
--- a/Tools/Scripts/count-skipped-out-of-process-frames
+++ b/Tools/Scripts/count-skipped-out-of-process-frames
@@ -1,0 +1,23 @@
+#!/bin/sh
+#
+# This script scans Source/WebCore and Source/WebKit/WebProcess for places where we are likely skipping code on out-of-process frames and provides a count.
+#
+
+count_occurrences() {
+    local pattern=$1
+    local flag=$2
+    grep "$flag" "$pattern" "$(dirname "$0")/../../Source/WebCore" "$(dirname "$0")/../../Source/WebKit/WebProcess" | wc -l | xargs
+}
+
+downcastLocalFrame=$(count_occurrences "[dD]owncast<\(WebCore::\)\?LocalFrame>" "-r")
+downcastLocalFrameView=$(count_occurrences "[dD]owncast<\(WebCore::\)\?LocalFrameView>" "-r")
+topDocument=$(count_occurrences "topDocument()" "-r")
+parentDocument=$(count_occurrences "parentDocument()" "-r")
+
+echo "Downcast LocalFrame remaining: $downcastLocalFrame"
+echo "Downcast LocalFrameView remaining: $downcastLocalFrameView"
+echo "topDocument() remaining: $topDocument"
+echo "parentDocument() remaining: $parentDocument"
+
+sum=$((downcastLocalFrame + downcastLocalFrameView + topDocument + parentDocument))
+echo "Total skipped out-of-process frames remaining: $sum"


### PR DESCRIPTION
#### 6f33b373c53add3b802ca2aaaed558db3bd7f466
<pre>
Add a script to count places we skip code on site isolated frames
<a href="https://bugs.webkit.org/show_bug.cgi?id=265558">https://bugs.webkit.org/show_bug.cgi?id=265558</a>
<a href="https://rdar.apple.com/118958958">rdar://118958958</a>

Reviewed by Alex Christensen.

This probably isn&apos;t comprehensive, and some of these may not need fixing, but it provides a rough estimate
we can use to track our progress.

Similar to `count-handwritten-cocoa-decoders`.

* Tools/Scripts/count-skipped-out-of-process-frames: Added.

Canonical link: <a href="https://commits.webkit.org/271316@main">https://commits.webkit.org/271316@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d5ae1a61c71e1787f8ea8f521f5d3b0f1469131d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/28037 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/6676 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/29344 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/30567 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/25559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/28533 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/8673 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/4064 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/30567 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/28304 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/8673 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/29344 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/30567 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/8673 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/29344 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/31256 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/8673 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/29344 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/31256 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/4852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/4064 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/31256 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/6393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/29344 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/5294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3620 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/5348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->