### PR TITLE
WebGLContextAttributes are used for GraphicsContextGL

### DIFF
--- a/LayoutTests/webgl/webgl-fail-platform-context-creation-no-crash-expected.txt
+++ b/LayoutTests/webgl/webgl-fail-platform-context-creation-no-crash-expected.txt
@@ -6,7 +6,7 @@ TEST COMPLETE: 5 PASS, 0 FAIL
 
 
 PASS [object WebGLRenderingContext] is non-null.
-PASS "failPlatformContextCreationForTesting" in glWorks.getContextAttributes() is true
+PASS "failContextCreationForTesting" in glWorks.getContextAttributes() is true
 PASS Received context lost error for glFails
 PASS glWorks.NO_ERROR is glWorks.getError()
 PASS successfullyParsed is true

--- a/LayoutTests/webgl/webgl-fail-platform-context-creation-no-crash.html
+++ b/LayoutTests/webgl/webgl-fail-platform-context-creation-no-crash.html
@@ -24,8 +24,8 @@ var glFails;
 function runTest() {
     glWorks = canvasWorks.getContext("webgl");
     shouldBeNonNull(glWorks);
-    shouldBeTrue('"failPlatformContextCreationForTesting" in glWorks.getContextAttributes()'); // Expects support for "DOM Testing APIs Enabled internal setting"
-    glFails = canvasFails.getContext("webgl", { failPlatformContextCreationForTesting: true });
+    shouldBeTrue('"failContextCreationForTesting" in glWorks.getContextAttributes()'); // Expects support for "DOM Testing APIs Enabled internal setting"
+    glFails = canvasFails.getContext("webgl", { failContextCreationForTesting: "FailPlatformContextCreation" });
     if (!glFails) {
         testPassed("Context was not returned");
         shouldBe("glWorks.NO_ERROR", "glWorks.getError()" );

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -397,7 +397,7 @@ bool HTMLCanvasElement::isWebGLType(const String& type)
         || type == "webkit-3d"_s;
 }
 
-GraphicsContextGLWebGLVersion HTMLCanvasElement::toWebGLVersion(const String& type)
+WebGLVersion HTMLCanvasElement::toWebGLVersion(const String& type)
 {
     ASSERT(isWebGLType(type));
     if (type == "webgl2"_s)

--- a/Source/WebCore/html/HTMLCanvasElement.h
+++ b/Source/WebCore/html/HTMLCanvasElement.h
@@ -84,7 +84,6 @@ public:
     CanvasRenderingContext2D* getContext2d(const String&, CanvasRenderingContext2DSettings&&);
 
 #if ENABLE(WEBGL)
-    using WebGLVersion = GraphicsContextGLWebGLVersion;
     static bool isWebGLType(const String&);
     static WebGLVersion toWebGLVersion(const String&);
     WebGLRenderingContextBase* createContextWebGL(WebGLVersion type, WebGLContextAttributes&& = { });

--- a/Source/WebCore/html/OffscreenCanvas.cpp
+++ b/Source/WebCore/html/OffscreenCanvas.cpp
@@ -228,7 +228,7 @@ void OffscreenCanvas::createContextWebGL(RenderingContextType contextType, WebGL
     } else
         return;
 
-    auto webGLVersion = (contextType == RenderingContextType::Webgl) ? GraphicsContextGLWebGLVersion::WebGL1 : GraphicsContextGLWebGLVersion::WebGL2;
+    auto webGLVersion = (contextType == RenderingContextType::Webgl) ? WebGLVersion::WebGL1 : WebGLVersion::WebGL2;
     m_context = WebGLRenderingContextBase::create(*this, attrs, webGLVersion);
 }
 

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -111,9 +111,9 @@ const GCGLuint64 MaxClientWaitTimeout = 0u;
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(WebGL2RenderingContext);
 
-std::unique_ptr<WebGL2RenderingContext> WebGL2RenderingContext::create(CanvasBase& canvas, GraphicsContextGLAttributes attributes)
+std::unique_ptr<WebGL2RenderingContext> WebGL2RenderingContext::create(CanvasBase& canvas, WebGLContextAttributes&& attributes)
 {
-    return std::unique_ptr<WebGL2RenderingContext>(new WebGL2RenderingContext(canvas, attributes));
+    return std::unique_ptr<WebGL2RenderingContext>(new WebGL2RenderingContext(canvas, WTFMove(attributes)));
 }
 
 WebGL2RenderingContext::~WebGL2RenderingContext()

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.h
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.h
@@ -45,7 +45,7 @@ class WebGLVertexArrayObject;
 class WebGL2RenderingContext final : public WebGLRenderingContextBase {
     WTF_MAKE_ISO_ALLOCATED(WebGL2RenderingContext);
 public:
-    static std::unique_ptr<WebGL2RenderingContext> create(CanvasBase&, GraphicsContextGLAttributes);
+    static std::unique_ptr<WebGL2RenderingContext> create(CanvasBase&, WebGLContextAttributes&&);
 
     ~WebGL2RenderingContext();
 

--- a/Source/WebCore/html/canvas/WebGLContextAttributes.h
+++ b/Source/WebCore/html/canvas/WebGLContextAttributes.h
@@ -33,8 +33,31 @@
 
 namespace WebCore {
 
+enum class WebGLVersion : uint8_t {
+    WebGL1,
+    WebGL2
+};
+
 using WebGLPowerPreference = GraphicsContextGLPowerPreference;
-using WebGLContextAttributes = GraphicsContextGLAttributes;
+
+using WebGLContextSimulatedCreationFailure = GraphicsContextGLSimulatedCreationFailure;
+
+struct WebGLContextAttributes {
+    bool alpha { true };
+    bool depth { true };
+    bool stencil { false };
+    bool antialias { true };
+    bool premultipliedAlpha { true };
+    bool preserveDrawingBuffer { false };
+    using PowerPreference = WebGLPowerPreference;
+    PowerPreference powerPreference { PowerPreference::Default };
+    bool failIfMajorPerformanceCaveat { false };
+#if ENABLE(WEBXR)
+    bool xrCompatible { false };
+#endif
+    using SimulatedCreationFailure = WebGLContextSimulatedCreationFailure;
+    SimulatedCreationFailure failContextCreationForTesting { SimulatedCreationFailure::None };
+};
 
 } // namespace WebCore
 

--- a/Source/WebCore/html/canvas/WebGLContextAttributes.idl
+++ b/Source/WebCore/html/canvas/WebGLContextAttributes.idl
@@ -37,6 +37,7 @@ enum WebGLPowerPreference {
     "None",
     "IPCBufferOOM",
     "CreationTimeout"
+    "FailPlatformContextCreation"
 };
 
 [
@@ -52,7 +53,6 @@ enum WebGLPowerPreference {
     WebGLPowerPreference powerPreference = "default";
     GLboolean failIfMajorPerformanceCaveat = false;
     [Conditional=WEBXR, EnabledBySetting=WebXREnabled] boolean xrCompatible = false;
-    [EnabledBySetting=DOMTestingAPIsEnabled] GLboolean failPlatformContextCreationForTesting = false;
     [EnabledBySetting=DOMTestingAPIsEnabled] WebGLContextSimulatedCreationFailure failContextCreationForTesting = "None";
 
 };

--- a/Source/WebCore/html/canvas/WebGLRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContext.cpp
@@ -112,9 +112,9 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(WebGLRenderingContext);
 
-std::unique_ptr<WebGLRenderingContext> WebGLRenderingContext::create(CanvasBase& canvas, GraphicsContextGLAttributes attributes)
+std::unique_ptr<WebGLRenderingContext> WebGLRenderingContext::create(CanvasBase& canvas, WebGLContextAttributes&& attributes)
 {
-    return std::unique_ptr<WebGLRenderingContext>(new WebGLRenderingContext(canvas, attributes));
+    return std::unique_ptr<WebGLRenderingContext>(new WebGLRenderingContext(canvas, WTFMove(attributes)));
 }
 
 WebGLRenderingContext::~WebGLRenderingContext()

--- a/Source/WebCore/html/canvas/WebGLRenderingContext.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContext.h
@@ -37,7 +37,7 @@ class WebGLTimerQueryEXT;
 class WebGLRenderingContext final : public WebGLRenderingContextBase {
     WTF_MAKE_ISO_ALLOCATED(WebGLRenderingContext);
 public:
-    static std::unique_ptr<WebGLRenderingContext> create(CanvasBase&, GraphicsContextGLAttributes);
+    static std::unique_ptr<WebGLRenderingContext> create(CanvasBase&, WebGLContextAttributes&&);
 
     ~WebGLRenderingContext();
 

--- a/Source/WebCore/platform/graphics/GraphicsContextGLAttributes.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGLAttributes.h
@@ -37,15 +37,11 @@ enum class GraphicsContextGLPowerPreference : uint8_t {
     HighPerformance
 };
 
-enum class GraphicsContextGLWebGLVersion : uint8_t {
-    WebGL1,
-    WebGL2
-};
-
 enum class GraphicsContextGLSimulatedCreationFailure : uint8_t {
     None,
     IPCBufferOOM,
-    CreationTimeout
+    CreationTimeout,
+    FailPlatformContextCreation
 };
 
 #if PLATFORM(MAC) || PLATFORM(MACCATALYST)
@@ -53,23 +49,15 @@ using PlatformGPUID = uint64_t;
 #endif
 
 struct GraphicsContextGLAttributes {
-    // WebGLContextAttributes
     bool alpha { true };
     bool depth { true };
     bool stencil { false };
     bool antialias { true };
     bool premultipliedAlpha { true };
     bool preserveDrawingBuffer { false };
-    bool failIfMajorPerformanceCaveat { false };
-    using PowerPreference = GraphicsContextGLPowerPreference;
-    PowerPreference powerPreference { PowerPreference::Default };
-
-    // Additional attributes.
+    GraphicsContextGLPowerPreference powerPreference { GraphicsContextGLPowerPreference::Default };
     float devicePixelRatio { 1 };
-    PowerPreference initialPowerPreference { PowerPreference::Default };
-    using WebGLVersion = GraphicsContextGLWebGLVersion;
-    WebGLVersion webGLVersion { WebGLVersion::WebGL1 };
-    bool forceRequestForHighPerformanceGPU { false };
+    bool isWebGL2 { false };
 #if PLATFORM(MAC) || PLATFORM(MACCATALYST)
     PlatformGPUID windowGPUID { 0 };
 #endif
@@ -79,18 +67,9 @@ struct GraphicsContextGLAttributes {
 #if ENABLE(WEBXR)
     bool xrCompatible { false };
 #endif
-    bool failPlatformContextCreationForTesting { false };
     using SimulatedCreationFailure = GraphicsContextGLSimulatedCreationFailure;
-    SimulatedCreationFailure failContextCreationForTesting { SimulatedCreationFailure::None }; // Not serialized.
-
-    PowerPreference effectivePowerPreference() const
-    {
-        if (forceRequestForHighPerformanceGPU)
-            return PowerPreference::HighPerformance;
-        return powerPreference;
-    }
+    SimulatedCreationFailure failContextCreationForTesting { SimulatedCreationFailure::None };
 };
-
 }
 
 #endif // ENABLE(WEBGL)

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
@@ -81,7 +81,7 @@ GraphicsContextGLANGLE::GraphicsContextGLANGLE(GraphicsContextGLAttributes attri
 
 bool GraphicsContextGLANGLE::initialize()
 {
-    if (contextAttributes().failPlatformContextCreationForTesting)
+    if (contextAttributes().failContextCreationForTesting == GraphicsContextGLAttributes::SimulatedCreationFailure::FailPlatformContextCreation)
         return false;
     if (!platformInitializeContext())
         return false;

--- a/Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.cpp
+++ b/Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.cpp
@@ -116,7 +116,7 @@ bool GraphicsContextGLGBM::platformInitializeContext()
         return false;
     }
 
-    m_isForWebGL2 = contextAttributes().webGLVersion == GraphicsContextGLWebGLVersion::WebGL2;
+    m_isForWebGL2 = contextAttributes().isWebGL2;
 
     Vector<EGLint> displayAttributes {
         EGL_PLATFORM_ANGLE_TYPE_ANGLE, EGL_PLATFORM_ANGLE_TYPE_OPENGLES_ANGLE,

--- a/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
@@ -169,7 +169,7 @@ RefPtr<VideoFrame> GraphicsContextGLTextureMapperANGLE::surfaceBufferToVideoFram
 
 bool GraphicsContextGLTextureMapperANGLE::platformInitializeContext()
 {
-    m_isForWebGL2 = contextAttributes().webGLVersion == GraphicsContextGLWebGLVersion::WebGL2;
+    m_isForWebGL2 = contextAttributes().isWebGL2;
 
     auto& sharedDisplay = PlatformDisplay::sharedDisplayForCompositing();
     m_displayObj = sharedDisplay.angleEGLDisplay();

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -5761,22 +5761,17 @@ void Internals::simulateEventForWebGLContext(SimulatedWebGLContextEvent event, W
 
 Internals::RequestedGPU Internals::requestedGPU(WebGLRenderingContext& context)
 {
-    UNUSED_PARAM(context);
-    if (auto optionalAttributes = context.getContextAttributes()) {
-        auto attributes = *optionalAttributes;
-        if (attributes.forceRequestForHighPerformanceGPU)
-            return RequestedGPU::HighPerformance;
-        switch (attributes.powerPreference) {
-        case GraphicsContextGLPowerPreference::Default:
-            return RequestedGPU::Default;
-        case GraphicsContextGLPowerPreference::LowPower:
-            return RequestedGPU::LowPower;
-        case GraphicsContextGLPowerPreference::HighPerformance:
-            return RequestedGPU::HighPerformance;
-        }
+    switch (context.creationAttributes().powerPreference) {
+    case WebGLPowerPreference::Default:
+        return RequestedGPU::Default;
+    case WebGLPowerPreference::LowPower:
+        return RequestedGPU::LowPower;
+    case WebGLPowerPreference::HighPerformance:
+        return RequestedGPU::HighPerformance;
     }
-
+    ASSERT_NOT_REACHED();
     return RequestedGPU::Default;
+
 }
 #endif
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2706,9 +2706,11 @@ header: <WebCore/GraphicsContextGLAttributes.h>
 };
 
 header: <WebCore/GraphicsContextGLAttributes.h>
-[CustomHeader] enum class WebCore::GraphicsContextGLWebGLVersion : uint8_t {
-    WebGL1,
-    WebGL2
+[CustomHeader] enum class WebCore::GraphicsContextGLSimulatedCreationFailure : uint8_t {
+    None,
+    IPCBufferOOM,
+    CreationTimeout,
+    FailPlatformContextCreation
 };
 
 struct WebCore::GraphicsContextGLAttributes {
@@ -2718,12 +2720,9 @@ struct WebCore::GraphicsContextGLAttributes {
     bool antialias;
     bool premultipliedAlpha;
     bool preserveDrawingBuffer;
-    bool failIfMajorPerformanceCaveat;
     WebCore::GraphicsContextGLPowerPreference powerPreference;
     float devicePixelRatio;
-    WebCore::GraphicsContextGLPowerPreference initialPowerPreference;
-    WebCore::GraphicsContextGLWebGLVersion webGLVersion;
-    bool forceRequestForHighPerformanceGPU;
+    bool isWebGL2;
 #if PLATFORM(MAC) || PLATFORM(MACCATALYST)
     uint64_t windowGPUID;
 #endif
@@ -2733,8 +2732,7 @@ struct WebCore::GraphicsContextGLAttributes {
 #if ENABLE(WEBXR)
     bool xrCompatible;
 #endif
-    bool failPlatformContextCreationForTesting;
-    [NotSerialized] WebCore::GraphicsContextGLSimulatedCreationFailure failContextCreationForTesting;
+    WebCore::GraphicsContextGLSimulatedCreationFailure failContextCreationForTesting;
 };
 #endif // ENABLE(GPU_PROCESS) && ENABLE(WEBGL)
 


### PR DESCRIPTION
#### bdc1a360d76f9dace3ce823d750c0231d3af7244
<pre>
WebGLContextAttributes are used for GraphicsContextGL
<a href="https://bugs.webkit.org/show_bug.cgi?id=265519">https://bugs.webkit.org/show_bug.cgi?id=265519</a>
<a href="https://rdar.apple.com/118931301">rdar://118931301</a>

Reviewed by Dan Glastonbury and Antti Koivisto.

Separate WebGLContextAttributes and GraphicsContextGLAttributes.
This makes it easier to move the default framebuffer implementation from
GraphicsContextGL to WebGLRenderingContext.

This is work towards fixing premultipliedAlpha=false compositing.

* LayoutTests/webgl/webgl-fail-platform-context-creation-no-crash-expected.txt:
* LayoutTests/webgl/webgl-fail-platform-context-creation-no-crash.html:
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::toWebGLVersion):
* Source/WebCore/html/HTMLCanvasElement.h:
* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::OffscreenCanvas::createContextWebGL):
* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::WebGL2RenderingContext::create):
* Source/WebCore/html/canvas/WebGL2RenderingContext.h:
* Source/WebCore/html/canvas/WebGLContextAttributes.h:
* Source/WebCore/html/canvas/WebGLContextAttributes.idl:
* Source/WebCore/html/canvas/WebGLRenderingContext.cpp:
(WebCore::WebGLRenderingContext::create):
* Source/WebCore/html/canvas/WebGLRenderingContext.h:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::resolveGraphicsContextGLAttributes):
(WebCore::WebGLRenderingContextBase::create):
(WebCore::WebGLRenderingContextBase::WebGLRenderingContextBase):
(WebCore::WebGLRenderingContextBase::initializeContextState):
(WebCore::WebGLRenderingContextBase::addActivityStateChangeObserverIfNecessary):
(WebCore::WebGLRenderingContextBase::getContextAttributes):
(WebCore::WebGLRenderingContextBase::makeXRCompatible):
(WebCore::WebGLRenderingContextBase::maybeRestoreContext):
(WebCore::isHighPerformanceContext): Deleted.
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
(WebCore::WebGLRenderingContextBase::creationAttributes const):
(WebCore::WebGLRenderingContextBase::isXRCompatible const):
* Source/WebCore/platform/graphics/GraphicsContextGLAttributes.h:
(WebCore::GraphicsContextGLAttributes::effectivePowerPreference const): Deleted.
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::initialize):
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm:
(WebCore::initializeEGLDisplay):
(WebCore::GraphicsContextGLCocoa::platformInitializeContext):
(WebCore::GraphicsContextGLCocoa::platformInitialize):
* Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.cpp:
(WebCore::GraphicsContextGLGBM::platformInitializeContext):
* Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp:
(WebCore::GraphicsContextGLTextureMapperANGLE::platformInitializeContext):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::requestedGPU):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/271461@main">https://commits.webkit.org/271461@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/27981cd730900a725e4ff8e57ee53fe2cad60366

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28203 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6844 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29556 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30732 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25697 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28700 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8879 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4227 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/25979 "Build was cancelled. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; layout-tests (exception)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28471 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5610 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24270 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4882 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5009 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25266 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31421 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25816 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25697 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31317 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4991 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3169 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29073 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6539 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/25066 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6819 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5428 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5506 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->