### PR TITLE
[UnifiedPDF] Implement pinch-zooming (macOS)

### DIFF
--- a/Source/WebKit/UIProcess/ViewGestureController.cpp
+++ b/Source/WebKit/UIProcess/ViewGestureController.cpp
@@ -679,6 +679,10 @@ void ViewGestureController::didCollectGeometryForMagnificationGesture(FloatRect 
     m_visibleContentRect = visibleContentRect;
     m_visibleContentRectIsValid = true;
     m_frameHandlesMagnificationGesture = frameHandlesMagnificationGesture;
+
+#if PLATFORM(MAC)
+    m_webPageProxy.didBeginMagnificationGesture();
+#endif
 }
 
 void ViewGestureController::prepareMagnificationGesture(FloatPoint origin)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -11346,8 +11346,17 @@ void WebPageProxy::setFooterBannerHeight(int height)
     send(Messages::WebPage::SetFooterBannerHeight(height));
 }
 
+void WebPageProxy::didBeginMagnificationGesture()
+{
+    if (!hasRunningProcess())
+        return;
+    send(Messages::WebPage::DidBeginMagnificationGesture());
+}
+
 void WebPageProxy::didEndMagnificationGesture()
 {
+    if (!hasRunningProcess())
+        return;
     send(Messages::WebPage::DidEndMagnificationGesture());
 }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1733,6 +1733,7 @@ public:
     void setHeaderBannerHeight(int);
     void setFooterBannerHeight(int);
 
+    void didBeginMagnificationGesture();
     void didEndMagnificationGesture();
 #endif
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
@@ -175,7 +175,9 @@ private:
     WebCore::FloatSize pdfDocumentSizeForPrinting() const override;
 
     void geometryDidChange(const WebCore::IntSize& pluginSize, const WebCore::AffineTransform& pluginToRootViewTransform) override;
-    void contentsScaleFactorChanged(float) override;
+    void deviceScaleFactorChanged(float) override;
+
+    void setPageScaleFactor(double, std::optional<WebCore::IntPoint> origin) override;
 
     WebCore::IntSize contentsSize() const override;
     unsigned firstPageHeight() const override;
@@ -217,7 +219,6 @@ private:
 
     bool supportsForms();
 
-    bool handlesPageScaleFactor() const;
     void updatePageAndDeviceScaleFactors();
 
     void createPasswordEntryForm();

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -105,7 +105,12 @@ public:
 
     virtual void geometryDidChange(const WebCore::IntSize& pluginSize, const WebCore::AffineTransform& pluginToRootViewTransform);
     virtual void visibilityDidChange(bool);
-    virtual void contentsScaleFactorChanged(float) { }
+    virtual void deviceScaleFactorChanged(float) { }
+
+    bool handlesPageScaleFactor() const;
+    virtual void didBeginMagnificationGesture() { }
+    virtual void didEndMagnificationGesture() { }
+    virtual void setPageScaleFactor(double, std::optional<WebCore::IntPoint> origin) = 0;
 
     void updateControlTints(WebCore::GraphicsContext&);
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -150,6 +150,11 @@ bool PDFPluginBase::isFullFramePlugin() const
     return downcast<PluginDocument>(*document).pluginWidget() == m_view;
 }
 
+bool PDFPluginBase::handlesPageScaleFactor() const
+{
+    return m_frame && m_frame->isMainFrame() && isFullFramePlugin();
+}
+
 bool PDFPluginBase::isLocked() const
 {
     return [m_pdfDocument isLocked];

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -68,6 +68,11 @@ private:
 
     CGFloat scaleFactor() const override;
 
+    void didBeginMagnificationGesture() override;
+    void didEndMagnificationGesture() override;
+    void setPageScaleFactor(double scale, std::optional<WebCore::IntPoint> origin) final;
+
+    WebCore::IntSize documentSize() const;
     WebCore::IntSize contentsSize() const override;
     unsigned firstPageHeight() const override;
 
@@ -118,6 +123,7 @@ private:
     void notifyFlushRequired(const GraphicsLayer*) override;
     void paintContents(const WebCore::GraphicsLayer*, WebCore::GraphicsContext&, const WebCore::FloatRect&, OptionSet<WebCore::GraphicsLayerPaintBehavior>) override;
     float deviceScaleFactor() const override;
+    float pageScaleFactor() const override;
 
     void updateLayerHierarchy();
 
@@ -153,6 +159,9 @@ private:
     RefPtr<WebCore::GraphicsLayer> m_contentsLayer;
 
     WebCore::ScrollingNodeID m_scrollingNodeID { 0 };
+
+    float m_scaleFactor { 1 };
+    bool m_inMagnificationGesture { false };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -309,22 +309,37 @@ void PluginView::manualLoadDidFail()
     m_plugin->streamDidFail();
 }
 
-void PluginView::pageScaleFactorDidChange()
-{
-    viewGeometryDidChange();
-}
-
 void PluginView::topContentInsetDidChange()
 {
     viewGeometryDidChange();
 }
 
-void PluginView::setPageScaleFactor(double scaleFactor)
+void PluginView::didBeginMagnificationGesture()
+{
+    if (!m_isInitialized)
+        return;
+
+    m_plugin->didBeginMagnificationGesture();
+}
+
+void PluginView::didEndMagnificationGesture()
+{
+    if (!m_isInitialized)
+        return;
+
+    m_plugin->didEndMagnificationGesture();
+}
+
+void PluginView::setPageScaleFactor(double scaleFactor, std::optional<IntPoint> origin)
 {
     m_pageScaleFactor = scaleFactor;
     m_webPage->send(Messages::WebPageProxy::PluginScaleFactorDidChange(scaleFactor));
     m_webPage->send(Messages::WebPageProxy::PluginZoomFactorDidChange(scaleFactor));
-    pageScaleFactorDidChange();
+
+    if (!m_isInitialized)
+        return;
+
+    m_plugin->setPageScaleFactor(scaleFactor, origin);
 }
 
 double PluginView::pageScaleFactor() const
@@ -344,7 +359,7 @@ void PluginView::setDeviceScaleFactor(float scaleFactor)
     if (!m_isInitialized)
         return;
 
-    m_plugin->contentsScaleFactorChanged(scaleFactor);
+    m_plugin->deviceScaleFactorChanged(scaleFactor);
 }
 
 id PluginView::accessibilityAssociatedPluginParentForElement(Element* element) const

--- a/Source/WebKit/WebProcess/Plugins/PluginView.h
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.h
@@ -77,10 +77,11 @@ public:
     WebCore::HTMLPlugInElement& pluginElement() const { return m_pluginElement; }
     const URL& mainResourceURL() const { return m_mainResourceURL; }
 
-    void setPageScaleFactor(double);
+    void didBeginMagnificationGesture();
+    void didEndMagnificationGesture();
+    void setPageScaleFactor(double, std::optional<WebCore::IntPoint> origin);
     double pageScaleFactor() const;
 
-    void pageScaleFactorDidChange();
     void topContentInsetDidChange();
 
     void webPageDestroyed();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -753,6 +753,7 @@ public:
     void setUseFormSemanticContext(bool);
     void semanticContextDidChange(bool);
 
+    void didBeginMagnificationGesture();
     void didEndMagnificationGesture();
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -567,6 +567,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
     SetHeaderBannerHeight(int height)
     SetFooterBannerHeight(int height)
 
+    DidBeginMagnificationGesture()
     DidEndMagnificationGesture()
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -1062,11 +1062,25 @@ void WebPage::playbackTargetPickerWasDismissed(PlaybackTargetClientContextIdenti
 }
 #endif
 
+void WebPage::didBeginMagnificationGesture()
+{
+#if ENABLE(PDF_PLUGIN)
+    if (auto* pluginView = mainFramePlugIn()) {
+        pluginView->didBeginMagnificationGesture();
+        return;
+    }
+#endif
+}
+
 void WebPage::didEndMagnificationGesture()
 {
 #if ENABLE(MAC_GESTURE_EVENTS)
     if (RefPtr localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame()))
         localMainFrame->eventHandler().didEndMagnificationGesture();
+#endif
+#if ENABLE(PDF_PLUGIN)
+    if (auto* pluginView = mainFramePlugIn())
+        pluginView->didEndMagnificationGesture();
 #endif
 }
 


### PR DESCRIPTION
#### 1d980c4592b05f24494e5fd86640b4289f2e01e5
<pre>
[UnifiedPDF] Implement pinch-zooming (macOS)
<a href="https://bugs.webkit.org/show_bug.cgi?id=265760">https://bugs.webkit.org/show_bug.cgi?id=265760</a>
&lt;<a href="https://rdar.apple.com/problem/114832109">rdar://problem/114832109</a>&gt;

Reviewed by Simon Fraser.

Implement pinch zooming (not HUD zooming or etc.) for the UnifiedPDFPlugin for macOS.

* Source/WebKit/UIProcess/ViewGestureController.cpp:
(WebKit::ViewGestureController::didCollectGeometryForMagnificationGesture):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didBeginMagnificationGesture):
(WebKit::WebPageProxy::didEndMagnificationGesture):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
Let the WebContent process know when we start a gesture (we already send the matching &quot;end&quot;).

* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(WebKit::PDFPlugin::installPDFDocument):
(WebKit::PDFPlugin::deviceScaleFactorChanged):
(WebKit::PDFPlugin::geometryDidChange):
(WebKit::PDFPlugin::setPageScaleFactor):
(WebKit::PDFPlugin::notifyContentScaleFactorChanged):
(WebKit::PDFPlugin::contentsScaleFactorChanged): Deleted.
(WebKit::PDFPlugin::handlesPageScaleFactor const): Deleted.
Two small changes to the legacy PDFPlugin:
- rename contentsScaleFactorChanged to deviceScaleFactorChanged since that&apos;s what it&apos;s used for.
- Adopt the new `origin` parameter on setPageScaleFactor instead of using the &quot;last mouse position&quot;.

This makes us match Preview and Web Content behavior when using the keyboard to zoom
(around the center of the view, not around the mouse!), and avoids the need to store
the last mouse position in UnifiedPDFPlugin (there remains one use in legacy PDFPlugin).

* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
(WebKit::PDFPluginBase::deviceScaleFactorChanged):
(WebKit::PDFPluginBase::didBeginMagnificationGesture):
(WebKit::PDFPluginBase::didEndMagnificationGesture):
(WebKit::PDFPluginBase::contentsScaleFactorChanged): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::handlesPageScaleFactor const):
* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::topContentInsetDidChange):
(WebKit::PluginView::didBeginMagnificationGesture):
(WebKit::PluginView::didEndMagnificationGesture):
(WebKit::PluginView::setPageScaleFactor):
(WebKit::PluginView::setDeviceScaleFactor):
(WebKit::PluginView::pageScaleFactorDidChange): Deleted.
* Source/WebKit/WebProcess/Plugins/PluginView.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::setTextZoomFactor):
(WebKit::WebPage::setPageZoomFactor):
(WebKit::WebPage::setPageAndTextZoomFactors):
(WebKit::WebPage::scalePage):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::didBeginMagnificationGesture):
(WebKit::WebPage::didEndMagnificationGesture):
Plumb beginning and end of magnification gestures, and the gesture origin, to the plugin.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::updateLayerHierarchy):
Mark our root layer as &quot;the one that applies the page scale&quot; if we&apos;re the whole main frame.

(WebKit::UnifiedPDFPlugin::paintContents):
(WebKit::UnifiedPDFPlugin::pageScaleFactor const):
(WebKit::UnifiedPDFPlugin::didBeginMagnificationGesture):
(WebKit::UnifiedPDFPlugin::didEndMagnificationGesture):
Keep track of when we&apos;re inside a magnification gesture, and tickle the layers
when the gesture ends.

(WebKit::UnifiedPDFPlugin::setPageScaleFactor):
Scale the contents layer with page scale, and counter-scroll to keep the
gesture origin in the same position.

For now, until we have async painting, we avoid updating the tiles until
the gesture ends.

(WebKit::UnifiedPDFPlugin::documentSize const):
(WebKit::UnifiedPDFPlugin::contentsSize const):
Split these two; documentSize is unscaled (scale=1); contentsSize is the
ScrollableArea contents size (which must have the scale applied).

Canonical link: <a href="https://commits.webkit.org/271501@main">https://commits.webkit.org/271501@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0429d70df7edd1bdb1c3a6019e9437e6f7296df

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28594 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7239 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29977 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/31241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/26117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9352 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4609 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/31241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28864 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5985 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24596 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/31241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/5357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/32560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26185 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26042 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/32560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/5320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/3489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/32560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6926 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6844 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5781 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/5839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->