### PR TITLE
[iOS] Adopt API replacements for returning an "acting parent UIScrollView"

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
@@ -61,11 +61,14 @@
     return self;
 }
 
-- (UIScrollView *)_actingParentScrollViewForScrollView:(UIScrollView *)scrollView
+#if !HAVE(UI_SCROLL_VIEW_ACTING_PARENT_FOR_SCROLL_VIEW)
+
+- (UIScrollView *)_actingParentScrollViewForScrollView:(WKBaseScrollView *)scrollView
 {
-    // An "acting parent" is a non-ancestor scrolling parent. We tell this to UIKit so it can propagate scrolls correctly.
-    return _scrollingTreeNodeDelegate->findActingScrollParent(scrollView);
+    return [self actingParentScrollViewForScrollView:scrollView];
 }
+
+#endif // !HAVE(UI_SCROLL_VIEW_ACTING_PARENT_FOR_SCROLL_VIEW)
 
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView
 {
@@ -182,6 +185,12 @@
         [self cancelPointersForGestureRecognizer:panGestureRecognizer];
 
     return axesToPrevent;
+}
+
+- (UIScrollView *)actingParentScrollViewForScrollView:(WKBaseScrollView *)scrollView
+{
+    // An "acting parent" is a non-ancestor scrolling parent. We tell this to UIKit so it can propagate scrolls correctly.
+    return _scrollingTreeNodeDelegate->findActingScrollParent(scrollView);
 }
 
 #if HAVE(UISCROLLVIEW_ASYNCHRONOUS_SCROLL_EVENT_HANDLING)

--- a/Source/WebKit/UIProcess/ios/WKBaseScrollView.h
+++ b/Source/WebKit/UIProcess/ios/WKBaseScrollView.h
@@ -40,6 +40,9 @@
 - (void)scrollView:(WKBaseScrollView *)scrollView handleScrollEvent:(UIScrollEvent *)event completion:(void(^)(BOOL handled))completion;
 #endif
 
+@optional
+- (UIScrollView *)actingParentScrollViewForScrollView:(WKBaseScrollView *)scrollView;
+
 @end
 
 @interface WKBaseScrollView : UIScrollView

--- a/Source/WebKit/UIProcess/ios/WKBaseScrollView.mm
+++ b/Source/WebKit/UIProcess/ios/WKBaseScrollView.mm
@@ -137,6 +137,18 @@
 
 #endif // HAVE(UISCROLLVIEW_ASYNCHRONOUS_SCROLL_EVENT_SUBCLASS_HOOKS)
 
+#if HAVE(UI_SCROLL_VIEW_ACTING_PARENT_FOR_SCROLL_VIEW)
+
+- (UIScrollView *)_actingParentScrollView
+{
+    if (![self.baseScrollViewDelegate respondsToSelector:@selector(actingParentScrollViewForScrollView:)])
+        return nil;
+
+    return [self.baseScrollViewDelegate actingParentScrollViewForScrollView:self];
+}
+
+#endif // HAVE(UI_SCROLL_VIEW_ACTING_PARENT_FOR_SCROLL_VIEW)
+
 #pragma mark - UIGestureRecognizerDelegate
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer


### PR DESCRIPTION
#### 591cf102f2e83039b430ad5a8b78e3992f17895b
<pre>
[iOS] Adopt API replacements for returning an &quot;acting parent UIScrollView&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=265801">https://bugs.webkit.org/show_bug.cgi?id=265801</a>
<a href="https://rdar.apple.com/119141181">rdar://119141181</a>

Reviewed by Aditya Keerthi and Megan Gardner.

Adopt a soon-to-be API replacement for this SPI scroll view delegate method:

```
-[UIScrollViewDelegate _actingParentScrollViewForScrollView:]
```

The replacement is just a subclassing hook on `UIScrollView` directly, which we can easily route
through our own `WKBaseScrollViewDelegate`, which allows us to share an implementation with the
legacy `-_actingParentScrollViewForScrollView:` delegate method.

* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm:
(-[WKScrollingNodeScrollViewDelegate _actingParentScrollViewForScrollView:]):
(-[WKScrollingNodeScrollViewDelegate actingParentScrollViewForScrollView:]):
* Source/WebKit/UIProcess/ios/WKBaseScrollView.h:
* Source/WebKit/UIProcess/ios/WKBaseScrollView.mm:
(-[WKBaseScrollView _actingParentScrollView]):

Canonical link: <a href="https://commits.webkit.org/271512@main">https://commits.webkit.org/271512@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88aae6bf10bec1b5300b036824ede883f62f04a2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28609 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7254 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29990 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/31248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/26124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9367 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4623 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/31248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28879 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5988 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24604 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/31248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5360 "Passed tests") | | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/32617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26188 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26050 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/32617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5327 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3498 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/32617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6936 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6853 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5791 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/5846 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->