### PR TITLE
Switch from fontForCaretSelection to returning the information in the stylingDictionary to remove more SPI.

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -4266,22 +4266,14 @@ WEBCORE_COMMAND_FOR_WEBVIEW(pasteAndMatchStyle);
     [result setObject:[UIColor blackColor] forKey:NSForegroundColorAttributeName];
 
     auto typingAttributes = _page->editorState().postLayoutData->typingAttributes;
-    CTFontSymbolicTraits symbolicTraits = 0;
-    if (typingAttributes.contains(WebKit::TypingAttribute::Bold))
-        symbolicTraits |= kCTFontBoldTrait;
-    if (typingAttributes.contains(WebKit::TypingAttribute::Italics))
-        symbolicTraits |= kCTFontTraitItalic;
-
-    // We chose a random font family and size.
-    // What matters are the traits but the caller expects a font object
-    // in the dictionary for NSFontAttributeName.
-    RetainPtr<CTFontDescriptorRef> fontDescriptor = adoptCF(CTFontDescriptorCreateWithNameAndSize(CFSTR("Helvetica"), 10));
-    if (symbolicTraits)
-        fontDescriptor = adoptCF(CTFontDescriptorCreateCopyWithSymbolicTraits(fontDescriptor.get(), symbolicTraits, symbolicTraits));
     
-    RetainPtr<CTFontRef> font = adoptCF(CTFontCreateWithFontDescriptor(fontDescriptor.get(), 10, nullptr));
+    UIFont *font = _autocorrectionData.font.get();
+    double zoomScale = self._contentZoomScale;
+    if (std::abs(zoomScale - 1) > FLT_EPSILON)
+        font = [font fontWithSize:font.pointSize * zoomScale];
+
     if (font)
-        [result setObject:(id)font.get() forKey:NSFontAttributeName];
+        [result setObject:font forKey:NSFontAttributeName];
     
     if (typingAttributes.contains(WebKit::TypingAttribute::Underline))
         [result setObject:@(NSUnderlineStyleSingle) forKey:NSUnderlineStyleAttributeName];
@@ -7546,13 +7538,6 @@ inline static UIShiftKeyState shiftKeyState(UIKeyModifierFlags flags)
 - (void)selectAll
 {
     RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
-}
-
-- (UIFont *)fontForCaretSelection
-{
-    UIFont *font = _autocorrectionData.font.get();
-    double zoomScale = self._contentZoomScale;
-    return std::abs(zoomScale - 1) > FLT_EPSILON ? [font fontWithSize:font.pointSize * zoomScale] : font;
 }
 
 - (BOOL)hasSelection


### PR DESCRIPTION
#### ea623fe8675130f284b0f115793dcbbf53bf6987
<pre>
Switch from fontForCaretSelection to returning the information in the stylingDictionary to remove more SPI.
<a href="https://bugs.webkit.org/show_bug.cgi?id=265708">https://bugs.webkit.org/show_bug.cgi?id=265708</a>
<a href="https://rdar.apple.com/119057964">rdar://119057964</a>

Reviewed by Wenson Hsieh.

In our continued effort to move off of SPI, remove this call and instead return the information in a API path.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView textStylingAtPosition:inDirection:]):
(-[WKContentView fontForCaretSelection]): Deleted.

Canonical link: <a href="https://commits.webkit.org/271515@main">https://commits.webkit.org/271515@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21e3bedc1c60d6e147f3dc8ebdd499df83985a25

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28605 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7250 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29987 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31245 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/26121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9363 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4620 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28875 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5992 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24599 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/5221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5362 "Passed tests") | | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/32611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26192 "Found 1 new API test failure: TestWebKitAPI.AutocorrectionTests.FontAtCaretWhenUsingUICTFontTextStyle (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26045 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31609 "layout-tests (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5324 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3496 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/29389 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6933 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6855 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5788 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5843 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->