### PR TITLE
[WebXR] Port enum classes to new serialization format

### DIFF
--- a/Source/WebCore/platform/xr/PlatformXR.h
+++ b/Source/WebCore/platform/xr/PlatformXR.h
@@ -57,7 +57,7 @@ inline bool isImmersive(SessionMode mode)
     return mode == ImmersiveAr || mode == ImmersiveVr;
 }
 
-enum class ReferenceSpaceType {
+enum class ReferenceSpaceType : uint8_t {
     Viewer,
     Local,
     LocalFloor,
@@ -71,7 +71,7 @@ enum class Eye {
     Right,
 };
 
-enum class VisibilityState {
+enum class VisibilityState : uint8_t {
     Visible,
     VisibleBlurred,
     Hidden
@@ -83,14 +83,14 @@ using LayerHandle = int;
 using InputSourceHandle = int;
 
 // https://immersive-web.github.io/webxr/#enumdef-xrhandedness
-enum class XRHandedness {
+enum class XRHandedness : uint8_t {
     None,
     Left,
     Right,
 };
 
 // https://immersive-web.github.io/webxr/#enumdef-xrtargetraymode
-enum class XRTargetRayMode {
+enum class XRTargetRayMode : uint8_t {
     Gaze,
     TrackedPointer,
     Screen,
@@ -786,73 +786,3 @@ inline Device::FrameData Device::FrameData::copy() const
 #endif // ENABLE(WEBXR)
 
 } // namespace PlatformXR
-
-#if ENABLE(WEBXR)
-
-namespace WTF {
-
-template<> struct EnumTraits<PlatformXR::SessionMode> {
-    using values = EnumValues<
-        PlatformXR::SessionMode,
-        PlatformXR::SessionMode::Inline,
-        PlatformXR::SessionMode::ImmersiveVr,
-        PlatformXR::SessionMode::ImmersiveAr
-    >;
-};
-
-template<> struct EnumTraits<PlatformXR::ReferenceSpaceType> {
-    using values = EnumValues<
-        PlatformXR::ReferenceSpaceType,
-        PlatformXR::ReferenceSpaceType::Viewer,
-        PlatformXR::ReferenceSpaceType::Local,
-        PlatformXR::ReferenceSpaceType::LocalFloor,
-        PlatformXR::ReferenceSpaceType::BoundedFloor,
-        PlatformXR::ReferenceSpaceType::Unbounded
-    >;
-};
-
-template<> struct EnumTraits<PlatformXR::VisibilityState> {
-    using values = EnumValues<
-        PlatformXR::VisibilityState,
-        PlatformXR::VisibilityState::Visible,
-        PlatformXR::VisibilityState::VisibleBlurred,
-        PlatformXR::VisibilityState::Hidden
-    >;
-};
-
-template<> struct EnumTraits<PlatformXR::XRHandedness> {
-    using values = EnumValues<
-        PlatformXR::XRHandedness,
-        PlatformXR::XRHandedness::None,
-        PlatformXR::XRHandedness::Left,
-        PlatformXR::XRHandedness::Right
-    >;
-};
-
-template<> struct EnumTraits<PlatformXR::XRTargetRayMode> {
-    using values = EnumValues<
-        PlatformXR::XRTargetRayMode,
-        PlatformXR::XRTargetRayMode::Gaze,
-        PlatformXR::XRTargetRayMode::TrackedPointer,
-        PlatformXR::XRTargetRayMode::Screen,
-        PlatformXR::XRTargetRayMode::TransientPointer
-    >;
-};
-
-template<> struct EnumTraits<PlatformXR::SessionFeature> {
-    using values = EnumValues<
-        PlatformXR::SessionFeature,
-        PlatformXR::SessionFeature::ReferenceSpaceTypeViewer,
-        PlatformXR::SessionFeature::ReferenceSpaceTypeLocal,
-        PlatformXR::SessionFeature::ReferenceSpaceTypeLocalFloor,
-        PlatformXR::SessionFeature::ReferenceSpaceTypeBoundedFloor,
-        PlatformXR::SessionFeature::ReferenceSpaceTypeUnbounded
-#if ENABLE(WEBXR_HANDS)
-        , PlatformXR::SessionFeature::HandTracking
-#endif
-    >;
-};
-
-}
-
-#endif

--- a/Source/WebKit/Shared/XR/XRSystem.serialization.in
+++ b/Source/WebKit/Shared/XR/XRSystem.serialization.in
@@ -32,6 +32,39 @@ enum class PlatformXR::SessionFeature : uint8_t {
 #endif
 };
 
+enum class PlatformXR::SessionMode : uint8_t {
+    Inline,
+    ImmersiveVr,
+    ImmersiveAr,
+};
+
+[Nested] enum class PlatformXR::ReferenceSpaceType : uint8_t {
+    Viewer,
+    Local,
+    LocalFloor,
+    BoundedFloor,
+    Unbounded
+};
+
+enum class PlatformXR::VisibilityState : uint8_t {
+    Visible,
+    VisibleBlurred,
+    Hidden
+};
+
+enum class PlatformXR::XRHandedness : uint8_t {
+    None,
+    Left,
+    Right,
+};
+
+enum class PlatformXR::XRTargetRayMode : uint8_t {
+    Gaze,
+    TrackedPointer,
+    Screen,
+    TransientPointer,
+};
+
 struct WebKit::XRDeviceInfo {
     WebKit::XRDeviceIdentifier identifier;
     bool supportsOrientationTracking;


### PR DESCRIPTION
#### 3fb2a422f959942a00e037541091558e8c3b18ed
<pre>
[WebXR] Port enum classes to new serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=265665">https://bugs.webkit.org/show_bug.cgi?id=265665</a>

Reviewed by Dan Glastonbury.

Move the XR enums to the new serialization format to be able to get
rid of the enum traits for them.

 * Source/WebCore/platform/xr/PlatformXR.h:
 * Source/WebKit/Shared/XR/XRSystem.serialization.in:

Canonical link: <a href="https://commits.webkit.org/271466@main">https://commits.webkit.org/271466@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64634841c2b1c001176e17dd2ca5589452c5b573

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28285 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6929 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29656 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30814 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25766 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28782 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8980 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4305 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26034 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28554 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5697 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24341 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4967 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5086 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25339 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31502 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25900 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25773 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31388 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5057 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3238 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29143 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6643 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6825 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5499 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5575 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->