### PR TITLE
[offlineasm] Incremental build failure when generator is interrupted

### DIFF
--- a/Source/JavaScriptCore/offlineasm/generate_offset_extractor.rb
+++ b/Source/JavaScriptCore/offlineasm/generate_offset_extractor.rb
@@ -41,6 +41,10 @@ IncludeFile.processIncludeOptions()
 inputFlnm = ARGV.shift
 settingsFlnm = ARGV.shift
 outputFlnm = ARGV.shift
+tempFlnm = File.join(
+    ENV['TARGET_TEMP_DIR'] || File.dirname(outputFlnm),
+    "#{File.basename(outputFlnm)}.part"
+)
 
 inputBackends = canonicalizeBackendNames(ARGV.shift.split(/[,\s]+/))
 includeOnlyBackends(inputBackends)
@@ -96,7 +100,7 @@ if $options[:depfile]
     depfile.puts(Shellwords.join(sources.sort))
 end
 
-File.open(outputFlnm, "w") {
+File.open(tempFlnm, "w") {
     | outp |
     $output = outp
     outp.puts inputHash
@@ -150,5 +154,5 @@ File.open(outputFlnm, "w") {
     }
 
     outp.puts "static const int64_t offsetExtractorTable[] = { };" if not configurationList.size
-
 }
+File.rename(tempFlnm, outputFlnm)

--- a/Source/JavaScriptCore/offlineasm/generate_settings_extractor.rb
+++ b/Source/JavaScriptCore/offlineasm/generate_settings_extractor.rb
@@ -40,6 +40,10 @@ IncludeFile.processIncludeOptions()
 
 inputFlnm = ARGV.shift
 outputFlnm = ARGV.shift
+tempFlnm = File.join(
+    ENV['TARGET_TEMP_DIR'] || File.dirname(outputFlnm),
+    "#{File.basename(outputFlnm)}.part"
+)
 
 inputBackends = canonicalizeBackendNames(ARGV.shift.split(/[,\s]+/))
 includeOnlyBackends(inputBackends)
@@ -78,7 +82,7 @@ if $options[:depfile]
     depfile.puts(Shellwords.join(sources.sort))
 end
 
-File.open(outputFlnm, "w") {
+File.open(tempFlnm, "w") {
     | outp |
     $output = outp
     outp.puts inputHash
@@ -96,5 +100,5 @@ File.open(outputFlnm, "w") {
         outp.puts "#{index},"
     }
     outp.puts "};"
-
 }
+File.rename(tempFlnm, outputFlnm)


### PR DESCRIPTION
#### 97b3a2dd3db7352fa6f8738688183b07c58bc031
<pre>
[offlineasm] Incremental build failure when generator is interrupted
<a href="https://bugs.webkit.org/show_bug.cgi?id=265729">https://bugs.webkit.org/show_bug.cgi?id=265729</a>
<a href="https://rdar.apple.com/119079705">rdar://119079705</a>

Reviewed by Alexey Proskuryakov.

offlineasm writes headers non-atomically, so if the script is
interrupted due to a build failure in a parallel task, it leaves a
partially-written header. The build system can&apos;t tell that this header
is incomplete, so its presence breaks subsequent rebuilds.

Fix by writing to a temporary file in the same directory (or
TARGET_TEMP_DIR in Xcode), and `rename`-ing once generation is complete.

* Source/JavaScriptCore/offlineasm/generate_offset_extractor.rb:
* Source/JavaScriptCore/offlineasm/generate_settings_extractor.rb:

Canonical link: <a href="https://commits.webkit.org/271640@main">https://commits.webkit.org/271640@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1ba3af351745703971618d6585faf6963518d8b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28854 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7496 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30223 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31471 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26318 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9737 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4853 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26361 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29125 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6282 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24789 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5395 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5626 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25801 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/32809 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/24946 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26470 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26242 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31783 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/29063 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5518 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3688 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29573 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7146 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/35470 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6944 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5995 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7651 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6039 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->