### PR TITLE
Implement declarativeNetRequest.updateEnabledRulesets

### DIFF
--- a/Source/WebKit/Shared/Extensions/WebExtensionDeclarativeNetRequestConstants.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionDeclarativeNetRequestConstants.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+namespace WebKit {
+
+static constexpr size_t webExtensionDeclarativeNetRequestMaximumNumberOfStaticRulesets = 100;
+static constexpr size_t webExtensionDeclarativeNetRequestMaximumNumberOfEnabledRulesets = 50;
+static constexpr size_t webExtensionDeclarativeNetRequestMaximumNumberOfDynamicAndSessionRules = 5000;
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -237,7 +237,8 @@ bool WebExtensionContext::load(WebExtensionController& controller, String storag
 
         // FIXME: <https://webkit.org/b/248429> Support dynamic content scripts by loading them from storage here.
 
-        loadDeclarativeNetRequestRules();
+        loadDeclarativeNetRequestRulesetStateFromStorage();
+        loadDeclarativeNetRequestRules([](bool) { });
 
         addInjectedContent();
     });
@@ -2344,11 +2345,10 @@ void WebExtensionContext::queueStartupAndInstallEventsForExtensionIfNecessary()
     bool extensionVersionDidChange = !m_previousVersion.isEmpty() && m_previousVersion != currentVersion;
 
     if (extensionVersionDidChange) {
-        // FIXME: Remove declarative net request modified rulesets.
-
         [m_state setObject:(NSString *)currentVersion forKey:lastSeenVersionStateKey];
         [m_state removeObjectForKey:backgroundContentEventListenersKey];
         [m_state removeObjectForKey:backgroundContentEventListenersVersionKey];
+        clearDeclarativeNetRequestRulesetState();
 
         writeStateToStorage();
 
@@ -2868,7 +2868,7 @@ static NSString *computeStringHashForContentBlockerRules(NSString *rules)
     return [hashAsString stringByAppendingString:[NSString stringWithFormat:@"-%zu", currentDeclarativeNetRequestRuleTranslatorVersion]];
 }
 
-void WebExtensionContext::compileDeclarativeNetRequestRules(NSArray *rulesData)
+void WebExtensionContext::compileDeclarativeNetRequestRules(NSArray *rulesData, CompletionHandler<void(bool)>&& completionHandler)
 {
     NSArray<NSString *> *jsonDeserializationErrorStrings;
     auto *allJSONObjects = [_WKWebExtensionDeclarativeNetRequestTranslator jsonObjectsFromData:rulesData errorStrings:&jsonDeserializationErrorStrings];
@@ -2877,26 +2877,30 @@ void WebExtensionContext::compileDeclarativeNetRequestRules(NSArray *rulesData)
     auto *allConvertedRules = [_WKWebExtensionDeclarativeNetRequestTranslator translateRules:allJSONObjects errorStrings:&parsingErrorStrings];
 
     auto *webKitRules = encodeJSONString(allConvertedRules, JSONOptions::FragmentsAllowed);
-    if (!webKitRules)
+    if (!webKitRules) {
+        completionHandler(false);
         return;
+    }
 
     auto *previouslyLoadedHash = objectForKey<NSString>(m_state, lastLoadedDNRHashStateKey);
     auto *hashOfWebKitRules = computeStringHashForContentBlockerRules(webKitRules);
 
-    [declarativeNetRequestRuleStore() lookUpContentRuleListForIdentifier:uniqueIdentifier() completionHandler:^(WKContentRuleList *foundRuleList, NSError *) {
+    [declarativeNetRequestRuleStore() lookUpContentRuleListForIdentifier:uniqueIdentifier() completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler), previouslyLoadedHash = String { previouslyLoadedHash }, hashOfWebKitRules = String { hashOfWebKitRules }, webKitRules = String { webKitRules }](WKContentRuleList *foundRuleList, NSError *) mutable {
         if (foundRuleList) {
             if ([previouslyLoadedHash isEqualToString:hashOfWebKitRules]) {
                 auto userContentControllers = hasAccessInPrivateBrowsing() ? extensionController()->allUserContentControllers() : extensionController()->allNonPrivateUserContentControllers();
                 for (auto& userContentController : userContentControllers)
                     userContentController.addContentRuleList(*foundRuleList->_contentRuleList, m_baseURL);
 
+                completionHandler(true);
                 return;
             }
         }
 
-        [declarativeNetRequestRuleStore() compileContentRuleListForIdentifier:uniqueIdentifier() encodedContentRuleList:webKitRules completionHandler:^(WKContentRuleList *ruleList, NSError *error) {
+        [declarativeNetRequestRuleStore() compileContentRuleListForIdentifier:uniqueIdentifier() encodedContentRuleList:webKitRules completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler), hashOfWebKitRules = String { hashOfWebKitRules }](WKContentRuleList *ruleList, NSError *error) mutable {
             if (error) {
                 RELEASE_LOG_ERROR(Extensions, "Error compiling declarativeNetRequest rules: %{public}@", privacyPreservingDescription(error));
+                completionHandler(false);
                 return;
             }
 
@@ -2906,18 +2910,22 @@ void WebExtensionContext::compileDeclarativeNetRequestRules(NSArray *rulesData)
             auto userContentControllers = hasAccessInPrivateBrowsing() ? extensionController()->allUserContentControllers() : extensionController()->allNonPrivateUserContentControllers();
             for (auto& userContentController : userContentControllers)
                 userContentController.addContentRuleList(*ruleList->_contentRuleList, m_baseURL);
-        }];
-    }];
+
+            completionHandler(true);
+        }).get()];
+    }).get()];
 }
 
-void WebExtensionContext::loadDeclarativeNetRequestRules()
+void WebExtensionContext::loadDeclarativeNetRequestRules(CompletionHandler<void(bool)>&& completionHandler)
 {
     // FIXME: rdar://118476702 - Load dynamic rules here.
     // FIXME: rdar://118476774 - Load session rules here.
     // FIXME: rdar://118476776 - Set state if the extension should show the blocked resource count as its badge text.
 
-    if (!hasPermission(_WKWebExtensionPermissionDeclarativeNetRequest) && !hasPermission(_WKWebExtensionPermissionDeclarativeNetRequestWithHostAccess))
+    if (!hasPermission(_WKWebExtensionPermissionDeclarativeNetRequest) && !hasPermission(_WKWebExtensionPermissionDeclarativeNetRequestWithHostAccess)) {
+        completionHandler(false);
         return;
+    }
 
     auto *allJSONData = [NSMutableArray array];
 
@@ -2933,11 +2941,13 @@ void WebExtensionContext::loadDeclarativeNetRequestRules()
     }
 
     if (!allJSONData.count) {
-        // FIXME: rdar://118476702 - When dynamic/session rules are supported, we should remove the content blocker if there are no rules.
+        removeDeclarativeNetRequestRules();
+        [declarativeNetRequestRuleStore() removeContentRuleListForIdentifier:uniqueIdentifier() completionHandler:^(NSError *) { }];
+        completionHandler(true);
         return;
     }
 
-    compileDeclarativeNetRequestRules(allJSONData);
+    compileDeclarativeNetRequestRules(allJSONData, WTFMove(completionHandler));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -254,7 +254,7 @@ public:
     const CommandsVector& commands();
     bool hasCommands();
 
-    const DeclarativeNetRequestRulesetVector& declarativeNetRequestRulesets();
+    DeclarativeNetRequestRulesetVector& declarativeNetRequestRulesets();
     bool hasContentModificationRules() { return !declarativeNetRequestRulesets().isEmpty(); }
 
     const InjectedContentVector& staticInjectedContents();

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -156,6 +156,8 @@ public:
     using MenuItemVector = Vector<Ref<WebExtensionMenuItem>>;
     using MenuItemMap = HashMap<String, Ref<WebExtensionMenuItem>>;
 
+    using DeclarativeNetRequestValidatedRulesets = std::pair<std::optional<WebExtension::DeclarativeNetRequestRulesetVector>, std::optional<String>>;
+
     enum class EqualityOnly : bool { No, Yes };
     enum class WindowIsClosing : bool { No, Yes };
     enum class ReloadFromOrigin : bool { No, Yes };
@@ -430,11 +432,14 @@ private:
     void removeInjectedContent(MatchPatternSet&);
     void removeInjectedContent(WebExtensionMatchPattern&);
 
-    void loadDeclarativeNetRequestRules();
-    void compileDeclarativeNetRequestRules(NSArray *);
+    void loadDeclarativeNetRequestRules(CompletionHandler<void(bool)>&&);
+    void compileDeclarativeNetRequestRules(NSArray *, CompletionHandler<void(bool)>&&);
     void removeDeclarativeNetRequestRules();
     void addDeclarativeNetRequestRulesToPrivateUserContentControllers();
     WKContentRuleListStore *declarativeNetRequestRuleStore();
+    void saveDeclarativeNetRequestRulesetStateToStorage(NSDictionary *rulesetState);
+    void loadDeclarativeNetRequestRulesetStateFromStorage();
+    void clearDeclarativeNetRequestRulesetState();
 
     // Action APIs
     void actionGetTitle(std::optional<WebExtensionWindowIdentifier>, std::optional<WebExtensionTabIdentifier>, CompletionHandler<void(std::optional<String>, std::optional<String>)>&&);
@@ -464,6 +469,10 @@ private:
 
     // DeclarativeNetRequest APIs
     void declarativeNetRequestGetEnabledRulesets(CompletionHandler<void(const Vector<String>&)>&&);
+    void declarativeNetRequestUpdateEnabledRulesets(const Vector<String>& rulesetIdentifiersToEnable, const Vector<String>& rulesetIdentifiersToDisable, CompletionHandler<void(std::optional<String>)>&&);
+    DeclarativeNetRequestValidatedRulesets declarativeNetRequestValidateRulesetIdentifiers(const Vector<String>&);
+    size_t declarativeNetRequestEnabledRulesetCount();
+    void declarativeNetRequestToggleRulesets(const Vector<String>& rulesetIdentifiers, bool newValue, NSMutableDictionary *rulesetIdentifiersToEnabledState);
 
     // Event APIs
     void addListener(WebPageProxyIdentifier, WebExtensionEventListenerType, WebExtensionContentWorldType);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
@@ -50,6 +50,7 @@ messages -> WebExtensionContext {
 
     // DeclarativeNetRequest
     DeclarativeNetRequestGetEnabledRulesets() -> (Vector<String> rulesetIdentifiers);
+    DeclarativeNetRequestUpdateEnabledRulesets(Vector<String> rulesetIdentifiersToEnable, Vector<String> rulesetIdentifiersToDisable) -> (std::optional<String> error);
 
     // Event APIs
     AddListener(WebKit::WebPageProxyIdentifier identifier, WebKit::WebExtensionEventListenerType type, WebKit::WebExtensionContentWorldType contentWorldType);

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -909,6 +909,7 @@
 		3326F2672B06A1F4001A535F /* _WKWebExtensionDeclarativeNetRequestTranslator.h in Headers */ = {isa = PBXBuildFile; fileRef = 3326F2632B06A1F4001A535F /* _WKWebExtensionDeclarativeNetRequestTranslator.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3326F2682B06A1F4001A535F /* _WKWebExtensionDeclarativeNetRequestTranslator.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3326F2642B06A1F4001A535F /* _WKWebExtensionDeclarativeNetRequestTranslator.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		3336763B130C99DC006C9DE2 /* WKResourceCacheManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 33367639130C99DC006C9DE2 /* WKResourceCacheManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		335698F62B19307700C7FEE4 /* WebExtensionDeclarativeNetRequestConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 335698F52B19307700C7FEE4 /* WebExtensionDeclarativeNetRequestConstants.h */; };
 		3375A37129429DDA0028536D /* WebExtensionAPIWebNavigationCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3375A37029429DDA0028536D /* WebExtensionAPIWebNavigationCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		3375A37529429DF50028536D /* WebExtensionAPIWebNavigation.h in Headers */ = {isa = PBXBuildFile; fileRef = 3375A37329429DF50028536D /* WebExtensionAPIWebNavigation.h */; };
 		3375A3772942A19D0028536D /* JSWebExtensionAPIWebNavigation.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3375A3762942A19C0028536D /* JSWebExtensionAPIWebNavigation.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
@@ -4654,6 +4655,7 @@
 		3326F2642B06A1F4001A535F /* _WKWebExtensionDeclarativeNetRequestTranslator.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKWebExtensionDeclarativeNetRequestTranslator.mm; sourceTree = "<group>"; };
 		33367638130C99DC006C9DE2 /* WKResourceCacheManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WKResourceCacheManager.cpp; sourceTree = "<group>"; };
 		33367639130C99DC006C9DE2 /* WKResourceCacheManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKResourceCacheManager.h; sourceTree = "<group>"; };
+		335698F52B19307700C7FEE4 /* WebExtensionDeclarativeNetRequestConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionDeclarativeNetRequestConstants.h; sourceTree = "<group>"; };
 		3375A37029429DDA0028536D /* WebExtensionAPIWebNavigationCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionAPIWebNavigationCocoa.mm; sourceTree = "<group>"; };
 		3375A37329429DF50028536D /* WebExtensionAPIWebNavigation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionAPIWebNavigation.h; sourceTree = "<group>"; };
 		3375A3762942A19C0028536D /* JSWebExtensionAPIWebNavigation.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = JSWebExtensionAPIWebNavigation.mm; sourceTree = "<group>"; };
@@ -12646,6 +12648,7 @@
 				1C3BEB482887415100E66E38 /* WebExtensionControllerIdentifier.h */,
 				1C3BEB46288740AE00E66E38 /* WebExtensionControllerParameters.h */,
 				1C4B7BBF28E7A43F00B7265A /* WebExtensionControllerParameters.serialization.in */,
+				335698F52B19307700C7FEE4 /* WebExtensionDeclarativeNetRequestConstants.h */,
 				B624FF1C2ABE54B500F6EDF6 /* WebExtensionDynamicScripts.serialization.in */,
 				B6114A8B293AE05200380B1B /* WebExtensionEventListenerType.h */,
 				8696CE2F297EB3C90081C800 /* WebExtensionEventListenerType.serialization.in */,
@@ -15782,6 +15785,7 @@
 				1C3BEB7B2888A00B00E66E38 /* WebExtensionControllerParameters.h in Headers */,
 				1C3BEB7D2888A01600E66E38 /* WebExtensionControllerProxy.h in Headers */,
 				1C3BEB512887492F00E66E38 /* WebExtensionControllerProxyMessages.h in Headers */,
+				335698F62B19307700C7FEE4 /* WebExtensionDeclarativeNetRequestConstants.h in Headers */,
 				B6D031052AC1F241006C8E0B /* WebExtensionDynamicScripts.h in Headers */,
 				B6114A8C293AE06800380B1B /* WebExtensionEventListenerType.h in Headers */,
 				1C4A14C62ABB710E00A1018C /* WebExtensionFrameIdentifier.h in Headers */,

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDeclarativeNetRequest.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDeclarativeNetRequest.h
@@ -29,6 +29,7 @@
 
 #include "JSWebExtensionAPIDeclarativeNetRequest.h"
 #include "WebExtensionAPIObject.h"
+#include "WebExtensionDeclarativeNetRequestConstants.h"
 
 namespace WebKit {
 
@@ -53,10 +54,9 @@ public:
     void isRegexSupported(NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
     void setExtensionActionOptions(NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
-    // FIXME: Put these in constants so they can be shared when they are used.
-    double maxNumberOfStaticRulesets() const { return 100; }
-    double maxNumberOfEnabledRulesets() const { return 50; }
-    double maxNumberOfDynamicAndSessionRules() const { return 5000; }
+    double maxNumberOfStaticRulesets() const { return webExtensionDeclarativeNetRequestMaximumNumberOfStaticRulesets; }
+    double maxNumberOfEnabledRulesets() const { return webExtensionDeclarativeNetRequestMaximumNumberOfEnabledRulesets; }
+    double maxNumberOfDynamicAndSessionRules() const { return webExtensionDeclarativeNetRequestMaximumNumberOfDynamicAndSessionRules; }
 #endif
 };
 


### PR DESCRIPTION
#### dc8ef58782b8f08276f8731a52ebbdb54d08ac9d
<pre>
Implement declarativeNetRequest.updateEnabledRulesets
<a href="https://bugs.webkit.org/show_bug.cgi?id=265616">https://bugs.webkit.org/show_bug.cgi?id=265616</a>
<a href="https://rdar.apple.com/118940027">rdar://118940027</a>

Reviewed by Timothy Hatcher.

When an extension calls updateEnabledRulesets - the following happens:
1) We validate the arguments in the WebProcess to make sure they are of the correct format
2) We call into the UI process to perform the work
3) The UI process makes sure all of the passed identifiers exist, and if they do, we attempt to perform the update

To do this, we modify the enabled state of the given rulesets, and attempt to load the declarativeNetRequest rules again.

If this succeeds, we write the updated state to disk. If it fails, we revert the changes that were made (and will continue to use
the old DNR rules).

This patch also adds tests for getEnabledRulesets and updateEnabledRulesets.

* Source/WebKit/Shared/Extensions/WebExtensionDeclarativeNetRequestConstants.h: Copied from Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDeclarativeNetRequestCocoa.mm.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDeclarativeNetRequestCocoa.mm:
(WebKit::WebExtensionContext::loadDeclarativeNetRequestRulesetStateFromStorage): Read the modified state of rulesets from State.plist
and apply it.
(WebKit::WebExtensionContext::saveDeclarativeNetRequestRulesetStateToStorage): Merge the given dictionary with the existing one and
save it to disk.
(WebKit::WebExtensionContext::declarativeNetRequestValidateRulesetIdentifiers): Make sure all of the ruleset identifiers exist and throw
an error if any don&apos;t.
(WebKit::WebExtensionContext::declarativeNetRequestEnabledRulesetCount): Get the count of enabled rulesets.
(WebKit::WebExtensionContext::declarativeNetRequestToggleRulesets): Set the state of the given rulesets.
(WebKit::WebExtensionContext::declarativeNetRequestUpdateEnabledRulesets): Perform the logic described in steps 3+ earlier in the commit message.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::populateDeclarativeNetRequestPropertiesIfNeeded): Adopt a few constants.
(WebKit::WebExtension::declarativeNetRequestRulesets): These ruleset objects can be changed, so don&apos;t return const.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::load): Call loadDeclarativeNetRequestRulesetStateFromStorage at startup. We don&apos;t want to call this each time that the
loadDeclarativeNetRequestRules is called, because we might be attempting to update the enabled rulesets and in that case we don&apos;t want to consult storage
yet.
(WebKit::WebExtensionContext::queueStartupAndInstallEventsForExtensionIfNecessary): Clear any customized rulesets upon update.
(WebKit::WebExtensionContext::compileDeclarativeNetRequestRules): Add a completion handler.
(WebKit::WebExtensionContext::loadDeclarativeNetRequestRules): Ditto.
* Source/WebKit/UIProcess/Extensions/WebExtension.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDeclarativeNetRequestCocoa.mm:
(WebKit::WebExtensionAPIDeclarativeNetRequest::updateEnabledRulesets): Perform argument validation.
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDeclarativeNetRequest.h:
(WebKit::WebExtensionAPIDeclarativeNetRequest::maxNumberOfStaticRulesets const): Use a constant.
(WebKit::WebExtensionAPIDeclarativeNetRequest::maxNumberOfEnabledRulesets const): Ditto.
(WebKit::WebExtensionAPIDeclarativeNetRequest::maxNumberOfDynamicAndSessionRules const): Ditto.

Canonical link: <a href="https://commits.webkit.org/271410@main">https://commits.webkit.org/271410@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf146d920b9fe38f4a5afa2886324a06d7e9908f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28279 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6922 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29638 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30809 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25762 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28776 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8973 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4301 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28547 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5688 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/24340 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4956 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/5080 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25338 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31498 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25891 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25772 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31386 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5053 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3234 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29140 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6639 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6778 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5495 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5571 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->