### PR TITLE
[UnifiedPDF] UnifiedPDFPlugin should be able to query PDFKit for annotations under a page point

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h
@@ -58,6 +58,10 @@ public:
     void setPDFDocument(PDFDocument *document) { m_pdfDocument = document; }
 
     size_t pageCount() const;
+    DisplayMode displayMode() const { return m_displayMode; }
+
+    static constexpr FloatSize documentMargin { 6, 8 };
+    static constexpr FloatSize pageMargin { 4, 6 };
 
     RetainPtr<PDFPage> pageAtIndex(PageIndex) const;
     WebCore::FloatRect boundsForPageAtIndex(PageIndex) const;
@@ -75,9 +79,6 @@ private:
 
     void layoutSingleColumn(float availableWidth, float maxRowWidth);
     void layoutTwoUpColumn(float availableWidth, float maxRowWidth);
-
-    static FloatSize documentMargin();
-    static FloatSize pageMargin();
 
     struct PageGeometry {
         WebCore::FloatRect normalizedBounds;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm
@@ -38,16 +38,6 @@ using namespace WebCore;
 
 static constexpr float minScale = 0.1; // Arbitrarily chosen min scale.
 
-FloatSize PDFDocumentLayout::documentMargin()
-{
-    return { 6, 8 };
-}
-
-FloatSize PDFDocumentLayout::pageMargin()
-{
-    return { 4, 6 };
-}
-
 PDFDocumentLayout::PDFDocumentLayout() = default;
 PDFDocumentLayout::~PDFDocumentLayout() = default;
 
@@ -84,8 +74,6 @@ void PDFDocumentLayout::updateLayout(IntSize pluginSize)
     float currentRowWidth = 0;
     bool isTwoUpLayout = m_displayMode == DisplayMode::TwoUp || m_displayMode == DisplayMode::TwoUpContinuous;
 
-    auto pageMargin = PDFDocumentLayout::pageMargin();
-
     for (PageIndex i = 0; i < pageCount; ++i) {
         auto page = pageAtIndex(i);
         if (!page) {
@@ -115,7 +103,6 @@ void PDFDocumentLayout::updateLayout(IntSize pluginSize)
         m_pageGeometry.append({ pageBounds, rotation });
     }
 
-    auto documentMargin = PDFDocumentLayout::documentMargin();
     maxRowWidth += 2 * documentMargin.width();
 
     layoutPages(pluginSize.width(), maxRowWidth);
@@ -141,9 +128,6 @@ void PDFDocumentLayout::layoutPages(float availableWidth, float maxRowWidth)
 
 void PDFDocumentLayout::layoutSingleColumn(float availableWidth, float maxRowWidth)
 {
-    auto documentMargin = PDFDocumentLayout::documentMargin();
-    auto pageMargin = PDFDocumentLayout::pageMargin();
-
     float currentYOffset = documentMargin.height();
     auto pageCount = this->pageCount();
 
@@ -170,9 +154,6 @@ void PDFDocumentLayout::layoutSingleColumn(float availableWidth, float maxRowWid
 
 void PDFDocumentLayout::layoutTwoUpColumn(float availableWidth, float maxRowWidth)
 {
-    auto documentMargin = PDFDocumentLayout::documentMargin();
-    auto pageMargin = PDFDocumentLayout::pageMargin();
-
     FloatSize currentRowSize;
     float currentYOffset = documentMargin.height();
     auto pageCount = this->pageCount();

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -168,6 +168,9 @@ private:
 
     RefPtr<WebCore::GraphicsLayer> createGraphicsLayer(const String& name, GraphicsLayer::Type);
 
+    WebCore::IntPoint convertFromPluginToDocument(const WebCore::IntPoint&) const;
+    std::optional<PDFDocumentLayout::PageIndex> nearestPageIndexForDocumentPoint(const WebCore::IntPoint&) const;
+    WebCore::IntPoint convertFromDocumentToPage(const WebCore::IntPoint&, PDFDocumentLayout::PageIndex) const;
     PDFElementTypes pdfElementTypesForPluginPoint(const WebCore::IntPoint&) const;
 
     PDFDocumentLayout m_documentLayout;


### PR DESCRIPTION
#### b3ccba3d047d8f956609df0364fd5b7b95a71efa
<pre>
[UnifiedPDF] UnifiedPDFPlugin should be able to query PDFKit for annotations under a page point
<a href="https://bugs.webkit.org/show_bug.cgi?id=265810">https://bugs.webkit.org/show_bug.cgi?id=265810</a>
<a href="https://rdar.apple.com/119147700">rdar://119147700</a>

Reviewed by Tim Horton.

We currently don&apos;t perform the required transformations to map a point
from the root view to the page space, and as such cannot perform
hit-testing to get the PDFAnnotation objects of interest under a page
point.

This commit introduces the required coordinate space plumbing so that
UnifiedPDFPlugin is able to reason in the PDFPage space. This allows us
to query PDFPage for annotations under a given point, which we need in
anticipation of getting cursor updates to work correctly over text and
other annotation types.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h:
(WebKit::PDFDocumentLayout::displayMode const):

Make displayMode publicly accessible.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm:
(WebKit::PDFDocumentLayout::updateLayout):
(WebKit::PDFDocumentLayout::layoutSingleColumn):
(WebKit::PDFDocumentLayout::layoutTwoUpColumn):
(WebKit::PDFDocumentLayout::documentMargin): Deleted.
(WebKit::PDFDocumentLayout::pageMargin): Deleted.

Move these to just be static constexpr properties on PDFDocumentLayout,
and adopt the change at call-sites.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::convertFromPluginToDocument const):
(WebKit::UnifiedPDFPlugin::nearestPageIndexForDocumentPoint const):
(WebKit::UnifiedPDFPlugin::convertFromDocumentToPage const):
(WebKit::UnifiedPDFPlugin::pdfElementTypesForPluginPoint const):

Introduce functions that return the data reflected by their names, all
to be consumed by pdfElementTypesForPluginPoint in anticipation of
cursor updates.

(WebKit::UnifiedPDFPlugin::performContextMenuAction const):
(WebKit::UnifiedPDFPlugin::handleContextMenuEvent):

Drive-by fix, make `#endif` scopes clearer.

Canonical link: <a href="https://commits.webkit.org/271528@main">https://commits.webkit.org/271528@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af10ddcd0e5fdcb907e4c6dc388e54411872b172

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28683 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7326 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30054 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31304 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/26175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9443 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4687 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28953 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6057 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24652 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5263 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/5416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/32642 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26257 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26099 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/31658 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/5380 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/3551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/29436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6995 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6860 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/5847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/5898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->