### PR TITLE
Remove ServerTimingEnabled preference

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -5766,19 +5766,6 @@ SerifFontFamily:
     WebCore:
       default: '""'
 
-ServerTimingEnabled:
-  type: bool
-  status: stable
-  category: networking
-  humanReadableName: "Server Timing"
-  humanReadableDescription: "Enable Server Timing API"
-  webcoreBinding: DeprecatedGlobalSettings
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-
 ServiceControlsEnabled:
   type: bool
   status: embedder

--- a/Source/WebCore/loader/ResourceTiming.cpp
+++ b/Source/WebCore/loader/ResourceTiming.cpp
@@ -27,7 +27,6 @@
 #include "ResourceTiming.h"
 
 #include "CachedResource.h"
-#include "DeprecatedGlobalSettings.h"
 #include "DocumentLoadTiming.h"
 #include "OriginAccessPatterns.h"
 #include "PerformanceServerTiming.h"
@@ -75,9 +74,6 @@ Vector<Ref<PerformanceServerTiming>> ResourceTiming::populateServerTiming() cons
 {
     // To increase privacy, this additional check was proposed at https://github.com/w3c/resource-timing/issues/342 .
     if (!m_isSameOriginRequest)
-        return { };
-
-    if (!DeprecatedGlobalSettings::serverTimingEnabled())
         return { };
 
     return WTF::map(m_serverTiming, [] (auto& entry) {

--- a/Source/WebCore/page/DeprecatedGlobalSettings.h
+++ b/Source/WebCore/page/DeprecatedGlobalSettings.h
@@ -86,9 +86,6 @@ public:
     static void setRestrictedHTTPResponseAccess(bool isEnabled) { shared().m_isRestrictedHTTPResponseAccess = isEnabled; }
     static bool restrictedHTTPResponseAccess() { return shared().m_isRestrictedHTTPResponseAccess; }
 
-    static void setServerTimingEnabled(bool isEnabled) { shared().m_isServerTimingEnabled = isEnabled; }
-    static bool serverTimingEnabled() { return shared().m_isServerTimingEnabled; }
-
     static void setAttrStyleEnabled(bool isEnabled) { shared().m_attrStyleEnabled = isEnabled; }
     static bool attrStyleEnabled() { return shared().m_attrStyleEnabled; }
 
@@ -189,7 +186,6 @@ private:
 
     bool m_isCustomPasteboardDataEnabled { false };
     bool m_isRestrictedHTTPResponseAccess { true };
-    bool m_isServerTimingEnabled { false };
     bool m_attrStyleEnabled { false };
     bool m_webSQLEnabled { false };
 

--- a/Source/WebCore/page/PerformanceResourceTiming.idl
+++ b/Source/WebCore/page/PerformanceResourceTiming.idl
@@ -55,7 +55,7 @@ typedef double DOMHighResTimeStamp;
     readonly attribute unsigned long long decodedBodySize;
 
     // https://www.w3.org/TR/server-timing/#extension-to-the-performanceresourcetiming-interface
-    [EnabledByDeprecatedGlobalSetting=ServerTimingEnabled] readonly attribute FrozenArray<PerformanceServerTiming> serverTiming;
+    readonly attribute FrozenArray<PerformanceServerTiming> serverTiming;
 
     [Default] object toJSON();
 };

--- a/Source/WebCore/page/PerformanceServerTiming.idl
+++ b/Source/WebCore/page/PerformanceServerTiming.idl
@@ -30,7 +30,6 @@ typedef double DOMHighResTimeStamp;
 
 [
     Exposed=*,
-    EnabledByDeprecatedGlobalSetting=ServerTimingEnabled
 ] interface PerformanceServerTiming {
     readonly attribute DOMString name;
     readonly attribute DOMHighResTimeStamp duration;

--- a/Source/WebKit/UIProcess/API/C/WKPreferences.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPreferences.cpp
@@ -1718,16 +1718,6 @@ bool WKPreferencesGetRestrictedHTTPResponseAccess(WKPreferencesRef preferencesRe
     return toImpl(preferencesRef)->restrictedHTTPResponseAccess();
 }
 
-void WKPreferencesSetServerTimingEnabled(WKPreferencesRef preferencesRef, bool flag)
-{
-    toImpl(preferencesRef)->setServerTimingEnabled(flag);
-}
-
-bool WKPreferencesGetServerTimingEnabled(WKPreferencesRef preferencesRef)
-{
-    return toImpl(preferencesRef)->serverTimingEnabled();
-}
-
 void WKPreferencesSetColorFilterEnabled(WKPreferencesRef preferencesRef, bool flag)
 {
     toImpl(preferencesRef)->setColorFilterEnabled(flag);
@@ -2089,6 +2079,15 @@ void WKPreferencesSetReferrerPolicyAttributeEnabled(WKPreferencesRef preferences
 }
 
 bool WKPreferencesGetReferrerPolicyAttributeEnabled(WKPreferencesRef preferencesRef)
+{
+    return true;
+}
+
+void WKPreferencesSetServerTimingEnabled(WKPreferencesRef preferencesRef, bool flag)
+{
+}
+
+bool WKPreferencesGetServerTimingEnabled(WKPreferencesRef preferencesRef)
 {
     return true;
 }

--- a/Source/WebKit/UIProcess/API/C/WKPreferencesRefPrivate.h
+++ b/Source/WebKit/UIProcess/API/C/WKPreferencesRefPrivate.h
@@ -481,10 +481,6 @@ WK_EXPORT void WKPreferencesSetShouldAllowUserInstalledFonts(WKPreferencesRef, b
 WK_EXPORT bool WKPreferencesGetShouldAllowUserInstalledFonts(WKPreferencesRef);
 
 // Defaults to false.
-WK_EXPORT void WKPreferencesSetServerTimingEnabled(WKPreferencesRef, bool flag);
-WK_EXPORT bool WKPreferencesGetServerTimingEnabled(WKPreferencesRef);
-
-// Defaults to false.
 WK_EXPORT void WKPreferencesSetColorFilterEnabled(WKPreferencesRef, bool flag);
 WK_EXPORT bool WKPreferencesGetColorFilterEnabled(WKPreferencesRef);
 
@@ -537,6 +533,8 @@ WK_EXPORT void WKPreferencesSetSyntheticEditingCommandsEnabled(WKPreferencesRef,
 WK_EXPORT bool WKPreferencesGetSyntheticEditingCommandsEnabled(WKPreferencesRef) WK_C_API_DEPRECATED;
 WK_EXPORT void WKPreferencesSetReferrerPolicyAttributeEnabled(WKPreferencesRef, bool flag) WK_C_API_DEPRECATED;
 WK_EXPORT bool WKPreferencesGetReferrerPolicyAttributeEnabled(WKPreferencesRef) WK_C_API_DEPRECATED;
+WK_EXPORT void WKPreferencesSetServerTimingEnabled(WKPreferencesRef, bool flag) WK_C_API_DEPRECATED;
+WK_EXPORT bool WKPreferencesGetServerTimingEnabled(WKPreferencesRef) WK_C_API_DEPRECATED;
 
 
 #ifdef __cplusplus

--- a/Source/WebKitLegacy/mac/WebView/WebPreferenceKeysPrivate.h
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferenceKeysPrivate.h
@@ -242,7 +242,6 @@
 #define WebKitWebAnimationsCompositeOperationsEnabledPreferenceKey @"WebKitWebAnimationsCompositeOperationsEnabled"
 #define WebKitWebAnimationsMutableTimelinesEnabledPreferenceKey @"WebKitWebAnimationsMutableTimelinesEnabled"
 #define WebKitMaskWebGLStringsEnabledPreferenceKey @"WebKitMaskWebGLStringsEnabled"
-#define WebKitServerTimingEnabledPreferenceKey @"WebKitServerTimingEnabled"
 #define WebKitCSSCustomPropertiesAndValuesEnabledPreferenceKey @"WebKitCSSCustomPropertiesAndValuesEnabled"
 #define WebKitPrivateClickMeasurementEnabledPreferenceKey @"WebKitPrivateClickMeasurementEnabled"
 #define WebKitGenericCueAPIEnabledKey @"WebKitGenericCueAPIEnabled"
@@ -275,3 +274,4 @@
 #define WebKitTransformStreamAPIEnabledPreferenceKey @"WebKitTransformStreamAPIEnabled"
 #define WebKitIntersectionObserverEnabledPreferenceKey @"WebKitIntersectionObserverEnabled"
 #define WebKitSyntheticEditingCommandsEnabledPreferenceKey @"WebKitSyntheticEditingCommandsEnabled"
+#define WebKitServerTimingEnabledPreferenceKey @"WebKitServerTimingEnabled"

--- a/Source/WebKitLegacy/mac/WebView/WebPreferences.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferences.mm
@@ -2946,16 +2946,6 @@ static RetainPtr<NSString>& classIBCreatorID()
     [self _setBoolValue:enabled forKey:WebKitMaskWebGLStringsEnabledPreferenceKey];
 }
 
-- (BOOL)serverTimingEnabled
-{
-    return [self _boolValueForKey:WebKitServerTimingEnabledPreferenceKey];
-}
-
-- (void)setServerTimingEnabled:(BOOL)flag
-{
-    [self _setBoolValue:flag forKey:WebKitServerTimingEnabledPreferenceKey];
-}
-
 - (BOOL)CSSCustomPropertiesAndValuesEnabled
 {
     return [self _boolValueForKey:WebKitCSSCustomPropertiesAndValuesEnabledPreferenceKey];
@@ -3336,6 +3326,15 @@ static RetainPtr<NSString>& classIBCreatorID()
 }
 
 - (void)setCSSIndividualTransformPropertiesEnabled:(BOOL)flag
+{
+}
+
+- (BOOL)serverTimingEnabled
+{
+    return YES;
+}
+
+- (void)setServerTimingEnabled:(BOOL)flag
 {
 }
 

--- a/Source/WebKitLegacy/mac/WebView/WebPreferencesPrivate.h
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferencesPrivate.h
@@ -307,7 +307,6 @@ extern NSString *WebPreferencesCacheModelChangedInternalNotification WEBKIT_DEPR
 @property (nonatomic) BOOL webAnimationsCompositeOperationsEnabled;
 @property (nonatomic) BOOL webAnimationsMutableTimelinesEnabled;
 @property (nonatomic) BOOL maskWebGLStringsEnabled;
-@property (nonatomic) BOOL serverTimingEnabled;
 @property (nonatomic) BOOL CSSCustomPropertiesAndValuesEnabled;
 @property (nonatomic) BOOL privateClickMeasurementEnabled;
 @property (nonatomic) BOOL genericCueAPIEnabled;
@@ -356,6 +355,7 @@ extern NSString *WebPreferencesCacheModelChangedInternalNotification WEBKIT_DEPR
 @property (nonatomic) BOOL transformStreamAPIEnabled;
 @property (nonatomic) BOOL lineHeightUnitsEnabled;
 @property (nonatomic) BOOL CSSIndividualTransformPropertiesEnabled;
+@property (nonatomic) BOOL serverTimingEnabled;
 
 - (void)setDiskImageCacheEnabled:(BOOL)enabled;
 


### PR DESCRIPTION
#### ea214e26778ceb84102fb5159cd896d6b35d5e40
<pre>
Remove ServerTimingEnabled preference
<a href="https://bugs.webkit.org/show_bug.cgi?id=265747">https://bugs.webkit.org/show_bug.cgi?id=265747</a>

Reviewed by Alex Christensen.

This was enabled by default over a year ago in 254940@main and we
already removed the preference that was enabled at the same time.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/loader/ResourceTiming.cpp:
(WebCore::ResourceTiming::populateServerTiming const):
* Source/WebCore/page/DeprecatedGlobalSettings.h:
(WebCore::DeprecatedGlobalSettings::setServerTimingEnabled): Deleted.
(WebCore::DeprecatedGlobalSettings::serverTimingEnabled): Deleted.
* Source/WebCore/page/PerformanceResourceTiming.idl:
* Source/WebCore/page/PerformanceServerTiming.idl:
* Source/WebKit/UIProcess/API/C/WKPreferences.cpp:
(WKPreferencesSetServerTimingEnabled):
(WKPreferencesGetServerTimingEnabled):
* Source/WebKit/UIProcess/API/C/WKPreferencesRefPrivate.h:
* Source/WebKitLegacy/mac/WebView/WebPreferenceKeysPrivate.h:
* Source/WebKitLegacy/mac/WebView/WebPreferences.mm:
(-[WebPreferences serverTimingEnabled]):
(-[WebPreferences setServerTimingEnabled:]):
* Source/WebKitLegacy/mac/WebView/WebPreferencesPrivate.h:

Canonical link: <a href="https://commits.webkit.org/271488@main">https://commits.webkit.org/271488@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eba4859fd23fdc9749dc0de114fbe2ccda3e2be4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28420 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7065 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29806 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31039 "Hash eba4859f for PR 21232 does not build (failure)") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25878 "Hash eba4859f for PR 21232 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28917 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9163 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4434 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/31039 "Hash eba4859f for PR 21232 does not build (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28689 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5828 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24452 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/31039 "Hash eba4859f for PR 21232 does not build (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5206 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25453 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31633 "Hash eba4859f for PR 21232 does not build (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/24584 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26029 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25894 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/31633 "Hash eba4859f for PR 21232 does not build (failure)") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/27514 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5166 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3342 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/31633 "Hash eba4859f for PR 21232 does not build (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6765 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/35038 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6835 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5622 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7577 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5686 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->