### PR TITLE
Clean up RenderElement::repaintAfterLayoutIfNeeded()

### DIFF
--- a/LayoutTests/editing/caret/insert-paragraph-does-not-paint-stale-carets-expected.txt
+++ b/LayoutTests/editing/caret/insert-paragraph-does-not-paint-stale-carets-expected.txt
@@ -1,4 +1,4 @@
-(repaint rects (rect 25 25 750 18) (rect 25 25 750 18) (rect 25 43 750 18) (rect 25 43 750 18) (rect 25 25 1 18) (rect 25 43 1 18) ) (repaint rects (rect 25 61 750 18) (rect 25 61 750 18) (rect 25 43 1 18) (rect 25 61 1 18) ) (repaint rects (rect 25 79 750 18) (rect 25 79 750 18) (rect 25 61 1 18) (rect 25 79 1 18) )
+(repaint rects (rect 25 25 750 18) (rect 25 43 750 18) (rect 25 25 1 18) (rect 25 43 1 18) ) (repaint rects (rect 25 61 750 18) (rect 25 43 1 18) (rect 25 61 1 18) ) (repaint rects (rect 25 79 750 18) (rect 25 61 1 18) (rect 25 79 1 18) )
 
 
 

--- a/LayoutTests/platform/gtk/editing/caret/insert-paragraph-does-not-paint-stale-carets-expected.txt
+++ b/LayoutTests/platform/gtk/editing/caret/insert-paragraph-does-not-paint-stale-carets-expected.txt
@@ -1,4 +1,4 @@
-(repaint rects (rect 25 25 750 18) (rect 25 25 750 18) (rect 25 43 750 18) (rect 25 43 750 18) (rect 25 25 1 17) (rect 25 43 1 17) ) (repaint rects (rect 25 61 750 18) (rect 25 61 750 18) (rect 25 43 1 17) (rect 25 61 1 17) ) (repaint rects (rect 25 79 750 18) (rect 25 79 750 18) (rect 25 61 1 17) (rect 25 79 1 17) )
+(repaint rects (rect 25 25 750 18) (rect 25 43 750 18) (rect 25 25 1 17) (rect 25 43 1 17) ) (repaint rects (rect 25 61 750 18) (rect 25 43 1 17) (rect 25 61 1 17) ) (repaint rects (rect 25 79 750 18) (rect 25 61 1 17) (rect 25 79 1 17) )
 
 
 

--- a/LayoutTests/platform/gtk/fast/repaint/4776765-expected.txt
+++ b/LayoutTests/platform/gtk/fast/repaint/4776765-expected.txt
@@ -4,8 +4,6 @@
 (repaint rects
   (rect 1 37 798 32)
   (rect 8 44 784 18)
-  (rect 1 37 798 32)
-  (rect 8 44 784 18)
   (rect 1 51 798 18)
   (rect 8 37 784 14)
   (rect 1 19 15 31)

--- a/LayoutTests/platform/ios-wk2/compositing/repaint/invalidations-on-composited-layers-expected.txt
+++ b/LayoutTests/platform/ios-wk2/compositing/repaint/invalidations-on-composited-layers-expected.txt
@@ -1,6 +1,5 @@
 (repaint rects
   (rect 8 13 784 14)
-  (rect 8 13 784 14)
   (rect 8 413 784 27)
   (rect 0 421 800 27)
 )

--- a/LayoutTests/platform/mac-monterey-wk2/fast/repaint/4776765-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2/fast/repaint/4776765-expected.txt
@@ -4,8 +4,6 @@
 (repaint rects
   (rect 1 37 798 32)
   (rect 8 44 784 18)
-  (rect 1 37 798 32)
-  (rect 8 44 784 18)
   (rect 1 51 798 18)
   (rect 8 37 784 14)
   (rect 1 19 15 32)

--- a/LayoutTests/platform/mac-monterey/editing/caret/insert-paragraph-does-not-paint-stale-carets-expected.txt
+++ b/LayoutTests/platform/mac-monterey/editing/caret/insert-paragraph-does-not-paint-stale-carets-expected.txt
@@ -1,4 +1,4 @@
-(repaint rects (rect 25 25 750 18) (rect 25 25 750 18) (rect 25 43 750 18) (rect 25 43 750 18) (rect 25 25 1 18) (rect 25 43 1 18) ) (repaint rects (rect 25 61 750 18) (rect 25 61 750 18) (rect 25 43 1 18) (rect 25 61 1 18) ) (repaint rects (rect 25 79 750 18) (rect 25 79 750 18) (rect 25 61 1 18) (rect 25 79 1 18) )
+(repaint rects (rect 25 25 750 18) (rect 25 43 750 18) (rect 25 25 1 18) (rect 25 43 1 18) ) (repaint rects (rect 25 61 750 18) (rect 25 43 1 18) (rect 25 61 1 18) ) (repaint rects (rect 25 79 750 18) (rect 25 61 1 18) (rect 25 79 1 18) )
 
 
 

--- a/LayoutTests/platform/mac-ventura-wk2/fast/repaint/4776765-expected.txt
+++ b/LayoutTests/platform/mac-ventura-wk2/fast/repaint/4776765-expected.txt
@@ -4,8 +4,6 @@
 (repaint rects
   (rect 1 37 798 32)
   (rect 8 44 784 18)
-  (rect 1 37 798 32)
-  (rect 8 44 784 18)
   (rect 1 51 798 18)
   (rect 8 37 784 14)
   (rect 1 19 15 32)

--- a/LayoutTests/platform/mac-ventura/editing/caret/insert-paragraph-does-not-paint-stale-carets-expected.txt
+++ b/LayoutTests/platform/mac-ventura/editing/caret/insert-paragraph-does-not-paint-stale-carets-expected.txt
@@ -1,4 +1,4 @@
-(repaint rects (rect 25 25 750 18) (rect 25 25 750 18) (rect 25 43 750 18) (rect 25 43 750 18) (rect 25 25 1 18) (rect 25 43 1 18) ) (repaint rects (rect 25 61 750 18) (rect 25 61 750 18) (rect 25 43 1 18) (rect 25 61 1 18) ) (repaint rects (rect 25 79 750 18) (rect 25 79 750 18) (rect 25 61 1 18) (rect 25 79 1 18) )
+(repaint rects (rect 25 25 750 18) (rect 25 43 750 18) (rect 25 25 1 18) (rect 25 43 1 18) ) (repaint rects (rect 25 61 750 18) (rect 25 43 1 18) (rect 25 61 1 18) ) (repaint rects (rect 25 79 750 18) (rect 25 61 1 18) (rect 25 79 1 18) )
 
 
 

--- a/LayoutTests/platform/mac-wk1/fast/repaint/4776765-expected.txt
+++ b/LayoutTests/platform/mac-wk1/fast/repaint/4776765-expected.txt
@@ -4,8 +4,6 @@
 (repaint rects
   (rect 1 37 798 32)
   (rect 8 44 784 18)
-  (rect 1 37 798 32)
-  (rect 8 44 784 18)
   (rect 1 51 798 18)
   (rect 8 37 784 14)
 )

--- a/LayoutTests/platform/mac/compositing/repaint/invalidations-on-composited-layers-expected.txt
+++ b/LayoutTests/platform/mac/compositing/repaint/invalidations-on-composited-layers-expected.txt
@@ -1,6 +1,5 @@
 (repaint rects
   (rect 8 13 784 15)
-  (rect 8 13 784 15)
   (rect 8 413 784 28)
   (rect 0 421 800 28)
 )

--- a/LayoutTests/platform/mac/editing/caret/insert-paragraph-does-not-paint-stale-carets-expected.txt
+++ b/LayoutTests/platform/mac/editing/caret/insert-paragraph-does-not-paint-stale-carets-expected.txt
@@ -1,4 +1,4 @@
-(repaint rects (rect 25 25 750 18) (rect 25 25 750 18) (rect 25 43 750 18) (rect 25 43 750 18) (rect 25 25 2 18) (rect 25 43 2 18) ) (repaint rects (rect 25 61 750 18) (rect 25 61 750 18) (rect 25 43 2 18) (rect 25 61 2 18) ) (repaint rects (rect 25 79 750 18) (rect 25 79 750 18) (rect 25 61 2 18) (rect 25 79 2 18) )
+(repaint rects (rect 25 25 750 18) (rect 25 43 750 18) (rect 25 25 2 18) (rect 25 43 2 18) ) (repaint rects (rect 25 61 750 18) (rect 25 43 2 18) (rect 25 61 2 18) ) (repaint rects (rect 25 79 750 18) (rect 25 61 2 18) (rect 25 79 2 18) )
 
 
 

--- a/LayoutTests/platform/mac/fast/repaint/4776765-expected.txt
+++ b/LayoutTests/platform/mac/fast/repaint/4776765-expected.txt
@@ -4,8 +4,6 @@
 (repaint rects
   (rect 1 37 798 32)
   (rect 8 44 784 18)
-  (rect 1 37 798 32)
-  (rect 8 44 784 18)
   (rect 1 51 798 18)
   (rect 8 37 784 14)
   (rect 1 19 16 32)


### PR DESCRIPTION
#### 5c239a3e46973761ff7d8a20b5a4ce27c0e8bd2d
<pre>
Clean up RenderElement::repaintAfterLayoutIfNeeded()
<a href="https://bugs.webkit.org/show_bug.cgi?id=265726">https://bugs.webkit.org/show_bug.cgi?id=265726</a>
<a href="https://rdar.apple.com/119077478">rdar://119077478</a>

Reviewed by Alan Baradlay.

Tidy up RenderElement::repaintAfterLayoutIfNeeded() by using a couple of lambda functions; one to replace
the standalone `mustRepaintBackgroundOrBorder()`, and a second to clarify the computation of `fullRepaint`.

There&apos;s one behavior change from:
        if (oldClippedOverflowRect.isEmpty() || newClippedOverflowRect.isEmpty())
            return true;

which removes some redundant repaints in fast/repaint/4776765.html.

* LayoutTests/editing/caret/insert-paragraph-does-not-paint-stale-carets-expected.txt:
* LayoutTests/platform/gtk/editing/caret/insert-paragraph-does-not-paint-stale-carets-expected.txt:
* LayoutTests/platform/gtk/fast/repaint/4776765-expected.txt:
* LayoutTests/platform/ios-wk2/compositing/repaint/invalidations-on-composited-layers-expected.txt:
* LayoutTests/platform/mac-monterey-wk2/fast/repaint/4776765-expected.txt:
* LayoutTests/platform/mac-monterey/editing/caret/insert-paragraph-does-not-paint-stale-carets-expected.txt:
* LayoutTests/platform/mac-ventura-wk2/fast/repaint/4776765-expected.txt:
* LayoutTests/platform/mac-ventura/editing/caret/insert-paragraph-does-not-paint-stale-carets-expected.txt:
* LayoutTests/platform/mac-wk1/fast/repaint/4776765-expected.txt:
* LayoutTests/platform/mac/compositing/repaint/invalidations-on-composited-layers-expected.txt:
* LayoutTests/platform/mac/editing/caret/insert-paragraph-does-not-paint-stale-carets-expected.txt:
* LayoutTests/platform/mac/fast/repaint/4776765-expected.txt:
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::repaintAfterLayoutIfNeeded):
(WebCore::mustRepaintBackgroundOrBorder): Deleted.

Canonical link: <a href="https://commits.webkit.org/271435@main">https://commits.webkit.org/271435@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4382955b78aeb96ebb7e5126a40683ef83aaa6e2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28411 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7056 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29797 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30938 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25869 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28908 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9154 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4425 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28680 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/5820 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24443 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5089 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5198 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25444 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31624 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26021 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25884 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31489 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5157 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3334 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29251 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6756 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6801 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5613 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5677 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->