### PR TITLE
Make has_json_wrapper and strip_json_wrapper private

### DIFF
--- a/Tools/Scripts/webkitpy/common/net/resultsjsonparser.py
+++ b/Tools/Scripts/webkitpy/common/net/resultsjsonparser.py
@@ -145,11 +145,7 @@ class JSONTestResult(object):
 
 class ParsedJSONResults(object):
     def __init__(self, json_string):
-        if not json_results_generator.has_json_wrapper(json_string):
-            return None
-
-        content_string = json_results_generator.strip_json_wrapper(json_string)
-        json_dict = json.loads(content_string)
+        json_dict = json_results_generator.load_jsons(json_string)
 
         json_results = []
         for_each_test(json_dict['tests'], lambda test, result: json_results.append(JSONTestResult(test, result)))

--- a/Tools/Scripts/webkitpy/layout_tests/layout_package/json_results_generator.py
+++ b/Tools/Scripts/webkitpy/layout_tests/layout_package/json_results_generator.py
@@ -40,24 +40,29 @@ _JSON_PREFIX_B = b"ADD_RESULTS("
 _JSON_SUFFIX_B = b");"
 
 
-def has_json_wrapper(string):
+def _has_json_wrapper(string):
     if isinstance(string, bytes):
         return string.startswith(_JSON_PREFIX_B) and string.endswith(_JSON_SUFFIX_B)
     else:
         return string.startswith(_JSON_PREFIX) and string.endswith(_JSON_SUFFIX)
 
 
-def strip_json_wrapper(json_content):
+def _strip_json_wrapper(json_content):
     # FIXME: Kill this code once the server returns json instead of jsonp.
-    if has_json_wrapper(json_content):
+    if _has_json_wrapper(json_content):
         return json_content[len(_JSON_PREFIX):len(json_content) - len(_JSON_SUFFIX)]
     return json_content
 
 
 def load_json(filesystem, file_path):
     content = filesystem.read_text_file(file_path)
-    content = strip_json_wrapper(content)
+    content = _strip_json_wrapper(content)
     return json.loads(content)
+
+
+def load_jsons(s):
+    s = _strip_json_wrapper(s)
+    return json.loads(s)
 
 
 def write_json(filesystem, json_object, file_path, callback=None):

--- a/Tools/Scripts/webkitpy/layout_tests/layout_package/json_results_generator_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/layout_package/json_results_generator_unittest.py
@@ -48,10 +48,10 @@ class JSONGeneratorTest(unittest.TestCase):
         self._FAILS_count = 0
         self._fixable_count = 0
 
-    def test_strip_json_wrapper(self):
-        json = "['contents']"
-        self.assertEqual(json_results_generator.strip_json_wrapper(json_results_generator._JSON_PREFIX + json + json_results_generator._JSON_SUFFIX), json)
-        self.assertEqual(json_results_generator.strip_json_wrapper(json), json)
+    def test_load_jsons(self):
+        json = '["contents"]'
+        self.assertEqual(json_results_generator.load_jsons(json_results_generator._JSON_PREFIX + json + json_results_generator._JSON_SUFFIX), ["contents"])
+        self.assertEqual(json_results_generator.load_jsons(json), ["contents"])
 
     def test_perf_metrics_for_test(self):
         individual_test_timings = []

--- a/Tools/Scripts/webkitpy/tool/servers/rebaselineserver_unittest.py
+++ b/Tools/Scripts/webkitpy/tool/servers/rebaselineserver_unittest.py
@@ -26,14 +26,13 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import json
 import unittest
 
-from webkitpy.common.net import resultsjsonparser_unittest
 from webkitpy.common.host_mock import MockHost
-from webkitpy.layout_tests.layout_package.json_results_generator import strip_json_wrapper
+from webkitpy.common.net import resultsjsonparser_unittest
+from webkitpy.layout_tests.layout_package.json_results_generator import load_jsons
 from webkitpy.port.base import Port
-from webkitpy.tool.commands.rebaselineserver import TestConfig, RebaselineServer
+from webkitpy.tool.commands.rebaselineserver import RebaselineServer, TestConfig
 from webkitpy.tool.servers import rebaselineserver
 
 
@@ -206,7 +205,7 @@ class RebaselineTestTest(unittest.TestCase):
 
     def test_gather_baselines(self):
         example_json = resultsjsonparser_unittest.ParsedJSONResultsTest._example_full_results_json
-        results_json = json.loads(strip_json_wrapper(example_json))
+        results_json = load_jsons(example_json)
         server = RebaselineServer()
         server._test_config = get_test_config()
         server._gather_baselines(results_json)


### PR DESCRIPTION
#### 42db72e3286bd02966fb16ea679d33e4e49ade3e
<pre>
Make has_json_wrapper and strip_json_wrapper private
<a href="https://bugs.webkit.org/show_bug.cgi?id=265692">https://bugs.webkit.org/show_bug.cgi?id=265692</a>

Reviewed by Jonathan Bedard.

This makes it very obvious nothing is actually using these, and allows
us to have the confidence both JSON and JSONP work everywhere.

* Tools/Scripts/webkitpy/common/net/resultsjsonparser.py:
(ParsedJSONResults.__init__):
* Tools/Scripts/webkitpy/layout_tests/layout_package/json_results_generator.py:
(_has_json_wrapper):
(_strip_json_wrapper):
(load_json):
(load_jsons):
(has_json_wrapper): Deleted.
(strip_json_wrapper): Deleted.
* Tools/Scripts/webkitpy/layout_tests/layout_package/json_results_generator_unittest.py:
(JSONGeneratorTest.test_load_jsons):
(JSONGeneratorTest.test_strip_json_wrapper): Deleted.
* Tools/Scripts/webkitpy/tool/servers/rebaselineserver_unittest.py:
(RebaselineTestTest.test_gather_baselines):

Canonical link: <a href="https://commits.webkit.org/271505@main">https://commits.webkit.org/271505@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/841d81c1697819f3b29aa665a12a9dc03822a201

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28294 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6938 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29679 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30823 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25770 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28791 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9064 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4313 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26063 "Build was cancelled. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests (exception)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28563 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5739 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24348 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4973 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/28455 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5117 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25346 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31511 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25940 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25780 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31397 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5061 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3246 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29151 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6650 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5506 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3692 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5579 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->