### PR TITLE
[WPE] WPE Platform: fix a typo in headless and DRM headers

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDisplayDRM.h
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDisplayDRM.h
@@ -26,7 +26,7 @@
 #ifndef WPEDisplayDRM_h
 #define WPEDisplayDRM_h
 
-#if !defined(__WPE_WAYLAND_H_INSIDE__) && !defined(BUILDING_WEBKIT)
+#if !defined(__WPE_DRM_H_INSIDE__) && !defined(BUILDING_WEBKIT)
 #error "Only <wpe/drm/wpe-drm.h> can be included directly."
 #endif
 

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEViewDRM.h
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEViewDRM.h
@@ -26,7 +26,7 @@
 #ifndef WPEViewDRM_h
 #define WPEViewDRM_h
 
-#if !defined(__WPE_WAYLAND_H_INSIDE__) && !defined(BUILDING_WEBKIT)
+#if !defined(__WPE_DRM_H_INSIDE__) && !defined(BUILDING_WEBKIT)
 #error "Only <wpe/drm/wpe-drm.h> can be included directly."
 #endif
 
@@ -43,4 +43,4 @@ WPE_API WPEView *wpe_view_drm_new (WPEDisplayDRM *display);
 
 G_END_DECLS
 
-#endif /* WPEView_h */
+#endif /* WPEViewDRM_h */

--- a/Source/WebKit/WPEPlatform/wpe/headless/WPEDisplayHeadless.h
+++ b/Source/WebKit/WPEPlatform/wpe/headless/WPEDisplayHeadless.h
@@ -26,7 +26,7 @@
 #ifndef WPEDisplayHeadless_h
 #define WPEDisplayHeadless_h
 
-#if !defined(__WPE_WAYLAND_H_INSIDE__) && !defined(BUILDING_WEBKIT)
+#if !defined(__WPE_HEADLESS_H_INSIDE__) && !defined(BUILDING_WEBKIT)
 #error "Only <wpe/headless/wpe-headless.h> can be included directly."
 #endif
 

--- a/Source/WebKit/WPEPlatform/wpe/headless/WPEViewHeadless.h
+++ b/Source/WebKit/WPEPlatform/wpe/headless/WPEViewHeadless.h
@@ -26,7 +26,7 @@
 #ifndef WPEViewHeadless_h
 #define WPEViewHeadless_h
 
-#if !defined(__WPE_WAYLAND_H_INSIDE__) && !defined(BUILDING_WEBKIT)
+#if !defined(__WPE_HEADLESS_H_INSIDE__) && !defined(BUILDING_WEBKIT)
 #error "Only <wpe/headless/wpe-headless.h> can be included directly."
 #endif
 
@@ -43,4 +43,4 @@ WPE_API WPEView *wpe_view_headless_new (WPEDisplayHeadless *display);
 
 G_END_DECLS
 
-#endif /* WPEView_h */
+#endif /* WPEViewHeadless_h */


### PR DESCRIPTION
#### 6ce37246c1d1381cf951a29289cfa2b048ea386b
<pre>
[WPE] WPE Platform: fix a typo in headless and DRM headers
<a href="https://bugs.webkit.org/show_bug.cgi?id=265670">https://bugs.webkit.org/show_bug.cgi?id=265670</a>

Reviewed by Michael Catanzaro.

Fix copy paste error.

* Source/WebKit/WPEPlatform/wpe/drm/WPEDisplayDRM.h:
* Source/WebKit/WPEPlatform/wpe/drm/WPEViewDRM.h:
* Source/WebKit/WPEPlatform/wpe/headless/WPEDisplayHeadless.h:
* Source/WebKit/WPEPlatform/wpe/headless/WPEViewHeadless.h:

Canonical link: <a href="https://commits.webkit.org/271389@main">https://commits.webkit.org/271389@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5681cf25e0583e954aee647cb9ffa8c69f91e59

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28240 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6883 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29598 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30771 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25734 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8921 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4263 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28508 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5654 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24309 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/4923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/5051 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31460 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25859 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/25747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31352 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5025 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/3207 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/29105 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6602 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5462 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3647 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5543 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->