### PR TITLE
Stop sending 2 Close frames from client-close_wsh

### DIFF
--- a/LayoutTests/http/tests/websocket/tests/hybi/client-close_wsh.py
+++ b/LayoutTests/http/tests/websocket/tests/hybi/client-close_wsh.py
@@ -18,12 +18,5 @@ def web_socket_transfer_data(request):
     data = struct.pack('!H', 1000) + ('close_frame[:2]={}'.format(close_frame[:2]).replace("='", "=b'")).encode()
     request.connection.write(stream.create_close_frame(data))
 
-    # If the following assertion fails, AssertionError will be raised,
-    # which will prevent pywebsocket from sending a close frame.
-    # In this case, the client will fail to finish closing handshake, thus
-    # closeEvent.wasClean will become false.
-    assert close_frame[:2] == b'\x88\x80'
-
-    # Pretend we have received a close frame from the client.
-    # After this function exits, pywebsocket will send a close frame automatically.
-    request.client_terminated = True
+    # Tell pywebsocket we have sent a close frame to the client, so it can close the connection.
+    request.server_terminated = True

--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -1912,8 +1912,6 @@ webkit.org/b/215476 [ Release ] imported/w3c/web-platform-tests/css/css-grid/abs
 
 webkit.org/b/215476 [ Release ] imported/w3c/web-platform-tests/css/css-text/overflow-wrap/overflow-wrap-break-word-long-crash.html [ Pass Timeout ]
 
-webkit.org/b/215773 http/tests/websocket/tests/hybi/client-close-2.html [ Pass Failure ]
-
 webkit.org/b/227283 imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-inline-contribution-001.html [ ImageOnlyFailure ]
 webkit.org/b/227283 imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-inline-contribution-002.html [ ImageOnlyFailure ]
 

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2199,9 +2199,6 @@ webkit.org/b/223944 [ BigSur Debug ] imported/w3c/web-platform-tests/xhr/event-u
 
 webkit.org/b/223816 [ arm64 ] platform/mac/fast/objc/webScriptObject-hasWebScriptKey.html [ Failure ]
 
-# rdar://80343074 ([ Mac wk1 ] http/tests/websocket/tests/hybi/client-close-2.html [ Failure ])
-http/tests/websocket/tests/hybi/client-close-2.html [ Pass Failure ]
-
 # webkit.org/b/221300 Updating tests expectations for 3 tests
 [ Monterey+ ] imported/w3c/web-platform-tests/media-source/mediasource-config-change-webm-v-bitrate.html [ Skip ]
 [ Monterey+ ] imported/w3c/web-platform-tests/media-source/mediasource-config-change-webm-v-framerate.html [ Skip ]


### PR DESCRIPTION
#### d4b790b2d8a6cb9fc0f699752c4cc9407080655e
<pre>
Stop sending 2 Close frames from client-close_wsh

<a href="https://bugs.webkit.org/show_bug.cgi?id=265209">https://bugs.webkit.org/show_bug.cgi?id=265209</a>
<a href="https://rdar.apple.com/problem/118889240">rdar://problem/118889240</a>

Reviewed by Alexey Proskuryakov.

Merge: <a href="https://chromium.googlesource.com/chromium/blink/+/2138625fb49a80512464cf45fc1244015054c8de">https://chromium.googlesource.com/chromium/blink/+/2138625fb49a80512464cf45fc1244015054c8de</a>

client-close_wsh.py generates one Close frame directly, and then pywebsocket sends
another one. Tell pywebsocket that the Close frame has already been sent.

* LayoutTests/http/tests/websocket/tests/hybi/client-close_wsh.py:
* LayoutTests/platform/ios-wk2/TestExpectations: Remove Test-specific Expectation
* LayoutTests/platform/mac-wk1/TestExpectations: Ditto

Canonical link: <a href="https://commits.webkit.org/271447@main">https://commits.webkit.org/271447@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72a76d1d295514a592ac73bd6809f44aca9bc780

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28423 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7068 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29809 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30950 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25881 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9167 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4437 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28692 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5832 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24454 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5098 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5210 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25455 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31636 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26033 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25896 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31498 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5169 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3345 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29261 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6768 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6809 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5625 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5689 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->