### PR TITLE
[WPE] clang warnings

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDRM.h
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDRM.h
@@ -128,7 +128,6 @@ public:
     bool supportsFormat(uint32_t, uint64_t) const;
 
 private:
-    Type m_type;
     uint32_t m_id { 0 };
     uint32_t m_possibleCrtcs { 0 };
     Vector<Format> m_formats;

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp
@@ -209,7 +209,17 @@ static const struct wl_surface_listener surfaceListener = {
         view->priv->wlOutputs.removeLast(output);
         wpe_view_wayland_update_scale(view);
         output->removeScaleObserver(view);
-    }
+    },
+#ifdef WL_SURFACE_PREFERRED_BUFFER_SCALE_SINCE_VERSION
+    // preferred_buffer_scale
+    [](void*, struct wl_surface*, int /* factor */)
+    {
+    },
+#endif
+    // axis_relative_direction
+    [](void*, struct wl_surface*, uint32_t /* direction */)
+    {
+    },
 };
 
 static const struct zwp_linux_dmabuf_feedback_v1_listener linuxDMABufFeedbackListener = {

--- a/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.h
+++ b/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.h
@@ -77,7 +77,7 @@ private:
     void preferredBufferFormatsDidChange() override;
 #endif
 
-    void visibilityDidChange(bool);
+    void visibilityDidChange(bool) override;
 
     AcceleratedSurfaceDMABuf(WebPage&, Client&);
 

--- a/Tools/PlatformWPE.cmake
+++ b/Tools/PlatformWPE.cmake
@@ -64,7 +64,6 @@ if (ENABLE_COG)
         BUILD_IN_SOURCE FALSE
         CONFIGURE_COMMAND
             meson setup <BINARY_DIR> <SOURCE_DIR>
-            --wipe
             --buildtype ${COG_MESON_BUILDTYPE}
             --pkg-config-path ${WPE_COG_PKG_CONFIG_PATH}
             -Dwpe_api=${WPE_API_VERSION}


### PR DESCRIPTION
#### c85ecce0422d8c2ae5af79632dc7b0b97e3baf72
<pre>
[WPE] clang warnings
<a href="https://bugs.webkit.org/show_bug.cgi?id=265716">https://bugs.webkit.org/show_bug.cgi?id=265716</a>

Reviewed by Michael Catanzaro.

Fix clang warnings and un-do the Cog meson --wipe change, that should be handled at the EWS level.
Re-configuring Cog for each incremental build shouldn&apos;t be needed.

* Source/WebKit/WPEPlatform/wpe/drm/WPEDRM.h:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp:
* Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.h:
* Tools/PlatformWPE.cmake:

Canonical link: <a href="https://commits.webkit.org/271427@main">https://commits.webkit.org/271427@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95219378df26cac27b49aabda1b4eb5222c01bff

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28358 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7002 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29739 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30885 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25817 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28855 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9096 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4372 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28627 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5768 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24397 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5042 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5146 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25396 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31571 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25969 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25833 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31446 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5106 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3286 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29204 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6705 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6796 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5560 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5625 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->