### PR TITLE
[view-transitions] Create renderers for pseudo-elements

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2845,6 +2845,7 @@ rendering/updating/RenderTreeBuilderTable.cpp
 rendering/updating/RenderTreePosition.cpp
 rendering/updating/RenderTreeUpdater.cpp
 rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
+rendering/updating/RenderTreeUpdaterViewTransition.cpp
 storage/Storage.cpp
 storage/StorageEvent.cpp
 storage/StorageEventDispatcher.cpp

--- a/Source/WebCore/dom/ViewTransition.h
+++ b/Source/WebCore/dom/ViewTransition.h
@@ -92,6 +92,11 @@ public:
         return m_keys;
     }
 
+    bool isEmpty() const
+    {
+        return m_keys.isEmpty();
+    }
+
     CapturedElement* find(const AtomString& key)
     {
         if (auto it = m_map.find(key); it != m_map.end())

--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -1110,4 +1110,14 @@ SingleThreadWeakHashSet<RenderCounter> RenderView::takeCountersNeedingUpdate()
     return std::exchange(m_countersNeedingUpdate, { });
 }
 
+SingleThreadWeakPtr<RenderElement> RenderView::viewTransitionRoot() const
+{
+    return m_viewTransitionRoot;
+}
+
+void RenderView::setViewTransitionRoot(RenderElement& renderer)
+{
+    m_viewTransitionRoot = renderer;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderView.h
+++ b/Source/WebCore/rendering/RenderView.h
@@ -210,6 +210,9 @@ public:
     void unregisterContainerQueryBox(const RenderBox&);
     const SingleThreadWeakHashSet<const RenderBox>& containerQueryBoxes() const { return m_containerQueryBoxes; }
 
+    SingleThreadWeakPtr<RenderElement> viewTransitionRoot() const;
+    void setViewTransitionRoot(RenderElement& renderer);
+
 private:
     void styleDidChange(StyleDifference, const RenderStyle* oldStyle) override;
 
@@ -279,6 +282,8 @@ private:
 
     SingleThreadWeakHashSet<const RenderBox> m_boxesWithScrollSnapPositions;
     SingleThreadWeakHashSet<const RenderBox> m_containerQueryBoxes;
+
+    SingleThreadWeakPtr<RenderElement> m_viewTransitionRoot;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -344,6 +344,8 @@ public:
 
     PseudoId styleType() const { return static_cast<PseudoId>(m_nonInheritedFlags.styleType); }
     void setStyleType(PseudoId styleType) { m_nonInheritedFlags.styleType = static_cast<unsigned>(styleType); }
+    const AtomString& functionalPseudoElementArgument() const;
+    void setFunctionalPseudoElementArgument(const AtomString&);
 
     RenderStyle* getCachedPseudoStyle(PseudoId) const;
     RenderStyle* addCachedPseudoStyle(std::unique_ptr<RenderStyle>);

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -667,6 +667,7 @@ inline bool RenderStyle::specifiesColumns() const { return !hasAutoColumnCount()
 constexpr OptionSet<Containment> RenderStyle::strictContainment() { return { Containment::Size, Containment::Layout, Containment::Paint, Containment::Style }; }
 inline StyleColor RenderStyle::strokeColor() const { return m_rareInheritedData->strokeColor; }
 inline float RenderStyle::strokeMiterLimit() const { return m_rareInheritedData->miterLimit; }
+inline const AtomString& RenderStyle::functionalPseudoElementArgument() const { return m_nonInheritedData->rareData->functionalPseudoElementArgument; }
 inline const TabSize& RenderStyle::tabSize() const { return m_rareInheritedData->tabSize; }
 inline TextAlignLast RenderStyle::textAlignLast() const { return static_cast<TextAlignLast>(m_rareInheritedData->textAlignLast); }
 inline TextBoxTrim RenderStyle::textBoxTrim() const { return static_cast<TextBoxTrim>(m_nonInheritedData->rareData->textBoxTrim); }

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -465,6 +465,16 @@ inline void RenderStyle::setFlexShrink(float shrink)
     SET_DOUBLY_NESTED(m_nonInheritedData, miscData, flexibleBox, flexShrink, clampedShrink);
 }
 
+inline void RenderStyle::setFunctionalPseudoElementArgument(const AtomString& identifier)
+{
+    ASSERT(styleType() == PseudoId::ViewTransitionGroup
+        || styleType() == PseudoId::ViewTransitionImagePair
+        || styleType() == PseudoId::ViewTransitionNew
+        || styleType() == PseudoId::ViewTransitionOld
+        || styleType() == PseudoId::Highlight);
+    SET_NESTED(m_nonInheritedData, rareData, functionalPseudoElementArgument, identifier);
+}
+
 inline void RenderStyle::setGridColumnList(const GridTrackList& list)
 {
     if (!compareEqual(m_nonInheritedData->rareData->grid->columns(), list))

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
@@ -91,6 +91,7 @@ StyleRareNonInheritedData::StyleRareNonInheritedData()
     // scrollbarGutter
     , scrollbarWidth(RenderStyle::initialScrollbarWidth())
     , zoom(RenderStyle::initialZoom())
+    , functionalPseudoElementArgument(nullAtom())
     , blockStepSize(RenderStyle::initialBlockStepSize())
     , blockStepInsert(static_cast<unsigned>(RenderStyle::initialBlockStepInsert()))
     , overscrollBehaviorX(static_cast<unsigned>(RenderStyle::initialOverscrollBehaviorX()))
@@ -179,6 +180,7 @@ inline StyleRareNonInheritedData::StyleRareNonInheritedData(const StyleRareNonIn
     , scrollbarGutter(o.scrollbarGutter)
     , scrollbarWidth(o.scrollbarWidth)
     , zoom(o.zoom)
+    , functionalPseudoElementArgument(o.functionalPseudoElementArgument)
     , blockStepSize(o.blockStepSize)
     , blockStepInsert(o.blockStepInsert)
     , overscrollBehaviorX(o.overscrollBehaviorX)
@@ -273,6 +275,7 @@ bool StyleRareNonInheritedData::operator==(const StyleRareNonInheritedData& o) c
         && scrollbarGutter == o.scrollbarGutter
         && scrollbarWidth == o.scrollbarWidth
         && zoom == o.zoom
+        && functionalPseudoElementArgument == o.functionalPseudoElementArgument
         && blockStepSize == o.blockStepSize
         && blockStepInsert == o.blockStepInsert
         && overscrollBehaviorX == o.overscrollBehaviorX

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
@@ -186,6 +186,7 @@ public:
     ScrollbarWidth scrollbarWidth { ScrollbarWidth::Auto };
 
     float zoom;
+    AtomString functionalPseudoElementArgument;
 
     std::optional<Length> blockStepSize;
     unsigned blockStepInsert : 1; // BlockStepInsert

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -47,6 +47,7 @@
 #include "RenderStyleConstants.h"
 #include "RenderStyleInlines.h"
 #include "RenderTreeUpdaterGeneratedContent.h"
+#include "RenderTreeUpdaterViewTransition.h"
 #include "RenderView.h"
 #include "SVGElement.h"
 #include "StyleResolver.h"
@@ -77,6 +78,7 @@ RenderTreeUpdater::Parent::Parent(Element& element, const Style::ElementUpdate* 
 RenderTreeUpdater::RenderTreeUpdater(Document& document, Style::PostResolutionCallbackDisabler&)
     : m_document(document)
     , m_generatedContent(makeUnique<GeneratedContent>(*this))
+    , m_viewTransition(makeUnique<ViewTransition>(*this))
     , m_builder(renderView())
 {
 }
@@ -338,6 +340,9 @@ void RenderTreeUpdater::updateAfterDescendants(Element& element, const Style::El
         return;
 
     generatedContent().updateBackdropRenderer(*renderer);
+    if (&element == element.document().documentElement())
+        viewTransition().updatePseudoElementTree(*renderer);
+
     m_builder.updateAfterDescendants(*renderer);
 
     if (element.hasCustomStyleResolveCallbacks() && update && update->change == Style::Change::Renderer)

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.h
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.h
@@ -54,6 +54,7 @@ public:
 
 private:
     class GeneratedContent;
+    class ViewTransition;
 
     void updateRenderTree(ContainerNode& root);
     void updateTextRenderer(Text&, const Style::TextUpdate*);
@@ -84,6 +85,7 @@ private:
     RenderTreePosition& renderTreePosition();
 
     GeneratedContent& generatedContent() { return *m_generatedContent; }
+    ViewTransition& viewTransition() { return *m_viewTransition; }
 
     void pushParent(Element&, const Style::ElementUpdate*);
     void popParent();
@@ -106,6 +108,7 @@ private:
     Vector<Parent> m_parentStack;
 
     std::unique_ptr<GeneratedContent> m_generatedContent;
+    std::unique_ptr<ViewTransition> m_viewTransition;
 
     RenderTreeBuilder m_builder;
 };

--- a/Source/WebCore/rendering/updating/RenderTreeUpdaterViewTransition.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdaterViewTransition.cpp
@@ -1,0 +1,236 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "RenderTreeUpdaterViewTransition.h"
+
+#include "RenderDescendantIterator.h"
+#include "RenderElement.h"
+#include "RenderStyleInlines.h"
+#include "RenderTreeUpdater.h"
+#include "RenderView.h"
+#include "StyleTreeResolver.h"
+#include "ViewTransition.h"
+
+namespace WebCore {
+
+RenderTreeUpdater::ViewTransition::ViewTransition(RenderTreeUpdater& updater)
+    : m_updater(updater)
+{
+}
+
+// The contents and ordering of the named elements map should remain stable during the duration of the transition.
+// We should only need to handle changes in the `display` CSS property by recreating / deleting renderers as needed.
+void RenderTreeUpdater::ViewTransition::updatePseudoElementTree(RenderElement& documentElementRenderer)
+{
+    auto destroyPseudoElementTreeIfNeeded = [&documentElementRenderer, this]() {
+        if (WeakPtr viewTransitionRoot = documentElementRenderer.view().viewTransitionRoot())
+            m_updater.m_builder.destroy(*viewTransitionRoot);
+    };
+
+    Ref document = documentElementRenderer.document();
+
+    // Intentionally bail out early here to avoid computing the style.
+    if (!document->hasViewTransitionPseudoElementTree() || !document->documentElement()) {
+        destroyPseudoElementTreeIfNeeded();
+        return;
+    }
+
+    // Destroy pseudo element tree ::view-transition has display: none or no style.
+    auto rootStyle = documentElementRenderer.getCachedPseudoStyle(PseudoId::ViewTransition, &documentElementRenderer.style());
+    if (!rootStyle || rootStyle->display() == DisplayType::None) {
+        destroyPseudoElementTreeIfNeeded();
+        return;
+    }
+
+    RefPtr activeViewTransition = document->activeViewTransition();
+    ASSERT(activeViewTransition);
+
+    auto newRootStyle = RenderStyle::clone(*rootStyle);
+
+    // Create ::view-transition as needed.
+    WeakPtr viewTransitionRoot = documentElementRenderer.view().viewTransitionRoot();
+    if (viewTransitionRoot)
+        viewTransitionRoot->setStyle(WTFMove(newRootStyle));
+    else {
+        auto newViewTransitionRoot = WebCore::createRenderer<RenderBlockFlow>(RenderObject::Type::BlockFlow, documentElementRenderer.document(), WTFMove(newRootStyle));
+        newViewTransitionRoot->initializeStyle();
+        documentElementRenderer.view().setViewTransitionRoot(*newViewTransitionRoot.get());
+        viewTransitionRoot = newViewTransitionRoot.get();
+        m_updater.m_builder.attach(documentElementRenderer, WTFMove(newViewTransitionRoot));
+    }
+
+    // No groups. The map is constant during the duration of the transition, so we don't need to handle deletions.
+    if (activeViewTransition->namedElements().isEmpty())
+        return;
+
+    // Traverse named elements map to update/build all ::view-transition-group().
+    Vector<SingleThreadWeakPtr<RenderObject>> descendantsToDelete;
+    auto* currentGroup = documentElementRenderer.view().viewTransitionRoot()->firstChild();
+    for (auto& name : activeViewTransition->namedElements().keys()) {
+        ASSERT(!currentGroup || currentGroup->style().styleType() == PseudoId::ViewTransitionGroup);
+        if (currentGroup && name == currentGroup->style().functionalPseudoElementArgument()) {
+            auto style = documentElementRenderer.getUncachedPseudoStyle({ PseudoId::ViewTransitionGroup, name }, &documentElementRenderer.style());
+            if (!style || style->display() == DisplayType::None)
+                descendantsToDelete.append(currentGroup);
+            else
+                updatePseudoElementGroup(*style, downcast<RenderElement>(*currentGroup), documentElementRenderer);
+        } else {
+            buildPseudoElementGroup(name, documentElementRenderer, currentGroup);
+            currentGroup = currentGroup ? currentGroup->previousSibling() : documentElementRenderer.view().viewTransitionRoot()->firstChild();
+        }
+        currentGroup = currentGroup ? currentGroup->nextSibling() : nullptr;
+    }
+
+    for (auto& descendant : descendantsToDelete) {
+        if (descendant)
+            m_updater.m_builder.destroy(*descendant);
+    }
+}
+
+void RenderTreeUpdater::ViewTransition::buildPseudoElementGroup(const AtomString& name, RenderElement& documentElementRenderer, RenderObject* beforeChild)
+{
+    Ref document = documentElementRenderer.document();
+    auto& documentElementStyle = documentElementRenderer.style();
+    auto createRendererIfNeeded = [&](const AtomString& name, PseudoId pseudoId) -> RenderPtr<RenderBlockFlow> {
+        auto style = documentElementRenderer.getUncachedPseudoStyle({ pseudoId, name }, &documentElementStyle);
+        if (!style || style->display() == DisplayType::None)
+            return nullptr;
+        auto newStyle = RenderStyle::clone(*style);
+        auto renderer = WebCore::createRenderer<RenderBlockFlow>(RenderObject::Type::BlockFlow, document, WTFMove(newStyle));
+        renderer->initializeStyle();
+        return renderer;
+    };
+
+    auto viewTransitionGroup = createRendererIfNeeded(name, PseudoId::ViewTransitionGroup);
+    auto viewTransitionImagePair = viewTransitionGroup ? createRendererIfNeeded(name, PseudoId::ViewTransitionImagePair) : nullptr;
+    auto viewTransitionOld = viewTransitionImagePair ? createRendererIfNeeded(name, PseudoId::ViewTransitionOld) : nullptr;
+    auto viewTransitionNew = viewTransitionImagePair ? createRendererIfNeeded(name, PseudoId::ViewTransitionNew) : nullptr;
+
+    if (viewTransitionOld)
+        m_updater.m_builder.attach(*viewTransitionImagePair, WTFMove(viewTransitionOld));
+
+    if (viewTransitionNew)
+        m_updater.m_builder.attach(*viewTransitionImagePair, WTFMove(viewTransitionNew));
+
+    if (viewTransitionImagePair)
+        m_updater.m_builder.attach(*viewTransitionGroup, WTFMove(viewTransitionImagePair));
+
+    if (viewTransitionGroup)
+        m_updater.m_builder.attach(*documentElementRenderer.view().viewTransitionRoot(), WTFMove(viewTransitionGroup), beforeChild);
+}
+
+void RenderTreeUpdater::ViewTransition::updatePseudoElementGroup(const RenderStyle& groupStyle, RenderElement& group, RenderElement& documentElementRenderer)
+{
+    auto& documentElementStyle = documentElementRenderer.style();
+    auto name = groupStyle.functionalPseudoElementArgument();
+
+    auto newGroupStyle = RenderStyle::clone(groupStyle);
+    group.setStyle(WTFMove(newGroupStyle));
+
+    auto createRendererIfNeeded = [&](PseudoId pseudoId) -> RenderPtr<RenderBlockFlow> {
+        auto style = documentElementRenderer.getUncachedPseudoStyle({ pseudoId, name }, &documentElementStyle);
+        if (!style || style->display() == DisplayType::None)
+            return nullptr;
+        auto newStyle = RenderStyle::clone(*style);
+        auto renderer = WebCore::createRenderer<RenderBlockFlow>(RenderObject::Type::BlockFlow, documentElementRenderer.document(), WTFMove(newStyle));
+        renderer->initializeStyle();
+        return renderer;
+    };
+
+    enum class ShouldDeleteRenderer : bool { No, Yes };
+    auto updateRenderer = [&](RenderObject& renderer) -> ShouldDeleteRenderer {
+        auto style = documentElementRenderer.getUncachedPseudoStyle({ renderer.style().styleType(), name }, &documentElementStyle);
+        if (!style || style->display() == DisplayType::None)
+            return ShouldDeleteRenderer::Yes;
+
+        auto newStyle = RenderStyle::clone(*style);
+        downcast<RenderElement>(renderer).setStyle(WTFMove(newStyle));
+        return ShouldDeleteRenderer::No;
+    };
+
+    // Create / remove ::view-transtion-image-pair itself.
+    SingleThreadWeakPtr<RenderElement> imagePair = downcast<RenderElement>(group.firstChild());
+    if (imagePair) {
+        ASSERT(imagePair->style().styleType() == PseudoId::ViewTransitionImagePair);
+        auto shouldDeleteRenderer = updateRenderer(*imagePair);
+        if (shouldDeleteRenderer == ShouldDeleteRenderer::Yes) {
+            m_updater.m_builder.destroy(*imagePair);
+            return;
+        }
+    } else if (auto newImagePair = createRendererIfNeeded(PseudoId::ViewTransitionImagePair)) {
+        imagePair = newImagePair.get();
+        m_updater.m_builder.attach(group, WTFMove(newImagePair));
+    } else
+        return;
+
+    auto* imagePairFirstChild = imagePair->firstChild();
+    // Build the ::view-transition-image-pair children if needed.
+    if (!imagePairFirstChild) {
+        if (auto viewTransitionOld = createRendererIfNeeded(PseudoId::ViewTransitionOld))
+            m_updater.m_builder.attach(*imagePair, WTFMove(viewTransitionOld));
+        if (auto viewTransitionNew = createRendererIfNeeded(PseudoId::ViewTransitionNew))
+            m_updater.m_builder.attach(*imagePair, WTFMove(viewTransitionNew));
+        return;
+    }
+
+    // Update pre-existing ::view-transition-image-pair children.
+    auto shouldDeleteViewTransitionOld = ShouldDeleteRenderer::No;
+
+    SingleThreadWeakPtr<RenderObject> viewTransitionOld;
+    SingleThreadWeakPtr<RenderObject> viewTransitionNew;
+
+    RenderPtr<RenderBlockFlow> newViewTransitionOld;
+    RenderPtr<RenderBlockFlow> newViewTransitionNew;
+    if (imagePairFirstChild->style().styleType() == PseudoId::ViewTransitionOld) {
+        viewTransitionOld = imagePairFirstChild;
+        shouldDeleteViewTransitionOld = updateRenderer(*viewTransitionOld);
+        viewTransitionNew = viewTransitionOld->nextSibling();
+        ASSERT(!viewTransitionNew || viewTransitionNew->style().styleType() == PseudoId::ViewTransitionNew);
+    } else {
+        ASSERT(imagePairFirstChild->style().styleType() == PseudoId::ViewTransitionNew);
+        viewTransitionNew = imagePairFirstChild;
+        newViewTransitionOld = createRendererIfNeeded(PseudoId::ViewTransitionOld);
+    }
+
+    auto shouldDeleteViewTransitionNew = ShouldDeleteRenderer::No;
+    if (!viewTransitionNew)
+        newViewTransitionNew = createRendererIfNeeded(PseudoId::ViewTransitionNew);
+    else
+        shouldDeleteViewTransitionNew = updateRenderer(*viewTransitionNew);
+
+    if (shouldDeleteViewTransitionNew == ShouldDeleteRenderer::Yes)
+        m_updater.m_builder.destroy(*viewTransitionNew);
+    else if (newViewTransitionNew)
+        m_updater.m_builder.attach(*imagePair, WTFMove(newViewTransitionNew));
+
+    if (shouldDeleteViewTransitionOld == ShouldDeleteRenderer::Yes)
+        m_updater.m_builder.destroy(*viewTransitionOld);
+    else if (newViewTransitionOld)
+        m_updater.m_builder.attach(*imagePair, WTFMove(newViewTransitionOld), viewTransitionNew.get());
+}
+
+
+}

--- a/Source/WebCore/rendering/updating/RenderTreeUpdaterViewTransition.h
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdaterViewTransition.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "RenderStyleConstants.h"
+#include "RenderTreeUpdater.h"
+
+namespace WebCore {
+
+class Element;
+class RenderQuote;
+
+class RenderTreeUpdater::ViewTransition {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    ViewTransition(RenderTreeUpdater&);
+
+    void updatePseudoElementTree(RenderElement&);
+private:
+    void buildPseudoElementGroup(const AtomString&, RenderElement&, RenderObject* = nullptr);
+    void updatePseudoElementGroup(const RenderStyle&, RenderElement&, RenderElement&);
+    RenderTreeUpdater& m_updater;
+};
+
+}

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -485,6 +485,8 @@ std::optional<ResolvedStyle> Resolver::styleForPseudoElement(const Element& elem
         return { };
 
     state.style()->setStyleType(pseudoElementRequest.pseudoId);
+    if (!pseudoElementRequest.nameIdentifier.isNull())
+        state.style()->setFunctionalPseudoElementArgument(pseudoElementRequest.nameIdentifier);
 
     applyMatchedProperties(state, collector.matchResult());
 


### PR DESCRIPTION
#### 5d7c3bb3e28035d21e4461474204eac7493419c4
<pre>
[view-transitions] Create renderers for pseudo-elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=265168">https://bugs.webkit.org/show_bug.cgi?id=265168</a>
<a href="https://rdar.apple.com/118667022">rdar://118667022</a>

Reviewed by Antti Koivisto.

Use the named elements map as input to build the pseudo element tree.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/ViewTransition.h:
(WebCore::OrderedNamedElementsMap::isEmpty const):
* Source/WebCore/rendering/RenderView.cpp:
(WebCore::RenderView::viewTransitionRoot const):
(WebCore::RenderView::setViewTransitionRoot):
* Source/WebCore/rendering/RenderView.h:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::functionalPseudoElementArgument const):
* Source/WebCore/rendering/style/RenderStyleSetters.h:
(WebCore::RenderStyle::setFunctionalPseudoElementArgument):
* Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp:
(WebCore::StyleRareNonInheritedData::StyleRareNonInheritedData):
(WebCore::StyleRareNonInheritedData::operator== const):
* Source/WebCore/rendering/style/StyleRareNonInheritedData.h:
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(WebCore::RenderTreeUpdater::RenderTreeUpdater):
(WebCore::RenderTreeUpdater::updateAfterDescendants):
* Source/WebCore/rendering/updating/RenderTreeUpdater.h:
(WebCore::RenderTreeUpdater::viewTransition):
* Source/WebCore/rendering/updating/RenderTreeUpdaterViewTransition.cpp: Added.
(WebCore::RenderTreeUpdater::ViewTransition::ViewTransition):
(WebCore::RenderTreeUpdater::ViewTransition::updatePseudoElementTree):
(WebCore::RenderTreeUpdater::ViewTransition::buildPseudoElementGroup):
(WebCore::RenderTreeUpdater::ViewTransition::updatePseudoElementGroup):
* Source/WebCore/rendering/updating/RenderTreeUpdaterViewTransition.h: Added.
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::styleForPseudoElement):

Canonical link: <a href="https://commits.webkit.org/273336@main">https://commits.webkit.org/273336@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ba26722a4fb260593199570642213e6c130e601

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35085 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14006 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37199 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37845 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/31684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36246 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16384 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11076 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35630 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11862 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31299 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10393 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10455 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31397 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39092 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31926 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31728 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/36462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10565 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8497 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34453 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/12350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8043 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11093 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/11412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->