### PR TITLE
Add menu item and keyCommand support to Web Extension commands.

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionCommand.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionCommand.h
@@ -28,7 +28,7 @@
 #import <Foundation/Foundation.h>
 
 #if TARGET_OS_IPHONE
-#import <UIKit/UICommand.h>
+#import <UIKit/UIKeyCommand.h>
 #endif
 
 @class _WKWebExtensionContext;
@@ -51,7 +51,7 @@ NS_SWIFT_NAME(WKWebExtension.Command)
 /*! @abstract The web extension context associated with the command. */
 @property (nonatomic, readonly, weak) _WKWebExtensionContext *webExtensionContext;
 
-/*! @abstract Unique identifier for the command. */
+/*! @abstract A unique identifier for the command. */
 @property (nonatomic, readonly, copy) NSString *identifier;
 
 /*!
@@ -79,6 +79,28 @@ NS_SWIFT_NAME(WKWebExtension.Command)
 #else
 @property (nonatomic) NSEventModifierFlags modifierFlags;
 #endif
+
+/*!
+ @abstract A menu item representation of the web extension command for use in menus.
+ @discussion This property provides a representation of the web extension command as a menu item to display in the app.
+ Selecting the menu item will perform the command, offering a convenient and visual way for users to execute this web extension command.
+ */
+#if TARGET_OS_IPHONE
+@property (nonatomic, readonly, copy) UIMenuElement *menuItem;
+#else
+@property (nonatomic, readonly, copy) NSMenuItem *menuItem;
+#endif
+
+#if TARGET_OS_IPHONE
+/*!
+ @abstract A key command representation of the web extension command for use in the responder chain.
+ @discussion This property provides a `UIKeyCommand` instance representing the web extension command, ready for integration in the app.
+ The property is `nil` if no shortcut is defined. Otherwise, the key command is fully configured with the necessary input key and modifier flags
+ to perform the associated command upon activation. It can be included in a view controller or other responder's `keyCommands` property, enabling
+ keyboard activation and discoverability of the web extension command.
+ */
+@property (nonatomic, readonly, copy, nullable) UIKeyCommand *keyCommand;
+#endif // TARGET_OS_IPHONE
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionCommand.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionCommand.mm
@@ -36,8 +36,10 @@
 
 #if USE(APPKIT)
 using CocoaModifierFlags = NSEventModifierFlags;
+using CocoaMenuItem = NSMenuItem;
 #else
 using CocoaModifierFlags = UIKeyModifierFlags;
+using CocoaMenuItem = UIMenuElement;
 #endif
 
 @implementation _WKWebExtensionCommand
@@ -122,6 +124,32 @@ using CocoaModifierFlags = UIKeyModifierFlags;
     _webExtensionCommand->setModifierFlags(optionSet);
 }
 
+- (CocoaMenuItem *)menuItem
+{
+    return _webExtensionCommand->platformMenuItem();
+}
+
+#if PLATFORM(IOS_FAMILY)
+- (UIKeyCommand *)keyCommand
+{
+    return _webExtensionCommand->keyCommand();
+}
+#endif
+
+- (NSString *)_shortcut
+{
+    return _webExtensionCommand->shortcutString();
+}
+
+#if USE(APPKIT)
+- (BOOL)_matchesEvent:(NSEvent *)event
+{
+    NSParameterAssert([event isKindOfClass:NSEvent.class]);
+
+    return _webExtensionCommand->matchesEvent(event);
+}
+#endif
+
 #pragma mark WKObject protocol implementation
 
 - (API::Object&)_apiObject
@@ -168,6 +196,30 @@ using CocoaModifierFlags = UIKeyModifierFlags;
 - (void)setModifierFlags:(CocoaModifierFlags)modifierFlags
 {
 }
+
+- (CocoaMenuItem *)menuItem
+{
+    return nil;
+}
+
+#if PLATFORM(IOS_FAMILY)
+- (UIKeyCommand *)keyCommand
+{
+    return nil;
+}
+#endif
+
+- (NSString *)_shortcut
+{
+    return nil;
+}
+
+#if USE(APPKIT)
+- (BOOL)_matchesEvent:(NSEvent *)event
+{
+    return NO;
+}
+#endif
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionCommandPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionCommandPrivate.h
@@ -27,4 +27,22 @@
 
 @interface _WKWebExtensionCommand ()
 
+/*!
+ @abstract Represents the shortcut for the web extension, formatted according to web extension specification.
+ @discussion This property provides a string representation of the shortcut, incorporating any customizations made to the `activationKey`
+ and `modifierFlags` properties. It will be empty if no shortcut is defined for the command.
+ */
+@property (nonatomic, readonly, copy) NSString *_shortcut;
+
+#if TARGET_OS_OSX
+/*!
+ @abstract Determines whether an event matches the command's activation key and modifier flags.
+ @discussion This method can be used to check if a given keyboard event corresponds to the command's activation key and modifiers, if any.
+ The app can use this during event handling in the app, without showing the command in a menu.
+ @param event The event to be checked against the command's activation key and modifiers.
+ @result A Boolean value indicating whether the event matches the command's shortcut.
+ */
+- (BOOL)_matchesEvent:(NSEvent *)event;
+#endif // TARGET_OS_OSX
+
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h
@@ -170,7 +170,7 @@ WK_CLASS_AVAILABLE(macos(13.3), ios(16.4))
 @property (nonatomic, copy) NSURL *baseURL;
 
 /*!
- @abstract An unique identifier used to distinguish the extension from other extensions and target it for messages.
+ @abstract A unique identifier used to distinguish the extension from other extensions and target it for messages.
  @discussion The default value is a unique value that matches the host in the default base URL. The identifier can be any
  value that is unique. Setting is only allowed when the context is not loaded. This value is accessible by the extension via
  `browser.runtime.id` and is used for messaging the extension via `browser.runtime.sendMessage()`.
@@ -530,6 +530,26 @@ WK_CLASS_AVAILABLE(macos(13.3), ios(16.4))
  @discussion This method performs the given command as if it was triggered by a user gesture within the context of the focused window and active tab.
  */
 - (void)performCommand:(_WKWebExtensionCommand *)command;
+
+#if TARGET_OS_OSX
+/*!
+ @abstract Performs the command associated with the given event.
+ @discussion This method checks for a command corresponding to the provided event and performs it, if available. The app should use this method to perform
+ any extension commands at an appropriate time in the app's event handling, like in `sendEvent:` of `NSApplication` or `NSWindow` subclasses.
+ @param event The event representing the user input.
+ @result Returns `YES` if a command corresponding to the event was found and performed, `NO` otherwise.
+ */
+- (BOOL)performCommandForEvent:(NSEvent *)event;
+
+/*!
+ @abstract Retrieves the command associated with the given event without performing it.
+ @discussion This method returns the command that corresponds to the provided event, if such a command exists. This provides a way to programmatically
+ determine what action would occur for a given event, without triggering the command.
+ @param event The event for which to retrieve the corresponding command.
+ @result The command associated with the event, or `nil` if there is no such command.
+ */
+- (nullable _WKWebExtensionCommand *)commandForEvent:(NSEvent *)event;
+#endif // TARGET_OS_OSX
 
 /*!
  @abstract Retrieves an array of menu items for a given tab.

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
@@ -545,6 +545,24 @@ static inline WebKit::WebExtensionContext::PermissionState toImpl(_WKWebExtensio
     _webExtensionContext->performCommand(command._webExtensionCommand, WebKit::WebExtensionContext::UserTriggered::Yes);
 }
 
+#if USE(APPKIT)
+- (BOOL)performCommandForEvent:(NSEvent *)event
+{
+    NSParameterAssert([event isKindOfClass:NSEvent.class]);
+
+    return _webExtensionContext->performCommand(event);
+}
+
+- (_WKWebExtensionCommand *)commandForEvent:(NSEvent *)event
+{
+    NSParameterAssert([event isKindOfClass:NSEvent.class]);
+
+    if (RefPtr result = _webExtensionContext->command(event))
+        return result->wrapper();
+    return nil;
+}
+#endif // USE(APPKIT)
+
 - (NSArray<CocoaMenuItem *> *)menuItemsForTab:(id<_WKWebExtensionTab>)tab
 {
     NSParameterAssert([tab conformsToProtocol:@protocol(_WKWebExtensionTab)]);
@@ -1050,6 +1068,18 @@ static inline OptionSet<WebKit::WebExtensionTab::ChangedProperties> toImpl(_WKWe
 - (void)performCommand:(_WKWebExtensionCommand *)command
 {
 }
+
+#if USE(APPKIT)
+- (BOOL)performCommandForEvent:(NSEvent *)event
+{
+    return NO;
+}
+
+- (_WKWebExtensionCommand *)commandForEvent:(NSEvent *)event
+{
+    return nil;
+}
+#endif // USE(APPKIT)
 
 - (NSArray<CocoaMenuItem *> *)menuItemsForTab:(id<_WKWebExtensionTab>)tab
 {

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMenuItemCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMenuItemCocoa.mm
@@ -47,34 +47,34 @@
 #endif
 
 #if USE(APPKIT)
-using MenuItemHandlerBlock = void (^)(id);
-
-@interface _WKWebExtensionMenuItem : NSMenuItem
-
-- (instancetype)initWithTitle:(NSString *)title handler:(MenuItemHandlerBlock)block;
-
-@property (nonatomic, copy) MenuItemHandlerBlock handler;
-
-@end
-
 @implementation _WKWebExtensionMenuItem
 
-- (instancetype)initWithTitle:(NSString *)title handler:(MenuItemHandlerBlock)handler
+- (instancetype)initWithTitle:(NSString *)title handler:(WebExtensionMenuItemHandlerBlock)handler
 {
-    ASSERT(handler);
+    RELEASE_ASSERT(handler);
 
     if (!(self = [super initWithTitle:title action:@selector(_performAction:) keyEquivalent:@""]))
         return nil;
 
     self.target = self;
-    _handler = handler;
+
+    _handler = [handler copy];
 
     return self;
 }
 
+- (id)copyWithZone:(NSZone *)zone
+{
+    _WKWebExtensionMenuItem *copy = [super copyWithZone:zone];
+    copy->_handler = [_handler copy];
+    return copy;
+}
+
 - (IBAction)_performAction:(id)sender
 {
-    _handler(sender);
+    ASSERT(_handler);
+    if (_handler)
+        _handler(sender);
 }
 
 @end

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -69,7 +69,6 @@
 OBJC_CLASS NSArray;
 OBJC_CLASS NSDate;
 OBJC_CLASS NSDictionary;
-OBJC_CLASS NSMenu;
 OBJC_CLASS NSMutableDictionary;
 OBJC_CLASS NSString;
 OBJC_CLASS NSURL;
@@ -83,6 +82,11 @@ OBJC_CLASS _WKWebExtensionContext;
 OBJC_CLASS _WKWebExtensionContextDelegate;
 OBJC_PROTOCOL(_WKWebExtensionTab);
 OBJC_PROTOCOL(_WKWebExtensionWindow);
+
+#if PLATFORM(MAC)
+OBJC_CLASS NSEvent;
+OBJC_CLASS NSMenu;
+#endif
 
 namespace WebKit {
 
@@ -325,6 +329,11 @@ public:
     const CommandsVector& commands();
     WebExtensionCommand* command(const String& identifier);
     void performCommand(WebExtensionCommand&, UserTriggered = UserTriggered::No);
+
+#if USE(APPKIT)
+    WebExtensionCommand* command(NSEvent *);
+    bool performCommand(NSEvent *);
+#endif
 
     NSArray *platformMenuItems(const WebExtensionTab&) const;
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionMenuItem.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionMenuItem.h
@@ -46,6 +46,18 @@ OBJC_CLASS UIMenuElement;
 using CocoaMenuItem = UIMenuElement;
 #endif
 
+#if defined(__OBJC__) && USE(APPKIT)
+using WebExtensionMenuItemHandlerBlock = void (^)(id);
+
+@interface _WKWebExtensionMenuItem : NSMenuItem
+
+- (instancetype)initWithTitle:(NSString *)title handler:(WebExtensionMenuItemHandlerBlock)block;
+
+@property (nonatomic, copy) WebExtensionMenuItemHandlerBlock handler;
+
+@end
+#endif // USE(APPKIT)
+
 namespace WebKit {
 
 class WebExtensionCommand;


### PR DESCRIPTION
#### 2a0077acd04eba49f32538cd85b7682d95d0253b
<pre>
Add menu item and keyCommand support to Web Extension commands.
<a href="https://webkit.org/b/265772">https://webkit.org/b/265772</a>
<a href="https://rdar.apple.com/problem/119111895">rdar://problem/119111895</a>

Reviewed by Brian Weinstein.

Adds a menuItem and keyCommand property to _WKWebExtensionCommand for macOS and iOS.
Also adds performCommandForEvent: and commandForEvent: to _WKWebExtensionContext for macOS.
Adds a private _shortcut to _WKWebExtensionCommand for use by Safari.

* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionCommand.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionCommand.mm:
(-[_WKWebExtensionCommand menuItem]): Added.
(-[_WKWebExtensionCommand keyCommand]): Added.
(-[_WKWebExtensionCommand _shortcut]): Added.
(-[_WKWebExtensionCommand _matchesEvent:]): Added.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionCommandPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm:
(-[_WKWebExtensionContext performCommandForEvent:]): Added.
(-[_WKWebExtensionContext commandForEvent:]): Added.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCommandCocoa.mm:
(+[_WKWebExtensionKeyCommand commandWithTitle:image:input:modifierFlags:handler:]): Added.
(-[_WKWebExtensionKeyCommand copyWithZone:]):
(-[_WKWebExtensionKeyCommand _resolvedTargetFromFirstTarget:]):
(-[_WKWebExtensionKeyCommand _performWebExtensionKeyCommand:]):
(WebKit::WebExtensionCommand::platformMenuItem const): Added.
(WebKit::WebExtensionCommand::keyCommand const): Added.
(WebKit::WebExtensionCommand::matchesEvent const): Added.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::performCommand): Added.
(WebKit::WebExtensionContext::command): Added.
(WebKit::WebExtensionContext::performMenuItem): Added.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMenuItemCocoa.mm:
(-[_WKWebExtensionMenuItem initWithTitle:handler:]):
(-[_WKWebExtensionMenuItem copyWithZone:]): Added.
(-[_WKWebExtensionMenuItem _performAction:]):
* Source/WebKit/UIProcess/Extensions/WebExtensionCommand.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionMenuItem.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPICommands.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/271532@main">https://commits.webkit.org/271532@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab17bf7274850067c0ea91ad17d0ea7b50ddb827

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28710 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/7353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30081 "Failed to checkout and rebase branch from PR 21249") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31329 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/26196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/29280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9474 "Failed to checkout and rebase branch from PR 21249") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/4713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28980 "Failed to checkout and rebase branch from PR 21249") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/9474 "Failed to checkout and rebase branch from PR 21249") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/30081 "Failed to checkout and rebase branch from PR 21249") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/5283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/9474 "Failed to checkout and rebase branch from PR 21249") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/30081 "Failed to checkout and rebase branch from PR 21249") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/32667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/9474 "Failed to checkout and rebase branch from PR 21249") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/30081 "Failed to checkout and rebase branch from PR 21249") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/32667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/5401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/4713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/32667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7018 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/30081 "Failed to checkout and rebase branch from PR 21249") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/5868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3706 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/5919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->