### PR TITLE
`showRenderTreeForThis` should output `PseudoId`

### DIFF
--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -1344,6 +1344,9 @@ void RenderObject::outputRenderObject(TextStream& stream, bool mark, int depth) 
     else
         stream << nameView;
 
+    if (style().styleType() != PseudoId::None)
+        stream << " (::" << style().styleType() << ")";
+
     if (is<RenderBox>(*this)) {
         auto& renderBox = downcast<RenderBox>(*this);
         FloatRect boxRect = renderBox.frameRect();


### PR DESCRIPTION
#### ba9a57c567bd7e2881f93430b1296f988d4af8e9
<pre>
`showRenderTreeForThis` should output `PseudoId`
<a href="https://bugs.webkit.org/show_bug.cgi?id=265769">https://bugs.webkit.org/show_bug.cgi?id=265769</a>
<a href="https://rdar.apple.com/119109505">rdar://119109505</a>

Reviewed by Simon Fraser.

Saves countless time debugging anonymous renderers.

Sample output:
```
(B)lock/(I)nline/I(N)line-block, (A)bsolute/Fi(X)ed/(R)elative/Stic(K)y, (F)loating, (O)verflow clip, Anon(Y)mous, (G)enerated, has(L)ayer, hasLayer(S)crollableArea, (C)omposited, Content-visibility:(H)idden/(A)uto, (S)kipped content, (+)Dirty style, (+)Dirty layout
B---YGLSC-- -+  RenderView at (0,0) size 1420x763 renderer (0x117000ac0) layout box (0x0) layout-&gt;[normal child]
B-----LS--- -+    HTML RenderBlock at (0,0) size 1420x84 renderer (0x117001e80) layout box (0x0) node (0x117001700) layout-&gt;[normal child]
B---------- -+      BODY RenderBody at (8,16) size 1404x52 renderer (0x117002110) layout box (0x0) node (0x117001940) layout-&gt;[normal child]
B---------- -+        DIV RenderBlock at (0,0) size 1404x52 renderer (0x117003a50) layout box (0x0) node (0x117003740) layout-&gt;[normal child]
BX--YGL---- --*   RenderBlock (::view-transition) at (0,0) size 1420x763 renderer (0x117004c90) layout box (0x1170076c0)
---------- --      line at (0.00,0.00) size (1420.00x0.00) baseline (0.00) enclosing top (0.00) bottom (0.00)
---------- --        Root inline box at (0.00,-14.00) size (0.00x18.00)
---------- --        Run(s):
BA--YGL---- --      RenderBlock (::view-transition-group) at (200,200) size 100x100 renderer (0x117004f20) layout box (0x117007770)
---------- --        line at (0.00,0.00) size (100.00x0.00) baseline (0.00) enclosing top (0.00) bottom (0.00)
---------- --          Root inline box at (0.00,-14.00) size (0.00x18.00)
---------- --          Run(s):
BA--YGL---- --        RenderBlock (::view-transition-image-pair) at (0,0) size 50x50 renderer (0x1170051b0) layout box (0x1170078d0)
---------- --          line at (0.00,0.00) size (50.00x0.00) baseline (0.00) enclosing top (0.00) bottom (0.00)
---------- --            Root inline box at (0.00,-14.00) size (0.00x18.00)
---------- --            Run(s):
BA--YGL---- --          RenderBlock (::view-transition-old) at (0,0) size 20x20 renderer (0x117005440) layout box (0x117008910)
BA--YGL---- --          RenderBlock (::view-transition-new) at (0,0) size 20x20 renderer (0x1170056d0) layout box (0x1170089c0)
BA--YGL---- --      RenderBlock (::view-transition-group) at (500,500) size 100x100 renderer (0x117005960) layout box (0x117007820)
---------- --        line at (0.00,0.00) size (100.00x0.00) baseline (0.00) enclosing top (0.00) bottom (0.00)
---------- --          Root inline box at (0.00,-14.00) size (0.00x18.00)
---------- --          Run(s):
BA--YGL---- --        RenderBlock (::view-transition-image-pair) at (0,0) size 50x50 renderer (0x117005bf0) layout box (0x117009150)
---------- --          line at (0.00,0.00) size (50.00x0.00) baseline (0.00) enclosing top (0.00) bottom (0.00)
---------- --            Root inline box at (0.00,-14.00) size (0.00x18.00)
---------- --            Run(s):
BA--YGL---- --          RenderBlock (::view-transition-old) at (0,0) size 20x20 renderer (0x117005e80) layout box (0x1170098e0)
BA--YGL---- --          RenderBlock (::view-transition-new) at (0,0) size 20x20 renderer (0x117006110) layout box (0x117009990)
```

* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::outputRenderObject const):

Canonical link: <a href="https://commits.webkit.org/271521@main">https://commits.webkit.org/271521@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/117b884c4a20be39d966be48b1ac5c552dd55165

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28687 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7330 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30058 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/31308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/26179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29197 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9447 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4691 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/31308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28957 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/6060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/24664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/31308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/5418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/25667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/32646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/26259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/26111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/32646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/5384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/3555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/32646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/6999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/6859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/5851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3701 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/5902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->