### PR TITLE
[CSS] Respect proximity in the cascade

### DIFF
--- a/LayoutTests/fast/css/scope-at-rule-expected.html
+++ b/LayoutTests/fast/css/scope-at-rule-expected.html
@@ -37,3 +37,9 @@
 <div>
   <span class="">should not be green</span>
 </div>
+<div>
+  <span class="green">should be green</span>
+</div>
+<div>
+  <span class="green">should be green</span>
+</div>

--- a/LayoutTests/fast/css/scope-at-rule.html
+++ b/LayoutTests/fast/css/scope-at-rule.html
@@ -26,6 +26,19 @@ video {
 @scope (.a) {
   :scope :scope .green-7 { color: green; }
 }
+
+@scope (.a) {
+  span.green-9 { color: green; }
+}
+@scope (.b) {
+  .green-8 { color: green; }
+  .green-9 { color: red; }
+}
+@scope (.a) {
+  .green-8 { color: red; }
+  .green-9 { color: red; }
+}
+
 </style>
 
 <div class="a">
@@ -67,5 +80,17 @@ video {
     <div class="a">
       <span class="green-7">should not be green</span>
     </div>
+  </div>
+</div>
+
+<div class="a">
+  <div class="b">
+    <span class="green-8">should be green</span>
+  </div>
+</div>
+
+<div class="a">
+  <div class="b">
+    <span class="green-9">should be green</span>
   </div>
 </div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-proximity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-proximity-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Alternating light/dark assert_equals: expected "rgb(100, 100, 100)" but got "rgb(200, 200, 200)"
-FAIL Proximity wins over order of appearance assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+PASS Alternating light/dark
+PASS Proximity wins over order of appearance
 PASS Specificity wins over proximity
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-specificity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-specificity-expected.txt
@@ -3,7 +3,7 @@ FAIL @scope (#main) { .b {  } } assert_equals: unscoped + scoped expected "2" bu
 FAIL @scope (#main) to (.b) { .a {  } } assert_equals: unscoped + scoped expected "2" but got "1"
 FAIL @scope (#main, .foo, .bar) { #a {  } } assert_equals: unscoped + scoped expected "2" but got "1"
 FAIL @scope (#main) { div.b {  } } assert_equals: unscoped + scoped expected "2" but got "1"
-FAIL @scope (#main) { :scope .b {  } } assert_equals: scoped + unscoped expected "1" but got "2"
+PASS @scope (#main) { :scope .b {  } }
 FAIL @scope (#main) { & .b {  } } assert_equals: scoped + unscoped expected "1" but got "2"
 FAIL @scope (#main) { div .b {  } } assert_equals: unscoped + scoped expected "2" but got "1"
 FAIL @scope (#main) { @scope (.a) { .b {  } } } assert_equals: unscoped + scoped expected "2" but got "1"

--- a/Source/WebCore/style/ElementRuleCollector.h
+++ b/Source/WebCore/style/ElementRuleCollector.h
@@ -61,8 +61,9 @@ public:
 };
 
 struct MatchedRule {
-    const RuleData* ruleData;
-    unsigned specificity;
+    const RuleData* ruleData { nullptr };
+    unsigned specificity { 0 };
+    unsigned scopingRootDistance { 0 };
     ScopeOrdinal styleScopeOrdinal;
     CascadeLayerPriority cascadeLayerPriority;
 };
@@ -120,7 +121,11 @@ private:
     void collectMatchingRulesForList(const RuleSet::RuleDataVector*, const MatchRequest&);
     bool ruleMatches(const RuleData&, unsigned& specificity, ScopeOrdinal, const Element* scopingRoot = nullptr);
     bool containerQueriesMatch(const RuleData&, const MatchRequest&);
-    std::pair<bool, std::optional<Vector<const Element*>>> scopeRulesMatch(const RuleData&, const MatchRequest&);
+    struct ScopingRootWithDistance {
+        const Element* scopingRoot { nullptr };
+        unsigned distance { std::numeric_limits<unsigned>::max() };
+    };
+    std::pair<bool, std::optional<Vector<ScopingRootWithDistance>>> scopeRulesMatch(const RuleData&, const MatchRequest&);
 
     void sortMatchedRules();
 
@@ -129,7 +134,7 @@ private:
     void sortAndTransferMatchedRules(DeclarationOrigin);
     void transferMatchedRules(DeclarationOrigin, std::optional<ScopeOrdinal> forScope = { });
 
-    void addMatchedRule(const RuleData&, unsigned specificity, const MatchRequest&);
+    void addMatchedRule(const RuleData&, unsigned specificity, unsigned scopingRootDistance, const MatchRequest&);
     void addMatchedProperties(MatchedProperties&&, DeclarationOrigin);
 
     const Element& element() const { return m_element.get(); }


### PR DESCRIPTION
#### 40cf94b5b6f9268ea70a80d6bf2f871115c11882
<pre>
[CSS] Respect proximity in the cascade
<a href="https://bugs.webkit.org/show_bug.cgi?id=264943">https://bugs.webkit.org/show_bug.cgi?id=264943</a>
<a href="https://rdar.apple.com/118507507">rdar://118507507</a>

Reviewed by Antti Koivisto.

<a href="https://drafts.csswg.org/css-cascade-6/#cascade-proximity">https://drafts.csswg.org/css-cascade-6/#cascade-proximity</a>

CSS Cascade level 6 introduces the new concept of proximity to decide
which rule to apply : the closest scope will be prioritized.

* LayoutTests/fast/css/scope-at-rule-expected.html:
* LayoutTests/fast/css/scope-at-rule.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-proximity-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-specificity-expected.txt:
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::addMatchedRule):
(WebCore::Style::ElementRuleCollector::collectMatchingRulesForList):
(WebCore::Style::ElementRuleCollector::scopeRulesMatch):
(WebCore::Style::compareRules):
* Source/WebCore/style/ElementRuleCollector.h:

Canonical link: <a href="https://commits.webkit.org/271557@main">https://commits.webkit.org/271557@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d0ef3140f2de984b31cf16a1b86628093166a720

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28776 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7419 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30149 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31395 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26253 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29346 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9550 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4778 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26313 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29046 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6147 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24736 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5338 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5490 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25743 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/32734 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26345 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26185 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/31734 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5458 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3629 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/29513 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7077 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/25537 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6881 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5928 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5976 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->