### PR TITLE
Add outlineBoundsRect to RepaintRects

### DIFF
--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -1217,13 +1217,13 @@ bool RenderBox::applyCachedClipAndScrollPosition(RepaintRects& rects, const Rend
         clipRect.expandToInfiniteX();
     if (effectiveOverflowY() == Overflow::Visible)
         clipRect.expandToInfiniteY();
+
     bool intersects;
     if (context.options.contains(VisibleRectContextOption::UseEdgeInclusiveIntersection))
-        intersects = rects.clippedOverflowRect.edgeInclusiveIntersect(clipRect);
-    else {
-        rects.clippedOverflowRect.intersect(clipRect);
-        intersects = !rects.clippedOverflowRect.isEmpty();
-    }
+        intersects = rects.edgeInclusiveIntersect(clipRect);
+    else
+        intersects = rects.intersect(clipRect);
+
     flipForWritingMode(rects);
     return intersects;
 }

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -2366,14 +2366,21 @@ ScrollAnchoringController* RenderObject::findScrollAnchoringControllerForRendere
     return renderer.view().frameView().scrollAnchoringController();
 }
 
-void RenderObject::RepaintRects::transform(TransformationMatrix& matrix)
+void RenderObject::RepaintRects::transform(const TransformationMatrix& matrix)
 {
     clippedOverflowRect = matrix.mapRect(clippedOverflowRect);
+    if (outlineBoundsRect)
+        *outlineBoundsRect = matrix.mapRect(*outlineBoundsRect);
 }
 
-void RenderObject::RepaintRects::transform(TransformationMatrix& matrix, float deviceScaleFactor)
+void RenderObject::RepaintRects::transform(const TransformationMatrix& matrix, float deviceScaleFactor)
 {
+    bool identicalRects = outlineBoundsRect && *outlineBoundsRect == clippedOverflowRect;
     clippedOverflowRect = LayoutRect(encloseRectToDevicePixels(matrix.mapRect(clippedOverflowRect), deviceScaleFactor));
+    if (identicalRects)
+        *outlineBoundsRect = clippedOverflowRect;
+    else if (outlineBoundsRect)
+        *outlineBoundsRect = LayoutRect(encloseRectToDevicePixels(matrix.mapRect(*outlineBoundsRect), deviceScaleFactor));
 }
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
@@ -262,13 +262,13 @@ bool RenderSVGModelObject::applyCachedClipAndScrollPosition(RepaintRects& rects,
         clipRect.expandToInfiniteX();
     if (effectiveOverflowY() == Overflow::Visible)
         clipRect.expandToInfiniteY();
+
     bool intersects;
     if (context.options.contains(VisibleRectContextOption::UseEdgeInclusiveIntersection))
-        intersects = rects.clippedOverflowRect.edgeInclusiveIntersect(clipRect);
-    else {
-        rects.clippedOverflowRect.intersect(clipRect);
-        intersects = !rects.clippedOverflowRect.isEmpty();
-    }
+        intersects = rects.edgeInclusiveIntersect(clipRect);
+    else
+        intersects = rects.intersect(clipRect);
+
     return intersects;
 }
 


### PR DESCRIPTION
#### 0bfa98376d7330aae32fffe27eff473b21693152
<pre>
Add outlineBoundsRect to RepaintRects
<a href="https://bugs.webkit.org/show_bug.cgi?id=265695">https://bugs.webkit.org/show_bug.cgi?id=265695</a>
<a href="https://rdar.apple.com/119049099">rdar://119049099</a>

Reviewed by Alan Baradlay.

Another step towards computing clippedOverflowRect and outlineBoundsRect in the same
ancestor traversal is adding an optioal outlineBoundsRect to RepaintRects. Note
that this isn&apos;t clipped by the `intersect` functions, replicating the unclipped
behavior of `outlineBoundsForRepaint()`.

No-one sets the outlineBoundsRect yet.

* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::applyCachedClipAndScrollPosition const):
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::RepaintRects::transform):
* Source/WebCore/rendering/RenderObject.h:
(WebCore::RenderObject::RepaintRects::RepaintRects):
(WebCore::RenderObject::RepaintRects::move):
(WebCore::RenderObject::RepaintRects::moveBy):
(WebCore::RenderObject::RepaintRects::expand):
(WebCore::RenderObject::RepaintRects::encloseToIntRects):
(WebCore::RenderObject::RepaintRects::unite):
(WebCore::RenderObject::RepaintRects::flipForWritingMode):
(WebCore::RenderObject::RepaintRects::intersect):
(WebCore::RenderObject::RepaintRects::edgeInclusiveIntersect):
* Source/WebCore/rendering/svg/RenderSVGModelObject.cpp:
(WebCore::RenderSVGModelObject::applyCachedClipAndScrollPosition const):

Canonical link: <a href="https://commits.webkit.org/271422@main">https://commits.webkit.org/271422@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b3d3aac1293b58654d7d6613d72f41541bf2614

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28300 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6944 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29684 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30829 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25774 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28797 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9003 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4318 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28569 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5711 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24355 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4984 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5094 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25353 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31516 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25912 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25787 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31403 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5064 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3248 "Found 1 new test failure: webrtc/video-rotation-black.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29159 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6655 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6790 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5511 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5582 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->