### PR TITLE
[web-animations] remove animationShorthandForParsing()

### DIFF
--- a/Source/WebCore/css/StylePropertyShorthand.cpp
+++ b/Source/WebCore/css/StylePropertyShorthand.cpp
@@ -25,24 +25,6 @@
 
 namespace WebCore {
 
-StylePropertyShorthand animationShorthandForParsing()
-{
-    // Animation-name must come last, so that keywords for other properties in the shorthand
-    // preferentially match those properties.
-    static const CSSPropertyID animationPropertiesForParsing[] = {
-        CSSPropertyAnimationDuration,
-        CSSPropertyAnimationTimingFunction,
-        CSSPropertyAnimationDelay,
-        CSSPropertyAnimationIterationCount,
-        CSSPropertyAnimationDirection,
-        CSSPropertyAnimationFillMode,
-        CSSPropertyAnimationPlayState,
-        CSSPropertyAnimationName
-    };
-
-    return StylePropertyShorthand(CSSPropertyAnimation, animationPropertiesForParsing);
-}
-
 StylePropertyShorthand transitionShorthandForParsing()
 {
     // Similar to animations, we have property after timing-function and delay after

--- a/Source/WebCore/css/StylePropertyShorthand.h
+++ b/Source/WebCore/css/StylePropertyShorthand.h
@@ -51,8 +51,7 @@ private:
     CSSPropertyID m_shorthandID { CSSPropertyInvalid };
 };
 
-// Custom StylePropertyShorthand functions.
-StylePropertyShorthand animationShorthandForParsing();
+// Custom StylePropertyShorthand function.
 StylePropertyShorthand transitionShorthandForParsing();
 
 // Returns empty value if the property is not a shorthand.

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -2679,7 +2679,7 @@ bool CSSPropertyParser::parseShorthand(CSSPropertyID property, bool important)
     case CSSPropertyColumns:
         return consumeColumns(important);
     case CSSPropertyAnimation:
-        return consumeAnimationShorthand(animationShorthandForParsing(), important);
+        return consumeAnimationShorthand(animationShorthand(), important);
     case CSSPropertyTransition:
         return consumeAnimationShorthand(transitionShorthandForParsing(), important);
     case CSSPropertyTextDecoration: {


### PR DESCRIPTION
#### 200b6e4332ed38369c450b6c287405b432488286
<pre>
[web-animations] remove animationShorthandForParsing()
<a href="https://bugs.webkit.org/show_bug.cgi?id=265571">https://bugs.webkit.org/show_bug.cgi?id=265571</a>
<a href="https://rdar.apple.com/118977751">rdar://118977751</a>

Reviewed by Antti Koivisto.

There is a dedicated function called `animationShorthandForParsing()` to get the `animation` shorthand
list of longhands specifically for parsing purposes, but that list matches the similar function generated
from `CSSProperties.json` exactly, and so is redundant and should be removed.

* Source/WebCore/css/StylePropertyShorthand.cpp:
(WebCore::animationShorthandForParsing): Deleted.
* Source/WebCore/css/StylePropertyShorthand.h:
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::CSSPropertyParser::parseShorthand):

Canonical link: <a href="https://commits.webkit.org/271335@main">https://commits.webkit.org/271335@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ca84a131b6065d4c57f1645538b3948d862b55a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28066 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6705 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29391 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30596 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25585 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28562 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8714 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4092 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/25349 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28333 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5459 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24125 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4705 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/4877 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25132 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31285 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25667 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25564 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31183 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4878 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3042 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28948 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6419 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5317 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3628 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5376 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->