### PR TITLE
Use Ref<MediaSample> in SampleMap

### DIFF
--- a/Source/WebCore/Modules/mediasource/SampleMap.cpp
+++ b/Source/WebCore/Modules/mediasource/SampleMap.cpp
@@ -106,26 +106,25 @@ void SampleMap::clear()
     m_totalSize = 0;
 }
 
-void SampleMap::addSample(MediaSample& sample)
+void SampleMap::addSample(Ref<MediaSample>&& sample)
+{
+    MediaTime presentationTime = sample->presentationTime();
+
+    m_totalSize += sample->sizeInBytes();
+
+    presentationOrder().m_samples.insert(PresentationOrderSampleMap::MapType::value_type(presentationTime, sample));
+
+    auto decodeKey = DecodeOrderSampleMap::KeyType(sample->decodeTime(), presentationTime);
+    decodeOrder().m_samples.insert(DecodeOrderSampleMap::MapType::value_type(decodeKey, WTFMove(sample)));
+}
+
+void SampleMap::removeSample(const MediaSample& sample)
 {
     MediaTime presentationTime = sample.presentationTime();
 
-    presentationOrder().m_samples.insert(PresentationOrderSampleMap::MapType::value_type(presentationTime, &sample));
+    m_totalSize -= sample.sizeInBytes();
 
     auto decodeKey = DecodeOrderSampleMap::KeyType(sample.decodeTime(), presentationTime);
-    decodeOrder().m_samples.insert(DecodeOrderSampleMap::MapType::value_type(decodeKey, &sample));
-
-    m_totalSize += sample.sizeInBytes();
-}
-
-void SampleMap::removeSample(MediaSample* sample)
-{
-    ASSERT(sample);
-    MediaTime presentationTime = sample->presentationTime();
-
-    m_totalSize -= sample->sizeInBytes();
-
-    auto decodeKey = DecodeOrderSampleMap::KeyType(sample->decodeTime(), presentationTime);
     presentationOrder().m_samples.erase(presentationTime);
     decodeOrder().m_samples.erase(decodeKey);
 }
@@ -148,8 +147,8 @@ PresentationOrderSampleMap::iterator PresentationOrderSampleMap::findSampleConta
 
     // Look at the previous sample; does it contain the requested time?
     --iter;
-    MediaSample& sample = *iter->second;
-    if (sample.presentationTime() + sample.duration() > time)
+    const auto& sample = iter->second;
+    if (sample->presentationTime() + sample->duration() > time)
         return iter;
     return end();
 }
@@ -167,8 +166,8 @@ PresentationOrderSampleMap::iterator PresentationOrderSampleMap::findSampleConta
 
     // Look at the previous sample; does it contain the requested time?
     --iter;
-    MediaSample& sample = *iter->second;
-    if (sample.presentationTime() + sample.duration() > time)
+    const auto& sample = iter->second;
+    if (sample->presentationTime() + sample->duration() > time)
         return iter;
     return ++iter;
 }
@@ -235,7 +234,7 @@ DecodeOrderSampleMap::reverse_iterator DecodeOrderSampleMap::findSyncSamplePrior
     if (reverseCurrentSamplePTS == m_presentationOrder.rend())
         return rend();
 
-    const RefPtr<MediaSample>& sample = reverseCurrentSamplePTS->second;
+    const auto& sample = reverseCurrentSamplePTS->second;
     reverse_iterator reverseCurrentSampleDTS = reverseFindSampleWithDecodeKey(KeyType(sample->decodeTime(), sample->presentationTime()));
 
     reverse_iterator foundSample = findSyncSamplePriorToDecodeIterator(reverseCurrentSampleDTS);
@@ -257,7 +256,7 @@ DecodeOrderSampleMap::iterator DecodeOrderSampleMap::findSyncSampleAfterPresenta
     if (currentSamplePTS == m_presentationOrder.end())
         return end();
 
-    const RefPtr<MediaSample>& sample = currentSamplePTS->second;
+    const auto& sample = currentSamplePTS->second;
     iterator currentSampleDTS = findSampleWithDecodeKey(KeyType(sample->decodeTime(), sample->presentationTime()));
     
     MediaTime upperBound = time + threshold;
@@ -289,11 +288,11 @@ PresentationOrderSampleMap::iterator_range PresentationOrderSampleMap::findSampl
 
 PresentationOrderSampleMap::iterator_range PresentationOrderSampleMap::findSamplesBetweenPresentationTimesFromEnd(const MediaTime& beginTime, const MediaTime& endTime)
 {
-    reverse_iterator rangeEnd = std::find_if(rbegin(), rend(), [&endTime](auto& value) {
+    reverse_iterator rangeEnd = std::find_if(rbegin(), rend(), [&endTime](const auto& value) {
         return value.first < endTime;
     });
 
-    reverse_iterator rangeStart = std::find_if(rangeEnd, rend(), [&beginTime](auto& value) {
+    reverse_iterator rangeStart = std::find_if(rangeEnd, rend(), [&beginTime](const auto& value) {
         return value.first < beginTime;
     });
 
@@ -304,10 +303,9 @@ PresentationOrderSampleMap::iterator_range PresentationOrderSampleMap::findSampl
     return { rangeStart.base(), rangeEnd.base() };
 }
 
-DecodeOrderSampleMap::reverse_iterator_range DecodeOrderSampleMap::findDependentSamples(MediaSample* sample)
+DecodeOrderSampleMap::reverse_iterator_range DecodeOrderSampleMap::findDependentSamples(const MediaSample& sample)
 {
-    ASSERT(sample);
-    reverse_iterator currentDecodeIter = reverseFindSampleWithDecodeKey(KeyType(sample->decodeTime(), sample->presentationTime()));
+    reverse_iterator currentDecodeIter = reverseFindSampleWithDecodeKey(KeyType(sample.decodeTime(), sample.presentationTime()));
     reverse_iterator nextSyncSample = findSyncSamplePriorToDecodeIterator(currentDecodeIter);
     return reverse_iterator_range(currentDecodeIter, nextSyncSample);
 }

--- a/Source/WebCore/Modules/mediasource/SampleMap.h
+++ b/Source/WebCore/Modules/mediasource/SampleMap.h
@@ -26,7 +26,7 @@
 #pragma once
 
 #include <wtf/MediaTime.h>
-#include <wtf/RefPtr.h>
+#include <wtf/Ref.h>
 #include <wtf/StdMap.h>
 
 namespace WebCore {
@@ -37,7 +37,7 @@ class SampleMap;
 class PresentationOrderSampleMap {
     friend class SampleMap;
 public:
-    using MapType = StdMap<MediaTime, RefPtr<MediaSample>>;
+    using MapType = StdMap<MediaTime, Ref<MediaSample>>;
     typedef MapType::iterator iterator;
     typedef MapType::const_iterator const_iterator;
     typedef MapType::reverse_iterator reverse_iterator;
@@ -74,7 +74,7 @@ class DecodeOrderSampleMap {
     friend class SampleMap;
 public:
     typedef std::pair<MediaTime, MediaTime> KeyType;
-    using MapType = StdMap<KeyType, RefPtr<MediaSample>>;
+    using MapType = StdMap<KeyType, Ref<MediaSample>>;
     typedef MapType::iterator iterator;
     typedef MapType::const_iterator const_iterator;
     typedef MapType::reverse_iterator reverse_iterator;
@@ -100,7 +100,7 @@ public:
     WEBCORE_EXPORT reverse_iterator findSyncSamplePriorToDecodeIterator(reverse_iterator);
     WEBCORE_EXPORT iterator findSyncSampleAfterPresentationTime(const MediaTime&, const MediaTime& threshold = MediaTime::positiveInfiniteTime());
     WEBCORE_EXPORT iterator findSyncSampleAfterDecodeIterator(iterator);
-    WEBCORE_EXPORT reverse_iterator_range findDependentSamples(MediaSample*);
+    WEBCORE_EXPORT reverse_iterator_range findDependentSamples(const MediaSample&);
     WEBCORE_EXPORT iterator_range findSamplesBetweenDecodeKeys(const KeyType&, const KeyType&);
 
 private:
@@ -115,8 +115,8 @@ public:
     WEBCORE_EXPORT bool empty() const;
     size_t size() const { return m_decodeOrder.m_samples.size(); }
     WEBCORE_EXPORT void clear();
-    WEBCORE_EXPORT void addSample(MediaSample&);
-    WEBCORE_EXPORT void removeSample(MediaSample*);
+    WEBCORE_EXPORT void addSample(Ref<MediaSample>&&);
+    WEBCORE_EXPORT void removeSample(const MediaSample&);
     size_t sizeInBytes() const { return m_totalSize; }
 
     template<typename I>
@@ -136,7 +136,7 @@ template<typename I>
 inline void SampleMap::addRange(I begin, I end)
 {
     for (I iter = begin; iter != end; ++iter)
-        addSample(*iter->second);
+        addSample(iter->second.copyRef());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.mm
@@ -300,13 +300,13 @@ private:
 
 static ImageDecoderAVFObjCSample* toSample(const PresentationOrderSampleMap::value_type& pair)
 {
-    return (ImageDecoderAVFObjCSample*)pair.second.get();
+    return (ImageDecoderAVFObjCSample*)pair.second.ptr();
 }
 
 template <typename Iterator>
 ImageDecoderAVFObjCSample* toSample(Iterator iter)
 {
-    return (ImageDecoderAVFObjCSample*)iter->second.get();
+    return (ImageDecoderAVFObjCSample*)iter->second.ptr();
 }
 
 #pragma mark - ImageDecoderAVFObjC
@@ -572,8 +572,8 @@ Vector<ImageDecoder::FrameInfo> ImageDecoderAVFObjC::frameInfos() const
         return { };
 
     return WTF::map(m_sampleData.presentationOrder(), [](auto& sample) {
-        auto* imageSample = (ImageDecoderAVFObjCSample*)sample.second.get();
-        return ImageDecoder::FrameInfo { imageSample->hasAlpha(), Seconds(imageSample->duration().toDouble()) };
+        auto& imageSample = static_cast<ImageDecoderAVFObjCSample&>(sample.second.get());
+        return ImageDecoder::FrameInfo { imageSample.hasAlpha(), Seconds(imageSample.duration().toDouble()) };
     });
 }
 

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -944,7 +944,7 @@ void MediaPlayerPrivateWebM::provideMediaData(TrackBuffer& trackBuffer, uint64_t
             break;
         }
 
-        auto sample = trackBuffer.decodeQueue().begin()->second;
+        Ref sample = trackBuffer.decodeQueue().begin()->second;
 
         if (sample->decodeTime() > trackBuffer.enqueueDiscontinuityBoundary()) {
             DEBUG_LOG(LOGIDENTIFIER, "bailing early because of unbuffered gap, new sample: ", sample->decodeTime(), " >= the current discontinuity boundary: ", trackBuffer.enqueueDiscontinuityBoundary());
@@ -961,7 +961,7 @@ void MediaPlayerPrivateWebM::provideMediaData(TrackBuffer& trackBuffer, uint64_t
         trackBuffer.setLastEnqueuedDecodeKey({ sample->decodeTime(), sample->presentationTime() });
         trackBuffer.setEnqueueDiscontinuityBoundary(sample->decodeTime() + sample->duration() + discontinuityTolerance);
 
-        enqueueSample(sample.releaseNonNull(), trackId);
+        enqueueSample(WTFMove(sample), trackId);
         ++enqueuedSamples;
     }
 
@@ -1105,7 +1105,7 @@ void MediaPlayerPrivateWebM::didProvideMediaDataForTrackId(Ref<MediaSampleAVFObj
     if (!trackBuffer)
         return;
 
-    auto sample = WTFMove(originalSample);
+    Ref sample = WTFMove(originalSample);
 
     MediaTime microsecond(1, 1000000);
     if (!trackBuffer->roundedTimestampOffset().isValid())
@@ -1115,7 +1115,7 @@ void MediaPlayerPrivateWebM::didProvideMediaDataForTrackId(Ref<MediaSampleAVFObj
     trackBuffer->samples().addSample(sample);
 
     DecodeOrderSampleMap::KeyType decodeKey(sample->decodeTime(), sample->presentationTime());
-    trackBuffer->decodeQueue().insert(DecodeOrderSampleMap::MapType::value_type(decodeKey, &sample.get()));
+    trackBuffer->decodeQueue().insert(DecodeOrderSampleMap::MapType::value_type(decodeKey, sample));
 
     trackBuffer->setLastDecodeTimestamp(sample->decodeTime());
     trackBuffer->setLastFrameDuration(sample->duration());

--- a/Source/WebCore/platform/graphics/gstreamer/ImageDecoderGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/ImageDecoderGStreamer.cpp
@@ -72,13 +72,13 @@ private:
 
 static ImageDecoderGStreamerSample* toSample(const PresentationOrderSampleMap::value_type& pair)
 {
-    return (ImageDecoderGStreamerSample*)pair.second.get();
+    return (ImageDecoderGStreamerSample*)pair.second.ptr();
 }
 
 template <typename Iterator>
 ImageDecoderGStreamerSample* toSample(Iterator iter)
 {
-    return (ImageDecoderGStreamerSample*)iter->second.get();
+    return (ImageDecoderGStreamerSample*)iter->second.ptr();
 }
 
 RefPtr<ImageDecoderGStreamer> ImageDecoderGStreamer::create(FragmentedSharedBuffer& data, const String& mimeType, AlphaOption alphaOption, GammaAndColorProfileOption gammaAndColorProfileOption)

--- a/Source/WebKit/Shared/mac/MediaFormatReader/MediaTrackReader.cpp
+++ b/Source/WebKit/Shared/mac/MediaFormatReader/MediaTrackReader.cpp
@@ -94,7 +94,7 @@ MediaTime MediaTrackReader::greatestPresentationTime() const
     if (sampleMap.empty())
         return MediaTime::invalidTime();
 
-    auto& lastSample = *sampleMap.decodeOrder().rbegin()->second;
+    const MediaSample& lastSample = sampleMap.decodeOrder().rbegin()->second;
     return lastSample.presentationTime() + lastSample.duration();
 }
 
@@ -184,7 +184,7 @@ OSStatus MediaTrackReader::copyProperty(CFStringRef key, CFAllocatorRef allocato
         return kCMBaseObjectError_ValueNotAvailable;
     }
 
-    auto& lastSample = *sampleMap.decodeOrder().rbegin()->second;
+    const MediaSample& lastSample = sampleMap.decodeOrder().rbegin()->second;
 
     if (CFEqual(key, PAL::get_MediaToolbox_kMTPluginTrackReaderProperty_FormatDescriptionArray())) {
         RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(lastSample.platformSample().type == PlatformSample::ByteRangeSampleType);


### PR DESCRIPTION
#### 9ab66ea20d6d624cca45d03cda802d3497757a7f
<pre>
Use Ref&lt;MediaSample&gt; in SampleMap
<a href="https://bugs.webkit.org/show_bug.cgi?id=265610">https://bugs.webkit.org/show_bug.cgi?id=265610</a>
<a href="https://rdar.apple.com/119005030">rdar://119005030</a>

Reviewed by Eric Carlson.

The RefPtr&lt;MediaSample&gt; in the SampleMap could never be null. This further enforces that it is so.

* Source/WebCore/Modules/mediasource/SampleMap.cpp:
(WebCore::SampleMap::addSample):
(WebCore::SampleMap::removeSample):
(WebCore::PresentationOrderSampleMap::findSampleContainingPresentationTime):
(WebCore::PresentationOrderSampleMap::findSampleContainingOrAfterPresentationTime):
(WebCore::DecodeOrderSampleMap::findSyncSamplePriorToPresentationTime):
(WebCore::DecodeOrderSampleMap::findSyncSampleAfterPresentationTime):
(WebCore::PresentationOrderSampleMap::findSamplesBetweenPresentationTimesFromEnd):
(WebCore::DecodeOrderSampleMap::findDependentSamples):
* Source/WebCore/Modules/mediasource/SampleMap.h:
(WebCore::SampleMap::addRange):
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::bufferedSamplesForTrackId):
(WebCore::SourceBufferPrivate::provideMediaData):
(WebCore::SourceBufferPrivate::processMediaSample):
* Source/WebCore/platform/graphics/TrackBuffer.cpp:
(WebCore::TrackBuffer::findSeekTimeForTargetTime):
(WebCore::TrackBuffer::removeSamples): Remove a potental UAF as MediaSample passed as argument may no longer exists
once it&apos;s been removed from the SampleMap.
(WebCore::TrackBuffer::removeCodedFrames):
* Source/WebCore/platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.mm:
(WebCore::toSample):
(WebCore::ImageDecoderAVFObjC::frameInfos const):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::provideMediaData):
(WebCore::MediaPlayerPrivateWebM::didProvideMediaDataForTrackId):
* Source/WebKit/Shared/mac/MediaFormatReader/MediaSampleCursor.cpp:
(WebKit::assumedDecodeTime):
(WebKit::stepIterator):
(WebKit::stepTime):
(WebKit::MediaSampleCursor::setLocator const):
(WebKit::MediaSampleCursor::locateMediaSample const):
(WebKit::MediaSampleCursor::getPlayableHorizon const):
* Source/WebKit/Shared/mac/MediaFormatReader/MediaTrackReader.cpp:
(WebKit::MediaTrackReader::greatestPresentationTime const):
(WebKit::MediaTrackReader::copyProperty):

Canonical link: <a href="https://commits.webkit.org/271365@main">https://commits.webkit.org/271365@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d0fb8f3f4a0f86afc5e5c48a1e70291315c5b54

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28161 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6802 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29514 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30690 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25658 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28658 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8825 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4185 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/25951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28429 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5561 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24236 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4816 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/4964 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25232 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31379 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25768 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25663 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31278 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4951 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3127 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29033 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/notification (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6498 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6745 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/5388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5464 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->