### PR TITLE
resync CSS selector parsing tests

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-has-disallow-nesting-has-inside-has-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-has-disallow-nesting-has-inside-has-expected.txt
@@ -1,5 +1,4 @@
 
 PASS ".a:has(.b:has(.c))" should be an invalid selector
-FAIL ".a:has(:is(.b:has(.c)))" should be a valid selector assert_equals: CSS.supports() reports the expected value expected true but got false
-FAIL ".a:has(:is(.b:has(.c), .d))" should be a valid selector assert_equals: CSS.supports() reports the expected value expected true but got false
+PASS CSS Selectors: The relational pseudo-class (disallow nesting :has() inside :has())
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-has-disallow-nesting-has-inside-has.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-has-disallow-nesting-has-inside-has.html
@@ -8,6 +8,12 @@
 <script src="/css/support/parsing-testcommon.js"></script>
 <script>
   test_invalid_selector('.a:has(.b:has(.c))');
-  test_valid_selector('.a:has(:is(.b:has(.c)))');
-  test_valid_selector('.a:has(:is(.b:has(.c), .d))');
+  test(() => {
+    // It's not easy to check that these are invalid because :is() and :where()
+    // use forgiving parsing. Check that they never match instead.
+    assert_false(document.documentElement.matches(":has(:is(:has(*)))"));
+    assert_false(document.documentElement.matches(":has(:where(:has(*)))"));
+    assert_true(document.documentElement.matches(":has(:is(:has(*), script))"));
+    assert_true(document.documentElement.matches(":has(:where(:has(*), script))"));
+  })
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-has-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-has-expected.txt
@@ -28,5 +28,4 @@ PASS ".a:has b" should be an invalid selector
 PASS ":has()" should be an invalid selector
 PASS ":has(123)" should be an invalid selector
 PASS ":has(.a, 123)" should be an invalid selector
-PASS ":has(:is(.a, 123))" should be a valid selector
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-has-forgiving-selector-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-has-forgiving-selector-expected.txt
@@ -1,0 +1,5 @@
+
+PASS ":has(:is(:has(*)))" should be a valid selector
+PASS ":has(:where(:has(*)))" should be a valid selector
+FAIL ":has(:is(.a, 123))" should be a valid selector assert_equals: CSS.supports() reports the expected value expected false but got true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-has-forgiving-selector.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-has-forgiving-selector.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Selectors: The relational pseudo-class (forgiving selector parsing)</title>
+<link rel="author" title="Steinar H. Gunderson" href="mailto:sesse@chromium.org">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/8356">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<script>
+  // disallow nesting :has() inside :has(), but serialize back unchanged
+  test_valid_forgiving_selector(':has(:is(:has(*)))');
+  test_valid_forgiving_selector(':has(:where(:has(*)))');
+  // serialize :is() back unchanged
+  test_valid_forgiving_selector(':has(:is(.a, 123))');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-has.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-has.html
@@ -37,5 +37,4 @@
   test_invalid_selector(':has()');
   test_invalid_selector(':has(123)');
   test_invalid_selector(':has(.a, 123)');
-  test_valid_selector(':has(:is(.a, 123))');
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-part-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-part-expected.txt
@@ -1,0 +1,27 @@
+
+PASS "::part(--foo)" should be a valid selector
+PASS "::part(bar)" should be a valid selector
+PASS "::part(--)" should be a valid selector
+PASS "::part(--0)" should be a valid selector
+PASS "::part(foo bar)" should be a valid selector
+PASS "::part(-foo bar)" should be a valid selector
+PASS "::part(foo):focus" should be a valid selector
+PASS "::part(foo):hover" should be a valid selector
+PASS "::part(foo):focus-within" should be a valid selector
+PASS "::part(foo)::before" should be a valid selector
+PASS "::part(foo)::after" should be a valid selector
+FAIL "::part(foo)::placeholder" should be a valid selector '::part(foo)::placeholder' is not a valid selector.
+PASS "::part(foo)::first-line" should be a valid selector
+PASS "::part(foo)::first-letter" should be a valid selector
+FAIL "::part(foo)::file-selector-button" should be a valid selector '::part(foo)::file-selector-button' is not a valid selector.
+PASS "::part(foo):is(:focus)" should be a valid selector
+PASS ":lang(en)::part(foo)" should be a valid selector
+PASS ":dir(ltr)::part(foo)" should be a valid selector
+PASS ":part()" should be an invalid selector
+PASS ":part(0)" should be an invalid selector
+PASS ":part('foo')" should be an invalid selector
+PASS ":part([foo])" should be an invalid selector
+FAIL "::part(foo):lang(en)" should be an invalid selector assert_throws_dom: "::part(foo):lang(en)" should throw in querySelector function "() => document.querySelector(selector)" did not throw
+FAIL "::part(foo):dir(ltr)" should be an invalid selector assert_throws_dom: "::part(foo):dir(ltr)" should throw in querySelector function "() => document.querySelector(selector)" did not throw
+PASS "::part(foo) + ::part(bar)" should be an invalid selector
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-part.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-part.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<meta charset="utf-8" />
+<title>CSS Selectors: part pseudo selectors</title>
+<link rel="help" href="https://drafts.csswg.org/css-shadow-parts/#part" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<script>
+  test_valid_selector("::part(--foo)");
+  test_valid_selector("::part(bar)");
+  test_valid_selector("::part(--)");
+  test_valid_selector("::part(--0)");
+  test_valid_selector("::part(foo bar)");
+  test_valid_selector("::part(-foo bar)");
+  test_valid_selector("::part(foo):focus");
+  test_valid_selector("::part(foo):hover");
+  test_valid_selector("::part(foo):focus-within");
+  test_valid_selector("::part(foo)::before");
+  test_valid_selector("::part(foo)::after");
+  test_valid_selector("::part(foo)::placeholder");
+  test_valid_selector("::part(foo)::first-line");
+  test_valid_selector("::part(foo)::first-letter");
+  test_valid_selector("::part(foo)::file-selector-button");
+  test_valid_selector("::part(foo):is(:focus)");
+  test_valid_selector(":lang(en)::part(foo)");
+  test_valid_selector(":dir(ltr)::part(foo)");
+  test_invalid_selector(":part()");
+  test_invalid_selector(":part(0)");
+  test_invalid_selector(":part('foo')");
+  test_invalid_selector(":part([foo])");
+  test_invalid_selector("::part(foo):lang(en)");
+  test_invalid_selector("::part(foo):dir(ltr)");
+  test_invalid_selector('::part(foo) + ::part(bar)');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-slotted-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-slotted-expected.txt
@@ -1,0 +1,20 @@
+
+PASS "::slotted(bar)" should be a valid selector
+PASS "::slotted([attr=\"foo\"])" should be a valid selector
+PASS "::slotted(*)" should be a valid selector
+PASS "::slotted(.class)" should be a valid selector
+PASS "::slotted(:not(foo))" should be a valid selector
+PASS "::slotted(:not(:nth-last-of-type(2)):not([slot=\"foo\"]))" should be a valid selector
+PASS "::slotted(:first-child)" should be a valid selector
+PASS "::slotted(:hover)" should be a valid selector
+PASS "::slotted" should be an invalid selector
+PASS "::slotted()" should be an invalid selector
+PASS "::slotted(0)" should be an invalid selector
+PASS ":slotted(foo)" should be an invalid selector
+PASS "::slotted(foo):first-child" should be an invalid selector
+PASS "::slotted(foo):hover" should be an invalid selector
+PASS "::slotted(foo):focus" should be an invalid selector
+PASS "::slotted(foo):lang(en)" should be an invalid selector
+PASS "::slotted(foo):dir(ltr)" should be an invalid selector
+PASS "::slotted(foo) + ::slotted(bar)" should be an invalid selector
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-slotted.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-slotted.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<meta charset="utf-8" />
+<title>CSS Selectors: slotted pseudo selectors</title>
+<link rel="help" href="https://drafts.csswg.org/css-scoping/#slotted-pseudo" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<script>
+  test_valid_selector("::slotted(bar)");
+  test_valid_selector('::slotted([attr="foo"])');
+  test_valid_selector("::slotted(*)");
+  test_valid_selector("::slotted(.class)");
+  test_valid_selector("::slotted(:not(foo))");
+  test_valid_selector('::slotted(:not(:nth-last-of-type(2)):not([slot="foo"]))');
+  test_valid_selector("::slotted(:first-child)");
+  test_valid_selector("::slotted(:hover)");
+  test_invalid_selector("::slotted");
+  test_invalid_selector("::slotted()");
+  test_invalid_selector("::slotted(0)");
+  test_invalid_selector(":slotted(foo)");
+  test_invalid_selector("::slotted(foo):first-child");
+  test_invalid_selector("::slotted(foo):hover");
+  test_invalid_selector("::slotted(foo):focus");
+  test_invalid_selector("::slotted(foo):lang(en)");
+  test_invalid_selector("::slotted(foo):dir(ltr)");
+  test_invalid_selector('::slotted(foo) + ::slotted(bar)');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-state-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-state-expected.txt
@@ -6,6 +6,10 @@ FAIL ":state(--0)" should be a valid selector ':state(--0)' is not a valid selec
 FAIL ":host(:state(--foo))" should be a valid selector ':host(:state(--foo))' is not a valid selector.
 FAIL "my-input[type=\"foo\"]:state(checked)" should be a valid selector 'my-input[type="foo"]:state(checked)' is not a valid selector.
 FAIL "my-input[type=\"foo\"]:state(--0)::before" should be a valid selector 'my-input[type="foo"]:state(--0)::before' is not a valid selector.
+FAIL "my-input[type=\"foo\"]:state(--0)::part(inner)" should be a valid selector 'my-input[type="foo"]:state(--0)::part(inner)' is not a valid selector.
+FAIL "my-input[type=\"foo\"]:state(--0)::part(inner):state(bar)" should be a valid selector 'my-input[type="foo"]:state(--0)::part(inner):state(bar)' is not a valid selector.
+FAIL "::part(inner):state(bar)::before" should be a valid selector '::part(inner):state(bar)::before' is not a valid selector.
+FAIL "::part(inner):state(bar)::after" should be a valid selector '::part(inner):state(bar)::after' is not a valid selector.
 PASS ":state" should be an invalid selector
 PASS ":state(" should be an invalid selector
 PASS ":state()" should be an invalid selector
@@ -14,4 +18,9 @@ PASS ":state(0rem)" should be an invalid selector
 PASS ":state(url())" should be an invalid selector
 PASS ":state(foo(1))" should be an invalid selector
 PASS ":state(:host)" should be an invalid selector
+PASS "my-input::after:state(foo)" should be an invalid selector
+PASS "::part(inner):state(bar)::before:state(foo)" should be an invalid selector
+PASS "::part(inner):state(bar)::after:state(foo)" should be an invalid selector
+PASS "my-input::first-letter:state(foo)" should be an invalid selector
+PASS "::slotted(foo):state(foo)" should be an invalid selector
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-state.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-state.html
@@ -13,6 +13,12 @@
   test_valid_selector(":host(:state(--foo))");
   test_valid_selector('my-input[type="foo"]:state(checked)');
   test_valid_selector('my-input[type="foo"]:state(--0)::before');
+  test_valid_selector('my-input[type="foo"]:state(--0)::part(inner)');
+  test_valid_selector(
+    'my-input[type="foo"]:state(--0)::part(inner):state(bar)',
+  );
+  test_valid_selector('::part(inner):state(bar)::before');
+  test_valid_selector('::part(inner):state(bar)::after');
   test_invalid_selector(":state");
   test_invalid_selector(":state(");
   test_invalid_selector(":state()");
@@ -21,4 +27,9 @@
   test_invalid_selector(":state(url())");
   test_invalid_selector(":state(foo(1))");
   test_invalid_selector(":state(:host)");
+  test_invalid_selector("my-input::after:state(foo)");
+  test_invalid_selector('::part(inner):state(bar)::before:state(foo)');
+  test_invalid_selector('::part(inner):state(bar)::after:state(foo)');
+  test_invalid_selector("my-input::first-letter:state(foo)");
+  test_invalid_selector('::slotted(foo):state(foo)');
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/w3c-import.log
@@ -20,10 +20,14 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-descendant.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-focus-visible.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-has-disallow-nesting-has-inside-has.html
+/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-has-forgiving-selector.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-has.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-id.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-is.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-not.html
+/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-part.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-sibling.html
+/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-slotted.html
+/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-state.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-universal.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-where.html


### PR DESCRIPTION
#### e694f63e91aad88d879b8730a588972b8f4a0ec2
<pre>
resync CSS selector parsing tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=265785">https://bugs.webkit.org/show_bug.cgi?id=265785</a>

Reviewed by Tim Nguyen.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/5ddf095c380db657c000017e46dfebc45e93f682">https://github.com/web-platform-tests/wpt/commit/5ddf095c380db657c000017e46dfebc45e93f682</a>

* LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-has-disallow-nesting-has-inside-has-expected.txt: Rebaselined.
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-has-disallow-nesting-has-inside-has.html:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-has-expected.txt: Rebaselined.
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-has-forgiving-selector-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-has-forgiving-selector.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-has.html:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-part-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-part.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-slotted-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-slotted.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-state-expected.txt: Rebaselined.
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-state.html:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/271484@main">https://commits.webkit.org/271484@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dea0fdacab1e128b6994459862b3b6b8e8f52bea

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28529 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7173 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29916 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31057 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25983 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9282 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4542 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28799 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5930 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24544 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5181 "Found 1 new API test failure: /WPE/TestWebKitWebView:/webkit/WebKitWebView/notification (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5307 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25544 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31757 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26130 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25986 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31575 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5269 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3440 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29347 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6871 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/25338 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6834 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5727 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5789 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->