### PR TITLE
[MSE] Remove need for SourceBufferPrivate to query MediaSource duration

### DIFF
--- a/Source/WebCore/Modules/mediasource/MediaSource.h
+++ b/Source/WebCore/Modules/mediasource/MediaSource.h
@@ -80,11 +80,11 @@ public:
     bool isClosed() const;
     bool isEnded() const;
     void sourceBufferDidChangeActiveState(SourceBuffer&, bool);
+    MediaTime duration() const;
 
     enum class EndOfStreamError { Network, Decode };
     void streamEndedWithError(std::optional<EndOfStreamError>);
 
-    MediaTime duration() const final;
     const PlatformTimeRanges& buffered() const final;
 
     bool attachToElement(HTMLMediaElement&);
@@ -186,7 +186,7 @@ private:
     PlatformTimeRanges m_buffered;
     PlatformTimeRanges m_liveSeekable;
     WeakPtr<HTMLMediaElement, WeakPtrImplWithEventTargetData> m_mediaElement;
-    MediaTime m_duration;
+    MediaTime m_duration { MediaTime::invalidTime() };
     std::optional<SeekTarget> m_pendingSeekTarget;
     std::optional<MediaTimePromise::Producer> m_seekTargetPromise;
     ReadyState m_readyState { ReadyState::Closed };

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.h
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.h
@@ -75,7 +75,7 @@ public:
     virtual void removeSourceBuffer(SourceBufferPrivate&);
     void sourceBufferPrivateDidChangeActiveState(SourceBufferPrivate&, bool active);
     virtual void notifyActiveSourceBuffersChanged() = 0;
-    virtual void durationChanged(const MediaTime&) = 0;
+    virtual void durationChanged(const MediaTime&);
     virtual void bufferedChanged(const PlatformTimeRanges&) { }
 
     virtual void markEndOfStream(EndOfStreamStatus) { m_isEnded = true; }
@@ -95,7 +95,7 @@ public:
     MediaTime duration() const;
     const PlatformTimeRanges& buffered() const;
 
-    bool hasFutureTime(const MediaTime& currentTime, const MediaTime& duration, const PlatformTimeRanges&) const;
+    bool hasFutureTime(const MediaTime& currentTime) const;
     bool hasAudio() const;
     bool hasVideo() const;
 
@@ -109,6 +109,7 @@ protected:
     bool m_isEnded { false };
 
 private:
+    MediaTime m_duration { MediaTime::invalidTime() };
     MediaTime m_timeFudgeFactor;
     ThreadSafeWeakPtr<MediaSourcePrivateClient> m_client;
 };

--- a/Source/WebCore/platform/graphics/MediaSourcePrivateClient.h
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivateClient.h
@@ -43,7 +43,6 @@ public:
     virtual ~MediaSourcePrivateClient() = default;
 
     virtual void setPrivateAndOpen(Ref<MediaSourcePrivate>&&) = 0;
-    virtual MediaTime duration() const = 0;
     virtual const PlatformTimeRanges& buffered() const = 0;
     virtual Ref<MediaTimePromise> waitForTarget(const SeekTarget&) = 0;
     virtual Ref<MediaPromise> seekToTime(const MediaTime&) = 0;

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
@@ -83,11 +83,9 @@ MediaTime SourceBufferPrivate::currentMediaTime() const
     return { };
 }
 
-MediaTime SourceBufferPrivate::duration() const
+MediaTime SourceBufferPrivate::mediaSourceDuration() const
 {
-    if (RefPtr mediaSource = m_mediaSource.get())
-        return mediaSource->duration();
-    return { };
+    return m_mediaSourceDuration;
 }
 
 void SourceBufferPrivate::resetTimestampOffsetInTrackBuffers()
@@ -718,7 +716,7 @@ Ref<MediaPromise> SourceBufferPrivate::append(Ref<SharedBuffer>&& buffer)
 
         Vector<Ref<MediaPromise>> promises;
         promises.append(updateBufferedFromTrackBuffers(trackBuffers));
-        if (m_groupEndTimestamp > duration()) {
+        if (m_groupEndTimestamp > mediaSourceDuration()) {
             // https://w3c.github.io/media-source/#sourcebuffer-coded-frame-processing
             // 5. If the media segment contains data beyond the current duration, then run the duration change algorithm with new
             // duration set to the maximum of the current duration and the group end timestamp.

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.h
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.h
@@ -118,6 +118,7 @@ public:
     virtual void setTimestampOffset(const MediaTime& timestampOffset) { m_timestampOffset = timestampOffset; }
     virtual void setAppendWindowStart(const MediaTime& appendWindowStart) { m_appendWindowStart = appendWindowStart;}
     virtual void setAppendWindowEnd(const MediaTime& appendWindowEnd) { m_appendWindowEnd = appendWindowEnd; }
+
     using ComputeSeekPromise = MediaTimePromise;
     WEBCORE_EXPORT virtual Ref<ComputeSeekPromise> computeSeekTime(const SeekTarget&);
     WEBCORE_EXPORT virtual void seekToTime(const MediaTime&);
@@ -125,6 +126,8 @@ public:
 
     WEBCORE_EXPORT void setClient(SourceBufferPrivateClient&);
     WEBCORE_EXPORT void detach();
+
+    void setMediaSourceDuration(const MediaTime& duration) { m_mediaSourceDuration = duration; }
 
     const PlatformTimeRanges& buffered() const { return m_buffered; }
 
@@ -168,7 +171,7 @@ protected:
     WEBCORE_EXPORT Ref<MediaPromise> updateBufferedFromTrackBuffers(const Vector<PlatformTimeRanges>&);
 
     MediaTime currentMediaTime() const;
-    MediaTime duration() const;
+    MediaTime mediaSourceDuration() const;
 
     using InitializationSegment = SourceBufferPrivateClient::InitializationSegment;
     WEBCORE_EXPORT void didReceiveInitializationSegment(InitializationSegment&&);
@@ -252,6 +255,7 @@ private:
     MediaTime m_appendWindowStart { MediaTime::zeroTime() };
     MediaTime m_appendWindowEnd { MediaTime::positiveInfiniteTime() };
     MediaTime m_highestPresentationTimestamp;
+    MediaTime m_mediaSourceDuration { MediaTime::invalidTime() };
 
     MediaTime m_groupStartTimestamp { MediaTime::invalidTime() };
     MediaTime m_groupEndTimestamp { MediaTime::zeroTime() };

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -477,7 +477,7 @@ MediaTime MediaPlayerPrivateMediaSourceAVFObjC::currentMediaTime() const
 
 bool MediaPlayerPrivateMediaSourceAVFObjC::currentMediaTimeMayProgress() const
 {
-    return m_mediaSourcePrivate ? m_mediaSourcePrivate->hasFutureTime(currentMediaTime(), durationMediaTime(), buffered()) : false;
+    return m_mediaSourcePrivate ? m_mediaSourcePrivate->hasFutureTime(currentMediaTime()) : false;
 }
 
 MediaTime MediaPlayerPrivateMediaSourceAVFObjC::clampTimeToLastSeekTime(const MediaTime& time) const

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm
@@ -114,8 +114,9 @@ void MediaSourcePrivateAVFObjC::notifyActiveSourceBuffersChanged()
         player->notifyActiveSourceBuffersChanged();
 }
 
-void MediaSourcePrivateAVFObjC::durationChanged(const MediaTime&)
+void MediaSourcePrivateAVFObjC::durationChanged(const MediaTime& duration)
 {
+    MediaSourcePrivate::durationChanged(duration);
     if (auto* player = this->player())
         player->durationChanged();
 }

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
@@ -105,11 +105,9 @@ private:
     bool isTimeBuffered(const MediaTime&) const;
 
     bool isMediaSource() const override { return true; }
-    RefPtr<MediaSourcePrivateClient> mediaSourcePrivateClient() { return m_mediaSource.get(); }
 
     void propagateReadyStateToPlayer();
 
-    ThreadSafeWeakPtr<MediaSourcePrivateClient> m_mediaSource;
     RefPtr<MediaSourcePrivateGStreamer> m_mediaSourcePrivate;
     MediaTime m_mediaTimeDuration { MediaTime::invalidTime() };
     bool m_isPipelinePlaying = true;

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
@@ -93,11 +93,11 @@ MediaSourcePrivateGStreamer::AddStatus MediaSourcePrivateGStreamer::addSourceBuf
     return MediaSourcePrivateGStreamer::AddStatus::Ok;
 }
 
-void MediaSourcePrivateGStreamer::durationChanged(const MediaTime&)
+void MediaSourcePrivateGStreamer::durationChanged(const MediaTime& duration)
 {
     ASSERT(isMainThread());
 
-    MediaTime duration = this->duration();
+    MediaSourcePrivate::durationChanged(duration);
     GST_TRACE_OBJECT(m_playerPrivate.pipeline(), "Duration: %" GST_TIME_FORMAT, GST_TIME_ARGS(toGstClockTime(duration)));
     if (!duration.isValid() || duration.isNegativeInfinite())
         return;

--- a/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp
@@ -200,7 +200,7 @@ MediaTime MockMediaPlayerMediaSource::currentMediaTime() const
 
 bool MockMediaPlayerMediaSource::currentMediaTimeMayProgress() const
 {
-    return m_mediaSourcePrivate && m_mediaSourcePrivate->hasFutureTime(currentMediaTime(), durationMediaTime(), buffered());
+    return m_mediaSourcePrivate && m_mediaSourcePrivate->hasFutureTime(currentMediaTime());
 }
 
 void MockMediaPlayerMediaSource::notifyActiveSourceBuffersChanged()

--- a/Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.cpp
@@ -74,6 +74,7 @@ MediaSourcePrivate::AddStatus MockMediaSourcePrivate::addSourceBuffer(const Cont
 
 void MockMediaSourcePrivate::durationChanged(const MediaTime& duration)
 {
+    MediaSourcePrivate::durationChanged(duration);
     m_player.updateDuration(duration);
 }
 

--- a/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp
@@ -73,11 +73,6 @@ void RemoteMediaSourceProxy::setPrivateAndOpen(Ref<MediaSourcePrivate>&& mediaSo
     m_private = WTFMove(mediaSourcePrivate);
 }
 
-MediaTime RemoteMediaSourceProxy::duration() const
-{
-    return m_duration;
-}
-
 const PlatformTimeRanges& RemoteMediaSourceProxy::buffered() const
 {
     return m_buffered;
@@ -141,10 +136,6 @@ void RemoteMediaSourceProxy::addSourceBuffer(const WebCore::ContentType& content
 
 void RemoteMediaSourceProxy::durationChanged(const MediaTime& duration)
 {
-    if (m_duration == duration)
-        return;
-
-    m_duration = duration;
     if (m_private)
         m_private->durationChanged(duration);
 }

--- a/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h
@@ -62,7 +62,6 @@ public:
 
     // MediaSourcePrivateClient overrides
     void setPrivateAndOpen(Ref<WebCore::MediaSourcePrivate>&&) final;
-    MediaTime duration() const final;
     const WebCore::PlatformTimeRanges& buffered() const final;
     Ref<WebCore::MediaTimePromise> waitForTarget(const WebCore::SeekTarget&) final;
     Ref<WebCore::MediaPromise> seekToTime(const MediaTime&) final;
@@ -97,7 +96,6 @@ private:
     RefPtr<WebCore::MediaSourcePrivate> m_private;
     WeakPtr<RemoteMediaPlayerProxy> m_remoteMediaPlayerProxy;
 
-    MediaTime m_duration;
     WebCore::PlatformTimeRanges m_buffered;
 
     Vector<RefPtr<RemoteSourceBufferProxy>> m_sourceBuffers;


### PR DESCRIPTION
#### adb77f8a601c3110242d8262cf2da0407fff971c
<pre>
[MSE] Remove need for SourceBufferPrivate to query MediaSource duration
<a href="https://bugs.webkit.org/show_bug.cgi?id=265778">https://bugs.webkit.org/show_bug.cgi?id=265778</a>
<a href="https://rdar.apple.com/119114938">rdar://119114938</a>

Reviewed by Youenn Fablet.

We notify each SourceBufferPrivate that the MediaSource duration has changed
and use this cache value instead.

Covered by existing tests, no change in observable behaviour.

* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::MediaSource):
(WebCore::MediaSource::hasFutureTime):
(WebCore::MediaSource::setDurationInternal):
* Source/WebCore/Modules/mediasource/MediaSource.h:
* Source/WebCore/platform/graphics/MediaSourcePrivate.cpp:
(WebCore::MediaSourcePrivate::hasFutureTime const):
We don&apos;t need to pass the duration nor the buffered range as the MediaSourcePrivate owns this information anyway.
(WebCore::MediaSourcePrivate::duration const):
(WebCore::MediaSourcePrivate::durationChanged):
* Source/WebCore/platform/graphics/MediaSourcePrivate.h:
* Source/WebCore/platform/graphics/MediaSourcePrivateClient.h:
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::mediaSourceDuration const):
Rename duration() to mediaSourceDuration() to remove ambiguity as to which duration this is related to.
(WebCore::SourceBufferPrivate::append):
(WebCore::SourceBufferPrivate::duration const): Deleted.
* Source/WebCore/platform/graphics/SourceBufferPrivate.h:
(WebCore::SourceBufferPrivate::setMediaSourceDuration):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::currentMediaTimeMayProgress const):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm:
(WebCore::MediaSourcePrivateAVFObjC::durationChanged):
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp:
(WebCore::MediaPlayerPrivateGStreamerMSE::load):
(WebCore::MediaPlayerPrivateGStreamerMSE::doSeek):
(WebCore::MediaPlayerPrivateGStreamerMSE::buffered const):
(WebCore::MediaPlayerPrivateGStreamerMSE::sourceSetup):
(WebCore::MediaPlayerPrivateGStreamerMSE::isTimeBuffered const):
(WebCore::MediaPlayerPrivateGStreamerMSE::durationChanged):
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h: remove need to keep reference to MediaSourcePrivateClient,
it was an API violation for the MediaPlayerPrivate to talk to the MediaSourcePrivateClient, this interface is reserved for the MediaSourcePrivate to talk to the MediaSource.
The MediaPlayerPrivateGStreamerMSE already contains a strong reference to the MediaSourcePrivate so we query it directly instead.
(The MediaSourcePrivateClient would have queried its private anyway)
(WebCore::MediaPlayerPrivateGStreamerMSE::mediaSourcePrivateClient): Deleted.
* Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp:
(WebCore::MockMediaPlayerMediaSource::currentMediaTimeMayProgress const):
* Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.cpp:
(WebCore::MockMediaSourcePrivate::durationChanged):
* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp:
(WebKit::RemoteMediaSourceProxy::durationChanged):
(WebKit::RemoteMediaSourceProxy::duration const): Deleted.
* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h:

Canonical link: <a href="https://commits.webkit.org/271514@main">https://commits.webkit.org/271514@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a401e56f3fba72e298c9fbd75deaee39ae88e2b8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28490 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7135 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29876 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31017 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25945 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28987 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9235 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4504 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26158 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28759 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5891 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24518 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5152 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5280 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25514 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31703 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26091 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25957 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31551 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5232 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3408 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29320 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/notification (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6833 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6854 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5689 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5752 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->