### PR TITLE
[Site Isolation] Fix some cases where we unnecessarily skip code on out-of-process frames

### DIFF
--- a/Source/WebCore/bindings/js/JSLocalDOMWindowCustom.cpp
+++ b/Source/WebCore/bindings/js/JSLocalDOMWindowCustom.cpp
@@ -156,9 +156,8 @@ bool jsLocalDOMWindowGetOwnPropertySlotRestrictedAccess(JSDOMGlobalObject* thisO
     // properties that are in Moz but not IE. Since we have some of these, we have to do it
     // the Moz way.
     // FIXME: Add support to named attributes on RemoteFrames.
-    auto* frame = window.frame();
-    if (auto* localFrame = dynamicDowncast<LocalFrame>(frame)) {
-        if (auto* scopedChild = dynamicDowncast<LocalFrame>(localFrame->tree().scopedChildBySpecifiedName(propertyNameToAtomString(propertyName)))) {
+    if (RefPtr frame = window.frame()) {
+        if (auto* scopedChild = dynamicDowncast<LocalFrame>(frame->tree().scopedChildBySpecifiedName(propertyNameToAtomString(propertyName)))) {
             slot.setValue(thisObject, PropertyAttribute::ReadOnly | PropertyAttribute::DontEnum, toJS(&lexicalGlobalObject, scopedChild->document()->domWindow()));
             return true;
         }

--- a/Source/WebCore/css/query/MediaQueryFeatures.cpp
+++ b/Source/WebCore/css/query/MediaQueryFeatures.cpp
@@ -250,9 +250,7 @@ const FeatureSchema& color()
     static MainThreadNeverDestroyed<IntegerSchema> schema {
         "color"_s,
         [](auto& context) {
-            if (auto* localFrame = dynamicDowncast<LocalFrame>(context.document.frame()->mainFrame()))
-                return screenDepthPerComponent(localFrame->view()); 
-            return 8;
+            return screenDepthPerComponent(context.document.frame()->mainFrame().virtualView());
         }
     };
     return schema;
@@ -351,9 +349,7 @@ const FeatureSchema& dynamicRange()
                     return true;
                 if (frame.settings().forcedSupportsHighDynamicRangeValue() == ForcedAccessibilityValue::Off)
                     return false;
-                if (auto* localFrame = dynamicDowncast<LocalFrame>(frame.mainFrame()))
-                    return screenSupportsHighDynamicRange(localFrame->view());
-                return false;
+                return screenSupportsHighDynamicRange(frame.mainFrame().virtualView());
             }();
 
             MatchingIdentifiers identifiers { CSSValueStandard };

--- a/Source/WebCore/dom/TreeScope.cpp
+++ b/Source/WebCore/dom/TreeScope.cpp
@@ -530,11 +530,8 @@ RefPtr<Element> TreeScope::findAnchor(StringView name)
 static Element* focusedFrameOwnerElement(Frame* focusedFrame, LocalFrame* currentFrame)
 {
     for (; focusedFrame; focusedFrame = focusedFrame->tree().parent()) {
-        if (focusedFrame->tree().parent() == currentFrame) {
-            if (auto* localFrame = dynamicDowncast<LocalFrame>(focusedFrame))
-                return localFrame->ownerElement();
-            return nullptr;
-        }
+        if (focusedFrame->tree().parent() == currentFrame)
+            return focusedFrame->ownerElement();
     }
     return nullptr;
 }

--- a/Source/WebCore/html/HTMLFrameElementBase.cpp
+++ b/Source/WebCore/html/HTMLFrameElementBase.cpp
@@ -161,8 +161,8 @@ void HTMLFrameElementBase::didFinishInsertingNode()
 void HTMLFrameElementBase::didAttachRenderers()
 {
     if (RenderWidget* part = renderWidget()) {
-        if (RefPtr frame = dynamicDowncast<LocalFrame>(contentFrame()))
-            part->setWidget(frame->view());
+        if (RefPtr frame = contentFrame())
+            part->setWidget(frame->virtualView());
     }
 }
 

--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -1044,11 +1044,7 @@ static bool isElementRectMostlyInMainFrame(const HTMLMediaElement& element)
     if (!documentFrame)
         return false;
 
-    auto* localFrame = dynamicDowncast<LocalFrame>(documentFrame->mainFrame());
-    if (!localFrame)
-        return false;
-
-    auto mainFrameView = localFrame->view();
+    RefPtr mainFrameView = documentFrame->mainFrame().virtualView();
     if (!mainFrameView)
         return false;
 

--- a/Source/WebCore/inspector/InspectorFrontendClientLocal.cpp
+++ b/Source/WebCore/inspector/InspectorFrontendClientLocal.cpp
@@ -237,9 +237,9 @@ bool InspectorFrontendClientLocal::canAttachWindow()
         return true;
 
     // Don't allow the attach if the window would be too small to accommodate the minimum inspector size.
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_inspectedPageController->inspectedPage().mainFrame());
-    unsigned inspectedPageHeight = localMainFrame ? localMainFrame->view()->visibleHeight() : 0;
-    unsigned inspectedPageWidth = localMainFrame ? localMainFrame->view()->visibleWidth() : 0;
+    Ref mainFrame = m_inspectedPageController->inspectedPage().mainFrame();
+    unsigned inspectedPageHeight = mainFrame->virtualView()->visibleHeight();
+    unsigned inspectedPageWidth = mainFrame->virtualView()->visibleWidth();
     unsigned maximumAttachedHeight = inspectedPageHeight * maximumAttachedHeightRatio;
     return minimumAttachedHeight <= maximumAttachedHeight && minimumAttachedWidth <= inspectedPageWidth;
 }
@@ -251,11 +251,7 @@ void InspectorFrontendClientLocal::setDockingUnavailable(bool unavailable)
 
 void InspectorFrontendClientLocal::changeAttachedWindowHeight(unsigned height)
 {
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_frontendPage->mainFrame());
-    if (!localMainFrame)
-        return;
-    auto* otherMainFrame = dynamicDowncast<LocalFrame>(m_inspectedPageController->inspectedPage().mainFrame());
-    unsigned totalHeight = localMainFrame->view()->visibleHeight() + (otherMainFrame ? otherMainFrame->view()->visibleHeight() : 0);
+    unsigned totalHeight = m_frontendPage->mainFrame().virtualView()->visibleHeight() + m_inspectedPageController->inspectedPage().mainFrame().virtualView()->visibleHeight();
     unsigned attachedHeight = constrainedAttachedWindowHeight(height, totalHeight);
     m_settings->setProperty(inspectorAttachedHeightSetting, String::number(attachedHeight));
     setAttachedWindowHeight(attachedHeight);
@@ -263,11 +259,7 @@ void InspectorFrontendClientLocal::changeAttachedWindowHeight(unsigned height)
 
 void InspectorFrontendClientLocal::changeAttachedWindowWidth(unsigned width)
 {
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_frontendPage->mainFrame());
-    if (!localMainFrame)
-        return;
-    auto* otherMainFrame = dynamicDowncast<LocalFrame>(m_inspectedPageController->inspectedPage().mainFrame());
-    unsigned totalWidth = localMainFrame->view()->visibleWidth() + (otherMainFrame ? localMainFrame->view()->visibleWidth() : 0);
+    unsigned totalWidth = m_frontendPage->mainFrame().virtualView()->visibleWidth() + m_inspectedPageController->inspectedPage().mainFrame().virtualView()->visibleWidth();
     unsigned attachedWidth = constrainedAttachedWindowWidth(width, totalWidth);
     setAttachedWindowWidth(attachedWidth);
 }
@@ -333,8 +325,7 @@ void InspectorFrontendClientLocal::setAttachedWindow(DockSide dockSide)
 
 void InspectorFrontendClientLocal::restoreAttachedWindowHeight()
 {
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_inspectedPageController->inspectedPage().mainFrame());
-    unsigned inspectedPageHeight = localMainFrame ? localMainFrame->view()->visibleHeight() : 0;
+    unsigned inspectedPageHeight = m_inspectedPageController->inspectedPage().mainFrame().virtualView()->visibleHeight();
     String value = m_settings->getProperty(inspectorAttachedHeightSetting);
     unsigned preferredHeight = value.isEmpty() ? defaultAttachedHeight : parseIntegerAllowingTrailingJunk<unsigned>(value).value_or(0);
 

--- a/Source/WebCore/inspector/InspectorFrontendHost.cpp
+++ b/Source/WebCore/inspector/InspectorFrontendHost.cpp
@@ -433,8 +433,7 @@ String InspectorFrontendHost::platformVersionName() const
 
 void InspectorFrontendHost::copyText(const String& text)
 {
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_frontendPage->mainFrame());
-    auto pageID = m_frontendPage && localMainFrame ? localMainFrame->pageID() : std::nullopt;
+    auto pageID = m_frontendPage ? m_frontendPage->mainFrame().pageID() : std::nullopt;
     Pasteboard::createForCopyAndPaste(PagePasteboardContext::create(WTFMove(pageID)))->writePlainText(text, Pasteboard::CannotSmartReplace);
 }
 

--- a/Source/WebCore/inspector/InspectorOverlay.cpp
+++ b/Source/WebCore/inspector/InspectorOverlay.cpp
@@ -106,12 +106,12 @@ static void truncateWithEllipsis(String& string, size_t length)
         string = makeString(StringView(string).left(length), horizontalEllipsis);
 }
 
-static FloatPoint localPointToRootPoint(const LocalFrameView* view, const FloatPoint& point)
+static FloatPoint localPointToRootPoint(const FrameView* view, const FloatPoint& point)
 {
     return view->contentsToRootView(point);
 }
 
-static void contentsQuadToCoordinateSystem(const LocalFrameView* mainView, const LocalFrameView* view, FloatQuad& quad, InspectorOverlay::CoordinateSystem coordinateSystem)
+static void contentsQuadToCoordinateSystem(const FrameView* mainView, const LocalFrameView* view, FloatQuad& quad, InspectorOverlay::CoordinateSystem coordinateSystem)
 {
     quad.setP1(localPointToRootPoint(view, quad.p1()));
     quad.setP2(localPointToRootPoint(view, quad.p2()));
@@ -145,8 +145,7 @@ static void buildRendererHighlight(RenderObject* renderer, const InspectorOverla
 
     highlight.setDataFromConfig(highlightConfig);
     auto* containingView = containingFrame->view();
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(containingFrame->page()->mainFrame());
-    auto* mainView = localMainFrame ? localMainFrame->view() : nullptr;
+    auto* mainView = containingFrame->page()->mainFrame().virtualView();
 
     // (Legacy)RenderSVGRoot should be highlighted through the isBox() code path, all other SVG elements should just dump their absoluteQuads().
     bool isSVGRenderer = renderer->node() && renderer->node()->isSVGElement() && !renderer->isRenderOrLegacyRenderSVGRoot();
@@ -319,8 +318,7 @@ static void drawShapeHighlight(GraphicsContext& context, Node& node, InspectorOv
         return;
 
     auto* containingView = containingFrame->view();
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(containingFrame->page()->mainFrame());
-    auto* mainView = localMainFrame ? localMainFrame->view() : nullptr;
+    auto* mainView = containingFrame->page()->mainFrame().virtualView();
 
     static constexpr auto shapeHighlightColor = SRGBA<uint8_t> { 96, 82, 127, 204 };
 
@@ -402,11 +400,7 @@ void InspectorOverlay::paint(GraphicsContext& context)
     if (!shouldShowOverlay())
         return;
 
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
-    if (!localMainFrame)
-        return;
-
-    FloatSize viewportSize = localMainFrame->view()->sizeForVisibleContent();
+    auto viewportSize = m_page.mainFrame().virtualView()->sizeForVisibleContent();
 
     context.clearRect({ FloatPoint::zero(), viewportSize });
 
@@ -603,12 +597,8 @@ void InspectorOverlay::highlightNode(Node* node, const InspectorOverlay::Highlig
 
 void InspectorOverlay::highlightQuad(std::unique_ptr<FloatQuad> quad, const InspectorOverlay::Highlight::Config& highlightConfig)
 {
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
-    if (!localMainFrame)
-        return;
-
     if (highlightConfig.usePageCoordinates)
-        *quad -= toIntSize(localMainFrame->view()->scrollPosition());
+        *quad -= toIntSize(m_page.mainFrame().virtualView()->scrollPosition());
 
     m_quadHighlightConfig = highlightConfig;
     m_highlightQuad = WTFMove(quad);
@@ -654,12 +644,7 @@ void InspectorOverlay::update()
         return;
     }
 
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
-    if (!localMainFrame)
-        return;
-
-    auto* view = localMainFrame->view();
-    if (!view)
+    if (!m_page.mainFrame().virtualView())
         return;
 
     m_client->highlight();
@@ -683,11 +668,7 @@ void InspectorOverlay::showPaintRect(const FloatRect& rect)
     if (!m_showPaintRects)
         return;
 
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
-    if (!localMainFrame)
-        return;
-
-    IntRect rootRect = localMainFrame->view()->contentsToRootView(enclosingIntRect(rect));
+    auto rootRect = m_page.mainFrame().virtualView()->contentsToRootView(enclosingIntRect(rect));
 
     const auto removeDelay = 250_ms;
 
@@ -1530,11 +1511,8 @@ std::optional<InspectorOverlay::Highlight::GridHighlightOverlay> InspectorOverla
     }
 
     constexpr auto translucentLabelBackgroundColor = Color::white.colorWithAlphaByte(230);
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
-    if (!localMainFrame)
-        return { };
 
-    auto* pageView = localMainFrame->view();
+    RefPtr pageView = m_page.mainFrame().virtualView();
     if (!pageView)
         return { };
     FloatRect viewportBounds = { { 0, 0 }, pageView->sizeForVisibleContent() };

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
@@ -1045,10 +1045,7 @@ void InspectorPageAgent::didPaint(RenderObject& renderer, const LayoutRect& rect
     Ref localFrame = view->frame();
     if (!localFrame->isMainFrame()) {
         IntRect rootViewRect = view->contentsToRootView(snappedIntRect(absoluteRect));
-        auto* localMainFrame = dynamicDowncast<LocalFrame>(localFrame->mainFrame());
-        if (!localMainFrame)
-            return;
-        rootRect = localMainFrame->view()->rootViewToContents(rootViewRect);
+        rootRect = localFrame->mainFrame().virtualView()->rootViewToContents(rootViewRect);
     }
 
     if (m_client->overridesShowPaintRects()) {

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1265,10 +1265,8 @@ void FrameLoader::completed()
 {
     Ref frame = m_frame.get();
 
-    for (RefPtr descendant = frame->tree().traverseNext(m_frame.ptr()); descendant; descendant = descendant->tree().traverseNext(m_frame.ptr())) {
-        if (RefPtr localDescendant = dynamicDowncast<LocalFrame>(*descendant))
-            localDescendant->navigationScheduler().startTimer();
-    }
+    for (RefPtr descendant = frame->tree().traverseNext(m_frame.ptr()); descendant; descendant = descendant->tree().traverseNext(m_frame.ptr()))
+        descendant->navigationScheduler().startTimer();
 
     if (RefPtr parent = m_frame->tree().parent()) {
         if (RefPtr localParent = dynamicDowncast<LocalFrame>(parent.releaseNonNull()))

--- a/Source/WebCore/page/DragController.cpp
+++ b/Source/WebCore/page/DragController.cpp
@@ -1367,12 +1367,9 @@ void DragController::beginDrag(DragItem dragItem, LocalFrame& frame, const IntPo
     m_didInitiateDrag = true;
     m_dragInitiator = frame.document();
 
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
-    if (!localMainFrame)
-        return;
     // Protect this frame and view, as a load may occur mid drag and attempt to unload this frame
-    Ref protectedLocalMainFrame(*localMainFrame);
-    RefPtr viewProtector = protectedLocalMainFrame->view();
+    Ref protectedLocalMainFrame(m_page.mainFrame());
+    RefPtr viewProtector = protectedLocalMainFrame->virtualView();
 
     auto mouseDownPointInRootViewCoordinates = viewProtector->rootViewToContents(frame.view()->contentsToRootView(mouseDownPoint));
     auto mouseDraggedPointInRootViewCoordinates = viewProtector->rootViewToContents(frame.view()->contentsToRootView(mouseDraggedPoint));

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -504,10 +504,8 @@ void FocusController::setFocusedInternal(bool focused)
     if (!isFocused())
         focusedOrMainFrame().eventHandler().stopAutoscrollTimer();
 
-    if (!focusedFrame()) {
-        if (auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame()))
-            setFocusedFrame(localMainFrame);
-    }
+    if (!focusedFrame())
+        setFocusedFrame(&m_page.mainFrame());
 
     auto* focusedFrame = focusedLocalFrame();
     if (focusedFrame && focusedFrame->view()) {
@@ -632,7 +630,7 @@ bool FocusController::advanceFocusInDocumentOrder(FocusDirection direction, Keyb
             return false;
 
         document->setFocusedElement(nullptr);
-        setFocusedFrame(dynamicDowncast<LocalFrame>(owner.contentFrame()));
+        setFocusedFrame(owner.contentFrame());
         return true;
     }
     
@@ -1029,17 +1027,13 @@ static void contentAreaDidShowOrHide(ScrollableArea* scrollableArea, bool didSho
 
 void FocusController::setIsVisibleAndActiveInternal(bool contentIsVisible)
 {
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
-    if (!localMainFrame)
-        return;
-
-    auto* view = localMainFrame->view();
+    auto* view = m_page.mainFrame().virtualView();
     if (!view)
         return;
 
     contentAreaDidShowOrHide(view, contentIsVisible);
 
-    for (Frame* frame = localMainFrame; frame; frame = frame->tree().traverseNext()) {
+    for (auto* frame = &m_page.mainFrame(); frame; frame = frame->tree().traverseNext()) {
         auto* localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;

--- a/Source/WebCore/page/IntersectionObserver.cpp
+++ b/Source/WebCore/page/IntersectionObserver.cpp
@@ -349,7 +349,7 @@ auto IntersectionObserver::computeIntersectionState(const IntersectionObserverRe
 
         ASSERT(frameView.frame().isMainFrame());
         // FIXME: Handle the case of an implicit-root observer that has a target in a different frame tree.
-        if (dynamicDowncast<LocalFrame>(targetRenderer->frame().mainFrame()) != &frameView.frame())
+        if (targetRenderer->frame().mainFrame() != frameView.frame())
             return;
 
         intersectionState.canComputeIntersection = true;

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -329,10 +329,7 @@ void LocalDOMWindow::dispatchAllPendingUnloadEvents()
 // 5) Translate the window rect coordinates to be within the coordinate space of the screen.
 FloatRect LocalDOMWindow::adjustWindowRect(Page& page, const FloatRect& pendingChanges)
 {
-    RefPtr localMainFrame = dynamicDowncast<LocalFrame>(page.mainFrame());
-    if (!localMainFrame)
-        return FloatRect();
-    FloatRect screen = screenAvailableRect(localMainFrame->view());
+    FloatRect screen = screenAvailableRect(page.mainFrame().virtualView());
     FloatRect window = page.chrome().windowRect();
 
     // Make sure we're in a valid state before adjusting dimensions.
@@ -1846,11 +1843,8 @@ void LocalDOMWindow::moveTo(int x, int y) const
 
     CheckedPtr page = frame()->page();
     auto fr = page->chrome().windowRect();
-    RefPtr localMainFrame = dynamicDowncast<LocalFrame>(page->mainFrame());
-    if (!localMainFrame)
-        return;
 
-    auto sr = screenAvailableRect(localMainFrame->view());
+    auto sr = screenAvailableRect(page->mainFrame().virtualView());
     fr.setLocation(sr.location());
     auto update = fr;
     update.move(x, y);

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -3007,11 +3007,7 @@ bool LocalFrameView::shouldUpdateCompositingLayersAfterScrolling() const
     if (!page)
         return true;
 
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(page->mainFrame());
-    if (!localMainFrame)
-        return true;
-
-    if (localMainFrame != m_frame.ptr())
+    if (page->mainFrame() != m_frame)
         return true;
 
     auto scrollingCoordinator = this->scrollingCoordinator();

--- a/Source/WebCore/page/PageOverlay.cpp
+++ b/Source/WebCore/page/PageOverlay.cpp
@@ -81,12 +81,7 @@ IntRect PageOverlay::bounds() const
     if (!m_overrideFrame.isEmpty())
         return { { }, m_overrideFrame.size() };
 
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
-    if (!localMainFrame)
-        return IntRect();
-
-    auto* frameView = localMainFrame->view();
-
+    RefPtr frameView = m_page->mainFrame().virtualView();
     if (!frameView)
         return IntRect();
 
@@ -189,8 +184,7 @@ void PageOverlay::drawRect(GraphicsContext& graphicsContext, const IntRect& dirt
     GraphicsContextStateSaver stateSaver(graphicsContext);
 
     if (m_overlayType == PageOverlay::OverlayType::Document) {
-        auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
-        if (auto* frameView = localMainFrame ? localMainFrame->view() : nullptr) {
+        if (auto* frameView = m_page->mainFrame().virtualView()) {
             auto offset = frameView->scrollOrigin();
             graphicsContext.translate(toFloatSize(offset));
             paintRect.moveBy(-offset);

--- a/Source/WebCore/page/ResourceUsageOverlay.cpp
+++ b/Source/WebCore/page/ResourceUsageOverlay.cpp
@@ -51,11 +51,9 @@ ResourceUsageOverlay::ResourceUsageOverlay(Page& page)
 ResourceUsageOverlay::~ResourceUsageOverlay()
 {
     platformDestroy();
-    if (auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame())) {
-        // FIXME: This is a hack so we don't try to uninstall the PageOverlay during Page destruction.
-        if (localMainFrame->page())
-            m_page.pageOverlayController().uninstallPageOverlay(*m_overlay, PageOverlay::FadeMode::DoNotFade);
-    }
+    // FIXME: This is a hack so we don't try to uninstall the PageOverlay during Page destruction.
+    if (m_page.mainFrame().page())
+        m_page.pageOverlayController().uninstallPageOverlay(*m_overlay, PageOverlay::FadeMode::DoNotFade);
 }
 
 void ResourceUsageOverlay::initialize()
@@ -114,10 +112,7 @@ bool ResourceUsageOverlay::mouseEvent(PageOverlay&, const PlatformMouseEvent& ev
                 newFrame.setX(0);
             if (newFrame.y() < m_page.topContentInset())
                 newFrame.setY(m_page.topContentInset());
-            auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
-            if (!localMainFrame)
-                break;
-            auto& frameView = *localMainFrame->view();
+            auto& frameView = *m_page.mainFrame().virtualView();
             if (newFrame.maxX() > frameView.width())
                 newFrame.setX(frameView.width() - newFrame.width());
             if (newFrame.maxY() > frameView.height())

--- a/Source/WebCore/page/SpatialNavigation.cpp
+++ b/Source/WebCore/page/SpatialNavigation.cpp
@@ -506,14 +506,11 @@ static LayoutRect rectToAbsoluteCoordinates(LocalFrame* initialFrame, const Layo
 {
     LayoutRect rect = initialRect;
     for (Frame* frame = initialFrame; frame; frame = frame->tree().parent()) {
-        auto* localFrame = dynamicDowncast<LocalFrame>(frame);
-        if (!localFrame)
-            continue;
-        if (Element* element = localFrame->ownerElement()) {
+        if (Element* element = frame->ownerElement()) {
             do {
                 rect.move(LayoutUnit(element->offsetLeft()), LayoutUnit(element->offsetTop()));
             } while ((element = element->offsetParent()));
-            rect.moveBy((-localFrame->view()->scrollPosition()));
+            rect.moveBy((-frame->virtualView()->scrollPosition()));
         }
     }
     return rect;

--- a/Source/WebCore/page/mac/DragControllerMac.mm
+++ b/Source/WebCore/page/mac/DragControllerMac.mm
@@ -100,10 +100,9 @@ void DragController::cleanupAfterSystemDrag()
     // call it anyway to be on the safe side.
     // We don't want to do this for WebKit2, since the client call to start the drag
     // is asynchronous.
-    if (auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame())) {
-        if (localMainFrame->view()->platformWidget())
-            dragEnded();
-    }
+
+    if (m_page.mainFrame().virtualView()->platformWidget())
+        dragEnded();
 #endif
 }
 

--- a/Source/WebCore/page/mac/ImageOverlayControllerMac.mm
+++ b/Source/WebCore/page/mac/ImageOverlayControllerMac.mm
@@ -72,11 +72,7 @@ void ImageOverlayController::updateDataDetectorHighlights(const HTMLElement& ove
     if (dataDetectorResultElementsWithHighlights == dataDetectorResultElements)
         return;
 
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
-    if (!localMainFrame)
-        return;
-
-    RefPtr mainFrameView = localMainFrame->view();
+    RefPtr mainFrameView = m_page->mainFrame().virtualView();
     if (!mainFrameView)
         return;
 
@@ -101,11 +97,7 @@ void ImageOverlayController::updateDataDetectorHighlights(const HTMLElement& ove
 
 bool ImageOverlayController::platformHandleMouseEvent(const PlatformMouseEvent& event)
 {
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
-    if (!localMainFrame)
-        return false;
-
-    RefPtr mainFrameView = localMainFrame->view();
+    RefPtr mainFrameView = m_page->mainFrame().virtualView();
     if (!mainFrameView)
         return false;
 

--- a/Source/WebCore/page/mac/ServicesOverlayController.mm
+++ b/Source/WebCore/page/mac/ServicesOverlayController.mm
@@ -398,14 +398,10 @@ void ServicesOverlayController::buildSelectionHighlight()
     if (!PAL::isDataDetectorsFrameworkAvailable())
         return;
 
-    RefPtr localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
-    if (!localMainFrame)
-        return;
-
     HashSet<RefPtr<DataDetectorHighlight>> newPotentialHighlights;
 
     if (auto selectionRange = m_page.selection().firstRange()) {
-        RefPtr mainFrameView = localMainFrame->view();
+        RefPtr mainFrameView = m_page.mainFrame().virtualView();
         if (!mainFrameView)
             return;
 
@@ -578,11 +574,7 @@ void ServicesOverlayController::determineActiveHighlight(bool& mouseIsOverActive
 
 bool ServicesOverlayController::mouseEvent(PageOverlay&, const PlatformMouseEvent& event)
 {
-    RefPtr localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
-    if (!localMainFrame)
-        return false;
-
-    m_mousePosition = localMainFrame->view()->windowToContents(event.position());
+    m_mousePosition = m_page.mainFrame().virtualView()->windowToContents(event.position());
 
     bool mouseIsOverActiveHighlightButton = false;
     determineActiveHighlight(mouseIsOverActiveHighlightButton);
@@ -645,11 +637,7 @@ void ServicesOverlayController::didScrollFrame(PageOverlay&, LocalFrame& frame)
 
 void ServicesOverlayController::handleClick(const IntPoint& clickPoint, DataDetectorHighlight& highlight)
 {
-    RefPtr localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
-    if (!localMainFrame)
-        return;
-
-    RefPtr frameView = localMainFrame->view();
+    RefPtr frameView = m_page.mainFrame().virtualView();
     if (!frameView)
         return;
 

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
@@ -893,11 +893,7 @@ void AsyncScrollingCoordinator::setFrameScrollingNodeState(ScrollingNodeID nodeI
     if (!is<ScrollingStateFrameScrollingNode>(stateNode))
         return;
 
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
-    if (!localMainFrame)
-        return;
-
-    auto& settings = localMainFrame->settings();
+    auto& settings = m_page->mainFrame().settings();
     auto& frameScrollingNode = downcast<ScrollingStateFrameScrollingNode>(*stateNode);
 
     frameScrollingNode.setFrameScaleFactor(frameView.frame().frameScaleFactor());

--- a/Source/WebCore/page/scrolling/ScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinator.cpp
@@ -359,11 +359,7 @@ void ScrollingCoordinator::setForceSynchronousScrollLayerPositionUpdates(bool fo
 
 bool ScrollingCoordinator::shouldUpdateScrollLayerPositionSynchronously(const LocalFrameView& frameView) const
 {
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
-    if (!localMainFrame)
-        return false;
-
-    if (&frameView == localMainFrame->view())
+    if (&frameView == m_page->mainFrame().virtualView())
         return !synchronousScrollingReasons(frameView.scrollingNodeID()).isEmpty();
     
     return true;

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -413,8 +413,7 @@ void WebFullScreenManager::close()
 
 void WebFullScreenManager::saveScrollPosition()
 {
-    if (auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->corePage()->mainFrame()))
-        m_scrollPosition = localMainFrame->view()->scrollPosition();
+    m_scrollPosition = m_page->corePage()->mainFrame().virtualView()->scrollPosition();
 }
 
 void WebFullScreenManager::restoreScrollPosition()

--- a/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp
@@ -426,7 +426,7 @@ RefPtr<WebFrame> InjectedBundleNodeHandle::htmlIFrameElementContentFrame()
     if (!iframeElement)
         return nullptr;
 
-    auto* frame = dynamicDowncast<LocalFrame>(iframeElement->contentFrame());
+    auto* frame = iframeElement->contentFrame();
     if (!frame)
         return nullptr;
 

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -332,10 +332,7 @@ static void addParametersShared(const LocalFrame* frame, NetworkResourceLoadPara
     // WebLocalFrameLoaderClient::applyToDocumentLoader stored the value on. Otherwise, we need to get the
     // value from the main frame's current DocumentLoader.
 
-    RefPtr mainFrame = dynamicDowncast<LocalFrame>(frame->mainFrame());
-    if (!mainFrame)
-        return;
-
+    Ref mainFrame = frame->mainFrame();
     RefPtr policySourceDocumentLoader = policySourceDocumentLoaderForFrame(*frame, isMainFrameNavigation);
 
     parameters.allowPrivacyProxy = policySourceDocumentLoader ? policySourceDocumentLoader->allowPrivacyProxy() : true;

--- a/Source/WebKit/WebProcess/WebCoreSupport/ShareableBitmapUtilities.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/ShareableBitmapUtilities.cpp
@@ -45,11 +45,7 @@ using namespace WebCore;
 RefPtr<ShareableBitmap> createShareableBitmap(RenderImage& renderImage, CreateShareableBitmapFromImageOptions&& options)
 {
     Ref frame = renderImage.frame();
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(frame->mainFrame());
-    if (!localMainFrame)
-        return { };
-
-    auto colorSpaceForBitmap = screenColorSpace(localMainFrame->view());
+    auto colorSpaceForBitmap = screenColorSpace(frame->mainFrame().virtualView());
     if (!renderImage.isRenderMedia() && !renderImage.opacity() && options.useSnapshotForTransparentImages == UseSnapshotForTransparentImages::Yes) {
         auto snapshotRect = renderImage.absoluteBoundingBoxRect();
         if (snapshotRect.isEmpty())

--- a/Source/WebKit/WebProcess/WebPage/FindController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/FindController.cpp
@@ -523,13 +523,8 @@ void FindController::redraw()
 Vector<FloatRect> FindController::rectsForTextMatchesInRect(IntRect clipRect)
 {
     Vector<FloatRect> rects;
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_webPage->corePage()->mainFrame());
-    if (!localMainFrame)
-        return rects;
-
-    auto* mainFrameView = localMainFrame->view();
-
-    for (RefPtr<Frame> frame = localMainFrame; frame; frame = frame->tree().traverseNext()) {
+    RefPtr mainFrameView = m_webPage->corePage()->mainFrame().virtualView();
+    for (RefPtr frame = &m_webPage->corePage()->mainFrame(); frame; frame = frame->tree().traverseNext()) {
         auto* localFrame = dynamicDowncast<LocalFrame>(frame.get());
         if (!localFrame)
             continue;

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -625,11 +625,10 @@ String WebFrame::selectionAsString() const
 
 IntSize WebFrame::size() const
 {
-    RefPtr localFrame = dynamicDowncast<LocalFrame>(m_coreFrame.get());
-    if (!localFrame)
+    if (!m_coreFrame)
         return IntSize();
 
-    RefPtr frameView = localFrame->view();
+    RefPtr frameView = m_coreFrame->virtualView();
     if (!frameView)
         return IntSize();
 
@@ -792,11 +791,10 @@ JSGlobalContextRef WebFrame::jsContextForWorld(InjectedBundleScriptWorld* world)
 
 JSGlobalContextRef WebFrame::jsContextForServiceWorkerWorld(DOMWrapperWorld& world)
 {
-    RefPtr localFrame = dynamicDowncast<LocalFrame>(m_coreFrame.get());
-    if (!localFrame || !localFrame->page())
+    if (!m_coreFrame || !m_coreFrame->page())
         return nullptr;
 
-    return toGlobalRef(localFrame->page()->serviceWorkerGlobalObject(world));
+    return toGlobalRef(m_coreFrame->page()->serviceWorkerGlobalObject(world));
 }
 
 JSGlobalContextRef WebFrame::jsContextForServiceWorkerWorld(InjectedBundleScriptWorld* world)
@@ -826,11 +824,10 @@ void WebFrame::setAccessibleName(const AtomString& accessibleName)
 
 IntRect WebFrame::contentBounds() const
 {
-    RefPtr localFrame = dynamicDowncast<LocalFrame>(m_coreFrame.get());
-    if (!localFrame)
+    if (!m_coreFrame)
         return IntRect();
     
-    RefPtr view = localFrame->view();
+    RefPtr view = m_coreFrame->virtualView();
     if (!view)
         return IntRect();
     
@@ -839,11 +836,10 @@ IntRect WebFrame::contentBounds() const
 
 IntRect WebFrame::visibleContentBounds() const
 {
-    RefPtr localFrame = dynamicDowncast<LocalFrame>(m_coreFrame.get());
-    if (!localFrame)
+    if (!m_coreFrame)
         return IntRect();
     
-    RefPtr view = localFrame->view();
+    RefPtr view = m_coreFrame->virtualView();
     if (!view)
         return IntRect();
     
@@ -867,11 +863,10 @@ IntRect WebFrame::visibleContentBoundsExcludingScrollbars() const
 
 IntSize WebFrame::scrollOffset() const
 {
-    RefPtr localFrame = dynamicDowncast<LocalFrame>(m_coreFrame.get());
-    if (!localFrame)
+    if (!m_coreFrame)
         return IntSize();
     
-    RefPtr view = localFrame->view();
+    RefPtr view = m_coreFrame->virtualView();
     if (!view)
         return IntSize();
 
@@ -893,11 +888,10 @@ bool WebFrame::hasHorizontalScrollbar() const
 
 bool WebFrame::hasVerticalScrollbar() const
 {
-    RefPtr localFrame = dynamicDowncast<LocalFrame>(m_coreFrame.get());
-    if (!localFrame)
+    if (!m_coreFrame)
         return false;
 
-    RefPtr view = localFrame->view();
+    RefPtr view = m_coreFrame->virtualView();
     if (!view)
         return false;
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1706,7 +1706,7 @@ bool WebPage::isEditingCommandEnabled(const String& commandName)
     
 void WebPage::clearMainFrameName()
 {
-    if (auto* frame = dynamicDowncast<LocalFrame>(mainFrame()))
+    if (auto* frame = mainFrame())
         frame->tree().clearName();
 }
 
@@ -2192,8 +2192,7 @@ void WebPage::setSize(const WebCore::IntSize& viewSize)
         return;
 
     m_viewSize = viewSize;
-    RefPtr localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
-    RefPtr view = localMainFrame ? localMainFrame->view() : nullptr;
+    RefPtr view = m_page->mainFrame().virtualView();
     if (!view) {
         ASSERT_NOT_REACHED();
         return;
@@ -2546,8 +2545,7 @@ void WebPage::scaleView(double scale)
     float pageScale = pageScaleFactor();
 
     IntPoint scrollPositionAtNewScale;
-    RefPtr localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
-    if (RefPtr mainFrameView = localMainFrame ? localMainFrame->view() : nullptr) {
+    if (RefPtr mainFrameView = m_page->mainFrame().virtualView()) {
         double scaleRatio = scale / viewScaleFactor();
         scrollPositionAtNewScale = mainFrameView->scrollPosition();
         scrollPositionAtNewScale.scale(scaleRatio);
@@ -3009,10 +3007,8 @@ void WebPage::paintSnapshotAtSize(const IntRect& rect, const IntSize& bitmapSize
 static DestinationColorSpace snapshotColorSpace(SnapshotOptions options, WebPage& page)
 {
 #if USE(CG)
-    if (options & SnapshotOptionsUseScreenColorSpace) {
-        if (auto* localMainFrame = dynamicDowncast<LocalFrame>(page.corePage()->mainFrame()))
-            return screenColorSpace(localMainFrame->view());
-    }
+    if (options & SnapshotOptionsUseScreenColorSpace)
+        return screenColorSpace(page.corePage()->mainFrame().virtualView());
 #endif
     return DestinationColorSpace::SRGB();
 }


### PR DESCRIPTION
#### 441ecb3a880a9aad39f1acd2d270300c94fc7b43
<pre>
[Site Isolation] Fix some cases where we unnecessarily skip code on out-of-process frames
<a href="https://bugs.webkit.org/show_bug.cgi?id=265563">https://bugs.webkit.org/show_bug.cgi?id=265563</a>
<a href="https://rdar.apple.com/118970867">rdar://118970867</a>

Reviewed by Alex Christensen.

There are several places where we are unnecessarily skipping code on out-of-process frames. We should
avoid downcasting to a local frame if it&apos;s not required.

* Source/WebCore/bindings/js/JSLocalDOMWindowCustom.cpp:
(WebCore::jsLocalDOMWindowGetOwnPropertySlotRestrictedAccess):
* Source/WebCore/css/query/MediaQueryFeatures.cpp:
(WebCore::MQ::Features::color):
(WebCore::MQ::Features::dynamicRange):
* Source/WebCore/dom/TreeScope.cpp:
(WebCore::focusedFrameOwnerElement):
* Source/WebCore/html/HTMLFrameElementBase.cpp:
(WebCore::HTMLFrameElementBase::didAttachRenderers):
* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::isElementRectMostlyInMainFrame):
* Source/WebCore/inspector/InspectorFrontendClientLocal.cpp:
(WebCore::InspectorFrontendClientLocal::canAttachWindow):
(WebCore::InspectorFrontendClientLocal::changeAttachedWindowHeight):

(WebCore::InspectorFrontendClientLocal::changeAttachedWindowWidth):

There is also a behavior change in this function. Previously, we did a null check on `otherMainFrame` and
then used the width on `localMainFrame`, which seemed like a bug.

(WebCore::InspectorFrontendClientLocal::restoreAttachedWindowHeight):
* Source/WebCore/inspector/InspectorFrontendHost.cpp:
(WebCore::InspectorFrontendHost::copyText):
* Source/WebCore/inspector/InspectorOverlay.cpp:
(WebCore::localPointToRootPoint):
(WebCore::contentsQuadToCoordinateSystem):
(WebCore::buildRendererHighlight):
(WebCore::drawShapeHighlight):
(WebCore::InspectorOverlay::paint):
(WebCore::InspectorOverlay::highlightQuad):
(WebCore::InspectorOverlay::update):
(WebCore::InspectorOverlay::showPaintRect):
(WebCore::InspectorOverlay::buildGridOverlay):
* Source/WebCore/inspector/agents/InspectorPageAgent.cpp:
(WebCore::InspectorPageAgent::didPaint):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::completed):
* Source/WebCore/page/DragController.cpp:
(WebCore::DragController::beginDrag):
* Source/WebCore/page/FocusController.cpp:
(WebCore::FocusController::setFocusedInternal):
(WebCore::FocusController::advanceFocusInDocumentOrder):
(WebCore::FocusController::setIsVisibleAndActiveInternal):
* Source/WebCore/page/IntersectionObserver.cpp:
(WebCore::IntersectionObserver::computeIntersectionState const):
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::adjustWindowRect):
(WebCore::LocalDOMWindow::moveTo const):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::shouldUpdateCompositingLayersAfterScrolling const):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::findString):
(WebCore::Page::screenPropertiesDidChange):
(WebCore::Page::lockAllOverlayScrollbarsToHidden):
(WebCore::Page::setVerticalScrollElasticity):
(WebCore::Page::setDebugger):
(WebCore::Page::subframeCount const):
* Source/WebCore/page/PageOverlay.cpp:
(WebCore::PageOverlay::bounds const):
(WebCore::PageOverlay::drawRect):
* Source/WebCore/page/ResourceUsageOverlay.cpp:
(WebCore::ResourceUsageOverlay::~ResourceUsageOverlay):
(WebCore::ResourceUsageOverlay::mouseEvent):
* Source/WebCore/page/SpatialNavigation.cpp:
(WebCore::rectToAbsoluteCoordinates):
* Source/WebCore/page/mac/DragControllerMac.mm:
(WebCore::DragController::cleanupAfterSystemDrag):
* Source/WebCore/page/mac/ImageOverlayControllerMac.mm:
(WebCore::ImageOverlayController::updateDataDetectorHighlights):
(WebCore::ImageOverlayController::platformHandleMouseEvent):
* Source/WebCore/page/mac/ServicesOverlayController.mm:
(WebCore::ServicesOverlayController::buildSelectionHighlight):
(WebCore::ServicesOverlayController::mouseEvent):
(WebCore::ServicesOverlayController::handleClick):
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::setFrameScrollingNodeState):
* Source/WebCore/page/scrolling/ScrollingCoordinator.cpp:
(WebCore::ScrollingCoordinator::shouldUpdateScrollLayerPositionSynchronously const):
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::WebFullScreenManager::saveScrollPosition):
* Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp:
(WebKit::InjectedBundleNodeHandle::htmlIFrameElementContentFrame):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::addParametersShared):
* Source/WebKit/WebProcess/WebCoreSupport/ShareableBitmapUtilities.cpp:
(WebKit::createShareableBitmap):
* Source/WebKit/WebProcess/WebPage/FindController.cpp:
(WebKit::FindController::rectsForTextMatchesInRect):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::size const):
(WebKit::WebFrame::jsContextForServiceWorkerWorld):
(WebKit::WebFrame::contentBounds const):
(WebKit::WebFrame::visibleContentBounds const):
(WebKit::WebFrame::scrollOffset const):
(WebKit::WebFrame::hasVerticalScrollbar const):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::clearMainFrameName):
(WebKit::WebPage::setSize):
(WebKit::WebPage::scaleView):
(WebKit::snapshotColorSpace):

Canonical link: <a href="https://commits.webkit.org/271358@main">https://commits.webkit.org/271358@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2046aff60d724c88713a458707ab5e69aa0a8a6a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28052 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6691 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29367 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30582 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25571 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28548 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8726 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4079 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/25332 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28319 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5470 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24101 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4688 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4887 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25108 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31271 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25677 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25542 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31169 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4864 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3030 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28938 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6406 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5304 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3636 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5363 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->