### PR TITLE
[JSC] Port enum classes to new serialization format

### DIFF
--- a/Source/JavaScriptCore/runtime/ConsoleTypes.h
+++ b/Source/JavaScriptCore/runtime/ConsoleTypes.h
@@ -76,43 +76,5 @@ enum class MessageLevel : uint8_t {
 
 } // namespace JSC
 
-namespace WTF {
-
-template<> struct EnumTraits<JSC::MessageSource> {
-    using values = EnumValues<
-        JSC::MessageSource,
-        JSC::MessageSource::XML,
-        JSC::MessageSource::JS,
-        JSC::MessageSource::Network,
-        JSC::MessageSource::ConsoleAPI,
-        JSC::MessageSource::Storage,
-        JSC::MessageSource::AppCache,
-        JSC::MessageSource::Rendering,
-        JSC::MessageSource::CSS,
-        JSC::MessageSource::Security,
-        JSC::MessageSource::ContentBlocker,
-        JSC::MessageSource::Media,
-        JSC::MessageSource::MediaSource,
-        JSC::MessageSource::WebRTC,
-        JSC::MessageSource::ITPDebug,
-        JSC::MessageSource::PrivateClickMeasurement,
-        JSC::MessageSource::PaymentRequest,
-        JSC::MessageSource::Other
-    >;
-};
-
-template<> struct EnumTraits<JSC::MessageLevel> {
-    using values = EnumValues<
-        JSC::MessageLevel,
-        JSC::MessageLevel::Log,
-        JSC::MessageLevel::Warning,
-        JSC::MessageLevel::Error,
-        JSC::MessageLevel::Debug,
-        JSC::MessageLevel::Info
-    >;
-};
-
-} // namespace WTF
-
 using JSC::MessageSource;
 using JSC::MessageLevel;

--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -399,6 +399,7 @@ set(WebKit_SERIALIZATION_IN_FILES
     Shared/GPUProcessConnectionParameters.serialization.in
     Shared/GPUProcessPreferencesForWebProcess.serialization.in
     Shared/GoToBackForwardItemParameters.serialization.in
+    Shared/JavaScriptCore.serialization.in
     Shared/LayerTreeContext.serialization.in
     Shared/LoadParameters.serialization.in
     Shared/LocalFrameCreationParameters.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -584,6 +584,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/ios/InteractionInformationRequest.serialization.in \
 	Shared/ios/WebAutocorrectionContext.serialization.in \
 	Shared/ios/WebAutocorrectionData.serialization.in \
+	Shared/JavaScriptCore.serialization.in \
 	Shared/LayerTreeContext.serialization.in \
 	Shared/LoadParameters.serialization.in \
 	Shared/LocalFrameCreationParameters.serialization.in \

--- a/Source/WebKit/Shared/JavaScriptCore.serialization.in
+++ b/Source/WebKit/Shared/JavaScriptCore.serialization.in
@@ -1,0 +1,50 @@
+# Copyright (C) 2023 Igalia S.L.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+header: <JavaScriptCore/ConsoleTypes.h>
+enum class JSC::MessageSource : uint8_t {
+    XML,
+    JS,
+    Network,
+    ConsoleAPI,
+    Storage,
+    AppCache,
+    Rendering,
+    CSS,
+    Security,
+    ContentBlocker,
+    Media,
+    MediaSource,
+    WebRTC,
+    ITPDebug,
+    PrivateClickMeasurement,
+    PaymentRequest,
+    Other,
+};
+
+enum class JSC::MessageLevel : uint8_t {
+    Log,
+    Warning,
+    Error,
+    Debug,
+    Info,
+};


### PR DESCRIPTION
#### 7bb974912a5e68c176c876e3ce7ba59149e056b5
<pre>
[JSC] Port enum classes to new serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=265679">https://bugs.webkit.org/show_bug.cgi?id=265679</a>

Reviewed by Alex Christensen.

Move JSC&apos;s console types to the new serialization format
and remove the EnumTraits for it. Use a new JavaScriptCore
serialization file to keep things tidy.

* Source/JavaScriptCore/runtime/ConsoleTypes.h:
* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Shared/JavaScriptCore.serialization.in: Added.

Canonical link: <a href="https://commits.webkit.org/271709@main">https://commits.webkit.org/271709@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d313d65737d6c24576a27900c1262ac232cc164

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28720 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7363 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30091 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31339 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26204 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9486 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4723 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26276 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28990 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6090 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24687 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5294 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5444 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25691 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/32677 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/24886 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26288 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26134 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31686 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/28102 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5410 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3582 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29466 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7028 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/35337 "Built successfully") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/6985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5878 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7628 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3778 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5928 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->