### PR TITLE
Various tests have incorrect webkit-test-runner option separator

### DIFF
--- a/LayoutTests/editing/selection/character-granularity-select-text-with-click-handler.html
+++ b/LayoutTests/editing/selection/character-granularity-select-text-with-click-handler.html
@@ -1,4 +1,4 @@
-<!-- webkit-test-runner [ useFlexibleViewport=true, useCharacterSelectionGranularity=true ] -->
+<!-- webkit-test-runner [ useFlexibleViewport=true useCharacterSelectionGranularity=true ] -->
 <meta name=viewport content="width=device-width, initial-scale=1">
 <div id="target" style="font-size: 75px;">WEBKIT</div>
 <script>

--- a/LayoutTests/editing/selection/character-granularity-selected-range-after-dismissing-selection.html
+++ b/LayoutTests/editing/selection/character-granularity-selected-range-after-dismissing-selection.html
@@ -1,4 +1,4 @@
-<!-- webkit-test-runner [ useFlexibleViewport=true, useCharacterSelectionGranularity=true ] -->
+<!-- webkit-test-runner [ useFlexibleViewport=true useCharacterSelectionGranularity=true ] -->
 <meta name=viewport content="width=device-width, initial-scale=1">
 <div style="font-size: 125px;">WEB<br>KIT</div>
 <div id="output" style="color: green; margin-top: 1em;"></div>

--- a/LayoutTests/editing/selection/ios/autoscroll-with-top-content-inset-2.html
+++ b/LayoutTests/editing/selection/ios/autoscroll-with-top-content-inset-2.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true, CSSScrollAnchoringEnabled=false, contentInset.top=150 ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true CSSScrollAnchoringEnabled=false contentInset.top=150 ] -->
 <html>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <head>

--- a/LayoutTests/editing/selection/ios/autoscroll-with-top-content-inset.html
+++ b/LayoutTests/editing/selection/ios/autoscroll-with-top-content-inset.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true, CSSScrollAnchoringEnabled=false, contentInset.top=100 ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true CSSScrollAnchoringEnabled=false contentInset.top=100 ] -->
 <html>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <head>

--- a/LayoutTests/fast/forms/ios/file-upload-panel-accept.html
+++ b/LayoutTests/fast/forms/ios/file-upload-panel-accept.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true, shouldHandleRunOpenPanel=false ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true shouldHandleRunOpenPanel=false ] -->
 <html>
 <head>
 <meta name="viewport" content="width=device-width">

--- a/LayoutTests/fast/forms/ios/file-upload-panel-capture.html
+++ b/LayoutTests/fast/forms/ios/file-upload-panel-capture.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true, shouldHandleRunOpenPanel=false, shouldPresentPopovers=false ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true shouldHandleRunOpenPanel=false shouldPresentPopovers=false ] -->
 <html>
 <head>
 <meta name="viewport" content="width=device-width">

--- a/LayoutTests/fast/forms/ios/file-upload-panel.html
+++ b/LayoutTests/fast/forms/ios/file-upload-panel.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true, shouldHandleRunOpenPanel=false, shouldPresentPopovers=false ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true shouldHandleRunOpenPanel=false shouldPresentPopovers=false ] -->
 <html>
 <head>
 <meta name="viewport" content="width=device-width">

--- a/LayoutTests/webgl/offscreen-webgl-errors-to-console.html
+++ b/LayoutTests/webgl/offscreen-webgl-errors-to-console.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ UseGPUProcessForWebGLEnabled=true, OffscreenCanvasEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ UseGPUProcessForWebGLEnabled=true OffscreenCanvasEnabled=true ] -->
 <html>
 <body>
 <script src="../resources/js-test-pre.js"></script>


### PR DESCRIPTION
#### 86188827f3481487ee31f9336c85e9d7ab9b4860
<pre>
Various tests have incorrect webkit-test-runner option separator
<a href="https://bugs.webkit.org/show_bug.cgi?id=265579">https://bugs.webkit.org/show_bug.cgi?id=265579</a>
<a href="https://rdar.apple.com/118985702">rdar://118985702</a>

Reviewed by Antti Koivisto.

Option &quot;true,&quot; is parsed as false.

* LayoutTests/editing/selection/character-granularity-select-text-with-click-handler.html:
* LayoutTests/editing/selection/character-granularity-selected-range-after-dismissing-selection.html:
* LayoutTests/editing/selection/ios/autoscroll-with-top-content-inset-2.html:
* LayoutTests/editing/selection/ios/autoscroll-with-top-content-inset.html:
* LayoutTests/fast/forms/ios/file-upload-panel-accept.html:
* LayoutTests/fast/forms/ios/file-upload-panel-capture.html:
* LayoutTests/fast/forms/ios/file-upload-panel.html:
* LayoutTests/webgl/offscreen-webgl-errors-to-console.html:

Canonical link: <a href="https://commits.webkit.org/271375@main">https://commits.webkit.org/271375@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/187ee80e76585d6be5898d32a3499dfd79b7e725

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28083 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6724 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29431 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30614 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25602 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8764 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4110 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/25499 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28351 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5503 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24157 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4723 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4918 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25155 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31303 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25710 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25581 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31207 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4895 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3059 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28966 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6435 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/24950 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6751 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5333 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5393 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->