### PR TITLE
[WPE] Fix missing initializer warning for member wl_pointer_listener::axis_relative_direction and related issues

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp
@@ -216,10 +216,6 @@ static const struct wl_surface_listener surfaceListener = {
     {
     },
 #endif
-    // axis_relative_direction
-    [](void*, struct wl_surface*, uint32_t /* direction */)
-    {
-    },
 };
 
 static const struct zwp_linux_dmabuf_feedback_v1_listener linuxDMABufFeedbackListener = {

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSeat.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSeat.cpp
@@ -262,7 +262,13 @@ const struct wl_pointer_listener WaylandSeat::s_pointerListener = {
             seat.m_pointer.frame.valueY = -value / 120;
             break;
         }
-    }
+    },
+#endif
+#ifdef WL_POINTER_AXIS_RELATIVE_DIRECTION_SINCE_VERSION
+    // axis_relative_direction
+    [](void*, struct wl_pointer*, uint32_t, uint32_t)
+    {
+    },
 #endif
 };
 


### PR DESCRIPTION
#### b9f2021a494c6be647ce1fe01ffc1a62d81b3bc1
<pre>
[WPE] Fix missing initializer warning for member wl_pointer_listener::axis_relative_direction and related issues
<a href="https://bugs.webkit.org/show_bug.cgi?id=265767">https://bugs.webkit.org/show_bug.cgi?id=265767</a>

Reviewed by Michael Catanzaro and Žan Doberšek.

Move axis_relative_direction from wl_surface_listener to wl_pointer_listener

* Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSeat.cpp:

Canonical link: <a href="https://commits.webkit.org/271479@main">https://commits.webkit.org/271479@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/397805bdd5a6ae35763e4b355ae4627565d4e0ba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28456 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7101 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29842 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30983 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25911 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9200 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4470 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28725 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5861 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24484 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5129 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5241 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31669 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26062 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25926 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31527 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5198 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3378 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29293 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6799 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6830 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5655 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5718 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->