### PR TITLE
Make CheckedPtr<Node> / CheckedRef<Node> crashes more actionable

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -906,6 +906,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     dom/Comment.h
     dom/ContainerNode.h
     dom/ContextDestructionObserver.h
+    dom/ContextDestructionObserverInlines.h
     dom/CrossOriginMode.h
     dom/CustomElementReactionQueue.h
     dom/DOMException.h

--- a/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "GPUDevice.h"
 
+#include "ContextDestructionObserverInlines.h"
 #include "DOMPromiseProxy.h"
 #include "GPUBindGroup.h"
 #include "GPUBindGroupDescriptor.h"
@@ -295,6 +296,11 @@ void GPUDevice::popErrorScope(ErrorScopePromise&& errorScopePromise)
             promise.resolve(error);
         });
     });
+}
+
+ScriptExecutionContext* GPUDevice::scriptExecutionContext() const
+{
+    return ActiveDOMObject::scriptExecutionContext();
 }
 
 }

--- a/Source/WebCore/Modules/WebGPU/GPUDevice.h
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.h
@@ -142,7 +142,7 @@ private:
 
     // EventTarget.
     EventTargetInterface eventTargetInterface() const final { return GPUDeviceEventTargetInterfaceType; }
-    ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
+    ScriptExecutionContext* scriptExecutionContext() const final;
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
 

--- a/Source/WebCore/Modules/encryptedmedia/CDM.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/CDM.cpp
@@ -30,6 +30,7 @@
 
 #include "CDMFactory.h"
 #include "CDMPrivate.h"
+#include "ContextDestructionObserverInlines.h"
 #include "Document.h"
 #include "InitDataRegistry.h"
 #include "MediaKeysRequirement.h"

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
@@ -34,6 +34,7 @@
 #include "CDM.h"
 #include "CDMInstance.h"
 #include "CDMKeyGroupingStrategy.h"
+#include "ContextDestructionObserverInlines.h"
 #include "DOMPromiseProxy.h"
 #include "Document.h"
 #include "EventLoop.h"
@@ -835,6 +836,11 @@ void MediaKeySession::stop()
         ALWAYS_LOG(logIdentifier, "::lambda, closed");
         sessionClosed();
     });
+}
+
+ScriptExecutionContext* MediaKeySession::scriptExecutionContext() const
+{
+    return ActiveDOMObject::scriptExecutionContext();
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySession.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySession.h
@@ -108,7 +108,7 @@ private:
 
     // EventTarget
     EventTargetInterface eventTargetInterface() const override { return MediaKeySessionEventTargetInterfaceType; }
-    ScriptExecutionContext* scriptExecutionContext() const override { return ActiveDOMObject::scriptExecutionContext(); }
+    ScriptExecutionContext* scriptExecutionContext() const override;
     void refEventTarget() override { ref(); }
     void derefEventTarget() override { deref(); }
 

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySystemRequest.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySystemRequest.cpp
@@ -27,6 +27,7 @@
 
 #if ENABLE(ENCRYPTED_MEDIA)
 
+#include "ContextDestructionObserverInlines.h"
 #include "Document.h"
 #include "JSDOMPromiseDeferred.h"
 #include "JSMediaKeySystemAccess.h"

--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
 
+#include "ContextDestructionObserverInlines.h"
 #include "Document.h"
 #include "EventLoop.h"
 #include "EventNames.h"
@@ -249,6 +250,11 @@ void WebKitMediaKeySession::stop()
 const char* WebKitMediaKeySession::activeDOMObjectName() const
 {
     return "WebKitMediaKeySession";
+}
+
+ScriptExecutionContext* WebKitMediaKeySession::scriptExecutionContext() const
+{
+    return ActiveDOMObject::scriptExecutionContext();
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.h
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.h
@@ -80,7 +80,7 @@ private:
     bool virtualHasPendingActivity() const final;
 
     EventTargetInterface eventTargetInterface() const final { return WebKitMediaKeySessionEventTargetInterfaceType; }
-    ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
+    ScriptExecutionContext* scriptExecutionContext() const final;
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger; }

--- a/Source/WebCore/Modules/entriesapi/FileSystemDirectoryReader.cpp
+++ b/Source/WebCore/Modules/entriesapi/FileSystemDirectoryReader.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "FileSystemDirectoryReader.h"
 
+#include "ContextDestructionObserverInlines.h"
 #include "DOMException.h"
 #include "DOMFileSystem.h"
 #include "Document.h"

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemDirectoryHandle.cpp
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemDirectoryHandle.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "FileSystemDirectoryHandle.h"
 
+#include "ContextDestructionObserverInlines.h"
 #include "FileSystemHandleCloseScope.h"
 #include "FileSystemStorageConnection.h"
 #include "JSDOMPromiseDeferred.h"

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemHandle.cpp
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemHandle.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "FileSystemHandle.h"
 
+#include "ContextDestructionObserverInlines.h"
 #include "FileSystemStorageConnection.h"
 #include "JSDOMPromiseDeferred.h"
 #include <wtf/IsoMallocInlines.h>

--- a/Source/WebCore/Modules/gamepad/GamepadHapticActuator.cpp
+++ b/Source/WebCore/Modules/gamepad/GamepadHapticActuator.cpp
@@ -28,6 +28,7 @@
 #if ENABLE(GAMEPAD)
 #include "GamepadHapticActuator.h"
 
+#include "ContextDestructionObserverInlines.h"
 #include "Document.h"
 #include "EventLoop.h"
 #include "Gamepad.h"

--- a/Source/WebCore/Modules/geolocation/Geolocation.cpp
+++ b/Source/WebCore/Modules/geolocation/Geolocation.cpp
@@ -30,6 +30,7 @@
 
 #if ENABLE(GEOLOCATION)
 
+#include "ContextDestructionObserverInlines.h"
 #include "Document.h"
 #include "EventLoop.h"
 #include "FeaturePolicy.h"
@@ -756,6 +757,11 @@ Navigator* Geolocation::navigator()
 LocalFrame* Geolocation::frame() const
 {
     return m_navigator ? m_navigator->frame() : nullptr;
+}
+
+Document* Geolocation::document() const
+{
+    return downcast<Document>(scriptExecutionContext());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/geolocation/Geolocation.h
+++ b/Source/WebCore/Modules/geolocation/Geolocation.h
@@ -60,7 +60,7 @@ public:
     WEBCORE_EXPORT ~Geolocation();
 
     WEBCORE_EXPORT void resetAllGeolocationPermission();
-    Document* document() const { return downcast<Document>(scriptExecutionContext()); }
+    WEBCORE_EXPORT Document* document() const;
 
     void getCurrentPosition(Ref<PositionCallback>&&, RefPtr<PositionErrorCallback>&&, PositionOptions&&);
     int watchPosition(Ref<PositionCallback>&&, RefPtr<PositionErrorCallback>&&, PositionOptions&&);

--- a/Source/WebCore/Modules/indexeddb/IDBActiveDOMObject.h
+++ b/Source/WebCore/Modules/indexeddb/IDBActiveDOMObject.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "ActiveDOMObject.h"
+#include "ContextDestructionObserverInlines.h"
 #include "ScriptExecutionContext.h"
 #include <wtf/Threading.h>
 

--- a/Source/WebCore/Modules/mediasource/SourceBufferList.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBufferList.cpp
@@ -33,6 +33,7 @@
 
 #if ENABLE(MEDIA_SOURCE)
 
+#include "ContextDestructionObserverInlines.h"
 #include "Event.h"
 #include "EventNames.h"
 #include "SourceBuffer.h"
@@ -107,6 +108,11 @@ void SourceBufferList::scheduleEvent(const AtomString& eventName)
 const char* SourceBufferList::activeDOMObjectName() const
 {
     return "SourceBufferList";
+}
+
+ScriptExecutionContext* SourceBufferList::scriptExecutionContext() const
+{
+    return ContextDestructionObserver::scriptExecutionContext();
 }
 
 WebCoreOpaqueRoot root(SourceBufferList* list)

--- a/Source/WebCore/Modules/mediasource/SourceBufferList.h
+++ b/Source/WebCore/Modules/mediasource/SourceBufferList.h
@@ -67,7 +67,7 @@ public:
 
     // EventTarget interface
     EventTargetInterface eventTargetInterface() const final { return SourceBufferListEventTargetInterfaceType; }
-    ScriptExecutionContext* scriptExecutionContext() const final { return ContextDestructionObserver::scriptExecutionContext(); }
+    ScriptExecutionContext* scriptExecutionContext() const final;
 
     using RefCounted<SourceBufferList>::ref;
     using RefCounted<SourceBufferList>::deref;

--- a/Source/WebCore/Modules/mediastream/MediaStream.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStream.cpp
@@ -30,6 +30,7 @@
 
 #if ENABLE(MEDIA_STREAM)
 
+#include "ContextDestructionObserverInlines.h"
 #include "Document.h"
 #include "Event.h"
 #include "EventNames.h"
@@ -378,6 +379,11 @@ const char* MediaStream::activeDOMObjectName() const
 bool MediaStream::virtualHasPendingActivity() const
 {
     return m_isActive;
+}
+
+ScriptExecutionContext* MediaStream::scriptExecutionContext() const
+{
+    return ContextDestructionObserver::scriptExecutionContext();
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/Modules/mediastream/MediaStream.h
+++ b/Source/WebCore/Modules/mediastream/MediaStream.h
@@ -94,7 +94,7 @@ public:
 
     // EventTarget
     EventTargetInterface eventTargetInterface() const final { return MediaStreamEventTargetInterfaceType; }
-    ScriptExecutionContext* scriptExecutionContext() const final { return ContextDestructionObserver::scriptExecutionContext(); }
+    ScriptExecutionContext* scriptExecutionContext() const final;
 
     using RefCounted<MediaStream>::ref;
     using RefCounted<MediaStream>::deref;

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
@@ -31,6 +31,7 @@
 #if ENABLE(MEDIA_STREAM)
 
 #include "CommonAtomStrings.h"
+#include "ContextDestructionObserverInlines.h"
 #include "Document.h"
 #include "Event.h"
 #include "EventNames.h"
@@ -740,6 +741,11 @@ bool MediaStreamTrack::wantsToCaptureAudio() const
 {
     ASSERT(isCaptureTrack() && m_private->isAudio());
     return !ended() && (!muted() || m_private->interrupted());
+}
+
+ScriptExecutionContext* MediaStreamTrack::scriptExecutionContext() const
+{
+    return ActiveDOMObject::scriptExecutionContext();
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
@@ -168,7 +168,7 @@ public:
 protected:
     MediaStreamTrack(ScriptExecutionContext&, Ref<MediaStreamTrackPrivate>&&);
 
-    ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
+    ScriptExecutionContext* scriptExecutionContext() const final;
         
     Ref<MediaStreamTrackPrivate> m_private;
         

--- a/Source/WebCore/Modules/mediastream/RTCDataChannel.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannel.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(WEB_RTC)
 
 #include "Blob.h"
+#include "ContextDestructionObserverInlines.h"
 #include "EventNames.h"
 #include "ExceptionCode.h"
 #include "Logging.h"
@@ -340,6 +341,11 @@ Ref<RTCDataChannel> RTCDataChannel::create(ScriptExecutionContext& context, RTCD
     }
 
     return channel;
+}
+
+ScriptExecutionContext* RTCDataChannel::scriptExecutionContext() const
+{
+    return ActiveDOMObject::scriptExecutionContext();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/RTCDataChannel.h
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannel.h
@@ -101,7 +101,7 @@ private:
     void removeFromDataChannelLocalMapIfNeeded();
 
     EventTargetInterface eventTargetInterface() const final { return RTCDataChannelEventTargetInterfaceType; }
-    ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
+    ScriptExecutionContext* scriptExecutionContext() const final;
 
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }

--- a/Source/WebCore/Modules/mediastream/RTCDtlsTransport.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCDtlsTransport.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(WEB_RTC)
 
 #include "Blob.h"
+#include "ContextDestructionObserverInlines.h"
 #include "EventNames.h"
 #include "Logging.h"
 #include "NotImplemented.h"
@@ -98,6 +99,11 @@ void RTCDtlsTransport::onStateChanged(RTCDtlsTransportState state, Vector<Ref<JS
 void RTCDtlsTransport::onError()
 {
     onStateChanged(RTCDtlsTransportState::Failed, { });
+}
+
+ScriptExecutionContext* RTCDtlsTransport::scriptExecutionContext() const
+{
+    return ActiveDOMObject::scriptExecutionContext();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/RTCDtlsTransport.h
+++ b/Source/WebCore/Modules/mediastream/RTCDtlsTransport.h
@@ -61,7 +61,7 @@ private:
 
     // EventTarget
     EventTargetInterface eventTargetInterface() const final { return RTCDtlsTransportEventTargetInterfaceType; }
-    ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
+    ScriptExecutionContext* scriptExecutionContext() const final;
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
 

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
@@ -36,6 +36,7 @@
 
 #if ENABLE(WEB_RTC)
 
+#include "ContextDestructionObserverInlines.h"
 #include "Document.h"
 #include "Event.h"
 #include "EventNames.h"
@@ -1081,6 +1082,11 @@ void RTCPeerConnection::updateSctpBackend(std::unique_ptr<RTCSctpTransportBacken
     if (!dtlsTransport)
         return;
     m_sctpTransport = RTCSctpTransport::create(*context, makeUniqueRefFromNonNullUniquePtr(WTFMove(sctpBackend)), dtlsTransport.releaseNonNull());
+}
+
+ScriptExecutionContext* RTCPeerConnection::scriptExecutionContext() const
+{
+    return ActiveDOMObject::scriptExecutionContext();
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
@@ -164,7 +164,7 @@ public:
 
     // EventTarget
     EventTargetInterface eventTargetInterface() const final { return RTCPeerConnectionEventTargetInterfaceType; }
-    ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
+    ScriptExecutionContext* scriptExecutionContext() const final;
 
     using RefCounted::ref;
     using RefCounted::deref;

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(WEB_RTC)
 
+#include "ContextDestructionObserverInlines.h"
 #include "CryptoKeyRaw.h"
 #include "JSDOMConvertBufferSource.h"
 #include "JSDOMPromiseDeferred.h"
@@ -285,6 +286,11 @@ ExceptionOr<RefPtr<WritableStream>> RTCRtpSFrameTransform::writable()
 bool RTCRtpSFrameTransform::virtualHasPendingActivity() const
 {
     return (m_isAttached || m_hasWritable) && hasEventListeners();
+}
+
+ScriptExecutionContext* RTCRtpSFrameTransform::scriptExecutionContext() const
+{
+    return ContextDestructionObserver::scriptExecutionContext();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.h
@@ -87,7 +87,7 @@ private:
 
     // EventTarget
     EventTargetInterface eventTargetInterface() const final { return RTCRtpSFrameTransformEventTargetInterfaceType; }
-    ScriptExecutionContext* scriptExecutionContext() const final { return ContextDestructionObserver::scriptExecutionContext(); }
+    ScriptExecutionContext* scriptExecutionContext() const final;
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
 

--- a/Source/WebCore/Modules/mediastream/RTCSctpTransport.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCSctpTransport.cpp
@@ -27,6 +27,7 @@
 
 #if ENABLE(WEB_RTC)
 
+#include "ContextDestructionObserverInlines.h"
 #include "EventNames.h"
 #include "Logging.h"
 #include "RTCDtlsTransport.h"
@@ -84,6 +85,11 @@ void RTCSctpTransport::onStateChanged(RTCSctpTransportState state, std::optional
             dispatchEvent(Event::create(eventNames().statechangeEvent, Event::CanBubble::Yes, Event::IsCancelable::No));
         }
     });
+}
+
+ScriptExecutionContext* RTCSctpTransport::scriptExecutionContext() const
+{
+    return ActiveDOMObject::scriptExecutionContext();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/RTCSctpTransport.h
+++ b/Source/WebCore/Modules/mediastream/RTCSctpTransport.h
@@ -58,7 +58,7 @@ private:
 
     // EventTarget
     EventTargetInterface eventTargetInterface() const final { return RTCSctpTransportEventTargetInterfaceType; }
-    ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
+    ScriptExecutionContext* scriptExecutionContext() const final;
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
 

--- a/Source/WebCore/Modules/notifications/Notification.cpp
+++ b/Source/WebCore/Modules/notifications/Notification.cpp
@@ -35,6 +35,7 @@
 
 #include "Notification.h"
 
+#include "ContextDestructionObserverInlines.h"
 #include "DedicatedWorkerGlobalScope.h"
 #include "Event.h"
 #include "EventNames.h"
@@ -488,6 +489,11 @@ void Notification::ensureOnNotificationThread(ScriptExecutionContextIdentifier c
 void Notification::ensureOnNotificationThread(const NotificationData& notification, Function<void(Notification*)>&& task)
 {
     ensureOnNotificationThread(notification.contextIdentifier, notification.notificationID, WTFMove(task));
+}
+
+ScriptExecutionContext* Notification::scriptExecutionContext() const
+{
+    return ActiveDOMObject::scriptExecutionContext();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/notifications/Notification.h
+++ b/Source/WebCore/Modules/notifications/Notification.h
@@ -113,7 +113,7 @@ public:
     static Permission permission(ScriptExecutionContext&);
     static void requestPermission(Document&, RefPtr<NotificationPermissionCallback>&&, Ref<DeferredPromise>&&);
 
-    ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
+    WEBCORE_EXPORT ScriptExecutionContext* scriptExecutionContext() const final;
 
     WEBCORE_EXPORT NotificationData data() const;
     RefPtr<NotificationResources> resources() const { return m_resources; }

--- a/Source/WebCore/Modules/speech/SpeechSynthesis.cpp
+++ b/Source/WebCore/Modules/speech/SpeechSynthesis.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(SPEECH_SYNTHESIS)
 
+#include "ContextDestructionObserverInlines.h"
 #include "Document.h"
 #include "EventNames.h"
 #include "FrameDestructionObserverInlines.h"
@@ -352,6 +353,11 @@ bool SpeechSynthesis::virtualHasPendingActivity() const
 void SpeechSynthesis::eventListenersDidChange()
 {
     m_hasEventListener = hasEventListeners(eventNames().voiceschangedEvent);
+}
+
+ScriptExecutionContext* SpeechSynthesis::scriptExecutionContext() const
+{
+    return ActiveDOMObject::scriptExecutionContext();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/speech/SpeechSynthesis.h
+++ b/Source/WebCore/Modules/speech/SpeechSynthesis.h
@@ -106,7 +106,7 @@ private:
     void handleSpeakingCompleted(SpeechSynthesisUtterance&, bool errorOccurred);
 
     // EventTarget
-    ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
+    ScriptExecutionContext* scriptExecutionContext() const final;
     EventTargetInterface eventTargetInterface() const final { return SpeechSynthesisEventTargetInterfaceType; }
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }

--- a/Source/WebCore/Modules/speech/SpeechSynthesisUtterance.cpp
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisUtterance.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "SpeechSynthesisUtterance.h"
 
+#include "ContextDestructionObserverInlines.h"
 #include "EventNames.h"
 #include "SpeechSynthesisErrorEvent.h"
 #include "SpeechSynthesisEvent.h"
@@ -125,6 +126,10 @@ bool SpeechSynthesisUtterance::virtualHasPendingActivity() const
     return m_activityCountForEventDispatch && hasEventListeners();
 }
 
+ScriptExecutionContext* SpeechSynthesisUtterance::scriptExecutionContext() const
+{
+    return ActiveDOMObject::scriptExecutionContext();
+}
 
 } // namespace WebCore
 

--- a/Source/WebCore/Modules/speech/SpeechSynthesisUtterance.h
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisUtterance.h
@@ -89,7 +89,7 @@ private:
     bool virtualHasPendingActivity() const final;
 
     // EventTarget
-    ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
+    ScriptExecutionContext* scriptExecutionContext() const final;
     EventTargetInterface eventTargetInterface() const final { return SpeechSynthesisUtteranceEventTargetInterfaceType; }
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }

--- a/Source/WebCore/Modules/web-locks/WebLockManager.cpp
+++ b/Source/WebCore/Modules/web-locks/WebLockManager.cpp
@@ -25,6 +25,7 @@
 #include "config.h"
 #include "WebLockManager.h"
 
+#include "ContextDestructionObserverInlines.h"
 #include "Document.h"
 #include "ExceptionCode.h"
 #include "ExceptionOr.h"

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioData.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioData.cpp
@@ -29,6 +29,7 @@
 
 #if ENABLE(WEB_CODECS)
 
+#include "ContextDestructionObserverInlines.h"
 #include "ExceptionOr.h"
 #include "JSDOMPromiseDeferred.h"
 #include "PlatformRawAudioData.h"

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp
@@ -29,6 +29,7 @@
 
 #if ENABLE(WEB_CODECS)
 
+#include "ContextDestructionObserverInlines.h"
 #include "DOMException.h"
 #include "Event.h"
 #include "EventNames.h"
@@ -323,6 +324,11 @@ const char* WebCodecsAudioDecoder::activeDOMObjectName() const
 bool WebCodecsAudioDecoder::virtualHasPendingActivity() const
 {
     return m_state == WebCodecsCodecState::Configured && (m_decodeQueueSize || m_beingDecodedQueueSize || m_isFlushing);
+}
+
+ScriptExecutionContext* WebCodecsAudioDecoder::scriptExecutionContext() const
+{
+    return ActiveDOMObject::scriptExecutionContext();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.h
@@ -87,7 +87,7 @@ private:
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
     EventTargetInterface eventTargetInterface() const final { return WebCodecsAudioDecoderEventTargetInterfaceType; }
-    ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
+    ScriptExecutionContext* scriptExecutionContext() const final;
 
     ExceptionOr<void> closeDecoder(Exception&&);
     ExceptionOr<void> resetDecoder(const Exception&);

--- a/Source/WebCore/Modules/webxr/WebXRInputSourceArray.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRInputSourceArray.cpp
@@ -28,6 +28,7 @@
 #include "WebXRInputSourceArray.h"
 
 #if ENABLE(WEBXR)
+#include "ContextDestructionObserverInlines.h"
 #include "EventNames.h"
 #include "WebXRInputSource.h"
 #include "WebXRSession.h"

--- a/Source/WebCore/Modules/webxr/WebXRReferenceSpace.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRReferenceSpace.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(WEBXR)
 
+#include "ContextDestructionObserverInlines.h"
 #include "Document.h"
 #include "WebXRFrame.h"
 #include "WebXRRigidTransform.h"

--- a/Source/WebCore/Modules/webxr/WebXRWebGLLayer.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRWebGLLayer.cpp
@@ -29,6 +29,7 @@
 
 #if ENABLE(WEBXR)
 
+#include "ContextDestructionObserverInlines.h"
 #include "HTMLCanvasElement.h"
 #include "IntSize.h"
 #include "OffscreenCanvas.h"

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -29,6 +29,7 @@
 #include "AnimationFrameRate.h"
 #include "AnimationFrameRatePreset.h"
 #include "CSSNumericValue.h"
+#include "ContextDestructionObserverInlines.h"
 #include "EventTarget.h"
 #include "ExceptionOr.h"
 #include "IDLTypes.h"

--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -6712,6 +6712,7 @@ sub GenerateCallbackImplementationContent
     my $visibleName = $codeGenerator->GetVisibleInterfaceName($interfaceOrCallback);
     my $className = "JS${name}";
 
+    $includesRef->{"ContextDestructionObserverInlines.h"} = 1;
     $includesRef->{"ScriptExecutionContext.h"} = 1;
 
     # Constructor

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.cpp
@@ -21,6 +21,7 @@
 #include "config.h"
 #include "JSTestCallbackFunction.h"
 
+#include "ContextDestructionObserverInlines.h"
 #include "JSDOMConvertNumbers.h"
 #include "JSDOMConvertStrings.h"
 #include "JSDOMExceptionHandling.h"

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionRethrow.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionRethrow.cpp
@@ -21,6 +21,7 @@
 #include "config.h"
 #include "JSTestCallbackFunctionRethrow.h"
 
+#include "ContextDestructionObserverInlines.h"
 #include "JSDOMConvertNumbers.h"
 #include "JSDOMConvertSequences.h"
 #include "JSDOMConvertStrings.h"

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.cpp
@@ -21,6 +21,7 @@
 #include "config.h"
 #include "JSTestCallbackFunctionWithThisObject.h"
 
+#include "ContextDestructionObserverInlines.h"
 #include "JSDOMConvertBase.h"
 #include "JSDOMConvertInterface.h"
 #include "JSDOMConvertSequences.h"

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.cpp
@@ -21,6 +21,7 @@
 #include "config.h"
 #include "JSTestCallbackFunctionWithTypedefs.h"
 
+#include "ContextDestructionObserverInlines.h"
 #include "JSDOMConvertBase.h"
 #include "JSDOMConvertNullable.h"
 #include "JSDOMConvertNumbers.h"

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp
@@ -24,6 +24,7 @@
 
 #include "JSTestCallbackInterface.h"
 
+#include "ContextDestructionObserverInlines.h"
 #include "JSDOMConstructorNotConstructable.h"
 #include "JSDOMConvertBase.h"
 #include "JSDOMConvertBoolean.h"

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.cpp
@@ -24,6 +24,7 @@
 
 #include "JSTestVoidCallbackFunction.h"
 
+#include "ContextDestructionObserverInlines.h"
 #include "JSDOMConvertBase.h"
 #include "JSDOMConvertBoolean.h"
 #include "JSDOMConvertBufferSource.h"

--- a/Source/WebCore/crypto/SubtleCrypto.cpp
+++ b/Source/WebCore/crypto/SubtleCrypto.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(WEB_CRYPTO)
 
+#include "ContextDestructionObserverInlines.h"
 #include "CryptoAlgorithm.h"
 #include "CryptoAlgorithmRegistry.h"
 #include "CryptoAlgorithmX25519Params.h"

--- a/Source/WebCore/dom/AbortSignal.cpp
+++ b/Source/WebCore/dom/AbortSignal.cpp
@@ -27,6 +27,7 @@
 #include "AbortSignal.h"
 
 #include "AbortAlgorithm.h"
+#include "ContextDestructionObserverInlines.h"
 #include "DOMException.h"
 #include "DOMTimer.h"
 #include "Event.h"
@@ -210,6 +211,11 @@ void AbortSignal::throwIfAborted(JSC::JSGlobalObject& lexicalGlobalObject)
     Ref vm = lexicalGlobalObject.vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     throwException(&lexicalGlobalObject, scope, m_reason.getValue());
+}
+
+ScriptExecutionContext* AbortSignal::scriptExecutionContext() const
+{
+    return ContextDestructionObserver::scriptExecutionContext();
 }
 
 WebCoreOpaqueRoot root(AbortSignal* signal)

--- a/Source/WebCore/dom/AbortSignal.h
+++ b/Source/WebCore/dom/AbortSignal.h
@@ -90,7 +90,7 @@ private:
 
     // EventTarget.
     EventTargetInterface eventTargetInterface() const final { return AbortSignalEventTargetInterfaceType; }
-    ScriptExecutionContext* scriptExecutionContext() const final { return ContextDestructionObserver::scriptExecutionContext(); }
+    ScriptExecutionContext* scriptExecutionContext() const final;
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
     void eventListenersDidChange() final;

--- a/Source/WebCore/dom/BroadcastChannel.cpp
+++ b/Source/WebCore/dom/BroadcastChannel.cpp
@@ -27,6 +27,7 @@
 #include "BroadcastChannel.h"
 
 #include "BroadcastChannelRegistry.h"
+#include "ContextDestructionObserverInlines.h"
 #include "EventNames.h"
 #include "MessageEvent.h"
 #include "Page.h"
@@ -293,6 +294,11 @@ bool BroadcastChannel::isEligibleForMessaging() const
         return document->isFullyActive();
 
     return !downcast<WorkerGlobalScope>(*context).isClosing();
+}
+
+ScriptExecutionContext* BroadcastChannel::scriptExecutionContext() const
+{
+    return ActiveDOMObject::scriptExecutionContext();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/BroadcastChannel.h
+++ b/Source/WebCore/dom/BroadcastChannel.h
@@ -73,7 +73,7 @@ private:
 
     // EventTarget
     EventTargetInterface eventTargetInterface() const final { return BroadcastChannelEventTargetInterfaceType; }
-    ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
+    WEBCORE_EXPORT ScriptExecutionContext* scriptExecutionContext() const final;
     void refEventTarget() final { RefCounted<BroadcastChannel>::ref(); }
     void derefEventTarget() final { RefCounted<BroadcastChannel>::deref(); }
     void eventListenersDidChange() final;

--- a/Source/WebCore/dom/ContainerNode.h
+++ b/Source/WebCore/dom/ContainerNode.h
@@ -290,8 +290,20 @@ inline void Node::setParentNode(ContainerNode* parent)
     m_refCountAndParentBit = (m_refCountAndParentBit & s_refCountMask) | !!parent;
 }
 
+inline ContainerNode* Node::parentNode() const
+{
+    ASSERT(isMainThreadOrGCThread());
+    return m_parentNode.get();
+}
+
 inline RefPtr<ContainerNode> Node::protectedParentNode() const
 {
+    return parentNode();
+}
+
+inline ContainerNode* Node::parentNodeGuaranteedHostFree() const
+{
+    ASSERT(!isShadowRoot());
     return parentNode();
 }
 

--- a/Source/WebCore/dom/ContextDestructionObserver.cpp
+++ b/Source/WebCore/dom/ContextDestructionObserver.cpp
@@ -61,9 +61,4 @@ void ContextDestructionObserver::contextDestroyed()
     m_scriptExecutionContext = nullptr;
 }
 
-RefPtr<ScriptExecutionContext> ContextDestructionObserver::protectedScriptExecutionContext() const
-{
-    return m_scriptExecutionContext.get();
-}
-
 } // namespace WebCore

--- a/Source/WebCore/dom/ContextDestructionObserver.h
+++ b/Source/WebCore/dom/ContextDestructionObserver.h
@@ -37,8 +37,8 @@ class ContextDestructionObserver {
 public:
     WEBCORE_EXPORT virtual void contextDestroyed();
 
-    ScriptExecutionContext* scriptExecutionContext() const { return m_scriptExecutionContext.get(); }
-    RefPtr<ScriptExecutionContext> protectedScriptExecutionContext() const;
+    ScriptExecutionContext* scriptExecutionContext() const; // Defined in ContextDestructionObserverInlines.h.
+    RefPtr<ScriptExecutionContext> protectedScriptExecutionContext() const; // Defined in ContextDestructionObserverInlines.h.
 
 protected:
     WEBCORE_EXPORT explicit ContextDestructionObserver(ScriptExecutionContext*);

--- a/Source/WebCore/dom/ContextDestructionObserverInlines.h
+++ b/Source/WebCore/dom/ContextDestructionObserverInlines.h
@@ -1,5 +1,5 @@
-/**
- * Copyright (C) 2018-2023 Apple Inc. All rights reserved.
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,27 +25,19 @@
 
 #pragma once
 
-#include "LayoutBox.h"
+#include "ContextDestructionObserver.h"
+#include "ScriptExecutionContext.h"
 
 namespace WebCore {
 
-namespace Layout {
-
-inline bool Box::isContainingBlockForFixedPosition() const
+inline ScriptExecutionContext* ContextDestructionObserver::scriptExecutionContext() const
 {
-    return isInitialContainingBlock() || isLayoutContainmentBox() || style().hasTransform();
+    return m_scriptExecutionContext.get();
 }
 
-inline bool Box::isContainingBlockForOutOfFlowPosition() const
+inline RefPtr<ScriptExecutionContext> ContextDestructionObserver::protectedScriptExecutionContext() const
 {
-    return isInitialContainingBlock() || isPositioned() || isLayoutContainmentBox() || style().hasTransform();
+    return m_scriptExecutionContext.get();
 }
 
-inline const ElementBox& Box::parent() const
-{
-    return *m_parent;
-}
-
-}
-
-}
+} // namespace WebCore

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -404,6 +404,10 @@ public:
     // Resolve ambiguity for CanMakeCheckedPtr.
     void incrementPtrCount() const { static_cast<const ContainerNode*>(this)->incrementPtrCount(); }
     void decrementPtrCount() const { static_cast<const ContainerNode*>(this)->decrementPtrCount(); }
+    uint32_t ptrCount() const { return static_cast<const ContainerNode*>(this)->ptrCount(); }
+    void markAsZombie() const { static_cast<const ContainerNode*>(this)->markAsZombie(); }
+    bool isZombie() const { return static_cast<const ContainerNode*>(this)->isZombie(); }
+    using ContainerNode::s_supportsCheckedPtrZombieMode;
 #if CHECKED_POINTER_DEBUG
     void registerCheckedPtr(const void* pointer) const { static_cast<const ContainerNode*>(this)->registerCheckedPtr(pointer); }
     void copyCheckedPtr(const void* source, const void* destination) const { static_cast<const ContainerNode*>(this)->copyCheckedPtr(source, destination); }

--- a/Source/WebCore/dom/EventTarget.cpp
+++ b/Source/WebCore/dom/EventTarget.cpp
@@ -58,7 +58,7 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(EventTarget);
 
-struct SameSizeAsEventTarget : ScriptWrappable, CanMakeWeakPtr<EventTarget, WeakPtrFactoryInitialization::Lazy, WeakPtrImplWithEventTargetData>, CanMakeCheckedPtr {
+struct SameSizeAsEventTarget : ScriptWrappable, CanMakeWeakPtr<EventTarget, WeakPtrFactoryInitialization::Lazy, WeakPtrImplWithEventTargetData>, CanMakeCheckedPtrWithZombieMode {
     virtual ~SameSizeAsEventTarget() = default; // Allocate vtable pointer.
 };
 

--- a/Source/WebCore/dom/EventTarget.h
+++ b/Source/WebCore/dom/EventTarget.h
@@ -79,7 +79,7 @@ private:
     EventTargetData m_eventTargetData;
 };
 
-class EventTarget : public ScriptWrappable, public CanMakeWeakPtr<EventTarget, WeakPtrFactoryInitialization::Lazy, WeakPtrImplWithEventTargetData>, public CanMakeCheckedPtr {
+class EventTarget : public ScriptWrappable, public CanMakeWeakPtr<EventTarget, WeakPtrFactoryInitialization::Lazy, WeakPtrImplWithEventTargetData>, public CanMakeCheckedPtrWithZombieMode {
     WTF_MAKE_ISO_ALLOCATED(EventTarget);
 public:
     static Ref<EventTarget> create(ScriptExecutionContext&);

--- a/Source/WebCore/dom/MessagePort.h
+++ b/Source/WebCore/dom/MessagePort.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include "ActiveDOMObject.h"
+#include "ContextDestructionObserverInlines.h"
 #include "EventTarget.h"
 #include "ExceptionOr.h"
 #include "MessagePortChannel.h"

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -2672,6 +2672,15 @@ void Node::removedLastRef()
     if (auto* svgElement = dynamicDowncast<SVGElement>(*this))
         svgElement->detachAllProperties();
 
+    if (UNLIKELY(ptrCount())) {
+        // There is a CheckedPtr / CheckedRef still pointing to this Node. Instead of destroying
+        // the Node and crashing in its destructor, we mark ourselves as a zombie. Any action on
+        // those CheckedPtr / CheckedRef will crash. Crashing when using the checked pointer
+        // generates a lot more useful crash traces.
+        markAsZombie();
+        return;
+    }
+
 #if ASSERT_ENABLED
     m_deletionHasBegun = true;
 #endif

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -129,7 +129,7 @@ public:
     virtual void setNodeValue(const String&);
     virtual NodeType nodeType() const = 0;
     virtual size_t approximateMemoryCost() const { return sizeof(*this); }
-    ContainerNode* parentNode() const;
+    inline ContainerNode* parentNode() const; // Defined in ContainerNode.h.
     inline RefPtr<ContainerNode> protectedParentNode() const; // Defined in ContainerNode.h.
     static ptrdiff_t parentNodeMemoryOffset() { return OBJECT_OFFSETOF(Node, m_parentNode); }
     inline Element* parentElement() const;
@@ -296,7 +296,7 @@ public:
     void queueTaskToDispatchEvent(TaskSource, Ref<Event>&&);
 
     // Use when it's guaranteed to that shadowHost is null.
-    ContainerNode* parentNodeGuaranteedHostFree() const;
+    inline ContainerNode* parentNodeGuaranteedHostFree() const; // Defined in ContainerNode.h.
     // Returns the parent node, but null if the parent node is a ShadowRoot.
     ContainerNode* nonShadowBoundaryParentNode() const;
 
@@ -845,18 +845,6 @@ inline void addSubresourceURL(ListHashSet<URL>& urls, const URL& url)
 {
     if (!url.isNull())
         urls.add(url);
-}
-
-inline ContainerNode* Node::parentNode() const
-{
-    ASSERT(isMainThreadOrGCThread());
-    return m_parentNode.get();
-}
-
-inline ContainerNode* Node::parentNodeGuaranteedHostFree() const
-{
-    ASSERT(!isShadowRoot());
-    return parentNode();
 }
 
 ALWAYS_INLINE void Node::setStyleFlag(NodeStyleFlag flag)

--- a/Source/WebCore/dom/ShadowRoot.h
+++ b/Source/WebCore/dom/ShadowRoot.h
@@ -66,8 +66,10 @@ public:
     virtual ~ShadowRoot();
 
     // Resolve ambiguity for CanMakeCheckedPtr.
+    using DocumentFragment::s_supportsCheckedPtrZombieMode;
     void incrementPtrCount() const { static_cast<const DocumentFragment*>(this)->incrementPtrCount(); }
     void decrementPtrCount() const { static_cast<const DocumentFragment*>(this)->decrementPtrCount(); }
+    bool isZombie() const { return static_cast<const DocumentFragment*>(this)->isZombie(); }
 #if CHECKED_POINTER_DEBUG
     void registerCheckedPtr(const void* pointer) const { static_cast<const DocumentFragment*>(this)->registerCheckedPtr(pointer); }
     void copyCheckedPtr(const void* source, const void* destination) const { static_cast<const DocumentFragment*>(this)->copyCheckedPtr(source, destination); }

--- a/Source/WebCore/dom/TreeScope.cpp
+++ b/Source/WebCore/dom/TreeScope.cpp
@@ -105,6 +105,13 @@ void TreeScope::decrementPtrCount() const
         checkedDowncast<ShadowRoot>(m_rootNode).decrementPtrCount();
 }
 
+bool TreeScope::isZombie() const
+{
+    if (auto* document = dynamicDowncast<Document>(m_rootNode))
+        return document->isZombie();
+    return checkedDowncast<ShadowRoot>(m_rootNode).isZombie();
+}
+
 #if CHECKED_POINTER_DEBUG
 void TreeScope::registerCheckedPtr(const void* pointer) const
 {

--- a/Source/WebCore/dom/TreeScope.h
+++ b/Source/WebCore/dom/TreeScope.h
@@ -68,8 +68,10 @@ public:
     void setParentTreeScope(TreeScope&);
 
     // For CheckedPtr / CheckedRef use.
+    static constexpr bool s_supportsCheckedPtrZombieMode = true;
     void incrementPtrCount() const;
     void decrementPtrCount() const;
+    WEBCORE_EXPORT bool isZombie() const;
 #if CHECKED_POINTER_DEBUG
     void registerCheckedPtr(const void*) const;
     void copyCheckedPtr(const void* source, const void* destination) const;

--- a/Source/WebCore/fileapi/Blob.cpp
+++ b/Source/WebCore/fileapi/Blob.cpp
@@ -35,6 +35,7 @@
 #include "BlobLoader.h"
 #include "BlobPart.h"
 #include "BlobURL.h"
+#include "ContextDestructionObserverInlines.h"
 #include "File.h"
 #include "JSDOMPromiseDeferred.h"
 #include "PolicyContainer.h"

--- a/Source/WebCore/fileapi/NetworkSendQueue.cpp
+++ b/Source/WebCore/fileapi/NetworkSendQueue.cpp
@@ -27,6 +27,7 @@
 #include "NetworkSendQueue.h"
 
 #include "BlobLoader.h"
+#include "ContextDestructionObserverInlines.h"
 #include "ScriptExecutionContext.h"
 
 namespace WebCore {

--- a/Source/WebCore/html/OffscreenCanvas.cpp
+++ b/Source/WebCore/html/OffscreenCanvas.cpp
@@ -32,6 +32,7 @@
 #include "CSSValuePool.h"
 #include "CanvasRenderingContext.h"
 #include "Chrome.h"
+#include "ContextDestructionObserverInlines.h"
 #include "Document.h"
 #include "EventDispatcher.h"
 #include "GPU.h"
@@ -620,6 +621,16 @@ void OffscreenCanvas::queueTaskKeepingObjectAlive(TaskSource source, Function<vo
 void OffscreenCanvas::dispatchEvent(Event& event)
 {
     EventDispatcher::dispatchEvent({ this }, event);
+}
+
+ScriptExecutionContext* OffscreenCanvas::scriptExecutionContext() const
+{
+    return ContextDestructionObserver::scriptExecutionContext();
+}
+
+ScriptExecutionContext* OffscreenCanvas::canvasBaseScriptExecutionContext() const
+{
+    return ContextDestructionObserver::scriptExecutionContext();
 }
 
 }

--- a/Source/WebCore/html/OffscreenCanvas.h
+++ b/Source/WebCore/html/OffscreenCanvas.h
@@ -164,8 +164,8 @@ private:
 
     bool isOffscreenCanvas() const final { return true; }
 
-    ScriptExecutionContext* scriptExecutionContext() const final { return ContextDestructionObserver::scriptExecutionContext(); }
-    ScriptExecutionContext* canvasBaseScriptExecutionContext() const final { return ContextDestructionObserver::scriptExecutionContext(); }
+    ScriptExecutionContext* scriptExecutionContext() const final;
+    ScriptExecutionContext* canvasBaseScriptExecutionContext() const final;
 
     EventTargetInterface eventTargetInterface() const final { return OffscreenCanvasEventTargetInterfaceType; }
     void refEventTarget() final { ref(); }

--- a/Source/WebCore/html/canvas/EXTDisjointTimerQuery.cpp
+++ b/Source/WebCore/html/canvas/EXTDisjointTimerQuery.cpp
@@ -29,6 +29,7 @@
 
 #include "EXTDisjointTimerQuery.h"
 
+#include "ContextDestructionObserverInlines.h"
 #include "EventLoop.h"
 #include "ScriptExecutionContext.h"
 #include "WebGLRenderingContext.h"

--- a/Source/WebCore/html/track/TextTrack.cpp
+++ b/Source/WebCore/html/track/TextTrack.cpp
@@ -35,6 +35,7 @@
 #if ENABLE(VIDEO)
 
 #include "CommonAtomStrings.h"
+#include "ContextDestructionObserverInlines.h"
 #include "DataCue.h"
 #include "Document.h"
 #include "Event.h"
@@ -614,6 +615,11 @@ void TextTrack::newCuesAvailable(const TextTrackCueList& list)
     m_clients.forEach([&] (auto& client) {
         client.textTrackAddCues(*this, list);
     });
+}
+
+ScriptExecutionContext* TextTrack::scriptExecutionContext() const
+{
+    return ActiveDOMObject::scriptExecutionContext();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/track/TextTrack.h
+++ b/Source/WebCore/html/track/TextTrack.h
@@ -148,7 +148,7 @@ protected:
 
 private:
     EventTargetInterface eventTargetInterface() const final { return TextTrackEventTargetInterfaceType; }
-    ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
+    ScriptExecutionContext* scriptExecutionContext() const final;
 
     bool enabled() const override;
 

--- a/Source/WebCore/html/track/TrackListBase.cpp
+++ b/Source/WebCore/html/track/TrackListBase.cpp
@@ -29,6 +29,7 @@
 
 #include "TrackListBase.h"
 
+#include "ContextDestructionObserverInlines.h"
 #include "EventNames.h"
 #include "ScriptExecutionContext.h"
 #include "TrackEvent.h"
@@ -161,6 +162,11 @@ bool TrackListBase::isAnyTrackEnabled() const
             return true;
     }
     return false;
+}
+
+ScriptExecutionContext* TrackListBase::scriptExecutionContext() const
+{
+    return ContextDestructionObserver::scriptExecutionContext();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/track/TrackListBase.h
+++ b/Source/WebCore/html/track/TrackListBase.h
@@ -55,7 +55,7 @@ public:
     EventTargetInterface eventTargetInterface() const override = 0;
     using RefCounted<TrackListBase>::ref;
     using RefCounted<TrackListBase>::deref;
-    ScriptExecutionContext* scriptExecutionContext() const final { return ContextDestructionObserver::scriptExecutionContext(); }
+    ScriptExecutionContext* scriptExecutionContext() const final;
 
     WebCoreOpaqueRoot opaqueRoot();
 

--- a/Source/WebCore/layout/formattingContexts/inline/InlineContentBreaker.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineContentBreaker.cpp
@@ -30,6 +30,7 @@
 #include "Hyphenation.h"
 #include "InlineItem.h"
 #include "InlineTextItem.h"
+#include "LayoutBoxInlines.h"
 #include "LayoutElementBox.h"
 #include "RenderStyleInlines.h"
 #include "TextUtil.h"

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBox.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBox.cpp
@@ -27,7 +27,9 @@
 #include "InlineLineBox.h"
 
 #include "InlineLevelBoxInlines.h"
+#include "InlineLineBoxInlines.h"
 #include "LayoutBoxGeometry.h"
+#include "LayoutBoxInlines.h"
 #include "LayoutElementBox.h"
 #include "RenderStyleInlines.h"
 

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBox.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBox.h
@@ -95,11 +95,11 @@ private:
 
     InlineLevelBox& rootInlineBox() { return m_rootInlineBox; }
 
-    const InlineLevelBox& parentInlineBox(const InlineLevelBox& inlineLevelBox) const { return const_cast<LineBox&>(*this).parentInlineBox(inlineLevelBox); }
-    InlineLevelBox& parentInlineBox(const InlineLevelBox&);
+    inline const InlineLevelBox& parentInlineBox(const InlineLevelBox&) const; // Defined in InlineLineBoxInlines.h.
+    inline InlineLevelBox& parentInlineBox(const InlineLevelBox&); // Defined in InlineLineBoxInlines.h.
 
-    const InlineLevelBox& parentInlineBox(const Line::Run& lineRun) const { return const_cast<LineBox&>(*this).parentInlineBox(lineRun); }
-    InlineLevelBox& parentInlineBox(const Line::Run&);
+    inline const InlineLevelBox& parentInlineBox(const Line::Run&) const; // Defined in InlineLineBoxInlines.h.
+    inline InlineLevelBox& parentInlineBox(const Line::Run&); // Defined in InlineLineBoxInlines.h.
 
     InlineLevelBox& inlineLevelBoxFor(const Line::Run&);
     InlineLevelBox* inlineLevelBoxFor(const Box& layoutBox);
@@ -133,16 +133,6 @@ inline InlineLevelBox* LineBox::inlineLevelBoxFor(const Box& layoutBox)
     if (entry == m_nonRootInlineLevelBoxMap.end())
         return nullptr;
     return &m_nonRootInlineLevelBoxList[entry->value];
-}
-
-inline InlineLevelBox& LineBox::parentInlineBox(const InlineLevelBox& inlineLevelBox)
-{
-    return *inlineLevelBoxFor(inlineLevelBox.layoutBox().parent());
-}
-
-inline InlineLevelBox& LineBox::parentInlineBox(const Line::Run& lineRun)
-{
-    return *inlineLevelBoxFor(lineRun.layoutBox().parent());
 }
 
 inline InlineLevelBox& LineBox::inlineLevelBoxFor(const Line::Run& lineRun)

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxInlines.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxInlines.h
@@ -1,5 +1,5 @@
-/**
- * Copyright (C) 2018-2023 Apple Inc. All rights reserved.
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,27 +25,31 @@
 
 #pragma once
 
+#include "InlineLineBox.h"
 #include "LayoutBox.h"
 
 namespace WebCore {
-
 namespace Layout {
 
-inline bool Box::isContainingBlockForFixedPosition() const
+inline const InlineLevelBox& LineBox::parentInlineBox(const InlineLevelBox& inlineLevelBox) const
 {
-    return isInitialContainingBlock() || isLayoutContainmentBox() || style().hasTransform();
+    return const_cast<LineBox&>(*this).parentInlineBox(inlineLevelBox);
 }
 
-inline bool Box::isContainingBlockForOutOfFlowPosition() const
+inline InlineLevelBox& LineBox::parentInlineBox(const InlineLevelBox& inlineLevelBox)
 {
-    return isInitialContainingBlock() || isPositioned() || isLayoutContainmentBox() || style().hasTransform();
+    return *inlineLevelBoxFor(inlineLevelBox.layoutBox().parent());
 }
 
-inline const ElementBox& Box::parent() const
+inline const InlineLevelBox& LineBox::parentInlineBox(const Line::Run& lineRun) const
 {
-    return *m_parent;
+    return const_cast<LineBox&>(*this).parentInlineBox(lineRun);
 }
 
+inline InlineLevelBox& LineBox::parentInlineBox(const Line::Run& lineRun)
+{
+    return *inlineLevelBoxFor(lineRun.layoutBox().parent());
 }
 
-}
+} // namespace Layout
+} // namespace WebCore

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
@@ -30,6 +30,7 @@
 #include "InlineFormattingUtils.h"
 #include "InlineTextBoxStyle.h"
 #include "LayoutBoxGeometry.h"
+#include "LayoutBoxInlines.h"
 #include "LayoutInitialContainingBlock.h"
 #include "RenderStyleInlines.h"
 #include "RubyFormattingContext.h"

--- a/Source/WebCore/layout/formattingContexts/table/TableGrid.cpp
+++ b/Source/WebCore/layout/formattingContexts/table/TableGrid.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "TableGrid.h"
 
+#include "LayoutBoxInlines.h"
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxTree.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxTree.cpp
@@ -40,6 +40,7 @@
 #include "RenderLineBreak.h"
 #include "RenderListItem.h"
 #include "RenderListMarker.h"
+#include "RenderObjectInlines.h"
 #include "RenderStyleSetters.h"
 #include "RenderTable.h"
 #include "RenderView.h"

--- a/Source/WebCore/layout/integration/inline/InlineIteratorBox.cpp
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorBox.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "InlineIteratorBox.h"
 
+#include "InlineIteratorBoxModernPathInlines.h"
 #include "InlineIteratorInlineBox.h"
 #include "InlineIteratorLineBox.h"
 #include "InlineIteratorTextBox.h"

--- a/Source/WebCore/layout/integration/inline/InlineIteratorBoxModernPath.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorBoxModernPath.h
@@ -174,56 +174,9 @@ public:
         ASSERT(box().isInlineBox());
     }
 
-    BoxModernPath firstLeafBoxForInlineBox() const
-    {
-        ASSERT(box().isInlineBox());
-
-        auto& inlineBox = box().layoutBox();
-
-        // The next box is the first descendant of this box;
-        auto first = *this;
-        first.traverseNextOnLine();
-
-        if (!first.atEnd() && !first.isWithinInlineBox(inlineBox))
-            first.setAtEnd();
-
-        return first;
-    }
-
-    BoxModernPath lastLeafBoxForInlineBox() const
-    {
-        ASSERT(box().isInlineBox());
-
-        auto& inlineBox = box().layoutBox();
-
-        // FIXME: Get the last box index directly from the display box.
-        auto last = firstLeafBoxForInlineBox();
-        for (auto box = last; !box.atEnd() && box.isWithinInlineBox(inlineBox); box.traverseNextOnLine())
-            last = box;
-
-        return last;
-    }
-
-    BoxModernPath parentInlineBox() const
-    {
-        ASSERT(!atEnd());
-
-        auto candidate = *this;
-
-        if (isRootInlineBox()) {
-            candidate.setAtEnd();
-            return candidate;
-        }
-
-        auto& parentLayoutBox = box().layoutBox().parent();
-        do {
-            candidate.traversePreviousBox();
-        } while (!candidate.atEnd() && &candidate.box().layoutBox() != &parentLayoutBox);
-
-        ASSERT(candidate.atEnd() || candidate.box().isInlineBox());
-
-        return candidate;
-    }
+    inline BoxModernPath firstLeafBoxForInlineBox() const; // Defined in InlineIteratorBoxModernPathInlines.h.
+    inline BoxModernPath lastLeafBoxForInlineBox() const; // Defined in InlineIteratorBoxModernPathInlines.h.
+    inline BoxModernPath parentInlineBox() const; // Defined in InlineIteratorBoxModernPathInlines.h.
 
     TextDirection direction() const { return bidiLevel() % 2 ? TextDirection::RTL : TextDirection::LTR; }
     bool isFirstLine() const { return !box().lineIndex(); }
@@ -235,15 +188,7 @@ public:
     auto& inlineContent() const { return *m_inlineContent; }
 
 private:
-    bool isWithinInlineBox(const Layout::Box& inlineBox)
-    {
-        auto* layoutBox = &box().layoutBox().parent();
-        for (; layoutBox->isInlineBox(); layoutBox = &layoutBox->parent()) {
-            if (layoutBox == &inlineBox)
-                return true;
-        }
-        return false;
-    }
+    inline bool isWithinInlineBox(const Layout::Box&); // Defined in InlineIteratorBoxModernPathInlines.h.
 
     void traverseNextBox()
     {

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.cpp
@@ -27,6 +27,7 @@
 #include "LayoutIntegrationInlineContent.h"
 
 #include "InlineIteratorBox.h"
+#include "LayoutIntegrationInlineContentInlines.h"
 #include "LayoutIntegrationLineLayout.h"
 #include "RenderStyleInlines.h"
 #include "TextPainter.h"

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.h
@@ -77,7 +77,7 @@ struct InlineContent : public CanMakeWeakPtr<InlineContent> {
 
     void shrinkToFit();
 
-    const LineLayout& lineLayout() const { return *m_lineLayout; }
+    inline const LineLayout& lineLayout() const; // Defined in LayoutIntegrationInlineContentInlines.h.
     const RenderObject& rendererForLayoutBox(const Layout::Box&) const;
     const RenderBlockFlow& formattingContextRoot() const;
 

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentInlines.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentInlines.h
@@ -1,5 +1,5 @@
-/**
- * Copyright (C) 2018-2023 Apple Inc. All rights reserved.
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,27 +25,15 @@
 
 #pragma once
 
-#include "LayoutBox.h"
+#include "LayoutIntegrationInlineContent.h"
 
 namespace WebCore {
+namespace LayoutIntegration {
 
-namespace Layout {
-
-inline bool Box::isContainingBlockForFixedPosition() const
+inline const LineLayout& InlineContent::lineLayout() const
 {
-    return isInitialContainingBlock() || isLayoutContainmentBox() || style().hasTransform();
+    return *m_lineLayout;
 }
 
-inline bool Box::isContainingBlockForOutOfFlowPosition() const
-{
-    return isInitialContainingBlock() || isPositioned() || isLayoutContainmentBox() || style().hasTransform();
-}
-
-inline const ElementBox& Box::parent() const
-{
-    return *m_parent;
-}
-
-}
-
-}
+} // namespace LayoutIntegration
+} // namespace WebCore

--- a/Source/WebCore/layout/layouttree/LayoutBox.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutBox.cpp
@@ -27,6 +27,7 @@
 #include "LayoutBox.h"
 
 #include "LayoutBoxGeometry.h"
+#include "LayoutBoxInlines.h"
 #include "LayoutContainingBlockChainIterator.h"
 #include "LayoutElementBox.h"
 #include "LayoutInitialContainingBlock.h"

--- a/Source/WebCore/layout/layouttree/LayoutBox.h
+++ b/Source/WebCore/layout/layouttree/LayoutBox.h
@@ -148,7 +148,7 @@ public:
     bool isInlineIntegrationRoot() const { return m_isInlineIntegrationRoot; }
     bool isFirstChildForIntegration() const { return m_isFirstChildForIntegration; }
 
-    const ElementBox& parent() const { return *m_parent; }
+    inline const ElementBox& parent() const; // Defined in LayoutBoxInlines.h.
     const Box* nextSibling() const { return m_nextSibling.get(); }
     const Box* nextInFlowSibling() const;
     const Box* nextInFlowOrFloatingSibling() const;

--- a/Source/WebCore/layout/layouttree/LayoutIterator.h
+++ b/Source/WebCore/layout/layouttree/LayoutIterator.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "LayoutBoxInlines.h"
 #include "LayoutInitialContainingBlock.h"
 
 namespace WebCore {

--- a/Source/WebCore/page/LocalDOMWindow.h
+++ b/Source/WebCore/page/LocalDOMWindow.h
@@ -28,6 +28,7 @@
 
 #include "Base64Utilities.h"
 #include "ContextDestructionObserver.h"
+#include "ContextDestructionObserverInlines.h"
 #include "DOMWindow.h"
 #include "ExceptionOr.h"
 #include "ImageBitmap.h"

--- a/Source/WebCore/page/ScreenOrientation.cpp
+++ b/Source/WebCore/page/ScreenOrientation.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "ScreenOrientation.h"
 
+#include "ContextDestructionObserverInlines.h"
 #include "Document.h"
 #include "DocumentInlines.h"
 #include "Element.h"
@@ -282,6 +283,11 @@ bool ScreenOrientation::virtualHasPendingActivity() const
 void ScreenOrientation::eventListenersDidChange()
 {
     m_hasChangeEventListener = hasEventListeners(eventNames().changeEvent);
+}
+
+ScriptExecutionContext* ScreenOrientation::scriptExecutionContext() const
+{
+    return ActiveDOMObject::scriptExecutionContext();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/ScreenOrientation.h
+++ b/Source/WebCore/page/ScreenOrientation.h
@@ -75,7 +75,7 @@ private:
 
     // EventTarget
     EventTargetInterface eventTargetInterface() const final { return ScreenOrientationEventTargetInterfaceType; }
-    ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
+    ScriptExecutionContext* scriptExecutionContext() const final;
     void refEventTarget() final { RefCounted::ref(); }
     void derefEventTarget() final { RefCounted::deref(); }
     void eventListenersDidChange() final;

--- a/Source/WebCore/page/scrolling/ScrollingStateNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateNode.h
@@ -307,11 +307,7 @@ public:
     WEBCORE_EXPORT void setLayer(const LayerRepresentation&);
 
     bool isAttachedToScrollingStateTree() const { return !!m_scrollingStateTree; }
-    ScrollingStateTree& scrollingStateTree() const
-    {
-        ASSERT(m_scrollingStateTree);
-        return *m_scrollingStateTree;
-    }
+    inline ScrollingStateTree& scrollingStateTree() const; // Defined in ScrollingStateTree.h.
     void attachAfterDeserialization(ScrollingStateTree&);
 
     ScrollingNodeID scrollingNodeID() const { return m_nodeID; }

--- a/Source/WebCore/page/scrolling/ScrollingStateTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateTree.h
@@ -123,6 +123,12 @@ private:
     bool m_hasNewRootStateNode { false };
 };
 
+inline ScrollingStateTree& ScrollingStateNode::scrollingStateTree() const
+{
+    ASSERT(m_scrollingStateTree);
+    return *m_scrollingStateTree;
+}
+
 } // namespace WebCore
 
 #ifndef NDEBUG

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -226,8 +226,8 @@ public:
     virtual ~RenderObject();
 
     Type type() const { return m_type; }
-    Layout::Box* layoutBox() { return m_layoutBox.get(); }
-    const Layout::Box* layoutBox() const { return m_layoutBox.get(); }
+    inline Layout::Box* layoutBox(); // Defined in RenderObjectInlines.h.
+    inline const Layout::Box* layoutBox() const; // Defined in RenderObjectInlines.h.
     void setLayoutBox(Layout::Box&);
     void clearLayoutBox();
 

--- a/Source/WebCore/rendering/RenderObjectInlines.h
+++ b/Source/WebCore/rendering/RenderObjectInlines.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "Document.h"
+#include "LayoutBox.h"
 #include "RenderObject.h"
 #include "RenderStyleInlines.h"
 
@@ -30,5 +31,7 @@ inline bool RenderObject::isAtomicInlineLevelBox() const { return style().isDisp
 inline bool RenderObject::isTransformed() const { return hasTransformRelatedProperty() && (style().affectsTransform() || hasSVGTransform()); }
 inline bool RenderObject::preservesNewline() const { return !isRenderSVGInlineText() && style().preserveNewline(); }
 inline Ref<Document> RenderObject::protectedDocument() const { return document(); }
+inline Layout::Box* RenderObject::layoutBox() { return m_layoutBox.get(); }
+inline const Layout::Box* RenderObject::layoutBox() const { return m_layoutBox.get(); }
 
 } // namespace WebCore

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -146,6 +146,7 @@ public:
 
     using CanMakeThreadSafeCheckedPtr::incrementPtrCount;
     using CanMakeThreadSafeCheckedPtr::decrementPtrCount;
+    using CanMakeThreadSafeCheckedPtr::s_supportsCheckedPtrZombieMode;
 #if CHECKED_POINTER_DEBUG
     using CanMakeThreadSafeCheckedPtr::registerCheckedPtr;
     using CanMakeThreadSafeCheckedPtr::copyCheckedPtr;

--- a/Source/WebKit/UIProcess/DrawingAreaProxy.cpp
+++ b/Source/WebKit/UIProcess/DrawingAreaProxy.cpp
@@ -113,6 +113,11 @@ bool DrawingAreaProxy::setSize(const IntSize& size, const IntSize& scrollDelta)
     return true;
 }
 
+WebPageProxy& DrawingAreaProxy::page() const
+{
+    return m_webPageProxy;
+}
+
 #if PLATFORM(COCOA)
 MachSendRight DrawingAreaProxy::createFence()
 {

--- a/Source/WebKit/UIProcess/DrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/DrawingAreaProxy.h
@@ -124,7 +124,7 @@ public:
     virtual bool shouldCoalesceVisualEditorStateUpdates() const { return false; }
     virtual bool shouldSendWheelEventsToEventDispatcher() const { return false; }
 
-    WebPageProxy& page() const { return m_webPageProxy; }
+    WebPageProxy& page() const;
     virtual void viewWillStartLiveResize() { };
     virtual void viewWillEndLiveResize() { };
 

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
@@ -310,6 +310,11 @@ bool SuspendedPageProxy::sendMessageWithAsyncReply(UniqueRef<IPC::Encoder>&& enc
     return m_process->sendMessage(WTFMove(encoder), sendOptions, WTFMove(handler));
 }
 
+WebPageProxy& SuspendedPageProxy::page() const
+{
+    return m_page.get();
+}
+
 #if !LOG_DISABLED
 
 const char* SuspendedPageProxy::loggingString() const

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.h
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.h
@@ -62,7 +62,7 @@ public:
 
     static RefPtr<WebProcessProxy> findReusableSuspendedPageProcess(WebProcessPool&, const WebCore::RegistrableDomain&, WebsiteDataStore&, WebProcessProxy::LockdownMode, const API::PageConfiguration&);
 
-    WebPageProxy& page() const { return m_page.get(); }
+    WebPageProxy& page() const;
     WebCore::PageIdentifier webPageID() const { return m_webPageID; }
     WebProcessProxy& process() const { return m_process.get(); }
     WebFrameProxy& mainFrame() { return m_mainFrame.get(); }


### PR DESCRIPTION
#### ddcad4bcc37973d9e527e7b9c74a37db6ec6545c
<pre>
Make CheckedPtr&lt;Node&gt; / CheckedRef&lt;Node&gt; crashes more actionable
<a href="https://bugs.webkit.org/show_bug.cgi?id=265667">https://bugs.webkit.org/show_bug.cgi?id=265667</a>
&lt;<a href="https://rdar.apple.com/problem/119046141">rdar://problem/119046141</a>&gt;

Reviewed by NOBODY (OOPS!).

Node subclasses CanMakeCheckedPtr. As a result, the behavior used to be that a
Node would crash (safely) on destruction if any CheckedPtr / CheckedRef to this
Node still exist, to prevent pointers from going stale.

The issue with this approach is that we&apos;re getting crashes in the wild in the
Node destructor but these are not really actionable because we don&apos;t have any
idea which CheckedPtr / CheckedRef remains and a lot of them exists in the
codebase, especially for Node.

I discussed this with Mark Lam and he suggested the new approach that I
implemented in this patch. When a node is about to get destroyed, we check
if there are still CheckedPtr/CheckedRef pointing to it. If there are, we
don&apos;t call `delete` on the Node and we mark it as a &quot;zombie&quot;. The &quot;zombie&quot;
flag is stored as the lowest bit of the ptrCount in CanMakeCheckedPtr.
Whenever someone tries to dereference a CheckedPtr / CheckedRef, we
RELEASE_ASSERT() that the object doesn&apos;t have the &quot;zombie&quot; flag set. We
do the same when a CheckedPtr / CheckedRef gets cleared/destroyed.

This effectively prevents use-after-free pointer usage, like we used to.
However, we now crash when using the bad / stale pointer, which should
make crash logs a lot more actionable.

In this patch, I have only applied the &quot;zombie&quot; approach to the Node
class. However, I intend to follow-up shortly to apply it to RenderObject
too. I think we should consider doing it for all classes.

This tested as performance neutral on Speedometer.

Note that the new zombie check means that the type needs to be included
when we call `.get()` on a CheckedPtr / CheckedRef. As a result, I had
to refactor some code. To avoid increasing the build time, I either moved
the functions out of line (when clearly not perf sensitive), or I moved
the inlines functions to &quot;FooInlines.h&quot; headers.

* Source/WTF/wtf/CheckedPtr.h:
(WTF::CheckedPtr::get const):
(WTF::CheckedPtr::getAllowingHashTableDeletedValue const):
(WTF::CheckedPtr::assertIsNotZombie const):
(WTF::DefaultHash&lt;CheckedPtr&lt;P&gt;&gt;::equal):
* Source/WTF/wtf/CheckedRef.h:
(WTF::CheckedRef::ptr const):
(WTF::CheckedRef::assertIsNotZombie const):
(WTF::CanMakeCheckedPtrBase::~CanMakeCheckedPtrBase):
(WTF::supportsZombieMode&gt;::ptrCount const):
(WTF::supportsZombieMode&gt;::incrementPtrCount const):
(WTF::supportsZombieMode&gt;::decrementPtrCount const):
(WTF::supportsZombieMode&gt;::isZombie const):
(WTF::supportsZombieMode&gt;::markAsZombie const):
(WTF::supportsZombieMode&gt;::registerCheckedPtr const):
(WTF::SingleThreadIntegralWrapper::assertThread const):
(WTF::=):
(WTF::CanMakeCheckedPtrBase::ptrCount const): Deleted.
(WTF::CanMakeCheckedPtrBase::incrementPtrCount const): Deleted.
(WTF::CanMakeCheckedPtrBase::decrementPtrCount const): Deleted.
(WTF::PtrCounterType&gt;::registerCheckedPtr const): Deleted.
(WTF::SingleThreadIntegralWrapper&lt;IntegralType&gt;::operator): Deleted.
* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/WebGPU/GPUDevice.cpp:
(WebCore::GPUDevice::scriptExecutionContext const):
* Source/WebCore/Modules/WebGPU/GPUDevice.h:
* Source/WebCore/Modules/encryptedmedia/CDM.cpp:
* Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp:
(WebCore::MediaKeySession::scriptExecutionContext const):
* Source/WebCore/Modules/encryptedmedia/MediaKeySession.h:
* Source/WebCore/Modules/encryptedmedia/MediaKeySystemRequest.cpp:
* Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.cpp:
(WebCore::WebKitMediaKeySession::scriptExecutionContext const):
* Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.h:
* Source/WebCore/Modules/gamepad/GamepadHapticActuator.cpp:
* Source/WebCore/Modules/geolocation/Geolocation.cpp:
(WebCore::Geolocation::document const):
* Source/WebCore/Modules/geolocation/Geolocation.h:
* Source/WebCore/Modules/indexeddb/IDBActiveDOMObject.h:
* Source/WebCore/Modules/mediasource/SourceBufferList.cpp:
(WebCore::SourceBufferList::scriptExecutionContext const):
* Source/WebCore/Modules/mediasource/SourceBufferList.h:
* Source/WebCore/Modules/mediastream/MediaStream.cpp:
(WebCore::MediaStream::scriptExecutionContext const):
* Source/WebCore/Modules/mediastream/MediaStream.h:
* Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp:
(WebCore::MediaStreamTrack::scriptExecutionContext const):
* Source/WebCore/Modules/mediastream/MediaStreamTrack.h:
* Source/WebCore/Modules/mediastream/RTCDataChannel.cpp:
(WebCore::RTCDataChannel::scriptExecutionContext const):
* Source/WebCore/Modules/mediastream/RTCDataChannel.h:
* Source/WebCore/Modules/mediastream/RTCDtlsTransport.cpp:
(WebCore::RTCDtlsTransport::scriptExecutionContext const):
* Source/WebCore/Modules/mediastream/RTCDtlsTransport.h:
* Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp:
(WebCore::RTCPeerConnection::scriptExecutionContext const):
* Source/WebCore/Modules/mediastream/RTCPeerConnection.h:
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp:
(WebCore::RTCRtpSFrameTransform::scriptExecutionContext const):
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.h:
* Source/WebCore/Modules/mediastream/RTCSctpTransport.cpp:
(WebCore::RTCSctpTransport::scriptExecutionContext const):
* Source/WebCore/Modules/mediastream/RTCSctpTransport.h:
* Source/WebCore/Modules/notifications/Notification.cpp:
(WebCore::Notification::scriptExecutionContext const):
* Source/WebCore/Modules/notifications/Notification.h:
* Source/WebCore/Modules/speech/SpeechSynthesisUtterance.cpp:
(WebCore::SpeechSynthesisUtterance::scriptExecutionContext const):
* Source/WebCore/Modules/speech/SpeechSynthesisUtterance.h:
* Source/WebCore/Modules/web-locks/WebLockManager.cpp:
* Source/WebCore/Modules/webcodecs/WebCodecsAudioData.cpp:
* Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp:
(WebCore::WebCodecsAudioDecoder::scriptExecutionContext const):
* Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.h:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/animation/WebAnimation.h:
* Source/WebCore/crypto/SubtleCrypto.cpp:
* Source/WebCore/dom/AbortSignal.cpp:
(WebCore::AbortSignal::scriptExecutionContext const):
* Source/WebCore/dom/AbortSignal.h:
* Source/WebCore/dom/BroadcastChannel.cpp:
(WebCore::BroadcastChannel::scriptExecutionContext const):
* Source/WebCore/dom/BroadcastChannel.h:
* Source/WebCore/dom/ContainerNode.h:
(WebCore::Node::parentNode const):
(WebCore::Node::parentNodeGuaranteedHostFree const):
* Source/WebCore/dom/ContextDestructionObserver.cpp:
(WebCore::ContextDestructionObserver::protectedScriptExecutionContext const): Deleted.
* Source/WebCore/dom/ContextDestructionObserver.h:
(WebCore::ContextDestructionObserver::scriptExecutionContext const): Deleted.
* Source/WebCore/dom/ContextDestructionObserverInlines.h: Copied from Source/WebCore/layout/layouttree/LayoutBoxInlines.h.
(WebCore::ContextDestructionObserver::scriptExecutionContext const):
(WebCore::ContextDestructionObserver::protectedScriptExecutionContext const):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::removedLastRef):
* Source/WebCore/dom/Document.h:
(WebCore::Document::ptrCount const):
(WebCore::Document::markAsZombie const):
(WebCore::Document::isZombie const):
* Source/WebCore/dom/EventTarget.cpp:
* Source/WebCore/dom/EventTarget.h:
* Source/WebCore/dom/MessagePort.h:
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::removedLastRef):
* Source/WebCore/dom/Node.h:
(WebCore::Node::parentNode const): Deleted.
(WebCore::Node::parentNodeGuaranteedHostFree const): Deleted.
* Source/WebCore/dom/ShadowRoot.h:
* Source/WebCore/dom/TreeScope.cpp:
(WebCore::TreeScope::isZombie const):
* Source/WebCore/dom/TreeScope.h:
* Source/WebCore/fileapi/Blob.cpp:
* Source/WebCore/fileapi/NetworkSendQueue.cpp:
* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::OffscreenCanvas::scriptExecutionContext const):
(WebCore::OffscreenCanvas::canvasBaseScriptExecutionContext const):
* Source/WebCore/html/OffscreenCanvas.h:
* Source/WebCore/html/canvas/EXTDisjointTimerQuery.cpp:
* Source/WebCore/html/track/TextTrack.cpp:
(WebCore::TextTrack::scriptExecutionContext const):
* Source/WebCore/html/track/TextTrack.h:
* Source/WebCore/html/track/TrackListBase.cpp:
(WebCore::TrackListBase::scriptExecutionContext const):
* Source/WebCore/html/track/TrackListBase.h:
* Source/WebCore/layout/formattingContexts/inline/InlineContentBreaker.cpp:
* Source/WebCore/layout/formattingContexts/inline/InlineLineBox.cpp:
* Source/WebCore/layout/formattingContexts/inline/InlineLineBox.h:
(WebCore::Layout::LineBox::parentInlineBox const): Deleted.
(WebCore::Layout::LineBox::parentInlineBox): Deleted.
* Source/WebCore/layout/formattingContexts/inline/InlineLineBoxInlines.h: Copied from Source/WebCore/layout/layouttree/LayoutBoxInlines.h.
(WebCore::Layout::LineBox::parentInlineBox const):
(WebCore::Layout::LineBox::parentInlineBox):
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp:
* Source/WebCore/layout/formattingContexts/table/TableGrid.cpp:
* Source/WebCore/layout/integration/LayoutIntegrationBoxTree.cpp:
* Source/WebCore/layout/integration/inline/InlineIteratorBox.cpp:
* Source/WebCore/layout/integration/inline/InlineIteratorBoxModernPath.h:
(WebCore::InlineIterator::BoxModernPath::firstLeafBoxForInlineBox const): Deleted.
(WebCore::InlineIterator::BoxModernPath::lastLeafBoxForInlineBox const): Deleted.
(WebCore::InlineIterator::BoxModernPath::parentInlineBox const): Deleted.
(WebCore::InlineIterator::BoxModernPath::isWithinInlineBox): Deleted.
* Source/WebCore/layout/integration/inline/InlineIteratorBoxModernPathInlines.h:
(WebCore::InlineIterator::BoxModernPath::parentInlineBox const):
(WebCore::InlineIterator::BoxModernPath::isWithinInlineBox):
(WebCore::InlineIterator::BoxModernPath::firstLeafBoxForInlineBox const):
(WebCore::InlineIterator::BoxModernPath::lastLeafBoxForInlineBox const):
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.cpp:
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.h:
(WebCore::LayoutIntegration::InlineContent::lineLayout const): Deleted.
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentInlines.h: Copied from Source/WebCore/layout/layouttree/LayoutBoxInlines.h.
(WebCore::LayoutIntegration::InlineContent::lineLayout const):
* Source/WebCore/layout/layouttree/LayoutBox.cpp:
* Source/WebCore/layout/layouttree/LayoutBox.h:
(WebCore::Layout::Box::parent const): Deleted.
* Source/WebCore/layout/layouttree/LayoutBoxInlines.h:
(WebCore::Layout::Box::parent const):
* Source/WebCore/layout/layouttree/LayoutIterator.h:
* Source/WebCore/page/LocalDOMWindow.h:
* Source/WebCore/page/ScreenOrientation.cpp:
(WebCore::ScreenOrientation::lock):
* Source/WebCore/page/ScreenOrientation.h:
* Source/WebCore/page/scrolling/ScrollingStateNode.h:
(WebCore::ScrollingStateNode::scrollingStateTree const): Deleted.
* Source/WebCore/page/scrolling/ScrollingStateTree.h:
(WebCore::ScrollingStateNode::scrollingStateTree const):
* Source/WebCore/rendering/RenderObject.h:
(WebCore::RenderObject::layoutBox): Deleted.
(WebCore::RenderObject::layoutBox const): Deleted.
* Source/WebCore/rendering/RenderObjectInlines.h:
(WebCore::RenderObject::layoutBox):
(WebCore::RenderObject::layoutBox const):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/UIProcess/DrawingAreaProxy.cpp:
(WebKit::DrawingAreaProxy::page const):
* Source/WebKit/UIProcess/DrawingAreaProxy.h:
(WebKit::DrawingAreaProxy::page const): Deleted.
* Source/WebKit/UIProcess/SuspendedPageProxy.cpp:
(WebKit::SuspendedPageProxy::page const):
* Source/WebKit/UIProcess/SuspendedPageProxy.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ddcad4bcc37973d9e527e7b9c74a37db6ec6545c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28326 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6970 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29707 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30853 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25793 "Hash ddcad4bc for PR 21178 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28823 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9045 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4341 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28595 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5731 "Found 60 new test failures: accessibility/ios-simulator/disabled-states.html, accessibility/ios-simulator/has-touch-event-listener-with-shadow.html, accessibility/set-selected-text-range-after-newline.html, accessibility/spinbutton-increment-decrement.html, animations/leak-document-with-css-animation.html, compositing/backing/backing-store-columns-inside-position-fixed.html, compositing/fixed-position-scroll-offset-history-restore.html, compositing/geometry/fixed-position-flipped-writing-mode.html, compositing/geometry/geometry-map-scroll-during-layout-assertion.html, compositing/geometry/layer-due-to-layer-children-switch.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24373 "Found 13 new API test failures: TestWebKitAPI.PasteHTML.StripsMSOListWhenMissingMSOHTMLElement, TestWebKitAPI.PasteWebArchive.PreservesMSOListInCompatibilityMode, TestWebKitAPI.GPUProcess.ExitsUnderMemoryPressureCanvasCase, TestWebKitAPI.PasteHTML.StripsSystemFontNames, TestWebKitAPI.PasteHTML.DoesNotAddStandardFontFamily, TestWebKitAPI.PasteRTFD.ImageElementUsesBlobURL, TestWebKitAPI.PasteHTML.PreservesMSOListOnH4, TestWebKitAPI.PasteHTML.PreservesMSOList, TestWebKitAPI.ServiceWorkers.ServerTrust, TestWebKitAPI.PasteRTFD.ImageElementUsesBlobURLInHTML ... (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5002 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5110 "Found 60 new test failures: imported/w3c/web-platform-tests/FileAPI/file/send-file-form-punctuation.html, imported/w3c/web-platform-tests/FileAPI/file/send-file-formdata-punctuation.any.html, imported/w3c/web-platform-tests/FileAPI/url/sandboxed-iframe.html, imported/w3c/web-platform-tests/IndexedDB/idbfactory-open-opaque-origin.html, imported/w3c/web-platform-tests/IndexedDB/idbindex-multientry.htm, imported/w3c/web-platform-tests/IndexedDB/idbobjectstore-rename-errors.html, imported/w3c/web-platform-tests/IndexedDB/reading-autoincrement-indexes-cursors.any.serviceworker.html, imported/w3c/web-platform-tests/IndexedDB/reading-autoincrement-indexes.any.serviceworker.html, imported/w3c/web-platform-tests/IndexedDB/reading-autoincrement-store-cursors.any.serviceworker.html, imported/w3c/web-platform-tests/IndexedDB/reading-autoincrement-store.any.serviceworker.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25372 "Found 60 new test failures: accessibility/mac/text-marker-sentence-nav.html, accessibility/table-cell-spans.html, animations/leak-document-with-css-animation.html, compositing/checkerboard.html, compositing/geometry/fixed-position-composited-switch.html, compositing/geometry/horizontal-scroll-composited.html, compositing/geometry/limit-layer-bounds-overflow-repaint.html, compositing/layer-creation/fixed-position-scroll.html, compositing/layer-creation/no-compositing-for-sticky.html, compositing/layers-inside-overflow-scroll.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31539 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/24500 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25932 "Found 18 new API test failures: TestWebKitAPI.PasteHTML.StripsMSOListWhenMissingMSOHTMLElement, TestWebKitAPI.WebKit.FindInPDFAfterReload, TestWebKitAPI.WKAttachmentTests.CopyAndPasteBetweenWebViews, TestWebKitAPI.GPUProcess.ExitsUnderMemoryPressureCanvasCase, TestWebKitAPI.WKAttachmentTestsIOS.TargetedPreviewIsClippedWhenDroppingTallImage, TestWebKitAPI.PasteHTML.DoesNotAddStandardFontFamily, TestWebKitAPI.PasteRTFD.ImageElementUsesBlobURL, TestWebKitAPI.ServiceWorkers.ServerTrust, TestWebKitAPI.PasteHTML.PreservesMSOList, TestWebKitAPI.PasteHTML.PreservesMSOListInCompatibilityMode ... (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25807 "Found 60 new test failures: accessibility/mac/pseudo-element-text-markers.html, accessibility/mac/text-marker-for-index.html, accessibility/smart-invert.html, animations/leak-document-with-css-animation.html, compositing/backing/backing-store-columns-inside-position-fixed.html, compositing/fixed-position-scroll-offset-history-restore.html, compositing/fixed-with-main-thread-scrolling.html, compositing/geometry/fixed-position-composited-switch.html, compositing/geometry/geometry-map-scroll-during-layout-assertion.html, compositing/geometry/layer-due-to-layer-children-switch.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31416 "Failure limit exceed. At least found 44 new test failures: animations/leak-document-with-css-animation.html, editing/selection/leak-document-with-selection-inside.html, editing/selection/navigation-clears-editor-state.html, fast/dom/HTMLTemplateElement/content-outlives-template-crash.html, fast/dom/ImageDocument-world-leak.html, fast/dom/NodeIterator/NodeIterator-leak-document.html, fast/dom/TreeWalker/TreeWalker-leak-document.html, fast/dom/dynamic-image-with-lazy-loading-leak.html, fast/dom/gc-dom-tree-lifetime.html, fast/dom/intersection-observer-document-leak.html ... (failure)") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/27423 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5083 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3263 "Found 60 new test failures: accessibility/mac/replace-text-with-empty-range.html, accessibility/mac/text-marker-line-boundary.html, accessibility/smart-invert.html, animations/leak-document-with-css-animation.html, compositing/fixed-position-scroll-offset-history-restore.html, compositing/geometry/fixed-position-composited-switch.html, compositing/geometry/geometry-map-scroll-during-layout-assertion.html, compositing/geometry/limit-layer-bounds-clipping-ancestor.html, compositing/iframes/fixed-position-iframe.html, compositing/iframes/nested-composited-iframe.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29181 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6676 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/34944 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5531 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7564 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5601 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->