### PR TITLE
[ iOS ] fast/mediastream/video-srcObject-fit-fill.html is a constant text failure

### DIFF
--- a/LayoutTests/fast/mediastream/video-srcObject-fit-fill.html
+++ b/LayoutTests/fast/mediastream/video-srcObject-fit-fill.html
@@ -51,7 +51,8 @@ async function validateSnapshot()
     const data = canvas.getContext('2d').getImageData(0, 0, canvas.width, canvas.height).data;
 
     // We inspect the horizontal line at pixel 50. We should get white, then green, then white.
-    // Green block width should be 300.
+    // We inspect the vertical line at pixel 100. We should get white, then green, then white.
+    // Green block aspect ratio should be roughly 3.
 
     const horizontalLine = 50;
     let j = 0;
@@ -63,14 +64,38 @@ async function validateSnapshot()
     if (!isPixelGreen(horizontalLine, j, canvas, data))
         return -2;
 
-    const startGreen = j;
+    let startGreen = j;
     while (isPixelGreen(horizontalLine, ++j, canvas, data)) { };
-    const endGreen = j;
+    let endGreen = j;
 
     if (!isPixelWhite(horizontalLine, j, canvas, data))
         return -3;
 
-    return endGreen - startGreen;
+    const width = endGreen - startGreen;
+
+    const verticalLine = 100;
+    let i = 0;
+
+    if (!isPixelWhite(i, verticalLine, canvas, data))
+        return -1;
+    while (isPixelWhite(++i, verticalLine, canvas, data)) { };
+
+    if (!isPixelGreen(i, verticalLine, canvas, data))
+        return -2;
+
+    startGreen = i;
+    while (isPixelGreen(++i, verticalLine, canvas, data)) { };
+    endGreen = i;
+
+    if (!isPixelWhite(i, verticalLine, canvas, data))
+        return -3;
+
+    const height = endGreen - startGreen;
+
+    if (!height)
+        return 0;
+
+    return width / height;
 }
 
 promise_test(async () => {
@@ -83,16 +108,17 @@ promise_test(async () => {
     await new Promise(resolve => setTimeout(resolve, 500));
 
     let counter = 0;
-    let result =  0;
-    while (counter++ < 150 && result !== 300) {
+    let aspectRatio =  0;
+    while (counter++ < 150 && aspectRatio < 2) {
         await new Promise(resolve => video.requestVideoFrameCallback(resolve));
         try {
-            result = await validateSnapshot();
+            aspectRatio = await validateSnapshot();
         } catch (e) {
             console.log(e);
         }
     }
-    assert_equals(result, 300);
+    assert_greater_than(aspectRatio, 2.9);
+    assert_less_than(aspectRatio, 3.1);
     image.parentNode.removeChild(image);
 }, "Validate video element is filled")
 </script>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -4649,9 +4649,6 @@ imported/w3c/web-platform-tests/uievents/order-of-events/mouse-events/wheel-scro
 #rdar://118015813 ([ iOS ]imported/w3c/web-platform-tests/css/cssom-view/scroll-behavior-main-frame-root.html is a flaky text failure (264281))
 imported/w3c/web-platform-tests/css/cssom-view/scroll-behavior-main-frame-root.html [ Pass Failure ]
 
-#rdar://118020922 ([ iOS ] fast/mediastream/video-srcObject-fit-fill.html is a constant text failure (264293))
-fast/mediastream/video-srcObject-fit-fill.html [ Failure ]
-
 # Failing word-break: auto-phrase tests.
 webkit.org/b/257698 imported/w3c/web-platform-tests/css/css-text/word-break/auto-phrase/word-break-auto-phrase-004.html [ ImageOnlyFailure ]
 webkit.org/b/257698 imported/w3c/web-platform-tests/css/css-text/word-break/auto-phrase/word-break-auto-phrase-005.html [ ImageOnlyFailure ]

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
@@ -31,6 +31,7 @@
 #import "PlatformCALayerRemote.h"
 #import "RemoteLayerTreeHost.h"
 #import "RemoteLayerTreeInteractionRegionLayers.h"
+#import "WKVideoView.h"
 #import <QuartzCore/QuartzCore.h>
 #import <WebCore/MediaPlayerEnumsCocoa.h>
 #import <WebCore/PlatformCAFilters.h>
@@ -307,8 +308,14 @@ void RemoteLayerTreePropertyApplier::applyPropertiesToLayer(CALayer *layer, Remo
 
 #if HAVE(AVKIT)
     if (properties.changedProperties & LayerChange::VideoGravityChanged) {
-        if ([layer respondsToSelector:@selector(setVideoGravity:)])
-            [(WebAVPlayerLayer*)layer setVideoGravity:convertMediaPlayerToAVLayerVideoGravity(properties.videoGravity)];
+        auto *playerLayer = layer;
+#if PLATFORM(IOS_FAMILY)
+        if (layerTreeNode && [layerTreeNode->uiView() isKindOfClass:WKVideoView.class])
+            playerLayer = [(WKVideoView*)layerTreeNode->uiView() playerLayer];
+#endif
+        ASSERT([playerLayer respondsToSelector:@selector(setVideoGravity:)]);
+        if ([playerLayer respondsToSelector:@selector(setVideoGravity:)])
+            [(WebAVPlayerLayer*)playerLayer setVideoGravity:convertMediaPlayerToAVLayerVideoGravity(properties.videoGravity)];
     }
 #endif
 }

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -764,8 +764,7 @@ RetainPtr<WKVideoView> VideoPresentationManagerProxy::createViewWithID(PlaybackS
         if (![[view layer] superlayer])
             [playerLayer addSublayer:[view layer]];
 
-        auto videoView = adoptNS([[WKVideoView alloc] initWithFrame:initialFrame]);
-        [videoView addSubview:playerView.get()];
+        auto videoView = adoptNS([[WKVideoView alloc] initWithFrame:initialFrame playerView:playerView.get()]);
 
         model->setPlayerLayer(WTFMove(playerLayer));
         model->setPlayerView(playerView.get());

--- a/Source/WebKit/UIProcess/ios/WKVideoView.h
+++ b/Source/WebKit/UIProcess/ios/WKVideoView.h
@@ -28,8 +28,12 @@
 #if PLATFORM(IOS_FAMILY)
 
 #import "RemoteLayerTreeViews.h"
+#import <WebCore/WebAVPlayerLayerView.h>
 
 @interface WKVideoView : WKCompositingView
+- (id)initWithFrame:(CGRect)frame playerView:(WebAVPlayerLayerView *)playerView;
+
+@property (nonatomic, readonly) CALayer *playerLayer;
 @end
 
 #endif

--- a/Source/WebKit/UIProcess/ios/WKVideoView.mm
+++ b/Source/WebKit/UIProcess/ios/WKVideoView.mm
@@ -27,10 +27,30 @@
 #include "WKVideoView.h"
 
 #if PLATFORM(IOS_FAMILY)
-@implementation WKVideoView
+@implementation WKVideoView {
+    WebAVPlayerLayerView* _playerView;
+}
+
 + (Class)layerClass
 {
     return [CALayer class];
+}
+
+- (id)initWithFrame:(CGRect)frame playerView:(WebAVPlayerLayerView *)playerView
+{
+    self = [super initWithFrame:frame];
+    if (!self)
+        return nil;
+
+    _playerView = playerView;
+    [self addSubview:playerView];
+
+    return self;
+}
+
+- (CALayer *)playerLayer
+{
+    return _playerView.layer;
 }
 
 - (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event


### PR DESCRIPTION
#### 3943142d2ef1777fc8977e6158eb10e053c3f8ca
<pre>
[ iOS ] fast/mediastream/video-srcObject-fit-fill.html is a constant text failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=264293">https://bugs.webkit.org/show_bug.cgi?id=264293</a>
<a href="https://rdar.apple.com/118020922">rdar://118020922</a>

Reviewed by Jer Noble.

The WebAVPlayerLayer was not receiving the gravity from WebProcess on iOS, which breaks its bounds computation.
Update RemoteLayerTreePropertyApplier::applyPropertiesToLayer to take into account WKVideoView.

We update fast/mediastream/video-srcObject-fit-fill.html to check for aspect ratio instead of pixel width to handle the various simulators.

* LayoutTests/fast/mediastream/video-srcObject-fit-fill.html:
* LayoutTests/platform/ios/TestExpectations:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(WebKit::RemoteLayerTreePropertyApplier::applyPropertiesToLayer):
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationManagerProxy::createViewWithID):
* Source/WebKit/UIProcess/ios/WKVideoView.h:
* Source/WebKit/UIProcess/ios/WKVideoView.mm:
(-[WKVideoView initWithFrame:playerView:]):
(+[WKVideoView playerLayerFromView:]):

Canonical link: <a href="https://commits.webkit.org/271859@main">https://commits.webkit.org/271859@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42b74951e03c6dc697f22d5ca97cdfeae7c8202d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29213 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7884 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30553 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31802 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26570 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10025 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5189 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26574 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29486 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6545 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25029 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5642 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5785 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26066 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33140 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26682 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26499 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32010 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5750 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3933 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29798 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7431 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/25860 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7079 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6263 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6275 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->