### PR TITLE
[LBSE] Fix some masker issues

### DIFF
--- a/LayoutTests/svg/repaint/mask-object-bounding-box-expected.txt
+++ b/LayoutTests/svg/repaint/mask-object-bounding-box-expected.txt
@@ -1,1 +1,4 @@
+(repaint rects
+  (rect 25 25 50 50)
+)
 

--- a/LayoutTests/svg/repaint/mask-object-bounding-box-shrink-expected.txt
+++ b/LayoutTests/svg/repaint/mask-object-bounding-box-shrink-expected.txt
@@ -1,1 +1,4 @@
+(repaint rects
+  (rect 0 0 100 100)
+)
 

--- a/LayoutTests/svg/repaint/mask-object-bounding-box-shrink.html
+++ b/LayoutTests/svg/repaint/mask-object-bounding-box-shrink.html
@@ -6,7 +6,7 @@
 <body onload="runRepaintTest()">
 <svg style="position: absolute; top: 0px; left: 0px; width: 500px; height: 200px">
     <defs>
-      <mask id="mask" maskUnits="objectBoundingBox">
+      <mask id="mask" maskContentUnits="objectBoundingBox">
         <rect id="maskContent" x="0" y="0" width="1" height="1"></rect>
       </mask>
     </defs>

--- a/LayoutTests/svg/repaint/mask-object-bounding-box-transformed-expected.txt
+++ b/LayoutTests/svg/repaint/mask-object-bounding-box-transformed-expected.txt
@@ -1,1 +1,4 @@
+(repaint rects
+  (rect 25 25 50 50)
+)
 

--- a/LayoutTests/svg/repaint/mask-object-bounding-box-transformed.html
+++ b/LayoutTests/svg/repaint/mask-object-bounding-box-transformed.html
@@ -6,7 +6,7 @@
 <body onload="runRepaintTest()">
 <svg style="position: absolute; top: 0px; left: 0px; width: 500px; height: 200px">
     <defs>
-      <mask id="mask" maskUnits="objectBoundingBox">
+      <mask id="mask" maskContentUnits="objectBoundingBox">
         <rect id="maskContent" x="0.25" y="0.25" width=".5" height=".5"></rect>
       </mask>
     </defs>

--- a/LayoutTests/svg/repaint/mask-object-bounding-box.html
+++ b/LayoutTests/svg/repaint/mask-object-bounding-box.html
@@ -6,7 +6,7 @@
 <body onload="runRepaintTest()">
 <svg style="position: absolute; top: 0px; left: 0px; width: 500px; height: 200px">
     <defs>
-      <mask id="mask" maskUnits="objectBoundingBox">
+      <mask id="mask" maskContentUnits="objectBoundingBox">
         <rect id="maskContent" x="0.25" y="0.25" width=".5" height=".5"></rect>
       </mask>
     </defs>

--- a/LayoutTests/svg/repaint/mask-user-space-on-use-expected.txt
+++ b/LayoutTests/svg/repaint/mask-user-space-on-use-expected.txt
@@ -1,1 +1,4 @@
+(repaint rects
+  (rect 25 25 50 50)
+)
 

--- a/LayoutTests/svg/repaint/mask-user-space-on-use-transformed-expected.txt
+++ b/LayoutTests/svg/repaint/mask-user-space-on-use-transformed-expected.txt
@@ -1,1 +1,4 @@
+(repaint rects
+  (rect 25 25 50 50)
+)
 

--- a/Source/WebCore/rendering/ReferencedSVGResources.h
+++ b/Source/WebCore/rendering/ReferencedSVGResources.h
@@ -57,7 +57,7 @@ public:
     ReferencedSVGResources(RenderElement&);
     ~ReferencedSVGResources();
 
-    static Vector<std::pair<AtomString, QualifiedName>> referencedSVGResourceIDs(const RenderStyle&);
+    static Vector<std::pair<AtomString, QualifiedName>> referencedSVGResourceIDs(const RenderStyle&, const Document&);
     void updateReferencedResources(TreeScope&, const Vector<std::pair<AtomString, QualifiedName>>&);
 
     // Legacy: Clipping needs a renderer, filters use an element.

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -2122,7 +2122,7 @@ void RenderElement::clearReferencedSVGResources()
 // This needs to run when the entire render tree has been constructed, so can't be called from styleDidChange.
 void RenderElement::updateReferencedSVGResources()
 {
-    auto referencedElementIDs = ReferencedSVGResources::referencedSVGResourceIDs(style());
+    auto referencedElementIDs = ReferencedSVGResources::referencedSVGResourceIDs(style(), document());
     if (!referencedElementIDs.isEmpty())
         ensureReferencedSVGResources().updateReferencedResources(treeScopeForSVGReferences(), referencedElementIDs);
     else


### PR DESCRIPTION
#### 1e7aa8e2316ac92eb922cc9dbe5c283be9538979
<pre>
[LBSE] Fix some masker issues
<a href="https://bugs.webkit.org/show_bug.cgi?id=265755">https://bugs.webkit.org/show_bug.cgi?id=265755</a>

Reviewed by Nikolas Zimmermann.

Clients of masks were not properly added in ReferencedSVGResources::referencedSVGResourceIDs, add logic for that, now
repaint rect results for the mask-object-bounding-box* tests are more as expected than before.
Also the mask-object-bounding-box* tests used the wrong unit attribute, to be consistent with the equivalent
clip-path tests &apos;maskContentUnits&apos; should be used. Finally, some more tests pass now, so update TestExpectations.

* LayoutTests/platform/mac-sonoma-wk2-lbse-text/TestExpectations:
* LayoutTests/svg/repaint/mask-object-bounding-box-expected.txt:
* LayoutTests/svg/repaint/mask-object-bounding-box-shrink-expected.txt:
* LayoutTests/svg/repaint/mask-object-bounding-box-shrink.html:
* LayoutTests/svg/repaint/mask-object-bounding-box-transformed-expected.txt:
* LayoutTests/svg/repaint/mask-object-bounding-box-transformed.html:
* LayoutTests/svg/repaint/mask-object-bounding-box.html:
* LayoutTests/svg/repaint/mask-user-space-on-use-expected.txt:
* LayoutTests/svg/repaint/mask-user-space-on-use-transformed-expected.txt:
* Source/WebCore/rendering/ReferencedSVGResources.cpp:
(WebCore::ReferencedSVGResources::referencedSVGResourceIDs):
* Source/WebCore/rendering/ReferencedSVGResources.h:
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::updateReferencedSVGResources):

Canonical link: <a href="https://commits.webkit.org/271631@main">https://commits.webkit.org/271631@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7ec60bcb2ef9dbdc39be4826718c7a9c72c143d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29089 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7759 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30429 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31691 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/26480 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29685 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9884 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/5065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29361 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/6411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/24939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5561 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/5687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/25967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33029 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/26567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/26404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/31933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/5666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/5065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/29717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/7330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/25763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6937 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/6169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/6187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->