### PR TITLE
[Wasm-GC] Fix initialization of portable reftype globals

### DIFF
--- a/JSTests/wasm/gc/js-api.js
+++ b/JSTests/wasm/gc/js-api.js
@@ -412,6 +412,25 @@ function testGlobal() {
     `);
     assert.eq(m.exports.f(m.exports.g.value), 42);
   }
+
+  // Test portable globals, with mutation.
+  {
+    let m = instantiate(`
+      (module
+        (type (sub (struct (field i32))))
+        (type (sub 0 (struct (field i32))))
+        (type (sub 0 (struct (field i32 i64))))
+        (global (export "g01") (mut (ref 0)) (struct.new 0 (i32.const 42)))
+        (global (export "g02") (mut (ref null 0)) (ref.null 0))
+        (global (export "g1") (mut (ref null 1)) (struct.new 1 (i32.const 42)))
+        (global (export "g2") (mut (ref null 2)) (struct.new 2 (i32.const 42) (i64.const 84)))
+      )
+    `);
+    m.exports.g01.value = m.exports.g1.value;
+    m.exports.g02.value = m.exports.g2.value;
+    m.exports.g1.value = null;
+    m.exports.g2.value = null;
+  }
 }
 
 function testTable() {

--- a/Source/JavaScriptCore/wasm/WasmGlobal.cpp
+++ b/Source/JavaScriptCore/wasm/WasmGlobal.cpp
@@ -147,7 +147,7 @@ void Global::set(JSGlobalObject* globalObject, JSValue argument)
 template<typename Visitor>
 void Global::visitAggregateImpl(Visitor& visitor)
 {
-    if (isFuncref(m_type) || isExternref(m_type)) {
+    if (isRefType(m_type)) {
         RELEASE_ASSERT(m_owner);
         visitor.append(m_value.m_externref);
     }


### PR DESCRIPTION
#### fc9e1f45e692511bdf47f9a49102cdeadcc6e707
<pre>
[Wasm-GC] Fix initialization of portable reftype globals
<a href="https://bugs.webkit.org/show_bug.cgi?id=265693">https://bugs.webkit.org/show_bug.cgi?id=265693</a>

Reviewed by Justin Michaud.

Ref-typed globals need to be initialized using the JSValue init path rather
than the &quot;as bits&quot; init path. This is less a problem for functions, as they are
held strongly by the instance, but for other GC types is a bigger problem.

For portable globals, the marking method also needs to check for all reftypes,
not just extern/func.

This is mostly tested by the existing gc/js-api.js test, one test was added for
the marking issue.

* JSTests/wasm/gc/js-api.js:
* Source/JavaScriptCore/wasm/WasmGlobal.cpp:
(JSC::Wasm::Global::visitAggregateImpl):
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp:
(JSC::WebAssemblyModuleRecord::initializeExports):

Canonical link: <a href="https://commits.webkit.org/271777@main">https://commits.webkit.org/271777@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c61e6de51ec9421593c8a0f2bf227d31fbd81b8a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28378 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7023 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29763 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30905 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25836 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9117 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4392 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26095 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28647 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5785 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24412 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5269 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5162 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25413 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31591 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/24545 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25986 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25851 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31460 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/27472 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5125 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3301 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29221 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6723 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/34996 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7033 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5580 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7569 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5644 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->