### PR TITLE
[GTK] Release unused buffers when the view is hidden

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/AcceleratedSurface.h
+++ b/Source/WebKit/WebProcess/WebPage/AcceleratedSurface.h
@@ -67,6 +67,8 @@ public:
     virtual void preferredBufferFormatsDidChange() { }
 #endif
 
+    virtual void visibilityDidChange(bool) { }
+
 protected:
     AcceleratedSurface(WebPage&, Client&);
 

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -266,12 +266,14 @@ void LayerTreeHost::sizeDidChange(const IntSize& size)
 void LayerTreeHost::pauseRendering()
 {
     m_isSuspended = true;
+    m_surface->visibilityDidChange(false);
     m_compositor->suspend();
 }
 
 void LayerTreeHost::resumeRendering()
 {
     m_isSuspended = false;
+    m_surface->visibilityDidChange(true);
     m_compositor->resume();
     scheduleLayerFlush();
 }


### PR DESCRIPTION
#### 7e2c70f8fafe4a8bea17c4ba84676cf826bb6cc0
<pre>
[GTK] Release unused buffers when the view is hidden
<a href="https://bugs.webkit.org/show_bug.cgi?id=265655">https://bugs.webkit.org/show_bug.cgi?id=265655</a>

Reviewed by Alejandro G. Castro.

Set a timer to release the free buffers when the view is not visible.

* Source/WebKit/WebProcess/WebPage/AcceleratedSurface.h:
(WebKit::AcceleratedSurface::visibilityDidChange):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::pauseRendering):
(WebKit::LayerTreeHost::resumeRendering):
* Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp:
(WebKit::AcceleratedSurfaceDMABuf::AcceleratedSurfaceDMABuf):
(WebKit::AcceleratedSurfaceDMABuf::SwapChain::releaseUnusedBuffers):
(WebKit::AcceleratedSurfaceDMABuf::visibilityDidChange):
(WebKit::AcceleratedSurfaceDMABuf::releaseUnusedBuffersTimerFired):
(WebKit::AcceleratedSurfaceDMABuf::didCreateCompositingRunLoop):
(WebKit::AcceleratedSurfaceDMABuf::willDestroyCompositingRunLoop):
* Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.h:

Canonical link: <a href="https://commits.webkit.org/271379@main">https://commits.webkit.org/271379@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78688500f0ee89f9637d409f226b7ed70db13703

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28210 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6851 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29563 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30739 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25704 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8889 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4234 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/25985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28478 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5625 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24275 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4895 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5023 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31428 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25831 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25702 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31321 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4998 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3174 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29077 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6546 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5435 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3644 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5513 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->