### PR TITLE
[Xcode] Make-based builds unnecessarily override PATH

### DIFF
--- a/Makefile.shared
+++ b/Makefile.shared
@@ -131,11 +131,6 @@ endif
 
 export DSYMUTIL_NUM_THREADS = $(shell sysctl -n hw.activecpu)
 
-# Run xcodebuild with the same PATH with which the Xcode IDE runs, to mitigate unnecessary rebuilds due to PATH differences.
-# See <rdar://problem/16466196>.
-export PATH = $(shell getconf PATH)
-
-
 define set_webkit_configuration
 	$(SCRIPTS_PATH)/set-webkit-configuration $1 $(CONFIG_OPTIONS)
 endef


### PR DESCRIPTION
#### 4d6ae578bb56ea5257473ba7acac467a34d466ba
<pre>
[Xcode] Make-based builds unnecessarily override PATH
<a href="https://bugs.webkit.org/show_bug.cgi?id=265609">https://bugs.webkit.org/show_bug.cgi?id=265609</a>
<a href="https://rdar.apple.com/16466196">rdar://16466196</a>

Reviewed by Alexey Proskuryakov.

Since <a href="https://commits.webkit.org/164487@main">https://commits.webkit.org/164487@main</a>, we pass
UseSanitizedBuildSystemEnvironment=YES to Xcode, which causes it to use
a well-defined PATH. Additionally, <a href="https://rdar.apple.com/16466196">rdar://16466196</a> made Xcode more
resilient to rebuilds where the PATH changes.

Remove the override.

* Makefile.shared:

Canonical link: <a href="https://commits.webkit.org/271362@main">https://commits.webkit.org/271362@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df39ee8c99da9f655510ed28ccbce3e34fd50426

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28154 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6795 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29507 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30683 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/25652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8816 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4178 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/25947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28422 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5553 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24225 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4807 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/4956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31372 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/24356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25760 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25650 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31271 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/27265 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/4945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3121 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/29036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6491 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/34775 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6743 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/5382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7529 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5457 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->