### PR TITLE
REGRESSION (270354@main?): [ macOS Release x86_64 wk2 ] media/media-source/mock-managedmse-bufferedchange.html is a flaky crash

### DIFF
--- a/LayoutTests/platform/wk2/TestExpectations
+++ b/LayoutTests/platform/wk2/TestExpectations
@@ -882,5 +882,3 @@ webkit.org/b/262088 [ Debug ] imported/w3c/web-platform-tests/fetch/private-netw
 webkit.org/b/262157 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-video.html [ Pass ImageOnlyFailure Crash ]
 
 webkit.org/b/261314 [ Debug ] fast/mediastream/captureStream/canvas3d.html [ Pass Failure ]
-
-webkit.org/b/265549 media/media-source/mock-managedmse-bufferedchange.html [ Pass Crash ]

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
@@ -59,11 +59,7 @@ MediaSourcePrivate::MediaSourcePrivate(MediaSourcePrivateClient& client)
 {
 }
 
-MediaSourcePrivate::~MediaSourcePrivate()
-{
-    for (auto& sourceBuffer : m_sourceBuffers)
-        sourceBuffer->clearMediaSource();
-}
+MediaSourcePrivate::~MediaSourcePrivate() = default;
 
 RefPtr<MediaSourcePrivateClient> MediaSourcePrivate::client() const
 {

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
@@ -70,13 +70,10 @@ void SourceBufferPrivate::removedFromMediaSource()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
 
-    Ref<SourceBufferPrivate> protectedThis { *this };
-
-    // m_mediaSource may hold the last reference to ourselves.
-    if (RefPtr mediaSource = m_mediaSource.get())
+    // The SourceBufferClient holds a strong reference to SourceBufferPrivate at this stage
+    // and can be safely removed from the MediaSourcePrivate which also holds a strong reference.
+    if (RefPtr mediaSource = std::exchange(m_mediaSource, nullptr).get())
         mediaSource->removeSourceBuffer(*this);
-
-    clearMediaSource();
 }
 
 MediaTime SourceBufferPrivate::currentMediaTime() const

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.h
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.h
@@ -95,7 +95,6 @@ public:
     // Overrides must call the base class.
     virtual void resetParserState();
     virtual void removedFromMediaSource();
-    void clearMediaSource() { m_mediaSource = nullptr; }
 
     virtual MediaPlayer::ReadyState readyState() const = 0;
     virtual void setReadyState(MediaPlayer::ReadyState) = 0;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
@@ -161,6 +161,7 @@ private:
     Ref<MediaPromise> appendInternal(Ref<SharedBuffer>&&) final;
     void abort() final;
     void resetParserStateInternal() final;
+    void removedFromMediaSource() final;
     MediaPlayer::ReadyState readyState() const final;
     void setReadyState(MediaPlayer::ReadyState) final;
     void flush(const AtomString& trackID) final;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
@@ -754,6 +754,16 @@ void SourceBufferPrivateAVFObjC::clearTracks()
     m_audioTracks.clear();
 }
 
+void SourceBufferPrivateAVFObjC::removedFromMediaSource()
+{
+    ALWAYS_LOG(LOGIDENTIFIER);
+
+    destroyStreamDataParser();
+    destroyRenderers();
+
+    SourceBufferPrivate::removedFromMediaSource();
+}
+
 MediaPlayer::ReadyState SourceBufferPrivateAVFObjC::readyState() const
 {
     if (auto player = this->player())


### PR DESCRIPTION
#### 74dab6364fd5764cab0b524f0a4377967de2ddee
<pre>
REGRESSION (270354@main?): [ macOS Release x86_64 wk2 ] media/media-source/mock-managedmse-bufferedchange.html is a flaky crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=265549">https://bugs.webkit.org/show_bug.cgi?id=265549</a>
<a href="https://rdar.apple.com/118951399">rdar://118951399</a>

Reviewed by Youenn Fablet.

In 270354@main, an incorrect assumption was made that the duplicated code found in the
SourceBufferPrivateAVFObjC destructor and SourceBufferPrivateAVFObjC::removedFromMediaSource
could be removed.
However, destructing the AVSampleBufferDisplayLayer in the SourceBuffer destructor is causing
a deadlock in the AVSampleBufferDisplayLayer as its waiting for all the CoreMedia threads to
shutdown; most of those threads waiting on a sync dispatch to the main thread.
As a result, the GPU process was getting killed after a few seconds. This explained the like
of backtrace or crashlog despite the process being shown as &quot;crashed&quot;.

Fly-by:
- the SourceBufferPrivate::m_mediaSource doesn&apos;t need to be cleared from the
MediaSourcePrivate destructor. It is a weak pointer and it will be set to zero automatically.
- Correct the SourceBufferPrivate::removedFromMediaSource comment. The SourceBufferClient owns
the last reference to the SourceBufferPrivate, as such we don&apos;t need to take a strong ref. Which
would be problematic anyway should it be called from the destructor.

This code is in need of a refactoring to avoid the back and forth re-entrancy between all the related objects.

Covered by existing tests.

* LayoutTests/platform/wk2/TestExpectations:
* Source/WebCore/platform/graphics/MediaSourcePrivate.cpp:
(WebCore::MediaSourcePrivate::~MediaSourcePrivate): Deleted.
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::removedFromMediaSource):
* Source/WebCore/platform/graphics/SourceBufferPrivate.h:
(WebCore::SourceBufferPrivate::clearMediaSource): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(WebCore::SourceBufferPrivateAVFObjC::removedFromMediaSource):

Canonical link: <a href="https://commits.webkit.org/271384@main">https://commits.webkit.org/271384@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c8ec1ecfe24e296775f0bc2db892a4d632297a57

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28199 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6840 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29552 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30728 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25693 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28696 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8893 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4223 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/25970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28467 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5624 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24269 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4870 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5022 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25265 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31417 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25830 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25696 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31314 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4987 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3164 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29069 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6535 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6759 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5424 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5502 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->