### PR TITLE
[Cocoa] Fullscreen on vice.com: CC font size is extremely large in portrait view

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/controls/text-tracks.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/text-tracks.css
@@ -81,7 +81,7 @@ video[controls]::-webkit-media-text-track-container.visible-controls-bar {
     writing-mode: horizontal-tb;
     background: rgba(0,0,0,0.8);
     overflow-wrap: break-word;
-    font: 5cqh sans-serif;
+    font: 5cqmin sans-serif;
     color: rgba(255,255,255,1);
     overflow: hidden;
     min-height: 0px;


### PR DESCRIPTION
#### bed0c2a8cb8ae071886d43295d004058a17188a0
<pre>
[Cocoa] Fullscreen on vice.com: CC font size is extremely large in portrait view
<a href="https://bugs.webkit.org/show_bug.cgi?id=265817">https://bugs.webkit.org/show_bug.cgi?id=265817</a>
<a href="https://rdar.apple.com/118030141">rdar://118030141</a>

Reviewed by Simon Fraser.

When a landscape video is presented in portrait mode (with large letterboxes), this causes the font size of the
associated text tracks to be absurdly large. Filed a spec issue on WebVTT (<a href="https://github.com/w3c/webvtt/issues/522)">https://github.com/w3c/webvtt/issues/522)</a>
to change the default font size be `5vmin` rather than `5vh`, but proceeding with changing WebKit&apos;s default
font size to be `5cqh` in the meantime.

* Source/WebCore/Modules/modern-media-controls/controls/text-tracks.css:
(::-webkit-media-text-track-region):

Canonical link: <a href="https://commits.webkit.org/271536@main">https://commits.webkit.org/271536@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bac97c80148106d9c6195ab347c50be3e91648ee

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28638 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7282 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30015 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31269 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26143 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29148 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9458 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4648 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26224 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28908 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6069 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24622 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5233 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/5426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25623 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/32601 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26267 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26069 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31624 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5348 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3521 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29402 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6959 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6866 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5813 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5867 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->