### PR TITLE
[WebRTC] RtpPacketizer::SplitAboutEqually() should return an empty std::vector when payload_len is 0

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format.cc
@@ -77,7 +77,12 @@ std::unique_ptr<RtpPacketizer> RtpPacketizer::Create(
 std::vector<int> RtpPacketizer::SplitAboutEqually(
     int payload_len,
     const PayloadSizeLimits& limits) {
+#ifdef WEBRTC_WEBKIT_BUILD
+  if (payload_len == 0)
+    return { };
+#else
   RTC_DCHECK_GT(payload_len, 0);
+#endif
   // First or last packet larger than normal are unsupported.
   RTC_DCHECK_GE(limits.first_packet_reduction_len, 0);
   RTC_DCHECK_GE(limits.last_packet_reduction_len, 0);

--- a/Source/ThirdParty/libwebrtc/WebKit/0001-WebRTC-RtpPacketizer-SplitAboutEqually-should-return-empty-std-vector.patch
+++ b/Source/ThirdParty/libwebrtc/WebKit/0001-WebRTC-RtpPacketizer-SplitAboutEqually-should-return-empty-std-vector.patch
@@ -1,0 +1,17 @@
+diff --git a/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format.cc b/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format.cc
+index a07337e69fdc..8297844ccc8a 100644
+--- a/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format.cc
++++ b/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format.cc
+@@ -77,7 +77,12 @@ std::unique_ptr<RtpPacketizer> RtpPacketizer::Create(
+ std::vector<int> RtpPacketizer::SplitAboutEqually(
+     int payload_len,
+     const PayloadSizeLimits& limits) {
++#ifdef WEBRTC_WEBKIT_BUILD
++  if (payload_len == 0)
++    return { };
++#else
+   RTC_DCHECK_GT(payload_len, 0);
++#endif
+   // First or last packet larger than normal are unsupported.
+   RTC_DCHECK_GE(limits.first_packet_reduction_len, 0);
+   RTC_DCHECK_GE(limits.last_packet_reduction_len, 0);


### PR DESCRIPTION
#### 1838f3eb70b2990d4dbdd0aeb5bd5189ef87d87d
<pre>
[WebRTC] RtpPacketizer::SplitAboutEqually() should return an empty std::vector when payload_len is 0
<a href="https://bugs.webkit.org/show_bug.cgi?id=265711">https://bugs.webkit.org/show_bug.cgi?id=265711</a>
&lt;<a href="https://rdar.apple.com/119073448">rdar://119073448</a>&gt;

Reviewed by Youenn Fablet.

* Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format.cc:
(webrtc::RtpPacketizer::SplitAboutEqually):
- Return empty std::vector&lt;int&gt; when payload_len is 0 so that various
  ::NumPackets() methods return 0 when there are no packets to create.

* Source/ThirdParty/libwebrtc/WebKit/0001-WebRTC-RtpPacketizer-SplitAboutEqually-should-return-empty-std-vector.patch: Add.

Canonical link: <a href="https://commits.webkit.org/271481@main">https://commits.webkit.org/271481@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c47467ed664edef793abb71c4baa0a964bdb9fa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28478 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7123 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29864 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31005 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25933 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9222 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4492 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28747 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5876 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24501 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5143 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5262 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25502 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31691 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26077 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25944 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31541 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5220 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3395 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29309 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6821 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5677 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3684 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5740 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->