### PR TITLE
Adopt -[UIScrollView showScrollIndicatorsForContentOffsetChanges:] for animated keyboard scrolling

### DIFF
--- a/Source/WebKit/UIProcess/ios/UIKitUtilities.h
+++ b/Source/WebKit/UIProcess/ios/UIKitUtilities.h
@@ -39,6 +39,7 @@
 @property (readonly, nonatomic) CGFloat _wk_contentHeightIncludingInsets;
 @property (readonly, nonatomic) BOOL _wk_isScrollAnimating;
 @property (readonly, nonatomic) BOOL _wk_isZoomAnimating;
+- (void)_wk_setContentOffsetAndShowScrollIndicators:(CGPoint)offset animated:(BOOL)animated;
 - (void)_wk_setTransfersHorizontalScrollingToParent:(BOOL)value;
 - (void)_wk_setTransfersVerticalScrollingToParent:(BOOL)value;
 - (void)_wk_stopScrollingAndZooming;

--- a/Source/WebKit/UIProcess/ios/WKKeyboardScrollingAnimator.mm
+++ b/Source/WebKit/UIProcess/ios/WKKeyboardScrollingAnimator.mm
@@ -641,24 +641,13 @@ static WebCore::FloatPoint farthestPointInDirection(WebCore::FloatPoint a, WebCo
     return [_delegate keyboardScrollViewAnimator:self distanceForIncrement:increment inDirection:direction];
 }
 
-static UIAxis axesForDelta(WebCore::FloatSize delta)
-{
-    UIAxis axes = UIAxisNeither;
-    if (delta.width())
-        axes = static_cast<UIAxis>(axes | UIAxisHorizontal);
-    if (delta.height())
-        axes = static_cast<UIAxis>(axes | UIAxisVertical);
-    return axes;
-}
-
 - (void)scrollToContentOffset:(WebCore::FloatPoint)contentOffset animated:(BOOL)animated
 {
     if (!_scrollView)
         return;
     if (_delegateRespondsToWillScroll)
         [_delegate keyboardScrollViewAnimatorWillScroll:self];
-    [_scrollView setContentOffset:contentOffset animated:animated];
-    [_scrollView _flashScrollIndicatorsForAxes:axesForDelta(WebCore::FloatPoint(_scrollView.contentOffset) - contentOffset) persistingPreviousFlashes:YES];
+    [_scrollView _wk_setContentOffsetAndShowScrollIndicators:contentOffset animated:animated];
 }
 
 - (void)willBeginScrollingToExtentWithAnimationInTrackingView:(UIView *)view


### PR DESCRIPTION
#### 4b3c6264047e1aba121521b83cf2a7e72c0435c5
<pre>
Adopt -[UIScrollView showScrollIndicatorsForContentOffsetChanges:] for animated keyboard scrolling
<a href="https://bugs.webkit.org/show_bug.cgi?id=265765">https://bugs.webkit.org/show_bug.cgi?id=265765</a>
<a href="https://rdar.apple.com/119105952">rdar://119105952</a>

Reviewed by Richard Robinson.

Stop using `-_flashScrollIndicatorsForAxes:persistingPreviousFlashes:` to show scroll indicators
after programmatically changing the content offset during animated keyboard scrolling; instead,
adopt `-showScrollIndicatorsForContentOffsetChanges:`, if available; with this new API, UIKit will
show scroll indicators on any axes that are programmatically scrolled during the call to the given
ObjC block, automatically persisting previous flashes.

* Source/WebKit/UIProcess/ios/UIKitUtilities.h:
* Source/WebKit/UIProcess/ios/UIKitUtilities.mm:
(axesForDelta):
(-[UIScrollView _wk_setContentOffsetAndShowScrollIndicators:animated:]):
* Source/WebKit/UIProcess/ios/WKKeyboardScrollingAnimator.mm:
(-[WKKeyboardScrollViewAnimator scrollToContentOffset:animated:]):
(axesForDelta): Deleted.

Canonical link: <a href="https://commits.webkit.org/271480@main">https://commits.webkit.org/271480@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2243020b124e398c0ba38dca892d1afccc22ca77

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28455 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7100 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29841 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30982 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25910 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9199 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4469 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28724 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5858 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24481 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5125 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5238 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31668 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26059 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25923 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31524 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5197 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3375 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29289 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/notification (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6798 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6831 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5654 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5717 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->