### PR TITLE
::backdrop is tree-abiding and should be allowed after ::slotted()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/backdrop-tree-abiding-slotted-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/backdrop-tree-abiding-slotted-expected.txt
@@ -1,0 +1,3 @@
+
+PASS ::backdrop is tree-abiding and should be allowed after ::slotted()
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/backdrop-tree-abiding-slotted.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/backdrop-tree-abiding-slotted.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Position Test: ::backdrop is tree abiding, allowed after ::slotted</title>
+<link rel="help" href="https://drafts.csswg.org/css-position-4/#backdrop">
+<link rel="help" href="https://drafts.csswg.org/css-pseudo-4/#tree-abiding">
+<link rel="help" href="https://drafts.csswg.org/css-scoping/#slotted-pseudo">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/declarative-shadow-dom-polyfill.js"></script>
+<div>
+  <template shadowrootmode="open">
+    <style>
+      ::slotted(dialog)::backdrop {
+        background-color: green;
+      }
+    </style>
+    <slot></slot>
+  </template>
+  <dialog id="target"></dialog>
+</div>
+<script>
+  const target = document.getElementById("target");
+  target.showModal();
+
+  test(() => {
+    assert_equals(getComputedStyle(target, "::backdrop").backgroundColor, "rgb(0, 128, 0)");
+  }, "::backdrop is tree-abiding and should be allowed after ::slotted()");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/w3c-import.log
@@ -15,6 +15,7 @@ None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-position/META.yml
+/LayoutTests/imported/w3c/web-platform-tests/css/css-position/backdrop-tree-abiding-slotted.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-position/fixed-z-index-blend-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-position/fixed-z-index-blend.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-position/hypothetical-box-scroll-parent-expected.html

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -466,6 +466,7 @@ static bool isTreeAbidingPseudoElement(CSSSelector::PseudoElementType pseudoElem
     case CSSSelector::PseudoElementBefore:
     case CSSSelector::PseudoElementAfter:
     case CSSSelector::PseudoElementMarker:
+    case CSSSelector::PseudoElementBackdrop:
         return true;
     default:
         return false;


### PR DESCRIPTION
#### 01864fd8625f9227ea7d965539fea4a7a47317a2
<pre>
::backdrop is tree-abiding and should be allowed after ::slotted()

<a href="https://bugs.webkit.org/show_bug.cgi?id=265611">https://bugs.webkit.org/show_bug.cgi?id=265611</a>

Reviewed by Tim Nguyen.

This patch is to align WebKIt with Blink / Chromium and Web-Specification [1]:

Merge: <a href="https://chromium-review.googlesource.com/c/chromium/src/+/4778566">https://chromium-review.googlesource.com/c/chromium/src/+/4778566</a>

[1] <a href="https://drafts.csswg.org/css-position-4/#backdrop">https://drafts.csswg.org/css-position-4/#backdrop</a>

When ::backdrop was moved into css-position, it was made tree-abiding, which means
that &apos;::slotted()::backdrop&apos; should be allowed.

This PR also syncs WPT test from upstream:

Upstream Hash: <a href="https://github.com/web-platform-tests/wpt/commit/3e2d8fc027ffccb98d701560e7ed9d72343b549a">https://github.com/web-platform-tests/wpt/commit/3e2d8fc027ffccb98d701560e7ed9d72343b549a</a>

* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(isTreeAbidingPseudoElement):
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/backdrop-tree-abiding-slotted.html: Add Test Case
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/backdrop-tree-abiding-slotted-expected.txt: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/271366@main">https://commits.webkit.org/271366@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1df2c96d5e7669038280b6e86a1c74920206ca94

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28153 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6794 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29506 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30682 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25651 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28650 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8815 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4177 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/25946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28421 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5549 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24222 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4806 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4953 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25216 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31371 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25756 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25647 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31270 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4944 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3118 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29024 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6490 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/25016 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6746 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5381 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5456 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->