### PR TITLE
Adopt alternatives for scroll view SPI: -_scrollView:asynchronouslyHandleScrollEvent:completion:

### DIFF
--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -487,7 +487,7 @@ UIProcess/ios/WebScreenOrientationManagerProxyIOS.mm
 UIProcess/ios/WKActionSheet.mm
 UIProcess/ios/WKActionSheetAssistant.mm
 UIProcess/ios/WKApplicationStateTrackingView.mm
-UIProcess/ios/WKAxisLockingScrollView.mm
+UIProcess/ios/WKBaseScrollView.mm
 UIProcess/ios/WKContentView.mm @no-unify
 UIProcess/ios/WKContentViewInteraction.mm @no-unify
 UIProcess/ios/WKDeferringGestureRecognizer.mm

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
@@ -23,7 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "WKAxisLockingScrollView.h"
+#import "WKBaseScrollView.h"
 #import "WKWebViewInternal.h"
 #import "_WKTapHandlingResult.h"
 
@@ -37,7 +37,7 @@ namespace WebKit {
 enum class TapHandlingResult : uint8_t;
 }
 
-@interface WKWebView (WKViewInternalIOS) <WKAxisLockingScrollViewDelegate>
+@interface WKWebView (WKViewInternalIOS) <WKBaseScrollViewDelegate>
 
 - (void)_setupScrollAndContentViews;
 - (void)_registerForNotifications;
@@ -172,10 +172,6 @@ enum class TapHandlingResult : uint8_t;
 
 #if ENABLE(LOCKDOWN_MODE_API)
 + (void)_clearLockdownModeWarningNeeded;
-#endif
-
-#if HAVE(UISCROLLVIEW_ASYNCHRONOUS_SCROLL_EVENT_HANDLING)
-- (void)_scrollView:(UIScrollView *)scrollView asynchronouslyHandleScrollEvent:(UIScrollEvent *)scrollEvent completion:(void (^)(BOOL handled))completion;
 #endif
 
 - (UIColor *)_insertionPointColor;

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -76,6 +76,7 @@ OBJC_CLASS NSTextAlternatives;
 OBJC_CLASS UIGestureRecognizer;
 OBJC_CLASS UIScrollEvent;
 OBJC_CLASS UIScrollView;
+OBJC_CLASS WKBaseScrollView;
 OBJC_CLASS _WKRemoteObjectRegistry;
 
 #if USE(APPKIT)
@@ -517,7 +518,7 @@ public:
     virtual void handleAutocorrectionContext(const WebAutocorrectionContext&) = 0;
 
 #if HAVE(UISCROLLVIEW_ASYNCHRONOUS_SCROLL_EVENT_HANDLING)
-    virtual void handleAsynchronousCancelableScrollEvent(UIScrollView *, UIScrollEvent *, void (^completion)(BOOL handled)) = 0;
+    virtual void handleAsynchronousCancelableScrollEvent(WKBaseScrollView *, UIScrollEvent *, void (^completion)(BOOL handled)) = 0;
 #endif
 
     virtual WebCore::Color contentViewBackgroundColor() = 0;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.h
@@ -26,7 +26,7 @@
 #if PLATFORM(IOS_FAMILY)
 
 #import "UIKitSPI.h"
-#import "WKAxisLockingScrollView.h"
+#import "WKBaseScrollView.h"
 #import <wtf/OptionSet.h>
 
 namespace WebCore {
@@ -69,7 +69,7 @@ class WebPageProxy;
 @interface WKUIRemoteView : _UIRemoteView <WKContentControlled>
 @end
 
-@interface WKChildScrollView : WKAxisLockingScrollView <WKContentControlled>
+@interface WKChildScrollView : WKBaseScrollView <WKContentControlled>
 @end
 
 #if USE(APPLE_INTERNAL_SDK)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm
@@ -433,12 +433,6 @@ static Class scrollViewScrollIndicatorClass()
     self.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
 #endif
 
-#if HAVE(UISCROLLVIEW_ASYNCHRONOUS_SCROLL_EVENT_HANDLING)
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    [self _setAllowsAsyncScrollEvent:YES];
-ALLOW_DEPRECATED_DECLARATIONS_END
-#endif
-
     return self;
 }
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeFrameScrollingNodeRemoteIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeFrameScrollingNodeRemoteIOS.h
@@ -27,7 +27,7 @@
 
 #if ENABLE(ASYNC_SCROLLING) && PLATFORM(IOS_FAMILY)
 
-OBJC_CLASS UIScrollView;
+OBJC_CLASS WKBaseScrollView;
 
 #include <WebCore/ScrollingTreeFrameScrollingNode.h>
 
@@ -40,7 +40,7 @@ public:
     static Ref<ScrollingTreeFrameScrollingNodeRemoteIOS> create(WebCore::ScrollingTree&, WebCore::ScrollingNodeType, WebCore::ScrollingNodeID);
     virtual ~ScrollingTreeFrameScrollingNodeRemoteIOS();
 
-    UIScrollView *scrollView() const;
+    WKBaseScrollView *scrollView() const;
 
 private:
     ScrollingTreeFrameScrollingNodeRemoteIOS(WebCore::ScrollingTree&, WebCore::ScrollingNodeType, WebCore::ScrollingNodeID);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeFrameScrollingNodeRemoteIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeFrameScrollingNodeRemoteIOS.mm
@@ -56,7 +56,7 @@ ScrollingTreeScrollingNodeDelegateIOS* ScrollingTreeFrameScrollingNodeRemoteIOS:
     return static_cast<ScrollingTreeScrollingNodeDelegateIOS*>(m_delegate.get());
 }
 
-UIScrollView *ScrollingTreeFrameScrollingNodeRemoteIOS::scrollView() const
+WKBaseScrollView *ScrollingTreeFrameScrollingNodeRemoteIOS::scrollView() const
 {
     return m_delegate ? delegate()->scrollView() : nil;
 }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeOverflowScrollingNodeIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeOverflowScrollingNodeIOS.h
@@ -29,7 +29,7 @@
 
 #include <WebCore/ScrollingTreeOverflowScrollingNode.h>
 
-OBJC_CLASS UIScrollView;
+OBJC_CLASS WKBaseScrollView;
 
 namespace WebKit {
 
@@ -40,7 +40,7 @@ public:
     static Ref<ScrollingTreeOverflowScrollingNodeIOS> create(WebCore::ScrollingTree&, WebCore::ScrollingNodeID);
     virtual ~ScrollingTreeOverflowScrollingNodeIOS();
 
-    UIScrollView* scrollView() const;
+    WKBaseScrollView *scrollView() const;
 
 private:
     ScrollingTreeOverflowScrollingNodeIOS(WebCore::ScrollingTree&, WebCore::ScrollingNodeID);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeOverflowScrollingNodeIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeOverflowScrollingNodeIOS.mm
@@ -56,7 +56,7 @@ ScrollingTreeScrollingNodeDelegateIOS& ScrollingTreeOverflowScrollingNodeIOS::de
     return *static_cast<ScrollingTreeScrollingNodeDelegateIOS*>(m_delegate.get());
 }
 
-UIScrollView* ScrollingTreeOverflowScrollingNodeIOS::scrollView() const
+WKBaseScrollView *ScrollingTreeOverflowScrollingNodeIOS::scrollView() const
 {
     return delegate().scrollView();
 }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreePluginScrollingNodeIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreePluginScrollingNodeIOS.h
@@ -29,7 +29,7 @@
 
 #include <WebCore/ScrollingTreePluginScrollingNode.h>
 
-OBJC_CLASS UIScrollView;
+OBJC_CLASS WKBaseScrollView;
 
 namespace WebKit {
 
@@ -40,7 +40,7 @@ public:
     static Ref<ScrollingTreePluginScrollingNodeIOS> create(WebCore::ScrollingTree&, WebCore::ScrollingNodeID);
     virtual ~ScrollingTreePluginScrollingNodeIOS();
 
-    UIScrollView* scrollView() const;
+    WKBaseScrollView *scrollView() const;
 
 private:
     ScrollingTreePluginScrollingNodeIOS(WebCore::ScrollingTree&, WebCore::ScrollingNodeID);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreePluginScrollingNodeIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreePluginScrollingNodeIOS.mm
@@ -56,7 +56,7 @@ ScrollingTreeScrollingNodeDelegateIOS& ScrollingTreePluginScrollingNodeIOS::dele
     return *static_cast<ScrollingTreeScrollingNodeDelegateIOS*>(m_delegate.get());
 }
 
-UIScrollView* ScrollingTreePluginScrollingNodeIOS::scrollView() const
+WKBaseScrollView *ScrollingTreePluginScrollingNodeIOS::scrollView() const
 {
     return delegate().scrollView();
 }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.h
@@ -33,6 +33,7 @@
 @class CALayer;
 @class UIScrollEvent;
 @class UIScrollView;
+@class WKBaseScrollView;
 @class WKScrollingNodeScrollViewDelegate;
 
 namespace WebCore {
@@ -70,7 +71,7 @@ public:
     void repositionScrollingLayers();
 
 #if HAVE(UISCROLLVIEW_ASYNCHRONOUS_SCROLL_EVENT_HANDLING)
-    void handleAsynchronousCancelableScrollEvent(UIScrollView *, UIScrollEvent *, void (^completion)(BOOL handled));
+    void handleAsynchronousCancelableScrollEvent(WKBaseScrollView *, UIScrollEvent *, void (^completion)(BOOL handled));
 #endif
 
     OptionSet<WebCore::TouchAction> activeTouchActions() const { return m_activeTouchActions; }
@@ -79,7 +80,7 @@ public:
     void cancelPointersForGestureRecognizer(UIGestureRecognizer*);
 
     UIScrollView *findActingScrollParent(UIScrollView *);
-    UIScrollView *scrollView() const;
+    WKBaseScrollView *scrollView() const;
 
     bool startAnimatedScrollToPosition(WebCore::FloatPoint) final;
     void stopAnimatedScroll() final;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
@@ -34,7 +34,7 @@
 #import "RemoteScrollingTree.h"
 #import "UIKitSPI.h"
 #import "UIKitUtilities.h"
-#import "WKAxisLockingScrollView.h"
+#import "WKBaseScrollView.h"
 #import "WKScrollView.h"
 #import "WebPageProxy.h"
 #import <QuartzCore/QuartzCore.h>
@@ -48,7 +48,7 @@
 #import <wtf/BlockObjCExceptions.h>
 #import <wtf/SetForScope.h>
 
-@interface WKScrollingNodeScrollViewDelegate () <WKAxisLockingScrollViewDelegate>
+@interface WKScrollingNodeScrollViewDelegate () <WKBaseScrollViewDelegate>
 @end
 
 @implementation WKScrollingNodeScrollViewDelegate
@@ -88,7 +88,7 @@
         _scrollingTreeNodeDelegate->clearActiveTouchActions();
         
         if (touchActions && !touchActions.containsAny({ WebCore::TouchAction::Auto, WebCore::TouchAction::Manipulation })) {
-            auto axesToPreventMomentumScrolling = dynamic_objc_cast<WKAxisLockingScrollView>(scrollView).axesToPreventMomentumScrolling;
+            auto axesToPreventMomentumScrolling = dynamic_objc_cast<WKBaseScrollView>(scrollView).axesToPreventMomentumScrolling;
             if (!touchActions.contains(WebCore::TouchAction::PanX) || (axesToPreventMomentumScrolling & UIAxisHorizontal))
                 targetContentOffset->x = scrollView.contentOffset.x;
             if (!touchActions.contains(WebCore::TouchAction::PanY) || (axesToPreventMomentumScrolling & UIAxisVertical))
@@ -144,13 +144,6 @@
     _scrollingTreeNodeDelegate->scrollDidEnd();
 }
 
-#if HAVE(UISCROLLVIEW_ASYNCHRONOUS_SCROLL_EVENT_HANDLING)
-- (void)_scrollView:(UIScrollView *)scrollView asynchronouslyHandleScrollEvent:(UIScrollEvent *)scrollEvent completion:(void (^)(BOOL handled))completion
-{
-    _scrollingTreeNodeDelegate->handleAsynchronousCancelableScrollEvent(scrollView, scrollEvent, completion);
-}
-#endif
-
 - (void)scrollViewWillBeginZooming:(UIScrollView *)scrollView withView:(UIView *)view
 {
     [self cancelPointersForGestureRecognizer:scrollView.pinchGestureRecognizer];
@@ -161,9 +154,9 @@
     _scrollingTreeNodeDelegate->cancelPointersForGestureRecognizer(gestureRecognizer);
 }
 
-#pragma mark - WKAxisLockingScrollViewDelegate
+#pragma mark - WKBaseScrollViewDelegate
 
-- (UIAxis)axesToPreventScrollingForPanGestureInScrollView:(WKAxisLockingScrollView *)scrollView
+- (UIAxis)axesToPreventScrollingForPanGestureInScrollView:(WKBaseScrollView *)scrollView
 {
     auto panGestureRecognizer = scrollView.panGestureRecognizer;
     _scrollingTreeNodeDelegate->computeActiveTouchActionsForGestureRecognizer(panGestureRecognizer);
@@ -190,6 +183,24 @@
 
     return axesToPrevent;
 }
+
+#if HAVE(UISCROLLVIEW_ASYNCHRONOUS_SCROLL_EVENT_HANDLING)
+
+#if !HAVE(UISCROLLVIEW_ASYNCHRONOUS_SCROLL_EVENT_SUBCLASS_HOOKS)
+
+- (void)_scrollView:(WKChildScrollView *)scrollView asynchronouslyHandleScrollEvent:(UIScrollEvent *)scrollEvent completion:(void (^)(BOOL handled))completion
+{
+    [self scrollView:scrollView handleScrollEvent:scrollEvent completion:completion];
+}
+
+#endif // !HAVE(UISCROLLVIEW_ASYNCHRONOUS_SCROLL_EVENT_SUBCLASS_HOOKS)
+
+- (void)scrollView:(WKBaseScrollView *)scrollView handleScrollEvent:(UIScrollEvent *)scrollEvent completion:(void (^)(BOOL handled))completion
+{
+    _scrollingTreeNodeDelegate->handleAsynchronousCancelableScrollEvent(scrollView, scrollEvent, completion);
+}
+
+#endif // HAVE(UISCROLLVIEW_ASYNCHRONOUS_SCROLL_EVENT_HANDLING)
 
 @end
 
@@ -254,14 +265,14 @@ void ScrollingTreeScrollingNodeDelegateIOS::commitStateAfterChildren(const Scrol
         || scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollOrigin)
         || scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollableAreaParams)) {
         BEGIN_BLOCK_OBJC_EXCEPTIONS
-        UIScrollView *scrollView = this->scrollView();
+        auto scrollView = this->scrollView();
         if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollContainerLayer)) {
             if (!m_scrollViewDelegate)
                 m_scrollViewDelegate = adoptNS([[WKScrollingNodeScrollViewDelegate alloc] initWithScrollingTreeNodeDelegate:this]);
 
             scrollView.scrollsToTop = NO;
             scrollView.delegate = m_scrollViewDelegate.get();
-            dynamic_objc_cast<WKAxisLockingScrollView>(scrollView).scrollAxisLockingDelegate = m_scrollViewDelegate.get();
+            scrollView.baseScrollViewDelegate = m_scrollViewDelegate.get();
 
             if ([scrollView respondsToSelector:@selector(_setAvoidsJumpOnInterruptedBounce:)]) {
                 scrollView.tracksImmediatelyWhileDecelerating = NO;
@@ -337,7 +348,7 @@ void ScrollingTreeScrollingNodeDelegateIOS::stopAnimatedScroll()
 }
 
 #if HAVE(UISCROLLVIEW_ASYNCHRONOUS_SCROLL_EVENT_HANDLING)
-void ScrollingTreeScrollingNodeDelegateIOS::handleAsynchronousCancelableScrollEvent(UIScrollView *scrollView, UIScrollEvent *scrollEvent, void (^completion)(BOOL handled))
+void ScrollingTreeScrollingNodeDelegateIOS::handleAsynchronousCancelableScrollEvent(WKBaseScrollView *scrollView, UIScrollEvent *scrollEvent, void (^completion)(BOOL handled))
 {
     auto* scrollingCoordinatorProxy = downcast<WebKit::RemoteScrollingTree>(scrollingTree()).scrollingCoordinatorProxy();
     if (scrollingCoordinatorProxy)
@@ -389,10 +400,10 @@ void ScrollingTreeScrollingNodeDelegateIOS::currentSnapPointIndicesDidChange(std
     scrollingTree().currentSnapPointIndicesDidChange(scrollingNode().scrollingNodeID(), horizontal, vertical);
 }
 
-UIScrollView *ScrollingTreeScrollingNodeDelegateIOS::scrollView() const
+WKBaseScrollView *ScrollingTreeScrollingNodeDelegateIOS::scrollView() const
 {
-    UIScrollView *scrollView = (UIScrollView *)[scrollLayer() delegate];
-    ASSERT([scrollView isKindOfClass:[UIScrollView class]]);
+    auto scrollView = dynamic_objc_cast<WKBaseScrollView>(scrollLayer().delegate);
+    ASSERT(scrollView);
     return scrollView;
 }
 

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -301,7 +301,7 @@ private:
     void showDictationAlternativeUI(const WebCore::FloatRect&, WebCore::DictationContext) final;
 
 #if HAVE(UISCROLLVIEW_ASYNCHRONOUS_SCROLL_EVENT_HANDLING)
-    void handleAsynchronousCancelableScrollEvent(UIScrollView *, UIScrollEvent *, void (^completion)(BOOL handled)) final;
+    void handleAsynchronousCancelableScrollEvent(WKBaseScrollView *, UIScrollEvent *, void (^completion)(BOOL handled)) final;
 #endif
 
     WebCore::Color contentViewBackgroundColor() final;

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -1084,9 +1084,9 @@ void PageClientImpl::showMediaControlsContextMenu(FloatRect&& targetFrame, Vecto
 #endif // ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
 
 #if HAVE(UISCROLLVIEW_ASYNCHRONOUS_SCROLL_EVENT_HANDLING)
-void PageClientImpl::handleAsynchronousCancelableScrollEvent(UIScrollView *scrollView, UIScrollEvent *scrollEvent, void (^completion)(BOOL handled))
+void PageClientImpl::handleAsynchronousCancelableScrollEvent(WKBaseScrollView *scrollView, UIScrollEvent *scrollEvent, void (^completion)(BOOL handled))
 {
-    [webView() _scrollView:scrollView asynchronouslyHandleScrollEvent:scrollEvent completion:completion];
+    [webView() scrollView:scrollView handleScrollEvent:scrollEvent completion:completion];
 }
 #endif
 

--- a/Source/WebKit/UIProcess/ios/WKBaseScrollView.h
+++ b/Source/WebKit/UIProcess/ios/WKBaseScrollView.h
@@ -29,17 +29,22 @@
 
 #import <UIKit/UIKit.h>
 
-@class WKAxisLockingScrollView;
+@class UIScrollEvent;
+@class WKBaseScrollView;
 
-@protocol WKAxisLockingScrollViewDelegate <NSObject>
+@protocol WKBaseScrollViewDelegate <NSObject>
 
-- (UIAxis)axesToPreventScrollingForPanGestureInScrollView:(WKAxisLockingScrollView *)scrollView;
+- (UIAxis)axesToPreventScrollingForPanGestureInScrollView:(WKBaseScrollView *)scrollView;
+
+#if HAVE(UISCROLLVIEW_ASYNCHRONOUS_SCROLL_EVENT_HANDLING)
+- (void)scrollView:(WKBaseScrollView *)scrollView handleScrollEvent:(UIScrollEvent *)event completion:(void(^)(BOOL handled))completion;
+#endif
 
 @end
 
-@interface WKAxisLockingScrollView : UIScrollView
+@interface WKBaseScrollView : UIScrollView
 
-@property (nonatomic, weak) id<WKAxisLockingScrollViewDelegate> scrollAxisLockingDelegate;
+@property (nonatomic, weak) id<WKBaseScrollViewDelegate> baseScrollViewDelegate;
 @property (nonatomic, readonly) UIAxis axesToPreventMomentumScrolling;
 
 @end

--- a/Source/WebKit/UIProcess/ios/WKScrollView.mm
+++ b/Source/WebKit/UIProcess/ios/WKScrollView.mm
@@ -154,7 +154,7 @@ static BOOL shouldForwardScrollViewDelegateMethodToExternalDelegate(SEL selector
 #endif
 }
 
-- (id)initWithFrame:(CGRect)frame
+- (instancetype)initWithFrame:(CGRect)frame
 {
     self = [super initWithFrame:frame];
 

--- a/Source/WebKit/UIProcess/ios/WKVelocityTrackingScrollView.h
+++ b/Source/WebKit/UIProcess/ios/WKVelocityTrackingScrollView.h
@@ -27,9 +27,9 @@
 
 #if PLATFORM(IOS_FAMILY)
 
-#import "WKAxisLockingScrollView.h"
+#import "WKBaseScrollView.h"
 
-@interface WKVelocityTrackingScrollView : WKAxisLockingScrollView
+@interface WKVelocityTrackingScrollView : WKBaseScrollView
 
 - (void)updateInteractiveScrollVelocity;
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2382,7 +2382,7 @@
 		F4DBC0BE276AA6A70001D169 /* _WKModalContainerInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = F4DBC0BC276AA6A70001D169 /* _WKModalContainerInfo.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F4DBC0C1276AA6CA0001D169 /* _WKModalContainerInfoInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = F4DBC0C0276AA6CA0001D169 /* _WKModalContainerInfoInternal.h */; };
 		F4DF71E82B069AC6009A4522 /* WKExtendedTextInputTraits.h in Headers */ = {isa = PBXBuildFile; fileRef = F4DF71D72B0689A5009A4522 /* WKExtendedTextInputTraits.h */; };
-		F4DF72122B0C3A8C009A4522 /* WKAxisLockingScrollView.h in Headers */ = {isa = PBXBuildFile; fileRef = F4DF72102B0C324F009A4522 /* WKAxisLockingScrollView.h */; };
+		F4DF72122B0C3A8C009A4522 /* WKBaseScrollView.h in Headers */ = {isa = PBXBuildFile; fileRef = F4DF72102B0C324F009A4522 /* WKBaseScrollView.h */; };
 		F4E727232A547F0400CE34FD /* WKTouchEventsGestureRecognizerTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = F4E727222A547E2100CE34FD /* WKTouchEventsGestureRecognizerTypes.h */; };
 		F4EB4AFD269CD7F300D297AE /* OSStateSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = F4EB4AFC269CD23600D297AE /* OSStateSPI.h */; };
 		F4EC94E32356CC57000BB614 /* ApplicationServicesSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 29D04E2821F7C73D0076741D /* ApplicationServicesSPI.h */; };
@@ -7700,8 +7700,8 @@
 		F4DD79EF2AD59BA6000C6821 /* WKVelocityTrackingScrollView.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = WKVelocityTrackingScrollView.mm; path = ios/WKVelocityTrackingScrollView.mm; sourceTree = "<group>"; };
 		F4DF71D72B0689A5009A4522 /* WKExtendedTextInputTraits.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WKExtendedTextInputTraits.h; path = ios/WKExtendedTextInputTraits.h; sourceTree = "<group>"; };
 		F4DF71D82B0689A5009A4522 /* WKExtendedTextInputTraits.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = WKExtendedTextInputTraits.mm; path = ios/WKExtendedTextInputTraits.mm; sourceTree = "<group>"; };
-		F4DF72102B0C324F009A4522 /* WKAxisLockingScrollView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WKAxisLockingScrollView.h; path = ios/WKAxisLockingScrollView.h; sourceTree = "<group>"; };
-		F4DF72112B0C324F009A4522 /* WKAxisLockingScrollView.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = WKAxisLockingScrollView.mm; path = ios/WKAxisLockingScrollView.mm; sourceTree = "<group>"; };
+		F4DF72102B0C324F009A4522 /* WKBaseScrollView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WKBaseScrollView.h; path = ios/WKBaseScrollView.h; sourceTree = "<group>"; };
+		F4DF72112B0C324F009A4522 /* WKBaseScrollView.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = WKBaseScrollView.mm; path = ios/WKBaseScrollView.mm; sourceTree = "<group>"; };
 		F4E2B44A268FDE1A00327ABC /* TapHandlingResult.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = TapHandlingResult.h; path = ios/TapHandlingResult.h; sourceTree = "<group>"; };
 		F4E47BB527B5AE5B00813B38 /* CocoaImage.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CocoaImage.mm; sourceTree = "<group>"; };
 		F4E727222A547E2100CE34FD /* WKTouchEventsGestureRecognizerTypes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WKTouchEventsGestureRecognizerTypes.h; path = ios/WKTouchEventsGestureRecognizerTypes.h; sourceTree = "<group>"; };
@@ -10264,8 +10264,8 @@
 				0FCB4E3B18BBE044000FCFC9 /* WKActionSheetAssistant.mm */,
 				A13DC680207AA6B20066EF72 /* WKApplicationStateTrackingView.h */,
 				A13DC681207AA6B20066EF72 /* WKApplicationStateTrackingView.mm */,
-				F4DF72102B0C324F009A4522 /* WKAxisLockingScrollView.h */,
-				F4DF72112B0C324F009A4522 /* WKAxisLockingScrollView.mm */,
+				F4DF72102B0C324F009A4522 /* WKBaseScrollView.h */,
+				F4DF72112B0C324F009A4522 /* WKBaseScrollView.mm */,
 				0FCB4E3C18BBE044000FCFC9 /* WKContentView.h */,
 				0FCB4E3D18BBE044000FCFC9 /* WKContentView.mm */,
 				0FCB4E6A18BBF26A000FCFC9 /* WKContentViewInteraction.h */,
@@ -16005,7 +16005,6 @@
 				577739952580388F0059348B /* WKASCAuthorizationPresenterDelegate.h in Headers */,
 				512F58F612A88A5400629530 /* WKAuthenticationChallenge.h in Headers */,
 				512F58F812A88A5400629530 /* WKAuthenticationDecisionListener.h in Headers */,
-				F4DF72122B0C3A8C009A4522 /* WKAxisLockingScrollView.h in Headers */,
 				37C4C08D1814AC5C003688B9 /* WKBackForwardList.h in Headers */,
 				37C4C0951814B9E6003688B9 /* WKBackForwardListInternal.h in Headers */,
 				37C4C08718149C5B003688B9 /* WKBackForwardListItem.h in Headers */,
@@ -16016,6 +16015,7 @@
 				BC646C1B11DD399F006455B0 /* WKBackForwardListRef.h in Headers */,
 				BCDDB317124EBD130048D13C /* WKBase.h in Headers */,
 				7CD5EBBB1746A83E000C1C45 /* WKBaseMac.h in Headers */,
+				F4DF72122B0C3A8C009A4522 /* WKBaseScrollView.h in Headers */,
 				BCBAAC73144E619E0053F82F /* WKBrowsingContextController.h in Headers */,
 				BCBAAC74144E61A50053F82F /* WKBrowsingContextControllerInternal.h in Headers */,
 				3788A05C14743C90006319E5 /* WKBrowsingContextControllerPrivate.h in Headers */,

--- a/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
+++ b/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
@@ -319,10 +319,6 @@ typedef NS_ENUM(NSUInteger, UIScrollPhase) {
 @interface UIScrollEvent : UIEvent
 @end
 
-@interface NSObject (UIScrollViewDelegate_ForWebKitOnly)
-- (void)_scrollView:(UIScrollView *)scrollView asynchronouslyHandleScrollEvent:(UIScrollEvent *)scrollEvent completion:(void (^)(BOOL handled))completion;
-@end
-
 @interface UITextInteractionAssistant : NSObject <UIResponderStandardEditActions>
 @end
 

--- a/Tools/TestWebKitAPI/Tests/ios/WKScrollViewTests.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/WKScrollViewTests.mm
@@ -43,6 +43,12 @@ constexpr CGFloat whiteColorComponents[4] = { 1, 1, 1, 1 };
 
 @end
 
+@interface WKWebView (WKBaseScrollViewDelegate)
+
+- (void)scrollView:(UIScrollView *)scrollView handleScrollEvent:(UIScrollEvent *)event completion:(void(^)(BOOL handled))completion;
+
+@end
+
 @implementation WKUIScrollEvent {
     UIScrollPhase _phase;
     CGPoint _location;
@@ -142,7 +148,7 @@ TEST(WKScrollViewTests, AsynchronousWheelEventHandling)
     auto synchronouslyHandleScrollEvent = ^(UIScrollPhase phase, CGPoint location, CGVector delta) {
         done = false;
         auto event = adoptNS([[WKUIScrollEvent alloc] initWithPhase:phase location:location delta:delta]);
-        [webView _scrollView:[webView scrollView] asynchronouslyHandleScrollEvent:event.get() completion:^(BOOL handled) {
+        [webView scrollView:[webView scrollView] handleScrollEvent:event.get() completion:^(BOOL handled) {
             wasHandled = handled;
             done = true;
         }];


### PR DESCRIPTION
#### 2699f14fcf782b29a5906b9ba8e4059d5503718a
<pre>
Adopt alternatives for scroll view SPI: -_scrollView:asynchronouslyHandleScrollEvent:completion:
<a href="https://bugs.webkit.org/show_bug.cgi?id=265732">https://bugs.webkit.org/show_bug.cgi?id=265732</a>
<a href="https://rdar.apple.com/114330492">rdar://114330492</a>

Reviewed by Richard Robinson.

Refactor support for handling async wheel events in WebKit, when scrolling via trackpad on iPadOS.
In place of these private scroll view delegate methods, we now have subclassing hooks on
`UIScrollView` that provide equivalent functionality.

To achieve this, we add async scroll event support to a common base class between `WKScrollView` and
`WKChildScrollView`. We rename this base class (currently, `WKAxisLockingScrollView`) into
`WKBaseScrollView` to reflect its new responsibility, and implement the new async scroll event
methods on `WKScrollingNodeScrollViewDelegate` and `WKWebView`.

For the legacy private delegate methods, we conditionalize their implementations on a new compile-
time flag (if `UISCROLLVIEW_ASYNCHRONOUS_SCROLL_EVENT_SUBCLASS_HOOKS` is off), and call through to
the new `WKBaseScrollViewDelegate` method.

* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _setupScrollAndContentViews]):

Move the `-_setAllowsAsyncScrollEvent:` call into `WKBaseScrollView`, only when the
`UISCROLLVIEW_ASYNCHRONOUS_SCROLL_EVENT_SUBCLASS_HOOKS` flag isn&apos;t set.

(-[WKWebView scrollViewWillEndDragging:withVelocity:targetContentOffset:]):
(-[WKWebView _scrollView:asynchronouslyHandleScrollEvent:completion:]):

Implement these legacy methods only when `UISCROLLVIEW_ASYNCHRONOUS_SCROLL_EVENT_SUBCLASS_HOOKS` is
not set.

(-[WKWebView scrollView:handleScrollEvent:completion:]):

Implement the new `WKBaseScrollView` delegate method for handling async scroll events.

(-[WKWebView axesToPreventScrollingForPanGestureInScrollView:]):
* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm:
(-[WKChildScrollView initWithFrame:]):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeFrameScrollingNodeRemoteIOS.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeFrameScrollingNodeRemoteIOS.mm:
(WebKit::ScrollingTreeFrameScrollingNodeRemoteIOS::scrollView const):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeOverflowScrollingNodeIOS.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeOverflowScrollingNodeIOS.mm:
(WebKit::ScrollingTreeOverflowScrollingNodeIOS::scrollView const):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreePluginScrollingNodeIOS.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreePluginScrollingNodeIOS.mm:
(WebKit::ScrollingTreePluginScrollingNodeIOS::scrollView const):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm:
(-[WKScrollingNodeScrollViewDelegate scrollViewWillEndDragging:withVelocity:targetContentOffset:]):
(-[WKScrollingNodeScrollViewDelegate axesToPreventScrollingForPanGestureInScrollView:]):
(-[WKScrollingNodeScrollViewDelegate _scrollView:asynchronouslyHandleScrollEvent:completion:]):
(-[WKScrollingNodeScrollViewDelegate scrollView:handleScrollEvent:completion:]):
(WebKit::ScrollingTreeScrollingNodeDelegateIOS::commitStateAfterChildren):
(WebKit::ScrollingTreeScrollingNodeDelegateIOS::handleAsynchronousCancelableScrollEvent):
(WebKit::ScrollingTreeScrollingNodeDelegateIOS::scrollView const):
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::handleAsynchronousCancelableScrollEvent):
* Source/WebKit/UIProcess/ios/WKBaseScrollView.h: Renamed from Source/WebKit/UIProcess/ios/WKAxisLockingScrollView.h.
* Source/WebKit/UIProcess/ios/WKBaseScrollView.mm: Renamed from Source/WebKit/UIProcess/ios/WKAxisLockingScrollView.mm.
(-[WKBaseScrollView initWithFrame:]):
(-[WKBaseScrollView addGestureRecognizer:]):
(-[WKBaseScrollView removeGestureRecognizer:]):
(-[WKBaseScrollView _updatePanGestureToPreventScrolling]):
(-[WKBaseScrollView _axesToPreventScrollingFromDelegate]):

Drive-by fix: fall back to `UIAxisNeither` instead of `UIAxisBoth` if the delegate is unset. Note
that this shouldn&apos;t actually change behavior in practice, since the delegate is always set for the
subclasses.

(-[WKBaseScrollView _subclassHandlesAsyncScrollEvent]):
(-[WKBaseScrollView _asynchronouslyHandleScrollEvent:completion:]):
(-[WKBaseScrollView gestureRecognizer:shouldRecognizeSimultaneouslyWithGestureRecognizer:]):
(-[WKBaseScrollView gestureRecognizerShouldBegin:]):
* Source/WebKit/UIProcess/ios/WKScrollView.mm:
(-[WKScrollView initWithFrame:]):
* Source/WebKit/UIProcess/ios/WKVelocityTrackingScrollView.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestRunnerShared/spi/UIKitSPIForTesting.h:
* Tools/TestWebKitAPI/Tests/ios/WKScrollViewTests.mm:

Canonical link: <a href="https://commits.webkit.org/271491@main">https://commits.webkit.org/271491@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6bb0036753f8211a7b46a44354ad3f91cfd17d7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28550 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7194 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29938 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31078 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26002 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29048 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9306 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4563 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28820 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5949 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24565 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5197 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5325 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25565 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31908 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26149 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26008 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/31589 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5289 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3456 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29361 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6892 "Built successfully") | | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6837 "'git push ...'") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5748 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5808 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->