### PR TITLE
[IFC][Ruby] Update fast/ruby/ruby-line-height.html to spec UA sheet line-height

### DIFF
--- a/LayoutTests/fast/ruby/ruby-line-height-expected.txt
+++ b/LayoutTests/fast/ruby/ruby-line-height-expected.txt
@@ -8,7 +8,7 @@ PASS getLineHeight('p') is "48px"
 PASS [object HTMLElement] is non-null.
 PASS getLineHeight('r') is "48px"
 PASS [object HTMLElement] is non-null.
-PASS getLineHeight('t') is "normal"
+PASS getLineHeight('t') is "8px"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/ruby/ruby-line-height.html
+++ b/LayoutTests/fast/ruby/ruby-line-height.html
@@ -1,4 +1,5 @@
-﻿<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!-- webkit-test-runner [ CSSBasedRubyEnabled=true ] -->
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
 <script src="../../resources/js-test-pre.js"></script>
@@ -16,12 +17,12 @@ function getLineHeight(id)
 }
 
 var div = document.createElement("div");
-div.innerHTML = "<p style='line-height: 300%' id='p'>The line height of this is <ruby id='r'>three times normal<rt id='t'>&quot;line-height: 48px;&quot;</rt></ruby>.</p>";
+div.innerHTML = "<p style='font-size: 16px; line-height: 300%' id='p'>The line height of this is <ruby id='r'>three times normal<rt id='t'>&quot;line-height: 48px;&quot;</rt></ruby>.</p>";
 document.body.appendChild(div);
 
 shouldBeEqualToString("getLineHeight('p')", "48px");
 shouldBeEqualToString("getLineHeight('r')", "48px");
-shouldBeEqualToString("getLineHeight('t')", "normal");
+shouldBeEqualToString("getLineHeight('t')", "8px");
 </script>
 <script src="../../resources/js-test-post.js"></script>
 </body>


### PR DESCRIPTION
#### ea5244ff065d50385c7320cdb6b3811ae88773b2
<pre>
[IFC][Ruby] Update fast/ruby/ruby-line-height.html to spec UA sheet line-height
<a href="https://bugs.webkit.org/show_bug.cgi?id=265576">https://bugs.webkit.org/show_bug.cgi?id=265576</a>
<a href="https://rdar.apple.com/118982013">rdar://118982013</a>

Reviewed by Alan Baradlay.

The ruby UA stylesheet <a href="https://www.w3.org/TR/css-ruby-1/#default-ua-ruby">https://www.w3.org/TR/css-ruby-1/#default-ua-ruby</a> has

rt { line-height: 1; }

Update the test for that (the old stylesheet has &apos;normal&apos;).

* LayoutTests/fast/ruby/ruby-line-height-expected.txt:
* LayoutTests/fast/ruby/ruby-line-height.html:

Also set font-size explicitly so the test works better across browsers.

Canonical link: <a href="https://commits.webkit.org/271340@main">https://commits.webkit.org/271340@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/277fb5f9047bc2c443af822b5d0e2baac04c7d83

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28076 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6716 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29414 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30607 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25596 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8728 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4102 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/25379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28344 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5472 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24145 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4720 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4889 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch.tentative.html (failure)") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/25148 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31296 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25679 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25576 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31199 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4889 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3051 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28961 "Found 1 new API test failure: /WebKitGTK/TestResources:/webkit/WebKitWebView/sync-request-on-max-conns (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6429 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/24936 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6728 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5327 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5386 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->