### PR TITLE
Reduce exposure of ImageBuffer's backend implementation detail

### DIFF
--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -250,7 +250,7 @@ void ImageBuffer::flushDrawingContext()
     // The direct backend context flush is not part of ImageBuffer abstraction semantics,
     // rather implementation detail of the ImageBufferBackends that need separate management
     // of their context lifetime for purposes of drawing from the image buffer.
-    if (auto* backend = ensureBackendCreated())
+    if (auto* backend = ensureBackend())
         backend->flushContext();
 }
 
@@ -270,34 +270,28 @@ void ImageBuffer::setBackend(std::unique_ptr<ImageBufferBackend>&& backend)
     ++m_backendGeneration;
 }
 
-std::unique_ptr<ImageBufferBackend> ImageBuffer::takeBackend()
-{
-    return WTFMove(m_backend);
-}
-
 IntSize ImageBuffer::backendSize() const
 {
     return calculateBackendSize(m_parameters.logicalSize, m_parameters.resolutionScale);
 }
 
-
 RefPtr<NativeImage> ImageBuffer::copyNativeImage() const
 {
-    if (auto* backend = ensureBackendCreated())
+    if (auto* backend = ensureBackend())
         return backend->copyNativeImage();
     return nullptr;
 }
 
 RefPtr<NativeImage> ImageBuffer::createNativeImageReference() const
 {
-    if (auto* backend = ensureBackendCreated())
+    if (auto* backend = ensureBackend())
         return backend->createNativeImageReference();
     return nullptr;
 }
 
 RefPtr<NativeImage> ImageBuffer::sinkIntoNativeImage()
 {
-    if (auto* backend = ensureBackendCreated())
+    if (auto* backend = ensureBackend())
         return backend->sinkIntoNativeImage();
     return nullptr;
 }
@@ -320,7 +314,7 @@ RefPtr<NativeImage> ImageBuffer::filteredNativeImage(Filter& filter)
 {
     ASSERT(!filter.filterRenderingModes().contains(FilterRenderingMode::GraphicsContext));
 
-    auto* backend = ensureBackendCreated();
+    auto* backend = ensureBackend();
     if (!backend)
         return nullptr;
 
@@ -361,7 +355,7 @@ RefPtr<NativeImage> ImageBuffer::filteredNativeImage(Filter& filter, Function<vo
 #if USE(CAIRO)
 RefPtr<cairo_surface_t> ImageBuffer::createCairoSurface()
 {
-    auto* backend = ensureBackendCreated();
+    auto* backend = ensureBackend();
     if (!backend)
         return nullptr;
 
@@ -387,13 +381,13 @@ RefPtr<NativeImage> ImageBuffer::sinkIntoNativeImage(RefPtr<ImageBuffer> source)
 
 void ImageBuffer::convertToLuminanceMask()
 {
-    if (auto* backend = ensureBackendCreated())
+    if (auto* backend = ensureBackend())
         backend->convertToLuminanceMask();
 }
 
 void ImageBuffer::transformToColorSpace(const DestinationColorSpace& newColorSpace)
 {
-    if (auto* backend = ensureBackendCreated()) {
+    if (auto* backend = ensureBackend()) {
         backend->transformToColorSpace(newColorSpace);
         m_parameters.colorSpace = newColorSpace;
     }
@@ -433,7 +427,7 @@ RefPtr<PixelBuffer> ImageBuffer::getPixelBuffer(const PixelBufferFormat& destina
     auto destination = allocator.createPixelBuffer(destinationFormat, sourceRectScaled.size());
     if (!destination)
         return nullptr;
-    if (auto* backend = ensureBackendCreated())
+    if (auto* backend = ensureBackend())
         backend->getPixelBuffer(sourceRectScaled, *destination);
     else
         destination->zeroFill();
@@ -443,7 +437,7 @@ RefPtr<PixelBuffer> ImageBuffer::getPixelBuffer(const PixelBufferFormat& destina
 void ImageBuffer::putPixelBuffer(const PixelBuffer& pixelBuffer, const IntRect& sourceRect, const IntPoint& destinationPoint, AlphaPremultiplication destinationFormat)
 {
     ASSERT(resolutionScale() == 1);
-    auto* backend = ensureBackendCreated();
+    auto* backend = ensureBackend();
     if (!backend)
         return;
     auto sourceRectScaled = sourceRect;
@@ -455,20 +449,20 @@ void ImageBuffer::putPixelBuffer(const PixelBuffer& pixelBuffer, const IntRect& 
 
 bool ImageBuffer::isInUse() const
 {
-    if (auto* backend = ensureBackendCreated())
+    if (auto* backend = ensureBackend())
         return backend->isInUse();
     return false;
 }
 
 void ImageBuffer::releaseGraphicsContext()
 {
-    if (auto* backend = ensureBackendCreated())
+    if (auto* backend = ensureBackend())
         return backend->releaseGraphicsContext();
 }
 
 bool ImageBuffer::setVolatile()
 {
-    if (auto* backend = ensureBackendCreated())
+    if (auto* backend = ensureBackend())
         return backend->setVolatile();
 
     return true; // Just claim we succeedded.
@@ -476,27 +470,27 @@ bool ImageBuffer::setVolatile()
 
 SetNonVolatileResult ImageBuffer::setNonVolatile()
 {
-    if (auto* backend = ensureBackendCreated())
+    if (auto* backend = ensureBackend())
         return backend->setNonVolatile();
     return SetNonVolatileResult::Valid;
 }
 
 VolatilityState ImageBuffer::volatilityState() const
 {
-    if (auto* backend = ensureBackendCreated())
+    if (auto* backend = ensureBackend())
         return backend->volatilityState();
     return VolatilityState::NonVolatile;
 }
 
 void ImageBuffer::setVolatilityState(VolatilityState volatilityState)
 {
-    if (auto* backend = ensureBackendCreated())
+    if (auto* backend = ensureBackend())
         backend->setVolatilityState(volatilityState);
 }
 
 std::unique_ptr<ThreadSafeImageBufferFlusher> ImageBuffer::createFlusher()
 {
-    if (auto* backend = ensureBackendCreated())
+    if (auto* backend = ensureBackend())
         return backend->createFlusher();
     return nullptr;
 }
@@ -504,6 +498,18 @@ std::unique_ptr<ThreadSafeImageBufferFlusher> ImageBuffer::createFlusher()
 unsigned ImageBuffer::backendGeneration() const
 {
     return m_backendGeneration;
+}
+
+ImageBufferBackendSharing* ImageBuffer::toBackendSharing()
+{
+    if (auto* backend = ensureBackend())
+        return backend->toBackendSharing();
+    return nullptr;
+}
+
+void ImageBuffer::transferToNewContext(const ImageBufferCreationContext& context)
+{
+    backend()->transferToNewContext(context);
 }
 
 String ImageBuffer::debugDescription() const

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -131,11 +131,12 @@ public:
     WEBCORE_EXPORT virtual void flushDrawingContext();
     WEBCORE_EXPORT virtual bool flushDrawingContextAsync();
 
-    WEBCORE_EXPORT std::unique_ptr<ImageBufferBackend> takeBackend();
     WEBCORE_EXPORT IntSize backendSize() const;
 
-    ImageBufferBackend* backend() const { return m_backend.get(); }
-    virtual ImageBufferBackend* ensureBackendCreated() const { return m_backend.get(); }
+    virtual void ensureBackendCreated() const { ensureBackend(); }
+    bool hasBackend() { return !!backend(); }
+
+    WEBCORE_EXPORT void transferToNewContext(const ImageBufferCreationContext&);
 
     RenderingResourceIdentifier renderingResourceIdentifier() const { return m_renderingResourceIdentifier; }
 
@@ -205,6 +206,9 @@ public:
 
     WEBCORE_EXPORT virtual String debugDescription() const;
 
+    // FIXME: This should just be "ImageBufferSharing".
+    WEBCORE_EXPORT virtual ImageBufferBackendSharing* toBackendSharing();
+
 protected:
     WEBCORE_EXPORT ImageBuffer(ImageBufferParameters, const ImageBufferBackend::Info&, std::unique_ptr<ImageBufferBackend>&& = nullptr, RenderingResourceIdentifier = RenderingResourceIdentifier::generate());
 
@@ -213,6 +217,8 @@ protected:
     WEBCORE_EXPORT virtual std::unique_ptr<SerializedImageBuffer> sinkIntoSerializedImageBuffer();
 
     WEBCORE_EXPORT void setBackend(std::unique_ptr<ImageBufferBackend>&&);
+    ImageBufferBackend* backend() const { return m_backend.get(); }
+    virtual ImageBufferBackend* ensureBackend() const { return m_backend.get(); }
 
     Parameters m_parameters;
     ImageBufferBackend::Info m_backendInfo;

--- a/Source/WebKit/GPUProcess/graphics/ImageBufferShareableAllocator.cpp
+++ b/Source/WebKit/GPUProcess/graphics/ImageBufferShareableAllocator.cpp
@@ -47,11 +47,7 @@ RefPtr<ImageBuffer> ImageBufferShareableAllocator::createImageBuffer(const Float
     if (!imageBuffer)
         return nullptr;
 
-    auto* backend = imageBuffer->backend();
-    if (!backend)
-        return nullptr;
-
-    auto* sharing = backend->toBackendSharing();
+    auto* sharing = imageBuffer->toBackendSharing();
     ASSERT(is<ImageBufferBackendHandleSharing>(sharing));
 
     auto bitmap = downcast<ImageBufferBackendHandleSharing>(*sharing).bitmap();

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
@@ -61,7 +61,7 @@ RemoteImageBuffer::~RemoteImageBuffer()
     // Volatile image buffers do not have contexts.
     if (m_imageBuffer->volatilityState() == WebCore::VolatilityState::Volatile)
         return;
-    if (!m_imageBuffer->backend())
+    if (!m_imageBuffer->hasBackend())
         return;
     // Unwind the context's state stack before destruction, since calls to restore may not have
     // been flushed yet, or the web process may have terminated.

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -178,7 +178,7 @@ void RemoteRenderingBackend::didFailCreateImageBuffer(RenderingResourceIdentifie
 void RemoteRenderingBackend::didCreateImageBuffer(Ref<ImageBuffer> imageBuffer)
 {
     auto imageBufferIdentifier = imageBuffer->renderingResourceIdentifier();
-    auto* sharing = imageBuffer->backend()->toBackendSharing();
+    auto* sharing = imageBuffer->toBackendSharing();
     auto handle = downcast<ImageBufferBackendHandleSharing>(*sharing).createBackendHandle();
     m_remoteDisplayLists.add(imageBufferIdentifier, RemoteDisplayListRecorder::create(imageBuffer.get(), imageBufferIdentifier, *this));
     m_remoteImageBuffers.add(imageBufferIdentifier, RemoteImageBuffer::create(WTFMove(imageBuffer), *this));
@@ -215,7 +215,7 @@ void RemoteRenderingBackend::moveToImageBuffer(RenderingResourceIdentifier image
     creationContext.surfacePool = &ioSurfacePool();
 #endif
     creationContext.resourceOwner = m_resourceOwner;
-    imageBuffer->backend()->transferToNewContext(creationContext);
+    imageBuffer->transferToNewContext(creationContext);
     didCreateImageBuffer(imageBuffer.releaseNonNull());
 }
 
@@ -340,11 +340,7 @@ void RemoteRenderingBackend::releaseRenderingResource(RenderingResourceIdentifie
 #if PLATFORM(COCOA)
 static std::optional<ImageBufferBackendHandle> handleFromBuffer(ImageBuffer& buffer)
 {
-    auto* backend = buffer.ensureBackendCreated();
-    if (!backend)
-        return std::nullopt;
-
-    auto* sharing = backend->toBackendSharing();
+    auto* sharing = buffer.toBackendSharing();
     if (is<ImageBufferBackendHandleSharing>(sharing))
         return downcast<ImageBufferBackendHandleSharing>(*sharing).createBackendHandle();
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
@@ -165,11 +165,7 @@ static bool hasValue(const ImageBufferBackendHandle& backendHandle)
 void RemoteLayerBackingStore::encode(IPC::Encoder& encoder) const
 {
     auto handleFromBuffer = [](ImageBuffer& buffer) -> std::optional<ImageBufferBackendHandle> {
-        auto* backend = buffer.ensureBackendCreated();
-        if (!backend)
-            return std::nullopt;
-
-        auto* sharing = backend->toBackendSharing();
+        auto* sharing = buffer.toBackendSharing();
         if (is<ImageBufferBackendHandleSharing>(sharing))
             return downcast<ImageBufferBackendHandleSharing>(*sharing).takeBackendHandle();
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStoreCollection.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStoreCollection.mm
@@ -122,12 +122,10 @@ bool RemoteLayerWithRemoteRenderingBackingStoreCollection::collectBackingStoreBu
         if (buffer->volatilityState() != WebCore::VolatilityState::NonVolatile)
             return;
 
-        // Clearing the backend handle in the webcontent process is necessary to have the surface in-use count drop to zero.
-        if (auto* backend = buffer->ensureBackendCreated()) {
-            auto* sharing = backend->toBackendSharing();
-            if (is<ImageBufferBackendHandleSharing>(sharing))
-                downcast<ImageBufferBackendHandleSharing>(*sharing).clearBackendHandle();
-        }
+        // Clearing the backend handle in the Web Content process is necessary to have the surface in-use count drop to zero.
+        auto* sharing = buffer->toBackendSharing();
+        if (is<ImageBufferBackendHandleSharing>(sharing))
+            downcast<ImageBufferBackendHandleSharing>(*sharing).clearBackendHandle();
 
         identifiers.append(buffer->renderingResourceIdentifier());
     };

--- a/Source/WebKit/Shared/WebImage.cpp
+++ b/Source/WebKit/Shared/WebImage.cpp
@@ -107,13 +107,9 @@ RefPtr<NativeImage> WebImage::copyNativeImage(BackingStoreCopy copyBehavior) con
 
 RefPtr<ShareableBitmap> WebImage::bitmap() const
 {
-    auto* backend = m_buffer->ensureBackendCreated();
-    if (!backend)
-        return nullptr;
-
     const_cast<ImageBuffer&>(*m_buffer.ptr()).flushDrawingContext();
 
-    auto* sharing = backend->toBackendSharing();
+    auto* sharing = m_buffer->toBackendSharing();
     if (!is<ImageBufferBackendHandleSharing>(sharing))
         return nullptr;
 
@@ -129,13 +125,9 @@ RefPtr<cairo_surface_t> WebImage::createCairoSurface()
 
 std::optional<ShareableBitmap::Handle> WebImage::createHandle(SharedMemory::Protection protection) const
 {
-    auto* backend = m_buffer->ensureBackendCreated();
-    if (!backend)
-        return std::nullopt;
-
     const_cast<ImageBuffer&>(*m_buffer.ptr()).flushDrawingContext();
 
-    auto* sharing = backend->toBackendSharing();
+    auto* sharing = m_buffer->toBackendSharing();
     if (!is<ImageBufferBackendHandleSharing>(sharing))
         return std::nullopt;
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
@@ -225,7 +225,7 @@ void RemoteImageBufferProxy::didCreateBackend(std::optional<ImageBufferBackendHa
     setBackend(WTFMove(backend));
 }
 
-ImageBufferBackend* RemoteImageBufferProxy::ensureBackendCreated() const
+ImageBufferBackend* RemoteImageBufferProxy::ensureBackend() const
 {
     if (!m_backend && m_remoteRenderingBackendProxy) {
         auto error = streamConnection().waitForAndDispatchImmediately<Messages::RemoteImageBufferProxy::DidCreateBackend>(m_renderingResourceIdentifier, RemoteRenderingBackendProxy::defaultTimeout);
@@ -426,7 +426,7 @@ void RemoteImageBufferProxy::prepareForBackingStoreChange()
     // process, we need to prepare for the backing store change before we let the change happen.
     if (!canMapBackingStore())
         return;
-    if (auto* backend = ensureBackendCreated())
+    if (auto* backend = ensureBackend())
         backend->ensureNativeImagesHaveCopiedBackingStore();
 }
 
@@ -442,7 +442,7 @@ std::unique_ptr<SerializedImageBuffer> RemoteImageBufferProxy::sinkIntoSerialize
 
     prepareForBackingStoreChange();
 
-    if (!ensureBackendCreated())
+    if (!ensureBackend())
         return nullptr;
 
     m_remoteRenderingBackendProxy->remoteResourceCacheProxy().forgetImageBuffer(m_renderingResourceIdentifier);

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
@@ -57,7 +57,7 @@ public:
 
     ~RemoteImageBufferProxy();
 
-    WebCore::ImageBufferBackend* ensureBackendCreated() const final;
+    WebCore::ImageBufferBackend* ensureBackend() const final;
 
     void clearBackend();
     void backingStoreWillChange();

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -330,11 +330,9 @@ auto RemoteRenderingBackendProxy::prepareBuffersForDisplay(const Vector<LayerPre
         if (!buffer)
             return;
 
-        if (auto* backend = buffer->ensureBackendCreated()) {
-            auto* sharing = backend->toBackendSharing();
-            if (is<ImageBufferBackendHandleSharing>(sharing))
-                downcast<ImageBufferBackendHandleSharing>(*sharing).clearBackendHandle();
-        }
+        auto* sharing = buffer->toBackendSharing();
+        if (is<ImageBufferBackendHandleSharing>(sharing))
+            downcast<ImageBufferBackendHandleSharing>(*sharing).clearBackendHandle();
     };
 
     auto inputData = WTF::map(prepareBuffersInput, [&](auto& perLayerData) {
@@ -382,11 +380,9 @@ auto RemoteRenderingBackendProxy::prepareBuffersForDisplay(const Vector<LayerPre
             return nullptr;
 
         if (handle) {
-            if (auto* backend = buffer->ensureBackendCreated()) {
-                auto* sharing = backend->toBackendSharing();
-                if (is<ImageBufferBackendHandleSharing>(sharing))
-                    downcast<ImageBufferBackendHandleSharing>(*sharing).setBackendHandle(WTFMove(*handle));
-            }
+            auto* sharing = buffer->toBackendSharing();
+            if (is<ImageBufferBackendHandleSharing>(sharing))
+                downcast<ImageBufferBackendHandleSharing>(*sharing).setBackendHandle(WTFMove(*handle));
         }
 
         if (isFrontBuffer) {

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm
@@ -127,13 +127,10 @@ public:
         auto clone = buffer.clone();
         if (!clone)
             return false;
-        auto* backend = clone->ensureBackendCreated();
-        if (!backend)
-            return false;
 
         clone->flushDrawingContext();
 
-        auto* sharing = dynamicDowncast<ImageBufferBackendHandleSharing>(backend->toBackendSharing());
+        auto* sharing = dynamicDowncast<ImageBufferBackendHandleSharing>(clone->toBackendSharing());
         if (!sharing)
             return false;
 

--- a/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.cpp
+++ b/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.cpp
@@ -379,12 +379,10 @@ void DrawingAreaWC::sendUpdateNonAC()
                 return;
             }
 
-            if (auto* backend = image->ensureBackendCreated()) {
-                auto* sharing = backend->toBackendSharing();
-                if (is<ImageBufferBackendHandleSharing>(sharing)) {
-                    if (auto handle = downcast<ImageBufferBackendHandleSharing>(*sharing).createBackendHandle())
-                        updateInfo.bitmapHandle = std::get<ShareableBitmap::Handle>(WTFMove(*handle));
-                }
+            auto* sharing = image->toBackendSharing();
+            if (is<ImageBufferBackendHandleSharing>(sharing)) {
+                if (auto handle = downcast<ImageBufferBackendHandleSharing>(*sharing).createBackendHandle())
+                    updateInfo.bitmapHandle = std::get<ShareableBitmap::Handle>(WTFMove(*handle));
             }
 
             send(Messages::DrawingAreaProxy::Update(stateID, WTFMove(updateInfo)));

--- a/Source/WebKit/WebProcess/WebPage/wc/WCBackingStore.h
+++ b/Source/WebKit/WebProcess/WebPage/wc/WCBackingStore.h
@@ -46,11 +46,9 @@ public:
     {
         std::optional<ImageBufferBackendHandle> handle;
         if (m_imageBuffer) {
-            if (auto* backend = m_imageBuffer->ensureBackendCreated()) {
-                auto* sharing = backend->toBackendSharing();
-                if (is<ImageBufferBackendHandleSharing>(sharing))
-                    handle = downcast<ImageBufferBackendHandleSharing>(*sharing).createBackendHandle();
-            }
+            auto* sharing = m_imageBuffer->toBackendSharing();
+            if (is<ImageBufferBackendHandleSharing>(sharing))
+                handle = downcast<ImageBufferBackendHandleSharing>(*sharing).createBackendHandle();
         }
         encoder << WTFMove(handle);
     }


### PR DESCRIPTION
#### f784aeef6e0a7be2725bf8e003511a7501683081
<pre>
Reduce exposure of ImageBuffer&apos;s backend implementation detail
<a href="https://bugs.webkit.org/show_bug.cgi?id=265623">https://bugs.webkit.org/show_bug.cgi?id=265623</a>

Reviewed by Matt Woodrow.

In preparation for an ImageBuffer subclass that owns multiple backends,
try to reduce non-ImageBuffer code&apos;s ability to get ahold of the backend directly.

To do this:
- rename ensureBackendCreated() to ensureBackend(); it still creates and returns the backend
- add ensureBackendCreated(), which creates but does not return the backend
- remove takeBackend(), which is unused
- add toBackendSharing(), which just delegates to the backend internally
- add transferToNewContext(), which just delegates to the backend internally
- add hasBackend(), which just returns the existence of the backend but does not expose it
- make backend() and ensureBackend() protected, entirely isolating the backend from the rest of WebCore

There is definitely more cleanup to be done; it seems prudent to eventually further
hide the backend from ImageBuffer clients (but we still have e.g. ensureBackendCreated
and hasBackend,  and the whole ImageBufferBackendSharing class structure
unnecessarily uses the &quot;Backend&quot; naming).

* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::flushDrawingContext):
(WebCore::ImageBuffer::copyNativeImage const):
(WebCore::ImageBuffer::createNativeImageReference const):
(WebCore::ImageBuffer::sinkIntoNativeImage):
(WebCore::ImageBuffer::filteredNativeImage):
(WebCore::ImageBuffer::createCairoSurface):
(WebCore::ImageBuffer::convertToLuminanceMask):
(WebCore::ImageBuffer::transformToColorSpace):
(WebCore::ImageBuffer::getPixelBuffer const):
(WebCore::ImageBuffer::putPixelBuffer):
(WebCore::ImageBuffer::isInUse const):
(WebCore::ImageBuffer::releaseGraphicsContext):
(WebCore::ImageBuffer::setVolatile):
(WebCore::ImageBuffer::setNonVolatile):
(WebCore::ImageBuffer::volatilityState const):
(WebCore::ImageBuffer::setVolatilityState):
(WebCore::ImageBuffer::createFlusher):
(WebCore::ImageBuffer::toBackendSharing):
(WebCore::ImageBuffer::transferToNewContext):
(WebCore::ImageBuffer::takeBackend): Deleted.
* Source/WebCore/platform/graphics/ImageBuffer.h:
(WebCore::ImageBuffer::ensureBackendCreated const):
(WebCore::ImageBuffer::hasBackend):
(WebCore::ImageBuffer::backend const):
(WebCore::ImageBuffer::ensureBackend const):
* Source/WebKit/GPUProcess/graphics/ImageBufferShareableAllocator.cpp:
(WebKit::ImageBufferShareableAllocator::createImageBuffer const):
* Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp:
(WebKit::RemoteImageBuffer::~RemoteImageBuffer):
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::didCreateImageBuffer):
(WebKit::RemoteRenderingBackend::moveToImageBuffer):
(WebKit::handleFromBuffer):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm:
(WebKit::RemoteLayerBackingStore::encode const):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStoreCollection.mm:
(WebKit::RemoteLayerWithRemoteRenderingBackingStoreCollection::collectBackingStoreBufferIdentifiersToMarkVolatile):
* Source/WebKit/Shared/WebImage.cpp:
(WebKit::WebImage::bitmap const):
(WebKit::WebImage::createHandle const):
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp:
(WebKit::RemoteImageBufferProxy::ensureBackend const):
(WebKit::RemoteImageBufferProxy::prepareForBackingStoreChange):
(WebKit::RemoteImageBufferProxy::sinkIntoSerializedImageBuffer):
(WebKit::RemoteImageBufferProxy::ensureBackendCreated const): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::prepareBuffersForDisplay):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm:
* Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.cpp:
(WebKit::DrawingAreaWC::sendUpdateNonAC):
* Source/WebKit/WebProcess/WebPage/wc/WCBackingStore.h:
(WebKit::WCBackingStore::encode const):

Canonical link: <a href="https://commits.webkit.org/271408@main">https://commits.webkit.org/271408@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb935b8f4de55188c39db5f568ff7b6d5a9cfaf7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28255 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6898 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29613 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30786 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25748 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28752 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8936 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4278 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28523 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5670 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24323 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4940 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5067 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25319 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31475 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25875 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25758 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31374 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5039 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3220 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29128 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6620 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6774 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5476 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5557 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->