### PR TITLE
[Wasm-GC] Fix array.new_data & array.new_elem for recursive array types

### DIFF
--- a/JSTests/wasm/gc/array_new_data.js
+++ b/JSTests/wasm/gc/array_new_data.js
@@ -354,7 +354,7 @@ function testSingletonArray() {
 }
 
 function testTypeErrors() {
-    let notArray = "WebAssembly.Module doesn't validate: array.new_data type index 0 does not reference an array definition, in function at index 0";
+    let notArray = "WebAssembly.Module doesn't validate: array.new_data index 0 does not reference an array definition, in function at index 0";
     let refType = "WebAssembly.Module doesn't validate: array.new_data expected numeric, packed, or vector type; found RefNull";
     let erroneousCase = (ty, msg) => {
         assert.throws(() => compile (`
@@ -424,6 +424,22 @@ function testBadOperands() {
                   "WebAssembly.Module doesn't parse at byte 5: can't pop empty stack in array.new_data, in function at index 0");
 }
 
+function testRecGroup() {
+    instantiate(`
+        (module
+          (memory (export "memory") 1)
+          (data "snails")
+          (rec (type (struct))
+               (type $arr (array (mut i8))))
+          (func (export "f") (result i32)
+            (i32.const 0)
+            (i32.const 1)
+            (array.new_data $arr 0)
+            (i32.const 0)
+            (array.get_u $arr)))
+    `);
+}
+
 testArrayNewCanonData();
 testBadDataSegment();
 testOtherDataSegments();
@@ -435,3 +451,4 @@ testZeroLengthArray();
 testSingletonArray();
 testTypeErrors();
 testBadOperands();
+testRecGroup();

--- a/JSTests/wasm/gc/array_new_elem.js
+++ b/JSTests/wasm/gc/array_new_elem.js
@@ -80,7 +80,7 @@ function testBadTypeIndex() {
           (i32.const 0)
           (array.get 0)))`);
 
-    assert.throws(f, WebAssembly.CompileError, "WebAssembly.Module doesn't validate: array.new_elem type index 1 does not reference an array definition, in function at index 1");
+    assert.throws(f, WebAssembly.CompileError, "WebAssembly.Module doesn't validate: array.new_elem index 1 does not reference an array definition, in function at index 1");
 }
 
 function testNonArrayType() {
@@ -97,7 +97,7 @@ function testNonArrayType() {
           (i32.const 0)
           (array.get 0)))`);
 
-    assert.throws(f, WebAssembly.CompileError, "WebAssembly.Module doesn't validate: array.new_elem type index 1 does not reference an array definition, in function at index 1");
+    assert.throws(f, WebAssembly.CompileError, "WebAssembly.Module doesn't validate: array.new_elem index 1 does not reference an array definition, in function at index 1");
 }
 
 function testImmutableArrayType() {
@@ -831,6 +831,23 @@ function testJSFunctions() {
     assert.eq(retVal, 47.5);
 }
 
+function testRecGroup() {
+    instantiate(`
+        (module
+          (func $f)
+          (func $g)
+          (rec (type (array (mut funcref)))
+               (type (struct)))
+          (elem (ref func) (ref.func $f) (item ref.func $f) (ref.func $g) (ref.func $g))
+          (func (export "f") (result funcref)
+            (i32.const 0)
+            (i32.const 4)
+            (array.new_elem 0 0)
+            (i32.const 2)
+            (array.get 0)))
+    `);
+}
+
 // FIXME: uncomment these tests once https://bugs.webkit.org/show_bug.cgi?id=251874 is fixed
 // testRefCallNullary();
 // testRefCall();
@@ -855,3 +872,4 @@ testZeroLengthArray();
 testNullFunctionIndex();
 testImportFunctions();
 testJSFunctions();
+testRecGroup();

--- a/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
+++ b/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
@@ -213,8 +213,9 @@ inline EncodedJSValue arrayNewData(Instance* instance, uint32_t typeIndex, uint3
 
     // Check that the type index is within bounds
     ASSERT(typeIndex < instance->module().moduleInformation().typeCount());
-    Wasm::TypeDefinition& arraySignature = instance->module().moduleInformation().typeSignatures[typeIndex];
+    const Wasm::TypeDefinition& arraySignature = instance->module().moduleInformation().typeSignatures[typeIndex]->expand();
     ASSERT(arraySignature.is<ArrayType>());
+
     // Get the array element type
     Wasm::FieldType fieldType = arraySignature.as<ArrayType>()->elementType();
 
@@ -260,7 +261,7 @@ inline EncodedJSValue arrayNewElem(Instance* instance, uint32_t typeIndex, uint3
     ASSERT(typeIndex < instance->module().moduleInformation().typeCount());
 
 #if ASSERT_ENABLED
-    Wasm::TypeDefinition& arraySignature = instance->module().moduleInformation().typeSignatures[typeIndex];
+    const Wasm::TypeDefinition& arraySignature = instance->module().moduleInformation().typeSignatures[typeIndex]->expand();
     ASSERT(arraySignature.is<ArrayType>());
 #else
     UNUSED_PARAM(typeIndex);


### PR DESCRIPTION
#### 992f87e27f7f214ec2e85607449dd5da87a39f1c
<pre>
[Wasm-GC] Fix array.new_data &amp; array.new_elem for recursive array types
<a href="https://bugs.webkit.org/show_bug.cgi?id=265677">https://bugs.webkit.org/show_bug.cgi?id=265677</a>

Reviewed by Justin Michaud.

Use helper functions to correctly handle recursive type cases in array.new_data
&amp; new_elem.

* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseExpression):
* Source/JavaScriptCore/wasm/WasmOperationsInlines.h:
(JSC::Wasm::arrayNewData):
(JSC::Wasm::arrayNewElem):

Canonical link: <a href="https://commits.webkit.org/271421@main">https://commits.webkit.org/271421@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac32c59364cca1321d6598d6c0bca1ffe45f7afb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28320 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6964 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29701 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30847 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25788 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9036 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4335 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28589 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5728 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24367 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4995 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5107 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25366 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31533 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/24495 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25929 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25800 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31411 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/27418 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5078 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3259 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29168 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6671 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/34938 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6787 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5526 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7562 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5596 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->