### PR TITLE
Element.setAttributeNode() should not treat attribute names case insensitively

### DIFF
--- a/LayoutTests/fast/dom/Attr/make-unique-element-data-while-replacing-attr.html
+++ b/LayoutTests/fast/dom/Attr/make-unique-element-data-while-replacing-attr.html
@@ -17,7 +17,7 @@ shouldBeEqualToString('element.getAttribute("width")', 'a');
 
 element.addEventListener('DOMSubtreeModified', () => { element.cloneNode(); }, true);
 
-let newAttr = document.createAttributeNS('http://www.w3.org/1999/xhtml','width');
+let newAttr = document.createAttributeNS('http://www.w3.org/XML/1998/namespace','width');
 newAttr.value = 'b';
 element.setAttributeNode(newAttr);
 

--- a/LayoutTests/fast/dom/Element/setAttributeNode-overriding-lowercase-values-2-expected.txt
+++ b/LayoutTests/fast/dom/Element/setAttributeNode-overriding-lowercase-values-2-expected.txt
@@ -16,13 +16,13 @@ PASS testElement.getAttributeNS("", "foobar") is null
 PASS testElement.hasAttributeNS("", "foobar") is false
 PASS testElement.getAttributeNS("", "FooBar") is null
 PASS testElement.hasAttributeNS("", "FooBar") is false
-PASS testElement.attributes.length is 1
-PASS testElement.getAttribute("foobar") is null
-PASS testElement.hasAttribute("foobar") is false
-PASS testElement.getAttribute("FooBar") is null
-PASS testElement.hasAttribute("FooBar") is false
-PASS testElement.getAttributeNS("ns1", "foobar") is null
-PASS testElement.hasAttributeNS("ns1", "foobar") is false
+PASS testElement.attributes.length is 2
+PASS testElement.getAttribute("foobar") is "WebKit"
+PASS testElement.hasAttribute("foobar") is true
+PASS testElement.getAttribute("FooBar") is "WebKit"
+PASS testElement.hasAttribute("FooBar") is true
+PASS testElement.getAttributeNS("ns1", "foobar") is "WebKit"
+PASS testElement.hasAttributeNS("ns1", "foobar") is true
 PASS testElement.getAttributeNS("ns1", "FooBar") is "Rocks!"
 PASS testElement.hasAttributeNS("ns1", "FooBar") is true
 PASS testElement.getAttributeNS("", "foobar") is null

--- a/LayoutTests/fast/dom/Element/setAttributeNode-overriding-lowercase-values-2.html
+++ b/LayoutTests/fast/dom/Element/setAttributeNode-overriding-lowercase-values-2.html
@@ -31,20 +31,18 @@ shouldBeFalse('testElement.hasAttributeNS("", "foobar")');
 shouldBe('testElement.getAttributeNS("", "FooBar")', 'null');
 shouldBeFalse('testElement.hasAttributeNS("", "FooBar")');
 
-// Setting this node through setAttributeNode() instead of setAttributeNodeNS()
-// erases the lowercase "foobar".
 var b = document.createAttributeNS('ns1', 'FooBar');
 b.value = "Rocks!";
 testElement.setAttributeNode(b);
 
-shouldBe('testElement.attributes.length', '1');
-shouldBe('testElement.getAttribute("foobar")', 'null');
-shouldBeFalse('testElement.hasAttribute("foobar")');
-shouldBe('testElement.getAttribute("FooBar")', 'null');
-shouldBeFalse('testElement.hasAttribute("FooBar")');
+shouldBe('testElement.attributes.length', '2');
+shouldBeEqualToString('testElement.getAttribute("foobar")', 'WebKit');
+shouldBeTrue('testElement.hasAttribute("foobar")');
+shouldBeEqualToString('testElement.getAttribute("FooBar")', 'WebKit');
+shouldBeTrue('testElement.hasAttribute("FooBar")');
 
-shouldBe('testElement.getAttributeNS("ns1", "foobar")', 'null');
-shouldBeFalse('testElement.hasAttributeNS("ns1", "foobar")');
+shouldBeEqualToString('testElement.getAttributeNS("ns1", "foobar")', 'WebKit');
+shouldBeTrue('testElement.hasAttributeNS("ns1", "foobar")');
 shouldBeEqualToString('testElement.getAttributeNS("ns1", "FooBar")', 'Rocks!');
 shouldBeTrue('testElement.hasAttributeNS("ns1", "FooBar")');
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/attributes-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/attributes-expected.txt
@@ -50,7 +50,9 @@ PASS Attribute loses its owner when removed
 PASS Basic functionality of getAttributeNode/getAttributeNodeNS
 PASS Basic functionality of setAttributeNode
 PASS setAttributeNode should distinguish attributes with same local name and different namespaces
-PASS setAttributeNode doesn't have case-insensitivity even with an HTMLElement
+PASS setAttributeNode doesn't have case-insensitivity even with an HTMLElement 1
+PASS setAttributeNode doesn't have case-insensitivity even with an HTMLElement 2
+PASS setAttributeNode doesn't have case-insensitivity even with an HTMLElement 3
 PASS Basic functionality of setAttributeNodeNS
 PASS If attr’s element is neither null nor element, throw an InUseAttributeError.
 PASS Replacing an attr by itself

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/attributes.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/attributes.html
@@ -588,7 +588,32 @@ test(function() {
   el.setAttributeNode(attr2);
   assert_equals(el.getAttributeNodeNS("ns1", "name").value, "value1");
   assert_equals(el.getAttributeNodeNS("ns1", "NAME").value, "VALUE2");
-}, "setAttributeNode doesn't have case-insensitivity even with an HTMLElement")
+}, "setAttributeNode doesn't have case-insensitivity even with an HTMLElement 1")
+
+test(function() {
+  var el = document.createElement("div");
+  var attr1 = document.createAttributeNS("ns1", "FOOBAR");
+  var attr2 = document.createAttributeNS("ns1", "FOOBAR");
+  assert_equals(el.setAttributeNode(attr1), null);
+  assert_equals(attr1.ownerElement, el);
+  assert_equals(attr2.ownerElement, null);
+  var oldAttr = el.setAttributeNode(attr2);
+  assert_equals(oldAttr, attr1);
+  assert_equals(attr1.ownerElement, null);
+  assert_equals(attr2.ownerElement, el);
+}, "setAttributeNode doesn't have case-insensitivity even with an HTMLElement 2")
+
+test(function() {
+  var el = document.createElement("div");
+  var attr1 = document.createAttributeNS("ns1", "foobar");
+  var attr2 = document.createAttributeNS("ns1", "FOOBAR");
+  assert_equals(el.setAttributeNode(attr1), null);
+  assert_equals(attr1.ownerElement, el);
+  assert_equals(attr2.ownerElement, null);
+  assert_equals(el.setAttributeNode(attr2), null);
+  assert_equals(attr1.ownerElement, el);
+  assert_equals(attr2.ownerElement, el);
+}, "setAttributeNode doesn't have case-insensitivity even with an HTMLElement 3")
 
 test(function() {
   var el = document.createElement("div")

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -208,16 +208,6 @@ static Attr* findAttrNodeInList(Vector<RefPtr<Attr>>& attrNodeList, const Qualif
     return nullptr;
 }
 
-static Attr* findAttrNodeInList(Vector<RefPtr<Attr>>& attrNodeList, const AtomString& localName, bool shouldIgnoreAttributeCase)
-{
-    const AtomString& caseAdjustedName = shouldIgnoreAttributeCase ? localName.convertToASCIILowercase() : localName;
-    for (auto& node : attrNodeList) {
-        if (node->qualifiedName().localName() == caseAdjustedName)
-            return node.get();
-    }
-    return nullptr;
-}
-
 static bool shouldAutofocus(const Element& element)
 {
     if (!element.hasAttributeWithoutSynchronization(HTMLNames::autofocusAttr))
@@ -3238,7 +3228,7 @@ void Element::attachAttributeNodeIfNeeded(Attr& attrNode)
 
 ExceptionOr<RefPtr<Attr>> Element::setAttributeNode(Attr& attrNode)
 {
-    RefPtr oldAttrNode = attrIfExists(attrNode.localName(), shouldIgnoreAttributeCase(*this));
+    RefPtr oldAttrNode = attrIfExists(attrNode.qualifiedName());
     if (oldAttrNode.get() == &attrNode)
         return oldAttrNode;
 
@@ -3254,7 +3244,7 @@ ExceptionOr<RefPtr<Attr>> Element::setAttributeNode(Attr& attrNode)
 
     auto& elementData = ensureUniqueElementData();
 
-    auto existingAttributeIndex = elementData.findAttributeIndexByName(attrNode.localName(), shouldIgnoreAttributeCase(*this));
+    auto existingAttributeIndex = elementData.findAttributeIndexByName(attrNode.qualifiedName());
 
     // Attr::value() will return its 'm_standaloneValue' member any time its Element is set to nullptr. We need to cache this value
     // before making changes to attrNode's Element connections.
@@ -4924,13 +4914,6 @@ void Element::setSavedLayerScrollPositionSlow(const IntPoint& position)
 {
     ASSERT(!position.isZero() || hasRareData());
     ensureElementRareData().setSavedLayerScrollPosition(position);
-}
-
-RefPtr<Attr> Element::attrIfExists(const AtomString& localName, bool shouldIgnoreAttributeCase)
-{
-    if (auto* attrNodeList = attrNodeListForElement(*this))
-        return findAttrNodeInList(*attrNodeList, localName, shouldIgnoreAttributeCase);
-    return nullptr;
 }
 
 RefPtr<Attr> Element::attrIfExists(const QualifiedName& name)

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -272,7 +272,6 @@ public:
     WEBCORE_EXPORT ExceptionOr<Ref<Attr>> removeAttributeNode(Attr&);
 
     RefPtr<Attr> attrIfExists(const QualifiedName&);
-    RefPtr<Attr> attrIfExists(const AtomString& localName, bool shouldIgnoreAttributeCase);
     Ref<Attr> ensureAttr(const QualifiedName&);
 
     const Vector<RefPtr<Attr>>& attrNodeList();


### PR DESCRIPTION
#### 76c6ef3c49b0b531921164ecac9087df29e76cff
<pre>
Element.setAttributeNode() should not treat attribute names case insensitively
<a href="https://bugs.webkit.org/show_bug.cgi?id=265597">https://bugs.webkit.org/show_bug.cgi?id=265597</a>

Reviewed by Brent Fulgham.

Stop treating the attribute names insensitively in Element.setAttributeNode() as this didn&apos;t
match the DOM specification [1] or the behavior of Chrome / Firefox.

Thanks to Claudio Saavedra from Igalia for finding the bug and starting the investigation
on this.

[1] <a href="https://dom.spec.whatwg.org/#dom-element-setattributenode">https://dom.spec.whatwg.org/#dom-element-setattributenode</a>

* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/attributes-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/attributes.html:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::setAttributeNode):
* Source/WebCore/dom/Element.h:

Canonical link: <a href="https://commits.webkit.org/271363@main">https://commits.webkit.org/271363@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e382664feaea8beec7d4eddbafa821c25ae82fe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28157 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6798 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29510 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30686 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25655 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28654 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8819 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4181 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/25949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28425 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5555 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24228 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4811 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/4958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25224 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31375 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25762 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25655 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31272 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/4948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3125 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29026 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6494 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/25024 "Passed tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/5385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3639 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5460 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->