### PR TITLE
Deploy more smart pointers in WebInspectorInterruptDispatcher.cpp

### DIFF
--- a/Source/WebKit/WebProcess/Inspector/WebInspectorInterruptDispatcher.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorInterruptDispatcher.cpp
@@ -56,8 +56,8 @@ void WebInspectorInterruptDispatcher::notifyNeedDebuggerBreak()
     if (!WebCore::commonVMOrNull())
         return;
 
-    JSC::VM& vm = WebCore::commonVM();
-    vm.notifyNeedDebuggerBreak();
+    Ref vm = WebCore::commonVM();
+    vm->notifyNeedDebuggerBreak();
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### b56c49e49d120afe484b4826825a1c1defdfad5b
<pre>
Deploy more smart pointers in WebInspectorInterruptDispatcher.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=265741">https://bugs.webkit.org/show_bug.cgi?id=265741</a>
<a href="https://rdar.apple.com/119084025">rdar://119084025</a>

Reviewed by Chris Dumez.

* Source/WebKit/WebProcess/Inspector/WebInspectorInterruptDispatcher.cpp:
(WebKit::WebInspectorInterruptDispatcher::notifyNeedDebuggerBreak):

Canonical link: <a href="https://commits.webkit.org/271452@main">https://commits.webkit.org/271452@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b87469816d725c56f23afd20fd58eb2d4c7aea61

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28410 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7055 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29796 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30937 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25868 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9150 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4424 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28679 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5816 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24442 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5088 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5194 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31623 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26017 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25883 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31488 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5156 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3333 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29250 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6755 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6816 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5612 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5676 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->