### PR TITLE
Remove DeprecatedGlobalSettings::shouldUseHighResolutionTimers()

### DIFF
--- a/Source/WebCore/page/DeprecatedGlobalSettings.cpp
+++ b/Source/WebCore/page/DeprecatedGlobalSettings.cpp
@@ -72,13 +72,6 @@ void DeprecatedGlobalSettings::setMediaSourceInlinePaintingEnabled(bool isEnable
 }
 #endif
 
-#if PLATFORM(WIN)
-void DeprecatedGlobalSettings::setShouldUseHighResolutionTimers(bool shouldUseHighResolutionTimers)
-{
-    shared().m_shouldUseHighResolutionTimers = shouldUseHighResolutionTimers;
-}
-#endif
-
 #if USE(AVFOUNDATION)
 void DeprecatedGlobalSettings::setAVFoundationEnabled(bool enabled)
 {

--- a/Source/WebCore/page/DeprecatedGlobalSettings.h
+++ b/Source/WebCore/page/DeprecatedGlobalSettings.h
@@ -33,11 +33,6 @@ namespace WebCore {
 
 class DeprecatedGlobalSettings {
 public:
-#if PLATFORM(WIN)
-    WEBCORE_EXPORT static void setShouldUseHighResolutionTimers(bool);
-    static bool shouldUseHighResolutionTimers() { return shared().m_shouldUseHighResolutionTimers; }
-#endif
-
 #if USE(AVFOUNDATION)
     WEBCORE_EXPORT static void setAVFoundationEnabled(bool);
     static bool isAVFoundationEnabled() { return shared().m_AVFoundationEnabled; }
@@ -184,9 +179,6 @@ private:
     bool m_mockScrollbarsEnabled { false };
     bool m_usesOverlayScrollbars { false };
 
-#if PLATFORM(WIN)
-    bool m_shouldUseHighResolutionTimers { true };
-#endif
 #if PLATFORM(IOS_FAMILY)
     bool m_networkDataUsageTrackingEnabled { false };
     String m_networkInterfaceName;

--- a/Source/WebCore/platform/win/MainThreadSharedTimerWin.cpp
+++ b/Source/WebCore/platform/win/MainThreadSharedTimerWin.cpp
@@ -133,35 +133,33 @@ void MainThreadSharedTimer::setFireInterval(Seconds intervalInSeconds)
     initializeOffScreenTimerWindow();
     bool timerSet = false;
 
-    if (DeprecatedGlobalSettings::shouldUseHighResolutionTimers()) {
-        if (interval < highResolutionThresholdMsec) {
-            if (!highResTimerActive) {
-                highResTimerActive = true;
-                timeBeginPeriod(timerResolution);
-            }
-            SetTimer(timerWindowHandle, endHighResTimerID, stopHighResTimerInMsec, 0);
+    if (interval < highResolutionThresholdMsec) {
+        if (!highResTimerActive) {
+            highResTimerActive = true;
+            timeBeginPeriod(timerResolution);
         }
+        SetTimer(timerWindowHandle, endHighResTimerID, stopHighResTimerInMsec, 0);
+    }
 
-        DWORD queueStatus = LOWORD(GetQueueStatus(QS_PAINT | QS_MOUSEBUTTON | QS_KEY | QS_RAWINPUT));
+    DWORD queueStatus = LOWORD(GetQueueStatus(QS_PAINT | QS_MOUSEBUTTON | QS_KEY | QS_RAWINPUT));
 
-        // Win32 has a tri-level queue with application messages > user input > WM_PAINT/WM_TIMER.
+    // Win32 has a tri-level queue with application messages > user input > WM_PAINT/WM_TIMER.
 
-        // If the queue doesn't contains input events, we use a higher priorty timer event posting mechanism.
-        if (!(queueStatus & (QS_MOUSEBUTTON | QS_KEY | QS_RAWINPUT))) {
-            if (intervalInMS < USER_TIMER_MINIMUM && !processingCustomTimerMessage && !(queueStatus & QS_PAINT)) {
-                // Call PostMessage immediately if the timer is already expired, unless a paint is pending.
-                // (we prioritize paints over timers)
-                if (InterlockedIncrement(&pendingTimers) == 1)
-                    PostMessage(timerWindowHandle, timerFiredMessage, 0, 0);
-                timerSet = true;
-            } else {
-                // Otherwise, delay the PostMessage via a CreateTimerQueueTimer
-                if (!timerQueue)
-                    timerQueue = CreateTimerQueue();
-                if (timer)
-                    DeleteTimerQueueTimer(timerQueue, timer, 0);
-                timerSet = CreateTimerQueueTimer(&timer, timerQueue, queueTimerProc, 0, intervalInMS, 0, WT_EXECUTEINTIMERTHREAD | WT_EXECUTEONLYONCE);
-            }
+    // If the queue doesn't contains input events, we use a higher priorty timer event posting mechanism.
+    if (!(queueStatus & (QS_MOUSEBUTTON | QS_KEY | QS_RAWINPUT))) {
+        if (intervalInMS < USER_TIMER_MINIMUM && !processingCustomTimerMessage && !(queueStatus & QS_PAINT)) {
+            // Call PostMessage immediately if the timer is already expired, unless a paint is pending.
+            // (we prioritize paints over timers)
+            if (InterlockedIncrement(&pendingTimers) == 1)
+                PostMessage(timerWindowHandle, timerFiredMessage, 0, 0);
+            timerSet = true;
+        } else {
+            // Otherwise, delay the PostMessage via a CreateTimerQueueTimer
+            if (!timerQueue)
+                timerQueue = CreateTimerQueue();
+            if (timer)
+                DeleteTimerQueueTimer(timerQueue, timer, 0);
+            timerSet = CreateTimerQueueTimer(&timer, timerQueue, queueTimerProc, 0, intervalInMS, 0, WT_EXECUTEINTIMERTHREAD | WT_EXECUTEONLYONCE);
         }
     }
 


### PR DESCRIPTION
#### 481ac16eb997d49e13611625e3c0ef2a8992ff22
<pre>
Remove DeprecatedGlobalSettings::shouldUseHighResolutionTimers()
<a href="https://bugs.webkit.org/show_bug.cgi?id=265748">https://bugs.webkit.org/show_bug.cgi?id=265748</a>

Reviewed by Don Olmstead.

This appears to be unused.

* Source/WebCore/page/DeprecatedGlobalSettings.cpp:
(WebCore::DeprecatedGlobalSettings::setShouldUseHighResolutionTimers): Deleted.
* Source/WebCore/page/DeprecatedGlobalSettings.h:
(WebCore::DeprecatedGlobalSettings::shouldUseHighResolutionTimers): Deleted.
* Source/WebCore/platform/win/MainThreadSharedTimerWin.cpp:
(WebCore::MainThreadSharedTimer::setFireInterval):

Canonical link: <a href="https://commits.webkit.org/271439@main">https://commits.webkit.org/271439@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2a549aae34d4e4a639508a20c1b5f0602e4ad26

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28419 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7064 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29805 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30946 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25877 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28916 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9162 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4433 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28688 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5827 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24451 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5096 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5205 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25452 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31632 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26028 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25893 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31496 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5165 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3341 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29259 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6764 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5621 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3664 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5685 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->