### PR TITLE
Element.cpp's findAttrNodeInList() does case-insensitive comparison incorrectly

### DIFF
--- a/LayoutTests/fast/dom/Element/setAttributeNode-same-attribute-name-uppercase-expected.txt
+++ b/LayoutTests/fast/dom/Element/setAttributeNode-same-attribute-name-uppercase-expected.txt
@@ -1,0 +1,11 @@
+Tests calling setAttributeNode() twice with different nodes containing the same attribute name that is uppercase.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS pic.setAttributeNode(attr1) is null
+PASS pic.setAttributeNode(attr2) is attr1
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/dom/Element/setAttributeNode-same-attribute-name-uppercase.html
+++ b/LayoutTests/fast/dom/Element/setAttributeNode-same-attribute-name-uppercase.html
@@ -1,0 +1,18 @@
+<html>
+<body>
+<script src="../../../resources/js-test.js"></script>
+<script>
+description("Tests calling setAttributeNode() twice with different nodes containing the same attribute name that is uppercase.");
+
+let pic = document.createElement("picture");
+pic.id = "picItem";
+document.body.append(pic);
+
+pic.setAttribute("aria-rowcount","0");
+let attr1 = document.createAttributeNS("http://www.w3.org/1999/xhtml","FOOBAR");
+shouldBeNull("pic.setAttributeNode(attr1)");
+let attr2 = document.createAttributeNS("http://www.w3.org/1999/xhtml","FOOBAR");
+shouldBe("pic.setAttributeNode(attr2)", "attr1");
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -210,10 +210,17 @@ static Attr* findAttrNodeInList(Vector<RefPtr<Attr>>& attrNodeList, const Qualif
 
 static Attr* findAttrNodeInList(Vector<RefPtr<Attr>>& attrNodeList, const AtomString& localName, bool shouldIgnoreAttributeCase)
 {
-    const AtomString& caseAdjustedName = shouldIgnoreAttributeCase ? localName.convertToASCIILowercase() : localName;
-    for (auto& node : attrNodeList) {
-        if (node->qualifiedName().localName() == caseAdjustedName)
-            return node.get();
+    if (shouldIgnoreAttributeCase) {
+        auto caseAdjustedName = localName.convertToASCIILowercase();
+        for (auto& node : attrNodeList) {
+            if (node->qualifiedName().localNameLowercase() == caseAdjustedName)
+                return node.get();
+        }
+    } else {
+        for (auto& node : attrNodeList) {
+            if (node->qualifiedName().localName() == localName)
+                return node.get();
+        }
     }
     return nullptr;
 }


### PR DESCRIPTION
#### 09a30303f2b11c9a0d604e59fe92a225ed28cb05
<pre>
Element.cpp&apos;s findAttrNodeInList() does case-insensitive comparison incorrectly
<a href="https://bugs.webkit.org/show_bug.cgi?id=265597">https://bugs.webkit.org/show_bug.cgi?id=265597</a>

Reviewed by NOBODY (OOPS!).

If you call setAttributeNode() twice with an Attr nodes that have the same uppercase
attribute name (e.g. &quot;FOOBAR&quot;), in the context of an HTML document, it will fail to
find the the previous Attr node when the second call happens. As a result, setAttributeNode()
will return null twice instead of returning the existing Attr name with the same name the
second time around.

The bug was in findAttrNodeInList(). When trying to do a case insensitive check, it would
lower case the input localName and then compare it to the local names of existing attributes,
without lower casing those. As a result, we would compare &quot;foobar&quot; to &quot;FOOBAR&quot; and fail to
match.

Thanks to Claudio Saavedra from Igalia for finding the bug and doing much of the investigation
on this.

* LayoutTests/fast/dom/Element/setAttributeNode-same-attribute-name-uppercase-expected.txt: Added.
* LayoutTests/fast/dom/Element/setAttributeNode-same-attribute-name-uppercase.html: Added.
* Source/WebCore/dom/Element.cpp:
(WebCore::findAttrNodeInList):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09a30303f2b11c9a0d604e59fe92a225ed28cb05

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28123 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6764 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29478 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30653 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/25634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28620 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8784 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4149 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/25597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28391 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5524 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24202 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4769 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/4938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25195 "Found 1 new test failure: fast/ruby/ruby-overhang-crash.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31342 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25731 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25627 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31243 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/4927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3095 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28999 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6471 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/24995 "1 flakes") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/5364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5430 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->