### PR TITLE
WebGL OffscreenCanvas returns previously created WebGL1 context when asking for WebGL2

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.getcontext.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.getcontext.html
@@ -34,6 +34,13 @@ test(function() {
     var ctx3 = offscreenCanvas2.getContext('webgl');
     var ctx4 = offscreenCanvas2.getContext('2d');
     assert_equals(ctx4, null);
+    var ctx5 = offscreenCanvas2.getContext('webgl2');
+    assert_equals(ctx5, null);
+
+    var offscreenCanvas3 = new OffscreenCanvas(1, 1);
+    var ctx6 = offscreenCanvas3.getContext('webgl2');
+    var ctx7 = offscreenCanvas3.getContext('webgl');
+    assert_equals(ctx7, null);
 }, "Test that getContext twice with different context type returns null the second time");
 
 test(function() {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.getcontext.worker.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.getcontext.worker.js
@@ -32,6 +32,13 @@ test(function() {
     var ctx3 = offscreenCanvas2.getContext('webgl');
     var ctx4 = offscreenCanvas2.getContext('2d');
     assert_equals(ctx4, null);
+    var ctx5 = offscreenCanvas2.getContext('webgl2');
+    assert_equals(ctx5, null);
+
+    var offscreenCanvas3 = new OffscreenCanvas(1, 1);
+    var ctx6 = offscreenCanvas3.getContext('webgl2');
+    var ctx7 = offscreenCanvas3.getContext('webgl');
+    assert_equals(ctx7, null);
 }, "Test that getContext twice with different context type returns null the second time");
 
 test(function() {

--- a/Source/WebCore/html/OffscreenCanvas.h
+++ b/Source/WebCore/html/OffscreenCanvas.h
@@ -176,12 +176,6 @@ private:
 
     void setSize(const IntSize&) final;
 
-#if ENABLE(WEBGL)
-    void createContextWebGL(RenderingContextType, WebGLContextAttributes&& = { });
-#endif
-
-    GPUCanvasContext* createContextWebGPU(RenderingContextType, GPU*);
-
     void createImageBuffer() const final;
     std::unique_ptr<SerializedImageBuffer> takeImageBuffer() const;
 


### PR DESCRIPTION
#### 355b4e8956f0c1bd5cdbdadae91036cb366da07e
<pre>
WebGL OffscreenCanvas returns previously created WebGL1 context when asking for WebGL2
<a href="https://bugs.webkit.org/show_bug.cgi?id=265656">https://bugs.webkit.org/show_bug.cgi?id=265656</a>
<a href="https://rdar.apple.com/problem/119028794">rdar://problem/119028794</a>

Reviewed by Dan Glastonbury.

If OffscreenCanvas has &quot;webgl&quot; contextId, it should return null
for &quot;webgl2&quot; and vice versa.

Simplify all context creation casts and checks with pattern:
    if (!m_context)
       .. try create context
    if (m_context is correct type)
       return the type
    return nullopt

Remove redundant createContextWebGL createContextWebGPU functions,
they were one-line functions that did not clarify anything.

* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::OffscreenCanvas::getContext):
(WebCore::OffscreenCanvas::createContextWebGL): Deleted.
(WebCore::OffscreenCanvas::createContextWebGPU): Deleted.
* Source/WebCore/html/OffscreenCanvas.h:

Canonical link: <a href="https://commits.webkit.org/271546@main">https://commits.webkit.org/271546@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69c5f38503f3742d0b9c75daf8f4a6bac93e3abc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28541 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7185 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29928 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31069 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25993 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29039 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9334 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4554 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26188 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28811 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5970 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24554 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5189 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5344 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25554 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31783 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26170 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25996 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31581 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5280 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3446 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29352 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6883 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/25348 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6876 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5739 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5799 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->