### PR TITLE
Hook up Web Extension context menus to WKWebView on macOS.

### DIFF
--- a/Source/WebCore/platform/LocalizedStrings.cpp
+++ b/Source/WebCore/platform/LocalizedStrings.cpp
@@ -136,9 +136,9 @@ String localizedString(const char* key)
 }
 #endif
 
-#if ENABLE(CONTEXT_MENUS) && PLATFORM(COCOA)
+#if PLATFORM(COCOA)
 
-static String truncatedStringForMenuItem(const String& original)
+String truncatedStringForMenuItem(const String& original)
 {
     // Truncate the string if it's too long. This number is roughly the same as the one used by AppKit.
     unsigned maxNumberOfGraphemeClustersInLookupMenuItem = 24;

--- a/Source/WebCore/platform/LocalizedStrings.h
+++ b/Source/WebCore/platform/LocalizedStrings.h
@@ -40,7 +40,11 @@
 namespace WebCore {
 
     class IntSize;
-    
+
+#if PLATFORM(COCOA)
+    WEBCORE_EXPORT String truncatedStringForMenuItem(const String&);
+#endif
+
     String inputElementAltText();
     String resetButtonDefaultLabel();
     String searchableIndexIntroduction();

--- a/Source/WebKit/Shared/Extensions/WebExtensionFrameIdentifier.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionFrameIdentifier.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "FrameInfoData.h"
 #include "WebFrame.h"
 #include "WebPage.h"
 #include <WebCore/Frame.h>
@@ -106,6 +107,16 @@ inline WebExtensionFrameIdentifier toWebExtensionFrameIdentifier(const WebFrame&
         return WebExtensionFrameConstants::MainFrameIdentifier;
 
     WebExtensionFrameIdentifier result { frame.frameID().object().toUInt64() };
+    ASSERT(result.isValid());
+    return result;
+}
+
+inline WebExtensionFrameIdentifier toWebExtensionFrameIdentifier(const FrameInfoData& frameInfoData)
+{
+    if (frameInfoData.isMainFrame)
+        return WebExtensionFrameConstants::MainFrameIdentifier;
+
+    WebExtensionFrameIdentifier result { frameInfoData.frameID.object().toUInt64() };
     ASSERT(result.isValid());
     return result;
 }

--- a/Source/WebKit/Shared/Extensions/WebExtensionMenuItem.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionMenuItem.serialization.in
@@ -63,12 +63,6 @@ enum class WebKit::WebExtensionMenuItemType : uint8_t {
     Video,
 };
 
-enum class WebKit::WebExtensionMenuItemMediaType : uint8_t {
-    Audio,
-    Image,
-    Video,
-}
-
 struct WebKit::WebExtensionMenuItemContextParameters {
     OptionSet<WebKit::WebExtensionMenuItemContextType> types;
 
@@ -79,7 +73,6 @@ struct WebKit::WebExtensionMenuItemContextParameters {
     String linkText;
     URL linkURL;
 
-    std::optional<WebKit::WebExtensionMenuItemMediaType> mediaType;
     URL sourceURL;
 
     String selectionString;

--- a/Source/WebKit/Shared/Extensions/WebExtensionMenuItemContextParameters.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionMenuItemContextParameters.h
@@ -34,12 +34,6 @@
 
 namespace WebKit {
 
-enum class WebExtensionMenuItemMediaType : uint8_t {
-    Audio,
-    Image,
-    Video,
-};
-
 struct WebExtensionMenuItemContextParameters {
     OptionSet<WebExtensionMenuItemContextType> types;
 
@@ -50,7 +44,6 @@ struct WebExtensionMenuItemContextParameters {
     String linkText;
     URL linkURL;
 
-    std::optional<WebExtensionMenuItemMediaType> mediaType;
     URL sourceURL;
 
     String selectionString;

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
@@ -33,6 +33,7 @@
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 #import "CocoaHelpers.h"
+#import "ContextMenuContextData.h"
 #import "Logging.h"
 #import "SandboxUtilities.h"
 #import "WebExtensionContext.h"
@@ -258,6 +259,16 @@ WebExtensionController::WebExtensionSet WebExtensionController::extensions() con
         extensions.addVoid(extensionContext->extension());
     return extensions;
 }
+
+#if PLATFORM(MAC)
+void WebExtensionController::addItemsToContextMenu(WebPageProxy& page, const ContextMenuContextData& contextData, NSMenu *menu)
+{
+    [menu addItem:NSMenuItem.separatorItem];
+
+    for (auto& context : m_extensionContexts)
+        context->addItemsToContextMenu(page, contextData, menu);
+}
+#endif
 
 void WebExtensionController::didStartProvisionalLoadForFrame(WebPageProxyIdentifier pageID, WebExtensionFrameIdentifier frameID, WebExtensionFrameIdentifier parentFrameID, const URL& targetURL, WallTime timestamp)
 {

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -69,6 +69,7 @@
 OBJC_CLASS NSArray;
 OBJC_CLASS NSDate;
 OBJC_CLASS NSDictionary;
+OBJC_CLASS NSMenu;
 OBJC_CLASS NSMutableDictionary;
 OBJC_CLASS NSString;
 OBJC_CLASS NSURL;
@@ -85,6 +86,7 @@ OBJC_PROTOCOL(_WKWebExtensionWindow);
 
 namespace WebKit {
 
+class ContextMenuContextData;
 class WebExtension;
 class WebUserContentControllerProxy;
 struct WebExtensionContextParameters;
@@ -327,6 +329,10 @@ public:
     const MenuItemVector& mainMenuItems() const { return m_mainMenuItems; }
     WebExtensionMenuItem* menuItem(const String& identifier) const;
     void performMenuItem(WebExtensionMenuItem&, const WebExtensionMenuItemContextParameters&, UserTriggered = UserTriggered::No);
+
+#if PLATFORM(MAC)
+    void addItemsToContextMenu(WebPageProxy&, const ContextMenuContextData&, NSMenu *);
+#endif
 
     void userGesturePerformed(WebExtensionTab&);
     bool hasActiveUserGesture(WebExtensionTab&) const;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
@@ -43,6 +43,7 @@
 #include <wtf/WeakHashSet.h>
 
 OBJC_CLASS NSError;
+OBJC_CLASS NSMenu;
 OBJC_PROTOCOL(_WKWebExtensionControllerDelegatePrivate);
 
 #ifdef __OBJC__
@@ -51,6 +52,7 @@ OBJC_PROTOCOL(_WKWebExtensionControllerDelegatePrivate);
 
 namespace WebKit {
 
+class ContextMenuContextData;
 class WebExtensionContext;
 class WebPageProxy;
 class WebProcessPool;
@@ -116,6 +118,10 @@ public:
 
     template<typename T>
     void sendToAllProcesses(const T& message, const ObjectIdentifierGenericBase& destinationID);
+
+#if PLATFORM(MAC)
+    void addItemsToContextMenu(WebPageProxy&, const ContextMenuContextData&, NSMenu *);
+#endif
 
 #ifdef __OBJC__
     _WKWebExtensionController *wrapper() const { return (_WKWebExtensionController *)API::ObjectImpl<API::Object::Type::WebExtensionController>::wrapper(); }

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionMenuItem.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionMenuItem.cpp
@@ -103,6 +103,9 @@ bool WebExtensionMenuItem::matches(const WebExtensionMenuItemContextParameters& 
     }
 
     auto matchesPattern = [&](const auto& patterns, const URL& url) {
+        if (patterns.isEmpty())
+            return true;
+
         for (const auto& pattern : patterns) {
             if (pattern->matchesURL(url))
                 return true;
@@ -111,27 +114,9 @@ bool WebExtensionMenuItem::matches(const WebExtensionMenuItemContextParameters& 
         return false;
     };
 
-    if (matchesType(ContextType::Page)) {
-        ASSERT(contextParameters.frameIdentifier);
-        ASSERT(!contextParameters.frameURL.isNull());
-
-        if (!isMainFrame(contextParameters.frameIdentifier))
-            return false;
-
-        if (!matchesPattern(documentPatterns(), contextParameters.frameURL))
-            return false;
-    }
-
-    if (matchesType(ContextType::Frame)) {
-        ASSERT(contextParameters.frameIdentifier);
-        ASSERT(!contextParameters.frameURL.isNull());
-
-        if (isMainFrame(contextParameters.frameIdentifier))
-            return false;
-
-        if (!matchesPattern(documentPatterns(), contextParameters.frameURL))
-            return false;
-    }
+    // Document patterns match for any context type.
+    if (!matchesPattern(documentPatterns(), contextParameters.frameURL))
+        return false;
 
     if (matchesType(ContextType::Link)) {
         ASSERT(!contextParameters.linkURL.isNull());

--- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
@@ -55,6 +55,10 @@
 #import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 #endif
 
+#if ENABLE(WK_WEB_EXTENSIONS)
+#import "WebExtensionController.h"
+#endif
+
 @interface WKUserDataWrapper : NSObject {
     RefPtr<API::Object> _webUserData;
 }
@@ -884,9 +888,15 @@ void WebContextMenuProxyMac::useContextMenuItems(Vector<Ref<WebContextMenuItem>>
             menuFromProposedMenu(menu);
             return;
         }
-        
+
         ASSERT(m_context.webHitTestResultData());
         Ref page = *this->page();
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+        if (RefPtr webExtensionController = page->webExtensionController())
+            webExtensionController->addItemsToContextMenu(page, m_context, menu);
+#endif
+
         page->contextMenuClient().menuFromProposedMenu(page, menu, m_context, m_userData.protectedObject().get(), WTFMove(menuFromProposedMenu));
     });
 }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm
@@ -476,30 +476,22 @@ void WebExtensionContextProxy::dispatchMenusClickedEvent(const WebExtensionMenuI
     if (!contextParameters.selectionString.isNull())
         info[selectionTextKey] = contextParameters.selectionString;
 
-    if (!contextParameters.sourceURL.isNull())
+    if (!contextParameters.sourceURL.isNull()) {
         info[srcURLKey] = contextParameters.sourceURL.string();
+
+        if (contextParameters.types.contains(WebExtensionMenuItemContextType::Audio))
+            info[mediaTypeKey] = audioKey;
+        else if (contextParameters.types.contains(WebExtensionMenuItemContextType::Image))
+            info[mediaTypeKey] = imageKey;
+        else if (contextParameters.types.contains(WebExtensionMenuItemContextType::Video))
+            info[mediaTypeKey] = videoKey;
+    }
 
     if (!contextParameters.linkURL.isNull())
         info[linkURLKey] = contextParameters.linkURL.string();
 
     if (!contextParameters.linkText.isNull())
         info[linkTextKey] = contextParameters.linkText;
-
-    if (contextParameters.mediaType) {
-        switch (contextParameters.mediaType.value()) {
-        case WebExtensionMenuItemMediaType::Audio:
-            info[mediaTypeKey] = audioKey;
-            break;
-
-        case WebExtensionMenuItemMediaType::Image:
-            info[mediaTypeKey] = imageKey;
-            break;
-
-        case WebExtensionMenuItemMediaType::Video:
-            info[mediaTypeKey] = videoKey;
-            break;
-        }
-    }
 
     if (contextParameters.frameIdentifier && !contextParameters.frameURL.isNull()) {
         info[editableKey] = @(contextParameters.editable);

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITest.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITest.h
@@ -48,7 +48,7 @@ public:
 
     void yield(JSContextRef, NSString *message);
 
-    void log(JSContextRef, NSString *message);
+    void log(JSContextRef, JSValue *);
 
     void fail(JSContextRef, NSString *message);
     void succeed(JSContextRef, NSString *message);

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionControllerProxyCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionControllerProxyCocoa.mm
@@ -104,8 +104,6 @@ void WebExtensionControllerProxy::serviceWorkerGlobalObjectIsAvailableForFrame(W
     JSObjectSetProperty(context, globalObject, toJSString("chrome").get(), namespaceObject, kJSPropertyAttributeNone, nullptr);
 }
 
-// MARK: Web Navigation
-
 void WebExtensionControllerProxy::didStartProvisionalLoadForFrame(WebPage& page, WebFrame& frame, const URL& url)
 {
     WebExtensionFrameIdentifier parentFrameID = frame.isMainFrame() ? WebExtensionFrameConstants::NoneIdentifier : toWebExtensionFrameIdentifier(*frame.parentFrame());

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITest.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITest.idl
@@ -38,7 +38,7 @@
     [NeedsScriptContext] void yield([Optional] DOMString message);
 
     // Logs a message during testing.
-    [NeedsScriptContext] void log(DOMString message);
+    [NeedsScriptContext] void log([ValuesAllowed] any message);
 
     // Alias for `assertTrue(false, message)`.
     [NeedsScriptContext] void fail([Optional] DOMString message);

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.h
@@ -63,7 +63,6 @@ public:
     void globalObjectIsAvailableForFrame(WebPage&, WebFrame&, WebCore::DOMWrapperWorld&);
     void serviceWorkerGlobalObjectIsAvailableForFrame(WebPage&, WebFrame&, WebCore::DOMWrapperWorld&);
 
-    // Web Navigation
     void didStartProvisionalLoadForFrame(WebPage&, WebFrame&, const URL&);
     void didCommitLoadForFrame(WebPage&, WebFrame&, const URL&);
     void didFinishLoadForFrame(WebPage&, WebFrame&, const URL&);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIMenus.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIMenus.mm
@@ -27,8 +27,11 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
+#import "TestUIDelegate.h"
+#import "TestWKWebView.h"
 #import "TestWebExtensionsDelegate.h"
 #import "WebExtensionUtilities.h"
+#import <WebKit/WKWebViewConfigurationPrivate.h>
 
 namespace TestWebKitAPI {
 
@@ -39,7 +42,7 @@ static auto *menusManifest = @{
     @"description": @"Menus Test",
     @"version": @"1",
 
-    @"permissions": @[ @"menus", @"contextMenus" ],
+    @"permissions": @[ @"menus", @"contextMenus", @"activeTab" ],
 
     @"background": @{
         @"scripts": @[ @"background.js" ],
@@ -215,10 +218,7 @@ TEST(WKWebExtensionAPIMenus, ActionMenus)
         @"browser.test.yield('Menus Created')"
     ]);
 
-    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:menusManifest resources:@{ @"background.js": backgroundScript }]);
-    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
-
-    [manager loadAndRun];
+    auto manager = Util::loadAndRunExtension(menusManifest, @{ @"background.js": backgroundScript });
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Menus Created");
 
@@ -280,10 +280,7 @@ TEST(WKWebExtensionAPIMenus, ActionSubmenus)
         @"browser.test.yield('Menus Created')",
     ]);
 
-    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:menusManifest resources:@{ @"background.js": backgroundScript }]);
-    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
-
-    [manager loadAndRun];
+    auto manager = Util::loadAndRunExtension(menusManifest, @{ @"background.js": backgroundScript });
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Menus Created");
 
@@ -385,10 +382,7 @@ TEST(WKWebExtensionAPIMenus, ActionSubmenusUpdate)
         @"browser.test.yield('Menus Created')",
     ]);
 
-    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:menusManifest resources:@{ @"background.js": backgroundScript }]);
-    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
-
-    [manager loadAndRun];
+    auto manager = Util::loadAndRunExtension(menusManifest, @{ @"background.js": backgroundScript });
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Menus Created");
 
@@ -463,10 +457,7 @@ TEST(WKWebExtensionAPIMenus, TabMenus)
         @"browser.test.yield('Menus Created')",
     ]);
 
-    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:menusManifest resources:@{ @"background.js": backgroundScript }]);
-    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
-
-    [manager loadAndRun];
+    auto manager = Util::loadAndRunExtension(menusManifest, @{ @"background.js": backgroundScript });
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Menus Created");
 
@@ -524,10 +515,7 @@ TEST(WKWebExtensionAPIMenus, MenuItemProperties)
         @"icon-20.png": largerIcon,
     };
 
-    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:menusManifest resources:resources]);
-    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
-
-    [manager loadAndRun];
+    auto manager = Util::loadAndRunExtension(menusManifest, resources);
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Menus Created");
 
@@ -608,10 +596,7 @@ TEST(WKWebExtensionAPIMenus, MenuItemPropertiesUpdate)
         @"icon-20.png": largerIcon,
     };
 
-    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:menusManifest resources:resources]);
-    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
-
-    [manager loadAndRun];
+    auto manager = Util::loadAndRunExtension(menusManifest, resources);
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Menus Created");
 
@@ -679,10 +664,7 @@ TEST(WKWebExtensionAPIMenus, ToggleCheckboxMenuItems)
         @"browser.test.yield('Menus Created')",
     ]);
 
-    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:menusManifest resources:@{ @"background.js": backgroundScript }]);
-    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
-
-    [manager loadAndRun];
+    auto manager = Util::loadAndRunExtension(menusManifest, @{ @"background.js": backgroundScript });
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Menus Created");
 
@@ -777,10 +759,7 @@ TEST(WKWebExtensionAPIMenus, RadioItemGrouping)
         @"browser.test.yield('Menus Created')",
     ]);
 
-    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:menusManifest resources:@{ @"background.js": backgroundScript }]);
-    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
-
-    [manager loadAndRun];
+    auto manager = Util::loadAndRunExtension(menusManifest, @{ @"background.js": backgroundScript });
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Menus Created");
 
@@ -844,10 +823,7 @@ TEST(WKWebExtensionAPIMenus, OnClick)
         @"}, () => browser.test.yield('Menu Item Created'))"
     ]);
 
-    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:menusManifest resources:@{ @"background.js": backgroundScript }]);
-    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
-
-    [manager loadAndRun];
+    auto manager = Util::loadAndRunExtension(menusManifest, @{ @"background.js": backgroundScript });
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Menu Item Created");
 
@@ -884,10 +860,7 @@ TEST(WKWebExtensionAPIMenus, OnClickAfterUpdate)
         @"browser.test.yield('Menu Item Created')"
     ]);
 
-    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:menusManifest resources:@{ @"background.js": backgroundScript }]);
-    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
-
-    [manager loadAndRun];
+    auto manager = Util::loadAndRunExtension(menusManifest, @{ @"background.js": backgroundScript });
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Menu Item Created");
 
@@ -900,7 +873,7 @@ TEST(WKWebExtensionAPIMenus, OnClickAfterUpdate)
     [manager run];
 }
 
-TEST(WKWebExtensionAPIMenus, ContextMenus)
+TEST(WKWebExtensionAPIMenus, ContextMenusNamespace)
 {
     auto *backgroundScript = Util::constructScript(@[
         @"browser.test.assertEq(typeof browser.contextMenus, 'object')",
@@ -910,6 +883,877 @@ TEST(WKWebExtensionAPIMenus, ContextMenus)
 
     Util::loadAndRunExtension(menusManifest, @{ @"background.js": backgroundScript });
 }
+
+#if PLATFORM(MAC)
+
+TEST(WKWebExtensionAPIMenus, MacContextMenuItems)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.menus.create({",
+        @"  id: 'context-menu-1',",
+        @"  title: 'Context Menu 1'",
+        @"})",
+
+        @"browser.menus.create({",
+        @"  id: 'context-menu-2',",
+        @"  title: 'Context Menu 2'",
+        @"})",
+
+        @"browser.menus.onClicked.addListener((info, tab) => {",
+        @"  browser.test.assertEq(typeof info, 'object')",
+        @"  browser.test.assertEq(typeof tab, 'object')",
+
+        @"  browser.test.assertEq(info.menuId, 'context-menu-1')",
+        @"  browser.test.assertEq(info.parentMenuId, undefined)",
+        @"  browser.test.assertEq(info.selectionText, undefined)",
+        @"  browser.test.assertEq(typeof info.pageUrl, 'string')",
+        @"  browser.test.assertTrue(info.pageUrl.startsWith('http://localhost:'))",
+        @"  browser.test.assertEq(info.frameId, 0)",
+        @"  browser.test.assertEq(info.editable, false)",
+
+        @"  browser.test.assertEq(typeof tab.id, 'number')",
+        @"  browser.test.assertEq(typeof tab.windowId, 'number')",
+
+        @"  browser.test.notifyPass()",
+        @"})",
+
+        @"browser.test.yield('Menus Created')",
+    ]);
+
+    auto delegate = adoptNS([[TestUIDelegate alloc] init]);
+
+    __block bool gotContextMenu = false;
+    delegate.get().getContextMenuFromProposedMenu = ^(NSMenu *menu, _WKContextMenuElementInfo *elementInfo, id<NSSecureCoding>, void (^completionHandler)(NSMenu *)) {
+        gotContextMenu = true;
+
+        NSMenuItem *extensionSubmenuItem = nil;
+        for (NSMenuItem *menuItem in menu.itemArray) {
+            if ([menuItem.title isEqualToString:@"Menus Test"]) {
+                extensionSubmenuItem = menuItem;
+                break;
+            }
+        }
+
+        EXPECT_NOT_NULL(extensionSubmenuItem);
+
+        NSArray *expectedTitles = @[ @"Context Menu 1", @"Context Menu 2" ];
+        NSMenu *extensionMenu = extensionSubmenuItem.submenu;
+        EXPECT_EQ(extensionMenu.itemArray.count, expectedTitles.count);
+
+        [extensionMenu.itemArray enumerateObjectsUsingBlock:^(NSMenuItem *menuItem, NSUInteger index, BOOL *stop) {
+            EXPECT_TRUE([menuItem isKindOfClass:[NSMenuItem class]]);
+            EXPECT_NS_EQUAL(menuItem.title, expectedTitles[index]);
+        }];
+
+        performMenuItemAction(extensionMenu.itemArray.firstObject);
+
+        completionHandler(nil);
+    };
+
+    auto manager = Util::loadAndRunExtension(menusManifest, @{ @"background.js": backgroundScript });
+
+    EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Menus Created");
+
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    EXPECT_FALSE([manager.get().context hasActiveUserGestureInTab:manager.get().defaultTab]);
+
+    auto *urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    configuration.get()._webExtensionController = manager.get().controller;
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
+    webView.get().UIDelegate = delegate.get();
+
+    manager.get().defaultTab.mainWebView = webView.get();
+
+    [webView synchronouslyLoadRequest:urlRequest];
+    [webView waitForNextPresentationUpdate];
+
+    [webView.get().window makeFirstResponder:webView.get()];
+
+    [webView mouseDownAtPoint:NSMakePoint(200, 200) simulatePressure:NO withFlags:0 eventType:NSEventTypeRightMouseDown];
+    [webView mouseUpAtPoint:NSMakePoint(200, 200) withFlags:0 eventType:NSEventTypeRightMouseUp];
+
+    Util::run(&gotContextMenu);
+
+    [manager run];
+
+    EXPECT_TRUE([manager.get().context hasActiveUserGestureInTab:manager.get().defaultTab]);
+}
+
+TEST(WKWebExtensionAPIMenus, MacActiveTabContextMenuItems)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.menus.create({",
+        @"  id: 'context-menu',",
+        @"  title: 'Context Menu Item'",
+        @"})",
+
+        @"browser.menus.onClicked.addListener((info, tab) => {",
+        @"  browser.test.assertEq(typeof info, 'object')",
+        @"  browser.test.assertEq(typeof tab, 'object')",
+
+        @"  browser.test.assertEq(info.menuId, 'context-menu')",
+        @"  browser.test.assertEq(info.parentMenuId, undefined)",
+        @"  browser.test.assertEq(info.selectionText, undefined)",
+        @"  browser.test.assertEq(typeof info.pageUrl, 'string')",
+        @"  browser.test.assertTrue(info.pageUrl.startsWith('http://localhost:'))",
+        @"  browser.test.assertEq(info.frameId, 0)",
+        @"  browser.test.assertEq(info.editable, false)",
+
+        @"  browser.test.assertEq(typeof tab.id, 'number')",
+        @"  browser.test.assertEq(typeof tab.windowId, 'number')",
+
+        @"  browser.test.notifyPass()",
+        @"})",
+
+        @"browser.test.yield('Menus Created')",
+    ]);
+
+    auto delegate = adoptNS([[TestUIDelegate alloc] init]);
+
+    __block bool gotContextMenu = false;
+    delegate.get().getContextMenuFromProposedMenu = ^(NSMenu *menu, _WKContextMenuElementInfo *, id<NSSecureCoding>, void (^completionHandler)(NSMenu *)) {
+        gotContextMenu = true;
+
+        NSMenuItem *selectionMenuItem = nil;
+        for (NSMenuItem *menuItem in menu.itemArray) {
+            if ([menuItem.title isEqualToString:@"Context Menu Item"]) {
+                selectionMenuItem = menuItem;
+                break;
+            }
+        }
+
+        EXPECT_NOT_NULL(selectionMenuItem);
+
+        performMenuItemAction(selectionMenuItem);
+
+        completionHandler(nil);
+    };
+
+    auto manager = Util::loadAndRunExtension(menusManifest, @{ @"background.js": backgroundScript });
+
+    EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Menus Created");
+
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:_WKWebExtensionPermissionActiveTab];
+
+    EXPECT_FALSE([manager.get().context hasActiveUserGestureInTab:manager.get().defaultTab]);
+
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    configuration.get()._webExtensionController = manager.get().controller;
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
+    webView.get().UIDelegate = delegate.get();
+
+    manager.get().defaultTab.mainWebView = webView.get();
+
+    [webView synchronouslyLoadRequest:server.requestWithLocalhost()];
+    [webView waitForNextPresentationUpdate];
+
+    [webView.get().window makeFirstResponder:webView.get()];
+
+    [webView mouseDownAtPoint:NSMakePoint(200, 200) simulatePressure:NO withFlags:0 eventType:NSEventTypeRightMouseDown];
+    [webView mouseUpAtPoint:NSMakePoint(200, 200) withFlags:0 eventType:NSEventTypeRightMouseUp];
+
+    Util::run(&gotContextMenu);
+
+    [manager run];
+
+    EXPECT_TRUE([manager.get().context hasActiveUserGestureInTab:manager.get().defaultTab]);
+}
+
+TEST(WKWebExtensionAPIMenus, MacURLPatternContextMenuItems)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.menus.create({",
+        @"  id: 'url-pattern-menu-item',",
+        @"  title: 'URL Pattern Item',",
+        @"  contexts: ['link'],",
+        @"  targetUrlPatterns: ['*://*.example.com/*'],",
+        @"  documentUrlPatterns: ['*://localhost/*']",
+        @"})",
+
+        @"browser.menus.create({",
+        @"  id: 'non-matching-menu-item',",
+        @"  title: 'Non-Matching Item',",
+        @"  contexts: ['link'],",
+        @"  targetUrlPatterns: ['*://*.other.com/*'],",
+        @"  documentUrlPatterns: ['*://*.apple.com/*']",
+        @"})",
+
+        @"browser.menus.onClicked.addListener((info, tab) => {",
+        @"  browser.test.assertEq(typeof info, 'object')",
+        @"  browser.test.assertEq(typeof tab, 'object')",
+
+        @"  browser.test.assertEq(info.menuId, 'url-pattern-menu-item')",
+        @"  browser.test.assertEq(info.parentMenuId, undefined)",
+        @"  browser.test.assertEq(info.selectionText, 'Large Example Link')",
+        @"  browser.test.assertEq(info.linkText, 'Large Example Link')",
+        @"  browser.test.assertEq(info.linkUrl, 'http://example.com/test')",
+        @"  browser.test.assertEq(typeof info.pageUrl, 'string')",
+        @"  browser.test.assertTrue(info.pageUrl.startsWith('http://localhost:'))",
+        @"  browser.test.assertEq(info.frameId, 0)",
+        @"  browser.test.assertEq(info.editable, false)",
+
+        @"  browser.test.assertEq(typeof tab.id, 'number')",
+        @"  browser.test.assertEq(typeof tab.windowId, 'number')",
+
+        @"  browser.test.notifyPass()",
+        @"})",
+
+        @"browser.test.yield('Menus Created')",
+    ]);
+
+    auto delegate = adoptNS([[TestUIDelegate alloc] init]);
+
+    __block bool gotContextMenu = false;
+    delegate.get().getContextMenuFromProposedMenu = ^(NSMenu *menu, _WKContextMenuElementInfo *elementInfo, id<NSSecureCoding>, void (^completionHandler)(NSMenu *)) {
+        gotContextMenu = true;
+
+        NSMenuItem *urlPatternMenuItem = nil;
+        NSMenuItem *nonMatchingMenuItem = nil;
+        for (NSMenuItem *menuItem in menu.itemArray) {
+            if ([menuItem.title isEqualToString:@"URL Pattern Item"])
+                urlPatternMenuItem = menuItem;
+            else if ([menuItem.title isEqualToString:@"Non-Matching Item"])
+                nonMatchingMenuItem = menuItem;
+        }
+
+        EXPECT_NOT_NULL(urlPatternMenuItem);
+        EXPECT_NULL(nonMatchingMenuItem);
+
+        performMenuItemAction(urlPatternMenuItem);
+
+        completionHandler(nil);
+    };
+
+    auto manager = Util::loadAndRunExtension(menusManifest, @{ @"background.js": backgroundScript });
+
+    EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Menus Created");
+
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<a href='http://example.com/test' style='font-size: 100px'>Large Example Link</p>"_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    configuration.get()._webExtensionController = manager.get().controller;
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
+    webView.get().UIDelegate = delegate.get();
+
+    manager.get().defaultTab.mainWebView = webView.get();
+
+    [webView synchronouslyLoadRequest:urlRequest];
+    [webView waitForNextPresentationUpdate];
+
+    [webView.get().window makeFirstResponder:webView.get()];
+
+    [webView mouseDownAtPoint:NSMakePoint(50, 50) simulatePressure:NO withFlags:0 eventType:NSEventTypeRightMouseDown];
+    [webView mouseUpAtPoint:NSMakePoint(50, 50) withFlags:0 eventType:NSEventTypeRightMouseUp];
+
+    Util::run(&gotContextMenu);
+
+    [manager run];
+}
+
+TEST(WKWebExtensionAPIMenus, MacSelectionContextMenuItems)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.menus.create({",
+        @"  id: 'selection-menu-item',",
+        @"  title: 'Selected: %s',",
+        @"  contexts: [ 'selection' ]",
+        @"})",
+
+        @"browser.menus.onClicked.addListener((info, tab) => {",
+        @"  browser.test.assertEq(typeof info, 'object')",
+        @"  browser.test.assertEq(typeof tab, 'object')",
+
+        @"  browser.test.assertEq(info.menuId, 'selection-menu-item')",
+        @"  browser.test.assertEq(info.parentMenuId, undefined)",
+        @"  browser.test.assertEq(info.selectionText, 'Example ')",
+        @"  browser.test.assertEq(typeof info.pageUrl, 'string')",
+        @"  browser.test.assertTrue(info.pageUrl.startsWith('http://localhost:'))",
+        @"  browser.test.assertEq(info.frameId, 0)",
+        @"  browser.test.assertEq(info.editable, false)",
+
+        @"  browser.test.assertEq(typeof tab.id, 'number')",
+        @"  browser.test.assertEq(typeof tab.windowId, 'number')",
+
+        @"  browser.test.notifyPass()",
+        @"})",
+
+        @"browser.test.yield('Menus Created')",
+    ]);
+
+    auto delegate = adoptNS([[TestUIDelegate alloc] init]);
+
+    __block bool gotContextMenu = false;
+    delegate.get().getContextMenuFromProposedMenu = ^(NSMenu *menu, _WKContextMenuElementInfo *, id<NSSecureCoding>, void (^completionHandler)(NSMenu *)) {
+        gotContextMenu = true;
+
+        NSMenuItem *selectionMenuItem = nil;
+        for (NSMenuItem *menuItem in menu.itemArray) {
+            if ([menuItem.title hasPrefix:@"Selected: "]) {
+                selectionMenuItem = menuItem;
+                break;
+            }
+        }
+
+        EXPECT_NOT_NULL(selectionMenuItem);
+        EXPECT_NS_EQUAL(selectionMenuItem.title, @"Selected: Example");
+
+        performMenuItemAction(selectionMenuItem);
+
+        completionHandler(nil);
+    };
+
+    auto manager = Util::loadAndRunExtension(menusManifest, @{ @"background.js": backgroundScript });
+
+    EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Menus Created");
+
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<p style='font-size: 100px'>Selection Example Text</p>"_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    configuration.get()._webExtensionController = manager.get().controller;
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
+    webView.get().UIDelegate = delegate.get();
+
+    manager.get().defaultTab.mainWebView = webView.get();
+
+    [webView synchronouslyLoadRequest:urlRequest];
+    [webView waitForNextPresentationUpdate];
+
+    [webView.get().window makeFirstResponder:webView.get()];
+
+    [webView mouseDownAtPoint:NSMakePoint(200, 200) simulatePressure:NO withFlags:0 eventType:NSEventTypeRightMouseDown];
+    [webView mouseUpAtPoint:NSMakePoint(200, 200) withFlags:0 eventType:NSEventTypeRightMouseUp];
+
+    Util::run(&gotContextMenu);
+
+    [manager run];
+}
+
+TEST(WKWebExtensionAPIMenus, MacLinkContextMenuItems)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.menus.create({",
+        @"  id: 'link-menu-item',",
+        @"  title: 'Link Item',",
+        @"  contexts: [ 'link' ]",
+        @"})",
+
+        @"browser.menus.onClicked.addListener((info, tab) => {",
+        @"  browser.test.assertEq(typeof info, 'object')",
+        @"  browser.test.assertEq(typeof tab, 'object')",
+
+        @"  browser.test.assertEq(info.menuId, 'link-menu-item')",
+        @"  browser.test.assertEq(info.parentMenuId, undefined)",
+        @"  browser.test.assertEq(info.selectionText, 'Large Example Link')",
+        @"  browser.test.assertEq(info.linkText, 'Large Example Link')",
+        @"  browser.test.assertEq(info.linkUrl, 'http://example.com/test')",
+        @"  browser.test.assertEq(typeof info.pageUrl, 'string')",
+        @"  browser.test.assertTrue(info.pageUrl.startsWith('http://localhost:'))",
+        @"  browser.test.assertEq(info.frameId, 0)",
+        @"  browser.test.assertEq(info.editable, false)",
+
+        @"  browser.test.assertEq(typeof tab.id, 'number')",
+        @"  browser.test.assertEq(typeof tab.windowId, 'number')",
+
+        @"  browser.test.notifyPass()",
+        @"})",
+
+        @"browser.test.yield('Menus Created')",
+    ]);
+
+    auto delegate = adoptNS([[TestUIDelegate alloc] init]);
+
+    __block bool gotContextMenu = false;
+    delegate.get().getContextMenuFromProposedMenu = ^(NSMenu *menu, _WKContextMenuElementInfo *, id<NSSecureCoding>, void (^completionHandler)(NSMenu *)) {
+        gotContextMenu = true;
+
+        NSMenuItem *linkMenuItem = nil;
+        for (NSMenuItem *menuItem in menu.itemArray) {
+            if ([menuItem.title isEqualToString:@"Link Item"]) {
+                linkMenuItem = menuItem;
+                break;
+            }
+        }
+
+        EXPECT_NOT_NULL(linkMenuItem);
+
+        performMenuItemAction(linkMenuItem);
+
+        completionHandler(nil);
+    };
+
+    auto manager = Util::loadAndRunExtension(menusManifest, @{ @"background.js": backgroundScript });
+
+    EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Menus Created");
+
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<a href='http://example.com/test' style='font-size: 100px'>Large Example Link</p>"_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    configuration.get()._webExtensionController = manager.get().controller;
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
+    webView.get().UIDelegate = delegate.get();
+
+    manager.get().defaultTab.mainWebView = webView.get();
+
+    [webView synchronouslyLoadRequest:urlRequest];
+    [webView waitForNextPresentationUpdate];
+
+    [webView.get().window makeFirstResponder:webView.get()];
+
+    [webView mouseDownAtPoint:NSMakePoint(200, 200) simulatePressure:NO withFlags:0 eventType:NSEventTypeRightMouseDown];
+    [webView mouseUpAtPoint:NSMakePoint(200, 200) withFlags:0 eventType:NSEventTypeRightMouseUp];
+
+    Util::run(&gotContextMenu);
+
+    [manager run];
+}
+
+TEST(WKWebExtensionAPIMenus, MacImageContextMenuItems)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.menus.create({",
+        @"  id: 'image-menu-item',",
+        @"  title: 'Image Item',",
+        @"  contexts: [ 'image' ]",
+        @"})",
+
+        @"browser.menus.onClicked.addListener((info, tab) => {",
+        @"  browser.test.assertEq(typeof info, 'object')",
+        @"  browser.test.assertEq(typeof tab, 'object')",
+
+        @"  browser.test.assertEq(info.menuId, 'image-menu-item')",
+        @"  browser.test.assertEq(info.parentMenuId, undefined)",
+        @"  browser.test.assertEq(info.mediaType, 'image')",
+        @"  browser.test.assertEq(info.srcUrl, 'http://example.com/example.png')",
+        @"  browser.test.assertEq(typeof info.pageUrl, 'string')",
+        @"  browser.test.assertTrue(info.pageUrl.startsWith('http://localhost:'))",
+        @"  browser.test.assertEq(info.frameId, 0)",
+        @"  browser.test.assertEq(info.editable, false)",
+
+        @"  browser.test.assertEq(typeof tab.id, 'number')",
+        @"  browser.test.assertEq(typeof tab.windowId, 'number')",
+
+        @"  browser.test.notifyPass()",
+        @"})",
+
+        @"browser.test.yield('Menus Created')",
+    ]);
+
+    auto delegate = adoptNS([[TestUIDelegate alloc] init]);
+
+    __block bool gotContextMenu = false;
+    delegate.get().getContextMenuFromProposedMenu = ^(NSMenu *menu, _WKContextMenuElementInfo *, id<NSSecureCoding>, void (^completionHandler)(NSMenu *)) {
+        gotContextMenu = true;
+
+        NSMenuItem *imageMenuItem = nil;
+        for (NSMenuItem *menuItem in menu.itemArray) {
+            if ([menuItem.title isEqualToString:@"Image Item"]) {
+                imageMenuItem = menuItem;
+                break;
+            }
+        }
+
+        EXPECT_NOT_NULL(imageMenuItem);
+
+        performMenuItemAction(imageMenuItem);
+
+        completionHandler(nil);
+    };
+
+    auto manager = Util::loadAndRunExtension(menusManifest, @{ @"background.js": backgroundScript });
+
+    EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Menus Created");
+
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<img src='http://example.com/example.png' style='width: 400px; height: 400px'>"_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    configuration.get()._webExtensionController = manager.get().controller;
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
+    webView.get().UIDelegate = delegate.get();
+
+    manager.get().defaultTab.mainWebView = webView.get();
+
+    [webView synchronouslyLoadRequest:urlRequest];
+    [webView waitForNextPresentationUpdate];
+
+    [webView.get().window makeFirstResponder:webView.get()];
+
+    [webView mouseDownAtPoint:NSMakePoint(200, 200) simulatePressure:NO withFlags:0 eventType:NSEventTypeRightMouseDown];
+    [webView mouseUpAtPoint:NSMakePoint(200, 200) withFlags:0 eventType:NSEventTypeRightMouseUp];
+
+    Util::run(&gotContextMenu);
+
+    [manager run];
+}
+
+TEST(WKWebExtensionAPIMenus, MacVideoContextMenuItems)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.menus.create({",
+        @"  id: 'video-menu-item',",
+        @"  title: 'Video Item',",
+        @"  contexts: [ 'video' ]",
+        @"})",
+
+        @"browser.menus.onClicked.addListener((info, tab) => {",
+        @"  browser.test.assertEq(typeof info, 'object')",
+        @"  browser.test.assertEq(typeof tab, 'object')",
+
+        @"  browser.test.assertEq(info.menuId, 'video-menu-item')",
+        @"  browser.test.assertEq(info.parentMenuId, undefined)",
+        @"  browser.test.assertEq(info.mediaType, 'video')",
+        @"  browser.test.assertEq(info.srcUrl, 'http://example.com/example.mp4')",
+        @"  browser.test.assertEq(typeof info.pageUrl, 'string')",
+        @"  browser.test.assertTrue(info.pageUrl.startsWith('http://localhost:'))",
+        @"  browser.test.assertEq(info.frameId, 0)",
+        @"  browser.test.assertEq(info.editable, false)",
+
+        @"  browser.test.assertEq(typeof tab.id, 'number')",
+        @"  browser.test.assertEq(typeof tab.windowId, 'number')",
+
+        @"  browser.test.notifyPass()",
+        @"})",
+
+        @"browser.test.yield('Menus Created')",
+    ]);
+
+    auto delegate = adoptNS([[TestUIDelegate alloc] init]);
+
+    __block bool gotContextMenu = false;
+    delegate.get().getContextMenuFromProposedMenu = ^(NSMenu *menu, _WKContextMenuElementInfo *, id<NSSecureCoding>, void (^completionHandler)(NSMenu *)) {
+        gotContextMenu = true;
+
+        NSMenuItem *videoMenuItem = nil;
+        for (NSMenuItem *menuItem in menu.itemArray) {
+            if ([menuItem.title isEqualToString:@"Video Item"]) {
+                videoMenuItem = menuItem;
+                break;
+            }
+        }
+
+        EXPECT_NOT_NULL(videoMenuItem);
+
+        performMenuItemAction(videoMenuItem);
+
+        completionHandler(nil);
+    };
+
+    auto manager = Util::loadAndRunExtension(menusManifest, @{ @"background.js": backgroundScript });
+
+    EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Menus Created");
+
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<video src='http://example.com/example.mp4' style='width: 400px; height: 400px' controls></video>"_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    configuration.get()._webExtensionController = manager.get().controller;
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
+    webView.get().UIDelegate = delegate.get();
+
+    manager.get().defaultTab.mainWebView = webView.get();
+
+    [webView synchronouslyLoadRequest:urlRequest];
+    [webView waitForNextPresentationUpdate];
+
+    [webView.get().window makeFirstResponder:webView.get()];
+
+    [webView mouseDownAtPoint:NSMakePoint(200, 200) simulatePressure:NO withFlags:0 eventType:NSEventTypeRightMouseDown];
+    [webView mouseUpAtPoint:NSMakePoint(200, 200) withFlags:0 eventType:NSEventTypeRightMouseUp];
+
+    Util::run(&gotContextMenu);
+
+    [manager run];
+}
+
+TEST(WKWebExtensionAPIMenus, MacAudioContextMenuItems)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.menus.create({",
+        @"  id: 'audio-menu-item',",
+        @"  title: 'Audio Item',",
+        @"  contexts: [ 'audio' ]",
+        @"})",
+
+        @"browser.menus.onClicked.addListener((info, tab) => {",
+        @"  browser.test.assertEq(typeof info, 'object')",
+        @"  browser.test.assertEq(typeof tab, 'object')",
+
+        @"  browser.test.assertEq(info.menuId, 'audio-menu-item')",
+        @"  browser.test.assertEq(info.parentMenuId, undefined)",
+        @"  browser.test.assertEq(info.mediaType, 'audio')",
+        @"  browser.test.assertEq(info.srcUrl, 'http://example.com/example.mp3')",
+        @"  browser.test.assertEq(typeof info.pageUrl, 'string')",
+        @"  browser.test.assertTrue(info.pageUrl.startsWith('http://localhost:'))",
+        @"  browser.test.assertEq(info.frameId, 0)",
+        @"  browser.test.assertEq(info.editable, false)",
+
+        @"  browser.test.assertEq(typeof tab.id, 'number')",
+        @"  browser.test.assertEq(typeof tab.windowId, 'number')",
+
+        @"  browser.test.notifyPass()",
+        @"})",
+
+        @"browser.test.yield('Menus Created')",
+    ]);
+
+    auto delegate = adoptNS([[TestUIDelegate alloc] init]);
+
+    __block bool gotContextMenu = false;
+    delegate.get().getContextMenuFromProposedMenu = ^(NSMenu *menu, _WKContextMenuElementInfo *, id<NSSecureCoding>, void (^completionHandler)(NSMenu *)) {
+        gotContextMenu = true;
+
+        NSMenuItem *audioMenuItem = nil;
+        for (NSMenuItem *menuItem in menu.itemArray) {
+            if ([menuItem.title isEqualToString:@"Audio Item"]) {
+                audioMenuItem = menuItem;
+                break;
+            }
+        }
+
+        EXPECT_NOT_NULL(audioMenuItem);
+
+        performMenuItemAction(audioMenuItem);
+
+        completionHandler(nil);
+    };
+
+    auto manager = Util::loadAndRunExtension(menusManifest, @{ @"background.js": backgroundScript });
+
+    EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Menus Created");
+
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<audio src='http://example.com/example.mp3' style='width: 400px; height: 400px' controls></audio>"_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    configuration.get()._webExtensionController = manager.get().controller;
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
+    webView.get().UIDelegate = delegate.get();
+
+    manager.get().defaultTab.mainWebView = webView.get();
+
+    [webView synchronouslyLoadRequest:urlRequest];
+    [webView waitForNextPresentationUpdate];
+
+    [webView.get().window makeFirstResponder:webView.get()];
+
+    [webView mouseDownAtPoint:NSMakePoint(200, 200) simulatePressure:NO withFlags:0 eventType:NSEventTypeRightMouseDown];
+    [webView mouseUpAtPoint:NSMakePoint(200, 200) withFlags:0 eventType:NSEventTypeRightMouseUp];
+
+    Util::run(&gotContextMenu);
+
+    [manager run];
+}
+
+TEST(WKWebExtensionAPIMenus, MacEditableContextMenuItems)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.menus.create({",
+        @"  id: 'editable-menu-item',",
+        @"  title: 'Editable Item',",
+        @"  contexts: [ 'editable' ]",
+        @"})",
+
+        @"browser.menus.onClicked.addListener((info, tab) => {",
+        @"  browser.test.assertEq(typeof info, 'object')",
+        @"  browser.test.assertEq(typeof tab, 'object')",
+
+        @"  browser.test.assertEq(info.menuId, 'editable-menu-item')",
+        @"  browser.test.assertEq(info.parentMenuId, undefined)",
+        @"  browser.test.assertEq(info.selectionText, 'Area')",
+        @"  browser.test.assertEq(info.editable, true)",
+
+        @"  browser.test.assertEq(typeof tab.id, 'number')",
+        @"  browser.test.assertEq(typeof tab.windowId, 'number')",
+
+        @"  browser.test.notifyPass()",
+        @"})",
+
+        @"browser.test.yield('Menus Created')",
+    ]);
+
+    auto delegate = adoptNS([[TestUIDelegate alloc] init]);
+
+    __block bool gotContextMenu = false;
+    delegate.get().getContextMenuFromProposedMenu = ^(NSMenu *menu, _WKContextMenuElementInfo *, id<NSSecureCoding>, void (^completionHandler)(NSMenu *)) {
+        gotContextMenu = true;
+
+        NSMenuItem *editableMenuItem = nil;
+        for (NSMenuItem *menuItem in menu.itemArray) {
+            if ([menuItem.title isEqualToString:@"Editable Item"]) {
+                editableMenuItem = menuItem;
+                break;
+            }
+        }
+
+        EXPECT_NOT_NULL(editableMenuItem);
+
+        performMenuItemAction(editableMenuItem);
+
+        completionHandler(nil);
+    };
+
+    auto manager = Util::loadAndRunExtension(menusManifest, @{ @"background.js": backgroundScript });
+
+    EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Menus Created");
+
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<textarea style='font-size: 100px; width: 400px; height: 400px'>Editable Text Area</textarea>"_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    configuration.get()._webExtensionController = manager.get().controller;
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
+    webView.get().UIDelegate = delegate.get();
+
+    manager.get().defaultTab.mainWebView = webView.get();
+
+    [webView synchronouslyLoadRequest:urlRequest];
+    [webView waitForNextPresentationUpdate];
+
+    [webView.get().window makeFirstResponder:webView.get()];
+
+    [webView mouseDownAtPoint:NSMakePoint(200, 200) simulatePressure:NO withFlags:0 eventType:NSEventTypeRightMouseDown];
+    [webView mouseUpAtPoint:NSMakePoint(200, 200) withFlags:0 eventType:NSEventTypeRightMouseUp];
+
+    Util::run(&gotContextMenu);
+
+    [manager run];
+}
+
+TEST(WKWebExtensionAPIMenus, MacFrameContextMenuItems)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.menus.create({",
+        @"  id: 'frame-menu-item',",
+        @"  title: 'Frame Item',",
+        @"  contexts: [ 'page', 'frame' ]",
+        @"})",
+
+        @"browser.menus.onClicked.addListener((info, tab) => {",
+        @"  browser.test.assertEq(typeof info, 'object')",
+        @"  browser.test.assertEq(typeof tab, 'object')",
+
+        @"  browser.test.assertEq(info.menuId, 'frame-menu-item')",
+        @"  browser.test.assertEq(info.parentMenuId, undefined)",
+        @"  browser.test.assertEq(info.selectionText, undefined)",
+        @"  browser.test.assertEq(typeof info.frameUrl, 'string')",
+        @"  browser.test.assertTrue(info.frameUrl.endsWith('frame.html'))",
+        @"  browser.test.assertTrue(info.frameId !== 0)",
+
+        @"  browser.test.assertEq(typeof tab.id, 'number')",
+        @"  browser.test.assertEq(typeof tab.windowId, 'number')",
+
+        @"  browser.test.notifyPass()",
+        @"})",
+
+        @"browser.test.yield('Menus Created')",
+    ]);
+
+    auto delegate = adoptNS([[TestUIDelegate alloc] init]);
+
+    __block bool gotContextMenu = false;
+    delegate.get().getContextMenuFromProposedMenu = ^(NSMenu *menu, _WKContextMenuElementInfo *, id<NSSecureCoding>, void (^completionHandler)(NSMenu *)) {
+        gotContextMenu = true;
+
+        NSMenuItem *frameMenuItem = nil;
+        for (NSMenuItem *menuItem in menu.itemArray) {
+            if ([menuItem.title isEqualToString:@"Frame Item"]) {
+                frameMenuItem = menuItem;
+                break;
+            }
+        }
+
+        EXPECT_NOT_NULL(frameMenuItem);
+
+        performMenuItemAction(frameMenuItem);
+
+        completionHandler(nil);
+    };
+
+    auto manager = Util::loadAndRunExtension(menusManifest, @{ @"background.js": backgroundScript });
+
+    EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Menus Created");
+
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<iframe src='frame.html' style='width: 400px; height: 400px'>"_s } },
+        { "/frame.html"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:server.requestWithLocalhost("/frame.html"_s).URL];
+
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    configuration.get()._webExtensionController = manager.get().controller;
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
+    webView.get().UIDelegate = delegate.get();
+
+    manager.get().defaultTab.mainWebView = webView.get();
+
+    [webView synchronouslyLoadRequest:urlRequest];
+    [webView waitForNextPresentationUpdate];
+
+    [webView.get().window makeFirstResponder:webView.get()];
+
+    [webView mouseDownAtPoint:NSMakePoint(200, 200) simulatePressure:NO withFlags:0 eventType:NSEventTypeRightMouseDown];
+    [webView mouseUpAtPoint:NSMakePoint(200, 200) withFlags:0 eventType:NSEventTypeRightMouseUp];
+
+    Util::run(&gotContextMenu);
+
+    [manager run];
+}
+
+#endif // PLATFORM(MAC)
 
 } // namespace TestWebKitAPI
 


### PR DESCRIPTION
#### 31af7ceffae9edab123477a13b7ddadbaef44f02
<pre>
Hook up Web Extension context menus to WKWebView on macOS.
<a href="https://webkit.org/b/265591">https://webkit.org/b/265591</a>
<a href="https://rdar.apple.com/problem/118995365">rdar://problem/118995365</a>

Reviewed by Brian Weinstein.

Include Web Extension context menus to WKWebViews that use the extension controller
and when the extension has permission to the page or activeTab.

* Source/WebCore/platform/LocalizedStrings.cpp:
(WebCore::truncatedStringForMenuItem): Change from a static to export it for WebKit to use.
* Source/WebCore/platform/LocalizedStrings.h:
* Source/WebKit/Shared/Extensions/WebExtensionFrameIdentifier.h:
(WebKit::toWebExtensionFrameIdentifier): Added.
* Source/WebKit/Shared/Extensions/WebExtensionMenuItem.serialization.in:
* Source/WebKit/Shared/Extensions/WebExtensionMenuItemContextParameters.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::addItemsToContextMenu): Added.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(WebKit::WebExtensionController::addItemsToContextMenu): Added.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMenuItemCocoa.mm:
(WebKit::WebExtensionMenuItem::WebExtensionMenuItem):
(WebKit::WebExtensionMenuItem::update):
(WebKit::WebExtensionMenuItem::platformMenuItem const):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionController.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionMenuItem.cpp:
(WebKit::WebExtensionMenuItem::matches const):
* Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm:
(WebKit::WebContextMenuProxyMac::useContextMenuItems):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm:
(WebKit::WebExtensionContextProxy::dispatchMenusClickedEvent):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITestCocoa.mm:
(WebKit::debugString): Move up, support functions.
(WebKit::WebExtensionAPITest::log): Support object logging as JSON.
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITest.h:
* Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionControllerProxyCocoa.mm:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITest.idl:
* Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIMenus.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/271407@main">https://commits.webkit.org/271407@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ebb2f1683c8a39a00fe9d15a54bdf3abc8837669

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28117 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6758 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29472 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30648 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25630 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28614 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8778 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4144 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/25595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28385 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5518 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24194 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4767 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4932 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25189 "Found 1 new test failure: fast/ruby/ruby-overhang-crash.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31337 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25725 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25620 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31238 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4923 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3091 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28995 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6467 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5361 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3655 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5426 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->