### PR TITLE
[MSE] remove MonitorSourceBuffer method from MediaSourcePrivateClient()

### DIFF
--- a/Source/WebCore/Modules/mediasource/MediaSource.h
+++ b/Source/WebCore/Modules/mediasource/MediaSource.h
@@ -77,6 +77,7 @@ public:
     void openIfInEndedState();
     void openIfDeferredOpen();
     virtual bool isOpen() const;
+    virtual void monitorSourceBuffers();
     bool isClosed() const;
     bool isEnded() const;
     void sourceBufferDidChangeActiveState(SourceBuffer&, bool);
@@ -89,7 +90,6 @@ public:
 
     bool attachToElement(HTMLMediaElement&);
     void detachFromElement(HTMLMediaElement&);
-    void monitorSourceBuffers() override;
     bool isSeeking() const { return !!m_pendingSeekTarget; }
     Ref<TimeRanges> seekable();
     ExceptionOr<void> setLiveSeekableRange(double start, double end);

--- a/Source/WebCore/platform/graphics/MediaSourcePrivateClient.h
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivateClient.h
@@ -46,7 +46,6 @@ public:
     virtual const PlatformTimeRanges& buffered() const = 0;
     virtual Ref<MediaTimePromise> waitForTarget(const SeekTarget&) = 0;
     virtual Ref<MediaPromise> seekToTime(const MediaTime&) = 0;
-    virtual void monitorSourceBuffers() = 0;
 
 #if !RELEASE_LOG_DISABLED
     virtual void setLogIdentifier(const void*) = 0;

--- a/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp
@@ -98,11 +98,6 @@ Ref<MediaPromise> RemoteMediaSourceProxy::seekToTime(const MediaTime& time)
     });
 }
 
-void RemoteMediaSourceProxy::monitorSourceBuffers()
-{
-    notImplemented();
-}
-
 #if !RELEASE_LOG_DISABLED
 void RemoteMediaSourceProxy::setLogIdentifier(const void*)
 {

--- a/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h
@@ -65,7 +65,6 @@ public:
     const WebCore::PlatformTimeRanges& buffered() const final;
     Ref<WebCore::MediaTimePromise> waitForTarget(const WebCore::SeekTarget&) final;
     Ref<WebCore::MediaPromise> seekToTime(const MediaTime&) final;
-    void monitorSourceBuffers() final;
 
 #if !RELEASE_LOG_DISABLED
     void setLogIdentifier(const void*) final;


### PR DESCRIPTION
#### af3e8935efa5f9b1755cff5ef9f4f77b111f717d
<pre>
[MSE] remove MonitorSourceBuffer method from MediaSourcePrivateClient()
<a href="https://bugs.webkit.org/show_bug.cgi?id=265780">https://bugs.webkit.org/show_bug.cgi?id=265780</a>
<a href="https://rdar.apple.com/119116250">rdar://119116250</a>

Reviewed by Youenn Fablet.

No change in observable behaviour, removing dead code.

* Source/WebCore/Modules/mediasource/MediaSource.h:
* Source/WebCore/platform/graphics/MediaSourcePrivateClient.h:
* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp:
(WebKit::RemoteMediaSourceProxy::monitorSourceBuffers): Deleted.
* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h:

Canonical link: <a href="https://commits.webkit.org/271516@main">https://commits.webkit.org/271516@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f72458660f7234753d052c7979e1b1401cbd0c9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28487 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7132 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29873 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31014 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25942 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28984 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9231 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4501 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26164 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28756 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5885 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24510 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5150 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5266 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25511 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31700 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26085 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25954 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31548 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5229 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3404 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29318 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6830 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6856 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5686 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5749 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->