### PR TITLE
Gracefully handle OOM while trying to describing a Symbol when creating an Error.

### DIFF
--- a/JSTests/stress/out-of-memory-while-describing-symbol-for-error.js
+++ b/JSTests/stress/out-of-memory-while-describing-symbol-for-error.js
@@ -1,0 +1,14 @@
+//@ skip if $memoryLimited
+
+let a = "?".repeat(2147483647);
+var exception;
+try {
+    var s = Symbol(a);
+    new s(2);
+} catch (e) {
+    exception = e;
+}
+
+if (exception != "TypeError: Symbol is not a constructor (evaluating 'new s(2)')")
+    throw "FAILED";
+

--- a/Source/JavaScriptCore/runtime/ExceptionHelpers.cpp
+++ b/Source/JavaScriptCore/runtime/ExceptionHelpers.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -62,8 +62,13 @@ String errorDescriptionForValue(JSGlobalObject* globalObject, JSValue v)
         return tryMakeString('"', string, '"');
     }
 
-    if (v.isSymbol())
-        return asSymbol(v)->descriptiveString();
+    if (v.isSymbol()) {
+        auto expectedDescription = asSymbol(v)->tryGetDescriptiveString();
+        if (expectedDescription)
+            return expectedDescription.value();
+        ASSERT(expectedDescription.error() == ErrorTypeWithExtension::OutOfMemoryError);
+        return String("Symbol"_s);
+    }
     if (v.isObject()) {
         VM& vm = globalObject->vm();
         JSObject* object = asObject(v);

--- a/Source/JavaScriptCore/runtime/Symbol.cpp
+++ b/Source/JavaScriptCore/runtime/Symbol.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2015-2016 Yusuke Suzuki <utatane.tea@gmail.com>.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -86,6 +86,14 @@ void Symbol::destroy(JSCell* cell)
 String Symbol::descriptiveString() const
 {
     return makeString("Symbol("_s, StringView(m_privateName.uid()), ')');
+}
+
+Expected<String, ErrorTypeWithExtension> Symbol::tryGetDescriptiveString() const
+{
+    String description = tryMakeString("Symbol("_s, StringView(m_privateName.uid()), ')');
+    if (!description)
+        return makeUnexpected(ErrorTypeWithExtension::OutOfMemoryError);
+    return description;
 }
 
 String Symbol::description() const

--- a/Source/JavaScriptCore/runtime/Symbol.h
+++ b/Source/JavaScriptCore/runtime/Symbol.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2015-2016 Yusuke Suzuki <utatane.tea@gmail.com>.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,8 +26,10 @@
 
 #pragma once
 
+#include "ErrorType.h"
 #include "JSString.h"
 #include "PrivateName.h"
+#include <wtf/Expected.h>
 
 namespace JSC {
 
@@ -56,6 +58,7 @@ public:
     PrivateName privateName() const { return m_privateName; }
     String descriptiveString() const;
     String description() const;
+    Expected<String, ErrorTypeWithExtension> tryGetDescriptiveString() const;
 
     JSValue toPrimitive(JSGlobalObject*, PreferredPrimitiveType) const;
     JSObject* toObject(JSGlobalObject*) const;


### PR DESCRIPTION
#### d1f1209a4e20008b342f8d4451b44429b75587b0
<pre>
Gracefully handle OOM while trying to describing a Symbol when creating an Error.
<a href="https://bugs.webkit.org/show_bug.cgi?id=265775">https://bugs.webkit.org/show_bug.cgi?id=265775</a>
<a href="https://rdar.apple.com/119046215">rdar://119046215</a>

Reviewed by Yusuke Suzuki.

If trying to describe a Symbol via stringifying it results in an OutOfMemoryError,
just simply describe is as a generic &quot;Symbol&quot; instead.

* JSTests/stress/out-of-memory-while-describing-symbol-for-error.js: Added.
(catch):
* Source/JavaScriptCore/runtime/ExceptionHelpers.cpp:
(JSC::errorDescriptionForValue):
* Source/JavaScriptCore/runtime/Symbol.cpp:
(JSC::Symbol::tryGetDescriptiveString const):
* Source/JavaScriptCore/runtime/Symbol.h:

Canonical link: <a href="https://commits.webkit.org/271458@main">https://commits.webkit.org/271458@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/440fc8fb5bf65c577f94cd71914d862bf1dff6d3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28479 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7124 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29865 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31006 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25934 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9223 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4493 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28748 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5877 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24503 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5145 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5258 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25504 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31692 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/24643 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26078 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25947 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31544 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/27573 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5221 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/3405 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29312 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6822 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/35097 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5678 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7584 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3671 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5741 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->