### PR TITLE
Remove RenderProgress's m_animationDuration

### DIFF
--- a/Source/WebCore/rendering/RenderProgress.cpp
+++ b/Source/WebCore/rendering/RenderProgress.cpp
@@ -69,8 +69,9 @@ RenderBox::LogicalExtentComputedValues RenderProgress::computeLogicalHeight(Layo
 
 double RenderProgress::animationProgress() const
 {
-    ASSERT(m_animationDuration > 0_s);
-    return m_animating ? (fmod((MonotonicTime::now() - m_animationStartTime).seconds(), m_animationDuration.seconds()) / m_animationDuration.seconds()) : 0;
+    auto duration = theme().animationDurationForProgressBar();
+    ASSERT(duration > 0_s);
+    return m_animating ? (fmod((MonotonicTime::now() - m_animationStartTime).seconds(), duration.seconds()) / duration.seconds()) : 0;
 }
 
 bool RenderProgress::isDeterminate() const
@@ -92,7 +93,6 @@ void RenderProgress::animationTimerFired()
 
 void RenderProgress::updateAnimationState()
 {
-    m_animationDuration = theme().animationDurationForProgressBar();
     auto repeatInterval = theme().animationRepeatIntervalForProgressBar(*this);
 
     bool animating = style().hasEffectiveAppearance() && repeatInterval > 0_s && !isDeterminate();

--- a/Source/WebCore/rendering/RenderProgress.h
+++ b/Source/WebCore/rendering/RenderProgress.h
@@ -50,7 +50,6 @@ private:
 
     double m_position;
     MonotonicTime m_animationStartTime;
-    Seconds m_animationDuration { 0_s };
     bool m_animating { false };
     Timer m_animationTimer;
 };


### PR DESCRIPTION
#### b4b36d9965664540c6dddf3e8cd02499f9abb049
<pre>
Remove RenderProgress&apos;s m_animationDuration
<a href="https://bugs.webkit.org/show_bug.cgi?id=265744">https://bugs.webkit.org/show_bug.cgi?id=265744</a>

Reviewed by Aditya Keerthi.

This way only consumers of animationProgress() (a single theme) pay the
cost.

In an equivalent case for &lt;input type=checkbox switch&gt; we also decided
that caching RenderTheme calls was not needed.

* Source/WebCore/rendering/RenderProgress.cpp:
(WebCore::RenderProgress::animationProgress const):
(WebCore::RenderProgress::updateAnimationState):
* Source/WebCore/rendering/RenderProgress.h:

Canonical link: <a href="https://commits.webkit.org/271438@main">https://commits.webkit.org/271438@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fad7a35c1f978907b54295622b51c9c3457521f6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28415 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7060 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29801 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30942 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25873 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28912 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9158 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4429 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28684 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5824 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24447 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5093 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5202 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25448 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31628 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26025 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25889 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31492 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5161 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3338 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29254 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6760 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5617 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3663 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5681 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->