### PR TITLE
[Cocoa] Fullscreen on dailymotion.com: Scrubbing on seekbar switches apps

### DIFF
--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -147,6 +147,7 @@ struct WKWebViewState {
     UIEdgeInsets _savedEdgeInset = UIEdgeInsetsZero;
     BOOL _savedHaveSetObscuredInsets = NO;
     UIEdgeInsets _savedObscuredInsets = UIEdgeInsetsZero;
+    UIRectEdge _savedObscuredInsetEdgesAffectedBySafeArea = UIRectEdgeAll;
     UIEdgeInsets _savedScrollIndicatorInsets = UIEdgeInsetsZero;
 #if !PLATFORM(WATCHOS) && !PLATFORM(APPLETV)
     BOOL _savedContentInsetAdjustmentBehaviorWasExternallyOverridden = NO;
@@ -172,6 +173,8 @@ struct WKWebViewState {
             webView._obscuredInsets = _savedObscuredInsets;
         else
             [webView _resetObscuredInsets];
+
+        webView._obscuredInsetEdgesAffectedBySafeArea = _savedObscuredInsetEdgesAffectedBySafeArea;
 
         auto* scrollView = (WKScrollView *)[webView scrollView];
         if (_savedContentInsetWasExternallyOverridden)
@@ -217,6 +220,7 @@ struct WKWebViewState {
         _savedPageScale = webView._pageScale;
         _savedHaveSetObscuredInsets = webView._haveSetObscuredInsets;
         _savedObscuredInsets = webView._obscuredInsets;
+        _savedObscuredInsetEdgesAffectedBySafeArea = webView._obscuredInsetEdgesAffectedBySafeArea;
         _savedContentInsetWasExternallyOverridden = scrollView._contentInsetWasExternallyOverridden;
         _savedEdgeInset = scrollView.contentInset;
         _savedContentOffset = scrollView.contentOffset;


### PR DESCRIPTION
#### 454a4a2f6f9f9f74f635f396c62ebc9dc1620b45
<pre>
[Cocoa] Fullscreen on dailymotion.com: Scrubbing on seekbar switches apps
<a href="https://bugs.webkit.org/show_bug.cgi?id=265816">https://bugs.webkit.org/show_bug.cgi?id=265816</a>
<a href="https://rdar.apple.com/118026820">rdar://118026820</a>

Reviewed by Tim Horton.

Ensure the bottom safeAreaInset is avoided by setting the WKWebView&apos;s _obscuredInsetEdgesAffectedBySafeArea
to UIRectEdgeAll. (The default is every edge except UIRectEdgeBottom.)

* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(WebKit::WKWebViewState::applyTo):
(WebKit::WKWebViewState::store):

Canonical link: <a href="https://commits.webkit.org/271538@main">https://commits.webkit.org/271538@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6f6a8193001e54b5ad8d315f4ea21a183a031a1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28635 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7280 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30014 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31268 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26142 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9395 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4647 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26223 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28905 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6016 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24623 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5232 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5381 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/32600 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26216 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26070 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31623 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5347 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3519 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29401 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6958 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6865 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5812 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5866 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->