### PR TITLE
Fix performance regression after 271209@main

### DIFF
--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoad.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoad.cpp
@@ -101,8 +101,8 @@ void SpeculativeLoad::willSendRedirectedRequest(ResourceRequest&& request, Resou
         m_cacheEntry = m_cache->makeRedirectEntry(request, redirectResponse, redirectRequest);
 
     // Don't follow the redirect. The redirect target will be registered for speculative load when it is loaded.
-    completionHandler({ });
     didComplete();
+    completionHandler({ });
 }
 
 void SpeculativeLoad::didReceiveResponse(ResourceResponse&& receivedResponse, PrivateRelayed privateRelayed, ResponseCompletionHandler&& completionHandler)


### PR DESCRIPTION
#### bbe1fd08c84508af0e8824856b928da3f641879e
<pre>
Fix performance regression after 271209@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=265826">https://bugs.webkit.org/show_bug.cgi?id=265826</a>
<a href="https://rdar.apple.com/118948980">rdar://118948980</a>

Reviewed by Per Arne Vollan.

271209@main introduced a CompletionHandler to SpeculativeLoad::willSendRedirectedRequest.
Before that change, we would just destroy the NetworkLoad and be done.
After that change, we call the redirect completion handler with an empty ResourceRequest
before destroying the NetworkLoad, which calls updateRequest and didCompleteWithError.
This PR changes calling the completion handler to after the call to SpeculativeLoad::didComplete
which destroys the NetworkLoad.  That way, the lambda at the end of the function
NetworkLoad::willPerformHTTPRedirection just finds a null weakThis and does none of this
unnecessary work.  I verified that this is what is going on on the sites in the radar
that showed a performance regression, and I verified that this change removes that unnecessary
work when not following redirects.

* Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoad.cpp:
(WebKit::NetworkCache::SpeculativeLoad::willSendRedirectedRequest):

Canonical link: <a href="https://commits.webkit.org/271526@main">https://commits.webkit.org/271526@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62be2be801b83af36124d697b84dc82b0f102dd0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28660 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7303 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30032 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31284 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26157 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9419 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4665 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28930 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6038 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24635 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5243 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/5398 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/32621 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26237 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26082 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31637 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5362 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3534 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29414 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6975 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5828 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3703 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/5880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->