### PR TITLE
Begin moving functions from LocalFrameView to FrameView

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1909,6 +1909,7 @@ page/EventHandler.cpp
 page/EventSource.cpp
 page/FocusController.cpp
 page/Frame.cpp
+page/FrameView.cpp
 page/FrameDestructionObserver.cpp
 page/FrameSnapshotting.cpp
 page/FrameTree.cpp

--- a/Source/WebCore/page/Frame.cpp
+++ b/Source/WebCore/page/Frame.cpp
@@ -30,6 +30,7 @@
 #include "NavigationScheduler.h"
 #include "Page.h"
 #include "RemoteFrame.h"
+#include "RenderElement.h"
 #include "WindowProxy.h"
 
 namespace WebCore {
@@ -120,6 +121,21 @@ Ref<WindowProxy> Frame::protectedWindowProxy() const
 CheckedRef<NavigationScheduler> Frame::checkedNavigationScheduler() const
 {
     return m_navigationScheduler.get();
+}
+
+RenderWidget* Frame::ownerRenderer() const
+{
+    RefPtr ownerElement = this->ownerElement();
+    if (!ownerElement)
+        return nullptr;
+    auto* object = ownerElement->renderer();
+    // FIXME: If <object> is ever fixed to disassociate itself from frames
+    // that it has started but canceled, then this can turn into an ASSERT
+    // since ownerElement would be nullptr when the load is canceled.
+    // https://bugs.webkit.org/show_bug.cgi?id=18585
+    if (!is<RenderWidget>(object))
+        return nullptr;
+    return downcast<RenderWidget>(object);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -42,6 +42,7 @@ class FrameLoadRequest;
 class HTMLFrameOwnerElement;
 class NavigationScheduler;
 class Page;
+class RenderWidget;
 class Settings;
 class WeakPtrImplWithEventTargetData;
 class WindowProxy;
@@ -89,6 +90,8 @@ public:
     virtual void setOpener(Frame*) = 0;
     virtual const Frame* opener() const = 0;
     virtual Frame* opener() = 0;
+
+    WEBCORE_EXPORT RenderWidget* ownerRenderer() const; // Renderer for the element that contains this frame.
 
 protected:
     Frame(Page&, FrameIdentifier, FrameType, HTMLFrameOwnerElement*, Frame* parent);

--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -1,0 +1,344 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "FrameView.h"
+
+#include "Chrome.h"
+#include "ChromeClient.h"
+#include "FocusController.h"
+#include "Frame.h"
+#include "HTMLFrameOwnerElement.h"
+#include "Page.h"
+#include "RenderElement.h"
+#include "RenderLayer.h"
+#include "RenderLayerScrollableArea.h"
+#include "RenderWidget.h"
+
+namespace WebCore {
+
+int FrameView::headerHeight() const
+{
+    Ref frame = this->frame();
+    if (!frame->isMainFrame())
+        return 0;
+    Page* page = frame->page();
+    return page ? page->headerHeight() : 0;
+}
+
+int FrameView::footerHeight() const
+{
+    Ref frame = this->frame();
+    if (!frame->isMainFrame())
+        return 0;
+    Page* page = frame->page();
+    return page ? page->footerHeight() : 0;
+}
+
+float FrameView::topContentInset(TopContentInsetType contentInsetTypeToReturn) const
+{
+    if (platformWidget() && contentInsetTypeToReturn == TopContentInsetType::WebCoreOrPlatformContentInset)
+        return platformTopContentInset();
+
+    Ref frame = this->frame();
+    if (!frame->isMainFrame())
+        return 0;
+
+    Page* page = frame->page();
+    return page ? page->topContentInset() : 0;
+}
+
+float FrameView::visibleContentScaleFactor() const
+{
+    Ref frame = this->frame();
+    if (!frame->isMainFrame())
+        return 1;
+
+    Page* page = frame->page();
+    // FIXME: This !delegatesScaling() is confusing, and the opposite behavior to Frame::frameScaleFactor().
+    // This function should probably be renamed to delegatedPageScaleFactor().
+    if (!page || !page->delegatesScaling())
+        return 1;
+
+    return page->pageScaleFactor();
+}
+
+bool FrameView::isActive() const
+{
+    Page* page = frame().page();
+    return page && page->focusController().isActive();
+}
+
+ScrollableArea* FrameView::enclosingScrollableArea() const
+{
+    Ref frame = this->frame();
+    if (frame->isMainFrame())
+        return nullptr;
+
+    auto* ownerElement = frame->ownerElement();
+    if (!ownerElement)
+        return nullptr;
+
+    auto* ownerRenderer = ownerElement->renderer();
+    if (!ownerRenderer)
+        return nullptr;
+
+    auto* layer = ownerRenderer->enclosingLayer();
+    if (!layer)
+        return nullptr;
+
+    auto* enclosingScrollableLayer = layer->enclosingScrollableLayer(IncludeSelfOrNot::IncludeSelf, CrossFrameBoundaries::No);
+    if (!enclosingScrollableLayer)
+        return nullptr;
+
+    return enclosingScrollableLayer->scrollableArea();
+}
+
+void FrameView::invalidateRect(const IntRect& rect)
+{
+    Ref frame = this->frame();
+    if (!parent()) {
+        if (auto* page = frame->page())
+            page->chrome().invalidateContentsAndRootView(rect);
+        return;
+    }
+
+    auto* renderer = frame->ownerRenderer();
+    if (!renderer)
+        return;
+
+    IntRect repaintRect = rect;
+    repaintRect.moveBy(roundedIntPoint(renderer->contentBoxLocation()));
+    renderer->repaintRectangle(repaintRect);
+}
+
+bool FrameView::forceUpdateScrollbarsOnMainThreadForPerformanceTesting() const
+{
+    Page* page = frame().page();
+    return page && page->settings().scrollingPerformanceTestingEnabled();
+}
+
+IntRect FrameView::scrollableAreaBoundingBox(bool*) const
+{
+    RenderWidget* ownerRenderer = frame().ownerRenderer();
+    if (!ownerRenderer)
+        return frameRect();
+
+    return ownerRenderer->absoluteContentQuad().enclosingBoundingBox();
+}
+
+HostWindow* FrameView::hostWindow() const
+{
+    auto* page = frame().page();
+    return page ? &page->chrome() : nullptr;
+}
+
+void FrameView::scrollbarStyleChanged(ScrollbarStyle newStyle, bool forceUpdate)
+{
+    Ref frame = this->frame();
+    if (!frame->isMainFrame())
+        return;
+
+    if (Page* page = frame->page())
+        page->chrome().client().recommendedScrollbarStyleDidChange(newStyle);
+
+    ScrollView::scrollbarStyleChanged(newStyle, forceUpdate);
+}
+
+bool FrameView::scrollAnimatorEnabled() const
+{
+    if (auto* page = frame().page())
+        return page->settings().scrollAnimatorEnabled();
+
+    return false;
+}
+
+IntRect FrameView::convertFromRendererToContainingView(const RenderElement* renderer, const IntRect& rendererRect) const
+{
+    IntRect rect = snappedIntRect(enclosingLayoutRect(renderer->localToAbsoluteQuad(FloatRect(rendererRect)).boundingBox()));
+
+    return contentsToView(rect);
+}
+
+IntRect FrameView::convertFromContainingViewToRenderer(const RenderElement* renderer, const IntRect& viewRect) const
+{
+    IntRect rect = viewToContents(viewRect);
+
+    // FIXME: we don't have a way to map an absolute rect down to a local quad, so just
+    // move the rect for now.
+    rect.setLocation(roundedIntPoint(renderer->absoluteToLocal(rect.location(), UseTransforms)));
+    return rect;
+}
+
+FloatRect FrameView::convertFromContainingViewToRenderer(const RenderElement* renderer, const FloatRect& viewRect) const
+{
+    FloatRect rect = viewToContents(viewRect);
+
+    return (renderer->absoluteToLocalQuad(rect)).boundingBox();
+}
+
+IntPoint FrameView::convertFromRendererToContainingView(const RenderElement* renderer, const IntPoint& rendererPoint) const
+{
+    IntPoint point = roundedIntPoint(renderer->localToAbsolute(rendererPoint, UseTransforms));
+
+    return contentsToView(point);
+}
+
+FloatPoint FrameView::convertFromRendererToContainingView(const RenderElement* renderer, const FloatPoint& rendererPoint) const
+{
+    return contentsToView(renderer->localToAbsolute(rendererPoint, UseTransforms));
+}
+
+IntPoint FrameView::convertFromContainingViewToRenderer(const RenderElement* renderer, const IntPoint& viewPoint) const
+{
+    IntPoint point = viewPoint;
+
+    // Convert from FrameView coords into page ("absolute") coordinates.
+    if (!delegatesScrollingToNativeView())
+        point = viewToContents(point);
+
+    return roundedIntPoint(renderer->absoluteToLocal(point, UseTransforms));
+}
+
+IntRect FrameView::convertToContainingView(const IntRect& localRect) const
+{
+    if (const ScrollView* parentScrollView = parent()) {
+        if (is<FrameView>(*parentScrollView)) {
+            const FrameView& parentView = downcast<FrameView>(*parentScrollView);
+            // Get our renderer in the parent view
+            RenderWidget* renderer = frame().ownerRenderer();
+            if (!renderer)
+                return localRect;
+
+            auto rect = localRect;
+            rect.moveBy(roundedIntPoint(renderer->contentBoxLocation()));
+            return parentView.convertFromRendererToContainingView(renderer, rect);
+        }
+        return Widget::convertToContainingView(localRect);
+    }
+    return localRect;
+}
+
+IntRect FrameView::convertFromContainingView(const IntRect& parentRect) const
+{
+    if (const ScrollView* parentScrollView = parent()) {
+        if (is<FrameView>(*parentScrollView)) {
+            const FrameView& parentView = downcast<FrameView>(*parentScrollView);
+
+            // Get our renderer in the parent view
+            RenderWidget* renderer = frame().ownerRenderer();
+            if (!renderer)
+                return parentRect;
+
+            auto rect = parentView.convertFromContainingViewToRenderer(renderer, parentRect);
+            rect.moveBy(-roundedIntPoint(renderer->contentBoxLocation()));
+            return rect;
+        }
+        return Widget::convertFromContainingView(parentRect);
+    }
+    return parentRect;
+}
+
+FloatRect FrameView::convertFromContainingView(const FloatRect& parentRect) const
+{
+    if (const ScrollView* parentScrollView = parent()) {
+        if (is<FrameView>(*parentScrollView)) {
+            const FrameView& parentView = downcast<FrameView>(*parentScrollView);
+
+            // Get our renderer in the parent view
+            RenderWidget* renderer = frame().ownerRenderer();
+            if (!renderer)
+                return parentRect;
+
+            auto rect = parentView.convertFromContainingViewToRenderer(renderer, parentRect);
+            rect.moveBy(-renderer->contentBoxLocation());
+            return rect;
+        }
+        return Widget::convertFromContainingView(parentRect);
+    }
+    return parentRect;
+}
+
+IntPoint FrameView::convertToContainingView(const IntPoint& localPoint) const
+{
+    if (const ScrollView* parentScrollView = parent()) {
+        if (is<FrameView>(*parentScrollView)) {
+            const FrameView& parentView = downcast<FrameView>(*parentScrollView);
+
+            // Get our renderer in the parent view
+            RenderWidget* renderer = frame().ownerRenderer();
+            if (!renderer)
+                return localPoint;
+
+            auto point = localPoint;
+            point.moveBy(roundedIntPoint(renderer->contentBoxLocation()));
+            return parentView.convertFromRendererToContainingView(renderer, point);
+        }
+        return Widget::convertToContainingView(localPoint);
+    }
+    return localPoint;
+}
+
+FloatPoint FrameView::convertToContainingView(const FloatPoint& localPoint) const
+{
+    if (const ScrollView* parentScrollView = parent()) {
+        if (is<FrameView>(*parentScrollView)) {
+            const FrameView& parentView = downcast<FrameView>(*parentScrollView);
+
+            // Get our renderer in the parent view
+            RenderWidget* renderer = frame().ownerRenderer();
+            if (!renderer)
+                return localPoint;
+
+            auto point = localPoint;
+            point.moveBy(renderer->contentBoxLocation());
+            return parentView.convertFromRendererToContainingView(renderer, point);
+        }
+        return Widget::convertToContainingView(localPoint);
+    }
+    return localPoint;
+}
+
+IntPoint FrameView::convertFromContainingView(const IntPoint& parentPoint) const
+{
+    if (const ScrollView* parentScrollView = parent()) {
+        if (is<FrameView>(*parentScrollView)) {
+            const FrameView& parentView = downcast<FrameView>(*parentScrollView);
+
+            // Get our renderer in the parent view
+            RenderWidget* renderer = frame().ownerRenderer();
+            if (!renderer)
+                return parentPoint;
+
+            auto point = parentView.convertFromContainingViewToRenderer(renderer, parentPoint);
+            point.moveBy(-roundedIntPoint(renderer->contentBoxLocation()));
+            return point;
+        }
+        return Widget::convertFromContainingView(parentPoint);
+    }
+    return parentPoint;
+}
+
+}

--- a/Source/WebCore/page/FrameView.h
+++ b/Source/WebCore/page/FrameView.h
@@ -38,6 +38,70 @@ public:
     virtual Type viewType() const = 0;
     virtual void writeRenderTreeAsText(TextStream&, OptionSet<RenderAsTextFlag>) = 0;
     virtual Frame& frame() const = 0;
+
+    WEBCORE_EXPORT int headerHeight() const final;
+    WEBCORE_EXPORT int footerHeight() const final;
+
+    WEBCORE_EXPORT float topContentInset(TopContentInsetType = TopContentInsetType::WebCoreContentInset) const final;
+
+    float visibleContentScaleFactor() const final;
+
+    HostWindow* hostWindow() const final;
+    WEBCORE_EXPORT void invalidateRect(const IntRect&) final;
+    bool isActive() const final;
+    bool forceUpdateScrollbarsOnMainThreadForPerformanceTesting() const final;
+    IntRect scrollableAreaBoundingBox(bool* = nullptr) const final;
+
+    void scrollbarStyleChanged(ScrollbarStyle, bool forceUpdate) override;
+
+    // Coordinate systems:
+    //
+    // "View"
+    //     Top left is top left of the FrameView/ScrollView/Widget. Size is Widget::boundsRect().size().
+    //
+    // "TotalContents"
+    //    Relative to ScrollView's scrolled contents, including headers and footers. Size is totalContentsSize().
+    //
+    // "Contents"
+    //    Relative to ScrollView's scrolled contents, excluding headers and footers, so top left is top left of the scroll view's
+    //    document, and size is contentsSize().
+    //
+    // "Absolute"
+    //    Relative to the document's scroll origin (non-zero for RTL documents), but affected by page zoom and page scale. Mostly used
+    //    in rendering code.
+    //
+    // "Document"
+    //    Relative to the document's scroll origin, but not affected by page zoom or page scale. Size is equivalent to CSS pixel dimensions.
+    //    FIXME: some uses are affected by page zoom (e.g. layout and visual viewports).
+    //
+    // "Client"
+    //    Relative to the visible part of the document (or, more strictly, the layout viewport rect), and with the same scaling
+    //    as Document coordinates, i.e. matching CSS pixels. Affected by scroll origin.
+    //
+    // "LayoutViewport"
+    //    Similar to client coordinates, but affected by page zoom (but not page scale).
+    //
+
+    // Methods to convert points and rects between the coordinate space of the renderer, and this view.
+    WEBCORE_EXPORT IntRect convertFromRendererToContainingView(const RenderElement*, const IntRect&) const;
+    WEBCORE_EXPORT IntRect convertFromContainingViewToRenderer(const RenderElement*, const IntRect&) const;
+    WEBCORE_EXPORT FloatRect convertFromContainingViewToRenderer(const RenderElement*, const FloatRect&) const;
+    WEBCORE_EXPORT IntPoint convertFromRendererToContainingView(const RenderElement*, const IntPoint&) const;
+    WEBCORE_EXPORT FloatPoint convertFromRendererToContainingView(const RenderElement*, const FloatPoint&) const;
+    WEBCORE_EXPORT IntPoint convertFromContainingViewToRenderer(const RenderElement*, const IntPoint&) const;
+
+    // Override ScrollView methods to do point conversion via renderers, in order to take transforms into account.
+    IntRect convertToContainingView(const IntRect&) const final;
+    IntRect convertFromContainingView(const IntRect&) const final;
+    FloatRect convertFromContainingView(const FloatRect&) const final;
+    IntPoint convertToContainingView(const IntPoint&) const final;
+    FloatPoint convertToContainingView(const FloatPoint&) const final;
+    IntPoint convertFromContainingView(const IntPoint&) const final;
+
+private:
+    ScrollableArea* enclosingScrollableArea() const final;
+
+    bool scrollAnimatorEnabled() const final;
 };
 
 }

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -194,14 +194,10 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject
     if (bounds.isEmpty())
         return std::nullopt;
 
-    auto* localFrame = dynamicDowncast<LocalFrame>(regionRenderer.document().frame()->mainFrame());
-    if (!localFrame)
-        return std::nullopt;
+    Ref mainFrameView = *regionRenderer.document().frame()->mainFrame().virtualView();
 
-    auto& mainFrameView = *localFrame->view();
-
-    FloatSize frameViewSize = mainFrameView.size();
-    auto scale = 1 / mainFrameView.visibleContentScaleFactor();
+    FloatSize frameViewSize = mainFrameView->size();
+    auto scale = 1 / mainFrameView->visibleContentScaleFactor();
     frameViewSize.scale(scale, scale);
     auto frameViewArea = frameViewSize.area();
 

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -757,21 +757,6 @@ RenderView* LocalFrame::contentRenderer() const
     return document() ? document()->renderView() : nullptr;
 }
 
-RenderWidget* LocalFrame::ownerRenderer() const
-{
-    RefPtr ownerElement = this->ownerElement();
-    if (!ownerElement)
-        return nullptr;
-    auto* object = ownerElement->renderer();
-    // FIXME: If <object> is ever fixed to disassociate itself from frames
-    // that it has started but canceled, then this can turn into an ASSERT
-    // since ownerElement would be nullptr when the load is canceled.
-    // https://bugs.webkit.org/show_bug.cgi?id=18585
-    if (!is<RenderWidget>(object))
-        return nullptr;
-    return downcast<RenderWidget>(object);
-}
-
 LocalFrame* LocalFrame::frameForWidget(const Widget& widget)
 {
     if (auto* renderer = RenderWidget::find(widget))

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -169,7 +169,6 @@ public:
     WEBCORE_EXPORT bool isRootFrame() const;
 
     WEBCORE_EXPORT RenderView* contentRenderer() const; // Root of the render tree for the document contained in this frame.
-    WEBCORE_EXPORT RenderWidget* ownerRenderer() const; // Renderer for the element that contains this frame.
 
     bool documentIsBeingReplaced() const { return m_documentIsBeingReplaced; }
 

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -99,9 +99,6 @@ public:
 
     virtual ~LocalFrameView();
 
-    HostWindow* hostWindow() const final;
-
-    WEBCORE_EXPORT void invalidateRect(const IntRect&) final;
     void setFrameRect(const IntRect&) final;
     Type viewType() const final { return Type::Local; }
     void writeRenderTreeAsText(TextStream&, OptionSet<RenderAsTextFlag>) override;
@@ -269,8 +266,6 @@ public:
 
     IntRect windowClipRect() const final;
     WEBCORE_EXPORT IntRect windowClipRectForFrameOwner(const HTMLFrameOwnerElement*, bool clipToLayerContents) const;
-
-    float visibleContentScaleFactor() const final;
 
 #if USE(COORDINATED_GRAPHICS)
     WEBCORE_EXPORT void setFixedVisibleContentRect(const IntRect&) final;
@@ -515,22 +510,6 @@ public:
     //    Similar to client coordinates, but affected by page zoom (but not page scale).
     //
 
-    // Methods to convert points and rects between the coordinate space of the renderer, and this view.
-    WEBCORE_EXPORT IntRect convertFromRendererToContainingView(const RenderElement*, const IntRect&) const;
-    WEBCORE_EXPORT IntRect convertFromContainingViewToRenderer(const RenderElement*, const IntRect&) const;
-    WEBCORE_EXPORT FloatRect convertFromContainingViewToRenderer(const RenderElement*, const FloatRect&) const;
-    WEBCORE_EXPORT IntPoint convertFromRendererToContainingView(const RenderElement*, const IntPoint&) const;
-    WEBCORE_EXPORT FloatPoint convertFromRendererToContainingView(const RenderElement*, const FloatPoint&) const;
-    WEBCORE_EXPORT IntPoint convertFromContainingViewToRenderer(const RenderElement*, const IntPoint&) const;
-
-    // Override ScrollView methods to do point conversion via renderers, in order to take transforms into account.
-    IntRect convertToContainingView(const IntRect&) const final;
-    IntRect convertFromContainingView(const IntRect&) const final;
-    FloatRect convertFromContainingView(const FloatRect&) const final;
-    IntPoint convertToContainingView(const IntPoint&) const final;
-    FloatPoint convertToContainingView(const FloatPoint&) const final;
-    IntPoint convertFromContainingView(const IntPoint&) const final;
-
     float documentToAbsoluteScaleFactor(std::optional<float> effectiveZoom = std::nullopt) const;
     float absoluteToDocumentScaleFactor(std::optional<float> effectiveZoom = std::nullopt) const;
 
@@ -582,7 +561,6 @@ public:
     void flushAnyPendingPostLayoutTasks();
 
     bool shouldSuspendScrollAnimations() const final;
-    void scrollbarStyleChanged(ScrollbarStyle, bool forceUpdate) override;
 
     RenderBox* embeddedContentBox() const;
     
@@ -623,9 +601,6 @@ public:
     const Pagination& pagination() const;
     void setPagination(const Pagination&);
 
-    bool isActive() const final;
-    bool forceUpdateScrollbarsOnMainThreadForPerformanceTesting() const final;
-
 #if HAVE(RUBBER_BANDING)
     WEBCORE_EXPORT GraphicsLayer* setWantsLayerForTopOverHangArea(bool) const;
     WEBCORE_EXPORT GraphicsLayer* setWantsLayerForBottomOverHangArea(bool) const;
@@ -637,10 +612,6 @@ public:
 
     LayoutPoint scrollPositionRespectingCustomFixedPosition() const;
 
-    WEBCORE_EXPORT int headerHeight() const final;
-    WEBCORE_EXPORT int footerHeight() const final;
-
-    WEBCORE_EXPORT float topContentInset(TopContentInsetType = TopContentInsetType::WebCoreContentInset) const final;
     void topContentInsetDidChange(float newTopContentInset);
 
     void topContentDirectionDidChange();
@@ -829,9 +800,6 @@ private:
     void invalidateScrollbarRect(Scrollbar&, const IntRect&) final;
     void scrollTo(const ScrollPosition&) final;
     void setVisibleScrollerThumbRect(const IntRect&) final;
-    ScrollableArea* enclosingScrollableArea() const final;
-    IntRect scrollableAreaBoundingBox(bool* = nullptr) const final;
-    bool scrollAnimatorEnabled() const final;
     GraphicsLayer* layerForScrollCorner() const final;
 #if HAVE(RUBBER_BANDING)
     GraphicsLayer* layerForOverhangAreas() const final;

--- a/Source/WebCore/page/RemoteFrameView.cpp
+++ b/Source/WebCore/page/RemoteFrameView.cpp
@@ -46,25 +46,6 @@ void RemoteFrameView::setFrameRect(const IntRect& newRect)
 
 // FIXME: Implement all the stubs below.
 
-void RemoteFrameView::invalidateRect(const IntRect&)
-{
-}
-
-bool RemoteFrameView::isActive() const
-{
-    return false;
-}
-
-bool RemoteFrameView::forceUpdateScrollbarsOnMainThreadForPerformanceTesting() const
-{
-    return false;
-}
-
-ScrollableArea* RemoteFrameView::enclosingScrollableArea() const
-{
-    return nullptr;
-}
-
 bool RemoteFrameView::isScrollableOrRubberbandable()
 {
     return false;
@@ -75,11 +56,6 @@ bool RemoteFrameView::hasScrollableOrRubberbandableAncestor()
     return false;
 }
 
-IntRect RemoteFrameView::scrollableAreaBoundingBox(bool*) const
-{
-    return { };
-}
-
 bool RemoteFrameView::shouldPlaceVerticalScrollbarOnLeft() const
 {
     return false;
@@ -87,11 +63,6 @@ bool RemoteFrameView::shouldPlaceVerticalScrollbarOnLeft() const
 
 void RemoteFrameView::invalidateScrollbarRect(Scrollbar&, const IntRect&)
 {
-}
-
-HostWindow* RemoteFrameView::hostWindow() const
-{
-    return nullptr;
 }
 
 IntRect RemoteFrameView::windowClipRect() const

--- a/Source/WebCore/page/RemoteFrameView.h
+++ b/Source/WebCore/page/RemoteFrameView.h
@@ -44,16 +44,10 @@ private:
     WEBCORE_EXPORT RemoteFrameView(RemoteFrame&);
 
     bool isRemoteFrameView() const final { return true; }
-    void invalidateRect(const IntRect&) final;
-    bool isActive() const final;
-    bool forceUpdateScrollbarsOnMainThreadForPerformanceTesting() const final;
-    ScrollableArea* enclosingScrollableArea() const final;
     bool isScrollableOrRubberbandable() final;
     bool hasScrollableOrRubberbandableAncestor() final;
-    IntRect scrollableAreaBoundingBox(bool*) const final;
     bool shouldPlaceVerticalScrollbarOnLeft() const final;
     void invalidateScrollbarRect(Scrollbar&, const IntRect&) final;
-    HostWindow* hostWindow() const final;
     IntRect windowClipRect() const final;
     void paintContents(GraphicsContext&, const IntRect& damageRect, SecurityOriginPaintPolicy, RegionContext*) final;
     void addedOrRemovedScrollbar() final;


### PR DESCRIPTION
#### 10d1e7485040a2f6ec54279ad9d7fe6dad7b5c44
<pre>
Begin moving functions from LocalFrameView to FrameView
<a href="https://bugs.webkit.org/show_bug.cgi?id=265709">https://bugs.webkit.org/show_bug.cgi?id=265709</a>
<a href="https://rdar.apple.com/119058105">rdar://119058105</a>

Reviewed by Alex Christensen.

* Source/WebCore/Sources.txt:
* Source/WebCore/page/Frame.cpp:
(WebCore::Frame::ownerRenderer const):
* Source/WebCore/page/Frame.h:
* Source/WebCore/page/FrameView.cpp: Added.
(WebCore::FrameView::headerHeight const):
(WebCore::FrameView::footerHeight const):
(WebCore::FrameView::topContentInset const):
(WebCore::FrameView::visibleContentScaleFactor const):
(WebCore::FrameView::isActive const):
(WebCore::FrameView::enclosingScrollableArea const):
(WebCore::FrameView::invalidateRect):
(WebCore::FrameView::forceUpdateScrollbarsOnMainThreadForPerformanceTesting const):
(WebCore::FrameView::scrollableAreaBoundingBox const):
(WebCore::FrameView::hostWindow const):
(WebCore::FrameView::scrollbarStyleChanged):
(WebCore::FrameView::scrollAnimatorEnabled const):
(WebCore::FrameView::convertFromRendererToContainingView const):
(WebCore::FrameView::convertFromContainingViewToRenderer const):
(WebCore::FrameView::convertToContainingView const):
(WebCore::FrameView::convertFromContainingView const):
* Source/WebCore/page/FrameView.h:
* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::interactionRegionForRenderedRegion):
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::ownerRenderer const): Deleted.
* Source/WebCore/page/LocalFrame.h:
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::invalidateRect): Deleted.
(WebCore::LocalFrameView::headerHeight const): Deleted.
(WebCore::LocalFrameView::footerHeight const): Deleted.
(WebCore::LocalFrameView::topContentInset const): Deleted.
(WebCore::LocalFrameView::hostWindow const): Deleted.
(WebCore::LocalFrameView::isActive const): Deleted.
(WebCore::LocalFrameView::forceUpdateScrollbarsOnMainThreadForPerformanceTesting const): Deleted.
(WebCore::LocalFrameView::visibleContentScaleFactor const): Deleted.
(WebCore::LocalFrameView::enclosingScrollableArea const): Deleted.
(WebCore::LocalFrameView::scrollableAreaBoundingBox const): Deleted.
(WebCore::LocalFrameView::scrollbarStyleChanged): Deleted.
(WebCore::LocalFrameView::scrollAnimatorEnabled const): Deleted.
(WebCore::LocalFrameView::convertFromRendererToContainingView const): Deleted.
(WebCore::LocalFrameView::convertFromContainingViewToRenderer const): Deleted.
(WebCore::LocalFrameView::convertToContainingView const): Deleted.
(WebCore::LocalFrameView::convertFromContainingView const): Deleted.
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/RemoteFrameView.cpp:
(WebCore::RemoteFrameView::invalidateRect): Deleted.
(WebCore::RemoteFrameView::isActive const): Deleted.
(WebCore::RemoteFrameView::forceUpdateScrollbarsOnMainThreadForPerformanceTesting const): Deleted.
(WebCore::RemoteFrameView::enclosingScrollableArea const): Deleted.
(WebCore::RemoteFrameView::scrollableAreaBoundingBox const): Deleted.
(WebCore::RemoteFrameView::hostWindow const): Deleted.
* Source/WebCore/page/RemoteFrameView.h:

Canonical link: <a href="https://commits.webkit.org/271493@main">https://commits.webkit.org/271493@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42c2a97c4ab7fed4de327260bddcdfda8033ff2c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28595 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7240 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/29978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/31242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/26118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29103 "Failed to checkout and rebase branch from PR 21199") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9353 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4610 "Failed to checkout and rebase branch from PR 21199") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/31242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28865 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/5984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/29978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/31242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/5356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/29978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/32561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/26184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/29978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/32561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/5321 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/51/builds/4610 "Failed to checkout and rebase branch from PR 21199") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/32561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/6927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/29978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/5782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3690 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/5840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->