### PR TITLE
REGRESSION (270847@main): Typing three '.' adds extra periods instead of combining

### DIFF
--- a/LayoutTests/editing/input/ios/autocorrection-replaces-three-dots-with-ellipsis-expected.txt
+++ b/LayoutTests/editing/input/ios/autocorrection-replaces-three-dots-with-ellipsis-expected.txt
@@ -1,0 +1,10 @@
+This test verifies that typing three '.' characters results in the '...' being replaced with a single ellipsis character ('…'). To test manually, focus the red box below and type '...'
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS editor.textContent became '…'
+PASS successfullyParsed is true
+
+TEST COMPLETE
+…

--- a/LayoutTests/editing/input/ios/autocorrection-replaces-three-dots-with-ellipsis.html
+++ b/LayoutTests/editing/input/ios/autocorrection-replaces-three-dots-with-ellipsis.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<style>
+body {
+    margin: 0;
+    font-size: 18px;
+    font-family: system-ui;
+    line-height: 150%;
+}
+
+#editor {
+    border: 1px solid tomato;
+    box-sizing: border-box;
+    outline: none;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("This test verifies that typing three '.' characters results in the '...' being replaced with a single ellipsis character ('…'). To test manually, focus the red box below and type '...'");
+
+    editor = document.getElementById("editor");
+    await UIHelper.activateElementAndWaitForInputSession(editor);
+
+    for (let character of [..."..."]) {
+        await UIHelper.typeCharacter(character);
+        await UIHelper.ensurePresentationUpdate();
+    }
+
+    await shouldBecomeEqual("editor.textContent", "'…'");
+
+    editor.blur();
+    await UIHelper.waitForKeyboardToHide();
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <div contenteditable id="editor"><br></div>
+</body>
+</html>

--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -1297,6 +1297,7 @@ typedef NS_ENUM(NSInteger, UIShiftKeyState) {
 @interface UIResponder (Internal)
 - (BOOL)_requiresKeyboardWhenFirstResponder;
 - (BOOL)_requiresKeyboardResetOnReload;
+- (UTF32Char)_characterInRelationToCaretSelection:(int)amount;
 @end
 
 WTF_EXTERN_C_BEGIN


### PR DESCRIPTION
#### 3fc6828f05499081fc602ef98715349aa167e5bd
<pre>
REGRESSION (270847@main): Typing three &apos;.&apos; adds extra periods instead of combining
<a href="https://bugs.webkit.org/show_bug.cgi?id=265671">https://bugs.webkit.org/show_bug.cgi?id=265671</a>
<a href="https://rdar.apple.com/118971986">rdar://118971986</a>

Reviewed by Tim Horton and Megan Gardner.

After the changes in 270847@main, typing three `&quot;.&quot;` characters results in the string `&quot;..…&quot;`,
instead of just a single ellipsis character. This is because UIKit now obtains a reinsertion string
when calling `-_expandSelectionToBackwardDeletionClusterWithReinsertionOut:`, underneath
`-[UIKeyboardImpl _deleteBackwardAndNotify:reinsertText:overrideOriginalContextBeforeInputWith:]`.
However, because we don&apos;t support synchronous calls to `-setSelectedRange:` with these new relative
ranges, UIKit&apos;s text reinsertion logic breaks, resulting in both the reinsertion string, `&quot;..&quot;`, as
well as the replacement string, `&quot;…&quot;`, being inserted into the document.

To fix this in the short term, we conditionalize this `WKRelativeTextRange` refactoring (as well as
moving away from `-_characterInRelationToCaretSelection:`) on async text input enablement. The real
fix will require UIKit changes — i.e., refactoring keyboard code to handle async text inputs that
return non-null `-textRangeFromPosition:toPosition:`, but (crucially) don&apos;t support calls to
`-setSelectedTextRange:` that are expected to synchronously update document state.

Test: editing/input/ios/autocorrection-replaces-three-dots-with-ellipsis.html

* LayoutTests/editing/input/ios/autocorrection-replaces-three-dots-with-ellipsis-expected.txt: Added.
* LayoutTests/editing/input/ios/autocorrection-replaces-three-dots-with-ellipsis.html: Added.

Add a new layout test to exercise this scenario.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _characterInRelationToCaretSelection:]):

Restore this private method implementation, but call directly into the superclass implementation
instead of relying on our custom logic, in the case where async text input is enabled.

(-[WKContentView textRangeFromPosition:toPosition:]):
(-[WKContentView positionFromPosition:offset:]):

Revert to returning `nil`, in the case where async text input is disabled.

Canonical link: <a href="https://commits.webkit.org/271402@main">https://commits.webkit.org/271402@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89579a87bfb75dc78988701f579eb2c171031b32

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28258 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6901 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29616 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30789 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25751 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8939 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4281 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28526 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5672 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24322 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4943 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/5069 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25318 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31478 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25877 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25754 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31368 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/5042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/3222 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29122 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/notification (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6623 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/25114 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6775 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5479 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/5560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->