### PR TITLE
Introduce WeakHashSetAssumingNoNullReferences<T> which is more efficient than WeakHashSet<T>

### DIFF
--- a/Source/WTF/wtf/WeakPtr.h
+++ b/Source/WTF/wtf/WeakPtr.h
@@ -35,10 +35,13 @@
 namespace WTF {
 
 enum class EnableWeakPtrThreadingAssertions : bool { No, Yes };
+enum class AssumeNoNullReferences : bool { No, Yes };
 template<typename, typename> class WeakPtrFactory;
 
 template<typename, typename, typename = DefaultWeakPtrImpl> class WeakHashMap;
-template<typename, typename = DefaultWeakPtrImpl, EnableWeakPtrThreadingAssertions = EnableWeakPtrThreadingAssertions::Yes> class WeakHashSet;
+template<typename, typename = DefaultWeakPtrImpl, EnableWeakPtrThreadingAssertions = EnableWeakPtrThreadingAssertions::Yes, AssumeNoNullReferences = AssumeNoNullReferences::No> class WeakHashSet;
+template<typename T, typename WeakPtrImpl = DefaultWeakPtrImpl, EnableWeakPtrThreadingAssertions enableWeakPtrThreadingAssertions = EnableWeakPtrThreadingAssertions::Yes>
+using WeakHashSetAssumingNoNullReferences = WeakHashSet<T, WeakPtrImpl, enableWeakPtrThreadingAssertions, AssumeNoNullReferences::Yes>;
 template <typename, typename = DefaultWeakPtrImpl, EnableWeakPtrThreadingAssertions = EnableWeakPtrThreadingAssertions::Yes> class WeakListHashSet;
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(WeakPtrImplBase);
@@ -149,7 +152,7 @@ public:
 
 private:
     template<typename, typename, typename> friend class WeakHashMap;
-    template<typename, typename, EnableWeakPtrThreadingAssertions> friend class WeakHashSet;
+    template<typename, typename, EnableWeakPtrThreadingAssertions, AssumeNoNullReferences> friend class WeakHashSet;
     template<typename, typename, EnableWeakPtrThreadingAssertions> friend class WeakListHashSet;
     template<typename, typename> friend class WeakPtr;
     template<typename, typename> friend class WeakPtrFactory;
@@ -258,7 +261,7 @@ public:
     void setBitfield(uint16_t value) const { return m_impl.setType(value); }
 
 private:
-    template<typename, typename, EnableWeakPtrThreadingAssertions> friend class WeakHashSet;
+    template<typename, typename, EnableWeakPtrThreadingAssertions, AssumeNoNullReferences> friend class WeakHashSet;
     template<typename, typename, EnableWeakPtrThreadingAssertions> friend class WeakListHashSet;
     template<typename, typename, typename> friend class WeakHashMap;
     template<typename, typename> friend class WeakPtr;
@@ -397,10 +400,12 @@ WeakPtr(const RefPtr<T>& value, EnableWeakPtrThreadingAssertions = EnableWeakPtr
 
 } // namespace WTF
 
+using WTF::AssumeNoNullReferences;
 using WTF::CanMakeWeakPtr;
 using WTF::EnableWeakPtrThreadingAssertions;
 using WTF::WeakHashMap;
 using WTF::WeakHashSet;
+using WTF::WeakHashSetAssumingNoNullReferences;
 using WTF::WeakListHashSet;
 using WTF::WeakPtr;
 using WTF::WeakPtrFactory;

--- a/Source/WebCore/css/CSSFontFace.cpp
+++ b/Source/WebCore/css/CSSFontFace.cpp
@@ -52,7 +52,7 @@ namespace WebCore {
 
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSFontFace);
 
-template<typename T> void iterateClients(WeakHashSet<CSSFontFace::Client>& clients, T callback)
+template<typename T> void iterateClients(WeakHashSetAssumingNoNullReferences<CSSFontFace::Client>& clients, T callback)
 {
     for (auto& client : copyToVectorOf<Ref<CSSFontFace::Client>>(clients))
         callback(client);

--- a/Source/WebCore/css/CSSFontFace.h
+++ b/Source/WebCore/css/CSSFontFace.h
@@ -191,7 +191,7 @@ private:
     float m_sizeAdjust { 1.0 };
 
     Vector<std::unique_ptr<CSSFontFaceSource>, 0, CrashOnOverflow, 0> m_sources;
-    WeakHashSet<Client> m_clients;
+    WeakHashSetAssumingNoNullReferences<Client> m_clients;
     WeakPtr<FontFace> m_wrapper;
     FontSelectionSpecifiedCapabilities m_fontSelectionCapabilities;
     

--- a/Source/WebCore/css/CSSStyleSheet.h
+++ b/Source/WebCore/css/CSSStyleSheet.h
@@ -184,7 +184,7 @@ private:
     MQ::MediaQueryList m_mediaQueries;
     WeakPtr<Style::Scope> m_styleScope;
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_constructorDocument;
-    WeakHashSet<ContainerNode, WeakPtrImplWithEventTargetData> m_adoptingTreeScopes;
+    WeakHashSetAssumingNoNullReferences<ContainerNode, WeakPtrImplWithEventTargetData> m_adoptingTreeScopes;
 
     CheckedPtr<Node> m_ownerNode;
     WeakPtr<CSSImportRule> m_ownerRule;

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2064,7 +2064,6 @@ void Document::unregisterMediaElement(HTMLMediaElement& element)
 
 void Document::forEachMediaElement(const Function<void(HTMLMediaElement&)>& function)
 {
-    ASSERT(!m_mediaElements.hasNullReferences());
     m_mediaElements.forEach([&](auto& element) {
         function(Ref { element });
     });
@@ -4842,7 +4841,6 @@ void Document::noteUserInteractionWithMediaElement()
 
 void Document::updateIsPlayingMedia()
 {
-    ASSERT(!m_audioProducers.hasNullReferences());
     MediaProducerMediaStateFlags state;
     for (auto& audioProducer : m_audioProducers)
         state.add(audioProducer.mediaState());
@@ -6348,7 +6346,6 @@ void Document::unregisterForCaptionPreferencesChangedCallbacks(HTMLMediaElement&
 
 void Document::captionPreferencesChanged()
 {
-    ASSERT(!m_captionPreferencesChangedElements.hasNullReferences());
     m_captionPreferencesChangedElements.forEach([](HTMLMediaElement& element) {
         Ref { element }->captionPreferencesChanged();
     });
@@ -7387,7 +7384,7 @@ void Document::removeMediaCanStartListener(MediaCanStartListener& listener)
 
 MediaCanStartListener* Document::takeAnyMediaCanStartListener()
 {
-    if (m_mediaCanStartListeners.isEmptyIgnoringNullReferences())
+    if (m_mediaCanStartListeners.isEmpty())
         return nullptr;
 
     MediaCanStartListener* listener = m_mediaCanStartListeners.begin().get();

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -2047,7 +2047,7 @@ private:
 
     mutable String m_uniqueIdentifier;
 
-    WeakHashSet<NodeIterator> m_nodeIterators;
+    WeakHashSetAssumingNoNullReferences<NodeIterator> m_nodeIterators;
     HashSet<CheckedRef<Range>> m_ranges;
 
     UniqueRef<Style::Scope> m_styleScope;
@@ -2121,25 +2121,25 @@ private:
     // Collection of canvas objects that need to do work after they've
     // rendered but before compositing, for the next frame. The set is
     // cleared after they've been called.
-    WeakHashSet<HTMLCanvasElement, WeakPtrImplWithEventTargetData> m_canvasesNeedingDisplayPreparation;
+    WeakHashSetAssumingNoNullReferences<HTMLCanvasElement, WeakPtrImplWithEventTargetData> m_canvasesNeedingDisplayPreparation;
 
     HashMap<String, RefPtr<HTMLCanvasElement>> m_cssCanvasElements;
 
-    WeakHashSet<Element, WeakPtrImplWithEventTargetData> m_documentSuspensionCallbackElements;
+    WeakHashSetAssumingNoNullReferences<Element, WeakPtrImplWithEventTargetData> m_documentSuspensionCallbackElements;
 
 #if ENABLE(VIDEO)
-    WeakHashSet<HTMLMediaElement, WeakPtrImplWithEventTargetData> m_mediaElements;
+    WeakHashSetAssumingNoNullReferences<HTMLMediaElement, WeakPtrImplWithEventTargetData> m_mediaElements;
 #endif
 
 #if ENABLE(VIDEO)
-    WeakHashSet<HTMLMediaElement, WeakPtrImplWithEventTargetData> m_captionPreferencesChangedElements;
+    WeakHashSetAssumingNoNullReferences<HTMLMediaElement, WeakPtrImplWithEventTargetData> m_captionPreferencesChangedElements;
     WeakPtr<HTMLMediaElement, WeakPtrImplWithEventTargetData> m_mediaElementShowingTextTrack;
 #endif
 
     CheckedPtr<Element> m_mainArticleElement;
     HashSet<CheckedPtr<Element>> m_articleElements;
 
-    WeakHashSet<VisibilityChangeClient> m_visibilityStateCallbackClients;
+    WeakHashSetAssumingNoNullReferences<VisibilityChangeClient> m_visibilityStateCallbackClients;
 
     std::unique_ptr<HashMap<String, WeakPtr<Element, WeakPtrImplWithEventTargetData>, ASCIICaseInsensitiveHash>> m_accessKeyCache;
 
@@ -2148,14 +2148,14 @@ private:
     RenderPtr<RenderView> m_renderView;
     std::unique_ptr<RenderStyle> m_initialContainingBlockStyle;
 
-    WeakHashSet<MediaCanStartListener> m_mediaCanStartListeners;
+    WeakHashSetAssumingNoNullReferences<MediaCanStartListener> m_mediaCanStartListeners;
     WeakHashSet<DisplayChangedObserver> m_displayChangedObservers;
 
 #if ENABLE(FULLSCREEN_API)
     UniqueRef<FullscreenManager> m_fullscreenManager;
 #endif
 
-    WeakHashSet<HTMLImageElement, WeakPtrImplWithEventTargetData> m_dynamicMediaQueryDependentImages;
+    WeakHashSetAssumingNoNullReferences<HTMLImageElement, WeakPtrImplWithEventTargetData> m_dynamicMediaQueryDependentImages;
 
     Vector<WeakPtr<IntersectionObserver>> m_intersectionObservers;
     Timer m_intersectionObserversInitialUpdateTimer;
@@ -2232,7 +2232,7 @@ private:
     Ref<CSSFontSelector> m_fontSelector;
     UniqueRef<DocumentFontLoader> m_fontLoader;
 
-    WeakHashSet<MediaProducer> m_audioProducers;
+    WeakHashSetAssumingNoNullReferences<MediaProducer> m_audioProducers;
     WeakPtr<SpeechRecognition> m_activeSpeechRecognition;
 
     WeakListHashSet<ShadowRoot, WeakPtrImplWithEventTargetData> m_inDocumentShadowRoots;
@@ -2311,7 +2311,7 @@ private:
 
     Vector<Function<void()>> m_whenIsVisibleHandlers;
 
-    WeakHashSet<Element, WeakPtrImplWithEventTargetData> m_elementsWithPendingUserAgentShadowTreeUpdates;
+    WeakHashSetAssumingNoNullReferences<Element, WeakPtrImplWithEventTargetData> m_elementsWithPendingUserAgentShadowTreeUpdates;
 
     Ref<ReportingScope> m_reportingScope;
 

--- a/Source/WebCore/dom/EventLoop.h
+++ b/Source/WebCore/dom/EventLoop.h
@@ -144,11 +144,11 @@ private:
 
     // Use a global queue instead of multiple task queues since HTML5 spec allows UA to pick arbitrary queue.
     Vector<std::unique_ptr<EventLoopTask>> m_tasks;
-    WeakHashSet<EventLoopTimer> m_scheduledTasks;
-    WeakHashSet<EventLoopTimer> m_repeatingTasks;
-    WeakHashSet<EventLoopTaskGroup> m_associatedGroups;
+    WeakHashSetAssumingNoNullReferences<EventLoopTimer> m_scheduledTasks;
+    WeakHashSetAssumingNoNullReferences<EventLoopTimer> m_repeatingTasks;
+    WeakHashSetAssumingNoNullReferences<EventLoopTaskGroup> m_associatedGroups;
     WeakHashSet<EventLoopTaskGroup> m_groupsWithSuspendedTasks;
-    WeakHashSet<ScriptExecutionContext> m_associatedContexts;
+    WeakHashSetAssumingNoNullReferences<ScriptExecutionContext> m_associatedContexts;
     bool m_isScheduledToRun { false };
     mutable Markable<MonotonicTime> m_nextTimerFireTimeCache;
 };

--- a/Source/WebCore/dom/MutationObserver.cpp
+++ b/Source/WebCore/dom/MutationObserver.cpp
@@ -67,7 +67,7 @@ MutationObserver::MutationObserver(Ref<MutationCallback>&& callback)
 
 MutationObserver::~MutationObserver()
 {
-    ASSERT(m_registrations.isEmptyIgnoringNullReferences());
+    ASSERT(m_registrations.isEmpty());
 }
 
 bool MutationObserver::validateOptions(MutationObserverOptions options)

--- a/Source/WebCore/dom/MutationObserver.h
+++ b/Source/WebCore/dom/MutationObserver.h
@@ -127,7 +127,7 @@ private:
     Ref<MutationCallback> m_callback;
     Vector<Ref<MutationRecord>> m_records;
     HashSet<GCReachableRef<Node>> m_pendingTargets;
-    WeakHashSet<MutationObserverRegistration> m_registrations;
+    WeakHashSetAssumingNoNullReferences<MutationObserverRegistration> m_registrations;
     unsigned m_priority;
 };
 

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -483,7 +483,7 @@ void Node::materializeRareData()
 void Node::clearRareData()
 {
     ASSERT(hasRareData());
-    ASSERT(!transientMutationObserverRegistry() || transientMutationObserverRegistry()->isEmptyIgnoringNullReferences());
+    ASSERT(!transientMutationObserverRegistry() || transientMutationObserverRegistry()->isEmpty());
 
     m_rareDataWithBitfields.setPointer(nullptr);
 }
@@ -2364,7 +2364,7 @@ Vector<std::unique_ptr<MutationObserverRegistration>>* Node::mutationObserverReg
     return &data->registry;
 }
 
-WeakHashSet<MutationObserverRegistration>* Node::transientMutationObserverRegistry()
+WeakHashSetAssumingNoNullReferences<MutationObserverRegistration>* Node::transientMutationObserverRegistry()
 {
     if (!hasRareData())
         return nullptr;

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -751,7 +751,7 @@ private:
     void materializeRareData();
 
     Vector<std::unique_ptr<MutationObserverRegistration>>* mutationObserverRegistry();
-    WeakHashSet<MutationObserverRegistration>* transientMutationObserverRegistry();
+    WeakHashSetAssumingNoNullReferences<MutationObserverRegistration>* transientMutationObserverRegistry();
 
     void adjustStyleValidity(Style::Validity, Style::InvalidationMode);
 

--- a/Source/WebCore/dom/NodeRareData.h
+++ b/Source/WebCore/dom/NodeRareData.h
@@ -216,7 +216,7 @@ class NodeMutationObserverData {
     WTF_MAKE_NONCOPYABLE(NodeMutationObserverData); WTF_MAKE_FAST_ALLOCATED;
 public:
     Vector<std::unique_ptr<MutationObserverRegistration>> registry;
-    WeakHashSet<MutationObserverRegistration> transientRegistry;
+    WeakHashSetAssumingNoNullReferences<MutationObserverRegistration> transientRegistry;
 
     NodeMutationObserverData() { }
 };

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -95,7 +95,7 @@ struct SameSizeAsRenderBlock : public RenderBox {
 static_assert(sizeof(RenderBlock) == sizeof(SameSizeAsRenderBlock), "RenderBlock should stay small");
 
 using TrackedDescendantsMap = WeakHashMap<const RenderBlock, std::unique_ptr<TrackedRendererListHashSet>>;
-using TrackedContainerMap = WeakHashMap<const RenderBox, WeakHashSet<const RenderBlock>>;
+using TrackedContainerMap = WeakHashMap<const RenderBox, WeakHashSetAssumingNoNullReferences<const RenderBlock>>;
 
 static TrackedDescendantsMap* percentHeightDescendantsMap;
 static TrackedContainerMap* percentHeightContainerMap;
@@ -121,7 +121,7 @@ static void insertIntoTrackedRendererMaps(const RenderBlock& container, RenderBo
         return;
     }
     
-    auto& containerSet = percentHeightContainerMap->add(descendant, WeakHashSet<const RenderBlock>()).iterator->value;
+    auto& containerSet = percentHeightContainerMap->add(descendant, WeakHashSetAssumingNoNullReferences<const RenderBlock>()).iterator->value;
     ASSERT(!containerSet.contains(container));
     containerSet.add(container);
 }
@@ -332,7 +332,7 @@ static void removeBlockFromPercentageDescendantAndContainerMaps(RenderBlock& blo
         auto& containerSet = it->value;
         ASSERT(containerSet.contains(block));
         containerSet.remove(block);
-        if (containerSet.isEmptyIgnoringNullReferences())
+        if (containerSet.isEmpty())
             percentHeightContainerMap->remove(it);
     }
 }

--- a/Source/WebCore/rendering/RenderFlexibleBox.h
+++ b/Source/WebCore/rendering/RenderFlexibleBox.h
@@ -276,17 +276,17 @@ private:
     // need an additional layout pass for correct stretch alignment handling, as
     // the first layout likely did not use the correct value for percentage
     // sizing of children.
-    WeakHashSet<const RenderBox> m_relaidOutChildren;
+    WeakHashSetAssumingNoNullReferences<const RenderBox> m_relaidOutChildren;
 
     mutable OrderIterator m_orderIterator { *this };
     std::optional<size_t> m_numberOfInFlowChildrenOnFirstLine { };
     std::optional<size_t> m_numberOfInFlowChildrenOnLastLine { };
 
     struct MarginTrimItems {
-        WeakHashSet<const RenderBox> m_itemsAtFlexLineStart;
-        WeakHashSet<const RenderBox> m_itemsAtFlexLineEnd;
-        WeakHashSet<const RenderBox> m_itemsOnFirstFlexLine;
-        WeakHashSet<const RenderBox> m_itemsOnLastFlexLine;
+        WeakHashSetAssumingNoNullReferences<const RenderBox> m_itemsAtFlexLineStart;
+        WeakHashSetAssumingNoNullReferences<const RenderBox> m_itemsAtFlexLineEnd;
+        WeakHashSetAssumingNoNullReferences<const RenderBox> m_itemsOnFirstFlexLine;
+        WeakHashSetAssumingNoNullReferences<const RenderBox> m_itemsOnLastFlexLine;
     } m_marginTrimItems;
 
     // This is SizeIsUnknown outside of layoutBlock()

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -2404,7 +2404,7 @@ static RenderLayer* findCommonAncestor(const RenderLayer& firstLayer, const Rend
     if (&firstLayer == &secondLayer)
         return const_cast<RenderLayer*>(&firstLayer);
 
-    WeakHashSet<const RenderLayer> ancestorChain;
+    WeakHashSetAssumingNoNullReferences<const RenderLayer> ancestorChain;
     for (auto* currLayer = &firstLayer; currLayer; currLayer = currLayer->parent())
         ancestorChain.add(*currLayer);
 

--- a/Source/WebCore/rendering/RenderLayerCompositor.h
+++ b/Source/WebCore/rendering/RenderLayerCompositor.h
@@ -136,8 +136,8 @@ private:
 
     ChromeClient& m_chromeClient;
 
-    WeakHashSet<RenderLayer> m_scrollingLayers;
-    WeakHashSet<RenderLayer> m_viewportConstrainedLayers;
+    WeakHashSetAssumingNoNullReferences<RenderLayer> m_scrollingLayers;
+    WeakHashSetAssumingNoNullReferences<RenderLayer> m_viewportConstrainedLayers;
 
     const bool m_coordinateViewportConstrainedLayers;
 };

--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -674,7 +674,7 @@ void RenderTableSection::computeOverflowFromCells(unsigned totalRows, unsigned n
 #endif
             if (cell->hasVisualOverflow() && !m_forceSlowPaintPathWithOverflowingCell) {
                 m_overflowingCells.add(*cell);
-                if (m_overflowingCells.computeSize() > maxAllowedOverflowingCellsCount) {
+                if (m_overflowingCells.size() > maxAllowedOverflowingCellsCount) {
                     // We need to set m_forcesSlowPaintPath only if there is a least one overflowing cells as the hit testing code rely on this information.
                     m_forceSlowPaintPathWithOverflowingCell = true;
                     // The slow path does not make any use of the overflowing cells info, don't hold on to the memory.
@@ -1225,7 +1225,7 @@ void RenderTableSection::paintObject(PaintInfo& paintInfo, const LayoutPoint& pa
     CellSpan dirtiedColumns = this->dirtiedColumns(tableAlignedRect);
 
     if (dirtiedColumns.start < dirtiedColumns.end) {
-        if (!m_hasMultipleCellLevels && m_overflowingCells.isEmptyIgnoringNullReferences()) {
+        if (!m_hasMultipleCellLevels && m_overflowingCells.isEmpty()) {
             if (paintInfo.phase == PaintPhase::CollapsedTableBorders) {
                 // Collapsed borders are painted from the bottom right to the top left so that precedence
                 // due to cell position is respected. We need to paint one row beyond the topmost dirtied
@@ -1283,7 +1283,7 @@ void RenderTableSection::paintObject(PaintInfo& paintInfo, const LayoutPoint& pa
 #if ASSERT_ENABLED
             unsigned totalRows = m_grid.size();
             unsigned totalCols = table()->columns().size();
-            ASSERT(m_overflowingCells.computeSize() < totalRows * totalCols * gMaxAllowedOverflowingCellRatioForFastPaintPath);
+            ASSERT(m_overflowingCells.size() < totalRows * totalCols * gMaxAllowedOverflowingCellRatioForFastPaintPath);
 #endif
 
             // To make sure we properly repaint the section, we repaint all the overflowing cells that we collected.
@@ -1314,7 +1314,7 @@ void RenderTableSection::paintObject(PaintInfo& paintInfo, const LayoutPoint& pa
             }
 
             // Sort the dirty cells by paint order.
-            if (m_overflowingCells.isEmptyIgnoringNullReferences())
+            if (m_overflowingCells.isEmpty())
                 std::stable_sort(cells.begin(), cells.end(), compareCellPositions);
             else
                 std::sort(cells.begin(), cells.end(), compareCellPositionsWithOverflowingCells);

--- a/Source/WebCore/rendering/RenderTableSection.h
+++ b/Source/WebCore/rendering/RenderTableSection.h
@@ -191,7 +191,7 @@ private:
     void distributeExtraLogicalHeightToAutoRows(LayoutUnit& extraLogicalHeight, unsigned autoRowsCount);
     void distributeRemainingExtraLogicalHeight(LayoutUnit& extraLogicalHeight);
 
-    bool hasOverflowingCell() const { return m_overflowingCells.computeSize() || m_forceSlowPaintPathWithOverflowingCell; }
+    bool hasOverflowingCell() const { return m_overflowingCells.size() || m_forceSlowPaintPathWithOverflowingCell; }
     void computeOverflowFromCells(unsigned totalRows, unsigned nEffCols);
 
     CellSpan fullTableRowSpan() const;
@@ -232,7 +232,7 @@ private:
     // This HashSet holds the overflowing cells for faster painting.
     // If we have more than gMaxAllowedOverflowingCellRatio * total cells, it will be empty
     // and m_forceSlowPaintPathWithOverflowingCell will be set to save memory.
-    WeakHashSet<RenderTableCell> m_overflowingCells;
+    WeakHashSetAssumingNoNullReferences<RenderTableCell> m_overflowingCells;
 
     // This map holds the collapsed border values for cells with collapsed borders.
     // It is held at RenderTableSection level to spare memory consumption by table cells.


### PR DESCRIPTION
#### 0cbfba40b63e9e2f500e8751446125086d4f375e
<pre>
Introduce WeakHashSetAssumingNoNullReferences&lt;T&gt; which is more efficient than WeakHashSet&lt;T&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=265807">https://bugs.webkit.org/show_bug.cgi?id=265807</a>

Reviewed by NOBODY (OOPS!).

Introduce WeakHashSetAssumingNoNullReferences&lt;T&gt; which is more efficient than WeakHashSet&lt;T&gt;.
It should only be used in cases where we don&apos;t rely on the WeakHashSet implementation
clearing out null references (because this isn&apos;t supposed to be any null references in the
map).

We&apos;ve recently converted many HashSet&lt;T*&gt; instead WeakHashSet&lt;T&gt; for hardening. In doing so,
we started incurring cost to clear (non-existing) null references and dealing with null
references when computing the size. Those cases should use WeakHashSetAssumingNoNullReferences&lt;T&gt;
for better performance.

This work is part of an effort to make WeakPtr and WeakPtr containers&apos;s performance acceptable
to use in hot code. This is important given that CheckedPtr / CheckedRef crashes are very hard
to debug.

In this patch, I started adoption of this new container type but it is not exhaustive. I plan
to adopt more widely in a follow-up. I also plan to do something similar for other weak container
types (WeakHashMap, WeakListHashSet, ...).

* Source/WTF/wtf/WeakHashSet.h:
(WTF::containerSize):
(WTF::copyToVector):
* Source/WTF/wtf/WeakPtr.h:
* Source/WebCore/css/CSSFontFace.cpp:
(WebCore::iterateClients):
* Source/WebCore/css/CSSFontFace.h:
* Source/WebCore/css/CSSStyleSheet.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::forEachMediaElement):
(WebCore::Document::updateIsPlayingMedia):
(WebCore::Document::captionPreferencesChanged):
(WebCore::Document::takeAnyMediaCanStartListener):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/EventLoop.h:
* Source/WebCore/dom/MutationObserver.cpp:
(WebCore::MutationObserver::~MutationObserver):
* Source/WebCore/dom/MutationObserver.h:
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::clearRareData):
(WebCore::Node::transientMutationObserverRegistry):
* Source/WebCore/dom/Node.h:
* Source/WebCore/dom/NodeRareData.h:
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::insertIntoTrackedRendererMaps):
(WebCore::removeBlockFromPercentageDescendantAndContainerMaps):
* Source/WebCore/rendering/RenderFlexibleBox.h:
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::findCommonAncestor):
* Source/WebCore/rendering/RenderLayerCompositor.h:
* Source/WebCore/rendering/RenderTableSection.cpp:
(WebCore::RenderTableSection::computeOverflowFromCells):
(WebCore::RenderTableSection::paintObject):
* Source/WebCore/rendering/RenderTableSection.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0cbfba40b63e9e2f500e8751446125086d4f375e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28612 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7257 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29993 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/31251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/26126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29122 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9371 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4626 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/31251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28882 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6001 "Found 1 new test failure: requestidlecallback/requestidlecallback-does-not-block-timer.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24606 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/31251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/5369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25607 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/32581 "Failed to checkout and rebase branch from PR 21290") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/24752 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26201 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26052 "Found 19 new test failures: imported/w3c/web-platform-tests/requestidlecallback/basic.html, imported/w3c/web-platform-tests/requestidlecallback/callback-exception.html, imported/w3c/web-platform-tests/requestidlecallback/callback-idle-periods.html, imported/w3c/web-platform-tests/requestidlecallback/callback-iframe.html, imported/w3c/web-platform-tests/requestidlecallback/callback-invoked.html, imported/w3c/web-platform-tests/requestidlecallback/callback-multiple-calls.html, imported/w3c/web-platform-tests/requestidlecallback/callback-removed-frame.html, imported/w3c/web-platform-tests/requestidlecallback/callback-suspended.html, imported/w3c/web-platform-tests/requestidlecallback/callback-timeRemaining-cross-realm-method.html, imported/w3c/web-platform-tests/requestidlecallback/callback-timeout-when-busy.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/32581 "Failed to checkout and rebase branch from PR 21290") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/27695 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/5330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3502 "Found 19 new test failures: imported/w3c/web-platform-tests/requestidlecallback/basic.html, imported/w3c/web-platform-tests/requestidlecallback/callback-exception.html, imported/w3c/web-platform-tests/requestidlecallback/callback-idle-periods.html, imported/w3c/web-platform-tests/requestidlecallback/callback-iframe.html, imported/w3c/web-platform-tests/requestidlecallback/callback-invoked.html, imported/w3c/web-platform-tests/requestidlecallback/callback-multiple-calls.html, imported/w3c/web-platform-tests/requestidlecallback/callback-removed-frame.html, imported/w3c/web-platform-tests/requestidlecallback/callback-suspended.html, imported/w3c/web-platform-tests/requestidlecallback/callback-timeRemaining-cross-realm-method.html, imported/w3c/web-platform-tests/requestidlecallback/callback-timeout-when-busy.html ... (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/32581 "Failed to checkout and rebase branch from PR 21290") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6939 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/35230 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5794 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7609 "Passed tests") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/5849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->