### PR TITLE
Remove ParserContentPolicy::AllowPluginContent

### DIFF
--- a/Source/WebCore/dom/DOMImplementation.cpp
+++ b/Source/WebCore/dom/DOMImplementation.cpp
@@ -97,14 +97,14 @@ static inline Ref<XMLDocument> createXMLDocument(const String& namespaceURI, con
         document = XMLDocument::createXHTML(nullptr, settings, URL());
     else
         document = XMLDocument::create(nullptr, settings, URL());
-    document->setParserContentPolicy({ ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::AllowPluginContent });
+    document->setParserContentPolicy({ ParserContentPolicy::AllowScriptingContent });
     return document.releaseNonNull();
 }
 
 ExceptionOr<Ref<XMLDocument>> DOMImplementation::createDocument(const AtomString& namespaceURI, const AtomString& qualifiedName, DocumentType* documentType)
 {
     Ref document = createXMLDocument(namespaceURI, m_document->protectedSettings());
-    document->setParserContentPolicy({ ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::AllowPluginContent });
+    document->setParserContentPolicy({ ParserContentPolicy::AllowScriptingContent });
     document->setContextDocument(m_document->contextDocument());
     document->setSecurityOriginPolicy(m_document->securityOriginPolicy());
 
@@ -137,7 +137,7 @@ Ref<CSSStyleSheet> DOMImplementation::createCSSStyleSheet(const String&, const S
 Ref<HTMLDocument> DOMImplementation::createHTMLDocument(String&& title)
 {
     Ref document = HTMLDocument::create(nullptr, m_document->protectedSettings(), URL(), { });
-    document->setParserContentPolicy({ ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::AllowPluginContent });
+    document->setParserContentPolicy({ ParserContentPolicy::AllowScriptingContent });
     document->open();
     document->write(nullptr, { "<!doctype html><html><head></head><body></body></html>"_s });
     if (!title.isNull()) {

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -911,7 +911,7 @@ void Document::commonTeardown()
 
 void Document::parseMarkupUnsafe(const String& markup, OptionSet<ParserContentPolicy> parserContentPolicy)
 {
-    auto policy = OptionSet<ParserContentPolicy> { ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::AllowPluginContent } | parserContentPolicy;
+    auto policy = OptionSet<ParserContentPolicy> { ParserContentPolicy::AllowScriptingContent } | parserContentPolicy;
     setParserContentPolicy(policy);
     bool usedFastPath = false;
     if (this->contentType() == "text/html"_s) {

--- a/Source/WebCore/dom/DocumentFragment.h
+++ b/Source/WebCore/dom/DocumentFragment.h
@@ -33,8 +33,8 @@ class DocumentFragment : public ContainerNode {
 public:
     WEBCORE_EXPORT static Ref<DocumentFragment> create(Document&);
 
-    void parseHTML(const String&, Element& contextElement, OptionSet<ParserContentPolicy> = { ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::AllowPluginContent });
-    bool parseXML(const String&, Element* contextElement, OptionSet<ParserContentPolicy> = { ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::AllowPluginContent });
+    void parseHTML(const String&, Element& contextElement, OptionSet<ParserContentPolicy> = { ParserContentPolicy::AllowScriptingContent });
+    bool parseXML(const String&, Element* contextElement, OptionSet<ParserContentPolicy> = { ParserContentPolicy::AllowScriptingContent });
 
     bool canContainRangeEndPoint() const final { return true; }
     virtual bool isTemplateContent() const { return false; }

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3753,7 +3753,7 @@ void Element::enqueueSecurityPolicyViolationEvent(SecurityPolicyViolationEventIn
 
 ExceptionOr<void> Element::replaceChildrenWithMarkup(const String& markup, OptionSet<ParserContentPolicy> parserContentPolicy)
 {
-    auto policy = OptionSet<ParserContentPolicy> { ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::AllowPluginContent } | parserContentPolicy;
+    auto policy = OptionSet<ParserContentPolicy> { ParserContentPolicy::AllowScriptingContent } | parserContentPolicy;
 
     Ref container = [this]() -> Ref<ContainerNode> {
         if (auto* templateElement = dynamicDowncast<HTMLTemplateElement>(*this))
@@ -3814,7 +3814,7 @@ ExceptionOr<void> Element::setOuterHTML(const String& html)
     RefPtr previous = previousSibling();
     RefPtr next = nextSibling();
 
-    auto fragment = createFragmentForInnerOuterHTML(*parent, html, { ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::AllowPluginContent });
+    auto fragment = createFragmentForInnerOuterHTML(*parent, html, { ParserContentPolicy::AllowScriptingContent });
     if (fragment.hasException())
         return fragment.releaseException();
 
@@ -5266,7 +5266,7 @@ ExceptionOr<void> Element::insertAdjacentHTML(const String& where, const String&
     if (contextElement.hasException())
         return contextElement.releaseException();
     // Step 3.
-    auto fragment = createFragmentForInnerOuterHTML(contextElement.releaseReturnValue(), markup, { ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::AllowPluginContent });
+    auto fragment = createFragmentForInnerOuterHTML(contextElement.releaseReturnValue(), markup, { ParserContentPolicy::AllowScriptingContent });
     if (fragment.hasException())
         return fragment.releaseException();
 

--- a/Source/WebCore/dom/ParserContentPolicy.h
+++ b/Source/WebCore/dom/ParserContentPolicy.h
@@ -31,13 +31,12 @@ namespace WebCore {
 
 enum class ParserContentPolicy : uint8_t {
     AllowScriptingContent = 1 << 0,
-    AllowPluginContent = 1 << 1,
-    DoNotMarkAlreadyStarted = 1 << 2,
-    AllowDeclarativeShadowRoots = 1 << 3,
-    AlwaysParseAsHTML = 1 << 4
+    DoNotMarkAlreadyStarted = 1 << 1,
+    AllowDeclarativeShadowRoots = 1 << 2,
+    AlwaysParseAsHTML = 1 << 3
 };
 
-constexpr OptionSet<ParserContentPolicy> DefaultParserContentPolicy = { ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::AllowPluginContent, ParserContentPolicy::AllowDeclarativeShadowRoots };
+constexpr OptionSet<ParserContentPolicy> DefaultParserContentPolicy = { ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::AllowDeclarativeShadowRoots };
 
 static inline bool scriptingContentIsAllowed(OptionSet<ParserContentPolicy> parserContentPolicy) 
 {
@@ -47,17 +46,6 @@ static inline bool scriptingContentIsAllowed(OptionSet<ParserContentPolicy> pars
 static inline OptionSet<ParserContentPolicy> disallowScriptingContent(OptionSet<ParserContentPolicy> parserContentPolicy)
 {
     parserContentPolicy.remove(ParserContentPolicy::AllowScriptingContent);
-    return parserContentPolicy;
-}
-
-static inline bool pluginContentIsAllowed(OptionSet<ParserContentPolicy> parserContentPolicy)
-{
-    return parserContentPolicy.contains(ParserContentPolicy::AllowPluginContent);
-}
-
-static inline OptionSet<ParserContentPolicy> allowPluginContent(OptionSet<ParserContentPolicy> parserContentPolicy)
-{
-    parserContentPolicy.add(ParserContentPolicy::AllowPluginContent);
     return parserContentPolicy;
 }
 

--- a/Source/WebCore/dom/Range.cpp
+++ b/Source/WebCore/dom/Range.cpp
@@ -756,7 +756,7 @@ ExceptionOr<Ref<DocumentFragment>> Range::createContextualFragment(const String&
         element = node.parentElement();
     if (!element || (element->document().isHTMLDocument() && is<HTMLHtmlElement>(*element)))
         element = HTMLBodyElement::create(node.protectedDocument());
-    return WebCore::createContextualFragment(*element, markup, { ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::AllowPluginContent, ParserContentPolicy::DoNotMarkAlreadyStarted });
+    return WebCore::createContextualFragment(*element, markup, { ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::DoNotMarkAlreadyStarted });
 }
 
 ExceptionOr<RefPtr<Node>> Range::checkNodeOffsetPair(Node& node, unsigned offset)

--- a/Source/WebCore/dom/ScriptableDocumentParser.cpp
+++ b/Source/WebCore/dom/ScriptableDocumentParser.cpp
@@ -38,9 +38,6 @@ ScriptableDocumentParser::ScriptableDocumentParser(Document& document, OptionSet
     , m_parserContentPolicy(parserContentPolicy)
     , m_scriptsWaitingForStylesheetsExecutionTimer(*this, &ScriptableDocumentParser::scriptsWaitingForStylesheetsExecutionTimerFired)
 {
-    if (!pluginContentIsAllowed(m_parserContentPolicy))
-        m_parserContentPolicy = allowPluginContent(m_parserContentPolicy);
-
     if (scriptingContentIsAllowed(m_parserContentPolicy) && !document.allowsContentJavaScript())
         m_parserContentPolicy = disallowScriptingContent(m_parserContentPolicy);
 }

--- a/Source/WebCore/dom/ShadowRoot.cpp
+++ b/Source/WebCore/dom/ShadowRoot.cpp
@@ -190,7 +190,7 @@ StyleSheetList& ShadowRoot::styleSheets()
 
 ExceptionOr<void> ShadowRoot::replaceChildrenWithMarkup(const String& markup, OptionSet<ParserContentPolicy> parserContentPolicy)
 {
-    auto policy = OptionSet<ParserContentPolicy> { ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::AllowPluginContent } | parserContentPolicy;
+    auto policy = OptionSet<ParserContentPolicy> { ParserContentPolicy::AllowScriptingContent } | parserContentPolicy;
 
     if (markup.isEmpty()) {
         ChildListMutationScope mutation(*this);

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -1380,11 +1380,11 @@ RefPtr<DocumentFragment> createFragmentForTransformToFragment(Document& outputDo
         // Unfortunately, that's an implementation detail of the parser.
         // We achieve that effect here by passing in a fake body element as context for the fragment.
         auto fakeBody = HTMLBodyElement::create(outputDoc);
-        fragment->parseHTML(WTFMove(sourceString), fakeBody, { ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::AllowPluginContent, ParserContentPolicy::DoNotMarkAlreadyStarted });
+        fragment->parseHTML(WTFMove(sourceString), fakeBody, { ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::DoNotMarkAlreadyStarted });
     } else if (sourceMIMEType == textPlainContentTypeAtom())
         fragment->parserAppendChild(Text::create(outputDoc, WTFMove(sourceString)));
     else {
-        bool successfulParse = fragment->parseXML(WTFMove(sourceString), nullptr, { ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::AllowPluginContent, ParserContentPolicy::DoNotMarkAlreadyStarted });
+        bool successfulParse = fragment->parseXML(WTFMove(sourceString), nullptr, { ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::DoNotMarkAlreadyStarted });
         if (!successfulParse)
             return nullptr;
     }

--- a/Source/WebCore/editing/markup.h
+++ b/Source/WebCore/editing/markup.h
@@ -80,7 +80,7 @@ private:
 };
 
 WEBCORE_EXPORT Ref<DocumentFragment> createFragmentFromText(const SimpleRange& context, const String& text);
-WEBCORE_EXPORT Ref<DocumentFragment> createFragmentFromMarkup(Document&, const String& markup, const String& baseURL, OptionSet<ParserContentPolicy> = { ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::AllowPluginContent });
+WEBCORE_EXPORT Ref<DocumentFragment> createFragmentFromMarkup(Document&, const String& markup, const String& baseURL, OptionSet<ParserContentPolicy> = { ParserContentPolicy::AllowScriptingContent });
 ExceptionOr<Ref<DocumentFragment>> createFragmentForInnerOuterHTML(Element&, const String& markup, OptionSet<ParserContentPolicy>);
 RefPtr<DocumentFragment> createFragmentForTransformToFragment(Document&, String&& sourceString, const String& sourceMIMEType);
 Ref<DocumentFragment> createFragmentForImageAndURL(Document&, const String&, PresentationSize preferredSize);

--- a/Source/WebCore/html/parser/HTMLConstructionSite.cpp
+++ b/Source/WebCore/html/parser/HTMLConstructionSite.cpp
@@ -219,7 +219,6 @@ static inline void executeTask(HTMLConstructionSiteTask& task)
 void HTMLConstructionSite::attachLater(Ref<ContainerNode>&& parent, Ref<Node>&& child, bool selfClosing)
 {
     ASSERT(scriptingContentIsAllowed(m_parserContentPolicy) || !is<Element>(child) || !isScriptElement(downcast<Element>(child.get())));
-    ASSERT(pluginContentIsAllowed(m_parserContentPolicy) || !child->isPluginElement());
 
     if (shouldFosterParent()) {
         fosterParent(WTFMove(child));

--- a/Source/WebCore/html/parser/HTMLDocumentParser.h
+++ b/Source/WebCore/html/parser/HTMLDocumentParser.h
@@ -51,7 +51,7 @@ public:
     static Ref<HTMLDocumentParser> create(HTMLDocument&, OptionSet<ParserContentPolicy> = DefaultParserContentPolicy);
     virtual ~HTMLDocumentParser();
 
-    static void parseDocumentFragment(const String&, DocumentFragment&, Element& contextElement, OptionSet<ParserContentPolicy> = { ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::AllowPluginContent });
+    static void parseDocumentFragment(const String&, DocumentFragment&, Element& contextElement, OptionSet<ParserContentPolicy> = { ParserContentPolicy::AllowScriptingContent });
 
     // For HTMLParserScheduler.
     void resumeParsingAfterYield();

--- a/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
+++ b/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
@@ -785,9 +785,6 @@ void HTMLTreeBuilder::processStartTagForInBody(AtomHTMLToken&& token)
     case TagName::applet:
     case TagName::embed:
     case TagName::object:
-        if (!pluginContentIsAllowed(m_tree.parserContentPolicy()))
-            return;
-        FALLTHROUGH;
     case TagName::marquee:
         m_tree.reconstructTheActiveFormattingElements();
         if (token.tagName() == TagName::embed) {

--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -184,7 +184,7 @@ ExceptionOr<Document*> XMLHttpRequest::responseXML()
                 responseDocument = HTMLDocument::create(nullptr, context.settings(), m_response.url(), { });
             else
                 responseDocument = XMLDocument::create(nullptr, context.settings(), m_response.url());
-            responseDocument->setParserContentPolicy({ ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::AllowPluginContent });
+            responseDocument->setParserContentPolicy({ ParserContentPolicy::AllowScriptingContent });
             responseDocument->overrideLastModified(m_response.lastModified());
             responseDocument->setContextDocument(context);
             responseDocument->setSecurityOriginPolicy(context.securityOriginPolicy());

--- a/Source/WebCore/xml/parser/XMLDocumentParser.h
+++ b/Source/WebCore/xml/parser/XMLDocumentParser.h
@@ -80,7 +80,7 @@ public:
     void setIsXHTMLDocument(bool isXHTML) { m_isXHTMLDocument = isXHTML; }
     bool isXHTMLDocument() const { return m_isXHTMLDocument; }
 
-    static bool parseDocumentFragment(const String&, DocumentFragment&, Element* parent = nullptr, OptionSet<ParserContentPolicy> = { ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::AllowPluginContent });
+    static bool parseDocumentFragment(const String&, DocumentFragment&, Element* parent = nullptr, OptionSet<ParserContentPolicy> = { ParserContentPolicy::AllowScriptingContent });
 
     // Used by XMLHttpRequest to check if the responseXML was well formed.
     bool wellFormed() const final { return !m_sawError; }

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -870,7 +870,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (!document)
         return nil;
 
-    return kit(createFragmentFromMarkup(*document, markupString, baseURLString, { WebCore::ParserContentPolicy::AllowPluginContent }).ptr());
+    return kit(createFragmentFromMarkup(*document, markupString, baseURLString, { }).ptr());
 }
 
 - (DOMDocumentFragment *)_documentFragmentWithNodesAsParagraphs:(NSArray *)nodes

--- a/Tools/TestWebKitAPI/Tests/WebCore/HTMLParserIdioms.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/HTMLParserIdioms.cpp
@@ -216,7 +216,7 @@ TEST(WebCoreHTMLParser, FastPathComplexHTMLEntityParsing)
 
     auto testFastParser = [&](const String& input) -> String {
         auto fragment = DocumentFragment::create(document);
-        bool result = tryFastParsingHTMLFragment(input, document, fragment, div, { ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::AllowPluginContent });
+        bool result = tryFastParsingHTMLFragment(input, document, fragment, div, { ParserContentPolicy::AllowScriptingContent });
         EXPECT_TRUE(result);
         auto textChild = dynamicDowncast<Text>(fragment->firstChild());
         EXPECT_TRUE(textChild);
@@ -246,7 +246,7 @@ TEST(WebCoreHTMLParser, FastPathHandlesLi)
     document->body()->appendChild(div);
 
     auto fragment = DocumentFragment::create(document);
-    bool result = tryFastParsingHTMLFragment("<div><li></li></div>"_s, document, fragment, div, { ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::AllowPluginContent });
+    bool result = tryFastParsingHTMLFragment("<div><li></li></div>"_s, document, fragment, div, { ParserContentPolicy::AllowScriptingContent });
     EXPECT_TRUE(result);
     EXPECT_STREQ("DIV", fragment->firstChild()->nodeName().utf8().data());
     EXPECT_STREQ("LI", fragment->firstChild()->firstChild()->nodeName().utf8().data());
@@ -267,7 +267,7 @@ TEST(WebCoreHTMLParser, FastPathFailsWithNestedLi)
     document->body()->appendChild(div);
 
     auto fragment = DocumentFragment::create(document);
-    bool result = tryFastParsingHTMLFragment("<li><li></li></li>"_s, document, fragment, div, { ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::AllowPluginContent });
+    bool result = tryFastParsingHTMLFragment("<li><li></li></li>"_s, document, fragment, div, { ParserContentPolicy::AllowScriptingContent });
     EXPECT_FALSE(result);
 }
 


### PR DESCRIPTION
#### f8b7eebd2e1daf72b27bbd5018924b1b3e194fc0
<pre>
Remove ParserContentPolicy::AllowPluginContent
<a href="https://bugs.webkit.org/show_bug.cgi?id=265319">https://bugs.webkit.org/show_bug.cgi?id=265319</a>
<a href="https://rdar.apple.com/119036905">rdar://119036905</a>

Reviewed by Chris Dumez.

Now that plugins have been removed there&apos;s no clear need for this
policy. Let&apos;s see what tests the bots uncover for us.

* Source/WebCore/dom/DOMImplementation.cpp:
(WebCore::createXMLDocument):
(WebCore::DOMImplementation::createDocument):
(WebCore::DOMImplementation::createHTMLDocument):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::parseMarkupUnsafe):
* Source/WebCore/dom/DocumentFragment.h:
(WebCore::DocumentFragment::parseHTML):
(WebCore::DocumentFragment::parseXML):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::replaceChildrenWithMarkup):
(WebCore::Element::setOuterHTML):
(WebCore::Element::insertAdjacentHTML):
* Source/WebCore/dom/ParserContentPolicy.h:
(WebCore::pluginContentIsAllowed): Deleted.
(WebCore::allowPluginContent): Deleted.
* Source/WebCore/dom/Range.cpp:
(WebCore::Range::createContextualFragment):
* Source/WebCore/dom/ScriptableDocumentParser.cpp:
(WebCore::ScriptableDocumentParser::ScriptableDocumentParser):
* Source/WebCore/dom/ShadowRoot.cpp:
(WebCore::ShadowRoot::replaceChildrenWithMarkup):
* Source/WebCore/editing/markup.cpp:
(WebCore::createFragmentForTransformToFragment):
* Source/WebCore/editing/markup.h:
(WebCore::createFragmentFromMarkup):
* Source/WebCore/html/parser/HTMLConstructionSite.cpp:
(WebCore::HTMLConstructionSite::attachLater):
* Source/WebCore/html/parser/HTMLDocumentParser.h:
(WebCore::HTMLDocumentParser::parseDocumentFragment):
* Source/WebCore/html/parser/HTMLTreeBuilder.cpp:
(WebCore::HTMLTreeBuilder::processStartTagForInBody):
* Source/WebCore/xml/XMLHttpRequest.cpp:
* Source/WebCore/xml/parser/XMLDocumentParser.h:
* Source/WebKitLegacy/mac/WebView/WebFrame.mm:
(-[WebFrame _documentFragmentWithMarkupString:baseURLString:]):
* Tools/TestWebKitAPI/Tests/WebCore/HTMLParserIdioms.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/271436@main">https://commits.webkit.org/271436@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78ffeb476fd097036455ad2898aa404954ea7515

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28364 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7009 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29747 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30891 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25823 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28861 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9103 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4378 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28633 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5771 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24401 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5053 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5149 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25402 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31577 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25973 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25839 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31452 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5112 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3289 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29208 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6711 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6802 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5567 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5632 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->