### PR TITLE
Add additional release asserts to ensure we not not calling SPI when using the Async input delegate.

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -3554,6 +3554,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (NSArray *)webSelectionRects
 {
+    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+
     if (!_page->editorState().hasPostLayoutAndVisualData() || _page->editorState().selectionIsNone)
         return nil;
     const auto& selectionGeometries = _page->editorState().visualData->selectionGeometries;
@@ -3835,6 +3837,8 @@ static void cancelPotentialTapIfNecessary(WKContentView* contentView)
 
 - (void)clearSelection
 {
+    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+
     [self _elementDidBlur];
     _page->clearSelection();
 }
@@ -5929,6 +5933,8 @@ static void logTextInteraction(const char* methodName, UIGestureRecognizer *loup
 
 - (BOOL)_allowAnimatedUpdateSelectionRectViews
 {
+    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+
     return NO;
 }
 
@@ -6858,6 +6864,8 @@ static UITextAutocapitalizationType toUITextAutocapitalize(WebCore::Autocapitali
 // (i.e. selectionRange) has shipped as API.
 - (NSRange)selectionRange
 {
+    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+
     return NSMakeRange(NSNotFound, 0);
 }
 
@@ -6884,6 +6892,7 @@ static UITextAutocapitalizationType toUITextAutocapitalize(WebCore::Autocapitali
 // Modify text without starting a new undo grouping.
 - (void)replaceRangeWithTextWithoutClosingTyping:(UITextRange *)range replacementText:(NSString *)text
 {
+    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 }
 
 // Caret rect support.  Shouldn't be necessary, but firstRectForRange doesn't offer precisely
@@ -7091,6 +7100,8 @@ inline static UIShiftKeyState shiftKeyState(UIKeyModifierFlags flags)
 
 - (void)handleKeyWebEvent:(::WebEvent *)theEvent
 {
+    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+
     _page->handleKeyboardEvent(WebKit::NativeWebKeyboardEvent(theEvent, WebKit::NativeWebKeyboardEvent::HandledByInputMethod::No));
 }
 
@@ -7470,10 +7481,13 @@ inline static UIShiftKeyState shiftKeyState(UIKeyModifierFlags flags)
 // Sets a buffer to make room for autocorrection views
 - (void)setBottomBufferHeight:(CGFloat)bottomBuffer
 {
+    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 }
 
 - (UIView *)automaticallySelectedOverlay
 {
+    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+
     return [self unscaledView];
 }
 
@@ -7486,6 +7500,8 @@ inline static UIShiftKeyState shiftKeyState(UIKeyModifierFlags flags)
 // alternative selection counts using the keys defined at the top of this header.
 - (NSArray *)metadataDictionariesForDictationResults
 {
+    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+
     return nil;
 }
 
@@ -7519,12 +7535,15 @@ inline static UIShiftKeyState shiftKeyState(UIKeyModifierFlags flags)
 
 - (BOOL)hasContent
 {
+    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+
     auto& editorState = _page->editorState();
     return !editorState.selectionIsNone && editorState.postLayoutData && editorState.postLayoutData->hasContent;
 }
 
 - (void)selectAll
 {
+    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 }
 
 - (UIColor *)textColorForCaretSelection
@@ -7541,6 +7560,8 @@ inline static UIShiftKeyState shiftKeyState(UIKeyModifierFlags flags)
 
 - (BOOL)hasSelection
 {
+    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+
     return NO;
 }
 
@@ -7577,6 +7598,8 @@ inline static UIShiftKeyState shiftKeyState(UIKeyModifierFlags flags)
 
 - (void)takeTraitsFrom:(UITextInputTraits *)traits
 {
+    RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
+
     [[self textInputTraits] takeTraitsFrom:traits];
 }
 


### PR DESCRIPTION
#### 237465e1ea2208b605a0ddbf0b0375ce96917476
<pre>
Add additional release asserts to ensure we not not calling SPI when using the Async input delegate.
<a href="https://bugs.webkit.org/show_bug.cgi?id=265604">https://bugs.webkit.org/show_bug.cgi?id=265604</a>
<a href="https://rdar.apple.com/119001813">rdar://119001813</a>

Reviewed by Wenson Hsieh.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView webSelectionRects]):
(-[WKContentView clearSelection]):
(-[WKContentView _allowAnimatedUpdateSelectionRectViews]):
(-[WKContentView selectionRange]):
(-[WKContentView replaceRangeWithTextWithoutClosingTyping:replacementText:]):
(-[WKContentView handleKeyWebEvent:]):
(-[WKContentView setBottomBufferHeight:]):
(-[WKContentView automaticallySelectedOverlay]):
(-[WKContentView metadataDictionariesForDictationResults]):
(-[WKContentView hasContent]):
(-[WKContentView selectAll]):
(-[WKContentView hasSelection]):
(-[WKContentView takeTraitsFrom:]):

Canonical link: <a href="https://commits.webkit.org/271417@main">https://commits.webkit.org/271417@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea252a3e5d0fe3735a01348d64d0cb7d9dff388e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28337 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6981 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29718 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30864 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25799 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9061 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4352 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28606 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5742 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24383 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5012 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/5120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31550 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/25943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/25817 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/31424 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/5089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/3269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/29182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6684 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6784 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5539 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/5607 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->