### PR TITLE
[Wasm-GC] Add test for bug258795

### DIFF
--- a/JSTests/wasm/gc/bug258795.js
+++ b/JSTests/wasm/gc/bug258795.js
@@ -1,0 +1,31 @@
+//@ skip if !$isSIMDPlatform
+//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+
+function module(bytes, valid = true) {
+  let buffer = new ArrayBuffer(bytes.length);
+  let view = new Uint8Array(buffer);
+  for (let i = 0; i < bytes.length; ++i) {
+    view[i] = bytes.charCodeAt(i);
+  }
+  return new WebAssembly.Module(buffer);
+}
+
+/*
+ *
+ * (module
+ *  (type $0 (func))
+ *  (type $1 (sub (func (param i32 i32 i32) (result i32))))
+ *  (memory $0 16 32)
+ *  (table $0 1 2 funcref)
+ *  (table $1 0 1 eqref)
+ *  (elem $0 (table $0) (i32.const 0) func $0)
+ *  (tag $tag$0)
+ *  (export "main" (func $0))
+ *  (func $0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ *   (i32.const -114)
+ *  )
+ * )
+ *
+ */
+const m = new WebAssembly.Instance(module('\x00\x61\x73\x6d\x01\x00\x00\x00\x01\x98\x80\x80\x80\x00\x04\x50\x00\x5f\x01\x7f\x00\x50\x00\x5e\x7b\x01\x50\x00\x60\x03\x7f\x7f\x7f\x01\x7f\x60\x00\x00\x03\x82\x80\x80\x80\x00\x01\x02\x04\x89\x80\x80\x80\x00\x02\x70\x01\x01\x02\x6d\x01\x00\x01\x05\x84\x80\x80\x80\x00\x01\x01\x10\x20\x0d\x83\x80\x80\x80\x00\x01\x00\x03\x07\x88\x80\x80\x80\x00\x01\x04\x6d\x61\x69\x6e\x00\x00\x09\x8b\x80\x80\x80\x00\x01\x06\x00\x41\x00\x0b\x70\x01\xd2\x00\x0b\x0a\x87\x80\x80\x80\x00\x01\x05\x00\x41\x8e\x7f\x0b'));
+m.exports.main();


### PR DESCRIPTION
#### 99f4cb87b46223e88cfac46dc467d8b10125e846
<pre>
[Wasm-GC] Add test for bug258795
<a href="https://bugs.webkit.org/show_bug.cgi?id=258795">https://bugs.webkit.org/show_bug.cgi?id=258795</a>

Reviewed by Justin Michaud.

Add test for already fixed bug. Needs SIMD.

* JSTests/wasm/gc/bug258795.js: Added.
(module):

Canonical link: <a href="https://commits.webkit.org/271955@main">https://commits.webkit.org/271955@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0011f956eb51a84c3182f3e3381dd450569248cb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30143 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8808 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31457 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32646 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27258 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11009 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6052 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27265 "Failure limit exceed. At least found 1 new test failure: imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-scroll-with-clip-and-abspos.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30443 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7392 "2 new passes 8 flakes 2 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25706 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6319 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6471 "Exiting early after 10 failures. 4565 tests run. 3 failures") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26799 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33984 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/25888 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27484 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27232 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32649 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/30275 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6421 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4587 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30454 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:afterAll (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8170 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/26599 "Exiting early after 10 failures. 19532 tests run. 3 flakes") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/36717 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7143 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7174 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7906 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6949 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->