### PR TITLE
[webkitscmpy] Collect diff from GitHub remote repository

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py
@@ -758,6 +758,60 @@ class TestGitHub(testing.TestCase):
         with self.assertRaises(ValueError):
             remote.GitHub(self.remote).checkout_url(http=True, ssh=True)
 
+    def test_diff(self):
+        with mocks.remote.GitHub():
+            repo = remote.GitHub(self.remote)
+            self.assertEqual([
+                'diff --git a/ChangeLog b/ChangeLog',
+                '--- a/ChangeLog',
+                '+++ b/ChangeLog',
+                '@@ -1,0 +1,0 @@',
+                '+Patch Series',
+            ], list(repo.diff(base='bae5d1e90999d4f916a8a15810ccfa43f37a2fd6')))
+
+    def test_diff_with_commit_message(self):
+        with mocks.remote.GitHub():
+            repo = remote.GitHub(self.remote)
+            self.assertEqual([
+                'From bae5d1e90999d4f916a8a15810ccfa43f37a2fd6',
+                'From: Jonathan Bedard <jbedard@apple.com>',
+                'Date: {}'.format(datetime.fromtimestamp(1601642800).strftime('%a %b %d %H:%M:%S %Y')),
+                'Subject: [PATCH] 8th commit',
+                '---',
+                'diff --git a/ChangeLog b/ChangeLog',
+                '--- a/ChangeLog',
+                '+++ b/ChangeLog',
+                '@@ -1,0 +1,0 @@',
+                '+8th commit',
+            ], list(repo.diff(base='3@main', head='4@main', include_log=True)))
+
+    def test_diff_with_commit_message_multiple(self):
+        self.maxDiff = None
+        with mocks.remote.GitHub():
+            repo = remote.GitHub(self.remote)
+            self.assertEqual([
+                'From bae5d1e90999d4f916a8a15810ccfa43f37a2fd6',
+                'From: Jonathan Bedard <jbedard@apple.com>',
+                'Date: {}'.format(datetime.fromtimestamp(1601642800).strftime('%a %b %d %H:%M:%S %Y')),
+                'Subject: [PATCH 1/2] 8th commit',
+                '---',
+                'diff --git a/ChangeLog b/ChangeLog',
+                '--- a/ChangeLog',
+                '+++ b/ChangeLog',
+                '@@ -1,0 +1,0 @@',
+                '+8th commit',
+                'From 1abe25b443e985f93b90d830e4a7e3731336af4d',
+                'From: Jonathan Bedard <jbedard@apple.com>',
+                'Date: {}'.format(datetime.fromtimestamp(1601637800).strftime('%a %b %d %H:%M:%S %Y')),
+                'Subject: [PATCH 2/2] 4th commit',
+                '---',
+                'diff --git a/ChangeLog b/ChangeLog',
+                '--- a/ChangeLog',
+                '+++ b/ChangeLog',
+                '@@ -1,0 +1,0 @@',
+                '+4th commit',
+            ], list(repo.diff(base='2@main', head='4@main', include_log=True)))
+
 
 class TestBitBucket(testing.TestCase):
     remote = 'https://bitbucket.example.com/projects/WEBKIT/repos/webkit'


### PR DESCRIPTION
#### 912bf757dabd4abf64bdacea33775bee027032ed
<pre>
[webkitscmpy] Collect diff from GitHub remote repository
<a href="https://bugs.webkit.org/show_bug.cgi?id=265590">https://bugs.webkit.org/show_bug.cgi?id=265590</a>
<a href="https://rdar.apple.com/118993239">rdar://118993239</a>

Reviewed by Dewei Zhu.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/git_hub.py:
(GitHub.commit): &apos;HEAD&apos; in GitHub means &quot;latest commit on the default branch&quot;.
(GitHub._diff_response): Return a response with a mock text diff.
(GitHub.request): Respect the &apos;application/vnd.github.diff&apos; header.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py:
(GitHub):
(GitHub.diff): Given a commit or commit range, return a line-by-line diff of
the provided range. If the caller requests it, include the commit messages for
the specified commits in the same patch format used by &apos;git format-patch&apos;.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py:

Canonical link: <a href="https://commits.webkit.org/271687@main">https://commits.webkit.org/271687@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6e5bbe4fe6eadcb311bf07a7263fc2e3fcb6d24

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29011 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7685 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30368 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31626 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26433 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29603 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9816 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4999 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26451 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29283 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6345 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24886 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5513 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/29171 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5643 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25911 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/32962 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26512 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26348 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31887 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5619 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3793 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29669 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/28778 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7275 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6972 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6116 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6140 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->