### PR TITLE
Add <input type=checkbox switch> pointer tracking

### DIFF
--- a/LayoutTests/fast/forms/switch/pointer-tracking-disabled-expected.html
+++ b/LayoutTests/fast/forms/switch/pointer-tracking-disabled-expected.html
@@ -1,0 +1,3 @@
+<!doctype html>
+<html>
+<input type=checkbox switch disabled>

--- a/LayoutTests/fast/forms/switch/pointer-tracking-disabled.html
+++ b/LayoutTests/fast/forms/switch/pointer-tracking-disabled.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html class="reftest-wait">
+<input type=checkbox switch disabled onclick=falseEnd()>
+<script>
+window.onload = () => {
+    window.eventSender.mouseMoveTo(10, 10);
+    window.eventSender.mouseDown();
+    window.eventSender.mouseMoveTo(50, 10);
+    window.eventSender.mouseUp();
+    setTimeout(() => document.documentElement.removeAttribute("class"), 50);
+}
+function falseEnd() {
+    document.body.innerHTML = "This test failed.";
+}
+</script>

--- a/LayoutTests/fast/forms/switch/pointer-tracking-expected-mismatch.html
+++ b/LayoutTests/fast/forms/switch/pointer-tracking-expected-mismatch.html
@@ -1,0 +1,3 @@
+<!doctype html>
+<html>
+<input type=checkbox switch>

--- a/LayoutTests/fast/forms/switch/pointer-tracking-there-and-back-again-expected.html
+++ b/LayoutTests/fast/forms/switch/pointer-tracking-there-and-back-again-expected.html
@@ -1,0 +1,3 @@
+<!doctype html>
+<html>
+<input type=checkbox switch>

--- a/LayoutTests/fast/forms/switch/pointer-tracking-there-and-back-again-rtl-expected.html
+++ b/LayoutTests/fast/forms/switch/pointer-tracking-there-and-back-again-rtl-expected.html
@@ -1,0 +1,3 @@
+<!doctype html>
+<html>
+<input type=checkbox switch dir=rtl>

--- a/LayoutTests/fast/forms/switch/pointer-tracking-there-and-back-again-rtl.html
+++ b/LayoutTests/fast/forms/switch/pointer-tracking-there-and-back-again-rtl.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html class="reftest-wait">
+<input type=checkbox switch onclick=end() dir=rtl>
+<script>
+window.onload = () => {
+    const input = document.querySelector("input");
+    window.eventSender.mouseMoveTo(input.offsetLeft + input.offsetWidth - 1, input.offsetTop);
+    window.eventSender.mouseDown();
+    window.eventSender.mouseMoveTo(input.offsetLeft, input.offsetTop);
+    window.eventSender.mouseMoveTo(input.offsetLeft + input.offsetWidth - 1, input.offsetTop);
+    window.eventSender.mouseUp();
+}
+function end() {
+    setTimeout(() => document.documentElement.removeAttribute("class"), 50);
+}
+</script>

--- a/LayoutTests/fast/forms/switch/pointer-tracking-there-and-back-again.html
+++ b/LayoutTests/fast/forms/switch/pointer-tracking-there-and-back-again.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html class="reftest-wait">
+<input type=checkbox switch onclick=end()>
+<script>
+window.onload = () => {
+    const input = document.querySelector("input");
+    window.eventSender.mouseMoveTo(input.offsetLeft, input.offsetTop);
+    window.eventSender.mouseDown();
+    window.eventSender.mouseMoveTo(input.offsetLeft + input.offsetWidth, input.offsetTop);
+    window.eventSender.mouseMoveTo(input.offsetLeft, input.offsetTop);
+    window.eventSender.mouseUp();
+}
+function end() {
+    setTimeout(() => document.documentElement.removeAttribute("class"), 50);
+}
+</script>

--- a/LayoutTests/fast/forms/switch/pointer-tracking.html
+++ b/LayoutTests/fast/forms/switch/pointer-tracking.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html class="reftest-wait">
+<input type=checkbox switch onclick=end()>
+<script>
+window.onload = () => {
+    window.eventSender.mouseMoveTo(10, 10);
+    window.eventSender.mouseDown();
+    window.eventSender.mouseMoveTo(50, 10);
+    window.eventSender.mouseUp();
+}
+function end() {
+    setTimeout(() => document.documentElement.removeAttribute("class"), 50);
+}
+</script>

--- a/Source/WebCore/html/CheckboxInputType.h
+++ b/Source/WebCore/html/CheckboxInputType.h
@@ -44,8 +44,8 @@ public:
     }
 
     bool valueMissing(const String&) const final;
-    void performSwitchCheckedChangeAnimation(WasSetByJavaScript);
     float switchCheckedChangeAnimationProgress() const;
+    bool isSwitchVisuallyOn() const;
 
 private:
     explicit CheckboxInputType(HTMLInputElement& element)
@@ -57,13 +57,25 @@ private:
     String valueMissingText() const final;
     void createShadowSubtree() final;
     void handleKeyupEvent(KeyboardEvent&) final;
+    void handleMouseDownEvent(MouseEvent&) final;
+    void handleMouseMoveEvent(MouseEvent&) final;
+    void startSwitchPointerTracking(int);
+    void stopSwitchPointerTracking();
+    bool isSwitchPointerTracking() const;
     void willDispatchClick(InputElementClickState&) final;
     void didDispatchClick(Event&, const InputElementClickState&) final;
     bool matchesIndeterminatePseudoClass() const final;
+    void willUpdateCheckedness(bool /* nowChecked */, WasSetByJavaScript);
     void disabledStateChanged() final;
+    void performSwitchCheckedChangeAnimation();
     void stopSwitchCheckedChangeAnimation();
     void switchCheckedChangeAnimationTimerFired();
 
+    // FIXME: Consider moving all switch-related state (and methods?) to their own object so
+    // CheckboxInputType can stay somewhat small.
+    std::optional<int> m_switchPointerTrackingXPositionStart { std::nullopt };
+    bool m_hasSwitchVisuallyOnChanged { false };
+    bool m_isSwitchVisuallyOn { false };
     Seconds m_switchCheckedChangeAnimationStartTime { 0_s };
     std::unique_ptr<Timer> m_switchCheckedChangeAnimationTimer;
 };

--- a/Source/WebCore/html/HTMLInputElement.h
+++ b/Source/WebCore/html/HTMLInputElement.h
@@ -341,6 +341,7 @@ public:
     bool hasEverBeenPasswordField() const { return m_hasEverBeenPasswordField; }
 
     float switchCheckedChangeAnimationProgress() const;
+    bool isSwitchVisuallyOn() const;
 
 protected:
     HTMLInputElement(const QualifiedName&, Document&, HTMLFormElement*, bool createdByParser);

--- a/Source/WebCore/html/InputType.cpp
+++ b/Source/WebCore/html/InputType.cpp
@@ -600,18 +600,6 @@ String InputType::validationMessage() const
     return emptyString();
 }
 
-void InputType::handleClickEvent(MouseEvent&)
-{
-}
-
-void InputType::handleMouseDownEvent(MouseEvent&)
-{
-}
-
-void InputType::handleDOMActivateEvent(Event&)
-{
-}
-
 bool InputType::allowsShowPickerAcrossFrames()
 {
     return false;
@@ -844,14 +832,6 @@ void InputType::setValue(const String& sanitizedValue, bool valueChanged, TextFi
 
     if (auto* cache = element()->document().existingAXObjectCache())
         cache->valueChanged(element());
-}
-
-void InputType::willDispatchClick(InputElementClickState&)
-{
-}
-
-void InputType::didDispatchClick(Event&, const InputElementClickState&)
-{
 }
 
 String InputType::localizeValue(const String& proposedValue) const

--- a/Source/WebCore/html/InputType.h
+++ b/Source/WebCore/html/InputType.h
@@ -270,11 +270,12 @@ public:
 
     // Event handlers.
 
-    virtual void handleClickEvent(MouseEvent&);
-    virtual void handleMouseDownEvent(MouseEvent&);
-    virtual void willDispatchClick(InputElementClickState&);
-    virtual void didDispatchClick(Event&, const InputElementClickState&);
-    virtual void handleDOMActivateEvent(Event&);
+    virtual void handleClickEvent(MouseEvent&) { }
+    virtual void handleMouseDownEvent(MouseEvent&) { }
+    virtual void handleMouseMoveEvent(MouseEvent&) { }
+    virtual void willDispatchClick(InputElementClickState&) { }
+    virtual void didDispatchClick(Event&, const InputElementClickState&) { }
+    virtual void handleDOMActivateEvent(Event&) { }
 
     virtual bool allowsShowPickerAcrossFrames();
     virtual void showPicker();
@@ -365,7 +366,7 @@ public:
 #if ENABLE(DATALIST_ELEMENT)
     virtual bool isFocusingWithDataListDropdown() const { return false; };
 #endif
-    virtual void willUpdateCheckedness(bool /*nowChecked*/) { }
+    virtual void willUpdateCheckedness(bool /*nowChecked*/, WasSetByJavaScript) { }
 
     // Parses the specified string for the type, and return
     // the Decimal value for the parsing result if the parsing

--- a/Source/WebCore/html/RadioInputType.cpp
+++ b/Source/WebCore/html/RadioInputType.cpp
@@ -92,7 +92,7 @@ void RadioInputType::forEachButtonInDetachedGroup(ContainerNode& rootNode, const
     }
 }
 
-void RadioInputType::willUpdateCheckedness(bool nowChecked)
+void RadioInputType::willUpdateCheckedness(bool nowChecked, WasSetByJavaScript)
 {
     if (!nowChecked)
         return;

--- a/Source/WebCore/html/RadioInputType.h
+++ b/Source/WebCore/html/RadioInputType.h
@@ -35,6 +35,8 @@
 
 namespace WebCore {
 
+enum class WasSetByJavaScript : bool;
+
 class RadioInputType final : public BaseCheckableInputType {
 public:
     static Ref<RadioInputType> create(HTMLInputElement& element)
@@ -62,7 +64,7 @@ private:
     void willDispatchClick(InputElementClickState&) final;
     void didDispatchClick(Event&, const InputElementClickState&) final;
     bool matchesIndeterminatePseudoClass() const final;
-    void willUpdateCheckedness(bool nowChecked) final;
+    void willUpdateCheckedness(bool /* nowChecked */, WasSetByJavaScript) final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/RangeInputType.cpp
+++ b/Source/WebCore/html/RangeInputType.cpp
@@ -126,6 +126,7 @@ StepRange RangeInputType::createStepRange(AnyStepHandling anyStepHandling) const
     return StepRange(minimum, RangeLimitations::Valid, minimum, maximum, step, rangeStepDescription);
 }
 
+// FIXME: Should this work for untrusted input?
 void RangeInputType::handleMouseDownEvent(MouseEvent& event)
 {
     ASSERT(element());
@@ -134,9 +135,6 @@ void RangeInputType::handleMouseDownEvent(MouseEvent& event)
         return;
 
     if (element()->isDisabledFormControl())
-        return;
-
-    if (event.button() != MouseButton::Left)
         return;
 
     auto* targetNode = dynamicDowncast<Node>(event.target());

--- a/Source/WebCore/platform/graphics/controls/SwitchThumbPart.h
+++ b/Source/WebCore/platform/graphics/controls/SwitchThumbPart.h
@@ -33,19 +33,23 @@ class SwitchThumbPart final : public ControlPart {
 public:
     static Ref<SwitchThumbPart> create()
     {
-        return adoptRef(*new SwitchThumbPart(0.0f));
+        return adoptRef(*new SwitchThumbPart(false, 0.0f));
     }
 
-    static Ref<SwitchThumbPart> create(float progress)
+    static Ref<SwitchThumbPart> create(bool isOn, float progress)
     {
-        return adoptRef(*new SwitchThumbPart(progress));
+        return adoptRef(*new SwitchThumbPart(isOn, progress));
     }
 
-    SwitchThumbPart(float progress)
+    SwitchThumbPart(bool isOn, float progress)
         : ControlPart(StyleAppearance::SwitchThumb)
+        , m_isOn(isOn)
         , m_progress(progress)
     {
     }
+
+    bool isOn() const { return m_isOn; }
+    void setIsOn(bool isOn) { m_isOn = isOn; }
 
     float progress() const { return m_progress; }
     void setProgress(float progress) { m_progress = progress; }
@@ -61,6 +65,7 @@ private:
         return controlFactory().createPlatformSwitchThumb(*this);
     }
 
+    bool m_isOn;
     float m_progress;
 };
 

--- a/Source/WebCore/platform/graphics/controls/SwitchTrackPart.h
+++ b/Source/WebCore/platform/graphics/controls/SwitchTrackPart.h
@@ -33,19 +33,23 @@ class SwitchTrackPart final : public ControlPart {
 public:
     static Ref<SwitchTrackPart> create()
     {
-        return adoptRef(*new SwitchTrackPart(0.0f));
+        return adoptRef(*new SwitchTrackPart(false, 0.0f));
     }
 
-    static Ref<SwitchTrackPart> create(float progress)
+    static Ref<SwitchTrackPart> create(bool isOn, float progress)
     {
-        return adoptRef(*new SwitchTrackPart(progress));
+        return adoptRef(*new SwitchTrackPart(isOn, progress));
     }
 
-    SwitchTrackPart(float progress)
+    SwitchTrackPart(bool isOn, float progress)
         : ControlPart(StyleAppearance::SwitchTrack)
+        , m_isOn(isOn)
         , m_progress(progress)
     {
     }
+
+    bool isOn() const { return m_isOn; }
+    void setIsOn(bool isOn) { m_isOn = isOn; }
 
     float progress() const { return m_progress; }
     void setProgress(float progress) { m_progress = progress; }
@@ -61,6 +65,7 @@ private:
         return controlFactory().createPlatformSwitchTrack(*this);
     }
 
+    bool m_isOn;
     float m_progress;
 };
 

--- a/Source/WebCore/platform/graphics/mac/controls/SwitchThumbMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SwitchThumbMac.mm
@@ -58,7 +58,7 @@ void SwitchThumbMac::draw(GraphicsContext& context, const FloatRoundedRect& bord
 {
     LocalDefaultSystemAppearance localAppearance(style.states.contains(ControlStyle::State::DarkAppearance), style.accentColor);
 
-    bool isOn = style.states.contains(ControlStyle::State::Checked);
+    bool isOn = owningPart().isOn();
     bool isRTL = style.states.contains(ControlStyle::State::RightToLeft);
     bool isEnabled = style.states.contains(ControlStyle::State::Enabled);
     bool isPressed = style.states.contains(ControlStyle::State::Pressed);

--- a/Source/WebCore/platform/graphics/mac/controls/SwitchTrackMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SwitchTrackMac.mm
@@ -135,7 +135,7 @@ static RefPtr<ImageBuffer> trackImage(GraphicsContext& context, RefPtr<ImageBuff
 
 void SwitchTrackMac::draw(GraphicsContext& context, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle& style)
 {
-    auto isOn = style.states.contains(ControlStyle::State::Checked);
+    auto isOn = owningPart().isOn();
     auto isRTL = style.states.contains(ControlStyle::State::RightToLeft);
     auto isEnabled = style.states.contains(ControlStyle::State::Enabled);
     auto isPressed = style.states.contains(ControlStyle::State::Pressed);

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -600,6 +600,7 @@ static void updateSwitchThumbPartForRenderer(SwitchThumbPart& switchThumbPart, c
     auto& input = checkedDowncast<HTMLInputElement>(*renderer.node()->shadowHost());
     ASSERT(input.isSwitch());
 
+    switchThumbPart.setIsOn(input.isSwitchVisuallyOn());
     switchThumbPart.setProgress(input.switchCheckedChangeAnimationProgress());
 }
 
@@ -608,6 +609,7 @@ static void updateSwitchTrackPartForRenderer(SwitchTrackPart& switchTrackPart, c
     auto& input = checkedDowncast<HTMLInputElement>(*renderer.node()->shadowHost());
     ASSERT(input.isSwitch());
 
+    switchTrackPart.setIsOn(input.isSwitchVisuallyOn());
     switchTrackPart.setProgress(input.switchCheckedChangeAnimationProgress());
 }
 
@@ -1310,13 +1312,8 @@ bool RenderTheme::isWindowActive(const RenderObject& renderer) const
 
 bool RenderTheme::isChecked(const RenderObject& renderer) const
 {
-    if (!renderer.node())
-        return false;
-    if (RefPtr element = dynamicDowncast<HTMLInputElement>(*renderer.node()))
-        return element->matchesCheckedPseudoClass();
-    if (RefPtr host = dynamicDowncast<HTMLInputElement>(renderer.node()->shadowHost()))
-        return host->matchesCheckedPseudoClass();
-    return false;
+    RefPtr element = dynamicDowncast<HTMLInputElement>(renderer.node());
+    return element && element->matchesCheckedPseudoClass();
 }
 
 bool RenderTheme::isIndeterminate(const RenderObject& renderer) const

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -264,6 +264,7 @@ public:
     virtual void paintSystemPreviewBadge(Image&, const PaintInfo&, const FloatRect&);
 #endif
     virtual Seconds switchCheckedChangeAnimationDuration() const { return 0_s; }
+    float switchPointerTrackingMagnitudeProportion() const { return 0.4f; }
 
 protected:
     virtual bool canPaint(const PaintInfo&, const Settings&, StyleAppearance) const { return true; }

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3267,10 +3267,12 @@ enum class WebCore::ApplePayButtonStyle : uint8_t {
 }
 
 [RefCounted, AdditionalEncoder=StreamConnectionEncoder] class WebCore::SwitchThumbPart {
+    bool isOn();
     [Validator='progress >= 0.0f && progress <= 1.0f'] float progress();
 };
 
 [RefCounted, AdditionalEncoder=StreamConnectionEncoder] class WebCore::SwitchTrackPart {
+    bool isOn();
     [Validator='progress >= 0.0f && progress <= 1.0f'] float progress();
 };
 


### PR DESCRIPTION
#### 870a0515b649fa5462225fbf33a150e41f1827b5
<pre>
Add &lt;input type=checkbox switch&gt; pointer tracking
<a href="https://bugs.webkit.org/show_bug.cgi?id=265658">https://bugs.webkit.org/show_bug.cgi?id=265658</a>

Reviewed by Aditya Keerthi.

This change enables the switch&apos;s thumb to be &quot;dragged&quot; left and right.

This requires the introduction of a visual on/off state as actual state
changes, i.e., to checkedness, are only made after the tracking stops.
As such we simplify RenderTheme::isChecked() back to how it was before
we started adding &lt;input type=checkbox switch&gt; as switches don&apos;t need
it.

Despite what 271327@main claimed this change makes CheckboxInputType
solely responsible for performSwitchCheckedChangeAnimation(). This
works by passing along the event&apos;s isTrusted() bit to
willUpdateCheckedness() and instead stopping the animation from there.

A future change might have to abstract some of the logic in
CheckboxInputType::handleMouseMoveEvent() somewhat as more platforms
become supported.

A difference with macOS switches is that these remain active/pressed
and responsive to mouseup events while tracking is ongoing. This
difference with is also there for checkboxes and radio buttons.

* LayoutTests/fast/forms/switch/pointer-tracking-disabled-expected.html: Added.
* LayoutTests/fast/forms/switch/pointer-tracking-disabled.html: Added.
* LayoutTests/fast/forms/switch/pointer-tracking-expected-mismatch.html: Added.
* LayoutTests/fast/forms/switch/pointer-tracking-there-and-back-again-expected.html: Added.
* LayoutTests/fast/forms/switch/pointer-tracking-there-and-back-again-rtl-expected.html: Added.
* LayoutTests/fast/forms/switch/pointer-tracking-there-and-back-again-rtl.html: Added.
* LayoutTests/fast/forms/switch/pointer-tracking-there-and-back-again.html: Added.
* LayoutTests/fast/forms/switch/pointer-tracking.html: Added.
* Source/WebCore/html/CheckboxInputType.cpp:
(WebCore::CheckboxInputType::handleMouseDownEvent):
(WebCore::CheckboxInputType::handleMouseMoveEvent):
(WebCore::CheckboxInputType::willDispatchClick):
(WebCore::CheckboxInputType::startSwitchPointerTracking):
(WebCore::CheckboxInputType::stopSwitchPointerTracking):
(WebCore::CheckboxInputType::isSwitchPointerTracking const):
(WebCore::CheckboxInputType::disabledStateChanged):
(WebCore::CheckboxInputType::willUpdateCheckedness):
(WebCore::CheckboxInputType::performSwitchCheckedChangeAnimation):
(WebCore::CheckboxInputType::isSwitchVisuallyOn const):
* Source/WebCore/html/CheckboxInputType.h:
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::setChecked):
(WebCore::HTMLInputElement::defaultEventHandler):
(WebCore::HTMLInputElement::switchCheckedChangeAnimationProgress const):
(WebCore::HTMLInputElement::isSwitchVisuallyOn const):
* Source/WebCore/html/HTMLInputElement.h:
* Source/WebCore/html/InputType.cpp:
(WebCore::InputType::handleClickEvent): Deleted.
(WebCore::InputType::handleMouseDownEvent): Deleted.
(WebCore::InputType::handleDOMActivateEvent): Deleted.
(WebCore::InputType::willDispatchClick): Deleted.
(WebCore::InputType::didDispatchClick): Deleted.
* Source/WebCore/html/InputType.h:
(WebCore::InputType::handleClickEvent):
(WebCore::InputType::handleMouseDownEvent):
(WebCore::InputType::handleMouseMoveEvent):
(WebCore::InputType::willDispatchClick):
(WebCore::InputType::didDispatchClick):
(WebCore::InputType::handleDOMActivateEvent):
(WebCore::InputType::willUpdateCheckedness):
* Source/WebCore/html/RadioInputType.cpp:
(WebCore::RadioInputType::willUpdateCheckedness):
* Source/WebCore/html/RadioInputType.h:
* Source/WebCore/html/RangeInputType.cpp:
(WebCore::RangeInputType::handleMouseDownEvent):
* Source/WebCore/platform/graphics/controls/SwitchThumbPart.h:
* Source/WebCore/platform/graphics/controls/SwitchTrackPart.h:
* Source/WebCore/platform/graphics/mac/controls/SwitchThumbMac.mm:
(WebCore::SwitchThumbMac::draw):
* Source/WebCore/platform/graphics/mac/controls/SwitchTrackMac.mm:
(WebCore::SwitchTrackMac::draw):
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::updateSwitchThumbPartForRenderer):
(WebCore::updateSwitchTrackPartForRenderer):
(WebCore::RenderTheme::isChecked const):
* Source/WebCore/rendering/RenderTheme.h:
(WebCore::RenderTheme::switchPointerTrackingMagnitudeProportion const):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/271542@main">https://commits.webkit.org/271542@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a7701869a18be8f8501336b51a57f7c6af8ed24

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28721 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7364 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30092 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31340 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/26205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29291 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9487 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4724 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28991 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6092 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24686 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5291 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/5446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25690 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/32678 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26290 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26133 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31683 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5411 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/3583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/29459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7029 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/25484 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6871 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5879 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5929 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->