### PR TITLE
[scroll-animations] `ViewTimeline` should be a subclass of `ScrollTimeline`

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/unattached-subject-inset-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/unattached-subject-inset-expected.txt
@@ -1,3 +1,5 @@
 
-FAIL Creating a view timeline with a subject that is not attached to the document works as expected assert_equals: Null source while detached expected (object) null but got (undefined) undefined
+FAIL Creating a view timeline with a subject that is not attached to the document works as expected assert_equals: Source resolved once attached expected Element node <div id="container">
+    <div class="filler"></div>
+  <di... but got null
 

--- a/Source/WebCore/animation/ScrollTimeline.h
+++ b/Source/WebCore/animation/ScrollTimeline.h
@@ -35,7 +35,7 @@ namespace WebCore {
 
 class Element;
 
-class ScrollTimeline final : public AnimationTimeline {
+class ScrollTimeline : public AnimationTimeline {
 public:
     static Ref<ScrollTimeline> create(ScrollTimelineOptions&& = { });
     static Ref<ScrollTimeline> create(const AtomString&, ScrollAxis);
@@ -48,9 +48,11 @@ public:
     const AtomString& name() const { return m_name; }
     void setName(const AtomString& name) { m_name = name; }
 
+protected:
+    explicit ScrollTimeline(const AtomString&, ScrollAxis);
+
 private:
     explicit ScrollTimeline(ScrollTimelineOptions&& = { });
-    explicit ScrollTimeline(const AtomString&, ScrollAxis);
 
     bool isScrollTimeline() const final { return true; }
 

--- a/Source/WebCore/animation/ViewTimeline.cpp
+++ b/Source/WebCore/animation/ViewTimeline.cpp
@@ -38,8 +38,8 @@ Ref<ViewTimeline> ViewTimeline::create(ViewTimelineOptions&& options)
 
 // FIXME: compute offset values from options.
 ViewTimeline::ViewTimeline(ViewTimelineOptions&& options)
-    : m_subject(WTFMove(options.subject))
-    , m_axis(options.axis)
+    : ScrollTimeline(nullAtom(), options.axis)
+    , m_subject(WTFMove(options.subject))
     , m_startOffset(CSSNumericFactory::px(0))
     , m_endOffset(CSSNumericFactory::px(0))
 {

--- a/Source/WebCore/animation/ViewTimeline.h
+++ b/Source/WebCore/animation/ViewTimeline.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include "AnimationTimeline.h"
 #include "CSSNumericValue.h"
+#include "ScrollTimeline.h"
 #include "ViewTimelineOptions.h"
 #include <wtf/Ref.h>
 #include <wtf/WeakPtr.h>
@@ -35,12 +35,11 @@ namespace WebCore {
 
 class Element;
 
-class ViewTimeline final : public AnimationTimeline {
+class ViewTimeline final : public ScrollTimeline {
 public:
     static Ref<ViewTimeline> create(ViewTimelineOptions&& = { });
 
     Element* subject() const { return m_subject.get(); }
-    ScrollAxis axis() const { return m_axis; }
     const CSSNumericValue& startOffset() const { return m_startOffset.get(); }
     const CSSNumericValue& endOffset() const { return m_endOffset.get(); }
 
@@ -50,7 +49,6 @@ private:
     bool isViewTimeline() const final { return true; }
 
     WeakPtr<Element, WeakPtrImplWithEventTargetData> m_subject;
-    ScrollAxis m_axis;
     Ref<CSSNumericValue> m_startOffset;
     Ref<CSSNumericValue> m_endOffset;
 };

--- a/Source/WebCore/animation/ViewTimeline.idl
+++ b/Source/WebCore/animation/ViewTimeline.idl
@@ -27,7 +27,7 @@
     EnabledBySetting=ScrollDrivenAnimationsEnabled,
     Exposed=Window,
     JSGenerateToJSObject
-] interface ViewTimeline : AnimationTimeline {
+] interface ViewTimeline : ScrollTimeline {
     constructor(optional ViewTimelineOptions options = {});
     readonly attribute Element subject;
     readonly attribute CSSNumericValue startOffset;


### PR DESCRIPTION
#### 95e0aa587869fa4b2b26a192f645769761e1afa1
<pre>
[scroll-animations] `ViewTimeline` should be a subclass of `ScrollTimeline`
<a href="https://bugs.webkit.org/show_bug.cgi?id=265668">https://bugs.webkit.org/show_bug.cgi?id=265668</a>

Reviewed by Dean Jackson.

When we added `ViewTimeline` in bug 264411 we overlooked how in the spec it was specified as
a `ScrollTimeline` subclass. We now fix this and remove the ScrollAxis member in `ViewTimeline`
since it exists already on `ScrollTimeline`.

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/unattached-subject-inset-expected.txt:
* Source/WebCore/animation/ScrollTimeline.h:
(WebCore::ScrollTimeline::ScrollTimeline):
* Source/WebCore/animation/ViewTimeline.cpp:
(WebCore::ViewTimeline::ViewTimeline):
* Source/WebCore/animation/ViewTimeline.h:
* Source/WebCore/animation/ViewTimeline.idl:

Canonical link: <a href="https://commits.webkit.org/271398@main">https://commits.webkit.org/271398@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc7432b8151e6454a524bd74ade154dd08514391

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28244 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6887 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29602 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30775 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25738 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28741 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8925 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4267 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28512 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5659 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24308 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4939 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5055 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25303 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31464 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25864 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25737 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/31370 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5029 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3211 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/29124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6609 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5466 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3650 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5547 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->