### PR TITLE
[UIAsyncTextInput] Keyboard sometimes autocapitalizes incorrectly while typing an inline completion

### DIFF
--- a/LayoutTests/editing/input/ios/typing-with-inline-predictions-expected.txt
+++ b/LayoutTests/editing/input/ios/typing-with-inline-predictions-expected.txt
@@ -1,0 +1,11 @@
+This test verifies that typing with inline predictions does not cause the keyboard to incorrectly autocapitalize words. This test requires WebKitTestRunner.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS isAutoShifted is false
+PASS input.value is "To whom it may concern"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/input/ios/typing-with-inline-predictions.html
+++ b/LayoutTests/editing/input/ios/typing-with-inline-predictions.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true allowsInlinePredictions=true ] -->
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<style>
+body {
+    margin: 0;
+    font-family: system-ui;
+    line-height: 150%;
+}
+
+input {
+    border: 1px solid tomato;
+    box-sizing: border-box;
+    outline: none;
+    font-size: 18px;
+    width: 300px;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("This test verifies that typing with inline predictions does not cause the keyboard to incorrectly autocapitalize words. This test requires WebKitTestRunner.");
+
+    input = document.querySelector("input");
+    await UIHelper.activateElementAndWaitForInputSession(input);
+
+    let characterCountBeforeLongPauseForInlinePredictions = 10;
+    for (let character of [..."to whom it may concern"]) {
+        await UIHelper.typeCharacter(character);
+        await UIHelper.ensurePresentationUpdate();
+        if (!--characterCountBeforeLongPauseForInlinePredictions)
+            await UIHelper.delayFor(500);
+    }
+
+    isAutoShifted = await UIHelper.keyboardIsAutomaticallyShifted();
+    shouldBeFalse("isAutoShifted");
+    shouldBeEqualToString("input.value", "To whom it may concern");
+
+    input.blur();
+    await UIHelper.waitForKeyboardToHide();
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <input />
+</body>
+</html>

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -505,6 +505,7 @@ struct ImageAnalysisContextMenuActionData {
     BOOL _isPresentingEditMenu;
     BOOL _isHandlingActiveKeyEvent;
     BOOL _isHandlingActivePressesEvent;
+    BOOL _isDeferringKeyEventsToInputMethod;
 
     BOOL _focusRequiresStrongPasswordAssistance;
     BOOL _waitingForEditDragSnapshot;


### PR DESCRIPTION
#### 01a600b1bfc9dba31c408eadc2900e28e1a63389
<pre>
[UIAsyncTextInput] Keyboard sometimes autocapitalizes incorrectly while typing an inline completion
<a href="https://bugs.webkit.org/show_bug.cgi?id=265764">https://bugs.webkit.org/show_bug.cgi?id=265764</a>
<a href="https://rdar.apple.com/119084774">rdar://119084774</a>

Reviewed by Richard Robinson.

After adopting `-invalidateTextEntryContext` in place of `-[UIKeyboardImpl layoutHasChanged]` when
the async text input codepath is enabled, the keyboard sometimes unexpectedly autocapitalizes when
typing while showing inline predictions in Mail compose.

This is because the replacement API (`-invalidateTextEntryContext`) now additionally updates text
context in addition to updating the layout and positioning of input method UI (i.e. when using
Chinese or Japanese input). This is meant to only be done only once, when initially starting IME
composition, in order to give certain web apps (e.g. Google Docs) a chance to reposition any
offscreen, hidden editable containers such that the input method UI and candidates bar shows up in
the right place — to achieve this, we set a `_candidateViewNeedsUpdate` flag upon setting any marked
text where the marked text range is previously empty, and clear out the flag after the next
selection change.

In iOS 17+, inline predictions also exercise this same marked text codepath; however, instead of
maintaining a persistent marked text string, inline predictions continuously clear out and reinsert
marked text as the prediction is regenerated while typing, which causes the
`_candidateViewNeedsUpdate` flag to be continuously set (and therefore, causes us to continuously
invoke `-invalidateTextEntryContext` while typing).

The combination of the above causes the keyboard to occasionally lose context while typing, which
results in the keyboard becoming erroneously autoshifted after typing a space. To fix this, we make
this logic more nuanced, such that we only `-invalidateTextEntryContext` if there&apos;s an active IME
session (excluding marked text, set by inline predictions).

Test: editing/input/ios/typing-with-inline-predictions.html

* LayoutTests/editing/input/ios/typing-with-inline-predictions-expected.txt: Added.
* LayoutTests/editing/input/ios/typing-with-inline-predictions.html: Added.

Add a layout test to exercise the change.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:

Introduce a new flag, `_isDeferringKeyEventsToInputMethod`, to track whether or not we have an
active IME session.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView cleanUpInteraction]):
(-[WKContentView canPerformActionForWebView:withSender:]):

Drive-by fix: replace some internal calls to `-hasContent` with an internal version instead,
`-_hasContent`, to avoid self-induced release assertions after 271417@main.

(-[WKContentView _setMarkedText:underlines:highlights:selectedRange:]):
(-[WKContentView unmarkText]):

Unset the new flag when committing marked text.

(-[WKContentView _internalHandleKeyWebEvent:withCompletionHandler:]):

Set the new flag, `_isDeferringKeyEventsToInputMethod`, if we&apos;ve actually deferred key event
handling to system IME.

(-[WKContentView hasContent]):
(-[WKContentView _hasContent]):

See drive-by fix above.

Canonical link: <a href="https://commits.webkit.org/271482@main">https://commits.webkit.org/271482@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46f5cf0f4b104665e0571976d18b9467409829e5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28450 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7095 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29836 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30977 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25905 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9194 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4464 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28719 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5855 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24477 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5122 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5235 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25478 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31663 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26056 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25919 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31522 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5192 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3372 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29287 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6793 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/25272 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6832 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5649 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5712 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->