### PR TITLE
[iOS] Grant media capabilities to the WebContent and GPU processes during capture and playback

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -4178,6 +4178,20 @@ MediaCapabilitiesExtensionsEnabled:
     WebCore:
       default: false
 
+MediaCapabilityGrantsEnabled:
+  type: bool
+  status: unstable
+  condition: ENABLE(PROCESS_CAPABILITIES)
+  humanReadableName: "Media Capability Grants"
+  humanReadableDescription: "Enable granting and revoking of media capabilities"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 MediaCaptionFormatTypesAllowedInLockdownMode:
   type: String
   status: embedder

--- a/Source/WebKit/Platform/Logging.h
+++ b/Source/WebKit/Platform/Logging.h
@@ -89,6 +89,7 @@ extern "C" {
     M(Printing) \
     M(PrivateClickMeasurement) \
     M(Process) \
+    M(ProcessCapabilities) \
     M(ProcessSuspension) \
     M(ProcessSwapping) \
     M(ProximityNetworking) \

--- a/Source/WebKit/Platform/cocoa/AssertionCapability.h
+++ b/Source/WebKit/Platform/cocoa/AssertionCapability.h
@@ -36,16 +36,17 @@ namespace WebKit {
 
 class AssertionCapability final : public ProcessCapability {
 public:
-    AssertionCapability(String domain, String name, String environmentIdentifier, Function<void()>&& willInvalidateFunction = nullptr, Function<void()>&& didInvalidateFunction = nullptr);
+    AssertionCapability(String environmentIdentifier, String domain, String name, Function<void()>&& willInvalidateFunction = nullptr, Function<void()>&& didInvalidateFunction = nullptr);
 
     const String& domain() const { return m_domain; }
     const String& name() const { return m_name; }
 
-#if USE(EXTENSIONKIT)
+    // ProcessCapability
+    String environmentIdentifier() const final { return m_environmentIdentifier; }
     RetainPtr<_SECapabilities> platformCapability() const final;
-#endif
 
 private:
+    String m_environmentIdentifier;
     String m_domain;
     String m_name;
     BlockPtr<void()> m_willInvalidateBlock;

--- a/Source/WebKit/Platform/cocoa/MediaCapability.h
+++ b/Source/WebKit/Platform/cocoa/MediaCapability.h
@@ -27,21 +27,42 @@
 
 #if ENABLE(PROCESS_CAPABILITIES)
 
+#include "ProcessCapability.h"
+#include <WebCore/RegistrableDomain.h>
 #include <wtf/Forward.h>
-#include <wtf/text/WTFString.h>
-
-OBJC_CLASS _SECapabilities;
+#include <wtf/WeakPtr.h>
 
 namespace WebKit {
 
-class ProcessCapability {
-public:
-    virtual ~ProcessCapability() = default;
-    virtual String environmentIdentifier() const = 0;
-    virtual RetainPtr<_SECapabilities> platformCapability() const = 0;
+class ProcessCapabilityGrant;
 
-protected:
-    ProcessCapability() = default;
+using WebCore::RegistrableDomain;
+
+class MediaCapability final : public ProcessCapability, public CanMakeWeakPtr<MediaCapability> {
+public:
+    explicit MediaCapability(RegistrableDomain);
+    explicit MediaCapability(const URL&);
+
+    enum class State : uint8_t {
+        Inactive,
+        Activating,
+        Active,
+        Deactivating,
+    };
+
+    State state() const { return m_state; }
+    void setState(State state) { m_state = state; }
+
+    const RegistrableDomain& registrableDomain() const { return m_registrableDomain; }
+
+    // ProcessCapability
+    String environmentIdentifier() const final;
+    RetainPtr<_SECapabilities> platformCapability() const final { return m_platformCapability.get(); }
+
+private:
+    State m_state { State::Inactive };
+    RegistrableDomain m_registrableDomain;
+    RetainPtr<_SECapabilities> m_platformCapability;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Platform/cocoa/ProcessCapabilityGrant.h
+++ b/Source/WebKit/Platform/cocoa/ProcessCapabilityGrant.h
@@ -27,21 +27,34 @@
 
 #if ENABLE(PROCESS_CAPABILITIES)
 
-#include <wtf/Forward.h>
+#include <wtf/RetainPtr.h>
 #include <wtf/text/WTFString.h>
 
-OBJC_CLASS _SECapabilities;
+OBJC_PROTOCOL(_SEGrant);
 
 namespace WebKit {
 
-class ProcessCapability {
+class ProcessCapabilityGrant {
 public:
-    virtual ~ProcessCapability() = default;
-    virtual String environmentIdentifier() const = 0;
-    virtual RetainPtr<_SECapabilities> platformCapability() const = 0;
+    ProcessCapabilityGrant() = default;
+    ProcessCapabilityGrant(ProcessCapabilityGrant&&) = default;
+    explicit ProcessCapabilityGrant(String environmentIdentifier);
+    ~ProcessCapabilityGrant();
 
-protected:
-    ProcessCapability() = default;
+    ProcessCapabilityGrant& operator=(ProcessCapabilityGrant&&) = default;
+    ProcessCapabilityGrant isolatedCopy() &&;
+
+    const String& environmentIdentifier() const { return m_environmentIdentifier; }
+    bool isEmpty() const;
+    bool isValid() const;
+
+    void setPlatformGrant(RetainPtr<_SEGrant>&&);
+
+private:
+    ProcessCapabilityGrant(String&&, RetainPtr<_SEGrant>&&);
+
+    String m_environmentIdentifier;
+    RetainPtr<_SEGrant> m_platformGrant;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Platform/spi/Cocoa/ExtensionKitSPI.h
+++ b/Source/WebKit/Platform/spi/Cocoa/ExtensionKitSPI.h
@@ -47,6 +47,9 @@ typedef void(^_SEServiceInteruptionHandler)();
 +(instancetype)assertionWithDomain:(NSString*)domain name:(NSString*)name;
 +(instancetype)assertionWithDomain:(NSString*)domain name:(NSString*)name environmentIdentifier:(NSString*)environmentIdentifier;
 +(instancetype)assertionWithDomain:(NSString*)domain name:(NSString*)name environmentIdentifier:(NSString*)environmentIdentifier willInvalidate:(void (^)())willInvalidateBlock didInvalidate:(void (^)())didInvalidateBlock;
++(instancetype)mediaWithWebsite:(NSString*)website;
+-(BOOL)setActive:(BOOL)active;
+@property (nonatomic, readonly) NSString *mediaEnvironment;
 @end
 
 NS_REFINED_FOR_SWIFT

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -81,9 +81,10 @@ Platform/classifier/cocoa/ResourceLoadStatisticsClassifierCocoa.cpp
 Platform/classifier/ResourceLoadStatisticsClassifier.cpp
 
 Platform/cocoa/AssertionCapability.mm @no-unify
+Platform/cocoa/MediaCapability.mm @no-unify
 Platform/cocoa/PaymentAuthorizationPresenter.mm
 Platform/cocoa/PaymentAuthorizationViewController.mm
-Platform/cocoa/ProcessCapability.cpp
+Platform/cocoa/ProcessCapabilityGrant.mm
 Platform/cocoa/WKPaymentAuthorizationDelegate.mm
 Platform/cocoa/WebKitAdditions.mm @no-unify
 Platform/cocoa/WebPrivacyHelpers.mm
@@ -401,6 +402,7 @@ UIProcess/Cocoa/PageClientImplCocoa.mm
 UIProcess/Cocoa/PlatformXRCoordinator.mm
 UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
 UIProcess/Cocoa/ProcessAssertionCocoa.mm
+UIProcess/Cocoa/ProcessCapabilityGranter.mm
 UIProcess/Cocoa/ResourceLoadDelegate.mm
 UIProcess/Cocoa/SafeBrowsingWarningCocoa.mm
 UIProcess/Cocoa/SessionStateCoding.mm

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
@@ -32,6 +32,7 @@
 #include "OverrideLanguages.h"
 #include "UIProcessLogInitialization.h"
 #include "WebPageProxy.h"
+#include "WebPageProxyIdentifier.h"
 #include "WebProcessProxy.h"
 #include <wtf/RunLoop.h>
 
@@ -43,11 +44,15 @@
 #endif
 
 #if PLATFORM(IOS_FAMILY) && !PLATFORM(MACCATALYST)
-#import <pal/spi/ios/MobileGestaltSPI.h>
+#include <pal/spi/ios/MobileGestaltSPI.h>
 #endif
 
 #if PLATFORM(VISION)
-#import <WebCore/ThermalMitigationNotifier.h>
+#include <WebCore/ThermalMitigationNotifier.h>
+#endif
+
+#if ENABLE(PROCESS_CAPABILITIES)
+#include "ProcessCapabilityGrant.h"
 #endif
 
 namespace WebKit {
@@ -85,6 +90,10 @@ AuxiliaryProcessProxy::~AuxiliaryProcessProxy()
     }
 
     replyToPendingMessages();
+
+#if ENABLE(PROCESS_CAPABILITIES)
+    ASSERT(m_processCapabilityGrants.isEmpty());
+#endif
 }
 
 void AuxiliaryProcessProxy::populateOverrideLanguagesLaunchOptions(ProcessLauncher::LaunchOptions& launchOptions) const

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
@@ -34,6 +34,8 @@
 #include <WebCore/ProcessIdentifier.h>
 #include <memory>
 #include <wtf/CheckedRef.h>
+#include <wtf/Forward.h>
+#include <wtf/HashMap.h>
 #include <wtf/ProcessID.h>
 #include <wtf/SystemTracing.h>
 #include <wtf/ThreadSafeRefCounted.h>
@@ -45,11 +47,14 @@ class SharedBuffer;
 
 namespace WebKit {
 
+class ProcessCapabilityGrant;
 class ProcessThrottler;
 class ProcessAssertion;
 class SandboxExtensionHandle;
 
 struct AuxiliaryProcessCreationParameters;
+
+using ProcessCapabilityGrantMap = HashMap<String, ProcessCapabilityGrant>;
 
 class AuxiliaryProcessProxy
     : public ThreadSafeRefCounted<AuxiliaryProcessProxy, WTF::DestructionThread::MainRunLoop>
@@ -187,6 +192,10 @@ public:
     static bool manageProcessesAsExtensions() { return s_manageProcessesAsExtensions; }
 #endif
 
+#if ENABLE(PROCESS_CAPABILITIES)
+    ProcessCapabilityGrantMap& processCapabilityGrants() { return m_processCapabilityGrants; }
+#endif
+
 protected:
     // ProcessLauncher::Client
     void didFinishLaunching(ProcessLauncher*, IPC::Connection::Identifier) override;
@@ -246,6 +255,9 @@ private:
     std::unique_ptr<ProcessThrottler::ForegroundActivity> m_lifetimeActivity;
     RefPtr<ProcessAssertion> m_boostedJetsamAssertion;
 #endif
+#endif
+#if ENABLE(PROCESS_CAPABILITIES)
+    ProcessCapabilityGrantMap m_processCapabilityGrants;
 #endif
 #if USE(EXTENSIONKIT)
     static bool s_manageProcessesAsExtensions;

--- a/Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm
@@ -387,7 +387,7 @@ ProcessAssertion::ProcessAssertion(AuxiliaryProcessProxy& process, const String&
             if (strongThis)
                 strongThis->processAssertionWillBeInvalidated();
         };
-        AssertionCapability capability { String(runningBoardDomain), String(runningBoardAssertionName), process.environmentIdentifier(), WTFMove(willInvalidateBlock), WTFMove(didInvalidateBlock) };
+        AssertionCapability capability { process.environmentIdentifier(), runningBoardDomain, runningBoardAssertionName, WTFMove(willInvalidateBlock), WTFMove(didInvalidateBlock) };
         m_capabilities = capability.platformCapability();
         m_process = process.extensionProcess();
         if (m_capabilities)

--- a/Source/WebKit/UIProcess/Cocoa/ProcessCapabilityGranter.mm
+++ b/Source/WebKit/UIProcess/Cocoa/ProcessCapabilityGranter.mm
@@ -1,0 +1,307 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "ProcessCapabilityGranter.h"
+
+#if ENABLE(PROCESS_CAPABILITIES)
+
+#import "ExtensionKitSPI.h"
+#import "GPUProcessProxy.h"
+#import "MediaCapability.h"
+#import "ProcessCapability.h"
+#import "ProcessCapabilityGrant.h"
+#import "WebProcessProxy.h"
+#import <wtf/CrossThreadCopier.h>
+#import <wtf/NativePromise.h>
+#import <wtf/NeverDestroyed.h>
+#import <wtf/UniqueRef.h>
+
+#define GRANTER_RELEASE_LOG(envID, fmt, ...) RELEASE_LOG(ProcessCapabilities, "%{public}s[envID=%{public}s] " fmt, __FUNCTION__, envID.utf8().data(), ##__VA_ARGS__)
+#define GRANTER_RELEASE_LOG_ERROR(envID, fmt, ...) RELEASE_LOG_ERROR(ProcessCapabilities, "%{public}s[envID=%{public}s] " fmt, __FUNCTION__, envID.utf8().data(), ##__VA_ARGS__)
+
+namespace WebKit {
+
+static WorkQueue& granterQueue()
+{
+    static NeverDestroyed<Ref<WorkQueue>> queue(WorkQueue::create("ProcessCapabilityGranter Queue", WorkQueue::QOS::UserInitiated));
+    return queue.get();
+}
+
+#if USE(EXTENSIONKIT)
+static RetainPtr<_SEGrant> grantCapability(_SECapabilities *capability, _SEExtensionProcess *process)
+{
+    ASSERT(capability);
+    if (!capability || !process)
+        return nil;
+
+    NSError *error = nil;
+    _SEGrant *grant = [process grantCapabilities:capability error:&error];
+    if (!grant)
+        RELEASE_LOG_ERROR(ProcessCapabilities, "%{public}s (process=%{public}p) failed with error: %{public}@", __FUNCTION__, process, error);
+
+    return grant;
+}
+#endif
+
+struct PlatformProcessCapabilityGrants {
+    RetainPtr<_SEGrant> gpuProcessGrant;
+    RetainPtr<_SEGrant> webProcessGrant;
+};
+
+enum class ProcessCapabilityGrantError: uint8_t {
+    PlatformError,
+};
+
+using ProcessCapabilityGrantsPromise = NativePromise<PlatformProcessCapabilityGrants, ProcessCapabilityGrantError>;
+
+static Ref<ProcessCapabilityGrantsPromise> grantCapabilityInternal(const ProcessCapability& capability, const GPUProcessProxy* gpuProcess, const WebProcessProxy* webProcess)
+{
+    RetainPtr gpuExtension = gpuProcess ? gpuProcess->extensionProcess() : nil;
+    RetainPtr webExtension = webProcess ? webProcess->extensionProcess() : nil;
+
+#if USE(EXTENSIONKIT)
+    return invokeAsync(granterQueue(), [
+        capability = capability.platformCapability(),
+        gpuExtension = WTFMove(gpuExtension),
+        webExtension = WTFMove(webExtension)
+    ] {
+        PlatformProcessCapabilityGrants grants {
+            grantCapability(capability.get(), gpuExtension.get()),
+            grantCapability(capability.get(), webExtension.get())
+        };
+        return ProcessCapabilityGrantsPromise::createAndResolve(WTFMove(grants));
+    });
+#else
+    UNUSED_PARAM(capability);
+    return ProcessCapabilityGrantsPromise::createAndReject(ProcessCapabilityGrantError::PlatformError);
+#endif
+}
+
+static bool prepareGrant(const String& environmentIdentifier, AuxiliaryProcessProxy& auxiliaryProcess)
+{
+    ProcessCapabilityGrant grant { environmentIdentifier };
+    auto& existingGrants = auxiliaryProcess.processCapabilityGrants();
+
+    auto result = existingGrants.add(environmentIdentifier, WTFMove(grant));
+    if (result.isNewEntry)
+        return true;
+
+    auto& existingGrant = result.iterator->value;
+    if (existingGrant.isEmpty() || existingGrant.isValid())
+        return false;
+
+    existingGrants.set(environmentIdentifier, WTFMove(grant));
+    return true;
+}
+
+static bool finalizeGrant(const String& environmentIdentifier, AuxiliaryProcessProxy* auxiliaryProcess, ProcessCapabilityGrant&& grant)
+{
+    if (!auxiliaryProcess) {
+        GRANTER_RELEASE_LOG_ERROR(environmentIdentifier, "auxiliaryProcess is null");
+        return false;
+    }
+
+    auto& existingGrants = auxiliaryProcess->processCapabilityGrants();
+
+    auto iterator = existingGrants.find(environmentIdentifier);
+    if (iterator == existingGrants.end()) {
+        GRANTER_RELEASE_LOG_ERROR(environmentIdentifier, "grant previously revoked");
+        return false;
+    }
+
+    if (grant.isValid()) {
+        iterator->value = WTFMove(grant);
+        return true;
+    }
+
+    GRANTER_RELEASE_LOG_ERROR(environmentIdentifier, "grant invalid");
+    existingGrants.remove(iterator);
+    return false;
+}
+
+UniqueRef<ProcessCapabilityGranter> ProcessCapabilityGranter::create(Client& client)
+{
+    return makeUniqueRef<ProcessCapabilityGranter>(client);
+}
+
+ProcessCapabilityGranter::ProcessCapabilityGranter(Client& client)
+    : m_client { client }
+{
+}
+
+void ProcessCapabilityGranter::grant(const ProcessCapability& capability)
+{
+    String environmentIdentifier = capability.environmentIdentifier();
+    if (environmentIdentifier.isEmpty()) {
+        GRANTER_RELEASE_LOG_ERROR(environmentIdentifier, "environmentIdentifier must not be empty");
+        return;
+    }
+
+    RefPtr gpuProcess = m_client->gpuProcessForCapabilityGranter(*this);
+    bool needsGPUProcessGrant = gpuProcess && prepareGrant(environmentIdentifier, *gpuProcess);
+
+    RefPtr webProcess = m_client->webProcessForCapabilityGranter(*this, environmentIdentifier);
+    bool needsWebProcessGrant = webProcess && prepareGrant(environmentIdentifier, *webProcess);
+
+    if (!needsGPUProcessGrant && !needsWebProcessGrant)
+        return;
+
+    grantCapabilityInternal(
+        capability,
+        needsGPUProcessGrant ? gpuProcess.get() : nullptr,
+        needsWebProcessGrant ? webProcess.get() : nullptr
+    )->whenSettled(RunLoop::main(), [
+        this,
+        weakThis = WeakPtr { *this },
+        environmentIdentifier,
+        needsGPUProcessGrant,
+        needsWebProcessGrant
+    ](auto&& result) {
+        ProcessCapabilityGrant gpuProcessGrant { environmentIdentifier };
+        gpuProcessGrant.setPlatformGrant(result ? WTFMove(result->gpuProcessGrant) : nil);
+
+        ProcessCapabilityGrant webProcessGrant { environmentIdentifier };
+        webProcessGrant.setPlatformGrant(result ? WTFMove(result->webProcessGrant) : nil);
+
+        if (!weakThis) {
+            invalidateGrants(Vector<ProcessCapabilityGrant>::from(WTFMove(gpuProcessGrant), WTFMove(webProcessGrant)));
+            return;
+        }
+
+        Vector<ProcessCapabilityGrant> grantsToInvalidate;
+        grantsToInvalidate.reserveInitialCapacity(2);
+
+        if (needsGPUProcessGrant) {
+            if (finalizeGrant(environmentIdentifier, m_client->gpuProcessForCapabilityGranter(*this).get(), WTFMove(gpuProcessGrant)))
+                GRANTER_RELEASE_LOG(environmentIdentifier, "granted for GPU process");
+            else {
+                GRANTER_RELEASE_LOG_ERROR(environmentIdentifier, "failed to grant for GPU process");
+                grantsToInvalidate.append(WTFMove(gpuProcessGrant));
+            }
+        } else
+            ASSERT(gpuProcessGrant.isEmpty());
+
+        if (needsWebProcessGrant) {
+            if (finalizeGrant(environmentIdentifier, m_client->webProcessForCapabilityGranter(*this, environmentIdentifier).get(), WTFMove(webProcessGrant)))
+                GRANTER_RELEASE_LOG(environmentIdentifier, "granted for WebContent process");
+            else {
+                GRANTER_RELEASE_LOG_ERROR(environmentIdentifier, "failed to grant for WebContent process");
+                grantsToInvalidate.append(WTFMove(webProcessGrant));
+            }
+        } else
+            ASSERT(webProcessGrant.isEmpty());
+
+        invalidateGrants(WTFMove(grantsToInvalidate));
+    });
+}
+
+void ProcessCapabilityGranter::revoke(const ProcessCapability& capability)
+{
+    Vector<ProcessCapabilityGrant> grants;
+    grants.reserveInitialCapacity(2);
+
+    String environmentIdentifier = capability.environmentIdentifier();
+
+    if (RefPtr gpuProcess = m_client->gpuProcessForCapabilityGranter(*this))
+        grants.append(gpuProcess->processCapabilityGrants().take(environmentIdentifier));
+
+    if (RefPtr webProcess = m_client->webProcessForCapabilityGranter(*this, environmentIdentifier))
+        grants.append(webProcess->processCapabilityGrants().take(environmentIdentifier));
+
+    invalidateGrants(WTFMove(grants));
+}
+
+using ProcessCapabilityActivationPromise = NativePromise<void, ProcessCapabilityGrantError>;
+
+void ProcessCapabilityGranter::setMediaCapabilityActive(MediaCapability& capability, bool isActive)
+{
+    switch (capability.state()) {
+    case MediaCapability::State::Inactive:
+    case MediaCapability::State::Deactivating:
+        if (!isActive)
+            return;
+        capability.setState(MediaCapability::State::Activating);
+        break;
+    case MediaCapability::State::Activating:
+    case MediaCapability::State::Active:
+        if (isActive)
+            return;
+        capability.setState(MediaCapability::State::Deactivating);
+        break;
+    }
+
+    GRANTER_RELEASE_LOG(capability.environmentIdentifier(), "%{public}s", isActive ? "activating" : "deactivating");
+
+    invokeAsync(granterQueue(), [platformCapability = capability.platformCapability(), isActive] {
+#if USE(EXTENSIONKIT)
+        if ([platformCapability setActive:isActive])
+            return ProcessCapabilityActivationPromise::createAndResolve();
+#endif
+        return ProcessCapabilityActivationPromise::createAndReject(ProcessCapabilityGrantError::PlatformError);
+    })->whenSettled(RunLoop::main(), [weakCapability = WeakPtr { capability }, isActive](auto&& result) {
+        auto capability = weakCapability.get();
+        if (!capability)
+            return;
+
+        if (!result) {
+            GRANTER_RELEASE_LOG_ERROR(capability->environmentIdentifier(), "failed to %{public}s", isActive ? "activate" : "deactivate");
+            capability->setState(MediaCapability::State::Inactive);
+            return;
+        }
+
+        switch (capability->state()) {
+        case MediaCapability::State::Deactivating:
+            if (!isActive)
+                capability->setState(MediaCapability::State::Inactive);
+            break;
+        case MediaCapability::State::Activating:
+            if (isActive)
+                capability->setState(MediaCapability::State::Active);
+            break;
+        case MediaCapability::State::Inactive:
+        case MediaCapability::State::Active:
+            ASSERT_NOT_REACHED();
+            return;
+        }
+
+        GRANTER_RELEASE_LOG(capability->environmentIdentifier(), "%{public}s", isActive ? "activated" : "deactivated");
+    });
+}
+
+void ProcessCapabilityGranter::invalidateGrants(Vector<ProcessCapabilityGrant>&& grants)
+{
+    granterQueue().dispatch([grants = crossThreadCopy(WTFMove(grants))]() mutable {
+        for (auto& grant : grants)
+            grant.setPlatformGrant(nil);
+    });
+}
+
+} // namespace WebKit
+
+#undef GRANTER_RELEASE_LOG
+#undef GRANTER_RELEASE_LOG_ERROR
+
+#endif // ENABLE(PROCESS_CAPABILITIES)

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -35,10 +35,12 @@
 #import "LegacyCustomProtocolManagerClient.h"
 #import "LockdownModeObserver.h"
 #import "Logging.h"
+#import "MediaCapability.h"
 #import "NetworkProcessCreationParameters.h"
 #import "NetworkProcessMessages.h"
 #import "NetworkProcessProxy.h"
 #import "PreferenceObserver.h"
+#import "ProcessCapabilityGranter.h"
 #import "ProcessThrottler.h"
 #import "SandboxExtension.h"
 #import "SandboxUtilities.h"
@@ -1201,5 +1203,38 @@ void WebProcessPool::registerHighDynamicRangeChangeCallback()
     } };
 }
 #endif // PLATFORM(IOS) || PLATFORM(VISION)
+
+#if ENABLE(PROCESS_CAPABILITIES)
+ProcessCapabilityGranter& WebProcessPool::processCapabilityGranter()
+{
+    if (!m_processCapabilityGranter)
+        m_processCapabilityGranter = ProcessCapabilityGranter::create(*this).moveToUniquePtr();
+    return *m_processCapabilityGranter;
+}
+
+RefPtr<GPUProcessProxy> WebProcessPool::gpuProcessForCapabilityGranter(const ProcessCapabilityGranter& processCapabilityGranter)
+{
+    ASSERT_UNUSED(processCapabilityGranter, m_processCapabilityGranter.get() == &processCapabilityGranter);
+    return gpuProcess();
+}
+
+RefPtr<WebProcessProxy> WebProcessPool::webProcessForCapabilityGranter(const ProcessCapabilityGranter& processCapabilityGranter, const String& environmentIdentifier)
+{
+    ASSERT_UNUSED(processCapabilityGranter, m_processCapabilityGranter.get() == &processCapabilityGranter);
+
+    auto index = processes().findIf([&](auto& process) {
+        return process->pages().containsIf([&](auto& page) {
+            if (auto& mediaCapability = page->mediaCapability())
+                return mediaCapability->environmentIdentifier() == environmentIdentifier;
+            return false;
+        });
+    });
+
+    if (index == notFound)
+        return nullptr;
+
+    return processes()[index].ptr();
+}
+#endif
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -74,6 +74,11 @@
 #include <WebCore/PlatformDisplay.h>
 #endif
 
+#if ENABLE(PROCESS_CAPABILITIES)
+#include "MediaCapability.h"
+#include "ProcessCapabilityGrant.h"
+#endif
+
 #define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, this->connection())
 
 namespace WebKit {
@@ -497,6 +502,15 @@ void GPUProcessProxy::gpuProcessExited(ProcessTerminationReason reason)
         ASSERT_NOT_REACHED();
         break;
     }
+
+#if ENABLE(PROCESS_CAPABILITIES)
+    // FIXME: Any ProcessCapabilityGranter can invalidate the GPUProcessProxy grants, so we pick the first one. In the future ProcessCapabilityGranter should be made a singleton.
+    for (auto& processPool : WebProcessPool::allProcessPools()) {
+        processPool->processCapabilityGranter().invalidateGrants(moveToVector(std::exchange(processCapabilityGrants(), { }).values()));
+        break;
+    }
+
+#endif
 
     if (singleton() == this)
         singleton() = nullptr;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h
@@ -31,6 +31,10 @@
 
 OBJC_CLASS UIScrollView;
 
+namespace WebCore {
+enum class TouchAction : uint8_t;
+}
+
 namespace WebKit {
 
 class RemoteLayerTreeNode;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
@@ -33,9 +33,10 @@
 #import "ScrollingTreeFrameScrollingNodeRemoteIOS.h"
 #import "ScrollingTreeOverflowScrollingNodeIOS.h"
 #import "ScrollingTreePluginScrollingNodeIOS.h"
+#import "WKBaseScrollView.h"
 #import "WebPageProxy.h"
 #import "WebProcessProxy.h"
-#import <UIKit/UIView.h>
+#import <WebCore/LocalFrameView.h>
 #import <WebCore/ScrollSnapOffsetsInfo.h>
 #import <WebCore/ScrollTypes.h>
 #import <WebCore/ScrollingStateFrameScrollingNode.h>

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -294,7 +294,7 @@ using ScrollingNodeID = uint64_t;
 using SleepDisablerIdentifier = ObjectIdentifier<SleepDisablerIdentifierType>;
 using UserMediaRequestIdentifier = ObjectIdentifier<UserMediaRequestIdentifierType>;
 
-}
+} // namespace WebCore
 
 OBJC_CLASS AMSUIEngagementTask;
 OBJC_CLASS CALayer;
@@ -335,6 +335,7 @@ class GamepadData;
 class GeolocationPermissionRequestManagerProxy;
 class LayerTreeContext;
 class LinkDecorationFilteringDataObserver;
+class MediaCapability;
 class MediaKeySystemPermissionRequestManagerProxy;
 class MediaSessionCoordinatorProxyPrivate;
 class MediaUsageManager;
@@ -2304,6 +2305,11 @@ public:
     bool shouldAllowAutoFillForCellularIdentifiers() const;
 #endif
 
+#if ENABLE(PROCESS_CAPABILITIES)
+    const std::optional<MediaCapability>& mediaCapability() const;
+    void updateMediaCapability();
+#endif
+
 private:
     WebPageProxy(PageClient&, WebProcessProxy&, Ref<API::PageConfiguration>&&);
     void platformInitialize();
@@ -2860,6 +2866,12 @@ private:
     bool useGPUProcessForDOMRenderingEnabled() const;
 
     void dispatchLoadEventToFrameOwnerElement(WebCore::FrameIdentifier);
+
+#if ENABLE(PROCESS_CAPABILITIES)
+    void setMediaCapability(std::optional<MediaCapability>&&);
+    bool shouldActivateMediaCapability() const;
+    bool shouldDeactivateMediaCapability() const;
+#endif
 
     template<typename F> decltype(auto) sendToWebPage(std::optional<WebCore::FrameIdentifier>, F&&);
     template<typename M, typename C> void sendToProcessContainingFrame(std::optional<WebCore::FrameIdentifier>, M&&, C&&);

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -86,6 +86,10 @@
 #include <WebCore/WebMediaSessionManagerClient.h>
 #endif
 
+#if ENABLE(PROCESS_CAPABILITIES)
+#include "MediaCapability.h"
+#endif
+
 namespace WebKit {
 
 struct PrivateClickMeasurementAndMetadata {
@@ -297,6 +301,10 @@ struct WebPageProxy::Internals final : WebPopupMenuProxy::Client
 
 #if ENABLE(WEBXR) && !USE(OPENXR)
     std::unique_ptr<PlatformXRSystem> xrSystem;
+#endif
+
+#if ENABLE(PROCESS_CAPABILITIES)
+    std::optional<MediaCapability> mediaCapability;
 #endif
 
     explicit Internals(WebPageProxy&);

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -147,6 +147,11 @@
 #include "IPCTesterMessages.h"
 #endif
 
+#if ENABLE(PROCESS_CAPABILITIES)
+#include "MediaCapability.h"
+#include "ProcessCapabilityGrant.h"
+#endif
+
 #define WEBPROCESSPOOL_RELEASE_LOG(channel, fmt, ...) RELEASE_LOG(channel, "%p - WebProcessPool::" fmt, this, ##__VA_ARGS__)
 #define WEBPROCESSPOOL_RELEASE_LOG_STATIC(channel, fmt, ...) RELEASE_LOG(channel, "WebProcessPool::" fmt, ##__VA_ARGS__)
 #define WEBPROCESSPOOL_RELEASE_LOG_ERROR(channel, fmt, ...) RELEASE_LOG_ERROR(channel, "%p - WebProcessPool::" fmt, this, ##__VA_ARGS__)
@@ -1008,6 +1013,15 @@ void WebProcessPool::processDidFinishLaunching(WebProcessProxy& process)
         process.protectedConnection()->ignoreTimeoutsForTesting();
 
     m_connectionClient.didCreateConnection(this, process.protectedWebConnection().get());
+
+#if ENABLE(PROCESS_CAPABILITIES)
+    for (auto& page : process.pages()) {
+        if (auto& mediaCapability = page->mediaCapability()) {
+            WEBPROCESSPOOL_RELEASE_LOG(ProcessCapabilities, "processDidFinishLaunching: granting media capability (envID=%{public}s)", mediaCapability->environmentIdentifier().utf8().data());
+            processCapabilityGranter().grant(*mediaCapability);
+        }
+    }
+#endif
 }
 
 void WebProcessPool::disconnectProcess(WebProcessProxy& process)
@@ -1042,6 +1056,10 @@ void WebProcessPool::disconnectProcess(WebProcessProxy& process)
 #endif
 
     removeProcessFromOriginCacheSet(process);
+
+#if ENABLE(PROCESS_CAPABILITIES)
+    processCapabilityGranter().invalidateGrants(moveToVector(std::exchange(process.processCapabilityGrants(), { }).values()));
+#endif
 }
 
 Ref<WebProcessProxy> WebProcessPool::processForRegistrableDomain(WebsiteDataStore& websiteDataStore, const RegistrableDomain& registrableDomain, WebProcessProxy::LockdownMode lockdownMode, const API::PageConfiguration& pageConfiguration)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1837,6 +1837,9 @@
 		A118A9F31908B8EA00F7C92B /* _WKNSFileManagerExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = A118A9F11908B8EA00F7C92B /* _WKNSFileManagerExtras.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A13B3DA2207F39DE0090C58D /* MobileWiFiSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = A13B3DA1207F39DE0090C58D /* MobileWiFiSPI.h */; };
 		A13DC682207AA6B20066EF72 /* WKApplicationStateTrackingView.h in Headers */ = {isa = PBXBuildFile; fileRef = A13DC680207AA6B20066EF72 /* WKApplicationStateTrackingView.h */; };
+		A141DF4F2B06ED0800E80B2D /* MediaCapability.h in Headers */ = {isa = PBXBuildFile; fileRef = A141DF4D2B06ECFB00E80B2D /* MediaCapability.h */; };
+		A141DF502B06ED0F00E80B2D /* MediaCapability.mm in Sources */ = {isa = PBXBuildFile; fileRef = A141DF4E2B06ECFB00E80B2D /* MediaCapability.mm */; };
+		A141DF522B07054900E80B2D /* ProcessCapabilityGrant.h in Headers */ = {isa = PBXBuildFile; fileRef = A141DF512B07054900E80B2D /* ProcessCapabilityGrant.h */; };
 		A15797642582B1DB00528236 /* MediaFormatReader.bundle in Copy Plug-ins */ = {isa = PBXBuildFile; fileRef = A16E66002581930800EE1749 /* MediaFormatReader.bundle */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		A15799B72584433200528236 /* MediaTrackReader.h in Headers */ = {isa = PBXBuildFile; fileRef = A15799AE2584433100528236 /* MediaTrackReader.h */; };
 		A15799BC2584433200528236 /* CoreMediaWrapped.h in Headers */ = {isa = PBXBuildFile; fileRef = A15799B32584433100528236 /* CoreMediaWrapped.h */; };
@@ -1859,6 +1862,7 @@
 		A1A4FE5A18DCE9FA00B5EA8A /* _WKDownload.h in Headers */ = {isa = PBXBuildFile; fileRef = A1A4FE5718DCE9FA00B5EA8A /* _WKDownload.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A1A4FE5C18DCE9FA00B5EA8A /* _WKDownloadInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = A1A4FE5918DCE9FA00B5EA8A /* _WKDownloadInternal.h */; };
 		A1A4FE6118DD54A400B5EA8A /* _WKDownloadDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = A1A4FE6018DD54A400B5EA8A /* _WKDownloadDelegate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A1AE0EC32B166439008A2563 /* ProcessCapabilityGranter.h in Headers */ = {isa = PBXBuildFile; fileRef = A1AE0EC12B1663D4008A2563 /* ProcessCapabilityGranter.h */; };
 		A1B4DCE125A7923C007D178C /* MediaSampleByteRange.h in Headers */ = {isa = PBXBuildFile; fileRef = A1B4DCDF25A79211007D178C /* MediaSampleByteRange.h */; };
 		A1C512C9190656E500448914 /* WebPreviewLoaderClient.h in Headers */ = {isa = PBXBuildFile; fileRef = A1C512C7190656E500448914 /* WebPreviewLoaderClient.h */; };
 		A1D615672B06BBAC002D0E19 /* ProcessCapability.h in Headers */ = {isa = PBXBuildFile; fileRef = A1D615622B06BBAB002D0E19 /* ProcessCapability.h */; };
@@ -6672,6 +6676,10 @@
 		A13B3DA1207F39DE0090C58D /* MobileWiFiSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MobileWiFiSPI.h; sourceTree = "<group>"; };
 		A13DC680207AA6B20066EF72 /* WKApplicationStateTrackingView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WKApplicationStateTrackingView.h; path = ios/WKApplicationStateTrackingView.h; sourceTree = "<group>"; };
 		A13DC681207AA6B20066EF72 /* WKApplicationStateTrackingView.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = WKApplicationStateTrackingView.mm; path = ios/WKApplicationStateTrackingView.mm; sourceTree = "<group>"; };
+		A141DF4D2B06ECFB00E80B2D /* MediaCapability.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MediaCapability.h; sourceTree = "<group>"; };
+		A141DF4E2B06ECFB00E80B2D /* MediaCapability.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MediaCapability.mm; sourceTree = "<group>"; };
+		A141DF512B07054900E80B2D /* ProcessCapabilityGrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ProcessCapabilityGrant.h; sourceTree = "<group>"; };
+		A141DF532B07069700E80B2D /* ProcessCapabilityGrant.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ProcessCapabilityGrant.mm; sourceTree = "<group>"; };
 		A15799AE2584433100528236 /* MediaTrackReader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MediaTrackReader.h; sourceTree = "<group>"; };
 		A15799AF2584433100528236 /* MediaSampleCursor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MediaSampleCursor.cpp; sourceTree = "<group>"; };
 		A15799B02584433100528236 /* MediaFormatReader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MediaFormatReader.cpp; sourceTree = "<group>"; };
@@ -6709,12 +6717,13 @@
 		A1A4FE5918DCE9FA00B5EA8A /* _WKDownloadInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKDownloadInternal.h; sourceTree = "<group>"; };
 		A1A4FE6018DD54A400B5EA8A /* _WKDownloadDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKDownloadDelegate.h; sourceTree = "<group>"; };
 		A1ADAFB52368E4B8009CB776 /* SharedMemory.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SharedMemory.cpp; sourceTree = "<group>"; };
+		A1AE0EC12B1663D4008A2563 /* ProcessCapabilityGranter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ProcessCapabilityGranter.h; sourceTree = "<group>"; };
+		A1AE0EC22B1663D4008A2563 /* ProcessCapabilityGranter.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ProcessCapabilityGranter.mm; sourceTree = "<group>"; };
 		A1B4DCDF25A79211007D178C /* MediaSampleByteRange.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MediaSampleByteRange.h; sourceTree = "<group>"; };
 		A1B4DCE025A79211007D178C /* MediaSampleByteRange.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MediaSampleByteRange.cpp; sourceTree = "<group>"; };
 		A1B9CA382246E54A003D6DCA /* WebPaymentCoordinatorCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebPaymentCoordinatorCocoa.mm; sourceTree = "<group>"; };
 		A1C512C6190656E500448914 /* WebPreviewLoaderClient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = WebPreviewLoaderClient.cpp; path = ios/WebPreviewLoaderClient.cpp; sourceTree = "<group>"; };
 		A1C512C7190656E500448914 /* WebPreviewLoaderClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WebPreviewLoaderClient.h; path = ios/WebPreviewLoaderClient.h; sourceTree = "<group>"; };
-		A1D07F562B07FA3A0024FABF /* ProcessCapability.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ProcessCapability.cpp; sourceTree = "<group>"; };
 		A1D615622B06BBAB002D0E19 /* ProcessCapability.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ProcessCapability.h; sourceTree = "<group>"; };
 		A1D615632B06BBAB002D0E19 /* AssertionCapability.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AssertionCapability.mm; sourceTree = "<group>"; };
 		A1D615662B06BBAB002D0E19 /* AssertionCapability.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AssertionCapability.h; sourceTree = "<group>"; };
@@ -8971,6 +8980,8 @@
 				C145CC0E23DCA427003A5EEB /* PreferenceObserver.h */,
 				C15CBB3323F34C3800300CC7 /* PreferenceObserver.mm */,
 				3AA50E2C28D37F8700D024E4 /* ProcessAssertionCocoa.mm */,
+				A1AE0EC12B1663D4008A2563 /* ProcessCapabilityGranter.h */,
+				A1AE0EC22B1663D4008A2563 /* ProcessCapabilityGranter.mm */,
 				5CB7AFDD23C5273D00E49CF3 /* ResourceLoadDelegate.h */,
 				5CB7AFDE23C5273D00E49CF3 /* ResourceLoadDelegate.mm */,
 				5CA9854B210BEB730057EB6B /* SafeBrowsingWarningCocoa.mm */,
@@ -11292,14 +11303,17 @@
 				F4351B9F25EEC87800D63892 /* ImageAnalysisUtilities.mm */,
 				BCE0937614FB128B001138D9 /* LayerHostingContext.h */,
 				BCE0937514FB128B001138D9 /* LayerHostingContext.mm */,
+				A141DF4D2B06ECFB00E80B2D /* MediaCapability.h */,
+				A141DF4E2B06ECFB00E80B2D /* MediaCapability.mm */,
 				F433C0A52958C22F00E771C2 /* NetworkIssueReporter.h */,
 				F433C0A62958C22F00E771C2 /* NetworkIssueReporter.mm */,
 				A1798B3D222D97A2000764BD /* PaymentAuthorizationPresenter.h */,
 				A1798B4A222F133A000764BD /* PaymentAuthorizationPresenter.mm */,
 				A1798B3F222D98B6000764BD /* PaymentAuthorizationViewController.h */,
 				A1798B40222D98B6000764BD /* PaymentAuthorizationViewController.mm */,
-				A1D07F562B07FA3A0024FABF /* ProcessCapability.cpp */,
 				A1D615622B06BBAB002D0E19 /* ProcessCapability.h */,
+				A141DF512B07054900E80B2D /* ProcessCapabilityGrant.h */,
+				A141DF532B07069700E80B2D /* ProcessCapabilityGrant.mm */,
 				4450AEBF1DC3FAE5009943F2 /* SharedMemoryCocoa.cpp */,
 				A181A79721ACAC610059A316 /* WebKitAdditions.mm */,
 				F4648E90296E81F500744170 /* WebPrivacyHelpers.h */,
@@ -15215,6 +15229,7 @@
 				7B1DB26625668CE1000E26BC /* ArrayReference.h in Headers */,
 				4955A6E628076D4D00BB91C4 /* ArrayReferenceTuple.h in Headers */,
 				A1D6156B2B06BBAC002D0E19 /* AssertionCapability.h in Headers */,
+				A1D6156B2B06BBAC002D0E19 /* AssertionCapability.h in Headers */,
 				AAFA634F234F7C6400FFA864 /* AsyncRevalidation.h in Headers */,
 				BCEE966D112FAF57006BCC24 /* Attachment.h in Headers */,
 				512F589712A8838800629530 /* AuthenticationChallengeProxy.h in Headers */,
@@ -15340,6 +15355,7 @@
 				1AA575FB1496B52600A4EE06 /* EventDispatcher.h in Headers */,
 				E31586CD2AD610F30062ED2A /* ExtensionEventHandler.h in Headers */,
 				A1D6156D2B06BCB2002D0E19 /* ExtensionKitSoftLink.h in Headers */,
+				A1D6156D2B06BCB2002D0E19 /* ExtensionKitSoftLink.h in Headers */,
 				E3E84BEE2AE1AA5A0091B3C2 /* ExtensionKitSPI.h in Headers */,
 				572EBBD72537EBAE000552B3 /* ExtraPrivateSymbolsForTAPI.h in Headers */,
 				57B8264823050C5100B72EB0 /* FidoService.h in Headers */,
@@ -15463,6 +15479,7 @@
 				1A6D86C21DF75265007745E8 /* MachMessage.h in Headers */,
 				1A24B5F311F531E800C38269 /* MachUtilities.h in Headers */,
 				462CD80C28204DFA00F0EA04 /* MarkSurfacesAsVolatileRequestIdentifier.h in Headers */,
+				A141DF4F2B06ED0800E80B2D /* MediaCapability.h in Headers */,
 				A15799BE2584433200528236 /* MediaFormatReader.h in Headers */,
 				9ACC07B125C815D800DC6386 /* MediaKeySystemPermissionRequest.h in Headers */,
 				9ACC07AD25C8132D00DC6386 /* MediaKeySystemPermissionRequestManager.h in Headers */,
@@ -15611,6 +15628,9 @@
 				5CB9310926E8439A0032B1C0 /* PrivateClickMeasurementXPCUtilities.h in Headers */,
 				86F9536518FF58F5001DB2EF /* ProcessAssertion.h in Headers */,
 				A1D615672B06BBAC002D0E19 /* ProcessCapability.h in Headers */,
+				A1D615672B06BBAC002D0E19 /* ProcessCapability.h in Headers */,
+				A141DF522B07054900E80B2D /* ProcessCapabilityGrant.h in Headers */,
+				A1AE0EC32B166439008A2563 /* ProcessCapabilityGranter.h in Headers */,
 				BC1A7C581136E19C00FB7167 /* ProcessLauncher.h in Headers */,
 				93E05E40282CD560000B69EB /* ProcessStateMonitor.h in Headers */,
 				463FD4821EB94EC000A2982C /* ProcessTerminationReason.h in Headers */,
@@ -18196,6 +18216,7 @@
 				572EBBDA2538F6B4000552B3 /* AppAttestInternalSoftLink.mm in Sources */,
 				EBA8D3B227A5E33F00CB7900 /* ApplePushServiceConnection.mm in Sources */,
 				A1D615722B06C7C2002D0E19 /* AssertionCapability.mm in Sources */,
+				A1D615722B06C7C2002D0E19 /* AssertionCapability.mm in Sources */,
 				CD4570D424411D0F00A3DCEB /* AudioSessionRoutingArbitrator.cpp in Sources */,
 				CD4570D3244113B500A3DCEB /* AudioSessionRoutingArbitratorProxyMessageReceiver.cpp in Sources */,
 				512F58A212A883AD00629530 /* AuthenticationManagerMessageReceiver.cpp in Sources */,
@@ -18255,6 +18276,7 @@
 				41A0EB142641714900794471 /* LibWebRTCCodecsProxy.mm in Sources */,
 				51F060E11654318500F3281C /* LibWebRTCNetworkMessageReceiver.cpp in Sources */,
 				449D90DA21FDC30B00F677C0 /* LocalAuthenticationSoftLink.mm in Sources */,
+				A141DF502B06ED0F00E80B2D /* MediaCapability.mm in Sources */,
 				07E19EFB23D401F10094FFB4 /* MediaPlayerPrivateRemoteMessageReceiver.cpp in Sources */,
 				1DF29E64257F37A3003C28AF /* MediaSourcePrivateRemoteMessageReceiver.cpp in Sources */,
 				9B4790912531563200EC11AB /* MessageArgumentDescriptions.cpp in Sources */,


### PR DESCRIPTION
#### 7b6ea01374235df040c52dfcd986447c7aec9aca
<pre>
[iOS] Grant media capabilities to the WebContent and GPU processes during capture and playback
<a href="https://bugs.webkit.org/show_bug.cgi?id=265588">https://bugs.webkit.org/show_bug.cgi?id=265588</a>
<a href="https://rdar.apple.com/116242683">rdar://116242683</a>

Reviewed by Per Arne Vollan.

This patch introduces MediaCapability and ProcessCapabilityGranter, responsible for granting,
revoking, and managing the activation of a MediaCapability.

A MediaCapability is created each time a WebPageProxy navigates to a new top privately-controlled
domain, and is granted to the page&apos;s GPU and WebContent processes. When media playback or capture
becomes active on the page the capability is activated, and remains active for as long as that page
is capable of playback or capture. Granting and activating these capabilities allows iOS to know the
process hierarchy and domain responsible for playback and capture, and allows the system to, e.g.,
resume the responsible processes when starting playback from Now Playing or account for the
responsible domain in System Status. Media capabilities will serve as a replacement to SPIs like
AVSystemController_PIDToInheritApplicationStateFrom and -[AVAudioSession setHostProcessAttribution:].

This feature is behind an off-by-default web preference (MediaCapabilityGrantsEnabled). Adding API
tests is tracked by <a href="https://rdar.apple.com/115750175">rdar://115750175</a>. It wasn&apos;t done in this patch because tests are blocked by
other work.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml: Added a web preference.
* Source/WebKit/Platform/Logging.h: Added a logging channel.

* Source/WebKit/Platform/cocoa/AssertionCapability.h:
* Source/WebKit/Platform/cocoa/AssertionCapability.mm:
(WebKit::AssertionCapability::AssertionCapability):
(WebKit::AssertionCapability::platformCapability const):

* Source/WebKit/Platform/cocoa/MediaCapability.h: Added a ProcessCapability subclass for media
capabilities.
* Source/WebKit/Platform/cocoa/MediaCapability.mm:
(WebKit::createPlatformCapability):
(WebKit::MediaCapability::MediaCapability):
(WebKit::MediaCapability::environmentIdentifier const):

* Source/WebKit/Platform/cocoa/ProcessCapability.h:
(WebKit::ProcessCapability::environmentIdentifier const): Deleted.

* Source/WebKit/Platform/cocoa/ProcessCapabilityGrant.h: Added a class to represent a capability
grant created by ProcessCapabilityGranter.
(WebKit::ProcessCapabilityGrant::environmentIdentifier const):
* Source/WebKit/Platform/cocoa/ProcessCapabilityGrant.mm:
(WebKit::platformInvalidate):
(WebKit::ProcessCapabilityGrant::ProcessCapabilityGrant):
(WebKit::ProcessCapabilityGrant::~ProcessCapabilityGrant):
(WebKit::ProcessCapabilityGrant::isEmpty const):
(WebKit::ProcessCapabilityGrant::isValid const):
(WebKit::ProcessCapabilityGrant::setPlatformGrant):

* Source/WebKit/Platform/spi/Cocoa/ExtensionKitSPI.h: Defined new _SECapabilities SPI.

* Source/WebKit/SourcesCocoa.txt:

* Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp: Stored a map of ProcessCapabilityGrants by
environmentIdentifier.
(WebKit::AuxiliaryProcessProxy::~AuxiliaryProcessProxy):
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.h:
(WebKit::AuxiliaryProcessProxy::processCapabilityGrants):
* Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm:
(WebKit::ProcessAssertion::ProcessAssertion):

* Source/WebKit/UIProcess/Cocoa/ProcessCapabilityGranter.h: Added.
* Source/WebKit/UIProcess/Cocoa/ProcessCapabilityGranter.mm: Added.
(WebKit::granterQueue): Defined a queue for granting, revoking, and activating.
(WebKit::grantCapability): Internal helpers for granting on granterQueue.
(WebKit::grantCapabilityInternal): Ditto.
(WebKit::prepareGrant): Ditto.
(WebKit::finalizeGrant): Ditto.
(WebKit::ProcessCapabilityGranter::create):
(WebKit::ProcessCapabilityGranter::ProcessCapabilityGranter):
(WebKit::ProcessCapabilityGranter::grant): Grants a capability to the GPU and WebContent processes.
(WebKit::ProcessCapabilityGranter::revoke): Revokes a capability previously granted to the GPU and
WebContent processes.
(WebKit::ProcessCapabilityGranter::setMediaCapabilityActive): Activates a capability.
(WebKit::ProcessCapabilityGranter::invalidateGrants): Invalidates a vector of grants in a single
batch.

* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::mediaCapability const): Returns the current media capability or nullopt.
(WebKit::WebPageProxy::setMediaCapability): Sets or clears the current media capability.
(WebKit::WebPageProxy::updateMediaCapability): Updates the current media capability when the top
privately-controlled domain changes, and activates or deactivates it as needed.
(WebKit::WebPageProxy::shouldActivateMediaCapability const): Defines when a media capability should
be activated.
(WebKit::WebPageProxy::shouldDeactivateMediaCapability const): Defines when a media capability
should be deactivated.
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::processCapabilityGranter): Creates a ProcessCapabilityGranter if needed and
returns a reference to it.
(WebKit::WebProcessPool::gpuProcessForCapabilityGranter): Returns a GPUProcessProxy, if one exists,
to ProcessCapabilityGranter.
(WebKit::WebProcessPool::webProcessForCapabilityGranter): Returns a WebProcessProxy for a given
environmentIdentifier, if one exists, to ProcessCapabilityGranter.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm: Fixed a unified source issue.

* Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp:
(WebKit::GPUProcessProxy::gpuProcessExited): Invalidated existing grants when the GPU process exits.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::dispatchActivityStateChange): Called updateMediaCapability().
(WebKit::WebPageProxy::didCommitLoadForFrame): Ditto.
(WebKit::WebPageProxy::updatePlayingMediaDidChange): Ditto.
(WebKit::WebPageProxy::resetState): Set the mediaCapability to nullopt.
(WebKit::WebPageProxy::gpuProcessDidFinishLaunching): Granted an existing media capability to the
new GPU process.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxyInternals.h:

* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::processDidFinishLaunching): Granted existing media capabilities to the new
WebContent process.
(WebKit::WebProcessPool::disconnectProcess): Invalidated existing grants for the process that
disconnected.
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/271761@main">https://commits.webkit.org/271761@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c629255ea2fd8c95c0a5d14d000da6fa1396329d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29573 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8235 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30887 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32092 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/26780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10388 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5528 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26787 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29846 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6875 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/25253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5876 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/6008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26341 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33436 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/25417 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/26976 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26761 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/32229 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/29789 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/5964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4156 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/30004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7700 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/36144 "Built successfully") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/7019 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Checked out pull request; Reviewed by Per Arne Vollan; compiling; layout-tests running") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6506 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7788 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3807 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/6487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->