### PR TITLE
Borders, backgrounds, and other table cell properties are lost when pasting tables into TextEdit

### DIFF
--- a/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
+++ b/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
@@ -285,6 +285,7 @@
 		F43E89382AEDB8C800097D2D /* CoreTelephonySoftLink.h in Headers */ = {isa = PBXBuildFile; fileRef = F43E89352AEDB8C800097D2D /* CoreTelephonySoftLink.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F44291641FA52670002CC93E /* FileSizeFormatter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F44291621FA52670002CC93E /* FileSizeFormatter.cpp */; };
 		F44291681FA52705002CC93E /* FileSizeFormatterCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = F44291661FA52705002CC93E /* FileSizeFormatterCocoa.mm */; };
+		F449AE2D2B1AC62C00294F34 /* NSTextTableSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = F449AE2C2B1AC62C00294F34 /* NSTextTableSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F44C007B29A06B1C00211F33 /* TranslationUIServicesSoftLink.h in Headers */ = {isa = PBXBuildFile; fileRef = F44C007929A06B1C00211F33 /* TranslationUIServicesSoftLink.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F44C007C29A06B1C00211F33 /* TranslationUIServicesSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = F44C007A29A06B1C00211F33 /* TranslationUIServicesSoftLink.mm */; };
 		F44C007E29A06BC200211F33 /* TranslationUIServicesSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = F44C007D29A06BC200211F33 /* TranslationUIServicesSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -673,6 +674,7 @@
 		F442915F1FA5261E002CC93E /* FileSizeFormatter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FileSizeFormatter.h; sourceTree = "<group>"; };
 		F44291621FA52670002CC93E /* FileSizeFormatter.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = FileSizeFormatter.cpp; sourceTree = "<group>"; };
 		F44291661FA52705002CC93E /* FileSizeFormatterCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FileSizeFormatterCocoa.mm; sourceTree = "<group>"; };
+		F449AE2C2B1AC62C00294F34 /* NSTextTableSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSTextTableSPI.h; sourceTree = "<group>"; };
 		F44C007929A06B1C00211F33 /* TranslationUIServicesSoftLink.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TranslationUIServicesSoftLink.h; sourceTree = "<group>"; };
 		F44C007A29A06B1C00211F33 /* TranslationUIServicesSoftLink.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TranslationUIServicesSoftLink.mm; sourceTree = "<group>"; };
 		F44C007D29A06BC200211F33 /* TranslationUIServicesSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TranslationUIServicesSPI.h; sourceTree = "<group>"; };
@@ -893,6 +895,7 @@
 				72BA2A872951462500678507 /* NSTextFieldCellSPI.h */,
 				0C7785821F45130F00F4EBB6 /* NSTextFinderSPI.h */,
 				93DB7D3624626BCC004BD8A3 /* NSTextInputContextSPI.h */,
+				F449AE2C2B1AC62C00294F34 /* NSTextTableSPI.h */,
 				93DB7D3924626F86004BD8A3 /* NSUndoManagerSPI.h */,
 				0C7785831F45130F00F4EBB6 /* NSViewSPI.h */,
 				0C7785841F45130F00F4EBB6 /* NSWindowSPI.h */,
@@ -1393,6 +1396,7 @@
 				DD20DDFB27BC90D70093D175 /* NSStringSPI.h in Headers */,
 				DD20DE3927BC90D80093D175 /* NSTextFinderSPI.h in Headers */,
 				DD20DE3A27BC90D80093D175 /* NSTextInputContextSPI.h in Headers */,
+				F449AE2D2B1AC62C00294F34 /* NSTextTableSPI.h in Headers */,
 				DD20DDFC27BC90D70093D175 /* NSTouchBarSPI.h in Headers */,
 				DD20DE3B27BC90D80093D175 /* NSUndoManagerSPI.h in Headers */,
 				DD20DDFD27BC90D70093D175 /* NSURLConnectionSPI.h in Headers */,

--- a/Source/WebCore/PAL/pal/PlatformMac.cmake
+++ b/Source/WebCore/PAL/pal/PlatformMac.cmake
@@ -143,6 +143,7 @@ list(APPEND PAL_PUBLIC_HEADERS
     spi/mac/NSSpellCheckerSPI.h
     spi/mac/NSTextFinderSPI.h
     spi/mac/NSTextInputContextSPI.h
+    spi/mac/NSTextTableSPI.h
     spi/mac/NSUndoManagerSPI.h
     spi/mac/NSViewSPI.h
     spi/mac/NSWindowSPI.h

--- a/Source/WebCore/PAL/pal/spi/ios/UIKitSPI.h
+++ b/Source/WebCore/PAL/pal/spi/ios/UIKitSPI.h
@@ -241,6 +241,10 @@ typedef NS_ENUM(NSUInteger, NSTextTabType) {
 - (void)setVerticalAlignment:(NSTextBlockVerticalAlignment)alignment;
 @end
 
+@interface NSTextBlock (Internal)
+- (void)_takeValuesFromTextBlock:(NSTextBlock *)other;
+@end
+
 @interface NSTextTable : NSTextBlock
 - (void)setNumberOfColumns:(NSUInteger)numCols;
 - (void)setCollapsesBorders:(BOOL)flag;

--- a/Source/WebCore/PAL/pal/spi/mac/NSTextTableSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSTextTableSPI.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#import <AppKit/NSTextTable.h>
+
+@interface NSTextBlock (Internal)
+- (void)_takeValuesFromTextBlock:(NSTextBlock *)other;
+@end

--- a/Source/WebCore/editing/cocoa/AttributedString.mm
+++ b/Source/WebCore/editing/cocoa/AttributedString.mm
@@ -33,6 +33,7 @@
 #import <wtf/cocoa/VectorCocoa.h>
 #if PLATFORM(MAC)
 #import <AppKit/AppKit.h>
+#import <pal/spi/mac/NSTextTableSPI.h>
 #else
 #import <pal/ios/UIKitSoftLink.h>
 #import "UIFoundationSoftLink.h"
@@ -119,6 +120,7 @@ inline static RetainPtr<NSParagraphStyle> reconstructStyle(const AttributedStrin
             replacementBlock = tableBlock;
         else if (!ensureTableResult.isNewEntry) {
             replacementBlock = adoptNS([[PlatformNSTextTableBlock alloc] initWithTable:table startingRow:tableBlock.startingRow rowSpan:tableBlock.rowSpan startingColumn:tableBlock.startingColumn columnSpan:tableBlock.columnSpan]);
+            [replacementBlock _takeValuesFromTextBlock:tableBlock];
             tableBlocks.set(tableBlockID, replacementBlock.get());
         }
 

--- a/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
+++ b/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
@@ -555,7 +555,15 @@ typedef NS_ENUM(NSUInteger, _UIClickInteractionEvent) {
 - (void)removeEmojiAlternatives;
 @end
 
+typedef NS_ENUM(NSInteger, NSTextBlockLayer) {
+    NSTextBlockPadding  = -1,
+    NSTextBlockBorder   =  0,
+    NSTextBlockMargin   =  1
+};
+
 @interface NSTextBlock : NSObject
+- (CGFloat)widthForLayer:(NSTextBlockLayer)layer edge:(CGRectEdge)edge;
+@property (nonatomic, copy) UIColor *backgroundColor;
 @end
 
 @interface NSTextTable : NSTextBlock


### PR DESCRIPTION
#### 3acbb664bd93438447218221d223c3466cdfa63c
<pre>
Borders, backgrounds, and other table cell properties are lost when pasting tables into TextEdit
<a href="https://bugs.webkit.org/show_bug.cgi?id=265712">https://bugs.webkit.org/show_bug.cgi?id=265712</a>
<a href="https://rdar.apple.com/119035264">rdar://119035264</a>

Reviewed by Richard Robinson.

Even after the fixes in 266700@main and 269265@main, attributed string serialization is still lossy.
In the process of preserving table structure in `reconstructStyle` by recreating any
`NSTextTableBlock` instances that point to separate tables but (originally) belonged to the same
`NSTextTable` upon encoding, we end up discarding the decoded `NSTextTableBlock`, and only carry
over some aspects of the block (i.e., row and column information).

This causes us to lose information about the style and layout of these tables, on various bits of
state on `NSTextTableBlock` that are populated in `HTMLConverter::_fillInBlock`.

To fix this, we adopt a UIFoundation SPI, `-_takeValuesFromTextBlock:`, that allows us to copy
across the entire state of the `NSTextTableBlock` in a way that preserves style and layout
information, without changing the containing `NSTextTable`, or any of the row/column values.

* Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj:
* Source/WebCore/PAL/pal/PlatformMac.cmake:
* Source/WebCore/PAL/pal/spi/ios/UIKitSPI.h:
* Source/WebCore/PAL/pal/spi/mac/NSTextTableSPI.h: Added.
* Source/WebCore/editing/cocoa/AttributedString.mm:
(WebCore::reconstructStyle):

Implement the main fix here, by using `-_takeValuesFromTextBlock:` to copy all layout and
presentational attributes from the original, decoded text block over to the new one that points to
the correct text table.

* Tools/TestRunnerShared/spi/UIKitSPIForTesting.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewGetContents.mm:

Canonical link: <a href="https://commits.webkit.org/271485@main">https://commits.webkit.org/271485@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7443dccc98b3fc8ee4702f1b542e80ad5e0962b4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28348 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6992 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29729 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30875 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25808 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28845 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9075 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4363 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26082 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28617 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5748 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24387 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5028 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5125 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25386 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31561 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25949 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25822 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31435 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5097 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3276 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29194 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6695 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6833 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5550 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5616 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->