### PR TITLE
[WebDriver] Convert EnterFullscreen.js to use new fullscreen API

### DIFF
--- a/Source/WebKit/UIProcess/Automation/atoms/EnterFullscreen.js
+++ b/Source/WebKit/UIProcess/Automation/atoms/EnterFullscreen.js
@@ -26,12 +26,12 @@
 function enterFullscreen() {
 
     let callback = arguments[0];
-    if (!document.webkitFullscreenEnabled) {
+    if (!document.fullscreenEnabled) {
         callback(false);
         return;
     }
 
-    if (document.webkitIsFullScreen) {
+    if (document.fullscreenElement) {
         callback(true);
         return;
     }
@@ -42,11 +42,11 @@ function enterFullscreen() {
         if (e.target !== document.documentElement)
             return;
 
-        if (!document.webkitIsFullScreen)
+        if (!document.fullscreenElement)
             return;
 
-        document.removeEventListener("webkitfullscreenerror", fullscreenChangeListener);
-        document.documentElement.removeEventListener("webkitfullscreenchange", fullscreenErrorListener);
+        document.removeEventListener("fullscreenchange", fullscreenChangeListener);
+        document.documentElement.removeEventListener("fullscreenerror", fullscreenErrorListener);
         callback(true);
     };
     fullscreenErrorListener = (e) => {
@@ -54,13 +54,13 @@ function enterFullscreen() {
         if (e.target !== document.documentElement)
             return;
 
-        document.removeEventListener("webkitfullscreenchange", fullscreenChangeListener);
-        document.documentElement.removeEventListener("webkitfullscreenerror", fullscreenErrorListener);
-        callback(!!document.webkitIsFullScreen);
+        document.removeEventListener("fullscreenchange", fullscreenChangeListener);
+        document.documentElement.removeEventListener("fullscreenerror", fullscreenErrorListener);
+        callback(!!document.fullscreenElement);
     };
 
     // The document fires change events, but the fullscreen element fires error events.
-    document.addEventListener("webkitfullscreenchange", fullscreenChangeListener);
-    document.documentElement.addEventListener("webkitfullscreenerror", fullscreenErrorListener);
-    document.documentElement.webkitRequestFullscreen();
+    document.addEventListener("fullscreenchange", fullscreenChangeListener);
+    document.documentElement.addEventListener("fullscreenerror", fullscreenErrorListener);
+    document.documentElement.requestFullscreen();
 }


### PR DESCRIPTION
#### f62c0edfc546848f8711146ce8a0a90d1c00ace4
<pre>
[WebDriver] Convert EnterFullscreen.js to use new fullscreen API
<a href="https://bugs.webkit.org/show_bug.cgi?id=265603">https://bugs.webkit.org/show_bug.cgi?id=265603</a>
<a href="https://rdar.apple.com/119001700">rdar://119001700</a>

Reviewed by Abrar Rahman Protyasha.

Use the new fullscreen API which has different user activation requirements:

The new fullscreen API only requires transient activation, the old API requires user gestures.

Also fix a typo when cleaning up event listeners.

* Source/WebKit/UIProcess/Automation/atoms/EnterFullscreen.js:
(enterFullscreen):

Canonical link: <a href="https://commits.webkit.org/281390@main">https://commits.webkit.org/281390@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93e64825c6721e6c198f10a0e2382e2de6750cdc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28140 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6781 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29494 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30669 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25645 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8864 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4164 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/25976 "Build was cancelled. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 39 flakes 200 failures; Uploaded test results; layout-tests (exception)") | [⏳ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28408 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5592 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4793 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4994 "Passed tests") | | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25799 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25636 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31358 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3108 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31257 "Passed tests") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29013 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13243 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4938 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6483 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5375 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5444 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->