### PR TITLE
Cleanup node tree side of :checked and :indeterminate

### DIFF
--- a/LayoutTests/imported/w3c/resources/resource-files.json
+++ b/LayoutTests/imported/w3c/resources/resource-files.json
@@ -7052,6 +7052,7 @@
         "web-platform-tests/html/semantics/scripting-1/the-script-element/support/script-onload-insertion-point-helper.html",
         "web-platform-tests/html/semantics/scripting-1/the-template-element/additions-to-the-css-user-agent-style-sheet/css-user-agent-style-sheet-test-001-ref.html",
         "web-platform-tests/html/semantics/selectors/pseudo-classes/focus-iframe.html",
+        "web-platform-tests/html/semantics/selectors/pseudo-classes/indeterminate-radio-group-ref.html",
         "web-platform-tests/html/semantics/text-level-semantics/the-b-element/b-usage-notref.html",
         "web-platform-tests/html/semantics/text-level-semantics/the-bdi-element/bdi-auto-dir-default-ref.html",
         "web-platform-tests/html/semantics/text-level-semantics/the-bdi-element/bdi-neutral-missing-pdf-ref.html",

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/checked-indeterminate.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/checked-indeterminate.window-expected.txt
@@ -1,0 +1,3 @@
+
+PASS An element can be :checked and :indeterminate at the same time
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/checked-indeterminate.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/checked-indeterminate.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/checked-indeterminate.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/checked-indeterminate.window.js
@@ -1,0 +1,27 @@
+test(() => {
+  const input = document.createElement("input");
+  input.type = "checkbox";
+
+  assert_false(input.matches(":checked:indeterminate"));
+  assert_false(input.matches(":checked"));
+  assert_false(input.matches(":indeterminate"));
+
+  input.checked = true;
+  input.indeterminate = true;
+
+  assert_true(input.matches(":checked:indeterminate"));
+  assert_true(input.matches(":checked"));
+  assert_true(input.matches(":indeterminate"));
+
+  input.indeterminate = false;
+
+  assert_false(input.matches(":checked:indeterminate"));
+  assert_true(input.matches(":checked"));
+  assert_false(input.matches(":indeterminate"));
+
+  input.checked = false;
+
+  assert_false(input.matches(":checked:indeterminate"));
+  assert_false(input.matches(":checked"));
+  assert_false(input.matches(":indeterminate"));
+}, "An element can be :checked and :indeterminate at the same time");

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/dir-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/dir-dynamic-expected.txt
@@ -1,0 +1,9 @@
+
+א;
+א;
+
+PASS Dynamically changing dir, text on input element
+PASS Dynamically changing dir, text on textarea element
+PASS Dynamically changing dir, text on div element
+PASS Dynamically changing dir, text on pre element
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/dir-dynamic.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/dir-dynamic.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <link rel="author" title="Vincent Hilla" href="mailto:vhilla@mozilla.com">
+  <link rel="help" href="https://html.spec.whatwg.org/#the-directionality">
+</head>
+<body>
+  <input id="inp"/>
+  <textarea id="ta"></textarea>
+  <div id="div"></div>
+  <pre id="pre"></pre>
+
+  <script>
+    function doTest(e) {
+      e.dir = "ltr";
+      assert_true(e.matches(":dir(ltr)"), "dir to ltr on " + e.tagName + " element");
+
+      e.dir = "rtl";
+      assert_true(e.matches(":dir(rtl)"), "dir to rtl on " + e.tagName + " element");
+
+      e.dir = "auto";
+      assert_true(e.matches(":dir(ltr)"), "dir to auto, empty text on " + e.tagName + " element");
+
+      e.value = "\u05D0;";
+      e.textContent = "\u05D0;";
+      assert_true(e.matches(":dir(rtl)"), "auto dir, text to Hebrew on " + e.tagName + " element");
+
+      e.dir = "ltr";
+      assert_true(e.matches(":dir(ltr)"), "dir to ltr, Hebrew text on " + e.tagName + " element");
+
+      e.dir = "auto";
+      assert_true(e.matches(":dir(rtl)"), "dir to auto, Hebrew text on " + e.tagName + " element");
+
+      e.removeAttribute("dir");
+      assert_true(e.matches(":dir(ltr)"), "dir removed, Hebrew text on " + e.tagName + " element");
+    }
+
+    const elements = [inp, ta, div, pre];
+    for (const e of elements) {
+      test(() => doTest(e), "Dynamically changing dir, text on " + e.tagName.toLowerCase() + " element");
+    }
+  </script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/dir-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/dir-expected.txt
@@ -3,3 +3,5 @@ PASS ':dir(rtl)' matches all elements whose directionality is 'rtl'.
 PASS ':dir(ltr)' matches all elements whose directionality is 'ltr'.
 PASS ':dir(ltr)' doesn't match elements not in the document.
 WERBEH HEBREW HEBREW WERBEH HEBREW إيان WERBEH WERBEH HEBREW ‮WERBEH‬      HEBREW إيان עברית
+إيان
+HEBREWإيان

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/dir.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/dir.html
@@ -35,8 +35,15 @@
     <bdo dir="auto" id=bdo3>HEBREW</bdo>
     <bdo dir="auto" id=bdo4>إيان</bdo>
     <bdo dir="ltr" id=bdo5>עברית</bdo>
+    <textarea dir="auto" id="ta1">إيان</textarea>
+    <textarea dir="auto" id="ta2">HEBREWإيان</textarea>
+    <textarea dir="auto" id="ta3">إيان</textarea>
+    <pre dir="auto" id="pre1">إيان</pre>
+    <pre dir="auto" id="pre2">HEBREWإيان</pre>
 
     <script id=script4>
+      ta3.value = "HEBREW";
+
       const rtlElements = [
         "bdo1",
         "bdi2",
@@ -46,6 +53,8 @@
         "span7",
         "input-tel3",
         "bdo4",
+        "ta1",
+        "pre1",
       ];
 
       testSelectorIdsMatch(":dir(rtl)", rtlElements, "':dir(rtl)' matches all elements whose directionality is 'rtl'.");
@@ -74,6 +83,9 @@
         "input-tel2",
         "bdo3",
         "bdo5",
+        "ta2",
+        "ta3",
+        "pre2",
         "script4",
       ];
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/disabled-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/disabled-expected.txt
@@ -5,9 +5,11 @@ PASS ':disabled' should also match elements whose disabled attribute has been se
 PASS ':disabled' should also match elements whose disabled attribute has been set twice
 PASS ':disabled' should also match disabled elements whose type has changed
 PASS ':disabled' should not match elements not in the document
+PASS ':disabled' should match elements that are appended to a disabled fieldset dynamically
 button1 button2
 Name on card:
 
 Card number:
 
+  button nested
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/disabled.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/disabled.html
@@ -57,4 +57,24 @@
   var input = document.createElement("input");
   input.setAttribute("disabled", "disabled");
   testSelectorIdsMatch(":disabled", ["button1", "input2", "select2", "optgroup2", "option2", "textarea2", "fieldset2", "clubname", "clubnum"], "':disabled' should not match elements not in the document");
+
+  var fieldset = document.createElement("fieldset");
+  fieldset.id = "fieldset_nested";
+  fieldset.innerHTML = `
+    <input id=input_nested>
+    <button id=button_nested>button nested</button>
+    <select id=select_nested>
+      <optgroup label="options" id=optgroup_nested>
+        <option value="options" id=option_nested>option nested</option>
+      </optgroup>
+    </select>
+    <textarea id=textarea_nested>textarea nested</textarea>
+    <object id=object_nested></object>
+    <output id=output_nested></output>
+    <fieldset id=fieldset_nested2>
+      <input id=input_nested2>
+    </fieldset>
+  `;
+  document.getElementById("fieldset2").appendChild(fieldset);
+  testSelectorIdsMatch("#fieldset2 :disabled", ["clubname", "clubnum", "fieldset_nested", "input_nested", "button_nested", "select_nested", "textarea_nested", "fieldset_nested2", "input_nested2"], "':disabled' should match elements that are appended to a disabled fieldset dynamically");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/indeterminate-radio-group-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/indeterminate-radio-group-expected.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Test reference</title>
+<style>
+label[for="two"] {
+  background: green;
+}
+</style>
+<form>
+  <input type="radio" name="a" id="one" value="1">
+  <label for="one">One</label>
+
+  <input type="radio" name="a" id="two" value="2" checked>
+  <label for="two">Two</label>
+
+  <input type="radio" name="a" id="three" value="3">
+  <label for="three">Three</label>
+
+  <input type="radio" name="a" id="four" value="4">
+  <label for="four">Four</label>
+</form>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/indeterminate-radio-group-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/indeterminate-radio-group-ref.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Test reference</title>
+<style>
+label[for="two"] {
+  background: green;
+}
+</style>
+<form>
+  <input type="radio" name="a" id="one" value="1">
+  <label for="one">One</label>
+
+  <input type="radio" name="a" id="two" value="2" checked>
+  <label for="two">Two</label>
+
+  <input type="radio" name="a" id="three" value="3">
+  <label for="three">Three</label>
+
+  <input type="radio" name="a" id="four" value="4">
+  <label for="four">Four</label>
+</form>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/indeterminate-radio-group.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/indeterminate-radio-group.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>:indeterminate and input type=radio</title>
+<link rel="author" href="mailto:emilio@crisal.io" title="Emilio Cobos Álvarez">
+<link rel="author" href="https://mozilla.org" title="Mozilla">
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1861346">
+<link rel="match" href="indeterminate-radio-group-ref.html">
+<style>
+input:checked + label {
+  background: green;
+}
+input:indeterminate + label {
+  background: red;
+}
+</style>
+<form>
+  <input type="radio" name="a" id="one" value="1">
+  <label for="one">One</label>
+
+  <input type="radio" name="a" id="two" value="2" checked>
+  <label for="two">Two</label>
+
+  <input type="radio" name="a" id="three" value="3">
+  <label for="three">Three</label>
+
+  <input type="radio" name="a" id="four" value="4">
+  <label for="four">Four</label>
+</form>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/readwrite-readonly.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/readwrite-readonly.html
@@ -44,6 +44,20 @@
 <p id=p2 contenteditable>paragraph2.</p>
 </div>
 
+<div id=set5>
+  <div id=cd1 contenteditable>
+    <p id=p3></p>
+    <input id=ci1 readonly>
+    <input id=ci2 disabled>
+    <input id=ci3>
+    <input id=ci4>
+    <textarea id=ct1 readonly></textarea>
+    <textarea id=ct2 disabled></textarea>
+    <textarea id=ct3></textarea>
+    <textarea id=ct4></textarea>
+  </div>
+</div>
+
 <script>
   testSelectorIdsMatch("#set0 :read-write", [], "The :read-write pseudo-class must not match input elements to which the readonly attribute does not apply");
 
@@ -96,5 +110,9 @@
   testSelectorIdsMatch("#set4 :read-write", ["p1", "p2"], "The :read-write pseudo-class must match elements that are editing hosts");
 
   testSelectorIdsMatch("#set4 :read-only", [], "The :read-only pseudo-class must not match elements that are editing hosts");
+
+  document.designMode = "off";
+
+  testSelectorIdsMatch("#set5 :read-write", ["cd1", "p3", "ci3", "ci4", "ct3", "ct4"], "The :read-write pseudo-class must match elements that are inside editing hosts, but not match inputs and textareas inside that aren't");
 
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/w3c-import.log
@@ -16,9 +16,11 @@ None
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/active-disabled.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/autofill.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/checked-indeterminate.window.js
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/checked-type-change.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/checked.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/default.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/dir-dynamic.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/dir-html-input-dynamic-text.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/dir.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/dir01.html
@@ -27,9 +29,13 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/focus-autofocus.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/focus-iframe.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/focus.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/indeterminate-radio-group-expected.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/indeterminate-radio-group-ref.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/indeterminate-radio-group.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/indeterminate-radio.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/indeterminate-type-change.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/indeterminate.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/input-checkbox-switch.tentative.window.js
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/inrange-outofrange-type-change.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/inrange-outofrange.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/invalid-after-clone.html
@@ -40,4 +46,5 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/required-optional-hidden.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/required-optional.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/utils.js
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/valid-invalid-fieldset-disconnected.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/valid-invalid.html

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/readwrite-readonly-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/readwrite-readonly-expected.txt
@@ -21,6 +21,7 @@ PASS The :read-write pseudo-class must match elements that are editable
 PASS The :read-only pseudo-class must not match elements that are editable
 PASS The :read-write pseudo-class must match elements that are editing hosts
 PASS The :read-only pseudo-class must not match elements that are editing hosts
+PASS The :read-write pseudo-class must match elements that are inside editing hosts, but not match inputs and textareas inside that aren't
 
 
 
@@ -28,3 +29,5 @@ PASS The :read-only pseudo-class must not match elements that are editing hosts
 paragraph1.
 
 paragraph2.
+
+

--- a/LayoutTests/platform/mac-wk2/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/readwrite-readonly-expected.txt
+++ b/LayoutTests/platform/mac-wk2/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/readwrite-readonly-expected.txt
@@ -21,6 +21,7 @@ PASS The :read-write pseudo-class must match elements that are editable
 PASS The :read-only pseudo-class must not match elements that are editable
 PASS The :read-write pseudo-class must match elements that are editing hosts
 PASS The :read-only pseudo-class must not match elements that are editing hosts
+PASS The :read-write pseudo-class must match elements that are inside editing hosts, but not match inputs and textareas inside that aren't
 
 
 
@@ -28,3 +29,5 @@ PASS The :read-only pseudo-class must not match elements that are editing hosts
 paragraph1.
 
 paragraph2.
+
+

--- a/LayoutTests/platform/mac/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/readwrite-readonly-expected.txt
+++ b/LayoutTests/platform/mac/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/readwrite-readonly-expected.txt
@@ -21,6 +21,7 @@ PASS The :read-write pseudo-class must match elements that are editable
 PASS The :read-only pseudo-class must not match elements that are editable
 PASS The :read-write pseudo-class must match elements that are editing hosts
 PASS The :read-only pseudo-class must not match elements that are editing hosts
+PASS The :read-write pseudo-class must match elements that are inside editing hosts, but not match inputs and textareas inside that aren't
 
 
 
@@ -28,3 +29,5 @@ PASS The :read-only pseudo-class must not match elements that are editing hosts
 paragraph1.
 
 paragraph2.
+
+

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/readwrite-readonly-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/readwrite-readonly-expected.txt
@@ -21,6 +21,7 @@ PASS The :read-write pseudo-class must match elements that are editable
 PASS The :read-only pseudo-class must not match elements that are editable
 PASS The :read-write pseudo-class must match elements that are editing hosts
 PASS The :read-only pseudo-class must not match elements that are editing hosts
+PASS The :read-write pseudo-class must match elements that are inside editing hosts, but not match inputs and textareas inside that aren't
 
 
 
@@ -28,3 +29,5 @@ PASS The :read-only pseudo-class must not match elements that are editing hosts
 paragraph1.
 
 paragraph2.
+
+

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -841,7 +841,7 @@ bool AccessibilityNodeObject::isChecked() const
 
     // First test for native checkedness semantics
     if (is<HTMLInputElement>(*node))
-        return downcast<HTMLInputElement>(*node).shouldAppearChecked();
+        return downcast<HTMLInputElement>(*node).matchesCheckedPseudoClass();
 
     // Else, if this is an ARIA checkbox or radio, respect the aria-checked attribute
     bool validRole = false;

--- a/Source/WebCore/css/SelectorCheckerTestFunctions.h
+++ b/Source/WebCore/css/SelectorCheckerTestFunctions.h
@@ -118,14 +118,10 @@ ALWAYS_INLINE bool isMediaDocument(const Element& element)
 
 ALWAYS_INLINE bool isChecked(const Element& element)
 {
-    // Even though WinIE allows checked and indeterminate to co-exist, the CSS selector spec says that
-    // you can't be both checked and indeterminate. We will behave like WinIE behind the scenes and just
-    // obey the CSS spec here in the test for matching the pseudo.
     if (auto* inputElement = dynamicDowncast<HTMLInputElement>(element))
-        return inputElement->shouldAppearChecked() && !inputElement->shouldAppearIndeterminate();
+        return inputElement->matchesCheckedPseudoClass();
     if (auto* option = dynamicDowncast<HTMLOptionElement>(element))
         return const_cast<HTMLOptionElement&>(*option).selected(AllowStyleInvalidation::No);
-
     return false;
 }
 

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -4313,7 +4313,7 @@ bool Element::matchesReadWritePseudoClass() const
 
 bool Element::matchesIndeterminatePseudoClass() const
 {
-    return shouldAppearIndeterminate();
+    return false;
 }
 
 bool Element::matchesDefaultPseudoClass() const
@@ -4335,11 +4335,6 @@ ExceptionOr<Element*> Element::closest(const String& selector)
     if (query.hasException())
         return query.releaseException();
     return query.releaseReturnValue().closest(*this);
-}
-
-bool Element::shouldAppearIndeterminate() const
-{
-    return false;
 }
 
 bool Element::mayCauseRepaintInsideViewport(const IntRect* visibleRect) const

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -527,7 +527,6 @@ public:
     virtual bool matchesDefaultPseudoClass() const;
     WEBCORE_EXPORT ExceptionOr<bool> matches(const String& selectors);
     WEBCORE_EXPORT ExceptionOr<Element*> closest(const String& selectors);
-    virtual bool shouldAppearIndeterminate() const;
 
     WEBCORE_EXPORT DOMTokenList& classList();
 

--- a/Source/WebCore/html/CheckboxInputType.cpp
+++ b/Source/WebCore/html/CheckboxInputType.cpp
@@ -118,11 +118,6 @@ void CheckboxInputType::didDispatchClick(Event& event, const InputElementClickSt
 
 bool CheckboxInputType::matchesIndeterminatePseudoClass() const
 {
-    return shouldAppearIndeterminate();
-}
-
-bool CheckboxInputType::shouldAppearIndeterminate() const
-{
     ASSERT(element());
     return element()->indeterminate() && !isSwitch();
 }

--- a/Source/WebCore/html/CheckboxInputType.h
+++ b/Source/WebCore/html/CheckboxInputType.h
@@ -60,7 +60,6 @@ private:
     void willDispatchClick(InputElementClickState&) final;
     void didDispatchClick(Event&, const InputElementClickState&) final;
     bool matchesIndeterminatePseudoClass() const final;
-    bool shouldAppearIndeterminate() const final;
     void disabledStateChanged() final;
     void stopSwitchCheckedChangeAnimation();
     void switchCheckedChangeAnimationTimerFired();

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -1970,7 +1970,7 @@ bool HTMLInputElement::isLabelable() const
     return m_inputType->isLabelable();
 }
 
-bool HTMLInputElement::shouldAppearChecked() const
+bool HTMLInputElement::matchesCheckedPseudoClass() const
 {
     return checked() && m_inputType->isCheckable();
 }
@@ -2025,19 +2025,7 @@ String HTMLInputElement::defaultToolTip() const
 
 bool HTMLInputElement::matchesIndeterminatePseudoClass() const
 {
-    // For input elements, matchesIndeterminatePseudoClass()
-    // is not equivalent to shouldAppearIndeterminate() because of radio button.
-    //
-    // A group of radio button without any checked button is indeterminate
-    // for the :indeterminate selector. On the other hand, RenderTheme
-    // currently only supports single element being indeterminate.
-    // Because of this, radio is indetermindate for CSS but not for render theme.
     return m_inputType->matchesIndeterminatePseudoClass();
-}
-
-bool HTMLInputElement::shouldAppearIndeterminate() const 
-{
-    return m_inputType->shouldAppearIndeterminate();
 }
 
 #if ENABLE(MEDIA_CAPTURE)

--- a/Source/WebCore/html/HTMLInputElement.h
+++ b/Source/WebCore/html/HTMLInputElement.h
@@ -190,10 +190,8 @@ public:
     WEBCORE_EXPORT HTMLElement* dataListButtonElement() const;
 #endif
 
-    // shouldAppearChecked is used by the rendering tree/CSS while checked() is used by JS to determine checked state
-    bool shouldAppearChecked() const;
+    bool matchesCheckedPseudoClass() const;
     bool matchesIndeterminatePseudoClass() const final;
-    bool shouldAppearIndeterminate() const final;
     void setDefaultCheckedState(bool);
 
     bool sizeShouldIncludeDecoration(int& preferredSize) const;

--- a/Source/WebCore/html/HTMLProgressElement.cpp
+++ b/Source/WebCore/html/HTMLProgressElement.cpp
@@ -159,7 +159,7 @@ void HTMLProgressElement::didAddUserAgentShadowRoot(ShadowRoot& root)
     inner->appendChild(bar);
 }
 
-bool HTMLProgressElement::shouldAppearIndeterminate() const
+bool HTMLProgressElement::matchesIndeterminatePseudoClass() const
 {
     return !isDeterminate();
 }

--- a/Source/WebCore/html/HTMLProgressElement.h
+++ b/Source/WebCore/html/HTMLProgressElement.h
@@ -48,7 +48,7 @@ private:
     HTMLProgressElement(const QualifiedName&, Document&);
     virtual ~HTMLProgressElement();
 
-    bool shouldAppearIndeterminate() const final;
+    bool matchesIndeterminatePseudoClass() const final;
     bool isLabelable() const final { return true; }
 
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;

--- a/Source/WebCore/html/InputType.cpp
+++ b/Source/WebCore/html/InputType.cpp
@@ -980,11 +980,6 @@ bool InputType::matchesIndeterminatePseudoClass() const
     return false;
 }
 
-bool InputType::shouldAppearIndeterminate() const
-{
-    return false;
-}
-
 bool InputType::isPresentingAttachedView() const
 {
     return false;

--- a/Source/WebCore/html/InputType.h
+++ b/Source/WebCore/html/InputType.h
@@ -359,7 +359,6 @@ public:
     virtual void updateAutoFillButton();
     virtual String defaultToolTip() const;
     virtual bool matchesIndeterminatePseudoClass() const;
-    virtual bool shouldAppearIndeterminate() const;
     virtual bool isPresentingAttachedView() const;
     virtual bool supportsSelectionAPI() const;
     virtual bool dirAutoUsesValue() const;

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -1313,16 +1313,18 @@ bool RenderTheme::isChecked(const RenderObject& renderer) const
     if (!renderer.node())
         return false;
     if (RefPtr element = dynamicDowncast<HTMLInputElement>(*renderer.node()))
-        return element->shouldAppearChecked();
+        return element->matchesCheckedPseudoClass();
     if (RefPtr host = dynamicDowncast<HTMLInputElement>(renderer.node()->shadowHost()))
-        return host->shouldAppearChecked();
+        return host->matchesCheckedPseudoClass();
     return false;
 }
 
 bool RenderTheme::isIndeterminate(const RenderObject& renderer) const
 {
+    // This does not currently support multiple elements and therefore radio buttons are excluded.
+    // FIXME: However, what about <progress>?
     RefPtr input = dynamicDowncast<HTMLInputElement>(renderer.node());
-    return input && input->shouldAppearIndeterminate();
+    return input && input->isCheckbox() && input->matchesIndeterminatePseudoClass();
 }
 
 bool RenderTheme::isEnabled(const RenderObject& renderer) const


### PR DESCRIPTION
#### 24caf261dab85775c66434d24f6de6f93926d9fa
<pre>
Cleanup node tree side of :checked and :indeterminate
<a href="https://bugs.webkit.org/show_bug.cgi?id=265660">https://bugs.webkit.org/show_bug.cgi?id=265660</a>

Reviewed by Tim Nguyen.

Rename shouldAppearChecked() to matchesCheckedPseudoClass() as that is
a clearer name that does not need a comment describing why things are
this way.

No longer check for :indeterminate in SelectorCheckerTestFunctions.h as
that goes against the HTML Standard and Selectors has been aligned with
that a while back:
<a href="https://html.spec.whatwg.org/#selector-checked">https://html.spec.whatwg.org/#selector-checked</a>
<a href="https://drafts.csswg.org/selectors/#checked">https://drafts.csswg.org/selectors/#checked</a>

And then finally instead of having everyone go out of their way to
cater to an oddity in RenderTheme, make RenderTheme handle it.

Relevant web-platform-tests directory is synchronized up to:
<a href="https://github.com/web-platform-tests/wpt/commit/e0e0f5b2721bf22568309f71a56ba7926348b0ef">https://github.com/web-platform-tests/wpt/commit/e0e0f5b2721bf22568309f71a56ba7926348b0ef</a>

* LayoutTests/imported/w3c/resources/resource-files.json:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/checked-indeterminate.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/checked-indeterminate.window.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/checked-indeterminate.window.js: Added.
(test):
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/dir-dynamic-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/dir-dynamic.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/dir-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/dir.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/disabled-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/disabled.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/indeterminate-radio-group-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/indeterminate-radio-group-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/indeterminate-radio-group.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/readwrite-readonly.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/w3c-import.log:
* LayoutTests/platform/mac-wk2/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/readwrite-readonly-expected.txt:
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::isChecked const):
* Source/WebCore/css/SelectorCheckerTestFunctions.h:
(WebCore::isChecked):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::matchesIndeterminatePseudoClass const):
(WebCore::Element::shouldAppearIndeterminate const): Deleted.
* Source/WebCore/dom/Element.h:
* Source/WebCore/html/CheckboxInputType.cpp:
(WebCore::CheckboxInputType::matchesIndeterminatePseudoClass const):
(WebCore::CheckboxInputType::shouldAppearIndeterminate const): Deleted.
* Source/WebCore/html/CheckboxInputType.h:
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::matchesCheckedPseudoClass const):
(WebCore::HTMLInputElement::matchesIndeterminatePseudoClass const):
(WebCore::HTMLInputElement::shouldAppearChecked const): Deleted.
(WebCore::HTMLInputElement::shouldAppearIndeterminate const): Deleted.
* Source/WebCore/html/HTMLInputElement.h:
* Source/WebCore/html/HTMLProgressElement.cpp:
(WebCore::HTMLProgressElement::matchesIndeterminatePseudoClass const):
(WebCore::HTMLProgressElement::shouldAppearIndeterminate const): Deleted.
* Source/WebCore/html/HTMLProgressElement.h:
* Source/WebCore/html/InputType.cpp:
(WebCore::InputType::shouldAppearIndeterminate const): Deleted.
* Source/WebCore/html/InputType.h:
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::isChecked const):
(WebCore::RenderTheme::isIndeterminate const):

Canonical link: <a href="https://commits.webkit.org/271430@main">https://commits.webkit.org/271430@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af61b55b097b800b78471852ddb673a7d4f05907

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28366 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7011 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29751 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30893 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25825 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28863 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9105 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4380 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28635 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5772 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24403 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5050 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5150 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25404 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31579 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25974 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25841 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31451 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5114 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3290 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29207 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6713 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/25198 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6798 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5569 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5634 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->