### PR TITLE
Add optimization for monospace font's content measuring

### DIFF
--- a/Source/WTF/wtf/unicode/CharacterNames.h
+++ b/Source/WTF/wtf/unicode/CharacterNames.h
@@ -138,6 +138,18 @@ constexpr UChar zeroWidthJoiner = 0x200D;
 constexpr UChar zeroWidthNoBreakSpace = 0xFEFF;
 constexpr UChar zeroWidthNonJoiner = 0x200C;
 constexpr UChar zeroWidthSpace = 0x200B;
+constexpr UChar lineSeparator = 0x2028;
+constexpr UChar paragraphSeparator = 0x2029;
+constexpr UChar mediumShade = 0x2592;
+constexpr UChar functionApplication = 0x2061;
+constexpr UChar invisibleTimes = 0x2062;
+constexpr UChar invisibleSeparator = 0x2063;
+constexpr UChar inhibitSymmetricSwapping = 0x206A;
+constexpr UChar activateSymmetricSwapping = 0x206B;
+constexpr UChar inhibitArabicFormShaping = 0x206C;
+constexpr UChar activateArabicFormShaping = 0x206D;
+constexpr UChar nationalDigitShapes = 0x206E;
+constexpr UChar nominalDigitShapes = 0x206F;
 
 } // namespace WTF::Unicode
 
@@ -242,3 +254,15 @@ using WTF::Unicode::zeroWidthJoiner;
 using WTF::Unicode::zeroWidthNoBreakSpace;
 using WTF::Unicode::zeroWidthNonJoiner;
 using WTF::Unicode::zeroWidthSpace;
+using WTF::Unicode::lineSeparator;
+using WTF::Unicode::paragraphSeparator;
+using WTF::Unicode::mediumShade;
+using WTF::Unicode::functionApplication;
+using WTF::Unicode::invisibleTimes;
+using WTF::Unicode::invisibleSeparator;
+using WTF::Unicode::inhibitSymmetricSwapping;
+using WTF::Unicode::activateSymmetricSwapping;
+using WTF::Unicode::inhibitArabicFormShaping;
+using WTF::Unicode::activateArabicFormShaping;
+using WTF::Unicode::nationalDigitShapes;
+using WTF::Unicode::nominalDigitShapes;

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2032,6 +2032,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/VideoTrackPrivate.h
     platform/graphics/VideoTrackPrivateClient.h
     platform/graphics/WidthCache.h
+    platform/graphics/WidthIterator.h
     platform/graphics/WindRule.h
 
     platform/graphics/angle/ANGLEHeaders.h

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
@@ -69,9 +69,13 @@ InlineLayoutUnit TextUtil::width(const InlineTextBox& inlineTextBox, const FontC
         ++to;
     auto width = 0.f;
     auto useSimplifiedContentMeasuring = inlineTextBox.canUseSimplifiedContentMeasuring();
-    if (useSimplifiedContentMeasuring)
-        width = fontCascade.widthForSimpleText(StringView(text).substring(from, to - from));
-    else {
+    if (useSimplifiedContentMeasuring) {
+        auto view = StringView(text).substring(from, to - from);
+        if (fontCascade.canTakeFixedPitchFastContentMeasuring())
+            width = fontCascade.widthForSimpleTextWithFixedPitch(view, inlineTextBox.style().collapseWhiteSpace());
+        else
+            width = fontCascade.widthForSimpleText(view);
+    } else {
         auto& style = inlineTextBox.style();
         auto directionalOverride = style.unicodeBidi() == UnicodeBidi::Override;
         auto run = WebCore::TextRun { StringView(text).substring(from, to - from), contentLogicalLeft, { }, ExpansionBehavior::defaultBehavior(), directionalOverride ? style.direction() : TextDirection::LTR, directionalOverride };

--- a/Source/WebCore/platform/graphics/Font.h
+++ b/Source/WebCore/platform/graphics/Font.h
@@ -65,8 +65,8 @@ class GlyphPage;
 
 struct GlyphData;
 
-enum FontVariant { AutoVariant, NormalVariant, SmallCapsVariant, EmphasisMarkVariant, BrokenIdeographVariant };
-enum Pitch { UnknownPitch, FixedPitch, VariablePitch };
+enum FontVariant : uint8_t { AutoVariant, NormalVariant, SmallCapsVariant, EmphasisMarkVariant, BrokenIdeographVariant };
+enum Pitch : uint8_t { UnknownPitch, FixedPitch, VariablePitch };
 enum class IsForPlatformFont : bool { No, Yes };
 
 // Used to create platform fonts.
@@ -181,6 +181,7 @@ public:
 
     void determinePitch();
     Pitch pitch() const { return m_treatAsFixedPitch ? FixedPitch : VariablePitch; }
+    bool canTakeFixedPitchFastContentMeasuring() const { return m_canTakeFixedPitchFastContentMeasuring; }
 
     Origin origin() const { return m_attributes.origin; }
     bool isInterstitial() const { return m_attributes.isInterstitial == IsInterstitial::Yes; }
@@ -356,6 +357,7 @@ private:
     float m_syntheticBoldOffset { 0 };
 
     unsigned m_treatAsFixedPitch : 1;
+    unsigned m_canTakeFixedPitchFastContentMeasuring : 1 { false };
     unsigned m_isBrokenIdeographFallback : 1;
     unsigned m_hasVerticalGlyphs : 1;
 

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -136,7 +136,8 @@ public:
 
     float widthOfTextRange(const TextRun&, unsigned from, unsigned to, WeakHashSet<const Font>* fallbackFonts = nullptr, float* outWidthBeforeRange = nullptr, float* outWidthAfterRange = nullptr) const;
     WEBCORE_EXPORT float width(const TextRun&, WeakHashSet<const Font>* fallbackFonts = nullptr, GlyphOverflow* = nullptr) const;
-    float widthForSimpleText(StringView text, TextDirection = TextDirection::LTR) const;
+    WEBCORE_EXPORT float widthForSimpleText(StringView text, TextDirection = TextDirection::LTR) const;
+    WEBCORE_EXPORT float widthForSimpleTextWithFixedPitch(StringView text, bool whitespaceIsCollapsed) const;
 
     std::unique_ptr<TextLayout, TextLayoutDeleter> createLayout(RenderText&, float xPos, bool collapseWhiteSpace) const;
     static float width(TextLayout&, unsigned from, unsigned len, WeakHashSet<const Font>* fallbackFonts = nullptr);
@@ -161,6 +162,7 @@ public:
     TextSpacingTrim textSpacingTrim() const { return m_fontDescription.textSpacingTrim(); }
     TextAutospace textAutospace() const { return m_fontDescription.textAutospace(); }
     bool isFixedPitch() const;
+    bool canTakeFixedPitchFastContentMeasuring() const;
     
     bool enableKerning() const { return m_enableKerning; }
     bool requiresShaping() const { return m_requiresShaping; }
@@ -188,7 +190,7 @@ public:
 
     const Font& primaryFont() const;
     const FontRanges& fallbackRangesAt(unsigned) const;
-    GlyphData glyphDataForCharacter(char32_t, bool mirror, FontVariant = AutoVariant) const;
+    WEBCORE_EXPORT GlyphData glyphDataForCharacter(char32_t, bool mirror, FontVariant = AutoVariant) const;
 
     const Font* fontForCombiningCharacterSequence(StringView) const;
 
@@ -208,7 +210,7 @@ public:
     WEBCORE_EXPORT static bool shouldDisableFontSubpixelAntialiasingForTesting();
 
     enum class CodePath : uint8_t { Auto, Simple, Complex, SimpleWithGlyphOverflow };
-    CodePath codePath(const TextRun&, std::optional<unsigned> from = std::nullopt, std::optional<unsigned> to = std::nullopt) const;
+    WEBCORE_EXPORT CodePath codePath(const TextRun&, std::optional<unsigned> from = std::nullopt, std::optional<unsigned> to = std::nullopt) const;
     static CodePath characterRangeCodePath(const LChar*, unsigned) { return CodePath::Simple; }
     static CodePath characterRangeCodePath(const UChar*, unsigned len);
 
@@ -354,6 +356,12 @@ inline bool FontCascade::isFixedPitch() const
 {
     ASSERT(m_fonts);
     return m_fonts->isFixedPitch(m_fontDescription);
+}
+
+inline bool FontCascade::canTakeFixedPitchFastContentMeasuring() const
+{
+    ASSERT(m_fonts);
+    return m_fonts->canTakeFixedPitchFastContentMeasuring(m_fontDescription);
 }
 
 inline FontSelector* FontCascade::fontSelector() const

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
@@ -136,6 +136,21 @@ void FontCascadeFonts::determinePitch(const FontCascadeDescription& description)
         m_pitch = VariablePitch;
 }
 
+void FontCascadeFonts::determineCanTakeFixedPitchFastContentMeasuring(const FontCascadeDescription& description)
+{
+#if PLATFORM(COCOA)
+    auto& primaryRanges = realizeFallbackRangesAt(description, 0);
+    unsigned numRanges = primaryRanges.size();
+    if (numRanges == 1)
+        m_canTakeFixedPitchFastContentMeasuring = triState(primaryRanges.fontForFirstRange().canTakeFixedPitchFastContentMeasuring());
+    else
+        m_canTakeFixedPitchFastContentMeasuring = TriState::False;
+#else
+    UNUSED_PARAM(description);
+    m_canTakeFixedPitchFastContentMeasuring = TriState::False;
+#endif
+}
+
 bool FontCascadeFonts::isLoadingCustomFonts() const
 {
     for (auto& fontRanges : m_realizedFallbackRanges) {

--- a/Source/WebCore/platform/graphics/WidthIterator.cpp
+++ b/Source/WebCore/platform/graphics/WidthIterator.cpp
@@ -665,8 +665,19 @@ bool WidthIterator::characterCanUseSimplifiedTextMeasuring(char32_t codePoint, b
     case zeroWidthNoBreakSpace:
     case zeroWidthNonJoiner:
     case zeroWidthJoiner:
+    case wordJoiner:
+    case zeroWidthSpace:
+    case functionApplication:
+    case invisibleTimes:
+    case invisibleSeparator:
+    case inhibitSymmetricSwapping:
+    case activateSymmetricSwapping:
+    case inhibitArabicFormShaping:
+    case activateArabicFormShaping:
+    case nationalDigitShapes:
+    case nominalDigitShapes:
+    case mediumShade:
         return false;
-        break;
     }
 
     if (codePoint >= HiraganaLetterSmallA || isControlCharacter(codePoint))

--- a/Source/WebCore/platform/graphics/WidthIterator.h
+++ b/Source/WebCore/platform/graphics/WidthIterator.h
@@ -60,7 +60,7 @@ public:
     float runWidthSoFar() const { return m_runWidthSoFar; }
     unsigned currentCharacterIndex() const { return m_currentCharacterIndex; }
 
-    static bool characterCanUseSimplifiedTextMeasuring(char32_t, bool whitespaceIsCollapsed);
+    WEBCORE_EXPORT static bool characterCanUseSimplifiedTextMeasuring(char32_t, bool whitespaceIsCollapsed);
 
 private:
     GlyphData glyphDataForCharacter(char32_t, bool mirror);

--- a/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
@@ -692,6 +692,13 @@ static int extractNumber(CFNumberRef number)
     return result;
 }
 
+static bool extractBoolean(CFBooleanRef value)
+{
+    if (value)
+        return CFBooleanGetValue(value);
+    return false;
+}
+
 void Font::determinePitch()
 {
     CTFontRef ctFont = m_platformData.ctFont();
@@ -712,14 +719,18 @@ void Font::determinePitch()
     auto fullName = adoptCF(CTFontCopyFullName(ctFont));
     auto familyName = adoptCF(CTFontCopyFamilyName(ctFont));
 
-    int fixedPitch = extractNumber(adoptCF(static_cast<CFNumberRef>(CTFontCopyAttribute(m_platformData.ctFont(), kCTFontFixedAdvanceAttribute))).get());
+    int fixedPitch = extractNumber(adoptCF(static_cast<CFNumberRef>(CTFontCopyAttribute(ctFont, kCTFontFixedAdvanceAttribute))).get());
+    bool userInstalled = extractBoolean(adoptCF(static_cast<CFBooleanRef>(CTFontCopyAttribute(ctFont, kCTFontUserInstalledAttribute))).get());
     m_treatAsFixedPitch = (CTFontGetSymbolicTraits(ctFont) & kCTFontMonoSpaceTrait) || fixedPitch || (caseInsensitiveCompare(fullName.get(), CFSTR("Osaka-Mono")) || caseInsensitiveCompare(fullName.get(), CFSTR("MS-PGothic")) || caseInsensitiveCompare(fullName.get(), CFSTR("MonotypeCorsiva")));
-#if PLATFORM(IOS_FAMILY)
     if (familyName && caseInsensitiveCompare(familyName.get(), CFSTR("Courier New"))) {
+#if PLATFORM(IOS_FAMILY)
         // Special case Courier New to not be treated as fixed pitch, as this will make use of a hacked space width which is undesireable for iPhone (see rdar://6269783).
         m_treatAsFixedPitch = false;
-    }
 #endif
+        // "Courier New" has many special case characters which does not have widths (u0181, u0182 etc.). Thus we disable fast content measuring for monospace fonts.
+        m_canTakeFixedPitchFastContentMeasuring = false;
+    } else
+        m_canTakeFixedPitchFastContentMeasuring = m_treatAsFixedPitch && !userInstalled;
 }
 
 FloatRect Font::platformBoundsForGlyph(Glyph glyph) const

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -202,6 +202,7 @@ if (ENABLE_WEBCORE)
         Tests/WebCore/KeyedCoding.cpp
         Tests/WebCore/LayoutUnitTests.cpp
         Tests/WebCore/MIMETypeRegistry.cpp
+        Tests/WebCore/MonospaceFontTests.cpp
         Tests/WebCore/NowPlayingInfoTests.cpp
         Tests/WebCore/ParsedContentRange.cpp
         Tests/WebCore/PublicSuffix.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1102,6 +1102,7 @@
 		E38A0D351FD50CC300E98C8B /* Threading.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38A0D341FD50CBC00E98C8B /* Threading.cpp */; };
 		E38D65CA23A45FAA0063D69A /* PackedRef.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38D65C823A45FA90063D69A /* PackedRef.cpp */; };
 		E38D65CB23A45FAA0063D69A /* PackedRefPtr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38D65C923A45FA90063D69A /* PackedRefPtr.cpp */; };
+		E38EDC372B1D673A00963F9B /* MonospaceFontTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38EDC2F2B1D673A00963F9B /* MonospaceFontTests.cpp */; };
 		E394AE6F23F2303E005B4936 /* GrantAccessToMobileAssets.mm in Sources */ = {isa = PBXBuildFile; fileRef = E394AE6E23F2303E005B4936 /* GrantAccessToMobileAssets.mm */; };
 		E3A1E77F21B25B39008C6007 /* URLParserTextEncoding.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3A1E77E21B25B39008C6007 /* URLParserTextEncoding.cpp */; };
 		E3A1E78221B25B7A008C6007 /* URL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3A1E78021B25B79008C6007 /* URL.cpp */; };
@@ -3407,6 +3408,7 @@
 		E38A0D341FD50CBC00E98C8B /* Threading.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Threading.cpp; sourceTree = "<group>"; };
 		E38D65C823A45FA90063D69A /* PackedRef.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PackedRef.cpp; sourceTree = "<group>"; };
 		E38D65C923A45FA90063D69A /* PackedRefPtr.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PackedRefPtr.cpp; sourceTree = "<group>"; };
+		E38EDC2F2B1D673A00963F9B /* MonospaceFontTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MonospaceFontTests.cpp; sourceTree = "<group>"; };
 		E394AE6E23F2303E005B4936 /* GrantAccessToMobileAssets.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = GrantAccessToMobileAssets.mm; sourceTree = "<group>"; };
 		E3953F951F2CF32100A76A2E /* Signals.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Signals.cpp; sourceTree = "<group>"; };
 		E398BC0F2041C76300387136 /* UniqueArray.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UniqueArray.cpp; sourceTree = "<group>"; };
@@ -4386,6 +4388,7 @@
 				076E507E1F45031E006E9F5A /* Logging.cpp */,
 				CE1866471F72E8F100A0CAB6 /* MarkedText.cpp */,
 				A5B149DD1F5A19DC00C6DAFF /* MIMETypeRegistry.cpp */,
+				E38EDC2F2B1D673A00963F9B /* MonospaceFontTests.cpp */,
 				5159F266260D43E300B2DA3C /* NowPlayingInfoTests.cpp */,
 				CD225C071C45A69200140761 /* ParsedContentRange.cpp */,
 				AA96CAB421C7DB4200FD2F97 /* ParsedContentType.cpp */,
@@ -6581,6 +6584,7 @@
 				A5B149DE1F5A19EA00C6DAFF /* MIMETypeRegistry.cpp in Sources */,
 				1CF087D825ED7F73004148CB /* MobileAssetSandboxCheck.mm in Sources */,
 				7C83E0B61D0A64B300FEBCF3 /* ModalAlertsSPI.cpp in Sources */,
+				E38EDC372B1D673A00963F9B /* MonospaceFontTests.cpp in Sources */,
 				F4E5CCC92A6C79770051934C /* MouseEventTests.mm in Sources */,
 				7CCE7F011A411AE600447C4C /* MouseMoveAfterCrash.cpp in Sources */,
 				F4010B8024DA24AC00A876E2 /* NavigationSwipeTests.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebCore/MonospaceFontTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/MonospaceFontTests.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include <JavaScriptCore/InitializeThreading.h>
+#include <WebCore/ComplexTextController.h>
+#include <WebCore/FontCascade.h>
+#include <WebCore/WidthIterator.h>
+#include <wtf/MainThread.h>
+#include <wtf/RunLoop.h>
+
+using namespace WebCore;
+
+namespace TestWebKitAPI {
+
+#if PLATFORM(COCOA)
+
+TEST(MonospaceFontsTest, EnsureMonospaceFontInvariants)
+{
+    RetainPtr collection = CTFontCollectionCreateFromAvailableFonts(nullptr);
+    RetainPtr results = adoptCF(CTFontCollectionCreateMatchingFontDescriptors(collection.get()));
+    if (results) {
+        for (unsigned i = 0, count = CFArrayGetCount(results.get()); i < count; ++i) {
+            RetainPtr fontDescriptor = static_cast<CTFontDescriptorRef>(CFArrayGetValueAtIndex(results.get(), i));
+            auto ctFont = adoptCF(CTFontCreateWithFontDescriptor(fontDescriptor.get(), 16.0, nullptr));
+            FontPlatformData platformData(ctFont.get(), 16.0);
+            FontCascade fontCascade(platformData);
+            if (fontCascade.canTakeFixedPitchFastContentMeasuring()) {
+                for (uint32_t character = 0; character <= UINT16_MAX; ++character) {
+                    const char16_t ch = character;
+                    StringView content(&ch, 1);
+                    if (fontCascade.codePath(TextRun(content)) == FontCascade::CodePath::Complex)
+                        continue;
+                    constexpr bool whitespaceIsCollapsed = false;
+                    if (!WidthIterator::characterCanUseSimplifiedTextMeasuring(character, whitespaceIsCollapsed))
+                        continue;
+                    auto glyphData = fontCascade.glyphDataForCharacter(character, false);
+                    if (!glyphData.isValid() || glyphData.font != &fontCascade.primaryFont())
+                        continue;
+                    fontCascade.fonts()->widthCache().clear();
+                    float width = fontCascade.widthForSimpleTextWithFixedPitch(content, whitespaceIsCollapsed);
+                    fontCascade.fonts()->widthCache().clear();
+                    float originalWidth = fontCascade.widthForSimpleText(content);
+                    EXPECT_EQ(originalWidth , width);
+                }
+                {
+                    const char16_t characters[] {
+                        ' ', ' ', 'a'
+                    };
+                    StringView content(characters, 3);
+                    constexpr bool whitespaceIsCollapsed = false;
+                    fontCascade.fonts()->widthCache().clear();
+                    float width = fontCascade.widthForSimpleTextWithFixedPitch(content, whitespaceIsCollapsed);
+                    fontCascade.fonts()->widthCache().clear();
+                    float originalWidth = fontCascade.widthForSimpleText(content);
+                    EXPECT_EQ(originalWidth , width);
+                }
+            }
+        }
+    }
+}
+
+#endif
+
+}


### PR DESCRIPTION
#### 8b1d31668fbca9ba382333b287d5ed2c97f3212d
<pre>
Add optimization for monospace font&apos;s content measuring
<a href="https://bugs.webkit.org/show_bug.cgi?id=265787">https://bugs.webkit.org/show_bug.cgi?id=265787</a>
<a href="https://rdar.apple.com/119124314">rdar://119124314</a>

Reviewed by Alan Baradlay.

This patch adds an optimization path for monospace fonts when measuring text width.
One of the problem is that a lot of monospace fonts are lying and we cannot simply believe that
this is actually monospace. Thus, our current approach is,

1. When they are monospace fonts from the system, we know that they are actually monospace (by ensuring
   it in our tests). Thus, we can safely assume that their characters are monospace. Only exception is
   &quot;Courier New&quot;, which has many strange characters. For now, we disable this optimization for &quot;Courier New&quot;.
2. We list up more format category unicode characters in characterCanUseSimplifiedTextMeasuring to avoid using
   monospace fast path for these characters. They are kind of control characters and we do not expect that they
   will appear in texts which should be rendered in a fast path.

* Source/WTF/wtf/unicode/CharacterNames.h:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp:
(WebCore::Layout::fixedPitchWidth):
(WebCore::Layout::TextUtil::width):
* Source/WebCore/platform/graphics/Font.h:
(WebCore::Font::canTakeFixedPitchFastContentMeasuring const):
* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::letterSpacing const): Deleted.
(WebCore::FontCascade::wordSpacing const): Deleted.
* Source/WebCore/platform/graphics/FontCascade.h:
(WebCore::FontCascade::canTakeFixedPitchFastContentMeasuring const):
(WebCore::FontCascade::letterSpacing const):
(WebCore::FontCascade::wordSpacing const):
* Source/WebCore/platform/graphics/FontCascadeFonts.cpp:
(WebCore::FontCascadeFonts::determineCanTakeFixedPitchFastContentMeasuring):
* Source/WebCore/platform/graphics/FontCascadeFonts.h:
(WebCore::FontCascadeFonts::isFixedPitch):
(WebCore::FontCascadeFonts::canTakeFixedPitchFastContentMeasuring):
* Source/WebCore/platform/graphics/WidthIterator.cpp:
(WebCore::WidthIterator::characterCanUseSimplifiedTextMeasuring):
* Source/WebCore/platform/graphics/WidthIterator.h:
* Source/WebCore/platform/graphics/coretext/FontCoreText.cpp:
(WebCore::extractBoolean):
(WebCore::Font::determinePitch):
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/MonospaceFontTests.cpp: Added.
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/271524@main">https://commits.webkit.org/271524@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c65b75fe3f8473082692abc14f2c21c190953772

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28676 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7319 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30047 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31297 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/26169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29186 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9436 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4680 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28946 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6048 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/24647 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5255 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/5408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25650 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/32634 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/24798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26247 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26094 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/31653 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/28000 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/5374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/3545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/29430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6988 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/35293 "Built successfully") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/5841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7623 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3702 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/5892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->