### PR TITLE
[Wasm-GC] Fix subtyping for nullref

### DIFF
--- a/JSTests/wasm/gc/subtyping.js
+++ b/JSTests/wasm/gc/subtyping.js
@@ -1,0 +1,105 @@
+//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+
+import * as assert from "../assert.js";
+import { compile, instantiate } from "./wast-wrapper.js";
+
+function module(bytes, valid = true) {
+  let buffer = new ArrayBuffer(bytes.length);
+  let view = new Uint8Array(buffer);
+  for (let i = 0; i < bytes.length; ++i) {
+    view[i] = bytes.charCodeAt(i);
+  }
+  return new WebAssembly.Module(buffer);
+}
+
+function testNone() {
+  compile(`
+    (module
+      (type (struct))
+      (global (ref null 0) (ref.null none)))
+  `);
+
+  compile(`
+    (module
+      (type (array i32))
+      (global (ref null 0) (ref.null none)))
+  `);
+
+  compile(`
+    (module
+      (global (ref null array) (ref.null none)))
+  `);
+
+  compile(`
+    (module
+      (global (ref null struct) (ref.null none)))
+  `);
+
+  compile(`
+    (module
+      (global (ref null i31) (ref.null none)))
+  `);
+
+  compile(`
+    (module
+      (global (ref null eq) (ref.null none)))
+  `);
+
+  compile(`
+    (module
+      (global (ref null any) (ref.null none)))
+  `);
+
+  compile(`
+    (module
+      (global (ref null none) (ref.null none)))
+  `);
+
+  assert.throws(
+    () => compile(`
+      (module
+        (type (func))
+        (global (ref null 0) (ref.null none)))
+    `),
+    WebAssembly.CompileError,
+    "WebAssembly.Module doesn't parse at byte 31: Global init_expr opcode of type RefNull doesn't match global's type RefNull"
+  );
+
+  assert.throws(
+    () => compile(`
+      (module
+        (global (ref null func) (ref.null none)))
+    `),
+    WebAssembly.CompileError,
+    "WebAssembly.Module doesn't parse at byte 20: Global init_expr opcode of type RefNull doesn't match global's type RefNull"
+  );
+
+  assert.throws(
+    () => compile(`
+      (module
+        (global (ref null nofunc) (ref.null none)))
+    `),
+    WebAssembly.CompileError,
+    "WebAssembly.Module doesn't parse at byte 20: Global init_expr opcode of type RefNull doesn't match global's type RefNull"
+  );
+
+  assert.throws(
+    () => compile(`
+      (module
+        (global (ref null extern) (ref.null none)))
+    `),
+    WebAssembly.CompileError,
+    "WebAssembly.Module doesn't parse at byte 20: Global init_expr opcode of type RefNull doesn't match global's type RefNull"
+  );
+
+  assert.throws(
+    () => compile(`
+      (module
+        (global (ref null noextern) (ref.null none)))
+    `),
+    WebAssembly.CompileError,
+    "WebAssembly.Module doesn't parse at byte 20: Global init_expr opcode of type RefNull doesn't match global's type RefNull"
+  );
+}
+
+testNone();

--- a/Source/JavaScriptCore/wasm/WasmFormat.h
+++ b/Source/JavaScriptCore/wasm/WasmFormat.h
@@ -169,7 +169,7 @@ inline bool isNullexternref(Type type)
 
 inline bool isInternalref(Type type)
 {
-    if (!Options::useWebAssemblyGC() || !isRefType(type) || !typeIndexIsType(type.index))
+    if (!Options::useWebAssemblyGC() || !isRefType(type))
         return false;
     if (typeIndexIsType(type.index)) {
         switch (static_cast<TypeKind>(type.index)) {


### PR DESCRIPTION
#### eaa3fcf1d383d5c6bc58c2502b5d6fcd7e28b62f
<pre>
[Wasm-GC] Fix subtyping for nullref
<a href="https://bugs.webkit.org/show_bug.cgi?id=265628">https://bugs.webkit.org/show_bug.cgi?id=265628</a>

Reviewed by Justin Michaud.

* JSTests/wasm/gc/subtyping.js: Added.
(module):
(testNone):
* Source/JavaScriptCore/wasm/WasmFormat.h:
(JSC::Wasm::isInternalref):

Canonical link: <a href="https://commits.webkit.org/271395@main">https://commits.webkit.org/271395@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3fdac24a0e4abac66c6fa6aaab9d480620b5b000

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28184 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6825 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29537 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30713 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25678 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8853 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4208 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/25962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28452 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5584 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24254 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4849 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4987 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25250 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31402 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/24383 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25791 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25681 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31303 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/27295 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4972 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3148 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29104 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6520 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/34805 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6770 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5409 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7536 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5487 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->