### PR TITLE
Add a MiniBrowser menu item to dump a WKWebView image snapshot

### DIFF
--- a/Tools/MiniBrowser/mac/BrowserWindowController.h
+++ b/Tools/MiniBrowser/mac/BrowserWindowController.h
@@ -48,6 +48,7 @@
 - (IBAction)openLocation:(id)sender;
 
 - (IBAction)saveAsPDF:(id)sender;
+- (IBAction)saveAsImage:(id)sender;
 - (IBAction)saveAsWebArchive:(id)sender;
 
 - (IBAction)fetch:(id)sender;

--- a/Tools/MiniBrowser/mac/BrowserWindowController.m
+++ b/Tools/MiniBrowser/mac/BrowserWindowController.m
@@ -112,6 +112,11 @@
     [self doesNotRecognizeSelector:_cmd];
 }
 
+- (IBAction)saveAsImage:(id)sender
+{
+    [self doesNotRecognizeSelector:_cmd];
+}
+
 - (IBAction)saveAsWebArchive:(id)sender
 {
     [self doesNotRecognizeSelector:_cmd];

--- a/Tools/MiniBrowser/mac/MainMenu.xib
+++ b/Tools/MiniBrowser/mac/MainMenu.xib
@@ -139,6 +139,12 @@
                                     <action selector="saveAsPDF:" target="-1" id="25T-Id-334"/>
                                 </connections>
                             </menuItem>
+                            <menuItem title="Save As Image…" keyEquivalent="S" id="gmS-3Q-oLt">
+                                <modifierMask key="keyEquivalentModifierMask" shift="YES" option="YES" command="YES"/>
+                                <connections>
+                                    <action selector="saveAsImage:" target="-1" id="25T-Id-335"/>
+                                </connections>
+                            </menuItem>
                             <menuItem title="Save As WebArchive..." id="112">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>

--- a/Tools/MiniBrowser/mac/WK1BrowserWindowController.m
+++ b/Tools/MiniBrowser/mac/WK1BrowserWindowController.m
@@ -150,6 +150,8 @@ static BOOL areEssentiallyEqual(double a, double b)
 
     if (action == @selector(saveAsPDF:))
         return NO;
+    if (action == @selector(saveAsImage:))
+        return NO;
     if (action == @selector(saveAsWebArchive:))
         return NO;
 

--- a/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
+++ b/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
@@ -267,6 +267,8 @@ static BOOL areEssentiallyEqual(double a, double b)
 
     if (action == @selector(saveAsPDF:))
         return YES;
+    if (action == @selector(saveAsImage:))
+        return YES;
     if (action == @selector(saveAsWebArchive:))
         return YES;
 
@@ -975,11 +977,25 @@ static BOOL isJavaScriptURL(NSURL *url)
     panel.allowedContentTypes = @[ UTTypePDF ];
 
     [panel beginSheetModalForWindow:self.window completionHandler:^(NSInteger result) {
-        if (result == NSModalResponseOK) {
-            [self->_webView createPDFWithConfiguration:nil completionHandler:^(NSData *pdfSnapshotData, NSError *error) {
-                [pdfSnapshotData writeToURL:[panel URL] options:0 error:nil];
-            }];
-        }
+        if (result != NSModalResponseOK)
+            return;
+        [self->_webView createPDFWithConfiguration:nil completionHandler:^(NSData *pdfSnapshotData, NSError *error) {
+            [pdfSnapshotData writeToURL:[panel URL] options:0 error:nil];
+        }];
+    }];
+}
+
+- (IBAction)saveAsImage:(id)sender
+{
+    NSSavePanel *panel = [NSSavePanel savePanel];
+    panel.allowedContentTypes = @[ UTTypeTIFF ];
+
+    [panel beginSheetModalForWindow:self.window completionHandler:^(NSInteger result) {
+        if (result != NSModalResponseOK)
+            return;
+        [self->_webView takeSnapshotWithConfiguration:nil completionHandler:^(NSImage *snapshot, NSError *error) {
+            [snapshot.TIFFRepresentation writeToURL:[panel URL] options:0 error:nil];
+        }];
     }];
 }
 
@@ -989,11 +1005,11 @@ static BOOL isJavaScriptURL(NSURL *url)
     panel.allowedContentTypes = @[ UTTypeWebArchive ];
 
     [panel beginSheetModalForWindow:self.window completionHandler:^(NSInteger result) {
-        if (result == NSModalResponseOK) {
-            [self->_webView createWebArchiveDataWithCompletionHandler:^(NSData *archiveData, NSError *error) {
-                [archiveData writeToURL:[panel URL] options:0 error:nil];
-            }];
-        }
+        if (result != NSModalResponseOK)
+            return;
+        [self->_webView createWebArchiveDataWithCompletionHandler:^(NSData *archiveData, NSError *error) {
+            [archiveData writeToURL:[panel URL] options:0 error:nil];
+        }];
     }];
 }
 


### PR DESCRIPTION
#### f8209111eace23050256e1f89d66cc8fb5dc962b
<pre>
Add a MiniBrowser menu item to dump a WKWebView image snapshot
<a href="https://bugs.webkit.org/show_bug.cgi?id=265629">https://bugs.webkit.org/show_bug.cgi?id=265629</a>

Reviewed by Aditya Keerthi.

* Tools/MiniBrowser/mac/BrowserWindowController.h:
* Tools/MiniBrowser/mac/BrowserWindowController.m:
(-[BrowserWindowController saveAsImage:]):
* Tools/MiniBrowser/mac/MainMenu.xib:
* Tools/MiniBrowser/mac/WK1BrowserWindowController.m:
(-[WK1BrowserWindowController validateMenuItem:]):
* Tools/MiniBrowser/mac/WK2BrowserWindowController.m:
(-[WK2BrowserWindowController validateMenuItem:]):
(-[WK2BrowserWindowController saveAsPDF:]):
(-[WK2BrowserWindowController saveAsImage:]):
(-[WK2BrowserWindowController saveAsWebArchive:]):
Add a menu item for takeSnapshot like we have for createPDF and createWebArchive.

Canonical link: <a href="https://commits.webkit.org/271383@main">https://commits.webkit.org/271383@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d69a41fd8e2f4e5a400af94829fd77b9b9efe76b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28183 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6824 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29536 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30712 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25677 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28680 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8852 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4207 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/25961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28451 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5583 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24249 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4851 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4986 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25245 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31401 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25790 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25676 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31297 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4971 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3149 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29054 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6519 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6760 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5408 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5486 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->