### PR TITLE
[view-transitions] Implement "capture new state" algorithm

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7052,7 +7052,6 @@ imported/w3c/web-platform-tests/css/css-view-transitions/web-animation-pseudo-in
 
 # Flakes
 imported/w3c/web-platform-tests/css/css-view-transitions/synchronous-callback-skipped-before-run.html [ Failure Pass ]
-imported/w3c/web-platform-tests/css/css-view-transitions/duplicate-tag-rejects-capture.html [ Failure Pass ]
 
 # -- END: View transitions -- #
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/duplicate-tag-rejects-capture-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/duplicate-tag-rejects-capture-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_true: ready not rejected before updateCallbackDone expected true got false
 
-FAIL Two different elements with the same name in the old DOM should skip the transition promise_test: Unhandled rejection with value: undefined
+PASS Two different elements with the same name in the old DOM should skip the transition
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/duplicate-tag-rejects-start-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/duplicate-tag-rejects-start-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Two different elements with the same name in the new DOM should skip the transition promise_test: Unhandled rejection with value: undefined
+PASS Two different elements with the same name in the new DOM should skip the transition
 


### PR DESCRIPTION
#### 7097e3442fce1622b1104d3bbc6b9040a05672ca
<pre>
[view-transitions] Implement &quot;capture new state&quot; algorithm
<a href="https://bugs.webkit.org/show_bug.cgi?id=265715">https://bugs.webkit.org/show_bug.cgi?id=265715</a>
<a href="https://rdar.apple.com/119068808">rdar://119068808</a>

Reviewed by Simon Fraser.

This commit:
- makes the &quot;named elements&quot; map use a custom built ordered map, since insertion order will be important when building the pseudo elements and rendering them
The pseudo element construction will be done in: <a href="https://github.com/WebKit/WebKit/pull/21205">https://github.com/WebKit/WebKit/pull/21205</a>

- implements the &quot;capture new state&quot; algorithm which simply re-validates the &quot;named elements&quot; map and throws an error if needed
- fixes error handling for the &quot;capture old state&quot; algorithm.

Spec:
- capture old state: <a href="https://drafts.csswg.org/css-view-transitions/#capture-old-state-algorithm">https://drafts.csswg.org/css-view-transitions/#capture-old-state-algorithm</a>
- capture new state: <a href="https://drafts.csswg.org/css-view-transitions/#capture-new-state-algorithm">https://drafts.csswg.org/css-view-transitions/#capture-new-state-algorithm</a>
- named elements: <a href="https://drafts.csswg.org/css-view-transitions/#viewtransition-named-elements">https://drafts.csswg.org/css-view-transitions/#viewtransition-named-elements</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/duplicate-tag-rejects-capture-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/duplicate-tag-rejects-start-expected.txt:
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::setupViewTransition):
(WebCore::effectiveViewTransitionName):
(WebCore::checkDuplicateViewTransitionName):
(WebCore::ViewTransition::captureOldState):
(WebCore::ViewTransition::captureNewState):
(WebCore::ViewTransition::activateViewTransition):
* Source/WebCore/dom/ViewTransition.h:
(WebCore::OrderedNamedElementsMap::contains const):
(WebCore::OrderedNamedElementsMap::add):
(WebCore::OrderedNamedElementsMap::remove):
(WebCore::OrderedNamedElementsMap::keys const):
(WebCore::OrderedNamedElementsMap::find):
(WebCore::ViewTransition::namedElements const):

Canonical link: <a href="https://commits.webkit.org/271483@main">https://commits.webkit.org/271483@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f1d63defd8bbc4570d2aaab1e74e5c3310b95cd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28505 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7150 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29891 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31032 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25960 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29002 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9251 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4519 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28774 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5904 "Found 1 new test failure: webrtc/audio-samplerate-change.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24527 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5162 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5281 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25527 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31718 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26104 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25969 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31561 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5246 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3422 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29331 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6848 "Built successfully") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/6836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5703 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3685 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5766 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->