### PR TITLE
Simplify the implementations of computeVisibleRectInContainer() slightly

### DIFF
--- a/Source/WebCore/rendering/RenderLayerModelObject.cpp
+++ b/Source/WebCore/rendering/RenderLayerModelObject.cpp
@@ -338,7 +338,7 @@ std::optional<LayoutRect> RenderLayerModelObject::computeVisibleRectInSVGContain
 
     ASSERT_UNUSED(containerIsSkipped, !containerIsSkipped);
 
-    LayoutRect adjustedRect = rect;
+    auto adjustedRect = rect;
 
     LayoutSize locationOffset;
     if (is<RenderSVGModelObject>(this))
@@ -346,20 +346,14 @@ std::optional<LayoutRect> RenderLayerModelObject::computeVisibleRectInSVGContain
     else if (is<RenderSVGBlock>(this))
         locationOffset = downcast<RenderSVGBlock>(*this).locationOffset();
 
-    LayoutPoint topLeft = adjustedRect.location();
-    topLeft.move(locationOffset);
 
     // We are now in our parent container's coordinate space. Apply our transform to obtain a bounding box
     // in the parent's coordinate space that encloses us.
-    if (hasLayer() && layer()->transform()) {
+    if (hasLayer() && layer()->transform())
         adjustedRect = layer()->transform()->mapRect(adjustedRect);
-        topLeft = adjustedRect.location();
-        topLeft.move(locationOffset);
-    }
 
-    // FIXME: We ignore the lightweight clipping rect that controls use, since if |o| is in mid-layout,
-    // its controlClipRect will be wrong. For overflow clip we use the values cached by the layer.
-    adjustedRect.setLocation(topLeft);
+    adjustedRect.move(locationOffset);
+
     if (localContainer->hasNonVisibleOverflow()) {
         bool isEmpty = !downcast<RenderLayerModelObject>(*localContainer).applyCachedClipAndScrollPosition(adjustedRect, container, context);
         if (isEmpty) {

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -1124,7 +1124,7 @@ std::optional<LayoutRect> RenderObject::computeVisibleRectInContainer(const Layo
     if (!parent)
         return rect;
 
-    LayoutRect adjustedRect = rect;
+    auto adjustedRect = rect;
     if (parent->hasNonVisibleOverflow()) {
         bool isEmpty = !downcast<RenderLayerModelObject>(*parent).applyCachedClipAndScrollPosition(adjustedRect, container, context);
         if (isEmpty) {

--- a/Source/WebCore/rendering/RenderTableCell.cpp
+++ b/Source/WebCore/rendering/RenderTableCell.cpp
@@ -418,9 +418,11 @@ std::optional<LayoutRect> RenderTableCell::computeVisibleRectInContainer(const L
 {
     if (container == this)
         return rect;
-    LayoutRect adjustedRect = rect;
+
+    auto adjustedRect = rect;
     if ((!view().frameView().layoutContext().isPaintOffsetCacheEnabled() || container || context.options.contains(VisibleRectContextOption::UseEdgeInclusiveIntersection)) && parent())
         adjustedRect.moveBy(-parentBox()->location()); // Rows are in the same coordinate space, so don't add their offset in.
+
     return RenderBlockFlow::computeVisibleRectInContainer(adjustedRect, container, context);
 }
 

--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -587,7 +587,7 @@ std::optional<LayoutRect> RenderView::computeVisibleRectInContainer(const Layout
     if (printing())
         return rect;
     
-    LayoutRect adjustedRect = rect;
+    auto adjustedRect = rect;
     if (style().isFlippedBlocksWritingMode()) {
         // We have to flip by hand since the view's logical height has not been determined.  We
         // can use the viewport width and height.
@@ -603,6 +603,7 @@ std::optional<LayoutRect> RenderView::computeVisibleRectInContainer(const Layout
     // Apply our transform if we have one (because of full page zooming).
     if (!container && layer() && layer()->transform())
         adjustedRect = LayoutRect(layer()->transform()->mapRect(snapRectToDevicePixels(adjustedRect, document().deviceScaleFactor())));
+
     return adjustedRect;
 }
 


### PR DESCRIPTION
#### 55dc29da9f7467101567baf29ce1936af2f88c00
<pre>
Simplify the implementations of computeVisibleRectInContainer() slightly
<a href="https://bugs.webkit.org/show_bug.cgi?id=265560">https://bugs.webkit.org/show_bug.cgi?id=265560</a>
<a href="https://rdar.apple.com/118961487">rdar://118961487</a>

Reviewed by Alan Baradlay.

RenderBox::computeVisibleRectInContainer() had some confusing logic that copied adjustedRect.location()
into a `topLeft` variable, modified it, and then set it back on adjustedRect. It&apos;s simpler, and will
help with future changes, to just modify adjustedRect&apos;s location directly.

It&apos;s made slightly more complex by the fact that we have to store `locationOffset`, which can be modified
for integral-snapped widgets, across the transform case that computes a new adjustedRect.

RenderInline::computeVisibleRectInContainer() and RenderLayerModelObject::computeVisibleRectInSVGContainer()
copied the same pattern and can also be simplified.

Remove comments about &quot;lightweight clipping rect that controls use&quot; that are probably no longer relevant.

* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::computeVisibleRectInContainer const):
* Source/WebCore/rendering/RenderInline.cpp:
(WebCore::RenderInline::computeVisibleRectInContainer const):
* Source/WebCore/rendering/RenderLayerModelObject.cpp:
(WebCore::RenderLayerModelObject::computeVisibleRectInSVGContainer const):
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::computeVisibleRectInContainer const):
* Source/WebCore/rendering/RenderTableCell.cpp:
(WebCore::RenderTableCell::computeVisibleRectInContainer const):
* Source/WebCore/rendering/RenderView.cpp:
(WebCore::RenderView::computeVisibleRectInContainer const):

Canonical link: <a href="https://commits.webkit.org/271339@main">https://commits.webkit.org/271339@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ac872373dfd042ac928a355d535c007d11ed3a7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28040 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6679 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29349 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30570 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25561 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28536 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8676 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4067 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/25322 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28307 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5423 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24082 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4674 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4847 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25090 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31259 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25632 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25523 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31150 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4854 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3020 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28922 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6395 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6729 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5296 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5351 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->