### PR TITLE
Avoid integer overflow in LayoutUnit's unary minus operator

### DIFF
--- a/Source/WebCore/platform/LayoutUnit.h
+++ b/Source/WebCore/platform/LayoutUnit.h
@@ -636,6 +636,10 @@ inline float operator-(const float a, const LayoutUnit& b)
 
 inline LayoutUnit operator-(const LayoutUnit& a)
 {
+    // -min() is saturated to max().
+    if (a == LayoutUnit::min())
+        return LayoutUnit::max();
+
     LayoutUnit returnVal;
     returnVal.setRawValue(-a.rawValue());
     return returnVal;

--- a/Tools/TestWebKitAPI/Tests/WebCore/LayoutUnitTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/LayoutUnitTests.cpp
@@ -245,4 +245,18 @@ TEST(WebCoreLayoutUnit, LayoutUnitPixelSnapping)
         ASSERT_FLOAT_EQ(roundToDevicePixel(LayoutUnit(i), 2), i + 0.25);
 }
 
+TEST(WebCoreLayoutUnit, LayoutUnitUnaryMinus)
+{
+    ASSERT_EQ(LayoutUnit(), -LayoutUnit());
+    ASSERT_EQ(LayoutUnit(999), -LayoutUnit(-999));
+    ASSERT_EQ(LayoutUnit(-999), -LayoutUnit(999));
+
+    LayoutUnit negativeMax;
+    negativeMax.setRawValue(LayoutUnit::min().rawValue() + 1);
+    ASSERT_EQ(negativeMax, -LayoutUnit::max());
+    ASSERT_EQ(LayoutUnit::max(), -negativeMax);
+    // -LayoutUnit::min() is saturated to LayoutUnit::max()
+    ASSERT_EQ(LayoutUnit::max(), -LayoutUnit::min());
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 2c3e402a8ea0e2b5f304e069b3ce8fd72c2fad44
<pre>
Avoid integer overflow in LayoutUnit&apos;s unary minus operator

<a href="https://bugs.webkit.org/show_bug.cgi?id=265825">https://bugs.webkit.org/show_bug.cgi?id=265825</a>

Reviewed by Alan Baradlay.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/ef6bea224f0266018c3b4fc63262769020b9a4c2">https://chromium.googlesource.com/chromium/src.git/+/ef6bea224f0266018c3b4fc63262769020b9a4c2</a>

This PR fixes potential &apos;integer overflow&apos; leading to crashes (in debug or fuzzer)
environments.

* Source/WebCore/platform/LayoutUnit.h:
(operator-):
* Tools/TestWebKitAPI/Tests/WebCore/LayoutUnitTests.cpp: Add Test Case &apos;LayoutUnitUnaryMinus&apos;

Canonical link: <a href="https://commits.webkit.org/271550@main">https://commits.webkit.org/271550@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f9a44fe4e806a2f5940ec45d6eb93f12f2d40d1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28658 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7301 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30030 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31283 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26156 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29168 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9417 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4663 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26238 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28928 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6031 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24634 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5250 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5394 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25636 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/32620 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26231 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26081 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31645 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5361 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3531 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29486 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6973 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6877 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5827 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5879 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->