### PR TITLE
[WPE] Unreviewed, build fix for Ubuntu LTS after 271330@main

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/drm/CMakeLists.txt
+++ b/Source/WebKit/WPEPlatform/wpe/drm/CMakeLists.txt
@@ -23,10 +23,16 @@ set(WPEPlatformDRM_PRIVATE_INCLUDE_DIRECTORIES
     "${WEBKIT_DIR}/WPEPlatform/wpe/drm"
 )
 
+set(WPEPlatformDRM_SYSTEM_INCLUDE_DIRECTORIES
+    ${GIO_UNIX_INCLUDE_DIRS}
+    ${WPEPlatform_SYSTEM_INCLUDE_DIRECTORIES}
+)
+
 set(WPEPlatformDRM_LIBRARIES
     Journald::Journald
     LibInput::LibInput
     Udev::Udev
+    ${GIO_UNIX_LIBRARIES}
 )
 
 set(WPEPlatformDRM_SOURCES_FOR_INTROSPECTION
@@ -37,7 +43,7 @@ set(WPEPlatformDRM_SOURCES_FOR_INTROSPECTION
 add_library(WPEPlatformDRM OBJECT ${WPEPlatformDRM_SOURCES})
 add_dependencies(WPEPlatformDRM WPEPlatformGeneratedEnumTypesHeader)
 target_include_directories(WPEPlatformDRM PRIVATE ${WPEPlatformDRM_PRIVATE_INCLUDE_DIRECTORIES})
-target_include_directories(WPEPlatformDRM SYSTEM PRIVATE ${WPEPlatform_SYSTEM_INCLUDE_DIRECTORIES})
+target_include_directories(WPEPlatformDRM SYSTEM PRIVATE ${WPEPlatformDRM_SYSTEM_INCLUDE_DIRECTORIES})
 target_link_libraries(WPEPlatformDRM ${WPEPlatform_LIBRARIES} ${WPEPlatformDRM_LIBRARIES})
 
 set_target_properties(WPEPlatformDRM PROPERTIES

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDRMSessionLogind.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDRMSessionLogind.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(JOURNALD_LOG)
 #include <errno.h>
+#include <glib-unix.h>
 #include <sys/stat.h>
 #include <sys/sysmacros.h>
 #include <systemd/sd-login.h>


### PR DESCRIPTION
#### a2701c1ad6e43d17cccca6f0470ca243808ac5aa
<pre>
[WPE] Unreviewed, build fix for Ubuntu LTS after 271330@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=265286">https://bugs.webkit.org/show_bug.cgi?id=265286</a>

* Source/WebKit/WPEPlatform/wpe/drm/CMakeLists.txt:
* Source/WebKit/WPEPlatform/wpe/drm/WPEDRMSessionLogind.cpp:

Canonical link: <a href="https://commits.webkit.org/271376@main">https://commits.webkit.org/271376@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3a323ea52cf85608d112757526674eaaf329129

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28211 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6852 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29564 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30740 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25705 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8890 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4235 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/25986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28479 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5619 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24276 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/4884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/5017 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31429 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25825 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25703 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/31322 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/4999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/3178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/29078 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/6547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/5436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3643 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/5514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->