### PR TITLE
Replace Document::setContent() with setMarkupUnsafe()

### DIFF
--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -458,7 +458,7 @@ public:
     bool shouldNotFireMutationEvents() const { return m_shouldNotFireMutationEvents; }
     void setShouldNotFireMutationEvents(bool fire) { m_shouldNotFireMutationEvents = fire; }
 
-    void parseMarkupUnsafe(const String&, OptionSet<ParserContentPolicy>);
+    void setMarkupUnsafe(const String&, OptionSet<ParserContentPolicy>);
     static Ref<Document> parseHTMLUnsafe(Document&, const String&);
 
     Element* elementForAccessKey(const String& key);
@@ -520,8 +520,6 @@ public:
     WEBCORE_EXPORT AtomString encoding() const;
 
     WEBCORE_EXPORT void setCharset(const String&); // Used by ObjC / GOBject bindings only.
-
-    void setContent(const String&);
 
     String suggestedMIMEType() const;
 

--- a/Source/WebCore/loader/cache/CachedSVGDocument.cpp
+++ b/Source/WebCore/loader/cache/CachedSVGDocument.cpp
@@ -23,6 +23,7 @@
 #include "config.h"
 #include "CachedSVGDocument.h"
 
+#include "ParserContentPolicy.h"
 #include "Settings.h"
 #include "SharedBuffer.h"
 
@@ -57,7 +58,7 @@ void CachedSVGDocument::finishLoading(const FragmentedSharedBuffer* data, const 
     if (data) {
         // We don't need to create a new frame because the new document belongs to the parent UseElement.
         auto document = SVGDocument::create(nullptr, m_settings, response().url());
-        document->setContent(m_decoder->decodeAndFlush(data->makeContiguous()->data(), data->size()));
+        document->setMarkupUnsafe(m_decoder->decodeAndFlush(data->makeContiguous()->data(), data->size()), { ParserContentPolicy::AllowDeclarativeShadowRoots });
         m_document = WTFMove(document);
     }
     CachedResource::finishLoading(data, metrics);

--- a/Source/WebCore/loader/cache/CachedSVGFont.cpp
+++ b/Source/WebCore/loader/cache/CachedSVGFont.cpp
@@ -31,6 +31,7 @@
 #include "FontCreationContext.h"
 #include "FontDescription.h"
 #include "FontPlatformData.h"
+#include "ParserContentPolicy.h"
 #include "SVGDocument.h"
 #include "SVGElementTypeHelpers.h"
 #include "SVGFontElement.h"
@@ -81,7 +82,7 @@ bool CachedSVGFont::ensureCustomFontData()
 
             ScriptDisallowedScope::DisableAssertionsInScope disabledScope;
 
-            externalSVGDocument->setContent(decoder->decodeAndFlush(m_data->makeContiguous()->data(), m_data->size()));
+            externalSVGDocument->setMarkupUnsafe(decoder->decodeAndFlush(m_data->makeContiguous()->data(), m_data->size()), { ParserContentPolicy::AllowDeclarativeShadowRoots });
             sawError = decoder->sawError();
             m_externalSVGDocument = WTFMove(externalSVGDocument);
         }

--- a/Source/WebCore/xml/DOMParser.cpp
+++ b/Source/WebCore/xml/DOMParser.cpp
@@ -44,7 +44,7 @@ ExceptionOr<Ref<Document>> DOMParser::parseFromString(const String& string, cons
     Ref document = DOMImplementation::createDocument(contentType, nullptr, m_settings, URL { });
     if (m_contextDocument)
         document->setContextDocument(*m_contextDocument.get());
-    document->parseMarkupUnsafe(string, { });
+    document->setMarkupUnsafe(string, { });
     if (m_contextDocument) {
         document->setURL(m_contextDocument->url());
         document->setSecurityOriginPolicy(m_contextDocument->securityOriginPolicy());

--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -184,16 +184,15 @@ ExceptionOr<Document*> XMLHttpRequest::responseXML()
                 responseDocument = HTMLDocument::create(nullptr, context.settings(), m_response.url(), { });
             else
                 responseDocument = XMLDocument::create(nullptr, context.settings(), m_response.url());
-            responseDocument->setParserContentPolicy({ ParserContentPolicy::AllowScriptingContent });
             responseDocument->overrideLastModified(m_response.lastModified());
             responseDocument->setContextDocument(context);
             responseDocument->setSecurityOriginPolicy(context.securityOriginPolicy());
             responseDocument->overrideMIMEType(mimeType);
-            responseDocument->setContent(m_responseBuilder.toStringPreserveCapacity());
+            responseDocument->setMarkupUnsafe(m_responseBuilder.toStringPreserveCapacity(), { });
             if (m_decoder)
                 responseDocument->setDecoder(m_decoder.copyRef());
 
-            if (!responseDocument->wellFormed())
+            if (!isHTML && !responseDocument->wellFormed())
                 m_responseDocument = nullptr;
             else
                 m_responseDocument = WTFMove(responseDocument);

--- a/Source/WebCore/xml/XSLTProcessor.cpp
+++ b/Source/WebCore/xml/XSLTProcessor.cpp
@@ -104,7 +104,7 @@ Ref<Document> XSLTProcessor::createDocumentFromSource(const String& sourceString
     decoder->setEncoding(sourceEncoding.isEmpty() ? PAL::UTF8Encoding() : PAL::TextEncoding(sourceEncoding), TextResourceDecoder::EncodingFromXMLHeader);
     result->setDecoder(WTFMove(decoder));
 
-    result->setContent(documentSource);
+    result->setMarkupUnsafe(documentSource, { ParserContentPolicy::AllowDeclarativeShadowRoots });
 
     return result.releaseNonNull();
 }


### PR DESCRIPTION
#### b8b8ec28a608aafb861fdd860249b33b094aa7a1
<pre>
Replace Document::setContent() with setMarkupUnsafe()
<a href="https://bugs.webkit.org/show_bug.cgi?id=265318">https://bugs.webkit.org/show_bug.cgi?id=265318</a>

Reviewed by Ryosuke Niwa.

Rename Document::parseMarkupUnsafe() to setMarkupUnsafe() as unlike the
public parseHTMLUnsafe() static method it does not return anything.

Merge setContent() into it to make the API somewhat clearer.

As a side effect this makes XMLHttpRequest use the fast HTML parser. To
account for that we stop doing the wellFormed() check for HTML as
document&apos;s parser will no longer be initialized and therefore that
starts returning false (whereas it used to always return true for
HTML).

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::setMarkupUnsafe):
(WebCore::Document::parseHTMLUnsafe):
(WebCore::Document::parseMarkupUnsafe): Deleted.
(WebCore::Document::setContent): Deleted.
* Source/WebCore/dom/Document.h:
* Source/WebCore/loader/cache/CachedSVGDocument.cpp:
(WebCore::CachedSVGDocument::finishLoading):
* Source/WebCore/loader/cache/CachedSVGFont.cpp:
(WebCore::CachedSVGFont::ensureCustomFontData):
* Source/WebCore/xml/DOMParser.cpp:
(WebCore::DOMParser::parseFromString):
* Source/WebCore/xml/XMLHttpRequest.cpp:
* Source/WebCore/xml/XSLTProcessor.cpp:
(WebCore::XSLTProcessor::createDocumentFromSource):

Canonical link: <a href="https://commits.webkit.org/272817@main">https://commits.webkit.org/272817@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a9a581d0e7a56d5a856a9858a9c1dfa43c469f3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33159 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11933 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35072 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35796 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29936 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34130 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14278 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9102 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29343 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33634 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10061 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29622 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8770 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8917 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29597 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37128 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30129 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29980 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35035 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9046 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6985 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32894 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10766 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7689 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9633 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9713 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->