### PR TITLE
[CSS] :scope matching for multiple scoping roots

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6920,6 +6920,9 @@ imported/w3c/web-platform-tests/navigation-api/scroll-behavior/scroll-on-synthet
 imported/w3c/web-platform-tests/navigation-api/scroll-behavior/scroll-without-intercept.html [ Pass ]
 imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/no-args.html [ Pass ]
 
+# css-scoping and css-nesting https://bugs.webkit.org/show_bug.cgi?id=265368
+imported/w3c/web-platform-tests/css/css-nesting/conditional-rules.html [ ImageOnlyFailure ]
+
 # -- View Transitions -- #
 # Reftest failures:
 imported/w3c/web-platform-tests/css/css-view-transitions/3d-transform-incoming.html [ ImageOnlyFailure ]

--- a/LayoutTests/fast/css/scope-at-rule-expected.html
+++ b/LayoutTests/fast/css/scope-at-rule-expected.html
@@ -29,3 +29,11 @@
 <div>
   <span class="green">should be green</span>
 </div>
+
+<div>
+  <span class="green">should be green</span>
+</div>
+
+<div>
+  <span class="">should not be green</span>
+</div>

--- a/LayoutTests/fast/css/scope-at-rule.html
+++ b/LayoutTests/fast/css/scope-at-rule.html
@@ -20,6 +20,12 @@ video {
 @scope (.b) to (.a) {
   .green-5 { color: green; }
 }
+@scope (.a) {
+  .green-6 :scope { color: green; }
+}
+@scope (.a) {
+  :scope :scope .green-7 { color: green; }
+}
 </style>
 
 <div class="a">
@@ -49,5 +55,17 @@ video {
 <div class="a">
   <div class="b">
     <span class="green-5">should be green</span>
+  </div>
+</div>
+
+<div class="green-6">
+    <span class="a">should be green</span>
+</div>
+
+<div class="a">
+  <div class="a">
+    <div class="a">
+      <span class="green-7">should not be green</span>
+    </div>
   </div>
 </div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-container-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-container-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Style rules within @container are scoped assert_equals: expected "1" but got "auto"
+PASS Style rules within @container are scoped
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-evaluation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-evaluation-expected.txt
@@ -1,9 +1,9 @@
 
 PASS Single scope
 PASS Scope can not match its own root without :scope
-FAIL Selecting self with :scope assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS Selecting self with :scope
 PASS Single scope with limit
-FAIL Single scope, :scope pseudo in main selector assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS Single scope, :scope pseudo in main selector
 FAIL Single scope, :scope pseudo in to-selector assert_equals: expected "rgb(0, 0, 0)" but got "rgb(0, 128, 0)"
 FAIL Multiple scopes, :scope pseudo in to-selector assert_equals: expected "rgb(0, 0, 0)" but got "rgb(0, 128, 0)"
 FAIL Inner @scope with :scope in from-selector assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
@@ -12,13 +12,13 @@ PASS Multiple scopes from same @scope-rule, both limited
 PASS Nested scopes
 FAIL Nested scopes, reverse assert_equals: expected "rgb(0, 0, 0)" but got "rgb(0, 128, 0)"
 PASS Nested scopes, with to-selector
-FAIL :scope selecting itself assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
-FAIL The scoping limit is not in scope assert_equals: expected "rgb(0, 0, 0)" but got "rgb(0, 128, 0)"
-FAIL Simulated inclusive scoping limit assert_equals: expected "rgb(0, 0, 0)" but got "rgb(0, 128, 0)"
+PASS :scope selecting itself
+PASS The scoping limit is not in scope
+PASS Simulated inclusive scoping limit
 FAIL Scope with no elements assert_equals: expected "rgb(0, 0, 0)" but got "rgb(0, 128, 0)"
 PASS :scope direct adjacent sibling
 PASS :scope indirect adjacent sibling
-FAIL Relative selector inside @scope assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS Relative selector inside @scope
 PASS :scope in two different compounds
 PASS Scope root with :has()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-focus-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-focus-expected.txt
@@ -1,6 +1,6 @@
 
 FAIL :focus via :scope in subject assert_equals: expected "1" but got "auto"
 FAIL :focus via :scope in non-subject assert_equals: expected "1" but got "auto"
-FAIL :focus in limit, :scope in subject assert_equals: expected "1" but got "auto"
+FAIL :focus in limit, :scope in subject assert_equals: expected "auto" but got "1"
 FAIL :focus in intermediate limit, :scope in subject assert_equals: expected "auto" but got "1"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-hover-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-hover-expected.txt
@@ -1,6 +1,6 @@
 
 FAIL :hover via :scope in subject assert_equals: expected "1" but got "auto"
 FAIL :hover via :scope in non-subject assert_equals: expected "1" but got "auto"
-FAIL :hover in limit, :scope in subject assert_equals: expected "1" but got "auto"
+FAIL :hover in limit, :scope in subject assert_equals: expected "auto" but got "1"
 FAIL :hover in intermediate limit, :scope in subject assert_equals: expected "auto" but got "1"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-implicit-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-implicit-expected.txt
@@ -1,10 +1,10 @@
 
-FAIL @scope without prelude implicitly scopes to parent of owner node assert_equals: expected "auto" but got "1"
+FAIL @scope without prelude implicitly scopes to parent of owner node assert_equals: expected "1" but got "auto"
 FAIL :scope can style implicit root assert_equals: expected "1" but got "auto"
-FAIL @scope works with two identical stylesheets assert_equals: expected "auto" but got "1"
+FAIL @scope works with two identical stylesheets assert_equals: expected "1" but got "auto"
 PASS @scope with effectively empty :is() must not match anything
-FAIL Implicit @scope has implicitly added :scope descendant combinator assert_equals: expected "auto" but got "1"
+PASS Implicit @scope has implicitly added :scope descendant combinator
 FAIL Implicit @scope with inner relative selector assert_equals: expected "1" but got "auto"
 FAIL Implicit @scope with inner nesting selector assert_equals: expected "1" but got "auto"
-FAIL Implicit @scope with limit assert_equals: expected "auto" but got "1"
+FAIL Implicit @scope with limit assert_equals: expected "1" but got "auto"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-invalidation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-invalidation-expected.txt
@@ -18,7 +18,7 @@ FAIL Element becoming root via ~ combinator assert_equals: expected "rgb(0, 128,
 FAIL Element becoming root via + combinator assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 FAIL :not(scope) in subject assert_equals: expected "rgb(0, 0, 0)" but got "rgb(0, 128, 0)"
 FAIL :not(scope) in ancestor assert_equals: expected "rgb(0, 0, 0)" but got "rgb(0, 128, 0)"
-FAIL :not(scope) in limit subject assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+FAIL :not(scope) in limit subject assert_equals: expected "rgb(0, 0, 0)" but got "rgb(0, 128, 0)"
 FAIL :not(scope) in limit ancestor assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 FAIL :nth-child() in scope root assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 FAIL :nth-child() in scope limit assert_equals: expected "rgb(0, 0, 0)" but got "rgb(0, 128, 0)"

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-layer-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-layer-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Style rules within @layer are scoped assert_equals: expected "1" but got "0"
+PASS Style rules within @layer are scoped
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-media-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-media-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Style rules within @media are scoped assert_equals: expected "1" but got "auto"
+PASS Style rules within @media are scoped
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-nesting-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-nesting-expected.txt
@@ -1,10 +1,10 @@
 
 FAIL Nesting-selector in <scope-end> assert_equals: expected "auto" but got "1"
-FAIL Implicit :scope in <scope-end> assert_equals: expected "1" but got "auto"
-FAIL Relative selectors in <scope-end> assert_equals: expected "1" but got "auto"
+FAIL Implicit :scope in <scope-end> assert_equals: expected "1" but got "42"
+PASS Relative selectors in <scope-end>
 FAIL Nesting-selector in the scope's <stylesheet> assert_equals: expected "1" but got "auto"
-FAIL Nesting-selector within :scope rule assert_equals: expected "2" but got "auto"
-FAIL Nesting-selector within :scope rule (double nested) assert_equals: expected "2" but got "auto"
+PASS Nesting-selector within :scope rule
+PASS Nesting-selector within :scope rule (double nested)
 FAIL @scope nested within style rule assert_equals: expected "1" but got "auto"
 FAIL Parent pseudo class within scope-start assert_equals: expected "1" but got "auto"
 FAIL Parent pseudo class within scope-end assert_equals: expected "1" but got "auto"

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-supports-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-supports-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Style rules within @supports are scoped assert_equals: expected "1" but got "auto"
+PASS Style rules within @supports are scoped
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-visited-cssom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-visited-cssom-expected.txt
@@ -7,12 +7,12 @@ PASS :link as scoping root
 FAIL :visited as scoping root assert_equals: expected "rgb(255, 255, 255)" but got "rgb(0, 128, 0)"
 PASS :not(:visited) as scoping root
 PASS :not(:link) as scoping root
-FAIL :link as scoping root, :scope assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 255, 255)"
-PASS :visited as scoping root, :scope
-FAIL :not(:visited) as scoping root, :scope assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 255, 255)"
+PASS :link as scoping root, :scope
+FAIL :visited as scoping root, :scope assert_equals: expected "rgb(255, 255, 255)" but got "rgb(0, 128, 0)"
+PASS :not(:visited) as scoping root, :scope
 PASS :not(:link) as scoping root, :scope
-FAIL :link as scoping limit assert_equals: expected "rgb(255, 255, 255)" but got "rgb(0, 128, 0)"
-PASS :visited as scoping limit
+PASS :link as scoping limit
+FAIL :visited as scoping limit assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 255, 255)"
 PASS :not(:link) as scoping limit
-FAIL :not(:visited) as scoping limit assert_equals: expected "rgb(255, 255, 255)" but got "rgb(0, 128, 0)"
+PASS :not(:visited) as scoping limit
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/conditional-rules.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/conditional-rules.html
@@ -70,6 +70,6 @@
   <div class="test test-6"></div>
   <div class="test test-10"></div>
   <div class="test test-11"></div>
-  <div class="test test-12"></div>
+  <div class="test test-12"><div class="test-12"></div></div>
   <div class="test"><div class="test-13"></div></div>
 </body>

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -1256,10 +1256,6 @@ static inline FunctionType addPseudoClassType(const CSSSelector& selector, Selec
         return FunctionType::SimpleSelectorChecker;
 
     case CSSSelector::PseudoClassType::Scope:
-        if (selectorContext != SelectorContext::QuerySelector) {
-            fragment.pseudoClasses.add(CSSSelector::PseudoClassType::Root);
-            return FunctionType::SimpleSelectorChecker;
-        }
         fragment.pseudoClasses.add(CSSSelector::PseudoClassType::Scope);
         return FunctionType::SelectorCheckerWithCheckingContext;
 
@@ -4446,8 +4442,6 @@ void SelectorCodeGenerator::generateElementIsRoot(Assembler::JumpList& failureCa
 
 void SelectorCodeGenerator::generateElementIsScopeRoot(Assembler::JumpList& failureCases)
 {
-    ASSERT(m_selectorContext == SelectorContext::QuerySelector);
-
     LocalRegister scope(m_registerAllocator);
     loadCheckingContext(scope);
     m_assembler.loadPtr(Assembler::Address(scope, OBJECT_OFFSETOF(SelectorChecker::CheckingContext, scope)), scope);

--- a/Source/WebCore/style/ElementRuleCollector.h
+++ b/Source/WebCore/style/ElementRuleCollector.h
@@ -118,9 +118,9 @@ private:
     void collectMatchingRules(CascadeLevel);
     void collectMatchingRules(const MatchRequest&);
     void collectMatchingRulesForList(const RuleSet::RuleDataVector*, const MatchRequest&);
-    bool ruleMatches(const RuleData&, unsigned& specificity, ScopeOrdinal);
+    bool ruleMatches(const RuleData&, unsigned& specificity, ScopeOrdinal, const Element* scopingRoot = nullptr);
     bool containerQueriesMatch(const RuleData&, const MatchRequest&);
-    bool scopeRulesMatch(const RuleData&, const MatchRequest&);
+    std::pair<bool, std::optional<Vector<const Element*>>> scopeRulesMatch(const RuleData&, const MatchRequest&);
 
     void sortMatchedRules();
 


### PR DESCRIPTION
#### 0bc5d3ab92365420fc03f522bc29a6e8c6f9025c
<pre>
[CSS] :scope matching for multiple scoping roots
<a href="https://bugs.webkit.org/show_bug.cgi?id=265288">https://bugs.webkit.org/show_bug.cgi?id=265288</a>
<a href="https://rdar.apple.com/118748899">rdar://118748899</a>

Reviewed by Antti Koivisto.

<a href="https://drafts.csswg.org/css-cascade-6/#scope-limits">https://drafts.csswg.org/css-cascade-6/#scope-limits</a>

This patch generates multiple matched rules, one for each scoping root.
They will all participate in the selector matching with a distinct :scope, and will be selected
based on specificity (and proximity in a future patch).

* LayoutTests/TestExpectations:
* LayoutTests/fast/css/scope-at-rule-expected.html:
* LayoutTests/fast/css/scope-at-rule.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-container-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-evaluation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-focus-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-hover-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-implicit-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-invalidation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-layer-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-media-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-nesting-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-supports-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-visited-cssom-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/conditional-rules.html:
* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::addPseudoClassType):
(WebCore::SelectorCompiler::SelectorCodeGenerator::generateElementIsScopeRoot):

Remove the assumption that :scope always means :root outside of SelectorQuery

* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::ruleMatches):
(WebCore::Style::ElementRuleCollector::collectMatchingRulesForList):
(WebCore::Style::ElementRuleCollector::scopeRulesMatch):
* Source/WebCore/style/ElementRuleCollector.h:

Canonical link: <a href="https://commits.webkit.org/271508@main">https://commits.webkit.org/271508@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f604e3fa6b6b0a76eb86eb5bd703d822e800231

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28589 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7234 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29972 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/31237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/26113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29093 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9347 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4604 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/31237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28859 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5976 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24583 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/31237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/5348 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25584 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/32567 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26176 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26029 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/31606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5316 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3483 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/29383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6921 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/25378 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6852 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5777 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5835 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->