### PR TITLE
REGRESSION (268955@main): Accepting inline predictions breaks ability to change selection by tapping in Mail compose

### DIFF
--- a/LayoutTests/editing/selection/ios/tap-to-change-selection-after-accepting-inline-prediction-expected.txt
+++ b/LayoutTests/editing/selection/ios/tap-to-change-selection-after-accepting-inline-prediction-expected.txt
@@ -1,0 +1,12 @@
+PASS targetContainsCaretSelection() became true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+I want to celebrate
+This test verifies that you can change an editable selection with a tap gesture after accepting an inline prediction. This test accepts an inline completion, taps the red box below, and verifies that the selection is correctly set. Requires WebKitTestRunner.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+
+

--- a/LayoutTests/editing/selection/ios/tap-to-change-selection-after-accepting-inline-prediction.html
+++ b/LayoutTests/editing/selection/ios/tap-to-change-selection-after-accepting-inline-prediction.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true allowsInlinePredictions=true ] -->
+<html>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<head>
+<style>
+body, html {
+    font-size: 16px;
+    font-family: system-ui;
+    margin: 0;
+}
+
+#target {
+    padding: 4px;
+    border: 1px solid tomato;
+    box-sizing: border-box;
+}
+</style>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<script>
+jsTestIsAsync = true;
+
+function targetContainsCaretSelection()
+{
+    if (getSelection().type !== "Caret")
+        return false;
+
+    let target = document.getElementById("target");
+    let container = getSelection().getRangeAt(0).startContainer;
+    while (container) {
+        if (container === target)
+            return true;
+        container = container.parentElement;
+    }
+    return false;
+}
+
+addEventListener("load", async () => {
+    description("This test verifies that you can change an editable selection with a tap gesture after accepting an inline prediction. This test accepts an inline completion, taps the red box below, and verifies that the selection is correctly set. Requires WebKitTestRunner.");
+    getSelection().setPosition(document.body, 0);
+
+    await UIHelper.activateAndWaitForInputSessionAt(10, 10);
+
+    for (let character of [..."I want to c"])
+        await UIHelper.typeCharacter(character);
+
+    await UIHelper.setInlinePrediction("elebrate");
+    await UIHelper.ensurePresentationUpdate();
+
+    await UIHelper.acceptInlinePrediction();
+    await UIHelper.ensurePresentationUpdate();
+
+    await UIHelper.activateElement(document.getElementById("target"));
+    await shouldBecomeEqual("targetContainsCaretSelection()", "true");
+
+    document.body.blur();
+    await UIHelper.waitForKeyboardToHide();
+
+    finishJSTest();
+});
+</script>
+</head>
+<body contenteditable>
+    <div><br></div>
+    <p id="description"></p>
+    <div id="target"><br></div>
+</body>
+</html>

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -602,6 +602,22 @@ window.UIHelper = class UIHelper {
         });
     }
 
+    static async setInlinePrediction(text)
+    {
+        if (!this.isWebKit2())
+            return Promise.resolve();
+
+        return new Promise(resolve => testRunner.runUIScript(`uiController.setInlinePrediction(\`${text}\`)`, resolve));
+    }
+
+    static async acceptInlinePrediction()
+    {
+        if (!this.isWebKit2())
+            return Promise.resolve();
+
+        return new Promise(resolve => testRunner.runUIScript(`uiController.acceptInlinePrediction()`, resolve));
+    }
+
     static async activateAndWaitForInputSessionAt(x, y)
     {
         if (!this.isWebKit2() || !this.isIOSFamily())

--- a/Source/WebKit/UIProcess/ios/UIKitUtilities.h
+++ b/Source/WebKit/UIProcess/ios/UIKitUtilities.h
@@ -45,6 +45,11 @@
 - (CGPoint)_wk_clampToScrollExtents:(CGPoint)contentOffset;
 @end
 
+@interface UIGestureRecognizer (WebKitInternal)
+@property (nonatomic, readonly) BOOL _wk_isTextInteractionLoupeGesture;
+@property (nonatomic, readonly) BOOL _wk_isTextInteractionTapGesture;
+@end
+
 @interface UIView (WebKitInternal)
 @property (nonatomic, readonly) UIViewController *_wk_viewControllerForFullScreenPresentation;
 @end

--- a/Source/WebKit/UIProcess/ios/UIKitUtilities.mm
+++ b/Source/WebKit/UIProcess/ios/UIKitUtilities.mm
@@ -198,6 +198,20 @@ static constexpr auto epsilonForComputingScrollability = 0.0001;
 
 @end
 
+@implementation UIGestureRecognizer (WebKitInternal)
+
+- (BOOL)_wk_isTextInteractionLoupeGesture
+{
+    return [self.name isEqualToString:@"UITextInteractionNameInteractiveRefinement"];
+}
+
+- (BOOL)_wk_isTextInteractionTapGesture
+{
+    return [self.name isEqualToString:@"UITextInteractionNameSingleTap"];
+}
+
+@end
+
 namespace WebKit {
 
 RetainPtr<UIAlertController> createUIAlertController(NSString *title, NSString *message)

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -402,8 +402,8 @@ struct ImageAnalysisContextMenuActionData {
     RetainPtr<UIPreviewItemController> _previewItemController;
 #endif
 
-    RetainPtr<UIGestureRecognizer> _textInteractionLoupeGestureRecognizer;
-    RetainPtr<UIGestureRecognizer> _textInteractionTapGestureRecognizer;
+    __weak UIGestureRecognizer *_cachedTextInteractionLoupeGestureRecognizer;
+    __weak UIGestureRecognizer *_cachedTextInteractionTapGestureRecognizer;
 
     RefPtr<WebCore::TextIndicator> _textIndicator;
     RetainPtr<WebTextIndicatorLayer> _textIndicatorLayer;

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -397,4 +397,7 @@ interface UIScriptController {
 
     readonly attribute unsigned long long currentImageAnalysisRequestID;
     undefined installFakeMachineReadableCodeResultsForImageAnalysis();
+
+    undefined setInlinePrediction(DOMString completion);
+    undefined acceptInlinePrediction();
 };

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -123,6 +123,9 @@ public:
     virtual bool isWindowContentViewFirstResponder() const { notImplemented(); return false; }
     virtual bool isWebContentFirstResponder() const { notImplemented(); return false; }
 
+    virtual void setInlinePrediction(JSStringRef) { notImplemented(); }
+    virtual void acceptInlinePrediction() { notImplemented(); }
+
     virtual void removeViewFromWindow(JSValueRef) { notImplemented(); }
     virtual void addViewToWindow(JSValueRef) { notImplemented(); }
 

--- a/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
+++ b/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
@@ -516,6 +516,8 @@ typedef enum {
 - (void)prepareKeyboardInputModeFromPreferences:(UIKeyboardInputMode *)lastUsedMode;
 - (BOOL)_shouldSuppressSoftwareKeyboard;
 - (void)syncInputManagerToAcceptedAutocorrection:(TIKeyboardCandidate *)autocorrection forInput:(TIKeyboardInput *)inputEvent;
+- (void)setInlineCompletionAsMarkedText:(NSAttributedString *)inlineCompletion selectedRange:(NSRange)selectedRange inputString:(NSString *)inputString searchString:(NSString *)searchString;
+@property (nonatomic, readonly) BOOL hasInlineCompletionAsMarkedText;
 @property (nonatomic, readonly) UIKeyboardInputMode *currentInputModeInPreference;
 @end
 

--- a/Tools/WebKitTestRunner/TestOptions.cpp
+++ b/Tools/WebKitTestRunner/TestOptions.cpp
@@ -189,6 +189,7 @@ const TestFeatures& TestOptions::defaults()
             { "noUseRemoteLayerTree", false },
             { "useThreadedScrolling", false },
             { "suppressInputAccessoryView", false },
+            { "allowsInlinePredictions", false },
             { "showsScrollIndicators", true },
             { "enhancedWindowingEnabled", false },
         };
@@ -252,6 +253,7 @@ const std::unordered_map<std::string, TestHeaderKeyType>& TestOptions::keyTypeMa
         { "useRemoteLayerTree", TestHeaderKeyType::BoolTestRunner },
         { "useThreadedScrolling", TestHeaderKeyType::BoolTestRunner },
         { "suppressInputAccessoryView", TestHeaderKeyType::BoolTestRunner },
+        { "allowsInlinePredictions", TestHeaderKeyType::BoolTestRunner },
         { "showsScrollIndicators", TestHeaderKeyType::BoolTestRunner },
         { "enhancedWindowingEnabled", TestHeaderKeyType::BoolTestRunner },
     

--- a/Tools/WebKitTestRunner/TestOptions.h
+++ b/Tools/WebKitTestRunner/TestOptions.h
@@ -78,6 +78,7 @@ public:
     bool noUseRemoteLayerTree() const { return boolTestRunnerFeatureValue("noUseRemoteLayerTree"); }
     bool useThreadedScrolling() const { return boolTestRunnerFeatureValue("useThreadedScrolling"); }
     bool suppressInputAccessoryView() const { return boolTestRunnerFeatureValue("suppressInputAccessoryView"); }
+    bool allowsInlinePredictions() const { return boolTestRunnerFeatureValue("allowsInlinePredictions"); }
     bool showsScrollIndicators() const { return boolTestRunnerFeatureValue("showsScrollIndicators"); }
     bool enhancedWindowingEnabled() const { return boolTestRunnerFeatureValue("enhancedWindowingEnabled"); }
     double contentInsetTop() const { return doubleTestRunnerFeatureValue("contentInset.top"); }

--- a/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
@@ -669,6 +669,9 @@ void TestController::configureWebpagePreferences(WKWebViewConfiguration *configu
     [webpagePreferences setPreferredContentMode:contentMode(options)];
 #endif
     configuration.defaultWebpagePreferences = webpagePreferences.get();
+#if HAVE(INLINE_PREDICTIONS)
+    configuration.allowsInlinePredictions = options.allowsInlinePredictions();
+#endif
 }
 
 WKRetainPtr<WKStringRef> TestController::takeViewPortSnapshot()

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
@@ -190,6 +190,9 @@ private:
     void becomeFirstResponder() override;
     void resignFirstResponder() override;
 
+    void setInlinePrediction(JSStringRef) final;
+    void acceptInlinePrediction() final;
+
     void simulateRotation(DeviceOrientation, JSValueRef callback);
 
     int64_t pasteboardChangeCount() const final;

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
@@ -1529,6 +1529,26 @@ bool UIScriptControllerIOS::isWebContentFirstResponder() const
     return [webView() _contentViewIsFirstResponder];
 }
 
+void UIScriptControllerIOS::setInlinePrediction(JSStringRef text)
+{
+    NSString *plainText = text->string();
+    auto attributedText = adoptNS([[NSAttributedString alloc] initWithString:plainText attributes:@{
+        NSBackgroundColorAttributeName : UIColor.clearColor,
+        NSForegroundColorAttributeName : UIColor.grayColor,
+    }]);
+    [UIKeyboardImpl.activeInstance setInlineCompletionAsMarkedText:attributedText.get() selectedRange:NSMakeRange(0, 0) inputString:plainText searchString:@""];
+}
+
+void UIScriptControllerIOS::acceptInlinePrediction()
+{
+    if (!UIKeyboardImpl.activeInstance.hasInlineCompletionAsMarkedText)
+        return;
+
+    [(id<UITextInput>)platformContentView() unmarkText];
+    auto emptyText = adoptNS([[NSAttributedString alloc] initWithString:@""]);
+    [UIKeyboardImpl.activeInstance setInlineCompletionAsMarkedText:emptyText.get() selectedRange:NSMakeRange(0, 0) inputString:@"" searchString:@""];
+}
+
 void UIScriptControllerIOS::becomeFirstResponder()
 {
     [webView() becomeFirstResponder];


### PR DESCRIPTION
#### 8796ae7158aac06497a247100c5e91ca8e25ae11
<pre>
REGRESSION (268955@main): Accepting inline predictions breaks ability to change selection by tapping in Mail compose
<a href="https://bugs.webkit.org/show_bug.cgi?id=265592">https://bugs.webkit.org/show_bug.cgi?id=265592</a>
<a href="https://rdar.apple.com/118094413">rdar://118094413</a>

Reviewed by Tim Horton and Abrar Rahman Protyasha.

After the changes in 268955@main, we sometimes end up with `_textInteractionLoupeGestureRecognizer`
and `_textInteractionTapGestureRecognizer` ivars that point to old gesture recognizers that are no
longer installed on the content view.

While we currently refresh these two references every time we call `-setUpTextSelectionAssistant`
(i.e. when we show or hide the keyboard, or change the focused element), it&apos;s actually possible for
UIKit to also add or remove these text interaction gestures from the content view; one of the ways
in which this may happen is upon accepting an inline prediction in Mail compose, which causes us to
get into a state where the text interaction multi-tap gesture is swapped out from underneath us,
subsequently causing `-gestureRecognizer:shouldRecognizeSimultaneouslyWithGestureRecognizer:` to no
longer return `YES` in the case of the synthetic click and text tap gestures. This leads to the
synthetic click taking precedence, causing single taps to try and change the selection to fail.

To fix this, we replace these ivars with properties on the content view, which internally check if
the last cached gesture is still installed on the content view; if not, we find the new gesture and
cache it.

Test: editing/selection/ios/tap-to-change-selection-after-accepting-inline-prediction.html

* LayoutTests/editing/selection/ios/tap-to-change-selection-after-accepting-inline-prediction-expected.txt: Added.
* LayoutTests/editing/selection/ios/tap-to-change-selection-after-accepting-inline-prediction.html: Added.

Add a new layout test to exercise the change.

* LayoutTests/resources/ui-helper.js:
(window.UIHelper.async setInlinePrediction):
(window.UIHelper.async acceptInlinePrediction):

Add test infrastructure for both setting and accepting inline predictions, relative to the current
selection.

* Source/WebKit/UIProcess/ios/UIKitUtilities.h:
* Source/WebKit/UIProcess/ios/UIKitUtilities.mm:
(-[UIGestureRecognizer _wk_isTextInteractionLoupeGesture]):
(-[UIGestureRecognizer _wk_isTextInteractionTapGesture]):

Add a couple of utility functions to return whether or not a given gesture recognizer is a text
interaction multi-tap or loupe gesture.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:

Replace uses of `_textInteractionTapGestureRecognizer` and `_textInteractionLoupeGestureRecognizer`
with the new properties instead, and rename these to `_cachedTextInteraction*GestureRecognizer` to
make it clear that these ivars may not be up to date. See above for more details.

In places where we already have a `UIGestureRecognizer` instance and we&apos;re checking whether or not
it&apos;s a loupe or tap gesture, we instead call into the category properties directly, to avoid
unnecessarily scanning the gesture recognizer list.

(-[WKContentView gestureRecognizer:canBePreventedByGestureRecognizer:]):
(-[WKContentView textInteractionLoupeGestureRecognizer]):
(-[WKContentView textInteractionTapGestureRecognizer]):
(-[WKContentView gestureRecognizer:shouldRecognizeSimultaneouslyWithGestureRecognizer:]):
(-[WKContentView textInteractionGesture:shouldBeginAtPoint:]):
(-[WKContentView setUpTextSelectionAssistant]):
(logTextInteraction):

Additionally, rename `logTextInteractionAssistantSelectionChange` to just `logTextInteraction`, now
that it doesn&apos;t take a text interaction assistant.

(-[WKContentView changeSelectionWithGestureAt:withGesture:withState:withFlags:]):
(-[WKContentView changeSelectionWithTouchAt:withSelectionTouch:baseIsStart:withFlags:]):
(-[WKContentView changeSelectionWithTouchesFrom:to:withGesture:withState:]):
(-[WKContentView _selectPositionAtPoint:stayingWithinFocusedElement:completionHandler:]):
(-[WKContentView selectPositionAtBoundary:inDirection:fromPoint:completionHandler:]):
(logTextInteractionAssistantSelectionChange): Deleted.
(-[WKContentView moveSelectionAtBoundary:inDirection:completionHandler:]):
(-[WKContentView selectTextWithGranularity:atPoint:completionHandler:]):
(-[WKContentView beginSelectionInDirection:completionHandler:]):
(-[WKContentView updateSelectionWithExtentPoint:completionHandler:]):
(-[WKContentView updateSelectionWithExtentPoint:withBoundary:completionHandler:]):
(-[WKContentView shouldDeferGestureDueToImageAnalysis:]):
(-[WKContentView deferringGestureRecognizer:shouldDeferOtherGestureRecognizer:]):
(-[WKContentView cancelActiveTextInteractionGestures]):
(-[WKContentView selectPositionAtPoint:withContextRequest:completionHandler:]):
* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
(WTR::UIScriptController::setInlinePrediction):
(WTR::UIScriptController::acceptInlinePrediction):
* Tools/TestRunnerShared/spi/UIKitSPIForTesting.h:
* Tools/WebKitTestRunner/TestOptions.cpp:
(WTR::TestOptions::defaults):
(WTR::TestOptions::keyTypeMapping):
* Tools/WebKitTestRunner/TestOptions.h:
(WTR::TestOptions::allowsInlinePredictions const):
* Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm:
(WTR::TestController::configureWebpagePreferences):
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h:
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm:
(WTR::UIScriptControllerIOS::setInlinePrediction):
(WTR::UIScriptControllerIOS::acceptInlinePrediction):

Canonical link: <a href="https://commits.webkit.org/271361@main">https://commits.webkit.org/271361@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c94fbc049c6adf0a197055483e2541608278175

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28134 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6775 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29488 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30663 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/25641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28631 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8795 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4159 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/25624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28402 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5534 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24212 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4783 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/4945 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25204 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31352 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25741 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25635 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31254 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4934 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3104 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29011 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6479 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/25004 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6742 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/5371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5439 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->