### PR TITLE
Update rapidfuzz to 3.4.0

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
@@ -77,9 +77,9 @@ AutoInstall.register(Package('funcsigs', Version(1, 0, 2)))
 AutoInstall.register(Package('idna', Version(2, 10)))
 
 if sys.version_info > (3, 0):
-    AutoInstall.register(Package('packaging', Version(21, 3)))
+    AutoInstall.register(Package('packaging', Version(21, 3), implicit_deps=['pyparsing']))
 else:
-    AutoInstall.register(Package('packaging', Version(20, 4)))
+    AutoInstall.register(Package('packaging', Version(20, 4), implicit_deps=['pyparsing', 'six']))
 
 AutoInstall.register(Package('pyparsing', Version(2, 4, 7)))
 

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/autoinstall.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/autoinstall.py
@@ -459,7 +459,7 @@ class AutoInstall(object):
     CA_CERT_PATH_ENV_VAR = 'AUTOINSTALL_CA_CERT_PATH'
 
     # This list of libraries is required to install other libraries, and must be installed first
-    BASE_LIBRARIES = ['setuptools', 'wheel', 'pyparsing', 'packaging', 'setuptools_scm']
+    BASE_LIBRARIES = ['setuptools', 'wheel', 'six', 'pyparsing', 'packaging', 'setuptools_scm']
     if sys.version_info >= (3, 0):
         BASE_LIBRARIES.insert(-1, 'tomli')
 

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -56,8 +56,7 @@ AutoInstall.register(Package('markupsafe', Version(1, 1, 1), pypi_name='MarkupSa
 AutoInstall.register(Package('webkitbugspy', Version(0, 8, 0)), local=True)
 
 if sys.version_info > (3, 6):
-    # FIXME: Remove wheel=False after upgrading past 2.15.1
-    AutoInstall.register(Package('rapidfuzz', Version(2, 11, 1), implicit_deps=['pyparsing'], wheel=False))
+    AutoInstall.register(Package('rapidfuzz', Version(3, 4, 0)))
 
 from webkitscmpy.contributor import Contributor
 from webkitscmpy.commit import Commit


### PR DESCRIPTION
#### 47c33f8d6a4786d1fa135242ec54a6254d258fae
<pre>
Update rapidfuzz to 3.4.0
<a href="https://bugs.webkit.org/show_bug.cgi?id=265809">https://bugs.webkit.org/show_bug.cgi?id=265809</a>
<a href="https://rdar.apple.com/problem/119145927">rdar://problem/119145927</a>

Reviewed by Jonathan Bedard.

We keep on finding bots which need rapidfuzz to be reinstalled because
the macOS universal2 wheel was broken
(c.f. <a href="https://github.com/WebKit/WebKit/pull/19835).">https://github.com/WebKit/WebKit/pull/19835).</a> Let&apos;s mitigate this
entire problem by just forcing rapidfuzz to be re-installed everywhere
by upgrading it.

I also found that 268494@main (ca3f26ebbb57) added pyparsing as an
implicit_dep, which should actually be on packaging, as that&apos;s where the
requirement actually is.

* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py:
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/autoinstall.py:
(AutoInstall):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py:

Canonical link: <a href="https://commits.webkit.org/271534@main">https://commits.webkit.org/271534@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58e3787c93e4ae5d08741d8b6324640b850f1e0b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28615 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7260 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29995 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31253 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26128 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29125 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9374 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4628 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26213 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28885 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6000 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24608 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5220 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/28775 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5368 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25609 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/32584 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26200 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26054 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31614 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5332 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3503 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29391 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/28382 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6941 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6863 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5796 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5851 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->