### PR TITLE
Enhance genericTypedArrayViewProtoFuncSortImpl to also handle an OutOfMemory case.

### DIFF
--- a/JSTests/stress/typedarray-sort-out-of-memory.js
+++ b/JSTests/stress/typedarray-sort-out-of-memory.js
@@ -1,0 +1,26 @@
+//@ skip if $memoryLimited
+
+let ar = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 1073741824));
+
+// No comparator version.
+var exception;
+try {
+    ar.sort();
+} catch (e) {
+    exception = e;
+}
+
+if (exception != "RangeError: Out of memory")
+    throw "FAILED: " + exception;
+
+// With comparator version.
+exception = undefined;
+try {
+    ar.sort((x, y) => { return x > y });
+} catch (e) {
+    exception = e;
+}
+
+if (exception != "RangeError: Out of memory")
+    throw "FAILED: " + exception;
+

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayView.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayView.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -120,7 +120,8 @@ public:
     static inline ElementType toAdaptorNativeFromValue(JSGlobalObject*, JSValue);
     static inline std::optional<ElementType> toAdaptorNativeFromValueWithoutCoercion(JSValue);
 
-    inline bool sort();
+    enum class SortResult { Success, OutOfMemory, Failed };
+    inline SortResult sort();
 
     inline bool canAccessRangeQuickly(size_t offset, size_t length);
     

--- a/Source/WTF/wtf/Vector.h
+++ b/Source/WTF/wtf/Vector.h
@@ -847,7 +847,8 @@ public:
     template<typename U> bool appendIfNotContains(const U&);
 
     void shrink(size_t size);
-    void grow(size_t size);
+    ALWAYS_INLINE void grow(size_t size) { growImpl<FailureAction::Crash>(size); }
+    ALWAYS_INLINE bool tryGrow(size_t size) { return growImpl<FailureAction::Report>(size); }
     void resize(size_t size);
     void resizeToFit(size_t size);
     ALWAYS_INLINE void reserveCapacity(size_t newCapacity) { reserveCapacity<FailureAction::Crash>(newCapacity); }
@@ -943,6 +944,7 @@ public:
     template<typename U> bool unsafeAppendWithoutCapacityCheck(const U*, size_t);
 
 private:
+    template<FailureAction> bool growImpl(size_t);
     template<FailureAction> bool reserveCapacity(size_t newCapacity);
     template<FailureAction> bool reserveInitialCapacity(size_t initialCapacity);
     template<FailureAction> bool growCapacityBy(size_t increment);
@@ -1280,15 +1282,22 @@ void Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::shrink(siz
 }
 
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
-void Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::grow(size_t size)
+template<FailureAction failureAction>
+bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::growImpl(size_t size)
 {
     ASSERT_WITH_SECURITY_IMPLICATION(size >= m_size);
-    if (size > capacity())
-        expandCapacity<FailureAction::Crash>(size);
+    if (size > capacity()) {
+        bool success = expandCapacity<failureAction>(size);
+        if constexpr (failureAction == FailureAction::Report) {
+            if (UNLIKELY(!success))
+                return false;
+        }
+    }
     asanBufferSizeWillChangeTo(size);
     if (begin())
         TypeOperations::initializeIfNonPOD(end(), begin() + size);
     m_size = size;
+    return true;
 }
 
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>


### PR DESCRIPTION
#### 7dcd9cb1553ae285bbac270e2ddfd93c55988595
<pre>
Enhance genericTypedArrayViewProtoFuncSortImpl to also handle an OutOfMemory case.
<a href="https://bugs.webkit.org/show_bug.cgi?id=265743">https://bugs.webkit.org/show_bug.cgi?id=265743</a>
<a href="https://rdar.apple.com/119042412">rdar://119042412</a>

Reviewed by Yusuke Suzuki.

1. Add a Vector::tryGrow implementation.
2. Make JSGenericTypedArrayView&lt;Adaptor&gt;::sort return a SortResult.
3. Make clients of sort also check for the OutOfMemory error case, and throw an
   OutOfMemoryError.

* JSTests/stress/typedarray-sort-out-of-memory.js: Added.
(catch):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayView.h:
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h:
(JSC::JSGenericTypedArrayView&lt;Adaptor&gt;::sort):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h:
(JSC::genericTypedArrayViewProtoFuncSortImpl):
* Source/WTF/wtf/Vector.h:
(WTF::Vector::grow):
(WTF::Vector::tryGrow):
(WTF::Malloc&gt;::growImpl):
(WTF::Malloc&gt;::grow): Deleted.

Canonical link: <a href="https://commits.webkit.org/271457@main">https://commits.webkit.org/271457@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37a48d3be5b5d13f5d42239f134f49b3f994f7ca

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28454 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7099 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29840 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30981 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25909 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9198 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4468 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28723 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5860 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24483 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5128 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5240 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25484 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31667 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/24618 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26061 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25925 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31525 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/27548 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5196 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3377 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29291 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/replaced-objects (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6797 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/35072 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5653 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7581 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3670 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5716 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->