### PR TITLE
REGRESSION (269598@main?): [ macOS Debug ] ASSERTION FAILED: m_networkProcessToKeepAliveUntilDataStoreIsCreated == networkProcess.ptr() in TestWebKitAPI.WKWebsiteDataStoreConfiguration.TotalQuotaRatio result of constant crash

### DIFF
--- a/Source/WebKit/Shared/Cocoa/XPCEndpointClient.mm
+++ b/Source/WebKit/Shared/Cocoa/XPCEndpointClient.mm
@@ -26,6 +26,7 @@
 #import "config.h"
 #import "XPCEndpointClient.h"
 
+#import "Logging.h"
 #import <wtf/cocoa/Entitlements.h>
 #import <wtf/spi/darwin/XPCSPI.h>
 #import <wtf/text/ASCIILiteral.h>
@@ -46,7 +47,7 @@ void XPCEndpointClient::setEndpoint(xpc_endpoint_t endpoint)
         xpc_connection_set_event_handler(m_connection.get(), ^(xpc_object_t message) {
             xpc_type_t type = xpc_get_type(message);
             if (type == XPC_TYPE_ERROR) {
-                if (message == XPC_ERROR_CONNECTION_INVALID || message == XPC_ERROR_TERMINATION_IMMINENT) {
+                if (message == XPC_ERROR_CONNECTION_INVALID || message == XPC_ERROR_TERMINATION_IMMINENT || XPC_ERROR_CONNECTION_INTERRUPTED) {
                     Locker locker { m_connectionLock };
                     m_connection = nullptr;
                 }

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -691,9 +691,6 @@ private:
 
     VisibleWebPageCounter m_visiblePageCounter;
     RefPtr<WebsiteDataStore> m_websiteDataStore;
-#if PLATFORM(COCOA)
-    RefPtr<NetworkProcessProxy> m_networkProcessToKeepAliveUntilDataStoreIsCreated;
-#endif
 
     bool m_isUnderMemoryPressure { false };
 


### PR DESCRIPTION
#### b2ed5aecee27ad7088dc72a0b871f56f61ac456c
<pre>
REGRESSION (269598@main?): [ macOS Debug ] ASSERTION FAILED: m_networkProcessToKeepAliveUntilDataStoreIsCreated == networkProcess.ptr() in TestWebKitAPI.WKWebsiteDataStoreConfiguration.TotalQuotaRatio result of constant crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=265489">https://bugs.webkit.org/show_bug.cgi?id=265489</a>
<a href="https://rdar.apple.com/118904784">rdar://118904784</a>

Reviewed by Per Arne Vollan and Chris Dumez.

The assertion fails because m_networkProcessToKeepAliveUntilDataStoreIsCreated still points to old default network
process after it exits. The reason why WebProcessProxy has m_networkProcessToKeepAliveUntilDataStoreIsCreated is that
WebProcessProxy needs to launch network process and hold it alive for sending LaunchServicesDatabase to web process,
when there is no WebsiteDataStore (i.e. the web process is prewarmed). This patch removes
m_networkProcessToKeepAliveUntilDataStoreIsCreated from WebProcessProxy and delays the LaunchServicesDatabase sending
to when WebProcessProxy is assigned a WebsiteDataStore. In that case, WebProcessProxy could use the network process of
the WebsiteDataStore.

This patch also has a fix to clear m_connection of XPCEndpointClient when remote process is terminated, so web process
can accept new connection from the relaunched network process.

* Source/WebKit/Shared/Cocoa/XPCEndpointClient.mm:
(WebKit::XPCEndpointClient::setEndpoint):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::setWebsiteDataStore):
(WebKit::WebProcessProxy::didFinishLaunching):
* Source/WebKit/UIProcess/WebProcessProxy.h:

Canonical link: <a href="https://commits.webkit.org/271385@main">https://commits.webkit.org/271385@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5b236b74b47ba62c665bca25ec7dce09f640153

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28149 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6790 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29502 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30678 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25649 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8810 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4173 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/25945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28417 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5550 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24229 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4815 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4954 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31367 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25757 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25656 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31269 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4942 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3117 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29023 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/notification (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6487 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6761 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5379 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5452 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->