### PR TITLE
[WebGPU] Dynamics offsets is in bytes but code assumes it is in uints

### DIFF
--- a/Source/WebGPU/WebGPU/PipelineLayout.mm
+++ b/Source/WebGPU/WebGPU/PipelineLayout.mm
@@ -53,7 +53,7 @@ static void addInitialOffset(uint32_t initialOffset, uint32_t offset, uint32_t g
 {
     if (initialOffset != offset) {
         offsets.add(groupIndex, Vector<uint32_t>((offset - initialOffset) / sizeof(uint32_t)));
-        dynamicOffets.add(groupIndex, initialOffset);
+        dynamicOffets.add(groupIndex, initialOffset / sizeof(uint32_t));
     }
 }
 


### PR DESCRIPTION
#### 2714034088ac2026e0088d10c83241acfe386a15
<pre>
[WebGPU] Dynamics offsets is in bytes but code assumes it is in uints
<a href="https://bugs.webkit.org/show_bug.cgi?id=265564">https://bugs.webkit.org/show_bug.cgi?id=265564</a>
radar://118971735

Reviewed by Tadeu Zagallo.

Rest of the code assumed dynamic offset was in uints but it
was being stored in bytes, unlike offsets, so unify the two.

* Source/WebGPU/WebGPU/PipelineLayout.mm:
(WebGPU::addInitialOffset):

Canonical link: <a href="https://commits.webkit.org/271351@main">https://commits.webkit.org/271351@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d28e0ffa2b214519abd02f963783a825fe097632

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28054 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6693 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29370 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30584 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25573 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8695 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4081 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/25330 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28321 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5441 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24106 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4687 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4860 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31273 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25649 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25547 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31168 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4866 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3032 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28937 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6408 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6736 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5306 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5365 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->