### PR TITLE
[UnifiedPDF] Start creating context menu in UnifiedPDFPlugin.

### DIFF
--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -1114,6 +1114,9 @@
 /* Title of the context menu item to show when PDFPlugin was used instead of a blocked plugin */
 "Show in blocked plug-in" = "Show in blocked plug-in";
 
+/* Open with Preview context menu item */
+"Open with Preview" = "Open with Preview";
+
 /* Single Page context menu item */
 "Single Page" = "Single Page";
 

--- a/Source/WebCore/platform/LocalizedStrings.cpp
+++ b/Source/WebCore/platform/LocalizedStrings.cpp
@@ -503,6 +503,13 @@ String contextMenuItemTagTranslate(const String& selectedString)
 }
 #endif
 
+#if ENABLE(UNIFIED_PDF)
+String contextMenuItemPDFOpenWithPreview()
+{
+    return WEB_UI_STRING("Open with Preview", "Open with Preview context menu item");
+}
+#endif
+
 #if ENABLE(PDFJS)
 String contextMenuItemPDFAutoSize()
 {

--- a/Source/WebCore/platform/LocalizedStrings.h
+++ b/Source/WebCore/platform/LocalizedStrings.h
@@ -174,6 +174,9 @@ namespace WebCore {
 #if HAVE(TRANSLATION_UI_SERVICES)
     String contextMenuItemTagTranslate(const String& selectedString);
 #endif
+#if ENABLE(UNIFIED_PDF)
+    WEBCORE_EXPORT String contextMenuItemPDFOpenWithPreview();
+#endif
 #if ENABLE(PDFJS)
     String contextMenuItemPDFAutoSize();
     String contextMenuItemPDFZoomIn();

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -33,6 +33,8 @@
 #include <wtf/OptionSet.h>
 
 namespace WebKit {
+
+struct PDFContextMenu;
 class WebFrame;
 class WebMouseEvent;
 
@@ -88,6 +90,13 @@ private:
     bool handleKeyboardEvent(const WebKeyboardEvent&) override;
     bool handleEditingCommand(StringView commandName) override;
     bool isEditingCommandEnabled(StringView commandName) override;
+
+    enum class ContextMenuItemTag : uint8_t {
+        OpenWithPreview
+    };
+
+    PDFContextMenu createContextMenu(const WebCore::IntPoint& contextMenuPoint) const;
+    void performContextMenuAction(ContextMenuItemTag) const;
 
     String getSelectionString() const override;
     bool existingSelectionContainsPoint(const WebCore::FloatPoint&) const override;


### PR DESCRIPTION
#### 6a92aded2a217de967647f6a04139b078abf36c5
<pre>
[UnifiedPDF] Start creating context menu in UnifiedPDFPlugin.
<a href="https://bugs.webkit.org/show_bug.cgi?id=265605">https://bugs.webkit.org/show_bug.cgi?id=265605</a>
<a href="https://rdar.apple.com/119001947">rdar://119001947</a>

Reviewed by Simon Fraser.

UnifiedPDF will need to start creating its own context menu so we can
lay the initial groundwork by creating a context menu with a single
item. This will hopefully allow us to easily add additional items in
a subsequent patch without worrying about the architecture too much.
In this patch the item we will use will be the &quot;Open with Preview,&quot;
option.

UnifiedPDFPlugin will create its own PDFContextMenu with items and
send this over to the web page proxy. Each item will contain a tag that
is a ContextMenuAction that will be used to indicate what type of action
to perform once we get the result back.

* Source/WebCore/en.lproj/Localizable.strings:
* Source/WebCore/platform/LocalizedStrings.cpp:
(WebCore::contextMenuItemPDFOpenWithPreview):
* Source/WebCore/platform/LocalizedStrings.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::createContextMenu const):
(WebKit::UnifiedPDFPlugin::handleContextMenuEvent):
(WebKit::UnifiedPDFPlugin::performContextMenuAction const):

Canonical link: <a href="https://commits.webkit.org/271429@main">https://commits.webkit.org/271429@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b967f0f6bd485c782d36795b5cfed16cca3e6bbd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28338 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6982 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29719 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30865 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25800 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28835 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9059 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4353 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28607 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5741 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24382 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5019 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5119 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25381 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31551 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25942 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25816 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31425 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5090 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3270 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29183 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6685 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6799 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5540 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5608 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->