### PR TITLE
Replace bools in PDFContextMenuItem with enum classes.

### DIFF
--- a/Source/WebKit/Shared/mac/PDFContextMenu.h
+++ b/Source/WebKit/Shared/mac/PDFContextMenu.h
@@ -28,14 +28,18 @@
 #if ENABLE(PDF_PLUGIN) && PLATFORM(MAC)
 
 namespace WebKit {
+enum class ContextMenuItemEnablement : bool { Disabled, Enabled };
+
+enum class ContextMenuItemIsSeparator : bool { No, Yes };
     
+enum class ContextMenuItemHasAction : bool { No, Yes };
 struct PDFContextMenuItem {
     String title;
-    bool enabled;
-    bool separator;
     int state;
-    bool hasAction;
     int tag;
+    ContextMenuItemEnablement enabled;
+    ContextMenuItemHasAction hasAction;
+    ContextMenuItemIsSeparator separator;
 };
 
 struct PDFContextMenu {

--- a/Source/WebKit/Shared/mac/PDFContextMenuItem.serialization.in
+++ b/Source/WebKit/Shared/mac/PDFContextMenuItem.serialization.in
@@ -25,11 +25,11 @@
    
 [CustomHeader] struct WebKit::PDFContextMenuItem {
     String title;
-    bool enabled;
-    bool separator;
     int state;
-    bool hasAction;
     int tag;
+    WebKit::ContextMenuItemEnablement enabled;
+    WebKit::ContextMenuItemHasAction hasAction;
+    WebKit::ContextMenuItemIsSeparator separator;
 };
 
 struct WebKit::PDFContextMenu {

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -522,16 +522,16 @@ void WebPageProxy::showPDFContextMenu(const WebKit::PDFContextMenu& contextMenu,
     for (unsigned i = 0; i < contextMenu.items.size(); i++) {
         auto& item = contextMenu.items[i];
         
-        if (item.separator) {
+        if (item.separator == ContextMenuItemIsSeparator::Yes) {
             [nsMenu insertItem:[NSMenuItem separatorItem] atIndex:i];
             continue;
         }
         
         RetainPtr<NSMenuItem> nsItem = adoptNS([[NSMenuItem alloc] init]);
         [nsItem setTitle:item.title];
-        [nsItem setEnabled:item.enabled];
+        [nsItem setEnabled:item.enabled == ContextMenuItemEnablement::Enabled];
         [nsItem setState:item.state];
-        if (item.hasAction) {
+        if (item.hasAction == ContextMenuItemHasAction::Yes) {
             [nsItem setTarget:menuTarget.get()];
             [nsItem setAction:@selector(contextMenuAction:)];
         }

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -1993,7 +1993,11 @@ bool PDFPlugin::handleContextMenuEvent(const WebMouseEvent& event)
             continue;
         if ([NSStringFromSelector(item.action) isEqualToString:@"openWithPreview"])
             openInPreviewIndex = i;
-        PDFContextMenuItem menuItem { String([item title]), !![item isEnabled], !![item isSeparatorItem], static_cast<int>([item state]), !![item action], i };
+        PDFContextMenuItem menuItem { String([item title]), static_cast<int>([item state]), i,
+            [item isEnabled] ? ContextMenuItemEnablement::Enabled : ContextMenuItemEnablement::Disabled,
+            [item action] ? ContextMenuItemHasAction::Yes : ContextMenuItemHasAction::No,
+            [item isSeparatorItem] ? ContextMenuItemIsSeparator::Yes : ContextMenuItemIsSeparator::No
+        };
         items.append(WTFMove(menuItem));
     }
     PDFContextMenu contextMenu { point, WTFMove(items), WTFMove(openInPreviewIndex) };

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -580,7 +580,12 @@ PDFContextMenu UnifiedPDFPlugin::createContextMenu(const IntPoint& contextMenuPo
     Vector<PDFContextMenuItem> menuItems;
 
     // FIXME: We should also set the openInPreviewIndex when UnifiedPdfPlugin::openWithPreview is implemented
-    menuItems.append({ WebCore::contextMenuItemPDFOpenWithPreview(), true, false, 0, true, static_cast<uint8_t>(ContextMenuItemTag::OpenWithPreview) });
+    menuItems.append({ WebCore::contextMenuItemPDFOpenWithPreview(), 0,
+        enumToUnderlyingType(ContextMenuItemTag::OpenWithPreview),
+        ContextMenuItemEnablement::Enabled,
+        ContextMenuItemHasAction::Yes,
+        ContextMenuItemIsSeparator::No
+    });
 
     return { contextMenuPoint, WTFMove(menuItems), { } };
 }


### PR DESCRIPTION
#### 6e2b89f53e56d4171becce375bf908ce725e9d30
<pre>
Replace bools in PDFContextMenuItem with enum classes.
<a href="https://bugs.webkit.org/show_bug.cgi?id=265815.">https://bugs.webkit.org/show_bug.cgi?id=265815.</a>
<a href="https://rdar.apple.com/problem/119150073">rdar://problem/119150073</a>.

Reviewed by Simon Fraser.

enabled, separator, and hasAction are all bools which can be represented
as an enum class.

* Source/WebKit/Shared/mac/PDFContextMenu.h:
* Source/WebKit/Shared/mac/PDFContextMenuItem.serialization.in:
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::showPDFContextMenu):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(WebKit::PDFPlugin::handleContextMenuEvent):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::createContextMenu const):

Canonical link: <a href="https://commits.webkit.org/271554@main">https://commits.webkit.org/271554@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6a64392ee5b426eee42146377c8ab66dac58a08

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28699 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7342 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30070 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31319 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26186 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9507 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4703 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26261 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28969 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6109 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24681 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5278 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5460 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/32657 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26307 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26128 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31669 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5391 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3579 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29447 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7008 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6879 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5858 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5909 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->