### PR TITLE
Begin implementing back/forward cache for site isolation

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2764,7 +2764,8 @@ void Document::attachToCachedFrame(CachedFrameBase& cachedFrame)
     RELEASE_ASSERT(cachedFrame.document() == this);
     ASSERT(cachedFrame.view());
     ASSERT(m_backForwardCacheState == Document::InBackForwardCache);
-    observeFrame(cachedFrame.view()->protectedFrame().ptr());
+    if (auto* localFrameView = dynamicDowncast<LocalFrameView>(cachedFrame.view()))
+        observeFrame(localFrameView->protectedFrame().ptr());
 }
 
 void Document::detachFromCachedFrame(CachedFrameBase& cachedFrame)

--- a/Source/WebCore/history/CachedFrame.h
+++ b/Source/WebCore/history/CachedFrame.h
@@ -48,19 +48,19 @@ public:
     void restore();
 
     Document* document() const { return m_document.get(); }
-    LocalFrameView* view() const { return m_view.get(); }
+    FrameView* view() const { return m_view.get(); }
     const URL& url() const { return m_url; }
     bool isMainFrame() { return m_isMainFrame; }
 
 protected:
-    CachedFrameBase(LocalFrame&);
+    CachedFrameBase(Frame&);
     ~CachedFrameBase();
 
     void pruneDetachedChildFrames();
 
     RefPtr<Document> m_document;
     RefPtr<DocumentLoader> m_documentLoader;
-    RefPtr<LocalFrameView> m_view;
+    RefPtr<FrameView> m_view;
     URL m_url;
     std::unique_ptr<ScriptCachedFrameData> m_cachedFrameScriptData;
     std::unique_ptr<CachedFramePlatformData> m_cachedFramePlatformData;
@@ -72,7 +72,7 @@ protected:
 class CachedFrame : private CachedFrameBase {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    explicit CachedFrame(LocalFrame&);
+    explicit CachedFrame(Frame&);
 
     void open();
     void clear();

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -2446,11 +2446,13 @@ void FrameLoader::open(CachedFrameBase& cachedFrame)
     
     // When navigating to a CachedFrame its FrameView should never be null.  If it is we'll crash in creative ways downstream.
     ASSERT(view);
-    view->setWasScrolledByUser(false);
+    if (RefPtr localView = dynamicDowncast<LocalFrameView>(view.get()))
+        localView->setWasScrolledByUser(false);
 
     Ref frame = m_frame.get();
     std::optional<IntRect> previousViewFrameRect = frame->view() ?  frame->view()->frameRect() : std::optional<IntRect>(std::nullopt);
-    frame->setView(view.copyRef());
+    if (RefPtr localView = dynamicDowncast<LocalFrameView>(view.get()))
+        frame->setView(localView.releaseNonNull());
 
     // Use the previous ScrollView's frame rect.
     if (previousViewFrameRect)

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -72,6 +72,7 @@ class FormState;
 class FormSubmission;
 class FrameLoadRequest;
 class FrameNetworkingContext;
+class HistoryController;
 class HistoryItem;
 class LocalFrameLoaderClient;
 class NavigationAction;
@@ -115,7 +116,6 @@ public:
     class PolicyChecker;
     PolicyChecker& policyChecker() const { return *m_policyChecker; }
 
-    class HistoryController;
     HistoryController& history() const { return *m_history; }
     ResourceLoadNotifier& notifier() const { return m_notifier; }
 
@@ -342,6 +342,10 @@ public:
 
     void switchBrowsingContextsGroup();
 
+    // HistoryController specific.
+    void loadItem(HistoryItem&, HistoryItem* fromItem, FrameLoadType, ShouldTreatAsContinuingLoad);
+    HistoryItem* requestedHistoryItem() const { return m_requestedHistoryItem.get(); }
+
 private:
     enum FormSubmissionCacheLoadPolicy {
         MayAttemptCacheOnlyLoadForFormSubmissionItem,
@@ -434,10 +438,6 @@ private:
 
     enum class LoadContinuingState : uint8_t { NotContinuing, ContinuingWithRequest, ContinuingWithHistoryItem };
     bool shouldTreatCurrentLoadAsContinuingLoad() const { return m_currentLoadContinuingState != LoadContinuingState::NotContinuing; }
-
-    // HistoryController specific.
-    void loadItem(HistoryItem&, HistoryItem* fromItem, FrameLoadType, ShouldTreatAsContinuingLoad);
-    HistoryItem* requestedHistoryItem() const { return m_requestedHistoryItem.get(); }
 
     // SubframeLoader specific.
     void loadURLIntoChildFrame(const URL&, const String& referer, LocalFrame*);

--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -60,16 +60,16 @@ static inline void addVisitedLink(Page& page, const URL& url)
     page.visitedLinkStore().addVisitedLink(page, computeSharedStringHash(url.string()));
 }
 
-FrameLoader::HistoryController::HistoryController(LocalFrame& frame)
+HistoryController::HistoryController(LocalFrame& frame)
     : m_frame(frame)
     , m_frameLoadComplete(true)
     , m_defersLoading(false)
 {
 }
 
-FrameLoader::HistoryController::~HistoryController() = default;
+HistoryController::~HistoryController() = default;
 
-void FrameLoader::HistoryController::saveScrollPositionAndViewStateToItem(HistoryItem* item)
+void HistoryController::saveScrollPositionAndViewStateToItem(HistoryItem* item)
 {
     auto* frameView = m_frame.view();
     if (!item || !frameView)
@@ -104,7 +104,7 @@ void FrameLoader::HistoryController::saveScrollPositionAndViewStateToItem(Histor
     item->notifyChanged();
 }
 
-void FrameLoader::HistoryController::clearScrollPositionAndViewState()
+void HistoryController::clearScrollPositionAndViewState()
 {
     if (!m_currentItem)
         return;
@@ -124,7 +124,7 @@ void FrameLoader::HistoryController::clearScrollPositionAndViewState()
  2) If the layout happens after the load completes, the attempt to restore at load completion time silently
  fails.  We then successfully restore it when the layout happens.
 */
-void FrameLoader::HistoryController::restoreScrollPositionAndViewState()
+void HistoryController::restoreScrollPositionAndViewState()
 {
     if (!m_currentItem || !m_frame.loader().stateMachine().committedFirstRealDocumentLoad())
         return;
@@ -172,12 +172,12 @@ void FrameLoader::HistoryController::restoreScrollPositionAndViewState()
 #endif
 }
 
-void FrameLoader::HistoryController::updateBackForwardListForFragmentScroll()
+void HistoryController::updateBackForwardListForFragmentScroll()
 {
     updateBackForwardListClippedAtTarget(false);
 }
 
-void FrameLoader::HistoryController::saveDocumentState()
+void HistoryController::saveDocumentState()
 {
     // FIXME: Reading this bit of FrameLoader state here is unfortunate.  I need to study
     // this more to see if we can remove this dependency.
@@ -212,7 +212,7 @@ void FrameLoader::HistoryController::saveDocumentState()
 
 // Walk the frame tree, telling all frames to save their form state into their current
 // history item.
-void FrameLoader::HistoryController::saveDocumentAndScrollState()
+void HistoryController::saveDocumentAndScrollState()
 {
     for (Frame* frame = &m_frame; frame; frame = frame->tree().traverseNext(&m_frame)) {
         auto* localFrame = dynamicDowncast<LocalFrame>(frame);
@@ -223,7 +223,7 @@ void FrameLoader::HistoryController::saveDocumentAndScrollState()
     }
 }
 
-void FrameLoader::HistoryController::restoreDocumentState()
+void HistoryController::restoreDocumentState()
 {
     switch (m_frame.loader().loadType()) {
     case FrameLoadType::Reload:
@@ -254,7 +254,7 @@ void FrameLoader::HistoryController::restoreDocumentState()
     m_frame.document()->setStateForNewFormElements(m_currentItem->documentState());
 }
 
-void FrameLoader::HistoryController::invalidateCurrentItemCachedPage()
+void HistoryController::invalidateCurrentItemCachedPage()
 {
     if (!currentItem())
         return;
@@ -275,7 +275,7 @@ void FrameLoader::HistoryController::invalidateCurrentItemCachedPage()
     }
 }
 
-bool FrameLoader::HistoryController::shouldStopLoadingForHistoryItem(HistoryItem& targetItem) const
+bool HistoryController::shouldStopLoadingForHistoryItem(HistoryItem& targetItem) const
 {
     if (!m_currentItem)
         return false;
@@ -289,7 +289,7 @@ bool FrameLoader::HistoryController::shouldStopLoadingForHistoryItem(HistoryItem
 
 // Main funnel for navigating to a previous location (back/forward, non-search snap-back)
 // This includes recursion to handle loading into framesets properly
-void FrameLoader::HistoryController::goToItem(HistoryItem& targetItem, FrameLoadType type, ShouldTreatAsContinuingLoad shouldTreatAsContinuingLoad)
+void HistoryController::goToItem(HistoryItem& targetItem, FrameLoadType type, ShouldTreatAsContinuingLoad shouldTreatAsContinuingLoad)
 {
     LOG(History, "HistoryController %p goToItem %p type=%d", this, &targetItem, static_cast<int>(type));
 
@@ -326,7 +326,7 @@ void FrameLoader::HistoryController::goToItem(HistoryItem& targetItem, FrameLoad
     recursiveGoToItem(targetItem, currentItem.get(), type, shouldTreatAsContinuingLoad);
 }
 
-void FrameLoader::HistoryController::setDefersLoading(bool defer)
+void HistoryController::setDefersLoading(bool defer)
 {
     m_defersLoading = defer;
     if (!defer && m_deferredItem) {
@@ -335,7 +335,7 @@ void FrameLoader::HistoryController::setDefersLoading(bool defer)
     }
 }
 
-void FrameLoader::HistoryController::updateForBackForwardNavigation()
+void HistoryController::updateForBackForwardNavigation()
 {
     LOG(History, "HistoryController %p updateForBackForwardNavigation: Updating History for back/forward navigation in frame %p (main frame %d) %s", this, &m_frame, m_frame.isMainFrame(), m_frame.loader().documentLoader() ? m_frame.loader().documentLoader()->url().string().utf8().data() : "");
 
@@ -348,7 +348,7 @@ void FrameLoader::HistoryController::updateForBackForwardNavigation()
     updateCurrentItem();
 }
 
-void FrameLoader::HistoryController::updateForReload()
+void HistoryController::updateForReload()
 {
     LOG(History, "HistoryController %p updateForReload: Updating History for reload in frame %p (main frame %d) %s", this, &m_frame, m_frame.isMainFrame(), m_frame.loader().documentLoader() ? m_frame.loader().documentLoader()->url().string().utf8().data() : "");
 
@@ -373,7 +373,7 @@ void FrameLoader::HistoryController::updateForReload()
 //     2) Global history: Handled by the client.
 //     3) Visited links: Handled by the PageGroup.
 
-void FrameLoader::HistoryController::updateForStandardLoad(HistoryUpdateType updateType)
+void HistoryController::updateForStandardLoad(HistoryUpdateType updateType)
 {
     LOG(History, "HistoryController %p updateForStandardLoad: Updating History for standard load in frame %p (main frame %d) %s", this, &m_frame, m_frame.isMainFrame(), m_frame.loader().documentLoader()->url().string().ascii().data());
 
@@ -407,7 +407,7 @@ void FrameLoader::HistoryController::updateForStandardLoad(HistoryUpdateType upd
     }
 }
 
-void FrameLoader::HistoryController::updateForRedirectWithLockedBackForwardList()
+void HistoryController::updateForRedirectWithLockedBackForwardList()
 {
     LOG(History, "HistoryController %p updateForRedirectWithLockedBackForwardList: Updating History for redirect load in frame %p (main frame %d) %s", this, &m_frame, m_frame.isMainFrame(), m_frame.loader().documentLoader() ? m_frame.loader().documentLoader()->url().string().utf8().data() : "");
     
@@ -444,7 +444,7 @@ void FrameLoader::HistoryController::updateForRedirectWithLockedBackForwardList(
     }
 }
 
-void FrameLoader::HistoryController::updateForClientRedirect()
+void HistoryController::updateForClientRedirect()
 {
     LOG(History, "HistoryController %p updateForClientRedirect: Updating History for client redirect in frame %p (main frame %d) %s", this, &m_frame, m_frame.isMainFrame(), m_frame.loader().documentLoader() ? m_frame.loader().documentLoader()->url().string().utf8().data() : "");
 
@@ -464,7 +464,7 @@ void FrameLoader::HistoryController::updateForClientRedirect()
     }
 }
 
-void FrameLoader::HistoryController::updateForCommit()
+void HistoryController::updateForCommit()
 {
     FrameLoader& frameLoader = m_frame.loader();
     LOG(History, "HistoryController %p updateForCommit: Updating History for commit in frame %p (main frame %d) %s", this, &m_frame, m_frame.isMainFrame(), m_frame.loader().documentLoader() ? m_frame.loader().documentLoader()->url().string().utf8().data() : "");
@@ -495,19 +495,19 @@ void FrameLoader::HistoryController::updateForCommit()
     }
 }
 
-bool FrameLoader::HistoryController::isReplaceLoadTypeWithProvisionalItem(FrameLoadType type)
+bool HistoryController::isReplaceLoadTypeWithProvisionalItem(FrameLoadType type)
 {
     // Going back to an error page in a subframe can trigger a FrameLoadType::Replace
     // while m_provisionalItem is set, so we need to commit it.
     return type == FrameLoadType::Replace && m_provisionalItem;
 }
 
-bool FrameLoader::HistoryController::isReloadTypeWithProvisionalItem(FrameLoadType type)
+bool HistoryController::isReloadTypeWithProvisionalItem(FrameLoadType type)
 {
     return (type == FrameLoadType::Reload || type == FrameLoadType::ReloadFromOrigin) && m_provisionalItem;
 }
 
-void FrameLoader::HistoryController::recursiveUpdateForCommit()
+void HistoryController::recursiveUpdateForCommit()
 {
     // The frame that navigated will now have a null provisional item.
     // Ignore it and its children.
@@ -546,7 +546,7 @@ void FrameLoader::HistoryController::recursiveUpdateForCommit()
     }
 }
 
-void FrameLoader::HistoryController::updateForSameDocumentNavigation()
+void HistoryController::updateForSameDocumentNavigation()
 {
     if (m_frame.document()->url().isEmpty())
         return;
@@ -569,7 +569,7 @@ void FrameLoader::HistoryController::updateForSameDocumentNavigation()
     }
 }
 
-void FrameLoader::HistoryController::recursiveUpdateForSameDocumentNavigation()
+void HistoryController::recursiveUpdateForSameDocumentNavigation()
 {
     // The frame that navigated will now have a null provisional item.
     // Ignore it and its children.
@@ -595,7 +595,7 @@ void FrameLoader::HistoryController::recursiveUpdateForSameDocumentNavigation()
     }
 }
 
-void FrameLoader::HistoryController::updateForFrameLoadCompleted()
+void HistoryController::updateForFrameLoadCompleted()
 {
     // Even if already complete, we might have set a previous item on a frame that
     // didn't do any data loading on the past transaction. Make sure to track that
@@ -603,21 +603,21 @@ void FrameLoader::HistoryController::updateForFrameLoadCompleted()
     m_frameLoadComplete = true;
 }
 
-void FrameLoader::HistoryController::setCurrentItem(HistoryItem& item)
+void HistoryController::setCurrentItem(HistoryItem& item)
 {
     m_frameLoadComplete = false;
     m_previousItem = m_currentItem;
     m_currentItem = &item;
 }
 
-void FrameLoader::HistoryController::setCurrentItemTitle(const StringWithDirection& title)
+void HistoryController::setCurrentItemTitle(const StringWithDirection& title)
 {
     // FIXME: This ignores the title's direction.
     if (m_currentItem)
         m_currentItem->setTitle(title.string);
 }
 
-bool FrameLoader::HistoryController::currentItemShouldBeReplaced() const
+bool HistoryController::currentItemShouldBeReplaced() const
 {
     // From the HTML5 spec for location.assign():
     //  "If the browsing context's session history contains only one Document,
@@ -626,7 +626,7 @@ bool FrameLoader::HistoryController::currentItemShouldBeReplaced() const
     return m_currentItem && !m_previousItem && equalIgnoringASCIICase(m_currentItem->urlString(), aboutBlankURL().string());
 }
 
-void FrameLoader::HistoryController::clearPreviousItem()
+void HistoryController::clearPreviousItem()
 {
     m_previousItem = nullptr;
     for (auto* child = m_frame.tree().firstChild(); child; child = child->tree().nextSibling()) {
@@ -637,12 +637,12 @@ void FrameLoader::HistoryController::clearPreviousItem()
     }
 }
 
-void FrameLoader::HistoryController::setProvisionalItem(HistoryItem* item)
+void HistoryController::setProvisionalItem(HistoryItem* item)
 {
     m_provisionalItem = item;
 }
 
-void FrameLoader::HistoryController::initializeItem(HistoryItem& item)
+void HistoryController::initializeItem(HistoryItem& item)
 {
     DocumentLoader* documentLoader = m_frame.loader().documentLoader();
     ASSERT(documentLoader);
@@ -687,7 +687,7 @@ void FrameLoader::HistoryController::initializeItem(HistoryItem& item)
     item.setFormInfoFromRequest(documentLoader->request());
 }
 
-Ref<HistoryItem> FrameLoader::HistoryController::createItem(HistoryItemClient& client)
+Ref<HistoryItem> HistoryController::createItem(HistoryItemClient& client)
 {
     Ref<HistoryItem> item = HistoryItem::create(client);
     initializeItem(item);
@@ -698,7 +698,7 @@ Ref<HistoryItem> FrameLoader::HistoryController::createItem(HistoryItemClient& c
     return item;
 }
 
-Ref<HistoryItem> FrameLoader::HistoryController::createItemTree(HistoryItemClient& client, LocalFrame& targetFrame, bool clipAtTarget)
+Ref<HistoryItem> HistoryController::createItemTree(HistoryItemClient& client, LocalFrame& targetFrame, bool clipAtTarget)
 {
     Ref<HistoryItem> bfItem = createItem(client);
     if (!m_frameLoadComplete)
@@ -743,7 +743,7 @@ Ref<HistoryItem> FrameLoader::HistoryController::createItemTree(HistoryItemClien
 // tracking whether each frame already has the content the item requests.  If there is
 // a match, we set the provisional item and recurse.  Otherwise we will reload that
 // frame and all its kids in recursiveGoToItem.
-void FrameLoader::HistoryController::recursiveSetProvisionalItem(HistoryItem& item, HistoryItem* fromItem)
+void HistoryController::recursiveSetProvisionalItem(HistoryItem& item, HistoryItem* fromItem)
 {
     if (!itemsAreClones(item, fromItem))
         return;
@@ -765,7 +765,7 @@ void FrameLoader::HistoryController::recursiveSetProvisionalItem(HistoryItem& it
 
 // We now traverse the frame tree and item tree a second time, loading frames that
 // do have the content the item requests.
-void FrameLoader::HistoryController::recursiveGoToItem(HistoryItem& item, HistoryItem* fromItem, FrameLoadType type, ShouldTreatAsContinuingLoad shouldTreatAsContinuingLoad)
+void HistoryController::recursiveGoToItem(HistoryItem& item, HistoryItem* fromItem, FrameLoadType type, ShouldTreatAsContinuingLoad shouldTreatAsContinuingLoad)
 {
     if (!itemsAreClones(item, fromItem)) {
         m_frame.loader().loadItem(item, fromItem, type, shouldTreatAsContinuingLoad);
@@ -786,7 +786,7 @@ void FrameLoader::HistoryController::recursiveGoToItem(HistoryItem& item, Histor
 }
 
 // The following logic must be kept in sync with WebKit::WebBackForwardListItem::itemIsClone().
-bool FrameLoader::HistoryController::itemsAreClones(HistoryItem& item1, HistoryItem* item2) const
+bool HistoryController::itemsAreClones(HistoryItem& item1, HistoryItem* item2) const
 {
     // If the item we're going to is a clone of the item we're at, then we do
     // not need to load it again.  The current frame tree and the frame tree
@@ -801,7 +801,7 @@ bool FrameLoader::HistoryController::itemsAreClones(HistoryItem& item1, HistoryI
 }
 
 // Helper method that determines whether the current frame tree matches given history item's.
-bool FrameLoader::HistoryController::currentFramesMatchItem(HistoryItem& item) const
+bool HistoryController::currentFramesMatchItem(HistoryItem& item) const
 {
     if ((!m_frame.tree().uniqueName().isEmpty() || !item.target().isEmpty()) && m_frame.tree().uniqueName() != item.target())
         return false;
@@ -818,7 +818,7 @@ bool FrameLoader::HistoryController::currentFramesMatchItem(HistoryItem& item) c
     return true;
 }
 
-void FrameLoader::HistoryController::updateBackForwardListClippedAtTarget(bool doClip)
+void HistoryController::updateBackForwardListClippedAtTarget(bool doClip)
 {
     // In the case of saving state about a page with frames, we store a tree of items that mirrors the frame tree.  
     // The item that was the target of the user's navigation is designated as the "targetItem".  
@@ -844,7 +844,7 @@ void FrameLoader::HistoryController::updateBackForwardListClippedAtTarget(bool d
     page->backForward().addItem(WTFMove(topItem));
 }
 
-void FrameLoader::HistoryController::updateCurrentItem()
+void HistoryController::updateCurrentItem()
 {
     if (!m_currentItem)
         return;
@@ -868,7 +868,7 @@ void FrameLoader::HistoryController::updateCurrentItem()
     }
 }
 
-void FrameLoader::HistoryController::pushState(RefPtr<SerializedScriptValue>&& stateObject, const String& title, const String& urlString)
+void HistoryController::pushState(RefPtr<SerializedScriptValue>&& stateObject, const String& title, const String& urlString)
 {
     if (!m_currentItem)
         return;
@@ -910,7 +910,7 @@ void FrameLoader::HistoryController::pushState(RefPtr<SerializedScriptValue>&& s
     m_frame.loader().client().updateGlobalHistory();
 }
 
-void FrameLoader::HistoryController::replaceState(RefPtr<SerializedScriptValue>&& stateObject, const String& title, const String& urlString)
+void HistoryController::replaceState(RefPtr<SerializedScriptValue>&& stateObject, const String& title, const String& urlString)
 {
     if (!m_currentItem)
         return;
@@ -932,7 +932,7 @@ void FrameLoader::HistoryController::replaceState(RefPtr<SerializedScriptValue>&
     m_frame.loader().client().updateGlobalHistory();
 }
 
-void FrameLoader::HistoryController::replaceCurrentItem(HistoryItem* item)
+void HistoryController::replaceCurrentItem(HistoryItem* item)
 {
     if (!item)
         return;
@@ -944,12 +944,12 @@ void FrameLoader::HistoryController::replaceCurrentItem(HistoryItem* item)
         m_currentItem = item;
 }
 
-RefPtr<HistoryItem> FrameLoader::HistoryController::protectedCurrentItem() const
+RefPtr<HistoryItem> HistoryController::protectedCurrentItem() const
 {
     return m_currentItem;
 }
 
-RefPtr<HistoryItem> FrameLoader::HistoryController::protectedProvisionalItem() const
+RefPtr<HistoryItem> HistoryController::protectedProvisionalItem() const
 {
     return m_provisionalItem;
 }

--- a/Source/WebCore/loader/HistoryController.h
+++ b/Source/WebCore/loader/HistoryController.h
@@ -42,7 +42,7 @@ enum class ShouldTreatAsContinuingLoad : uint8_t;
 
 struct StringWithDirection;
 
-class FrameLoader::HistoryController {
+class HistoryController {
     WTF_MAKE_NONCOPYABLE(HistoryController);
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 public:

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -28,6 +28,7 @@
 
 #include "APINavigation.h"
 #include "APIWebsitePolicies.h"
+#include "BrowsingContextGroup.h"
 #include "DrawingAreaProxy.h"
 #include "FormDataReference.h"
 #include "GoToBackForwardItemParameters.h"
@@ -104,6 +105,8 @@ ProvisionalPageProxy::ProvisionalPageProxy(WebPageProxy& page, Ref<WebProcessPro
         ASSERT(&suspendedPage->process() == m_process.ptr());
         suspendedPage->unsuspend();
         m_mainFrame = &suspendedPage->mainFrame();
+        m_browsingContextGroup = &suspendedPage->browsingContextGroup();
+        m_remotePageProxyState = suspendedPage->takeRemotePageProxyState();
     }
 
     initializeWebPage(websitePolicies);

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.h
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.h
@@ -31,6 +31,7 @@
 #include "NetworkResourceLoadIdentifier.h"
 #include "PolicyDecision.h"
 #include "ProcessThrottler.h"
+#include "RemotePageProxyState.h"
 #include "SandboxExtension.h"
 #include "WebFramePolicyListenerProxy.h"
 #include "WebPageProxyIdentifier.h"
@@ -57,6 +58,7 @@ enum class ShouldTreatAsContinuingLoad : uint8_t;
 
 namespace WebKit {
 
+class BrowsingContextGroup;
 class DrawingAreaProxy;
 class RemotePageProxy;
 class SuspendedPageProxy;
@@ -90,6 +92,8 @@ public:
 
     WebCore::PageIdentifier webPageID() const { return m_webPageID; }
     WebFrameProxy* mainFrame() const { return m_mainFrame.get(); }
+    BrowsingContextGroup* browsingContextGroup() { return m_browsingContextGroup.get(); }
+    RemotePageProxyState takeRemotePageProxyState() { return std::exchange(m_remotePageProxyState, { }); }
     WebProcessProxy& process() { return m_process.get(); }
     ProcessSwapRequestedByClient processSwapRequestedByClient() const { return m_processSwapRequestedByClient; }
     uint64_t navigationID() const { return m_navigationID; }
@@ -185,6 +189,8 @@ private:
     RefPtr<WebsiteDataStore> m_websiteDataStore;
     std::unique_ptr<DrawingAreaProxy> m_drawingArea;
     RefPtr<WebFrameProxy> m_mainFrame;
+    RefPtr<BrowsingContextGroup> m_browsingContextGroup;
+    RemotePageProxyState m_remotePageProxyState;
     uint64_t m_navigationID;
     bool m_isServerRedirect;
     WebCore::ResourceRequest m_request;

--- a/Source/WebKit/UIProcess/RemotePageProxy.cpp
+++ b/Source/WebKit/UIProcess/RemotePageProxy.cpp
@@ -209,4 +209,9 @@ RefPtr<WebPageProxy> RemotePageProxy::protectedPage() const
     return m_page.get();
 }
 
+WebPageProxy* RemotePageProxy::page() const
+{
+    return m_page.get();
+}
+
 }

--- a/Source/WebKit/UIProcess/RemotePageProxy.h
+++ b/Source/WebKit/UIProcess/RemotePageProxy.h
@@ -69,7 +69,7 @@ public:
     static Ref<RemotePageProxy> create(WebPageProxy& page, WebProcessProxy& process, const WebCore::RegistrableDomain& domain, WebPageProxyMessageReceiverRegistration* registrationToTransfer = nullptr) { return adoptRef(*new RemotePageProxy(page, process, domain, registrationToTransfer)); }
     ~RemotePageProxy();
 
-    WebPageProxy* page() const { return m_page.get(); }
+    WebPageProxy* page() const;
     RefPtr<WebPageProxy> protectedPage() const;
 
     template<typename M> void send(M&&);

--- a/Source/WebKit/UIProcess/RemotePageProxyState.h
+++ b/Source/WebKit/UIProcess/RemotePageProxyState.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "RemotePageProxy.h"
+#include <WebCore/RegistrableDomain.h>
+#include <wtf/HashMap.h>
+
+namespace WebKit {
+
+struct RemotePageProxyState {
+    HashMap<WebCore::RegistrableDomain, WeakPtr<RemotePageProxy>> domainToRemotePageProxyMap;
+    RefPtr<RemotePageProxy> remotePageProxyInOpenerProcess;
+    HashMap<WebPageProxyIdentifier, Ref<RemotePageProxy>> openedRemotePageProxies;
+};
+
+}

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
@@ -27,6 +27,7 @@
 #include "SuspendedPageProxy.h"
 
 #include "APIPageConfiguration.h"
+#include "BrowsingContextGroup.h"
 #include "DrawingAreaProxy.h"
 #include "HandleMessage.h"
 #include "Logging.h"
@@ -103,11 +104,12 @@ static const MessageNameSet& messageNamesToIgnoreWhileSuspended()
 }
 #endif
 
-SuspendedPageProxy::SuspendedPageProxy(WebPageProxy& page, Ref<WebProcessProxy>&& process, Ref<WebFrameProxy>&& mainFrame, ShouldDelayClosingUntilFirstLayerFlush shouldDelayClosingUntilFirstLayerFlush)
+SuspendedPageProxy::SuspendedPageProxy(WebPageProxy& page, Ref<WebProcessProxy>&& process, Ref<WebFrameProxy>&& mainFrame, Ref<BrowsingContextGroup>&& browsingContextGroup, RemotePageProxyState&& remotePageProxyState, ShouldDelayClosingUntilFirstLayerFlush shouldDelayClosingUntilFirstLayerFlush)
     : m_page(page)
     , m_webPageID(page.webPageID())
     , m_process(WTFMove(process))
     , m_mainFrame(WTFMove(mainFrame))
+    , m_browsingContextGroup(WTFMove(browsingContextGroup))
     , m_shouldDelayClosingUntilFirstLayerFlush(shouldDelayClosingUntilFirstLayerFlush)
     , m_suspensionTimeoutTimer(RunLoop::main(), this, &SuspendedPageProxy::suspensionTimedOut)
 #if USE(RUNNINGBOARD)
@@ -119,13 +121,21 @@ SuspendedPageProxy::SuspendedPageProxy(WebPageProxy& page, Ref<WebProcessProxy>&
     , m_contextIDForVisibilityPropagationInGPUProcess(page.contextIDForVisibilityPropagationInGPUProcess())
 #endif
 #endif
+    , m_remotePageProxyState(WTFMove(remotePageProxyState))
 {
     allSuspendedPages().add(*this);
     m_process->addSuspendedPageProxy(*this);
     m_messageReceiverRegistration.startReceivingMessages(m_process, m_webPageID, *this);
-    m_mainFrame->removeRemotePagesForSuspension();
     m_suspensionTimeoutTimer.startOneShot(suspensionTimeout);
-    send(Messages::WebPage::SetIsSuspended(true));
+    sendToAllProcesses(Messages::WebPage::SetIsSuspended(true));
+}
+
+template<typename T>
+void SuspendedPageProxy::sendToAllProcesses(T&& message)
+{
+    // FIXME: Iterate m_remotePageProxyState.domainToRemotePageProxyMap.values() and send to each RemotePageProxy's process.
+    // FIXME: Rename m_process to m_mainFrameProcess and make its use aware of site isolation.
+    m_process->send(std::forward<T>(message), m_webPageID);
 }
 
 SuspendedPageProxy::~SuspendedPageProxy()
@@ -187,7 +197,7 @@ void SuspendedPageProxy::unsuspend()
     ASSERT(m_suspensionState == SuspensionState::Suspended);
 
     m_suspensionState = SuspensionState::Resumed;
-    send(Messages::WebPage::SetIsSuspended(false));
+    sendToAllProcesses(Messages::WebPage::SetIsSuspended(false));
 }
 
 void SuspendedPageProxy::close()
@@ -199,7 +209,7 @@ void SuspendedPageProxy::close()
 
     RELEASE_LOG(ProcessSwapping, "%p - SuspendedPageProxy::close()", this);
     m_isClosed = true;
-    send(Messages::WebPage::Close());
+    sendToAllProcesses(Messages::WebPage::Close());
 }
 
 void SuspendedPageProxy::pageDidFirstLayerFlush()
@@ -286,28 +296,6 @@ void SuspendedPageProxy::didReceiveMessage(IPC::Connection& connection, IPC::Dec
 bool SuspendedPageProxy::didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&)
 {
     return false;
-}
-
-IPC::Connection* SuspendedPageProxy::messageSenderConnection() const
-{
-    return m_process->connection();
-}
-
-uint64_t SuspendedPageProxy::messageSenderDestinationID() const
-{
-    return m_webPageID.toUInt64();
-}
-
-bool SuspendedPageProxy::sendMessage(UniqueRef<IPC::Encoder>&& encoder, OptionSet<IPC::SendOption> sendOptions)
-{
-    // Send messages via the WebProcessProxy instead of the IPC::Connection since AuxiliaryProcessProxy implements queueing of messages
-    // while the process is still launching.
-    return m_process->sendMessage(WTFMove(encoder), sendOptions);
-}
-
-bool SuspendedPageProxy::sendMessageWithAsyncReply(UniqueRef<IPC::Encoder>&& encoder, AsyncReplyHandler handler, OptionSet<IPC::SendOption> sendOptions)
-{
-    return m_process->sendMessage(WTFMove(encoder), sendOptions, WTFMove(handler));
 }
 
 #if !LOG_DISABLED

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -515,13 +515,6 @@ RefPtr<RemotePageProxy> WebFrameProxy::remotePageProxy()
     return m_remotePageProxy;
 }
 
-void WebFrameProxy::removeRemotePagesForSuspension()
-{
-    m_remotePageProxy = nullptr;
-    for (auto& child : m_childFrames)
-        child->removeRemotePagesForSuspension();
-}
-
 bool WebFrameProxy::isFocused() const
 {
     auto* webPage = page();

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -165,7 +165,6 @@ public:
     ProvisionalFrameProxy* provisionalFrame() { return m_provisionalFrame.get(); }
     std::unique_ptr<ProvisionalFrameProxy> takeProvisionalFrame();
     RefPtr<RemotePageProxy> remotePageProxy();
-    void removeRemotePagesForSuspension();
 
     bool isFocused() const;
 

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -32,6 +32,7 @@
 #include "LayerTreeContext.h"
 #include "PageLoadState.h"
 #include "ProcessThrottler.h"
+#include "RemotePageProxyState.h"
 #include "ScrollingAccelerationCurve.h"
 #include "VisibleWebPageCounter.h"
 #include "WebColorPicker.h"
@@ -212,9 +213,8 @@ struct WebPageProxy::Internals final : WebPopupMenuProxy::Client
     WindowKind windowKind { WindowKind::Unparented };
     PageAllowedToRunInTheBackgroundCounter::Token pageAllowedToRunInTheBackgroundToken;
 
-    HashMap<WebCore::RegistrableDomain, WeakPtr<RemotePageProxy>> domainToRemotePageProxyMap;
-    RefPtr<RemotePageProxy> remotePageProxyInOpenerProcess;
-    HashMap<WebPageProxyIdentifier, Ref<RemotePageProxy>> openedRemotePageProxies;
+    RemotePageProxyState remotePageProxyState;
+
     WebPageProxyMessageReceiverRegistration messageReceiverRegistration;
 
     WeakHashSet<WebPageProxy> m_openedPages;

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -7779,6 +7779,7 @@
 		FA651BA72AA3CBB600747576 /* NetworkTransportReceiveStream.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NetworkTransportReceiveStream.h; sourceTree = "<group>"; };
 		FA651BAE2AA3E5FB00747576 /* WebTransportSendStreamSink.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WebTransportSendStreamSink.h; path = Network/WebTransportSendStreamSink.h; sourceTree = "<group>"; };
 		FA651BAF2AA3E5FB00747576 /* WebTransportSendStreamSink.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = WebTransportSendStreamSink.cpp; path = Network/WebTransportSendStreamSink.cpp; sourceTree = "<group>"; };
+		FA821D402B1FA5D500482A33 /* RemotePageProxyState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemotePageProxyState.h; sourceTree = "<group>"; };
 		FA96E4AC2AA90A1E0090C5A3 /* WebHistoryItemClient.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebHistoryItemClient.cpp; sourceTree = "<group>"; };
 		FA96E4AD2AA90A1E0090C5A3 /* WebHistoryItemClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebHistoryItemClient.h; sourceTree = "<group>"; };
 		FA9CD6332A01B21700EA5CAC /* NetworkOriginAccessPatterns.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = NetworkOriginAccessPatterns.cpp; sourceTree = "<group>"; };
@@ -13062,6 +13063,7 @@
 				5CCB54DB2A4FEA6A0005FAA8 /* RemotePageDrawingAreaProxy.h */,
 				5C907E9A294D507100B3402D /* RemotePageProxy.cpp */,
 				5C907E99294D507100B3402D /* RemotePageProxy.h */,
+				FA821D402B1FA5D500482A33 /* RemotePageProxyState.h */,
 				5CEB40A22A534EE100563C91 /* RemotePageVisitedLinkStoreRegistration.h */,
 				BC111B08112F5E3C00337BAB /* ResponsivenessTimer.cpp */,
 				1A30066C1110F4F70031937C /* ResponsivenessTimer.h */,

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1857,6 +1857,7 @@ void WebPage::suspendForProcessSwap()
         send(Messages::WebPageProxy::DidFailToSuspendAfterProcessSwap());
     };
 
+    // FIXME: Make this work if the main frame is not a LocalFrame.
     RefPtr currentHistoryItem = m_mainFrame->coreLocalFrame()->loader().history().currentItem();
     if (!currentHistoryItem) {
         failedToSuspend();


### PR DESCRIPTION
#### 00dcbd8c70b8cb1baa57c6ba0ccdd5a15819887f
<pre>
Begin implementing back/forward cache for site isolation
<a href="https://bugs.webkit.org/show_bug.cgi?id=265561">https://bugs.webkit.org/show_bug.cgi?id=265561</a>
<a href="https://rdar.apple.com/118965412">rdar://118965412</a>

Reviewed by Pascoe.

My approach before was to terminate the iframe processes when we navigate away,
which seems to match other browsers but doesn&apos;t match our existing behavior of
being able to quickly navigate back to a fully functional page.  We need to keep
the processes alive and make CachedFrame able to handle RemoteFrames in order to
keep that speed.  If we get a memory pressure warning, we will remove back/forward
cache entries, but if we have the memory let&apos;s keep the existing behavior.

This is the first of at least two PRs to get back/forward navigation working with
site isolation.  I make CachedFrame able to handle RemoteFrames, I made
HistoryController a non-nested class to be able to be owned by RemoteFrames (but
I didn&apos;t change that ownership yet), and I swap RemotePageProxy state to a
SuspendedPageProxy when suspending.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::attachToCachedFrame):
* Source/WebCore/history/CachedFrame.cpp:
(WebCore::CachedFrameBase::CachedFrameBase):
(WebCore::CachedFrameBase::restore):
(WebCore::CachedFrame::CachedFrame):
(WebCore::CachedFrame::open):
(WebCore::CachedFrame::destroy):
* Source/WebCore/history/CachedFrame.h:
(WebCore::CachedFrameBase::view const):
* Source/WebCore/history/CachedPage.cpp:
(WebCore::CachedPage::CachedPage):
(WebCore::firePageShowEvent):
(WebCore::CachedPage::restore):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::open):
* Source/WebKit/UIProcess/SuspendedPageProxy.cpp:
(WebKit::SuspendedPageProxy::SuspendedPageProxy):
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::removeRemotePagesForSuspension): Deleted.
* Source/WebKit/UIProcess/WebFrameProxy.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/271590@main">https://commits.webkit.org/271590@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4b3d1e8edc08d60e7d1f317883208b56fc47a0f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28895 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7536 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30251 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31509 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26342 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29467 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9663 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4884 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29167 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6230 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24813 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5432 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/5563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25830 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/32846 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26424 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26268 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31810 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/5542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3707 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29591 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7174 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6020 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3723 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/6063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->