### PR TITLE
[WPE] Fix build without journald after 271330@main

### DIFF
--- a/Source/WTF/wtf/PlatformGTK.cmake
+++ b/Source/WTF/wtf/PlatformGTK.cmake
@@ -84,7 +84,7 @@ list(APPEND WTF_LIBRARIES
     ZLIB::ZLIB
 )
 
-if (Journald_FOUND)
+if (ENABLE_JOURNALD_LOG)
     list(APPEND WTF_LIBRARIES Journald::Journald)
 endif ()
 

--- a/Source/WTF/wtf/PlatformWPE.cmake
+++ b/Source/WTF/wtf/PlatformWPE.cmake
@@ -56,7 +56,7 @@ list(APPEND WTF_LIBRARIES
     ZLIB::ZLIB
 )
 
-if (Journald_FOUND)
+if (ENABLE_JOURNALD_LOG)
     list(APPEND WTF_LIBRARIES Journald::Journald)
 endif ()
 

--- a/Source/WebKit/WPEPlatform/wpe/drm/CMakeLists.txt
+++ b/Source/WebKit/WPEPlatform/wpe/drm/CMakeLists.txt
@@ -29,11 +29,14 @@ set(WPEPlatformDRM_SYSTEM_INCLUDE_DIRECTORIES
 )
 
 set(WPEPlatformDRM_LIBRARIES
-    Journald::Journald
     LibInput::LibInput
     Udev::Udev
     ${GIO_UNIX_LIBRARIES}
 )
+
+if (ENABLE_JOURNALD_LOG)
+    list(APPEND WPEPlatformDRM_LIBRARIES Journald::Journald)
+endif ()
 
 set(WPEPlatformDRM_SOURCES_FOR_INTROSPECTION
     ${WPEPlatformDRM_INSTALLED_HEADERS}


### PR DESCRIPTION
#### 0e4ff5c33c288c3b15384a57cf228962f181aa95
<pre>
[WPE] Fix build without journald after 271330@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=265663">https://bugs.webkit.org/show_bug.cgi?id=265663</a>

Reviewed by Michael Catanzaro.

* Source/WTF/wtf/PlatformGTK.cmake:
* Source/WTF/wtf/PlatformWPE.cmake:

Drive-by fix to use ENABLE_JOURNALD_LOG instead of Journald_FOUND.

* Source/WebKit/WPEPlatform/wpe/drm/CMakeLists.txt:

The Journald::Journald target should not be used if journald support
is not enabled.

Canonical link: <a href="https://commits.webkit.org/271392@main">https://commits.webkit.org/271392@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7130347bc1f6fcc48148a96ca76fcca3ff6e60d7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28227 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6868 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29580 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30756 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25721 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8908 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4251 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/25994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28495 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5646 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24298 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4905 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5035 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25289 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31445 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/24426 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25843 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25727 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31336 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/27338 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5014 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3198 "Found 1 new test failure: imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-createDataChannel.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29099 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6562 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/34848 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6768 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5453 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7540 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5530 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->