### PR TITLE
[masonry] Remove support for special first track handling

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1622,6 +1622,10 @@ imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/masonry-c
 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/masonry-columns-subgrid-named-lines-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/masonry-columns-subgrid-named-lines-003.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-columns-item-placement-auto-flow-next-001.html [ Skip ]
+webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/grid-placement/masonry-grid-placement-named-lines-002.html [ ImageOnlyFailure ]
+webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-002.html [ ImageOnlyFailure ]
+webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-004.html [ ImageOnlyFailure ]
+webkit.org/b/266091 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/masonry-rows-subgrid-named-lines-001.html [ ImageOnlyFailure ]
 
 # Timeout
 imported/w3c/web-platform-tests/css/css-grid/parsing/grid-template-columns-crash.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-001-expected.html
@@ -34,12 +34,12 @@ item {
 <body>
 
 <grid>
+  <item style="grid-column:1">6</item>
+  <item style="grid-column:2">5</item>
+  <item style="grid-column:span 2">4</item>
   <item style="margin-top:10px">3</item>
   <item style="grid-column:span 2">1</item>
   <item>2</item>
-  <item style="grid-column:2">5</item>
-  <item style="grid-column:span 2">4</item>
-  <item style="grid-column:1">6</item>
 </grid>
 
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-001-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-001-ref.html
@@ -34,12 +34,12 @@ item {
 <body>
 
 <grid>
+  <item style="grid-column:1">6</item>
+  <item style="grid-column:2">5</item>
+  <item style="grid-column:span 2">4</item>
   <item style="margin-top:10px">3</item>
   <item style="grid-column:span 2">1</item>
   <item>2</item>
-  <item style="grid-column:2">5</item>
-  <item style="grid-column:span 2">4</item>
-  <item style="grid-column:1">6</item>
 </grid>
 
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-001.html
@@ -36,12 +36,12 @@ item {
 <body>
 
 <grid>
-  <item style="grid-column:2/span 2">1</item>
-  <item>2</item>
-  <item style="margin-top:10px">3</item>
-  <item style="grid-column:3/span 2">4</item>
+  <item style="grid-column:1">6</item>
   <item>5</item>
-  <item>6</item>
+  <item style="margin-top:10px">3</item>
+  <item style="grid-column:span 2">1</item>
+  <item>2</item>
+  <item style="grid-column:3/span 2">4</item>
 </grid>
 
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-002.html
@@ -36,12 +36,12 @@ item {
 <body>
 
 <grid>
-  <item style="grid-column:foo 2; grid-row:span 2">2</item>
+  <item style="grid-column:1/span 4;">1</item>
   <item>3</item>
+  <item style="grid-column:foo 2; grid-row:span 2">2</item>
   <item style="grid-column:span 3">4</item>
   <item>5</item>
   <item>6</item>
-  <item style="grid-column:span 4; grid-row:-100">1</item>
 </grid>
 
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-003.html
@@ -38,9 +38,9 @@ item {
 
 <grid>
   <item style="grid-row:-100">1</item>
+  <item>3</item>
   <item style="grid-column:foo 2; grid-row:span 2">2</item>
   <item style="grid-column:span 3">4</item>
-  <item>3</item>
   <item>5</item>
   <item>6</item>
 </grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/order/masonry-order-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/order/masonry-order-001-expected.html
@@ -38,6 +38,6 @@ item {
   <item style="margin-top:10px">4</item>
   <item>6</item>
   <item>2</item>
+  <item style="grid-column: span 2">5</item>
   <item>3</item>
-  <item style="grid-column:3/span 2">5</item>
 </grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/order/masonry-order-001-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/order/masonry-order-001-ref.html
@@ -38,6 +38,6 @@ item {
   <item style="margin-top:10px">4</item>
   <item>6</item>
   <item>2</item>
+  <item style="grid-column: span 2">5</item>
   <item>3</item>
-  <item style="grid-column:3/span 2">5</item>
 </grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/order/masonry-order-002-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/order/masonry-order-002-expected.html
@@ -34,10 +34,10 @@ item {
 <body>
 
 <grid>
-  <item>1</item>
-  <item style="margin-top:10px">4</item>
-  <item>6</item>
-  <item>2</item>
-  <item style="grid-column:1/span 2">5</item>
-  <item style="grid-column:3">3</item>
+  <item style="grid-column: 1">1</item>
+  <item style="margin-top:10px; grid-column: 2;">4</item>
+  <item style="grid-column: 3">6</item>
+  <item style="grid-column: 4">2</item>
+  <item style="grid-column: 2/span 2">5</item>
+  <item>3</item>
 </grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/order/masonry-order-002-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/order/masonry-order-002-ref.html
@@ -34,10 +34,10 @@ item {
 <body>
 
 <grid>
-  <item>1</item>
-  <item style="margin-top:10px">4</item>
-  <item>6</item>
-  <item>2</item>
-  <item style="grid-column:1/span 2">5</item>
-  <item style="grid-column:3">3</item>
+  <item style="grid-column: 1">1</item>
+  <item style="margin-top:10px; grid-column: 2;">4</item>
+  <item style="grid-column: 3">6</item>
+  <item style="grid-column: 4">2</item>
+  <item style="grid-column: 2/span 2">5</item>
+  <item>3</item>
 </grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/order/masonry-order-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/order/masonry-order-002.html
@@ -39,8 +39,8 @@ item {
 <grid>
   <item>1</item>
   <item style="order:1">2</item>
-  <item style="order:2">3</item>
+  <item style="order:1">3</item>
   <item style="margin-top:10px">4</item>
-  <item style="order:1; grid-column:span 2">5</item>
+  <item style="order:2; grid-column:span 2">5</item>
   <item>6</item>
 </grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-explicit-block.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-explicit-block.html
@@ -13,7 +13,7 @@
 <style>
 grid {
     display: grid;
-    grid-template-columns: auto 1fr;
+    grid-template-columns: 100px 1fr;
     grid-template-rows: masonry;
     width: 300px;
     height: 100px;
@@ -33,8 +33,6 @@ box2 {
 box3 {
     height: 50px;
     width: 100px;
-    grid-row: 2;
-    grid-column: 1;
     background-color: purple;
 }
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-span-row.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-span-row.html
@@ -13,7 +13,7 @@
 <style>
 grid {
     display: grid;
-    grid-template-columns: auto 1fr;
+    grid-template-columns: 50px 1fr;
     grid-template-rows: masonry;
     width: 300px;
     height: 100px;
@@ -40,8 +40,7 @@ box3 {
 box4 {
     height: 50px;
     width: 300px;
-    grid-column-start: 1;
-    grid-column-end: 3;
+    grid-column: span 2;
     background-color: green;
 }
 </style>
@@ -49,8 +48,8 @@ box4 {
 <grid>
     <box1>1</box1>
     <box2>2</box2>
-    <box3>3</box3>
     <box4>4</box4>
+    <box3>3</box3>
 </grid>
 
 </body>

--- a/Source/WebCore/rendering/GridMasonryLayout.cpp
+++ b/Source/WebCore/rendering/GridMasonryLayout.cpp
@@ -59,7 +59,6 @@ void GridMasonryLayout::performMasonryPlacement(unsigned gridAxisTracks, GridTra
     m_renderGrid.populateGridPositionsForDirection(GridTrackSizingDirection::ForRows);
 
     // 2.4 Masonry Layout Algorithm
-    addItemsToFirstTrack();
     
     // the insertIntoGridAndLayoutItem() will modify the m_autoFlowNextCursor, so m_autoFlowNextCursor needs to be reset.
     m_autoFlowNextCursor = 0;
@@ -75,7 +74,7 @@ void GridMasonryLayout::performMasonryPlacement(unsigned gridAxisTracks, GridTra
 void GridMasonryLayout::collectMasonryItems()
 {
     ASSERT(m_gridAxisTracksCount);
-    m_firstTrackItems.clear();
+
     m_itemsWithDefiniteGridAxisPosition.shrink(0);
     m_itemsWithIndefiniteGridAxisPosition.shrink(0);
 
@@ -84,10 +83,7 @@ void GridMasonryLayout::collectMasonryItems()
         if (grid.orderIterator().shouldSkipChild(*child))
             continue;
 
-        auto gridArea = grid.gridItemArea(*child);
-        if (m_firstTrackItems.size() != m_gridAxisTracksCount && itemGridAreaStartsAtFirstLine(gridArea, m_masonryAxisDirection) && m_renderGrid.itemGridAreaIsWithinImplicitGrid(gridArea, m_gridAxisTracksCount + 1, gridAxisDirection()))
-            m_firstTrackItems.add(child, gridArea);
-        else if (m_renderGrid.style().masonryAutoFlow().placementOrder == MasonryAutoFlowPlacementOrder::Ordered)
+        if (m_renderGrid.style().masonryAutoFlow().placementOrder == MasonryAutoFlowPlacementOrder::Ordered)
             m_itemsWithDefiniteGridAxisPosition.append(child);
         else if (m_renderGrid.style().masonryAutoFlow().placementOrder == MasonryAutoFlowPlacementOrder::DefiniteFirst) {
             if (hasDefiniteGridAxisPosition(*child, gridAxisDirection()))
@@ -115,16 +111,6 @@ void GridMasonryLayout::resizeAndResetRunningPositions()
 {
     m_runningPositions.resize(m_gridAxisTracksCount);
     m_runningPositions.fill(LayoutUnit());
-}
-
-void GridMasonryLayout::addItemsToFirstTrack()
-{
-    for (auto& [item, gridArea] : m_firstTrackItems) {
-        ASSERT(item);
-        if (!item)
-            continue;
-        insertIntoGridAndLayoutItem(*item, gridArea);
-    }
 }
 
 void GridMasonryLayout::placeItemsUsingOrderModifiedDocumentOrder()

--- a/Source/WebCore/rendering/GridMasonryLayout.h
+++ b/Source/WebCore/rendering/GridMasonryLayout.h
@@ -53,7 +53,6 @@ private:
     GridArea gridAreaForDefiniteGridAxisItem(const RenderBox&) const;
 
     void collectMasonryItems();
-    void addItemsToFirstTrack(); 
     void placeItemsUsingOrderModifiedDocumentOrder(); 
     void placeItemsWithDefiniteGridAxisPosition();
     void placeItemsWithIndefiniteGridAxisPosition();
@@ -78,7 +77,6 @@ private:
 
     unsigned m_gridAxisTracksCount;
 
-    HashMap<RenderBox*, GridArea> m_firstTrackItems;
     Vector<RenderBox*> m_itemsWithDefiniteGridAxisPosition;
     Vector<RenderBox*> m_itemsWithIndefiniteGridAxisPosition;
 


### PR DESCRIPTION
#### 5f45e4707561fd2dce89400f9a0acd5f7568d856
<pre>
[masonry] Remove support for special first track handling
<a href="https://bugs.webkit.org/show_bug.cgi?id=265682">https://bugs.webkit.org/show_bug.cgi?id=265682</a>

Reviewed by Sammy Gill.

Remove support for first tracks from CSS Masonry.

Added several test cases to test expectations.
These are outside the scope of this patch.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-001-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-001-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-001.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-002.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-003.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/order/masonry-order-001-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/order/masonry-order-001-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/order/masonry-order-002-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/order/masonry-order-002-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/order/masonry-order-002.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-explicit-block.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-span-row.html:
* Source/WebCore/rendering/GridMasonryLayout.cpp:
(WebCore::GridMasonryLayout::performMasonryPlacement):
(WebCore::GridMasonryLayout::collectMasonryItems):
(WebCore::GridMasonryLayout::addItemsToFirstTrack): Deleted.
* Source/WebCore/rendering/GridMasonryLayout.h:

Canonical link: <a href="https://commits.webkit.org/271757@main">https://commits.webkit.org/271757@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74855f5a804fec1ddaaf24d324dcf306c1826508

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29569 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8232 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30884 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32089 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/26777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30172 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10385 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5525 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29842 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6869 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/25250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5874 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/6004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26338 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33433 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/26972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/26758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/32225 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/5961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/4153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/30000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/7697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/26139 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7016 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/6503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/6484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->