### PR TITLE
EWS shouldn't rely on getting JSONP layout tests results

### DIFF
--- a/Tools/CISupport/ews-build/layout_test_failures.py
+++ b/Tools/CISupport/ews-build/layout_test_failures.py
@@ -33,13 +33,9 @@ class LayoutTestFailures(object):
         self.did_exceed_test_failure_limit = did_exceed_test_failure_limit
 
     @classmethod
-    def has_json_wrapper(cls, string):
-        return string.startswith(cls._JSON_PREFIX) and string.endswith(cls._JSON_SUFFIX)
-
-    @classmethod
-    def strip_json_wrapper(cls, json_content):
-        if cls.has_json_wrapper(json_content):
-            return json_content[len(cls._JSON_PREFIX):len(json_content) - len(cls._JSON_SUFFIX)]
+    def _strip_json_wrapper(cls, json_content):
+        if json_content.startswith(cls._JSON_PREFIX) and json_content.endswith(cls._JSON_SUFFIX):
+            return json_content[len(cls._JSON_PREFIX):-len(cls._JSON_SUFFIX)]
         return json_content
 
     @classmethod
@@ -47,14 +43,13 @@ class LayoutTestFailures(object):
         if not string:
             return None
 
-        string = string.strip()
-        if not cls.has_json_wrapper(string):
-            return None
-
-        content_string = cls.strip_json_wrapper(string)
+        content_string = cls._strip_json_wrapper(string.strip())
         # Workaround for https://github.com/buildbot/buildbot/issues/4906
         content_string = ''.join(content_string.splitlines())
-        json_dict = json.loads(content_string)
+        try:
+            json_dict = json.loads(content_string)
+        except json.JSONDecodeError:
+            return None
 
         failing_tests = []
         flaky_tests = []

--- a/Tools/CISupport/ews-build/layout_test_failures_unittest.py
+++ b/Tools/CISupport/ews-build/layout_test_failures_unittest.py
@@ -1,0 +1,108 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+import json
+import unittest
+
+from .layout_test_failures import LayoutTestFailures
+
+sample_json = """{"tests":{"http":{"tests":{"IndexedDB":{"collect-IDB-objects.https.html":{"report":"FLAKY","expected":"PASS","actual":"TEXT PASS"}},"xmlhttprequest":{"on-network-timeout-error-during-preflight.html":{"report":"FLAKY","expected":"PASS","actual":"TIMEOUT PASS"}}}},"transitions":{"lengthsize-transition-to-from-auto.html":{"report":"FLAKY","expected":"PASS","actual":"TIMEOUT PASS"}},"imported":{"blink":{"storage":{"indexeddb":{"blob-valid-before-commit.html":{"report":"FLAKY","expected":"PASS","actual":"TIMEOUT PASS","has_stderr":true}}}}},"fast":{"text":{"font-weight-fallback.html":{"report":"FLAKY","expected":"PASS","actual":"TIMEOUT PASS","has_stderr":true,"reftest_type":["=="]}},"scrolling":{"ios":{"reconcile-layer-position-recursive.html":{"report":"REGRESSION","expected":"PASS","actual":"TEXT"}}}}},"skipped":13174,"num_regressions":1,"other_crashes":{},"interrupted":false,"num_missing":0,"layout_tests_dir":"/Volumes/Data/worker/iOS-12-Simulator-WK2-Tests-EWS/build/LayoutTests","version":4,"num_passes":42158,"pixel_tests_enabled":false,"date":"11:28AM on July 16, 2019","has_pretty_patch":true,"fixable":55329,"num_flaky":5,"uses_expectations_file":true}"""
+
+sample_failing_tests = ["fast/scrolling/ios/reconcile-layer-position-recursive.html"]
+
+sample_flaky_tests = [
+    "http/tests/IndexedDB/collect-IDB-objects.https.html",
+    "http/tests/xmlhttprequest/on-network-timeout-error-during-preflight.html",
+    "transitions/lengthsize-transition-to-from-auto.html",
+    "imported/blink/storage/indexeddb/blob-valid-before-commit.html",
+    "fast/text/font-weight-fallback.html",
+]
+
+
+class TestLayoutTestFailures(unittest.TestCase):
+    def test_results_from_string_valid_jsonp(self):
+        failures = LayoutTestFailures.results_from_string(
+            f"ADD_RESULTS({sample_json});"
+        )
+        self.assertEqual(sample_failing_tests, failures.failing_tests)
+        self.assertEqual(sample_flaky_tests, failures.flaky_tests)
+        self.assertEqual(False, failures.did_exceed_test_failure_limit)
+
+    def test_results_from_string_valid_json(self):
+        failures = LayoutTestFailures.results_from_string(sample_json)
+        self.assertEqual(sample_failing_tests, failures.failing_tests)
+        self.assertEqual(sample_flaky_tests, failures.flaky_tests)
+        self.assertEqual(False, failures.did_exceed_test_failure_limit)
+
+    def test_results_from_string_invalid_json(self):
+        failures = LayoutTestFailures.results_from_string(sample_json + " invalid JSON")
+        self.assertEqual(None, failures)
+
+    def test_results_from_string_invalid_jsonp_suffix(self):
+        failures = LayoutTestFailures.results_from_string(
+            f"ADD_RESULTS({sample_json}); invalid JSONP"
+        )
+        self.assertEqual(None, failures)
+
+    def test_results_from_string_invalid_jsonp_suffix_valid_js(self):
+        failures = LayoutTestFailures.results_from_string(
+            f"ADD_RESULTS({sample_json}); null"
+        )
+        self.assertEqual(None, failures)
+
+    def test_results_from_string_invalid_jsonp_internal(self):
+        failures = LayoutTestFailures.results_from_string(
+            f"ADD_RESULTS({sample_json} invalid JSON);"
+        )
+        self.assertEqual(None, failures)
+
+    def test_results_from_string_empty(self):
+        failures = LayoutTestFailures.results_from_string("")
+        self.assertEqual(None, failures)
+
+    def test_results_from_string_ws_only(self):
+        failures = LayoutTestFailures.results_from_string("\x20" * 10)
+        self.assertEqual(None, failures)
+
+    def test_results_from_string_split_at_4096(self):
+        # c.f. https://github.com/buildbot/buildbot/issues/4906
+        long_json = f'{{"{"a" * 2500}":"{"b" * 2500}",{sample_json[1:]}'
+
+        long_json_lines = []
+        for i in range(0, len(long_json), 4096):
+            long_json_lines.append(long_json[i:i + 4096])
+
+        new_json = "\n".join(long_json_lines)
+
+        # Check we now have invalid JSON
+        try:
+            json.loads(new_json)
+        except json.JSONDecodeError:
+            pass
+        else:
+            self.assertTrue(False, msg="Unreachable!")
+
+        failures = LayoutTestFailures.results_from_string(new_json)
+        self.assertEqual(sample_failing_tests, failures.failing_tests)
+        self.assertEqual(sample_flaky_tests, failures.flaky_tests)
+        self.assertEqual(False, failures.did_exceed_test_failure_limit)

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -2033,6 +2033,25 @@ ts","version":4,"num_passes":42158,"pixel_tests_enabled":false,"date":"11:28AM o
         self.assertEqual(self.getProperty(self.property_failures), ['fast/scrolling/ios/reconcile-layer-position-recursive.html'])
         return rc
 
+    def test_parse_results_invalid_json(self):
+        self.configureStep()
+        self.setProperty('fullPlatform', 'ios-simulator')
+        self.setProperty('configuration', 'release')
+        self.expectRemoteCommands(
+            ExpectShell(workdir='wkdir',
+                        logfiles={'json': self.jsonFileName},
+                        logEnviron=False,
+                        command=['python3', 'Tools/Scripts/run-webkit-tests', '--no-build', '--no-show-results', '--no-new-test-results', '--clobber-old-results', '--release', '--results-directory', 'layout-test-results', '--debug-rwt-logging', '--exit-after-n-failures', '60', '--skip-failing-tests'],
+                        )
+            + 2
+            + ExpectShell.log('json', stdout=self.results_json_with_newlines + " non-JSON nonsense"),
+        )
+        self.expectOutcome(result=FAILURE, state_string='layout-tests (failure)')
+        rc = self.runStep()
+        self.assertEqual(self.getProperty(self.property_exceed_failure_limit), None)
+        self.assertEqual(self.getProperty(self.property_failures), None)
+        return rc
+
     def test_parse_results_json_with_missing_results(self):
         self.configureStep()
         self.setProperty('fullPlatform', 'ios-simulator')


### PR DESCRIPTION
#### 82a9b67dbeea7129c871d30079df408fc127d066
<pre>
EWS shouldn&apos;t rely on getting JSONP layout tests results
<a href="https://bugs.webkit.org/show_bug.cgi?id=265606">https://bugs.webkit.org/show_bug.cgi?id=265606</a>

Reviewed by Jonathan Bedard.

Instead of erroring if we don&apos;t have JSONP, match webkitpy
(webkitpy.layout_tests.layout_package.json_results_generator) behaviour
of optionally stripping the JSONP wrapper and then failing if we can&apos;t
actually parse the JSON.

* Tools/CISupport/ews-build/layout_test_failures.py:
(LayoutTestFailures._strip_json_wrapper):
(LayoutTestFailures.results_from_string):
(LayoutTestFailures.has_json_wrapper): Deleted.
(LayoutTestFailures.strip_json_wrapper): Deleted.
* Tools/CISupport/ews-build/layout_test_failures_unittest.py: Added.
(TestLayoutTestFailures):
(TestLayoutTestFailures.test_results_from_string_valid_jsonp):
(TestLayoutTestFailures.test_results_from_string_valid_json):
(TestLayoutTestFailures.test_results_from_string_invalid_json):
(TestLayoutTestFailures.test_results_from_string_invalid_jsonp_suffix):
(TestLayoutTestFailures.test_results_from_string_invalid_jsonp_suffix_valid_js):
(TestLayoutTestFailures.test_results_from_string_invalid_jsonp_internal):
(TestLayoutTestFailures.test_results_from_string_empty):
(TestLayoutTestFailures.test_results_from_string_ws_only):
(TestLayoutTestFailures.test_results_from_string_split_at_4096):
* Tools/CISupport/ews-build/steps_unittest.py:

Canonical link: <a href="https://commits.webkit.org/271360@main">https://commits.webkit.org/271360@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d4f26d7c6113dbab9beb0aeb0e590f1d9328e950

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28158 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6799 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29511 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30687 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/25656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28655 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8820 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4182 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/25948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28426 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/5556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/24226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4809 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/4959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/25222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31376 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/25763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/25653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/31274 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/4949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/3124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/29029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/27926 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/6495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/5386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3638 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5461 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->