### PR TITLE
Optimize use of WeakPtr with RenderObject types

### DIFF
--- a/Source/WTF/wtf/CheckedRef.h
+++ b/Source/WTF/wtf/CheckedRef.h
@@ -421,6 +421,7 @@ public:
 
     operator IntegralType() const;
     explicit operator bool() const;
+    SingleThreadIntegralWrapper& operator=(IntegralType);
     SingleThreadIntegralWrapper& operator++();
     SingleThreadIntegralWrapper& operator--();
 
@@ -457,6 +458,14 @@ inline SingleThreadIntegralWrapper<IntegralType>::operator bool() const
 {
     assertThread();
     return m_value;
+}
+
+template <typename IntegralType>
+inline SingleThreadIntegralWrapper<IntegralType>& SingleThreadIntegralWrapper<IntegralType>::operator=(IntegralType value)
+{
+    assertThread();
+    m_value = value;
+    return *this;
 }
 
 template <typename IntegralType>

--- a/Source/WTF/wtf/WeakHashCountedSet.h
+++ b/Source/WTF/wtf/WeakHashCountedSet.h
@@ -114,6 +114,10 @@ inline bool WeakHashCountedSet<Value, WeakPtrImpl>::remove(iterator it)
 template<typename Value, typename WeakMapImpl>
 size_t containerSize(const WeakHashCountedSet<Value, WeakMapImpl>& container) { return container.computeSize(); }
 
+template<typename Value>
+using SingleThreadWeakHashCountedSet = WeakHashCountedSet<Value, SingleThreadWeakPtrImpl>;
+
 } // namespace WTF
 
+using WTF::SingleThreadWeakHashCountedSet;
 using WTF::WeakHashCountedSet;

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.h
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.h
@@ -152,7 +152,7 @@ protected:
     virtual bool isIgnoredElementWithinMathTree() const;
 #endif
 
-    WeakPtr<RenderObject> m_renderer;
+    SingleThreadWeakPtr<RenderObject> m_renderer;
 
 private:
     bool isAccessibilityRenderObject() const final { return true; }

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -2676,7 +2676,7 @@ bool ComputedStyleExtractor::updateStyleIfNeededForProperty(Element& element, CS
     return true;
 }
 
-static inline const RenderStyle* computeRenderStyleForProperty(Element& element, PseudoId pseudoElementSpecifier, CSSPropertyID propertyID, std::unique_ptr<RenderStyle>& ownedStyle, WeakPtr<RenderElement> renderer)
+static inline const RenderStyle* computeRenderStyleForProperty(Element& element, PseudoId pseudoElementSpecifier, CSSPropertyID propertyID, std::unique_ptr<RenderStyle>& ownedStyle, SingleThreadWeakPtr<RenderElement> renderer)
 {
     if (!renderer)
         renderer = element.renderer();

--- a/Source/WebCore/dom/FullscreenManager.cpp
+++ b/Source/WebCore/dom/FullscreenManager.cpp
@@ -531,7 +531,7 @@ bool FullscreenManager::willEnterFullscreen(Element& element)
     for (auto ancestor : makeReversedRange(ancestorsInTreeOrder)) {
         ancestor->document().hideAllPopoversUntil(nullptr, FocusPreviousElement::No, FireEvents::No);
 
-        auto containingBlockBeforeStyleResolution = WeakPtr<RenderBlock> { };
+        auto containingBlockBeforeStyleResolution = SingleThreadWeakPtr<RenderBlock> { };
         if (auto* renderer = ancestor->renderer())
             containingBlockBeforeStyleResolution = renderer->containingBlock();
 

--- a/Source/WebCore/editing/TextIterator.h
+++ b/Source/WebCore/editing/TextIterator.h
@@ -162,7 +162,7 @@ private:
     InlineIterator::TextLogicalOrderCache m_remainingTextRunLogicalOrderCache;
 
     // Used to point to RenderText object for :first-letter.
-    WeakPtr<RenderText> m_firstLetterText;
+    SingleThreadWeakPtr<RenderText> m_firstLetterText;
 
     // Used to do the whitespace collapsing logic.
     RefPtr<Text> m_lastTextNode;

--- a/Source/WebCore/html/CustomPaintImage.h
+++ b/Source/WebCore/html/CustomPaintImage.h
@@ -56,7 +56,7 @@ private:
 
     WeakPtr<PaintWorkletGlobalScope::PaintDefinition> m_paintDefinition;
     Vector<AtomString> m_inputProperties;
-    WeakPtr<const RenderElement> m_element;
+    SingleThreadWeakPtr<const RenderElement> m_element;
     Vector<String> m_arguments;
 };
 

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.h
@@ -289,7 +289,7 @@ private:
     std::optional<InspectorOverlay::Flex::Config> m_inspectModeFlexOverlayConfig;
     std::unique_ptr<InspectorHistory> m_history;
     std::unique_ptr<DOMEditor> m_domEditor;
-    WeakHashMap<RenderObject, Vector<size_t>> m_flexibleBoxRendererCachedItemsAtStartOfLine;
+    SingleThreadWeakHashMap<RenderObject, Vector<size_t>> m_flexibleBoxRendererCachedItemsAtStartOfLine;
 
     Vector<Inspector::Protocol::DOM::NodeId> m_destroyedDetachedNodeIdentifiers;
     Vector<std::pair<Inspector::Protocol::DOM::NodeId, Inspector::Protocol::DOM::NodeId>> m_destroyedAttachedNodeIdentifiers;

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxTree.h
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxTree.h
@@ -86,9 +86,9 @@ private:
     void insertChild(UniqueRef<Layout::Box>, RenderObject&, const RenderObject* beforeChild = nullptr);
 
     RenderBlock& m_rootRenderer;
-    Vector<WeakPtr<RenderObject>, 1> m_renderers;
+    Vector<SingleThreadWeakPtr<RenderObject>, 1> m_renderers;
 
-    HashMap<CheckedRef<const Layout::Box>, WeakPtr<RenderObject>> m_boxToRendererMap;
+    HashMap<CheckedRef<const Layout::Box>, SingleThreadWeakPtr<RenderObject>> m_boxToRendererMap;
 };
 
 #if ENABLE(TREE_DEBUGGING)

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.h
@@ -68,7 +68,7 @@ private:
     const RenderInline* m_layerRenderer { nullptr };
     const InlineContent& m_inlineContent;
     const BoxTree& m_boxTree;
-    WeakListHashSet<RenderInline> m_outlineObjects;
+    SingleThreadWeakListHashSet<RenderInline> m_outlineObjects;
 };
 
 class LayerPaintScope {

--- a/Source/WebCore/loader/ImageLoader.h
+++ b/Source/WebCore/loader/ImageLoader.h
@@ -39,7 +39,7 @@ class Page;
 class RenderImageResource;
 
 template<typename T, typename Counter> class EventSender;
-using ImageEventSender = EventSender<ImageLoader, WTF::DefaultWeakPtrImpl>;
+using ImageEventSender = EventSender<ImageLoader, SingleThreadWeakPtrImpl>;
 
 enum class RelevantMutation : bool { No, Yes };
 enum class LazyImageLoadState : uint8_t { None, Deferred, LoadImmediately, FullImage };

--- a/Source/WebCore/loader/LinkPreloadResourceClients.h
+++ b/Source/WebCore/loader/LinkPreloadResourceClients.h
@@ -72,7 +72,7 @@ protected:
     CachedResource* ownedResource() { return m_resource.get(); }
 
 private:
-    WeakPtr<LinkLoader> m_loader;
+    SingleThreadWeakPtr<LinkLoader> m_loader;
     CachedResourceHandle<CachedResource> m_resource;
 };
 

--- a/Source/WebCore/loader/cache/CachedImage.h
+++ b/Source/WebCore/loader/cache/CachedImage.h
@@ -191,7 +191,7 @@ private:
     using ContainerContextRequests = HashMap<const CachedImageClient*, ContainerContext>;
     ContainerContextRequests m_pendingContainerContextRequests;
 
-    WeakHashSet<CachedImageClient> m_clientsWaitingForAsyncDecoding;
+    SingleThreadWeakHashSet<CachedImageClient> m_clientsWaitingForAsyncDecoding;
 
     RefPtr<CachedImageObserver> m_imageObserver;
     RefPtr<Image> m_image;

--- a/Source/WebCore/loader/cache/CachedResource.cpp
+++ b/Source/WebCore/loader/cache/CachedResource.cpp
@@ -786,7 +786,7 @@ void CachedResource::switchClientsToRevalidatedResource()
     ASSERT(!m_handleCount);
     m_handlesToRevalidate.clear();
 
-    Vector<WeakPtr<CachedResourceClient>> clientsToMove;
+    Vector<SingleThreadWeakPtr<CachedResourceClient>> clientsToMove;
     for (auto entry : m_clients) {
         auto& client = entry.key;
         unsigned count = entry.value;

--- a/Source/WebCore/loader/cache/CachedResource.h
+++ b/Source/WebCore/loader/cache/CachedResource.h
@@ -348,7 +348,7 @@ protected:
     void restartDecodedDataDeletionTimer();
 
     // FIXME: Make the rest of these data members private and use functions in derived classes instead.
-    WeakHashCountedSet<CachedResourceClient> m_clients;
+    SingleThreadWeakHashCountedSet<CachedResourceClient> m_clients;
     std::unique_ptr<ResourceRequest> m_originalRequest; // Needed by Ping loads.
     RefPtr<SubresourceLoader> m_loader;
     RefPtr<FragmentedSharedBuffer> m_data;
@@ -378,7 +378,7 @@ private:
     WallTime m_responseTimestamp { WallTime::now() };
     ResourceLoaderIdentifier m_identifierForLoadWithoutResourceLoader;
 
-    WeakHashMap<CachedResourceClient, std::unique_ptr<Callback>> m_clientsAwaitingCallback;
+    SingleThreadWeakHashMap<CachedResourceClient, std::unique_ptr<Callback>> m_clientsAwaitingCallback;
 
     // These handles will need to be updated to point to the m_resourceToRevalidate in case we get 304 response.
     HashSet<CachedResourceHandleBase*> m_handlesToRevalidate;

--- a/Source/WebCore/loader/cache/CachedResourceClient.h
+++ b/Source/WebCore/loader/cache/CachedResourceClient.h
@@ -33,7 +33,7 @@ namespace WebCore {
 class CachedResource;
 class NetworkLoadMetrics;
 
-class WEBCORE_EXPORT CachedResourceClient : public CanMakeWeakPtr<CachedResourceClient> {
+class WEBCORE_EXPORT CachedResourceClient : public CanMakeSingleThreadWeakPtr<CachedResourceClient> {
     WTF_MAKE_NONCOPYABLE(CachedResourceClient);
 public:
     enum CachedResourceClientType {

--- a/Source/WebCore/loader/cache/CachedResourceClientWalker.h
+++ b/Source/WebCore/loader/cache/CachedResourceClientWalker.h
@@ -61,7 +61,7 @@ public:
 
 private:
     CachedResourceHandle<CachedResource> m_resource;
-    FixedVector<WeakPtr<CachedResourceClient>> m_clientVector;
+    FixedVector<SingleThreadWeakPtr<CachedResourceClient>> m_clientVector;
     size_t m_index { 0 };
 };
 

--- a/Source/WebCore/page/AutoscrollController.h
+++ b/Source/WebCore/page/AutoscrollController.h
@@ -77,7 +77,7 @@ private:
 #endif
 
     Timer m_autoscrollTimer;
-    WeakPtr<RenderBox> m_autoscrollRenderer;
+    SingleThreadWeakPtr<RenderBox> m_autoscrollRenderer;
     AutoscrollType m_autoscrollType { NoAutoscroll };
     IntPoint m_dragAndDropAutoscrollReferencePosition;
     WallTime m_dragAndDropAutoscrollStartTime;

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -1899,7 +1899,7 @@ HandleUserInputEventResult EventHandler::handleMousePressEvent(const PlatformMou
     auto localPoint = roundedIntPoint(mouseEvent.hitTestResult().localPoint());
     if (layer && layer->isPointInResizeControl(localPoint)) {
         layer->setInResizeMode(true);
-        m_resizeLayer = WeakPtr { layer };
+        m_resizeLayer = *layer;
         m_offsetFromResizeCorner = layer->offsetFromResizeCorner(localPoint);
         return true;
     }

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -618,7 +618,7 @@ private:
     DeferrableOneShotTimer m_textRecognitionHoverTimer;
 #endif
     std::unique_ptr<AutoscrollController> m_autoscrollController;
-    WeakPtr<RenderLayer> m_resizeLayer;
+    SingleThreadWeakPtr<RenderLayer> m_resizeLayer;
 
     double m_maxMouseMovedDuration { 0 };
 

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -1274,7 +1274,7 @@ void LocalFrameView::adjustScrollbarsForLayout(bool isFirstLayout)
         setScrollbarModes(hMode, vMode);
 }
 
-void LocalFrameView::willDoLayout(WeakPtr<RenderElement> layoutRoot)
+void LocalFrameView::willDoLayout(SingleThreadWeakPtr<RenderElement> layoutRoot)
 {
     bool subtreeLayout = !is<RenderView>(*layoutRoot);
     if (subtreeLayout)
@@ -1304,7 +1304,7 @@ void LocalFrameView::willDoLayout(WeakPtr<RenderElement> layoutRoot)
     forceLayoutParentViewIfNeeded();
 }
 
-void LocalFrameView::didLayout(WeakPtr<RenderElement> layoutRoot)
+void LocalFrameView::didLayout(SingleThreadWeakPtr<RenderElement> layoutRoot)
 {
     ScriptDisallowedScope::InMainThread scriptDisallowedScope;
 
@@ -1546,7 +1546,7 @@ void LocalFrameView::addSlowRepaintObject(RenderElement& renderer)
     bool hadSlowRepaintObjects = hasSlowRepaintObjects();
 
     if (!m_slowRepaintObjects)
-        m_slowRepaintObjects = makeUnique<WeakHashSet<RenderElement>>();
+        m_slowRepaintObjects = makeUnique<SingleThreadWeakHashSet<RenderElement>>();
 
     auto addResult = m_slowRepaintObjects->add(renderer);
     if (addResult.isNewEntry) {
@@ -1596,7 +1596,7 @@ bool LocalFrameView::hasViewportConstrainedObjects() const
 void LocalFrameView::addViewportConstrainedObject(RenderLayerModelObject& object)
 {
     if (!m_viewportConstrainedObjects)
-        m_viewportConstrainedObjects = makeUnique<WeakHashSet<RenderLayerModelObject>>();
+        m_viewportConstrainedObjects = makeUnique<SingleThreadWeakHashSet<RenderLayerModelObject>>();
 
     if (!m_viewportConstrainedObjects->contains(object)) {
         m_viewportConstrainedObjects->add(object);
@@ -3698,7 +3698,7 @@ void LocalFrameView::scrollToTextFragmentRange()
     TemporarySelectionChange selectionChange(document, { range }, { TemporarySelectionOption::RevealSelection, TemporarySelectionOption::RevealSelectionBounds, TemporarySelectionOption::UserTriggered, TemporarySelectionOption::ForceCenterScroll });
 }
 
-void LocalFrameView::updateEmbeddedObject(const WeakPtr<RenderEmbeddedObject>& embeddedObject)
+void LocalFrameView::updateEmbeddedObject(const SingleThreadWeakPtr<RenderEmbeddedObject>& embeddedObject)
 {
     // The to-be-updated renderer is passed in as WeakPtr for convenience, but it will be alive at this point.
     ASSERT(embeddedObject);
@@ -3741,7 +3741,7 @@ bool LocalFrameView::updateEmbeddedObjects()
         // the underlying object can be destroyed, leaving the CheckedPtr dangling. Instead, construct a WeakPtr
         // that can be passed to the updateEmbeddedObject() method.
 
-        WeakPtr<RenderEmbeddedObject> weakObject;
+        SingleThreadWeakPtr<RenderEmbeddedObject> weakObject;
         {
             CheckedPtr embeddedObject = m_embeddedObjectsToUpdate->takeFirst();
             if (!embeddedObject)

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -346,12 +346,12 @@ public:
     void removeSlowRepaintObject(RenderElement&);
     bool hasSlowRepaintObject(const RenderElement& renderer) const;
     bool hasSlowRepaintObjects() const;
-    WeakHashSet<RenderElement>* slowRepaintObjects() const { return m_slowRepaintObjects.get(); }
+    SingleThreadWeakHashSet<RenderElement>* slowRepaintObjects() const { return m_slowRepaintObjects.get(); }
 
     // Includes fixed- and sticky-position objects.
     void addViewportConstrainedObject(RenderLayerModelObject&);
     void removeViewportConstrainedObject(RenderLayerModelObject&);
-    const WeakHashSet<RenderLayerModelObject>* viewportConstrainedObjects() const { return m_viewportConstrainedObjects.get(); }
+    const SingleThreadWeakHashSet<RenderLayerModelObject>* viewportConstrainedObjects() const { return m_viewportConstrainedObjects.get(); }
     WEBCORE_EXPORT bool hasViewportConstrainedObjects() const;
 
     float frameScaleFactor() const;
@@ -845,7 +845,7 @@ private:
 
     void updateEmbeddedObjectsTimerFired();
     bool updateEmbeddedObjects();
-    void updateEmbeddedObject(const WeakPtr<RenderEmbeddedObject>&);
+    void updateEmbeddedObject(const SingleThreadWeakPtr<RenderEmbeddedObject>&);
 
     void updateWidgetPositionsTimerFired();
 
@@ -880,8 +880,8 @@ private:
 
     RenderElement* viewportRenderer() const;
     
-    void willDoLayout(WeakPtr<RenderElement> layoutRoot);
-    void didLayout(WeakPtr<RenderElement> layoutRoot);
+    void willDoLayout(SingleThreadWeakPtr<RenderElement> layoutRoot);
+    void didLayout(SingleThreadWeakPtr<RenderElement> layoutRoot);
 
     FloatSize calculateSizeForCSSViewportUnitsOverride(std::optional<OverrideViewportSize>) const;
 
@@ -913,7 +913,7 @@ private:
 
     HashSet<CheckedPtr<Widget>> m_widgetsInRenderTree;
     std::unique_ptr<ListHashSet<CheckedPtr<RenderEmbeddedObject>>> m_embeddedObjectsToUpdate;
-    std::unique_ptr<WeakHashSet<RenderElement>> m_slowRepaintObjects;
+    std::unique_ptr<SingleThreadWeakHashSet<RenderElement>> m_slowRepaintObjects;
 
     HashMap<ScrollingNodeID, WeakPtr<ScrollableArea>> m_scrollingNodeIDToPluginScrollableAreaMap;
 
@@ -983,7 +983,7 @@ private:
 
     std::unique_ptr<ScrollableAreaSet> m_scrollableAreas;
     std::unique_ptr<ScrollableAreaSet> m_scrollableAreasForAnimatedScroll;
-    std::unique_ptr<WeakHashSet<RenderLayerModelObject>> m_viewportConstrainedObjects;
+    std::unique_ptr<SingleThreadWeakHashSet<RenderLayerModelObject>> m_viewportConstrainedObjects;
 
     OptionSet<LayoutMilestone> m_milestonesPendingPaint;
 

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -185,7 +185,7 @@ void LocalFrameViewLayoutContext::performLayout()
     TraceScope tracingScope(PerformLayoutStart, PerformLayoutEnd);
     ScriptDisallowedScope::InMainThread scriptDisallowedScope;
     InspectorInstrumentation::willLayout(view().frame());
-    WeakPtr<RenderElement> layoutRoot;
+    SingleThreadWeakPtr<RenderElement> layoutRoot;
     
     m_layoutTimer.stop();
     m_setNeedsLayoutWasDeferred = false;
@@ -621,11 +621,11 @@ void LocalFrameViewLayoutContext::popLayoutState()
 
 void LocalFrameViewLayoutContext::setBoxNeedsTransformUpdateAfterContainerLayout(RenderBox& box, RenderBlock& container)
 {
-    auto it = m_containersWithDescendantsNeedingTransformUpdate.ensure(container, [] { return Vector<WeakPtr<RenderBox>>({ }); });
+    auto it = m_containersWithDescendantsNeedingTransformUpdate.ensure(container, [] { return Vector<SingleThreadWeakPtr<RenderBox>>({ }); });
     it.iterator->value.append(WeakPtr { box });
 }
 
-Vector<WeakPtr<RenderBox>> LocalFrameViewLayoutContext::takeBoxesNeedingTransformUpdateAfterContainerLayout(RenderBlock& container)
+Vector<SingleThreadWeakPtr<RenderBox>> LocalFrameViewLayoutContext::takeBoxesNeedingTransformUpdateAfterContainerLayout(RenderBlock& container)
 {
     return m_containersWithDescendantsNeedingTransformUpdate.take(container);
 }

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.h
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.h
@@ -58,7 +58,7 @@ struct UpdateScrollInfoAfterLayoutTransaction {
     ~UpdateScrollInfoAfterLayoutTransaction();
 
     int nestedCount { 0 };
-    WeakHashSet<RenderBlock> blocks;
+    SingleThreadWeakHashSet<RenderBlock> blocks;
 };
 
 class LocalFrameViewLayoutContext : public CanMakeCheckedPtr {
@@ -133,7 +133,7 @@ public:
     UpdateScrollInfoAfterLayoutTransaction& updateScrollInfoAfterLayoutTransaction();
     UpdateScrollInfoAfterLayoutTransaction* updateScrollInfoAfterLayoutTransactionIfExists() { return m_updateScrollInfoAfterLayoutTransaction.get(); }
     void setBoxNeedsTransformUpdateAfterContainerLayout(RenderBox&, RenderBlock& container);
-    Vector<WeakPtr<RenderBox>> takeBoxesNeedingTransformUpdateAfterContainerLayout(RenderBlock&);
+    Vector<SingleThreadWeakPtr<RenderBox>> takeBoxesNeedingTransformUpdateAfterContainerLayout(RenderBlock&);
 
 private:
     friend class LayoutScope;
@@ -179,7 +179,7 @@ private:
     LocalFrameView& m_frameView;
     Timer m_layoutTimer;
     Timer m_postLayoutTaskTimer;
-    WeakPtr<RenderElement> m_subtreeLayoutRoot;
+    SingleThreadWeakPtr<RenderElement> m_subtreeLayoutRoot;
 
     bool m_layoutSchedulingIsEnabled { true };
     bool m_firstLayout { true };
@@ -197,7 +197,7 @@ private:
     std::unique_ptr<Layout::LayoutTree> m_layoutTree;
     std::unique_ptr<Layout::LayoutState> m_layoutState;
     std::unique_ptr<UpdateScrollInfoAfterLayoutTransaction> m_updateScrollInfoAfterLayoutTransaction;
-    WeakHashMap<RenderBlock, Vector<WeakPtr<RenderBox>>> m_containersWithDescendantsNeedingTransformUpdate;
+    SingleThreadWeakHashMap<RenderBlock, Vector<SingleThreadWeakPtr<RenderBox>>> m_containersWithDescendantsNeedingTransformUpdate;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1264,7 +1264,7 @@ private:
     int m_footerHeight { 0 };
 
     std::unique_ptr<RenderingUpdateScheduler> m_renderingUpdateScheduler;
-    WeakHashSet<const RenderObject> m_relevantUnpaintedRenderObjects;
+    SingleThreadWeakHashSet<const RenderObject> m_relevantUnpaintedRenderObjects;
 
     Region m_topRelevantPaintedRegion;
     Region m_bottomRelevantPaintedRegion;

--- a/Source/WebCore/platform/PODInterval.h
+++ b/Source/WebCore/platform/PODInterval.h
@@ -130,10 +130,10 @@ private:
     using Base = PODIntervalBase<T, UserData>;
 };
 
-template<class T, class U> class PODInterval<T, WeakPtr<U>> : public PODIntervalBase<T, WeakPtr<U>> {
+template<typename T, typename U, typename WeakPtrImpl> class PODInterval<T, WeakPtr<U, WeakPtrImpl>> : public PODIntervalBase<T, WeakPtr<U, WeakPtrImpl>> {
 public:
-    PODInterval(const T& low, const T& high, WeakPtr<U>&& data)
-        : PODIntervalBase<T, WeakPtr<U>>(low, high, WTFMove(data))
+    PODInterval(const T& low, const T& high, WeakPtr<U, WeakPtrImpl>&& data)
+        : PODIntervalBase<T, WeakPtr<U, WeakPtrImpl>>(low, high, WTFMove(data))
     {
     }
 
@@ -147,7 +147,7 @@ public:
     }
 
 private:
-    using Base = PODIntervalBase<T, WeakPtr<U>>;
+    using Base = PODIntervalBase<T, WeakPtr<U, WeakPtrImpl>>;
 };
 
 #ifndef NDEBUG

--- a/Source/WebCore/rendering/AccessibilityRegionContext.h
+++ b/Source/WebCore/rendering/AccessibilityRegionContext.h
@@ -82,7 +82,7 @@ private:
         return mappedRect;
     }
 
-    WeakHashMap<RenderText, FloatRect> m_accumulatedRenderTextRects;
+    SingleThreadWeakHashMap<RenderText, FloatRect> m_accumulatedRenderTextRects;
 }; // class AccessibilityRegionContext
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/AncestorSubgridIterator.cpp
+++ b/Source/WebCore/rendering/AncestorSubgridIterator.cpp
@@ -32,7 +32,7 @@ namespace WebCore {
 
 AncestorSubgridIterator::AncestorSubgridIterator() { }
 
-AncestorSubgridIterator::AncestorSubgridIterator(WeakPtr<RenderGrid> firstAncestorSubgrid, GridTrackSizingDirection direction)
+AncestorSubgridIterator::AncestorSubgridIterator(SingleThreadWeakPtr<RenderGrid> firstAncestorSubgrid, GridTrackSizingDirection direction)
     : m_firstAncestorSubgrid(firstAncestorSubgrid)
     , m_direction(direction)
 {
@@ -40,7 +40,7 @@ AncestorSubgridIterator::AncestorSubgridIterator(WeakPtr<RenderGrid> firstAncest
 }
 
 
-AncestorSubgridIterator::AncestorSubgridIterator(WeakPtr<RenderGrid> firstAncestorSubgrid, WeakPtr<RenderGrid> currentAncestorSubgrid, GridTrackSizingDirection direction)
+AncestorSubgridIterator::AncestorSubgridIterator(SingleThreadWeakPtr<RenderGrid> firstAncestorSubgrid, SingleThreadWeakPtr<RenderGrid> currentAncestorSubgrid, GridTrackSizingDirection direction)
     : m_firstAncestorSubgrid(firstAncestorSubgrid)
     , m_currentAncestorSubgrid(currentAncestorSubgrid)
     , m_direction(direction)
@@ -48,7 +48,7 @@ AncestorSubgridIterator::AncestorSubgridIterator(WeakPtr<RenderGrid> firstAncest
     ASSERT_IMPLIES(firstAncestorSubgrid, firstAncestorSubgrid->isSubgrid(direction));
 }
 
-AncestorSubgridIterator::AncestorSubgridIterator(WeakPtr<RenderGrid> firstAncestorSubgrid, WeakPtr<RenderGrid> currentAncestorSubgrid, std::optional<GridTrackSizingDirection> direction)
+AncestorSubgridIterator::AncestorSubgridIterator(SingleThreadWeakPtr<RenderGrid> firstAncestorSubgrid, SingleThreadWeakPtr<RenderGrid> currentAncestorSubgrid, std::optional<GridTrackSizingDirection> direction)
     : m_firstAncestorSubgrid(firstAncestorSubgrid)
     , m_currentAncestorSubgrid(currentAncestorSubgrid)
     , m_direction(direction)

--- a/Source/WebCore/rendering/AncestorSubgridIterator.h
+++ b/Source/WebCore/rendering/AncestorSubgridIterator.h
@@ -35,7 +35,7 @@ namespace WebCore {
 class AncestorSubgridIterator {
 public:
     AncestorSubgridIterator();
-    AncestorSubgridIterator(WeakPtr<RenderGrid> firstAncestorSubgrid, GridTrackSizingDirection);
+    AncestorSubgridIterator(SingleThreadWeakPtr<RenderGrid> firstAncestorSubgrid, GridTrackSizingDirection);
 
     RenderGrid& operator*();
 
@@ -45,11 +45,11 @@ public:
     AncestorSubgridIterator begin();
     AncestorSubgridIterator end();
 private:
-    AncestorSubgridIterator(WeakPtr<RenderGrid> firstAncestorSubgrid, WeakPtr<RenderGrid> currentAncestor, GridTrackSizingDirection);
-    AncestorSubgridIterator(WeakPtr<RenderGrid> firstAncestorSubgrid, WeakPtr<RenderGrid> currentAncestor, std::optional<GridTrackSizingDirection>);
+    AncestorSubgridIterator(SingleThreadWeakPtr<RenderGrid> firstAncestorSubgrid, SingleThreadWeakPtr<RenderGrid> currentAncestor, GridTrackSizingDirection);
+    AncestorSubgridIterator(SingleThreadWeakPtr<RenderGrid> firstAncestorSubgrid, SingleThreadWeakPtr<RenderGrid> currentAncestor, std::optional<GridTrackSizingDirection>);
 
-    const WeakPtr<const RenderGrid> m_firstAncestorSubgrid;
-    WeakPtr<RenderGrid> m_currentAncestorSubgrid { nullptr };
+    const SingleThreadWeakPtr<const RenderGrid> m_firstAncestorSubgrid;
+    SingleThreadWeakPtr<RenderGrid> m_currentAncestorSubgrid;
     const std::optional<GridTrackSizingDirection> m_direction;
 
 };

--- a/Source/WebCore/rendering/BaselineAlignment.h
+++ b/Source/WebCore/rendering/BaselineAlignment.h
@@ -76,7 +76,7 @@ private:
     BlockFlowDirection m_blockFlow;
     ItemPosition m_preference;
     LayoutUnit m_maxAscent;
-    WeakHashSet<RenderBox> m_items;
+    SingleThreadWeakHashSet<RenderBox> m_items;
 };
 
 //

--- a/Source/WebCore/rendering/FloatingObjects.cpp
+++ b/Source/WebCore/rendering/FloatingObjects.cpp
@@ -34,7 +34,7 @@
 namespace WebCore {
 
 struct SameSizeAsFloatingObject {
-    WeakPtr<RenderBox> renderer;
+    SingleThreadWeakPtr<RenderBox> renderer;
     WeakPtr<LegacyRootInlineBox> originatingLine;
     LayoutRect rect;
     int paginationStrut;
@@ -44,7 +44,7 @@ struct SameSizeAsFloatingObject {
 
 static_assert(sizeof(FloatingObject) == sizeof(SameSizeAsFloatingObject), "FloatingObject should stay small");
 #if !ASSERT_ENABLED
-static_assert(sizeof(WeakPtr<RenderBox>) == sizeof(void*), "WeakPtr should be same size as raw pointer");
+static_assert(sizeof(SingleThreadWeakPtr<RenderBox>) == sizeof(void*), "WeakPtr should be same size as raw pointer");
 static_assert(sizeof(CheckedPtr<LegacyRootInlineBox>) == sizeof(void*), "WeakPtr should be same size as raw pointer");
 #endif
 
@@ -165,7 +165,7 @@ public:
 protected:
     virtual bool updateOffsetIfNeeded(const FloatingObject&) = 0;
 
-    WeakPtr<const RenderBlockFlow> m_renderer;
+    SingleThreadWeakPtr<const RenderBlockFlow> m_renderer;
     LayoutUnit m_lineTop;
     LayoutUnit m_lineBottom;
     LayoutUnit m_offset;
@@ -220,7 +220,7 @@ public:
     LayoutUnit nextShapeLogicalBottom() const { return m_nextShapeLogicalBottom.value_or(nextLogicalBottom()); }
 
 private:
-    WeakPtr<const RenderBlockFlow> m_renderer;
+    SingleThreadWeakPtr<const RenderBlockFlow> m_renderer;
     LayoutUnit m_belowLogicalHeight;
     std::optional<LayoutUnit> m_nextLogicalBottom;
     std::optional<LayoutUnit> m_nextShapeLogicalBottom;

--- a/Source/WebCore/rendering/FloatingObjects.h
+++ b/Source/WebCore/rendering/FloatingObjects.h
@@ -103,7 +103,7 @@ public:
     LayoutSize translationOffsetToAncestor() const;
 
 private:
-    WeakPtr<RenderBox> m_renderer;
+    SingleThreadWeakPtr<RenderBox> m_renderer;
     WeakPtr<LegacyRootInlineBox> m_originatingLine;
     LayoutRect m_frameRect;
     LayoutUnit m_paginationStrut;
@@ -189,7 +189,7 @@ private:
     unsigned m_leftObjectsCount { 0 };
     unsigned m_rightObjectsCount { 0 };
     bool m_horizontalWritingMode { false };
-    WeakPtr<const RenderBlockFlow> m_renderer;
+    SingleThreadWeakPtr<const RenderBlockFlow> m_renderer;
 };
 
 #if ENABLE(TREE_DEBUGGING)

--- a/Source/WebCore/rendering/Grid.h
+++ b/Source/WebCore/rendering/Grid.h
@@ -33,7 +33,7 @@
 
 namespace WebCore {
 
-typedef Vector<WeakPtr<RenderBox>, 1> GridCell;
+typedef Vector<SingleThreadWeakPtr<RenderBox>, 1> GridCell;
 typedef Vector<Vector<GridCell>> GridAsMatrix;
 typedef ListHashSet<size_t> OrderedTrackIndexSet;
 

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -1089,7 +1089,7 @@ private:
     bool isComputingSizeContainment() const override { return renderGrid()->shouldApplySizeContainment(); }
     bool isComputingInlineSizeContainment() const override { return renderGrid()->shouldApplyInlineSizeContainment(); }
     bool isComputingSizeOrInlineSizeContainment() const override { return renderGrid()->shouldApplySizeOrInlineSizeContainment(); }
-    void accumulateFlexFraction(double& flexFraction, GridIterator&, GridTrackSizingDirection outermostDirection, WeakHashSet<RenderBox>& itemsSet) const;
+    void accumulateFlexFraction(double& flexFraction, GridIterator&, GridTrackSizingDirection outermostDirection, SingleThreadWeakHashSet<RenderBox>& itemsSet) const;
 };
 
 void IndefiniteSizeStrategy::layoutGridItemForMinSizeComputation(RenderBox& child, bool overrideSizeHasChanged) const
@@ -1113,7 +1113,7 @@ static inline double normalizedFlexFraction(const GridTrack& track)
     return track.baseSize() / std::max<double>(1, flexFactor);
 }
 
-void IndefiniteSizeStrategy::accumulateFlexFraction(double& flexFraction, GridIterator& iterator, GridTrackSizingDirection outermostDirection, WeakHashSet<RenderBox>& itemsSet) const
+void IndefiniteSizeStrategy::accumulateFlexFraction(double& flexFraction, GridIterator& iterator, GridTrackSizingDirection outermostDirection, SingleThreadWeakHashSet<RenderBox>& itemsSet) const
 {
     while (auto* gridItem = iterator.nextGridItem()) {
         if (is<RenderGrid>(gridItem) && downcast<RenderGrid>(gridItem)->isSubgridInParentDirection(iterator.direction())) {
@@ -1151,7 +1151,7 @@ double IndefiniteSizeStrategy::findUsedFlexFraction(Vector<unsigned>& flexibleSi
     if (!grid.hasGridItems())
         return flexFraction;
 
-    WeakHashSet<RenderBox> itemsSet;
+    SingleThreadWeakHashSet<RenderBox> itemsSet;
     for (const auto& trackIndex : flexibleSizedTracksIndex) {
         GridIterator iterator(grid, direction, trackIndex);
         accumulateFlexFraction(flexFraction, iterator, direction, itemsSet);
@@ -1352,7 +1352,7 @@ static LayoutUnit computeSubgridMarginBorderPadding(const RenderGrid* outermost,
     return subgridMbp;
 }
 
-void GridTrackSizingAlgorithm::accumulateIntrinsicSizesForTrack(GridTrack& track, unsigned trackIndex, GridIterator& iterator, Vector<GridItemWithSpan>& itemsSortedByIncreasingSpan, Vector<GridItemWithSpan>& itemsCrossingFlexibleTracks, WeakHashSet<RenderBox>& itemsSet, LayoutUnit currentAccumulatedMbp)
+void GridTrackSizingAlgorithm::accumulateIntrinsicSizesForTrack(GridTrack& track, unsigned trackIndex, GridIterator& iterator, Vector<GridItemWithSpan>& itemsSortedByIncreasingSpan, Vector<GridItemWithSpan>& itemsCrossingFlexibleTracks, SingleThreadWeakHashSet<RenderBox>& itemsSet, LayoutUnit currentAccumulatedMbp)
 {
     while (auto* gridItem = iterator.nextGridItem()) {
 
@@ -1461,7 +1461,7 @@ void GridTrackSizingAlgorithm::resolveIntrinsicTrackSizes()
 
     Vector<GridItemWithSpan> itemsSortedByIncreasingSpan;
     Vector<GridItemWithSpan> itemsCrossingFlexibleTracks;
-    WeakHashSet<RenderBox> itemsSet;
+    SingleThreadWeakHashSet<RenderBox> itemsSet;
 
     if (m_grid.hasGridItems()) {
         for (auto trackIndex : m_contentSizedTracksIndex) {

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
@@ -197,7 +197,7 @@ private:
     void stretchFlexibleTracks(std::optional<LayoutUnit> freeSpace);
     void stretchAutoTracks();
 
-    void accumulateIntrinsicSizesForTrack(GridTrack&, unsigned trackIndex, GridIterator&, Vector<GridItemWithSpan>& itemsSortedByIncreasingSpan, Vector<GridItemWithSpan>& itemsCrossingFlexibleTracks, WeakHashSet<RenderBox>& itemsSet, LayoutUnit currentAccumulatedMbp);
+    void accumulateIntrinsicSizesForTrack(GridTrack&, unsigned trackIndex, GridIterator&, Vector<GridItemWithSpan>& itemsSortedByIncreasingSpan, Vector<GridItemWithSpan>& itemsCrossingFlexibleTracks, SingleThreadWeakHashSet<RenderBox>& itemsSet, LayoutUnit currentAccumulatedMbp);
 
     bool copyUsedTrackSizesForSubgrid();
 
@@ -256,7 +256,7 @@ private:
     BaselineItemsCache m_columnBaselineItemsMap;
     BaselineItemsCache m_rowBaselineItemsMap;
 
-    WeakHashSet<RenderGrid> m_rowSubgridsWithBaselineAlignedItems;
+    SingleThreadWeakHashSet<RenderGrid> m_rowSubgridsWithBaselineAlignedItems;
 
     // This is a RAII class used to ensure that the track sizing algorithm is
     // executed as it is suppossed to be, i.e., first resolve columns and then

--- a/Source/WebCore/rendering/LayerAncestorClippingStack.h
+++ b/Source/WebCore/rendering/LayerAncestorClippingStack.h
@@ -49,7 +49,7 @@ struct CompositedClipData {
 
     friend bool operator==(const CompositedClipData&, const CompositedClipData&) = default;
     
-    WeakPtr<RenderLayer> clippingLayer; // For scroller entries, the scrolling layer. For other entries, the most-descendant layer that has a clip.
+    SingleThreadWeakPtr<RenderLayer> clippingLayer; // For scroller entries, the scrolling layer. For other entries, the most-descendant layer that has a clip.
     RoundedRect clipRect; // In the coordinate system of the RenderLayer that owns the stack.
     bool isOverflowScroll { false };
 };

--- a/Source/WebCore/rendering/LegacyInlineBox.cpp
+++ b/Source/WebCore/rendering/LegacyInlineBox.cpp
@@ -44,7 +44,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(LegacyInlineBox);
 struct SameSizeAsLegacyInlineBox {
     virtual ~SameSizeAsLegacyInlineBox() = default;
     void* a[3];
-    WeakPtr<RenderObject> r;
+    SingleThreadWeakPtr<RenderObject> r;
     FloatPoint b;
     float c[2];
     unsigned d : 23;

--- a/Source/WebCore/rendering/LegacyInlineBox.h
+++ b/Source/WebCore/rendering/LegacyInlineBox.h
@@ -278,7 +278,7 @@ private:
 
     LegacyInlineFlowBox* m_parent { nullptr }; // The box that contains us.
 
-    WeakPtr<RenderObject> m_renderer;
+    SingleThreadWeakPtr<RenderObject> m_renderer;
 
 private:
     float m_logicalWidth { 0 };

--- a/Source/WebCore/rendering/LegacyRootInlineBox.cpp
+++ b/Source/WebCore/rendering/LegacyRootInlineBox.cpp
@@ -49,7 +49,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(LegacyRootInlineBox);
 
 struct SameSizeAsLegacyRootInlineBox : LegacyInlineFlowBox, CanMakeWeakPtr<LegacyRootInlineBox>, CanMakeCheckedPtr {
     unsigned lineBreakPos;
-    WeakPtr<RenderObject> lineBreakObj;
+    SingleThreadWeakPtr<RenderObject> lineBreakObj;
     void* lineBreakContext;
     int layoutUnits[6];
     void* floats;
@@ -57,7 +57,7 @@ struct SameSizeAsLegacyRootInlineBox : LegacyInlineFlowBox, CanMakeWeakPtr<Legac
 
 static_assert(sizeof(LegacyRootInlineBox) == sizeof(SameSizeAsLegacyRootInlineBox), "LegacyRootInlineBox should stay small");
 #if !ASSERT_ENABLED
-static_assert(sizeof(WeakPtr<RenderObject>) == sizeof(void*), "WeakPtr should be same size as raw pointer");
+static_assert(sizeof(SingleThreadWeakPtr<RenderObject>) == sizeof(void*), "WeakPtr should be same size as raw pointer");
 #endif
 
 typedef HashMap<const LegacyRootInlineBox*, std::unique_ptr<LegacyEllipsisBox>> EllipsisBoxMap;

--- a/Source/WebCore/rendering/LegacyRootInlineBox.h
+++ b/Source/WebCore/rendering/LegacyRootInlineBox.h
@@ -130,7 +130,7 @@ public:
     const LegacyInlineBox* firstSelectedBox() const;
     const LegacyInlineBox* lastSelectedBox() const;
 
-    using CleanLineFloatList = Vector<WeakPtr<RenderBox>>;
+    using CleanLineFloatList = Vector<SingleThreadWeakPtr<RenderBox>>;
     void appendFloat(RenderBox& floatingBox)
     {
         ASSERT(!isDirty());
@@ -203,7 +203,7 @@ private:
 
     // Where this line ended. The exact object and the position within that object are stored so that
     // we can create an LegacyInlineIterator beginning just after the end of this line.
-    WeakPtr<RenderObject> m_lineBreakObj;
+    SingleThreadWeakPtr<RenderObject> m_lineBreakObj;
     RefPtr<BidiContext> m_lineBreakContext;
 
     LayoutUnit m_lineTop;

--- a/Source/WebCore/rendering/PaintInfo.h
+++ b/Source/WebCore/rendering/PaintInfo.h
@@ -53,7 +53,7 @@ typedef HashMap<OverlapTestRequestClient*, IntRect> OverlapTestRequestMap;
  */
 struct PaintInfo {
     PaintInfo(GraphicsContext& newContext, const LayoutRect& newRect, PaintPhase newPhase, OptionSet<PaintBehavior> newPaintBehavior,
-        RenderObject* newSubtreePaintRoot = nullptr, WeakListHashSet<RenderInline>* newOutlineObjects = nullptr,
+        RenderObject* newSubtreePaintRoot = nullptr, SingleThreadWeakListHashSet<RenderInline>* newOutlineObjects = nullptr,
         OverlapTestRequestMap* overlapTestRequests = nullptr, const RenderLayerModelObject* newPaintContainer = nullptr,
         const RenderLayer* enclosingSelfPaintingLayer = nullptr, bool newRequireSecurityOriginAccessForWidgets = false)
             : rect(newRect)
@@ -129,7 +129,7 @@ struct PaintInfo {
     PaintPhase phase;
     OptionSet<PaintBehavior> paintBehavior;
     RenderObject* subtreePaintRoot; // used to draw just one element and its visual children
-    WeakListHashSet<RenderInline>* outlineObjects; // used to list outlines that should be painted by a block with inline children
+    SingleThreadWeakListHashSet<RenderInline>* outlineObjects; // used to list outlines that should be painted by a block with inline children
     OverlapTestRequestMap* overlapTestRequests;
     const RenderLayerModelObject* paintContainer; // the layer object that originates the current painting
     bool requireSecurityOriginAccessForWidgets { false };

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -94,8 +94,8 @@ struct SameSizeAsRenderBlock : public RenderBox {
 
 static_assert(sizeof(RenderBlock) == sizeof(SameSizeAsRenderBlock), "RenderBlock should stay small");
 
-using TrackedDescendantsMap = WeakHashMap<const RenderBlock, std::unique_ptr<TrackedRendererListHashSet>>;
-using TrackedContainerMap = WeakHashMap<const RenderBox, WeakHashSet<const RenderBlock>>;
+using TrackedDescendantsMap = SingleThreadWeakHashMap<const RenderBlock, std::unique_ptr<TrackedRendererListHashSet>>;
+using TrackedContainerMap = SingleThreadWeakHashMap<const RenderBox, SingleThreadWeakHashSet<const RenderBlock>>;
 
 static TrackedDescendantsMap* percentHeightDescendantsMap;
 static TrackedContainerMap* percentHeightContainerMap;
@@ -121,7 +121,7 @@ static void insertIntoTrackedRendererMaps(const RenderBlock& container, RenderBo
         return;
     }
     
-    auto& containerSet = percentHeightContainerMap->add(descendant, WeakHashSet<const RenderBlock>()).iterator->value;
+    auto& containerSet = percentHeightContainerMap->add(descendant, SingleThreadWeakHashSet<const RenderBlock>()).iterator->value;
     ASSERT(!containerSet.contains(container));
     containerSet.add(container);
 }
@@ -229,7 +229,7 @@ public:
 
 private:
     using DescendantsMap = HashMap<CheckedPtr<const RenderBlock>, std::unique_ptr<TrackedRendererListHashSet>>;
-    using ContainerMap = WeakHashMap<const RenderBox, WeakPtr<const RenderBlock>>;
+    using ContainerMap = SingleThreadWeakHashMap<const RenderBox, SingleThreadWeakPtr<const RenderBlock>>;
     
     DescendantsMap m_descendantsMap;
     ContainerMap m_containerMap;
@@ -256,7 +256,7 @@ public:
     LayoutUnit m_pageLogicalOffset;
     LayoutUnit m_intrinsicBorderForFieldset;
     
-    std::optional<WeakPtr<RenderFragmentedFlow>> m_enclosingFragmentedFlow;
+    std::optional<SingleThreadWeakPtr<RenderFragmentedFlow>> m_enclosingFragmentedFlow;
 };
 
 typedef HashMap<const RenderBlock*, std::unique_ptr<RenderBlockRareData>> RenderBlockRareDataMap;

--- a/Source/WebCore/rendering/RenderBlock.h
+++ b/Source/WebCore/rendering/RenderBlock.h
@@ -39,7 +39,7 @@ class RenderText;
 struct BidiRun;
 struct PaintInfo;
 
-using TrackedRendererListHashSet = WeakListHashSet<RenderBox>;
+using TrackedRendererListHashSet = SingleThreadWeakListHashSet<RenderBox>;
 
 enum CaretType { CursorCaret, DragCaret };
 enum ContainingBlockState { NewContainingBlock, SameContainingBlock };

--- a/Source/WebCore/rendering/RenderBlockFlow.h
+++ b/Source/WebCore/rendering/RenderBlockFlow.h
@@ -149,7 +149,7 @@ public:
         MarginValues m_margins;
         int m_lineBreakToAvoidWidow;
 
-        WeakPtr<RenderMultiColumnFlow> m_multiColumnFlow;
+        SingleThreadWeakPtr<RenderMultiColumnFlow> m_multiColumnFlow;
 
         bool m_didBreakAtLineToAvoidWidow : 1;
     };

--- a/Source/WebCore/rendering/RenderBoxModelObject.cpp
+++ b/Source/WebCore/rendering/RenderBoxModelObject.cpp
@@ -127,7 +127,7 @@ static ContinuationChainNodeMap& continuationChainNodeMap()
     return map;
 }
 
-using FirstLetterRemainingTextMap = HashMap<const RenderBoxModelObject*, WeakPtr<RenderTextFragment>>;
+using FirstLetterRemainingTextMap = HashMap<const RenderBoxModelObject*, SingleThreadWeakPtr<RenderTextFragment>>;
 
 static FirstLetterRemainingTextMap& firstLetterRemainingTextMap()
 {

--- a/Source/WebCore/rendering/RenderBoxModelObject.h
+++ b/Source/WebCore/rendering/RenderBoxModelObject.h
@@ -246,7 +246,7 @@ public:
     struct ContinuationChainNode {
         WTF_MAKE_STRUCT_FAST_ALLOCATED;
 
-        WeakPtr<RenderBoxModelObject> renderer;
+        SingleThreadWeakPtr<RenderBoxModelObject> renderer;
         ContinuationChainNode* previous { nullptr };
         ContinuationChainNode* next { nullptr };
 

--- a/Source/WebCore/rendering/RenderButton.h
+++ b/Source/WebCore/rendering/RenderButton.h
@@ -76,8 +76,8 @@ private:
 
     bool isFlexibleBoxImpl() const override { return true; }
 
-    WeakPtr<RenderTextFragment> m_buttonText;
-    WeakPtr<RenderBlock> m_inner;
+    SingleThreadWeakPtr<RenderTextFragment> m_buttonText;
+    SingleThreadWeakPtr<RenderBlock> m_inner;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderCounter.cpp
+++ b/Source/WebCore/rendering/RenderCounter.cpp
@@ -49,7 +49,7 @@ using namespace HTMLNames;
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderCounter);
 
 using CounterMap = HashMap<AtomString, Ref<CounterNode>>;
-using CounterMaps = WeakHashMap<RenderElement, std::unique_ptr<CounterMap>>;
+using CounterMaps = SingleThreadWeakHashMap<RenderElement, std::unique_ptr<CounterMap>>;
 
 static CounterNode* makeCounterNode(RenderElement&, const AtomString& identifier, bool alwaysCreateCounter);
 

--- a/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.h
+++ b/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.h
@@ -64,7 +64,7 @@ private:
 
     struct ClampedContent {
         LayoutUnit contentHeight;
-        WeakPtr<const RenderBlockFlow> renderer;
+        SingleThreadWeakPtr<const RenderBlockFlow> renderer;
     };
     std::optional<ClampedContent> applyLineClamp(FlexBoxIterator&, bool relayoutChildren);
     std::optional<ClampedContent> applyModernLineClamp(FlexBoxIterator&);

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -2240,7 +2240,7 @@ std::unique_ptr<RenderStyle> RenderElement::animatedStyle()
     return result;
 }
 
-WeakPtr<RenderBlockFlow> RenderElement::backdropRenderer() const
+SingleThreadWeakPtr<RenderBlockFlow> RenderElement::backdropRenderer() const
 {
     return hasRareData() ? rareData().backdropRenderer : nullptr;
 }

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -277,7 +277,7 @@ public:
     virtual void suspendAnimations(MonotonicTime = MonotonicTime()) { }
     std::unique_ptr<RenderStyle> animatedStyle();
 
-    WeakPtr<RenderBlockFlow> backdropRenderer() const;
+    SingleThreadWeakPtr<RenderBlockFlow> backdropRenderer() const;
     void setBackdropRenderer(RenderBlockFlow&);
 
     ReferencedSVGResources& ensureReferencedSVGResources();

--- a/Source/WebCore/rendering/RenderFlexibleBox.h
+++ b/Source/WebCore/rendering/RenderFlexibleBox.h
@@ -276,17 +276,17 @@ private:
     // need an additional layout pass for correct stretch alignment handling, as
     // the first layout likely did not use the correct value for percentage
     // sizing of children.
-    WeakHashSet<const RenderBox> m_relaidOutChildren;
+    SingleThreadWeakHashSet<const RenderBox> m_relaidOutChildren;
 
     mutable OrderIterator m_orderIterator { *this };
     std::optional<size_t> m_numberOfInFlowChildrenOnFirstLine { };
     std::optional<size_t> m_numberOfInFlowChildrenOnLastLine { };
 
     struct MarginTrimItems {
-        WeakHashSet<const RenderBox> m_itemsAtFlexLineStart;
-        WeakHashSet<const RenderBox> m_itemsAtFlexLineEnd;
-        WeakHashSet<const RenderBox> m_itemsOnFirstFlexLine;
-        WeakHashSet<const RenderBox> m_itemsOnLastFlexLine;
+        SingleThreadWeakHashSet<const RenderBox> m_itemsAtFlexLineStart;
+        SingleThreadWeakHashSet<const RenderBox> m_itemsAtFlexLineEnd;
+        SingleThreadWeakHashSet<const RenderBox> m_itemsOnFirstFlexLine;
+        SingleThreadWeakHashSet<const RenderBox> m_itemsOnLastFlexLine;
     } m_marginTrimItems;
 
     // This is SizeIsUnknown outside of layoutBlock()

--- a/Source/WebCore/rendering/RenderFragmentContainer.h
+++ b/Source/WebCore/rendering/RenderFragmentContainer.h
@@ -145,7 +145,7 @@ private:
     LayoutPoint mapFragmentPointIntoFragmentedFlowCoordinates(const LayoutPoint&);
 
 protected:
-    WeakPtr<RenderFragmentedFlow> m_fragmentedFlow;
+    SingleThreadWeakPtr<RenderFragmentedFlow> m_fragmentedFlow;
 
 private:
     LayoutRect m_fragmentedFlowPortionRect;

--- a/Source/WebCore/rendering/RenderFragmentedFlow.cpp
+++ b/Source/WebCore/rendering/RenderFragmentedFlow.cpp
@@ -259,7 +259,7 @@ public:
     const LayoutUnit& lowValue() const { return m_offset; }
     const LayoutUnit& highValue() const { return m_offset; }
 
-    void collectIfNeeded(const PODInterval<LayoutUnit, WeakPtr<RenderFragmentContainer>>& interval)
+    void collectIfNeeded(const PODInterval<LayoutUnit, SingleThreadWeakPtr<RenderFragmentContainer>>& interval)
     {
         if (m_result)
             return;
@@ -271,7 +271,7 @@ public:
 
 private:
     LayoutUnit m_offset;
-    WeakPtr<RenderFragmentContainer> m_result;
+    SingleThreadWeakPtr<RenderFragmentContainer> m_result;
 };
 
 RenderFragmentContainer* RenderFragmentedFlow::fragmentAtBlockOffset(const RenderBox* clampBox, LayoutUnit offset, bool extendLastFragment) const

--- a/Source/WebCore/rendering/RenderFragmentedFlow.h
+++ b/Source/WebCore/rendering/RenderFragmentedFlow.h
@@ -43,9 +43,9 @@ class RenderStyle;
 class RenderFragmentContainer;
 class LegacyRootInlineBox;
 
-typedef WeakListHashSet<RenderFragmentContainer> RenderFragmentContainerList;
-typedef Vector<WeakPtr<RenderLayer>> RenderLayerList;
-typedef HashMap<const LegacyRootInlineBox*, WeakPtr<RenderFragmentContainer>> ContainingFragmentMap;
+typedef SingleThreadWeakListHashSet<RenderFragmentContainer> RenderFragmentContainerList;
+typedef Vector<SingleThreadWeakPtr<RenderLayer>> RenderLayerList;
+typedef HashMap<const LegacyRootInlineBox*, SingleThreadWeakPtr<RenderFragmentContainer>> ContainingFragmentMap;
 
 // RenderFragmentedFlow is used to collect all the render objects that participate in a
 // flow thread. It will also help in doing the layout. However, it will not render
@@ -226,8 +226,8 @@ protected:
         void clearRangeInvalidated() { m_rangeInvalidated = false; }
 
     private:
-        WeakPtr<RenderFragmentContainer> m_startFragment;
-        WeakPtr<RenderFragmentContainer> m_endFragment;
+        SingleThreadWeakPtr<RenderFragmentContainer> m_startFragment;
+        SingleThreadWeakPtr<RenderFragmentContainer> m_endFragment;
         bool m_rangeInvalidated;
     };
 
@@ -247,7 +247,7 @@ protected:
     RenderBoxToFragmentMap m_breakBeforeToFragmentMap;
     RenderBoxToFragmentMap m_breakAfterToFragmentMap;
 
-    using FragmentIntervalTree = PODIntervalTree<LayoutUnit, WeakPtr<RenderFragmentContainer>>;
+    using FragmentIntervalTree = PODIntervalTree<LayoutUnit, SingleThreadWeakPtr<RenderFragmentContainer>>;
     FragmentIntervalTree m_fragmentIntervalTree;
 
     CurrentRenderFragmentContainerMaintainer* m_currentFragmentMaintainer;

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -1814,7 +1814,7 @@ std::optional<LayoutUnit> RenderGrid::lastLineBaseline() const
     return baseline.value() + baselineChild->logicalTop().toInt();
 }
 
-WeakPtr<RenderBox> RenderGrid::getBaselineChild(ItemPosition alignment) const
+SingleThreadWeakPtr<RenderBox> RenderGrid::getBaselineChild(ItemPosition alignment) const
 {
     ASSERT(alignment == ItemPosition::Baseline || alignment == ItemPosition::LastBaseline);
     const RenderBox* baselineChild = nullptr;

--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -232,7 +232,7 @@ private:
     LayoutUnit baselinePosition(FontBaseline, bool firstLine, LineDirectionMode, LinePositionMode = PositionOnContainingLine) const final;
     std::optional<LayoutUnit> firstLineBaseline() const final;
     std::optional<LayoutUnit> lastLineBaseline() const final;
-    WeakPtr<RenderBox> getBaselineChild(ItemPosition alignment) const;
+    SingleThreadWeakPtr<RenderBox> getBaselineChild(ItemPosition alignment) const;
     std::optional<LayoutUnit> inlineBlockBaseline(LineDirectionMode) const final;
     bool isInlineBaselineAlignedChild(const RenderBox&) const;
 

--- a/Source/WebCore/rendering/RenderHighlight.h
+++ b/Source/WebCore/rendering/RenderHighlight.h
@@ -59,8 +59,8 @@ public:
     friend bool operator==(const RenderRange&, const RenderRange&) = default;
 
 private:
-    WeakPtr<RenderObject> m_start;
-    WeakPtr<RenderObject> m_end;
+    SingleThreadWeakPtr<RenderObject> m_start;
+    SingleThreadWeakPtr<RenderObject> m_end;
     unsigned m_startOffset { 0 };
     unsigned m_endOffset { 0 };
 };

--- a/Source/WebCore/rendering/RenderImageResource.h
+++ b/Source/WebCore/rendering/RenderImageResource.h
@@ -70,7 +70,7 @@ protected:
 private:
     virtual LayoutSize imageSize(float multiplier, CachedImage::SizeType) const;
 
-    WeakPtr<RenderElement> m_renderer;
+    SingleThreadWeakPtr<RenderElement> m_renderer;
     CachedResourceHandle<CachedImage> m_cachedImage;
     bool m_cachedImageRemoveClientIsNeeded { true };
 };

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -2396,7 +2396,7 @@ static RenderLayer* findCommonAncestor(const RenderLayer& firstLayer, const Rend
     if (&firstLayer == &secondLayer)
         return const_cast<RenderLayer*>(&firstLayer);
 
-    WeakHashSet<const RenderLayer> ancestorChain;
+    SingleThreadWeakHashSet<const RenderLayer> ancestorChain;
     for (auto* currLayer = &firstLayer; currLayer; currLayer = currLayer->parent())
         ancestorChain.add(*currLayer);
 

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -152,7 +152,7 @@ struct ScrollRectToVisibleOptions {
 
 using ScrollingScope = uint64_t;
 
-class RenderLayer : public CanMakeWeakPtr<RenderLayer>, public CanMakeCheckedPtr {
+class RenderLayer : public CanMakeSingleThreadWeakPtr<RenderLayer>, public CanMakeCheckedPtr {
     WTF_MAKE_ISO_ALLOCATED(RenderLayer);
 public:
     friend class RenderReplica;
@@ -1300,7 +1300,7 @@ private:
     RenderLayer* m_first { nullptr };
     RenderLayer* m_last { nullptr };
 
-    WeakPtr<RenderLayer> m_backingProviderLayer;
+    SingleThreadWeakPtr<RenderLayer> m_backingProviderLayer;
 
     // For layers that establish stacking contexts, m_posZOrderList holds a sorted list of all the
     // descendant layers within the stacking context that have z-indices of 0 or greater
@@ -1335,11 +1335,11 @@ private:
     RenderPtr<RenderReplica> m_reflection;
 
     // Pointer to the enclosing RenderLayer that caused us to be paginated. It is 0 if we are not paginated.
-    WeakPtr<RenderLayer> m_enclosingPaginationLayer;
+    SingleThreadWeakPtr<RenderLayer> m_enclosingPaginationLayer;
 
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
     // Pointer to the enclosing RenderSVGHiddenContainer or RenderSVGResourceContainer, if present.
-    WeakPtr<RenderSVGHiddenContainer> m_enclosingSVGHiddenOrResourceContainer;
+    SingleThreadWeakPtr<RenderSVGHiddenContainer> m_enclosingSVGHiddenOrResourceContainer;
 #endif
 
     IntRect m_blockSelectionGapsBounds;

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -290,7 +290,7 @@ void RenderLayerBacking::willDestroyLayer(const GraphicsLayer* layer)
         compositor().layerTiledBackingUsageChanged(layer, false);
 }
 
-static void clearBackingSharingLayerProviders(WeakListHashSet<RenderLayer>& sharingLayers, const RenderLayer& providerLayer)
+static void clearBackingSharingLayerProviders(SingleThreadWeakListHashSet<RenderLayer>& sharingLayers, const RenderLayer& providerLayer)
 {
     for (auto& layer : sharingLayers) {
         if (layer.backingProviderLayer() == &providerLayer)
@@ -298,7 +298,7 @@ static void clearBackingSharingLayerProviders(WeakListHashSet<RenderLayer>& shar
     }
 }
 
-void RenderLayerBacking::setBackingSharingLayers(WeakListHashSet<RenderLayer>&& sharingLayers)
+void RenderLayerBacking::setBackingSharingLayers(SingleThreadWeakListHashSet<RenderLayer>&& sharingLayers)
 {
     bool sharingLayersChanged = m_backingSharingLayers.computeSize() != sharingLayers.computeSize();
     // For layers that used to share and no longer do, and are not composited, recompute repaint rects.

--- a/Source/WebCore/rendering/RenderLayerBacking.h
+++ b/Source/WebCore/rendering/RenderLayerBacking.h
@@ -68,8 +68,8 @@ public:
     RenderLayer& owningLayer() const { return m_owningLayer; }
 
     // Included layers are non-z-order descendant layers that are painted into this backing.
-    const WeakListHashSet<RenderLayer>& backingSharingLayers() const { return m_backingSharingLayers; }
-    void setBackingSharingLayers(WeakListHashSet<RenderLayer>&&);
+    const SingleThreadWeakListHashSet<RenderLayer>& backingSharingLayers() const { return m_backingSharingLayers; }
+    void setBackingSharingLayers(SingleThreadWeakListHashSet<RenderLayer>&&);
 
     bool hasBackingSharingLayers() const { return !m_backingSharingLayers.isEmptyIgnoringNullReferences(); }
 
@@ -410,7 +410,7 @@ private:
     RenderLayer& m_owningLayer;
     
     // A list other layers that paint into this backing store, later than m_owningLayer in paint order.
-    WeakListHashSet<RenderLayer> m_backingSharingLayers;
+    SingleThreadWeakListHashSet<RenderLayer> m_backingSharingLayers;
 
     std::unique_ptr<LayerAncestorClippingStack> m_ancestorClippingStack; // Only used if we are clipped by an ancestor which is not a stacking context.
     std::unique_ptr<LayerAncestorClippingStack> m_overflowControlsHostLayerAncestorClippingStack; // Used when we have an overflow controls host layer which was reparented, and needs clipping by ancestors.

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -294,8 +294,8 @@ public:
     BackingSharingState() = default;
 
     struct Provider {
-        WeakPtr<RenderLayer> providerLayer;
-        WeakListHashSet<RenderLayer> sharingLayers;
+        SingleThreadWeakPtr<RenderLayer> providerLayer;
+        SingleThreadWeakListHashSet<RenderLayer> sharingLayers;
         LayoutRect absoluteBounds;
     };
 
@@ -331,7 +331,7 @@ private:
 
     Vector<Provider> m_backingProviderCandidates;
     RenderLayer* m_backingSharingStackingContext { nullptr };
-    WeakHashSet<RenderLayer> m_layersPendingRepaint;
+    SingleThreadWeakHashSet<RenderLayer> m_layersPendingRepaint;
 };
 
 WTF::TextStream& operator<<(WTF::TextStream&, const RenderLayerCompositor::BackingSharingState::Provider&);

--- a/Source/WebCore/rendering/RenderLayerCompositor.h
+++ b/Source/WebCore/rendering/RenderLayerCompositor.h
@@ -136,8 +136,8 @@ private:
 
     ChromeClient& m_chromeClient;
 
-    WeakHashSet<RenderLayer> m_scrollingLayers;
-    WeakHashSet<RenderLayer> m_viewportConstrainedLayers;
+    SingleThreadWeakHashSet<RenderLayer> m_scrollingLayers;
+    SingleThreadWeakHashSet<RenderLayer> m_viewportConstrainedLayers;
 
     const bool m_coordinateViewportConstrainedLayers;
 };
@@ -640,8 +640,8 @@ private:
     Color m_viewBackgroundColor;
     Color m_rootExtendedBackgroundColor;
 
-    HashMap<ScrollingNodeID, WeakPtr<RenderLayer>> m_scrollingNodeToLayerMap;
-    WeakHashSet<RenderLayer> m_layersWithUnresolvedRelations;
+    HashMap<ScrollingNodeID, SingleThreadWeakPtr<RenderLayer>> m_scrollingNodeToLayerMap;
+    SingleThreadWeakHashSet<RenderLayer> m_layersWithUnresolvedRelations;
 #if PLATFORM(IOS_FAMILY)
     std::unique_ptr<LegacyWebKitScrollingLayerCoordinator> m_legacyScrollingLayerCoordinator;
 #endif

--- a/Source/WebCore/rendering/RenderLayoutState.h
+++ b/Source/WebCore/rendering/RenderLayoutState.h
@@ -45,13 +45,13 @@ class RenderLayoutState {
 public:
     struct TextBoxTrim {
         bool trimFirstFormattedLine { false };
-        WeakPtr<const RenderBlockFlow> trimLastFormattedLineOnTarget;
+        SingleThreadWeakPtr<const RenderBlockFlow> trimLastFormattedLineOnTarget;
     };
     struct LineClamp {
         size_t maximumLineCount { 0 };
         size_t currentLineCount { 0 };
         std::optional<LayoutUnit> clampedContentLogicalHeight;
-        WeakPtr<const RenderBlockFlow> clampedRenderer;
+        SingleThreadWeakPtr<const RenderBlockFlow> clampedRenderer;
     };
 
     RenderLayoutState()
@@ -141,7 +141,7 @@ private:
     Vector<bool> m_blockStartTrimming;
 
     // The current line grid that we're snapping to and the offset of the start of the grid.
-    WeakPtr<RenderBlockFlow> m_lineGrid;
+    SingleThreadWeakPtr<RenderBlockFlow> m_lineGrid;
 
     // FIXME: Distinguish between the layout clip rect and the paint clip rect which may be larger,
     // e.g., because of composited scrolling.

--- a/Source/WebCore/rendering/RenderLineBoxList.cpp
+++ b/Source/WebCore/rendering/RenderLineBoxList.cpp
@@ -222,7 +222,7 @@ void RenderLineBoxList::paint(RenderBoxModelObject* renderer, PaintInfo& paintIn
         return;
 
     PaintInfo info(paintInfo);
-    WeakListHashSet<RenderInline> outlineObjects;
+    SingleThreadWeakListHashSet<RenderInline> outlineObjects;
     info.outlineObjects = &outlineObjects;
 
     // See if our root lines intersect with the dirty rect.  If so, then we paint

--- a/Source/WebCore/rendering/RenderListItem.h
+++ b/Source/WebCore/rendering/RenderListItem.h
@@ -75,7 +75,7 @@ private:
     void updateValueNow() const;
     void counterDirectivesChanged();
 
-    WeakPtr<RenderListMarker> m_marker;
+    SingleThreadWeakPtr<RenderListMarker> m_marker;
     mutable std::optional<int> m_value;
     bool m_notInList { false };
 };

--- a/Source/WebCore/rendering/RenderListMarker.h
+++ b/Source/WebCore/rendering/RenderListMarker.h
@@ -84,7 +84,7 @@ private:
     uint8_t m_textWithoutSuffixLength { 0 };
     bool m_textIsLeftToRightDirection { true };
     RefPtr<StyleImage> m_image;
-    WeakPtr<RenderListItem> m_listItem;
+    SingleThreadWeakPtr<RenderListItem> m_listItem;
     LayoutUnit m_lineOffsetForListItem;
     LayoutUnit m_lineLogicalOffsetForListItem;
 };

--- a/Source/WebCore/rendering/RenderMenuList.h
+++ b/Source/WebCore/rendering/RenderMenuList.h
@@ -141,8 +141,8 @@ private:
 
     bool isFlexibleBoxImpl() const override { return true; }
 
-    WeakPtr<RenderText> m_buttonText;
-    WeakPtr<RenderBlock> m_innerBlock;
+    SingleThreadWeakPtr<RenderText> m_buttonText;
+    SingleThreadWeakPtr<RenderBlock> m_innerBlock;
 
     bool m_needsOptionsWidthUpdate;
     int m_optionsWidth;

--- a/Source/WebCore/rendering/RenderMultiColumnFlow.h
+++ b/Source/WebCore/rendering/RenderMultiColumnFlow.h
@@ -95,7 +95,7 @@ public:
     // FIXME: Eventually as column and fragment flow threads start nesting, this will end up changing.
     bool shouldCheckColumnBreaks() const override;
 
-    typedef HashMap<const RenderBox*, WeakPtr<RenderMultiColumnSpannerPlaceholder>> SpannerMap;
+    typedef HashMap<const RenderBox*, SingleThreadWeakPtr<RenderMultiColumnSpannerPlaceholder>> SpannerMap;
     SpannerMap& spannerMap() { return *m_spannerMap; }
 
 private:

--- a/Source/WebCore/rendering/RenderMultiColumnSpannerPlaceholder.h
+++ b/Source/WebCore/rendering/RenderMultiColumnSpannerPlaceholder.h
@@ -51,8 +51,8 @@ private:
     void paint(PaintInfo&, const LayoutPoint&) override { }
     ASCIILiteral renderName() const override;
 
-    WeakPtr<RenderBox> m_spanner;
-    WeakPtr<RenderMultiColumnFlow> m_fragmentedFlow;
+    SingleThreadWeakPtr<RenderBox> m_spanner;
+    SingleThreadWeakPtr<RenderMultiColumnFlow> m_fragmentedFlow;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -1230,7 +1230,7 @@ private:
 
         // From RenderElement
         std::unique_ptr<ReferencedSVGResources> referencedSVGResources;
-        WeakPtr<RenderBlockFlow> backdropRenderer;
+        SingleThreadWeakPtr<RenderBlockFlow> backdropRenderer;
 
         // From RenderBox
         RefPtr<ControlPart> controlPart;

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -158,7 +158,7 @@ void RenderTable::styleDidChange(StyleDifference diff, const RenderStyle* oldSty
         invalidateCollapsedBorders();
 }
 
-static inline void resetSectionPointerIfNotBefore(WeakPtr<RenderTableSection>& section, RenderObject* before)
+static inline void resetSectionPointerIfNotBefore(SingleThreadWeakPtr<RenderTableSection>& section, RenderObject* before)
 {
     if (!before || !section)
         return;

--- a/Source/WebCore/rendering/RenderTable.h
+++ b/Source/WebCore/rendering/RenderTable.h
@@ -274,16 +274,16 @@ private:
 
     mutable Vector<LayoutUnit> m_columnPos;
     mutable Vector<ColumnStruct> m_columns;
-    mutable Vector<WeakPtr<RenderTableCaption>> m_captions;
-    mutable Vector<WeakPtr<RenderTableCol>> m_columnRenderers;
+    mutable Vector<SingleThreadWeakPtr<RenderTableCaption>> m_captions;
+    mutable Vector<SingleThreadWeakPtr<RenderTableCol>> m_columnRenderers;
 
     unsigned effectiveIndexOfColumn(const RenderTableCol&) const;
     typedef HashMap<const RenderTableCol*, unsigned> EffectiveColumnIndexMap;
     mutable EffectiveColumnIndexMap m_effectiveColumnIndexMap;
 
-    mutable WeakPtr<RenderTableSection> m_head;
-    mutable WeakPtr<RenderTableSection> m_foot;
-    mutable WeakPtr<RenderTableSection> m_firstBody;
+    mutable SingleThreadWeakPtr<RenderTableSection> m_head;
+    mutable SingleThreadWeakPtr<RenderTableSection> m_foot;
+    mutable SingleThreadWeakPtr<RenderTableSection> m_firstBody;
 
     std::unique_ptr<TableLayout> m_tableLayout;
 

--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -946,14 +946,14 @@ void RenderTableSection::paint(PaintInfo& paintInfo, const LayoutPoint& paintOff
         paintOutline(paintInfo, LayoutRect(adjustedPaintOffset, size()));
 }
 
-static inline bool compareCellPositions(const WeakPtr<RenderTableCell>& elem1, const WeakPtr<RenderTableCell>& elem2)
+static inline bool compareCellPositions(const SingleThreadWeakPtr<RenderTableCell>& elem1, const SingleThreadWeakPtr<RenderTableCell>& elem2)
 {
     return elem1->rowIndex() < elem2->rowIndex();
 }
 
 // This comparison is used only when we have overflowing cells as we have an unsorted array to sort. We thus need
 // to sort both on rows and columns to properly repaint.
-static inline bool compareCellPositionsWithOverflowingCells(const WeakPtr<RenderTableCell>& elem1, const WeakPtr<RenderTableCell>& elem2)
+static inline bool compareCellPositionsWithOverflowingCells(const SingleThreadWeakPtr<RenderTableCell>& elem1, const SingleThreadWeakPtr<RenderTableCell>& elem2)
 {
     if (elem1->rowIndex() != elem2->rowIndex())
         return elem1->rowIndex() < elem2->rowIndex();

--- a/Source/WebCore/rendering/RenderTableSection.h
+++ b/Source/WebCore/rendering/RenderTableSection.h
@@ -232,7 +232,7 @@ private:
     // This HashSet holds the overflowing cells for faster painting.
     // If we have more than gMaxAllowedOverflowingCellRatio * total cells, it will be empty
     // and m_forceSlowPaintPathWithOverflowingCell will be set to save memory.
-    WeakHashSet<RenderTableCell> m_overflowingCells;
+    SingleThreadWeakHashSet<RenderTableCell> m_overflowingCells;
 
     // This map holds the collapsed border values for cells with collapsed borders.
     // It is held at RenderTableSection level to spare memory consumption by table cells.

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -153,9 +153,9 @@ static HashMap<const RenderText*, String>& originalTextMap()
     return map;
 }
 
-static HashMap<const RenderText*, WeakPtr<RenderInline>>& inlineWrapperForDisplayContentsMap()
+static HashMap<const RenderText*, SingleThreadWeakPtr<RenderInline>>& inlineWrapperForDisplayContentsMap()
 {
-    static NeverDestroyed<HashMap<const RenderText*, WeakPtr<RenderInline>>> map;
+    static NeverDestroyed<HashMap<const RenderText*, SingleThreadWeakPtr<RenderInline>>> map;
     return map;
 }
 

--- a/Source/WebCore/rendering/RenderTextFragment.h
+++ b/Source/WebCore/rendering/RenderTextFragment.h
@@ -66,7 +66,7 @@ private:
     // Alternative description that can be used for accessibility instead of the native text.
     String m_altText;
     String m_contentString;
-    WeakPtr<RenderBoxModelObject> m_firstLetter;
+    SingleThreadWeakPtr<RenderBoxModelObject> m_firstLetter;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -930,12 +930,12 @@ void RenderView::removeRendererWithPausedImageAnimations(RenderElement& renderer
 
 void RenderView::resumePausedImageAnimationsIfNeeded(const IntRect& visibleRect)
 {
-    Vector<std::pair<WeakPtr<RenderElement>, WeakPtr<CachedImage>>, 10> toRemove;
+    Vector<std::pair<SingleThreadWeakPtr<RenderElement>, WeakPtr<CachedImage>>, 10> toRemove;
     for (auto it : m_renderersWithPausedImageAnimation) {
         auto& renderer = it.key;
         for (auto& image : it.value) {
             if (renderer.repaintForPausedImageAnimationsIfNeeded(visibleRect, *image))
-                toRemove.append({ renderer, image });
+                toRemove.append({ WeakPtr { renderer }, image });
         }
     }
     for (auto& pair : toRemove)
@@ -1131,7 +1131,7 @@ void RenderView::addCounterNeedingUpdate(RenderCounter& renderer)
     m_countersNeedingUpdate.add(renderer);
 }
 
-WeakHashSet<RenderCounter> RenderView::takeCountersNeedingUpdate()
+SingleThreadWeakHashSet<RenderCounter> RenderView::takeCountersNeedingUpdate()
 {
     return std::exchange(m_countersNeedingUpdate, { });
 }

--- a/Source/WebCore/rendering/RenderView.h
+++ b/Source/WebCore/rendering/RenderView.h
@@ -161,7 +161,7 @@ public:
     void setHasQuotesNeedingUpdate(bool b) { m_hasQuotesNeedingUpdate = b; }
 
     void addCounterNeedingUpdate(RenderCounter&);
-    WeakHashSet<RenderCounter> takeCountersNeedingUpdate();
+    SingleThreadWeakHashSet<RenderCounter> takeCountersNeedingUpdate();
 
     void incrementRendersWithOutline() { ++m_renderersWithOutlineCount; }
     void decrementRendersWithOutline() { ASSERT(m_renderersWithOutlineCount > 0); --m_renderersWithOutlineCount; }
@@ -195,7 +195,7 @@ public:
         ~RepaintRegionAccumulator();
 
     private:
-        WeakPtr<RenderView> m_rootView;
+        SingleThreadWeakPtr<RenderView> m_rootView;
         bool m_wasAccumulatingRepaintRegion { false };
     };
 
@@ -207,11 +207,11 @@ public:
 
     void registerBoxWithScrollSnapPositions(const RenderBox&);
     void unregisterBoxWithScrollSnapPositions(const RenderBox&);
-    const WeakHashSet<const RenderBox>& boxesWithScrollSnapPositions() { return m_boxesWithScrollSnapPositions; }
+    const SingleThreadWeakHashSet<const RenderBox>& boxesWithScrollSnapPositions() { return m_boxesWithScrollSnapPositions; }
 
     void registerContainerQueryBox(const RenderBox&);
     void unregisterContainerQueryBox(const RenderBox&);
-    const WeakHashSet<const RenderBox>& containerQueryBoxes() const { return m_containerQueryBoxes; }
+    const SingleThreadWeakHashSet<const RenderBox>& containerQueryBoxes() const { return m_containerQueryBoxes; }
 
 private:
     void styleDidChange(StyleDifference, const RenderStyle* oldStyle) override;
@@ -246,7 +246,7 @@ private:
     mutable std::unique_ptr<Region> m_accumulatedRepaintRegion;
     RenderSelection m_selection;
 
-    WeakPtr<RenderLayer> m_styleChangeLayerMutationRoot;
+    SingleThreadWeakPtr<RenderLayer> m_styleChangeLayerMutationRoot;
 
     // FIXME: Only used by embedded WebViews inside AppKit NSViews.  Find a way to remove.
     struct LegacyPrinting {
@@ -264,7 +264,7 @@ private:
     void lazyRepaintTimerFired();
 
     Timer m_lazyRepaintTimer;
-    WeakHashSet<RenderBox> m_renderersNeedingLazyRepaint;
+    SingleThreadWeakHashSet<RenderBox> m_renderersNeedingLazyRepaint;
 
     std::unique_ptr<ImageQualityController> m_imageQualityController;
     std::optional<LayoutSize> m_pageLogicalSize;
@@ -273,7 +273,7 @@ private:
 
     bool m_hasQuotesNeedingUpdate { false };
 
-    WeakHashSet<RenderCounter> m_countersNeedingUpdate;
+    SingleThreadWeakHashSet<RenderCounter> m_countersNeedingUpdate;
     unsigned m_renderCounterCount { 0 };
     unsigned m_renderersWithOutlineCount { 0 };
 
@@ -281,12 +281,12 @@ private:
     bool m_needsRepaintHackAfterCompositingLayerUpdateForDebugOverlaysOnly { false };
     bool m_needsEventRegionUpdateForNonCompositedFrame { false };
 
-    WeakHashMap<RenderElement, Vector<WeakPtr<CachedImage>>> m_renderersWithPausedImageAnimation;
+    SingleThreadWeakHashMap<RenderElement, Vector<WeakPtr<CachedImage>>> m_renderersWithPausedImageAnimation;
     WeakHashSet<SVGSVGElement, WeakPtrImplWithEventTargetData> m_SVGSVGElementsWithPausedImageAnimation;
-    WeakHashSet<RenderElement> m_visibleInViewportRenderers;
+    SingleThreadWeakHashSet<RenderElement> m_visibleInViewportRenderers;
 
-    WeakHashSet<const RenderBox> m_boxesWithScrollSnapPositions;
-    WeakHashSet<const RenderBox> m_containerQueryBoxes;
+    SingleThreadWeakHashSet<const RenderBox> m_boxesWithScrollSnapPositions;
+    SingleThreadWeakHashSet<const RenderBox> m_containerQueryBoxes;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/line/LineLayoutState.h
+++ b/Source/WebCore/rendering/line/LineLayoutState.h
@@ -160,7 +160,7 @@ private:
 
     LayoutUnit m_adjustedLogicalLineTop;
 
-    WeakPtr<RenderFragmentedFlow> m_fragmentedFlow;
+    SingleThreadWeakPtr<RenderFragmentedFlow> m_fragmentedFlow;
 
     FloatList m_floatList;
     // FIXME: Should this be a range object instead of two ints?

--- a/Source/WebCore/rendering/mathml/RenderMathMLFenced.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLFenced.h
@@ -55,7 +55,7 @@ private:
     String m_close;
     RefPtr<StringImpl> m_separators;
 
-    WeakPtr<RenderMathMLFencedOperator> m_closeFenceRenderer;
+    SingleThreadWeakPtr<RenderMathMLFencedOperator> m_closeFenceRenderer;
 };
 
 }

--- a/Source/WebCore/rendering/style/StyleGeneratedImage.h
+++ b/Source/WebCore/rendering/style/StyleGeneratedImage.h
@@ -42,7 +42,7 @@ struct ResourceLoaderOptions;
 
 class StyleGeneratedImage : public StyleImage {
 public:
-    const WeakHashCountedSet<RenderElement>& clients() const { return m_clients; }
+    const SingleThreadWeakHashCountedSet<RenderElement>& clients() const { return m_clients; }
 
 protected:
     explicit StyleGeneratedImage(StyleImage::Type, bool fixedSize);
@@ -76,7 +76,7 @@ protected:
 
     FloatSize m_containerSize;
     bool m_fixedSize;
-    WeakHashCountedSet<RenderElement> m_clients;
+    SingleThreadWeakHashCountedSet<RenderElement> m_clients;
     HashMap<FloatSize, std::unique_ptr<CachedGeneratedImage>> m_images;
 };
 

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.h
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.h
@@ -125,7 +125,7 @@ private:
     FloatRect m_objectBoundingBox;
     FloatRect m_objectBoundingBoxWithoutTransformations;
     mutable Markable<FloatRect, FloatRect::MarkableTraits> m_strokeBoundingBox;
-    WeakHashSet<LegacyRenderSVGResourceContainer> m_resourcesNeedingToInvalidateClients;
+    SingleThreadWeakHashSet<LegacyRenderSVGResourceContainer> m_resourcesNeedingToInvalidateClients;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/RenderSVGViewportContainer.h
+++ b/Source/WebCore/rendering/svg/RenderSVGViewportContainer.h
@@ -62,7 +62,7 @@ private:
 
     AffineTransform m_supplementalLayerTransform;
     FloatRect m_viewport;
-    WeakPtr<RenderSVGRoot> m_owningSVGRoot;
+    SingleThreadWeakPtr<RenderSVGRoot> m_owningSVGRoot;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
@@ -264,7 +264,7 @@ void SVGRenderSupport::layoutChildren(RenderElement& start, bool selfNeedsLayout
 {
     bool layoutSizeChanged = layoutSizeOfNearestViewportChanged(start);
     bool transformChanged = transformToRootChanged(&start);
-    WeakHashSet<RenderElement> elementsThatDidNotReceiveLayout;
+    SingleThreadWeakHashSet<RenderElement> elementsThatDidNotReceiveLayout;
 
     for (auto& child : childrenOfType<RenderObject>(start)) {
         bool needsLayout = selfNeedsLayout;
@@ -562,9 +562,9 @@ SVGHitTestCycleDetectionScope::~SVGHitTestCycleDetectionScope()
     ASSERT_UNUSED(result, result);
 }
 
-WeakHashSet<RenderElement>& SVGHitTestCycleDetectionScope::visitedElements()
+SingleThreadWeakHashSet<RenderElement>& SVGHitTestCycleDetectionScope::visitedElements()
 {
-    static NeverDestroyed<WeakHashSet<RenderElement>> s_visitedElements;
+    static NeverDestroyed<SingleThreadWeakHashSet<RenderElement>> s_visitedElements;
     return s_visitedElements;
 }
 

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.h
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.h
@@ -108,8 +108,8 @@ public:
     static bool isVisiting(const RenderElement&);
 
 private:
-    static WeakHashSet<RenderElement>& visitedElements();
-    WeakPtr<RenderElement> m_element;
+    static SingleThreadWeakHashSet<RenderElement>& visitedElements();
+    SingleThreadWeakPtr<RenderElement> m_element;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/SVGResources.cpp
+++ b/Source/WebCore/rendering/svg/SVGResources.cpp
@@ -459,7 +459,7 @@ bool SVGResources::resourceDestroyed(LegacyRenderSVGResourceContainer& resource)
     return foundResources;
 }
 
-void SVGResources::buildSetOfResources(WeakHashSet<LegacyRenderSVGResourceContainer>& set)
+void SVGResources::buildSetOfResources(SingleThreadWeakHashSet<LegacyRenderSVGResourceContainer>& set)
 {
     if (isEmpty())
         return;

--- a/Source/WebCore/rendering/svg/SVGResources.h
+++ b/Source/WebCore/rendering/svg/SVGResources.h
@@ -63,7 +63,7 @@ public:
     // Chainable resources - linked through xlink:href
     LegacyRenderSVGResourceContainer* linkedResource() const { return m_linkedResource.get(); }
 
-    void buildSetOfResources(WeakHashSet<LegacyRenderSVGResourceContainer>&);
+    void buildSetOfResources(SingleThreadWeakHashSet<LegacyRenderSVGResourceContainer>&);
 
     // Methods operating on all cached resources
     void removeClientFromCache(RenderElement&, bool markForInvalidation = true) const;
@@ -110,9 +110,9 @@ private:
         WTF_MAKE_FAST_ALLOCATED;
     public:
         ClipperFilterMaskerData() = default;
-        WeakPtr<LegacyRenderSVGResourceClipper> clipper;
-        WeakPtr<LegacyRenderSVGResourceFilter> filter;
-        WeakPtr<LegacyRenderSVGResourceMasker> masker;
+        SingleThreadWeakPtr<LegacyRenderSVGResourceClipper> clipper;
+        SingleThreadWeakPtr<LegacyRenderSVGResourceFilter> filter;
+        SingleThreadWeakPtr<LegacyRenderSVGResourceMasker> masker;
     };
 
     // From SVG 1.1 2nd Edition
@@ -121,9 +121,9 @@ private:
         WTF_MAKE_FAST_ALLOCATED;
     public:
         MarkerData() = default;
-        WeakPtr<LegacyRenderSVGResourceMarker> markerStart;
-        WeakPtr<LegacyRenderSVGResourceMarker> markerMid;
-        WeakPtr<LegacyRenderSVGResourceMarker> markerEnd;
+        SingleThreadWeakPtr<LegacyRenderSVGResourceMarker> markerStart;
+        SingleThreadWeakPtr<LegacyRenderSVGResourceMarker> markerMid;
+        SingleThreadWeakPtr<LegacyRenderSVGResourceMarker> markerEnd;
     };
 
     // From SVG 1.1 2nd Edition
@@ -134,14 +134,14 @@ private:
         WTF_MAKE_FAST_ALLOCATED;
     public:
         FillStrokeData() = default;
-        WeakPtr<LegacyRenderSVGResourceContainer> fill;
-        WeakPtr<LegacyRenderSVGResourceContainer> stroke;
+        SingleThreadWeakPtr<LegacyRenderSVGResourceContainer> fill;
+        SingleThreadWeakPtr<LegacyRenderSVGResourceContainer> stroke;
     };
 
     std::unique_ptr<ClipperFilterMaskerData> m_clipperFilterMaskerData;
     std::unique_ptr<MarkerData> m_markerData;
     std::unique_ptr<FillStrokeData> m_fillStrokeData;
-    WeakPtr<LegacyRenderSVGResourceContainer> m_linkedResource;
+    SingleThreadWeakPtr<LegacyRenderSVGResourceContainer> m_linkedResource;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/SVGResourcesCache.cpp
+++ b/Source/WebCore/rendering/svg/SVGResourcesCache.cpp
@@ -54,7 +54,7 @@ void SVGResourcesCache::addResourcesFromRenderer(RenderElement& renderer, const 
     SVGResourcesCycleSolver::resolveCycles(renderer, resources);
 
     // Walk resources and register the render object at each resources.
-    WeakHashSet<LegacyRenderSVGResourceContainer> resourceSet;
+    SingleThreadWeakHashSet<LegacyRenderSVGResourceContainer> resourceSet;
     resources.buildSetOfResources(resourceSet);
 
     for (auto& resourceContainer : resourceSet)
@@ -74,7 +74,7 @@ void SVGResourcesCache::removeResourcesFromRenderer(RenderElement& renderer)
         return;
 
     // Walk resources and register the render object at each resources.
-    WeakHashSet<LegacyRenderSVGResourceContainer> resourceSet;
+    SingleThreadWeakHashSet<LegacyRenderSVGResourceContainer> resourceSet;
     resources->buildSetOfResources(resourceSet);
 
     for (auto& resourceContainer : resourceSet)

--- a/Source/WebCore/rendering/svg/SVGResourcesCycleSolver.cpp
+++ b/Source/WebCore/rendering/svg/SVGResourcesCycleSolver.cpp
@@ -34,7 +34,7 @@
 namespace WebCore {
 
 bool SVGResourcesCycleSolver::resourceContainsCycles(LegacyRenderSVGResourceContainer& resource,
-    WeakHashSet<LegacyRenderSVGResourceContainer>& activeResources, WeakHashSet<LegacyRenderSVGResourceContainer>& acyclicResources)
+    SingleThreadWeakHashSet<LegacyRenderSVGResourceContainer>& activeResources, SingleThreadWeakHashSet<LegacyRenderSVGResourceContainer>& acyclicResources)
 {
     if (acyclicResources.contains(resource))
         return false;
@@ -52,7 +52,7 @@ bool SVGResourcesCycleSolver::resourceContainsCycles(LegacyRenderSVGResourceCont
         }
         if (is<RenderElement>(*node)) {
             if (auto* resources = SVGResourcesCache::cachedResourcesForRenderer(downcast<RenderElement>(*node))) {
-                WeakHashSet<LegacyRenderSVGResourceContainer> resourceSet;
+                SingleThreadWeakHashSet<LegacyRenderSVGResourceContainer> resourceSet;
                 resources->buildSetOfResources(resourceSet);
 
                 for (auto& resource : resourceSet) {
@@ -77,11 +77,11 @@ void SVGResourcesCycleSolver::resolveCycles(RenderElement& renderer, SVGResource
         RELEASE_ASSERT_NOT_REACHED();
 #endif
 
-    WeakHashSet<LegacyRenderSVGResourceContainer> localResources;
+    SingleThreadWeakHashSet<LegacyRenderSVGResourceContainer> localResources;
     resources.buildSetOfResources(localResources);
 
-    WeakHashSet<LegacyRenderSVGResourceContainer> activeResources;
-    WeakHashSet<LegacyRenderSVGResourceContainer> acyclicResources;
+    SingleThreadWeakHashSet<LegacyRenderSVGResourceContainer> activeResources;
+    SingleThreadWeakHashSet<LegacyRenderSVGResourceContainer> acyclicResources;
 
     if (is<LegacyRenderSVGResourceContainer>(renderer))
         activeResources.add(downcast<LegacyRenderSVGResourceContainer>(renderer));

--- a/Source/WebCore/rendering/svg/SVGResourcesCycleSolver.h
+++ b/Source/WebCore/rendering/svg/SVGResourcesCycleSolver.h
@@ -37,7 +37,7 @@ public:
 private:
     SVGResourcesCycleSolver() { }
 
-    static bool resourceContainsCycles(LegacyRenderSVGResourceContainer&, WeakHashSet<LegacyRenderSVGResourceContainer>& activeResources, WeakHashSet<LegacyRenderSVGResourceContainer>& acyclicResources);
+    static bool resourceContainsCycles(LegacyRenderSVGResourceContainer&, SingleThreadWeakHashSet<LegacyRenderSVGResourceContainer>& activeResources, SingleThreadWeakHashSet<LegacyRenderSVGResourceContainer>& acyclicResources);
     static void breakCycle(LegacyRenderSVGResourceContainer&, SVGResources&);
 };
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResource.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResource.cpp
@@ -147,7 +147,7 @@ static inline LegacyRenderSVGResource* requestPaintingResource(RenderSVGResource
 
 void LegacyRenderSVGResource::removeAllClientsFromCache(bool markForInvalidation)
 {
-    WeakHashSet<RenderObject> visitedRenderers;
+    SingleThreadWeakHashSet<RenderObject> visitedRenderers;
     removeAllClientsFromCacheIfNeeded(markForInvalidation, &visitedRenderers);
 }
 
@@ -169,7 +169,7 @@ LegacyRenderSVGResourceSolidColor* LegacyRenderSVGResource::sharedSolidPaintingR
     return s_sharedSolidPaintingResource;
 }
 
-static void removeFromCacheAndInvalidateDependencies(RenderElement& renderer, bool needsLayout, WeakHashSet<RenderObject>* visitedRenderers)
+static void removeFromCacheAndInvalidateDependencies(RenderElement& renderer, bool needsLayout, SingleThreadWeakHashSet<RenderObject>* visitedRenderers)
 {
     if (auto* resources = SVGResourcesCache::cachedResourcesForRenderer(renderer)) {
         if (LegacyRenderSVGResourceFilter* filter = resources->filter())
@@ -210,11 +210,11 @@ static void removeFromCacheAndInvalidateDependencies(RenderElement& renderer, bo
 
 void LegacyRenderSVGResource::markForLayoutAndParentResourceInvalidation(RenderObject& object, bool needsLayout)
 {
-    WeakHashSet<RenderObject> visitedRenderers;
+    SingleThreadWeakHashSet<RenderObject> visitedRenderers;
     markForLayoutAndParentResourceInvalidationIfNeeded(object, needsLayout, &visitedRenderers);
 }
 
-void LegacyRenderSVGResource::markForLayoutAndParentResourceInvalidationIfNeeded(RenderObject& object, bool needsLayout, WeakHashSet<RenderObject>* visitedRenderers)
+void LegacyRenderSVGResource::markForLayoutAndParentResourceInvalidationIfNeeded(RenderObject& object, bool needsLayout, SingleThreadWeakHashSet<RenderObject>* visitedRenderers)
 {
     ASSERT(object.node());
 #if ENABLE(LAYER_BASED_SVG_ENGINE)

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResource.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResource.h
@@ -61,7 +61,7 @@ public:
     virtual ~LegacyRenderSVGResource() = default;
 
     void removeAllClientsFromCache(bool markForInvalidation = true);
-    virtual void removeAllClientsFromCacheIfNeeded(bool markForInvalidation, WeakHashSet<RenderObject>* visitedRenderers) = 0;
+    virtual void removeAllClientsFromCacheIfNeeded(bool markForInvalidation, SingleThreadWeakHashSet<RenderObject>* visitedRenderers) = 0;
     virtual void removeClientFromCache(RenderElement&, bool markForInvalidation = true) = 0;
 
     virtual bool applyResource(RenderElement&, const RenderStyle&, GraphicsContext*&, OptionSet<RenderSVGResourceMode>) = 0;
@@ -76,7 +76,7 @@ public:
     static LegacyRenderSVGResourceSolidColor* sharedSolidPaintingResource();
 
     static void markForLayoutAndParentResourceInvalidation(RenderObject&, bool needsLayout = true);
-    static void markForLayoutAndParentResourceInvalidationIfNeeded(RenderObject&, bool needsLayout, WeakHashSet<RenderObject>* visitedRenderers);
+    static void markForLayoutAndParentResourceInvalidationIfNeeded(RenderObject&, bool needsLayout, SingleThreadWeakHashSet<RenderObject>* visitedRenderers);
 
 protected:
     void fillAndStrokePathOrShape(GraphicsContext&, OptionSet<RenderSVGResourceMode>, const Path*, const RenderElement* shape) const;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp
@@ -57,7 +57,7 @@ LegacyRenderSVGResourceClipper::LegacyRenderSVGResourceClipper(SVGClipPathElemen
 
 LegacyRenderSVGResourceClipper::~LegacyRenderSVGResourceClipper() = default;
 
-void LegacyRenderSVGResourceClipper::removeAllClientsFromCacheIfNeeded(bool markForInvalidation, WeakHashSet<RenderObject>* visitedRenderers)
+void LegacyRenderSVGResourceClipper::removeAllClientsFromCacheIfNeeded(bool markForInvalidation, SingleThreadWeakHashSet<RenderObject>* visitedRenderers)
 {
     m_clipBoundaries.fill(FloatRect { });
     m_clipperMap.clear();

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.h
@@ -65,7 +65,7 @@ public:
 
     inline SVGClipPathElement& clipPathElement() const;
 
-    void removeAllClientsFromCacheIfNeeded(bool markForInvalidation, WeakHashSet<RenderObject>* visitedRenderers) override;
+    void removeAllClientsFromCacheIfNeeded(bool markForInvalidation, SingleThreadWeakHashSet<RenderObject>* visitedRenderers) override;
     void removeClientFromCache(RenderElement&, bool markForInvalidation = true) override;
 
     bool applyResource(RenderElement&, const RenderStyle&, GraphicsContext*&, OptionSet<RenderSVGResourceMode>) override;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp
@@ -94,11 +94,11 @@ void LegacyRenderSVGResourceContainer::markAllClientsForRepaint()
 
 void LegacyRenderSVGResourceContainer::markAllClientsForInvalidation(InvalidationMode mode)
 {
-    WeakHashSet<RenderObject> visitedRenderers;
+    SingleThreadWeakHashSet<RenderObject> visitedRenderers;
     markAllClientsForInvalidationIfNeeded(mode, &visitedRenderers);
 }
 
-void LegacyRenderSVGResourceContainer::markAllClientsForInvalidationIfNeeded(InvalidationMode mode, WeakHashSet<RenderObject>* visitedRenderers)
+void LegacyRenderSVGResourceContainer::markAllClientsForInvalidationIfNeeded(InvalidationMode mode, SingleThreadWeakHashSet<RenderObject>* visitedRenderers)
 {
     // FIXME: Style invalidation should either be a pre-layout task or this function
     // should never get called while in layout. See webkit.org/b/208903.

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.h
@@ -61,7 +61,7 @@ protected:
     virtual bool selfNeedsClientInvalidation() const { return everHadLayout() && selfNeedsLayout(); }
 
     void markAllClientsForInvalidation(InvalidationMode);
-    void markAllClientsForInvalidationIfNeeded(InvalidationMode, WeakHashSet<RenderObject>* visitedRenderers);
+    void markAllClientsForInvalidationIfNeeded(InvalidationMode, SingleThreadWeakHashSet<RenderObject>* visitedRenderers);
     void markClientForInvalidation(RenderObject&, InvalidationMode);
 
 private:
@@ -73,8 +73,8 @@ private:
     void registerResource();
 
     AtomString m_id;
-    WeakHashSet<RenderElement> m_clients;
-    WeakHashSet<RenderLayer> m_clientLayers;
+    SingleThreadWeakHashSet<RenderElement> m_clients;
+    SingleThreadWeakHashSet<RenderLayer> m_clientLayers;
     bool m_registered { false };
     bool m_isInvalidating { false };
 };

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.cpp
@@ -54,7 +54,7 @@ bool LegacyRenderSVGResourceFilter::isIdentity() const
     return SVGFilter::isIdentity(filterElement());
 }
 
-void LegacyRenderSVGResourceFilter::removeAllClientsFromCacheIfNeeded(bool markForInvalidation, WeakHashSet<RenderObject>* visitedRenderers)
+void LegacyRenderSVGResourceFilter::removeAllClientsFromCacheIfNeeded(bool markForInvalidation, SingleThreadWeakHashSet<RenderObject>* visitedRenderers)
 {
     LOG(Filters, "LegacyRenderSVGResourceFilter %p removeAllClientsFromCacheIfNeeded", this);
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.h
@@ -62,7 +62,7 @@ public:
     inline SVGFilterElement& filterElement() const;
     bool isIdentity() const;
 
-    void removeAllClientsFromCacheIfNeeded(bool markForInvalidation, WeakHashSet<RenderObject>* visitedRenderers) override;
+    void removeAllClientsFromCacheIfNeeded(bool markForInvalidation, SingleThreadWeakHashSet<RenderObject>* visitedRenderers) override;
     void removeClientFromCache(RenderElement&, bool markForInvalidation = true) override;
 
     bool applyResource(RenderElement&, const RenderStyle&, GraphicsContext*&, OptionSet<RenderSVGResourceMode>) override;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.cpp
@@ -41,7 +41,7 @@ LegacyRenderSVGResourceGradient::LegacyRenderSVGResourceGradient(Type type, SVGG
 {
 }
 
-void LegacyRenderSVGResourceGradient::removeAllClientsFromCacheIfNeeded(bool markForInvalidation, WeakHashSet<RenderObject>* visitedRenderers)
+void LegacyRenderSVGResourceGradient::removeAllClientsFromCacheIfNeeded(bool markForInvalidation, SingleThreadWeakHashSet<RenderObject>* visitedRenderers)
 {
     m_gradientMap.clear();
     m_shouldCollectGradientAttributes = true;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.h
@@ -61,7 +61,7 @@ class LegacyRenderSVGResourceGradient : public LegacyRenderSVGResourceContainer 
 public:
     SVGGradientElement& gradientElement() const { return static_cast<SVGGradientElement&>(LegacyRenderSVGResourceContainer::element()); }
 
-    void removeAllClientsFromCacheIfNeeded(bool markForInvalidation, WeakHashSet<RenderObject>* visitedRenderers) final;
+    void removeAllClientsFromCacheIfNeeded(bool markForInvalidation, SingleThreadWeakHashSet<RenderObject>* visitedRenderers) final;
     void removeClientFromCache(RenderElement&, bool markForInvalidation = true) final;
 
     bool applyResource(RenderElement&, const RenderStyle&, GraphicsContext*&, OptionSet<RenderSVGResourceMode>) final;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMarker.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMarker.cpp
@@ -54,7 +54,7 @@ void LegacyRenderSVGResourceMarker::layout()
     LegacyRenderSVGContainer::layout();
 }
 
-void LegacyRenderSVGResourceMarker::removeAllClientsFromCacheIfNeeded(bool markForInvalidation, WeakHashSet<RenderObject>* visitedRenderers)
+void LegacyRenderSVGResourceMarker::removeAllClientsFromCacheIfNeeded(bool markForInvalidation, SingleThreadWeakHashSet<RenderObject>* visitedRenderers)
 {
     markAllClientsForInvalidationIfNeeded(markForInvalidation ? LayoutAndBoundariesInvalidation : ParentOnlyInvalidation, visitedRenderers);
 }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMarker.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMarker.h
@@ -35,7 +35,7 @@ public:
 
     inline SVGMarkerElement& markerElement() const;
 
-    void removeAllClientsFromCacheIfNeeded(bool markForInvalidation, WeakHashSet<RenderObject>* visitedRenderers) override;
+    void removeAllClientsFromCacheIfNeeded(bool markForInvalidation, SingleThreadWeakHashSet<RenderObject>* visitedRenderers) override;
     void removeClientFromCache(RenderElement&, bool markForInvalidation = true) override;
 
     void draw(PaintInfo&, const AffineTransform&);

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.cpp
@@ -42,7 +42,7 @@ LegacyRenderSVGResourceMasker::LegacyRenderSVGResourceMasker(SVGMaskElement& ele
 
 LegacyRenderSVGResourceMasker::~LegacyRenderSVGResourceMasker() = default;
 
-void LegacyRenderSVGResourceMasker::removeAllClientsFromCacheIfNeeded(bool markForInvalidation, WeakHashSet<RenderObject>* visitedRenderers)
+void LegacyRenderSVGResourceMasker::removeAllClientsFromCacheIfNeeded(bool markForInvalidation, SingleThreadWeakHashSet<RenderObject>* visitedRenderers)
 {
     m_maskContentBoundaries.fill(FloatRect { });
     m_masker.clear();

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.h
@@ -45,7 +45,7 @@ public:
 
     inline SVGMaskElement& maskElement() const;
 
-    void removeAllClientsFromCacheIfNeeded(bool markForInvalidation, WeakHashSet<RenderObject>* visitedRenderers) override;
+    void removeAllClientsFromCacheIfNeeded(bool markForInvalidation, SingleThreadWeakHashSet<RenderObject>* visitedRenderers) override;
     void removeClientFromCache(RenderElement&, bool markForInvalidation = true) override;
     bool applyResource(RenderElement&, const RenderStyle&, GraphicsContext*&, OptionSet<RenderSVGResourceMode>) override;
     bool drawContentIntoContext(GraphicsContext&, const FloatRect& objectBoundingBox);

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.cpp
@@ -48,7 +48,7 @@ SVGPatternElement& LegacyRenderSVGResourcePattern::patternElement() const
     return downcast<SVGPatternElement>(LegacyRenderSVGResourceContainer::element());
 }
 
-void LegacyRenderSVGResourcePattern::removeAllClientsFromCacheIfNeeded(bool markForInvalidation, WeakHashSet<RenderObject>* visitedRenderers)
+void LegacyRenderSVGResourcePattern::removeAllClientsFromCacheIfNeeded(bool markForInvalidation, SingleThreadWeakHashSet<RenderObject>* visitedRenderers)
 {
     m_patternMap.clear();
     m_shouldCollectPatternAttributes = true;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.h
@@ -45,7 +45,7 @@ public:
     LegacyRenderSVGResourcePattern(SVGPatternElement&, RenderStyle&&);
     SVGPatternElement& patternElement() const;
 
-    void removeAllClientsFromCacheIfNeeded(bool markForInvalidation, WeakHashSet<RenderObject>* visitedRenderers) override;
+    void removeAllClientsFromCacheIfNeeded(bool markForInvalidation, SingleThreadWeakHashSet<RenderObject>* visitedRenderers) override;
     void removeClientFromCache(RenderElement&, bool markForInvalidation = true) override;
 
     bool applyResource(RenderElement&, const RenderStyle&, GraphicsContext*&, OptionSet<RenderSVGResourceMode>) override;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceSolidColor.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceSolidColor.h
@@ -33,7 +33,7 @@ public:
     LegacyRenderSVGResourceSolidColor();
     virtual ~LegacyRenderSVGResourceSolidColor();
 
-    void removeAllClientsFromCacheIfNeeded(bool, WeakHashSet<RenderObject>*) override { }
+    void removeAllClientsFromCacheIfNeeded(bool, SingleThreadWeakHashSet<RenderObject>*) override { }
     void removeClientFromCache(RenderElement&, bool = true) override { }
 
     bool applyResource(RenderElement&, const RenderStyle&, GraphicsContext*&, OptionSet<RenderSVGResourceMode>) override;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h
@@ -119,7 +119,7 @@ private:
     mutable Markable<FloatRect, FloatRect::MarkableTraits> m_accurateRepaintBoundingBox;
     mutable AffineTransform m_localToParentTransform;
     AffineTransform m_localToBorderBoxTransform;
-    WeakHashSet<LegacyRenderSVGResourceContainer> m_resourcesNeedingToInvalidateClients;
+    SingleThreadWeakHashSet<LegacyRenderSVGResourceContainer> m_resourcesNeedingToInvalidateClients;
     bool m_isLayoutSizeChanged : 1;
     bool m_needsBoundariesOrTransformUpdate : 1;
     bool m_hasBoxDecorations : 1;

--- a/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
@@ -629,7 +629,7 @@ void RenderTreeBuilder::normalizeTreeAfterStyleChange(RenderElement& renderer, R
 
             // Style change may have moved some subtree out of the fragmented flow. Their flow states have already been updated (see adjustFragmentedFlowStateOnContainingBlockChangeIfNeeded)
             // and here is where we take care of the remaining, spanner tree mutation.
-            WeakHashSet<RenderElement> spannerContainingBlockSet;
+            SingleThreadWeakHashSet<RenderElement> spannerContainingBlockSet;
             for (auto& descendant : descendantsOfType<RenderMultiColumnSpannerPlaceholder>(renderer)) {
                 if (auto* containingBlock = descendant.containingBlock(); containingBlock && containingBlock->enclosingFragmentedFlow() != enclosingFragmentedFlow)
                     spannerContainingBlockSet.add(*containingBlock);

--- a/Source/WebCore/rendering/updating/RenderTreePosition.h
+++ b/Source/WebCore/rendering/updating/RenderTreePosition.h
@@ -54,7 +54,7 @@ public:
 
 private:
     RenderElement& m_parent;
-    WeakPtr<RenderObject> m_nextSibling { nullptr };
+    SingleThreadWeakPtr<RenderObject> m_nextSibling;
     bool m_hasValidNextSibling { false };
 #if ASSERT_ENABLED
     unsigned m_assertionLimitCounter { 0 };

--- a/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.h
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.h
@@ -52,7 +52,7 @@ private:
     bool needsPseudoElement(const RenderStyle*);
 
     RenderTreeUpdater& m_updater;
-    WeakPtr<RenderQuote> m_previousUpdatedQuote;
+    SingleThreadWeakPtr<RenderQuote> m_previousUpdatedQuote;
 };
 
 }

--- a/Source/WebCore/svg/graphics/SVGResourceImage.h
+++ b/Source/WebCore/svg/graphics/SVGResourceImage.h
@@ -49,7 +49,7 @@ private:
 
     void dump(WTF::TextStream&) const final;
 
-    WeakPtr<LegacyRenderSVGResourceContainer> m_renderResource;
+    SingleThreadWeakPtr<LegacyRenderSVGResourceContainer> m_renderResource;
     URL m_reresolvedURL;
 };
 


### PR DESCRIPTION
#### 206fc19611d7c0b49d5d67a7e0bed5c3051cab3d
<pre>
Optimize use of WeakPtr with RenderObject types
<a href="https://bugs.webkit.org/show_bug.cgi?id=265763">https://bugs.webkit.org/show_bug.cgi?id=265763</a>

Reviewed by Darin Adler.

We&apos;ve found that converting CheckedPtr to WeakPtr in hot code path has caused
performance regressions. At the same time, CheckedPtr crashes are much harder
to investigate.

After some investigation, I found that DefaultWeakPtrImpl subclasses
ThreadSafeRefCounted. For many types though, we don&apos;t really need this thread
safety and the cost incurred to achieve it.

I this patch, I introduce a SingleThreadWeakPtrImpl which relies on a
SingleThreadIntegralWrapper&lt;uint32_t&gt; internally. In release builds, this
achieves better performance. In debug, threading assertion are in place to
make sure it is indeed safe to use SingleThreadWeakPtrImpl.

In this patch, I also port CachedResourceClient to SingleThreadWeakPtrImpl since
subclasses are main thread only. RenderObject is the particular subclasses I am
interested in since it is performance sensitive and since we have not so
actionable CheckedPtr crashes in the wild involving RenderObject.

In follow-up patches, I am planning to replace usage for CheckedPtr with WeakPtr
for RenderObject, to make those crashes actionable.

* Source/WTF/wtf/CheckedRef.h:
(WTF::=):
* Source/WTF/wtf/WeakPtr.h:
(WTF::WeakPtrImplBaseSingleThread::get):
(WTF::WeakPtrImplBaseSingleThread::operator bool const):
(WTF::WeakPtrImplBaseSingleThread::clear):
(WTF::WeakPtrImplBaseSingleThread::wasConstructedOnMainThread const):
(WTF::WeakPtrImplBaseSingleThread::WeakPtrImplBaseSingleThread):
(WTF::WeakPtrImplBaseSingleThread::refCount const):
(WTF::WeakPtrImplBaseSingleThread::ref const):
(WTF::WeakPtrImplBaseSingleThread::deref const):
* Source/WebCore/accessibility/AccessibilityRenderObject.h:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::computeRenderStyleForProperty):
* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::willEnterFullscreen):
* Source/WebCore/editing/TextIterator.h:
* Source/WebCore/html/CustomPaintImage.h:
* Source/WebCore/inspector/agents/InspectorDOMAgent.h:
* Source/WebCore/layout/integration/LayoutIntegrationBoxTree.h:
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.h:
* Source/WebCore/loader/ImageLoader.h:
* Source/WebCore/loader/LinkPreloadResourceClients.h:
* Source/WebCore/loader/cache/CachedImage.h:
* Source/WebCore/loader/cache/CachedResource.cpp:
(WebCore::CachedResource::switchClientsToRevalidatedResource):
* Source/WebCore/loader/cache/CachedResource.h:
* Source/WebCore/loader/cache/CachedResourceClient.h:
* Source/WebCore/loader/cache/CachedResourceClientWalker.h:
* Source/WebCore/page/AutoscrollController.h:
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::handleMousePressEvent):
* Source/WebCore/page/EventHandler.h:
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::willDoLayout):
(WebCore::LocalFrameView::didLayout):
(WebCore::LocalFrameView::addSlowRepaintObject):
(WebCore::LocalFrameView::addViewportConstrainedObject):
(WebCore::LocalFrameView::updateEmbeddedObject):
(WebCore::LocalFrameView::updateEmbeddedObjects):
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/LocalFrameViewLayoutContext.cpp:
(WebCore::LocalFrameViewLayoutContext::performLayout):
(WebCore::LocalFrameViewLayoutContext::setBoxNeedsTransformUpdateAfterContainerLayout):
(WebCore::LocalFrameViewLayoutContext::takeBoxesNeedingTransformUpdateAfterContainerLayout):
* Source/WebCore/page/LocalFrameViewLayoutContext.h:
* Source/WebCore/page/Page.h:
* Source/WebCore/platform/PODInterval.h:
* Source/WebCore/rendering/AccessibilityRegionContext.h:
* Source/WebCore/rendering/AncestorSubgridIterator.cpp:
(WebCore::AncestorSubgridIterator::AncestorSubgridIterator):
* Source/WebCore/rendering/AncestorSubgridIterator.h:
(): Deleted.
* Source/WebCore/rendering/BaselineAlignment.h:
* Source/WebCore/rendering/FloatingObjects.cpp:
* Source/WebCore/rendering/FloatingObjects.h:
* Source/WebCore/rendering/Grid.h:
* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::IndefiniteSizeStrategy::accumulateFlexFraction const):
(WebCore::IndefiniteSizeStrategy::findUsedFlexFraction const):
(WebCore::GridTrackSizingAlgorithm::accumulateIntrinsicSizesForTrack):
(WebCore::GridTrackSizingAlgorithm::resolveIntrinsicTrackSizes):
* Source/WebCore/rendering/GridTrackSizingAlgorithm.h:
* Source/WebCore/rendering/LayerAncestorClippingStack.h:
* Source/WebCore/rendering/LegacyInlineBox.cpp:
* Source/WebCore/rendering/LegacyInlineBox.h:
* Source/WebCore/rendering/LegacyRootInlineBox.cpp:
* Source/WebCore/rendering/LegacyRootInlineBox.h:
* Source/WebCore/rendering/PaintInfo.h:
(WebCore::PaintInfo::PaintInfo):
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::insertIntoTrackedRendererMaps):
* Source/WebCore/rendering/RenderBlock.h:
* Source/WebCore/rendering/RenderBlockFlow.h:
* Source/WebCore/rendering/RenderBoxModelObject.cpp:
* Source/WebCore/rendering/RenderBoxModelObject.h:
* Source/WebCore/rendering/RenderButton.h:
* Source/WebCore/rendering/RenderCounter.cpp:
* Source/WebCore/rendering/RenderDeprecatedFlexibleBox.h:
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::backdropRenderer const):
* Source/WebCore/rendering/RenderElement.h:
* Source/WebCore/rendering/RenderFlexibleBox.h:
* Source/WebCore/rendering/RenderFragmentContainer.h:
* Source/WebCore/rendering/RenderFragmentedFlow.cpp:
(WebCore::RenderFragmentedFlow::FragmentSearchAdapter::collectIfNeeded):
* Source/WebCore/rendering/RenderFragmentedFlow.h:
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::getBaselineChild const):
* Source/WebCore/rendering/RenderGrid.h:
* Source/WebCore/rendering/RenderHighlight.h:
* Source/WebCore/rendering/RenderImageResource.h:
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::findCommonAncestor):
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::clearBackingSharingLayerProviders):
(WebCore::RenderLayerBacking::setBackingSharingLayers):
* Source/WebCore/rendering/RenderLayerBacking.h:
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
* Source/WebCore/rendering/RenderLayerCompositor.h:
* Source/WebCore/rendering/RenderLayoutState.h:
* Source/WebCore/rendering/RenderLineBoxList.cpp:
(WebCore::RenderLineBoxList::paint const):
* Source/WebCore/rendering/RenderListItem.h:
* Source/WebCore/rendering/RenderListMarker.h:
* Source/WebCore/rendering/RenderMenuList.h:
* Source/WebCore/rendering/RenderMultiColumnFlow.h:
* Source/WebCore/rendering/RenderMultiColumnSpannerPlaceholder.h:
* Source/WebCore/rendering/RenderObject.h:
* Source/WebCore/rendering/RenderTable.cpp:
(WebCore::resetSectionPointerIfNotBefore):
* Source/WebCore/rendering/RenderTable.h:
* Source/WebCore/rendering/RenderTableSection.cpp:
(WebCore::compareCellPositions):
(WebCore::compareCellPositionsWithOverflowingCells):
* Source/WebCore/rendering/RenderTableSection.h:
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::inlineWrapperForDisplayContentsMap):
* Source/WebCore/rendering/RenderTextFragment.h:
* Source/WebCore/rendering/RenderView.cpp:
(WebCore::RenderView::resumePausedImageAnimationsIfNeeded):
(WebCore::RenderView::takeCountersNeedingUpdate):
* Source/WebCore/rendering/RenderView.h:
* Source/WebCore/rendering/line/LineLayoutState.h:
* Source/WebCore/rendering/mathml/RenderMathMLFenced.h:
* Source/WebCore/rendering/style/StyleGeneratedImage.h:
(WebCore::StyleGeneratedImage::clients const):
* Source/WebCore/rendering/svg/RenderSVGRoot.h:
* Source/WebCore/rendering/svg/RenderSVGViewportContainer.h:
* Source/WebCore/rendering/svg/SVGRenderSupport.cpp:
(WebCore::SVGRenderSupport::layoutChildren):
(WebCore::SVGHitTestCycleDetectionScope::visitedElements):
* Source/WebCore/rendering/svg/SVGRenderSupport.h:
* Source/WebCore/rendering/svg/SVGResources.cpp:
(WebCore::SVGResources::buildSetOfResources):
* Source/WebCore/rendering/svg/SVGResources.h:
* Source/WebCore/rendering/svg/SVGResourcesCache.cpp:
(WebCore::SVGResourcesCache::addResourcesFromRenderer):
(WebCore::SVGResourcesCache::removeResourcesFromRenderer):
* Source/WebCore/rendering/svg/SVGResourcesCycleSolver.cpp:
(WebCore::SVGResourcesCycleSolver::resourceContainsCycles):
(WebCore::SVGResourcesCycleSolver::resolveCycles):
* Source/WebCore/rendering/svg/SVGResourcesCycleSolver.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResource.cpp:
(WebCore::LegacyRenderSVGResource::removeAllClientsFromCache):
(WebCore::removeFromCacheAndInvalidateDependencies):
(WebCore::LegacyRenderSVGResource::markForLayoutAndParentResourceInvalidation):
(WebCore::LegacyRenderSVGResource::markForLayoutAndParentResourceInvalidationIfNeeded):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResource.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp:
(WebCore::LegacyRenderSVGResourceClipper::removeAllClientsFromCacheIfNeeded):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp:
(WebCore::LegacyRenderSVGResourceContainer::markAllClientsForInvalidation):
(WebCore::LegacyRenderSVGResourceContainer::markAllClientsForInvalidationIfNeeded):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.cpp:
(WebCore::LegacyRenderSVGResourceFilter::removeAllClientsFromCacheIfNeeded):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.cpp:
(WebCore::LegacyRenderSVGResourceGradient::removeAllClientsFromCacheIfNeeded):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMarker.cpp:
(WebCore::LegacyRenderSVGResourceMarker::removeAllClientsFromCacheIfNeeded):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMarker.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.cpp:
(WebCore::LegacyRenderSVGResourceMasker::removeAllClientsFromCacheIfNeeded):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.cpp:
(WebCore::LegacyRenderSVGResourcePattern::removeAllClientsFromCacheIfNeeded):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceSolidColor.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h:
* Source/WebCore/rendering/updating/RenderTreeBuilder.cpp:
(WebCore::RenderTreeBuilder::normalizeTreeAfterStyleChange):
* Source/WebCore/rendering/updating/RenderTreePosition.h:
* Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.h:
* Source/WebCore/svg/graphics/SVGResourceImage.h:

Canonical link: <a href="https://commits.webkit.org/271522@main">https://commits.webkit.org/271522@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b904a80d15e83f35bf6b29b3e1399f0e5857328c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28644 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7288 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30019 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31273 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26146 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29154 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9402 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4652 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28914 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6021 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24632 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5245 "Found 1 new API test failure: /WPE/TestWebKitWebView:/webkit/WebKitWebView/notification (failure)") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/5386 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25633 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/32606 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/24774 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26221 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26079 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/31642 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/27812 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5351 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/3525 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/29419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6963 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/35262 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6857 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5817 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7617 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5870 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->