### PR TITLE
CSS Counters not properly updated on style changes

### DIFF
--- a/LayoutTests/fast/css/counters/counter-increment-not-reflected-on-stylechange-expected.txt
+++ b/LayoutTests/fast/css/counters/counter-increment-not-reflected-on-stylechange-expected.txt
@@ -1,0 +1,6 @@
+PASS internals.counterValue(document.getElementById('inner1')) is "1"
+PASS internals.counterValue(document.getElementById('inner2')) is "2"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/css/counters/counter-increment-not-reflected-on-stylechange.html
+++ b/LayoutTests/fast/css/counters/counter-increment-not-reflected-on-stylechange.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<script src="../../../resources/js-test.js"></script>
+<style>
+    #outer
+    {
+        counter-reset: c;
+    }
+
+    #outer > div:before
+    {
+        content: counter(c);
+    }
+
+    .active > div:before {
+        counter-increment: c;
+    }
+
+    .inactive > div:before {
+        counter-increment: none;
+    }
+</style>
+
+<div id="outer">
+    <div id="inner1"></div>
+    <div id="inner2"></div>
+</div>
+
+<script>
+    var outerDiv = document.getElementById("outer");
+    outerDiv.className = "inactive";
+    outerDiv.offsetTop;
+    outerDiv.className = "active";
+
+    shouldBeEqualToString("internals.counterValue(document.getElementById('inner1'))", "1");
+    shouldBeEqualToString("internals.counterValue(document.getElementById('inner2'))", "2");
+</script>

--- a/Source/WebCore/rendering/RenderCounter.cpp
+++ b/Source/WebCore/rendering/RenderCounter.cpp
@@ -586,6 +586,9 @@ void RenderCounter::rendererStyleChangedSlowCase(RenderElement& renderer, const 
                 RenderCounter::destroyCounterNodes(renderer);
         }
     } else {
+        if (renderer.hasCounterNodeMap())
+            RenderCounter::destroyCounterNodes(renderer);
+
         for (auto& key : newStyle.counterDirectives().map.keys()) {
             // We must create this node here, because the added node may be a node with no display such as
             // as those created by the increment or reset directives and the re-layout that will happen will


### PR DESCRIPTION
#### f8d357e1814f503c9df5fdc766855eb805bf5b67
<pre>
CSS Counters not properly updated on style changes

<a href="https://bugs.webkit.org/show_bug.cgi?id=256540">https://bugs.webkit.org/show_bug.cgi?id=256540</a>
<a href="https://rdar.apple.com/problem/109416780">rdar://problem/109416780</a>

Reviewed by Simon Fraser.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=197703

When oldstyle does not have counterDirectives and
new style have counterDirectives on style change
previous counter nodes were not cleared because of
which oldstyle values are reflected.

* Source/WebCore/rendering/RenderCounter.cpp:
(enderCounter::rendererStyleChangedSlowCase):
* LayoutTests/fast/css/counters/counter-increment-not-reflected-on-stylechange.html: Add Test Case
* LayoutTests/fast/css/counters/counter-increment-not-reflected-on-stylechange-expected.txt: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/271451@main">https://commits.webkit.org/271451@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b71fa05a6bb06c4f4ae5961869cbb93e29b390b4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28457 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7102 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29843 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30984 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25912 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28954 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9201 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4471 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28726 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/5862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/24485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/5127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/5242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/25486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31670 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/26063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/25927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/31526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5199 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/3379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/29292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6800 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/25280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5656 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3667 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5719 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->