### PR TITLE
Implement declarativeNetRequest.setExtensionActionOptions

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
@@ -607,10 +607,15 @@ void NavigationState::NavigationClient::decidePolicyForNavigationAction(WebPageP
 }
 
 #if ENABLE(CONTENT_EXTENSIONS)
-void NavigationState::NavigationClient::contentRuleListNotification(WebPageProxy&, URL&& url, ContentRuleListResults&& results)
+void NavigationState::NavigationClient::contentRuleListNotification(WebPageProxy& page, URL&& url, ContentRuleListResults&& results)
 {
     if (!m_navigationState)
         return;
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+    if (RefPtr extensionController = page.webExtensionController())
+        extensionController->handleContentRuleListNotification(page.identifier(), url, results);
+#endif
 
     if (!m_navigationState->m_navigationDelegateMethods.webViewURLContentRuleListIdentifiersNotifications
         && !m_navigationState->m_navigationDelegateMethods.webViewContentRuleListWithIdentifierPerformedActionForURL)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
@@ -181,7 +181,7 @@ WebExtensionContext* WebExtensionAction::extensionContext() const
 
 void WebExtensionAction::clearCustomizations()
 {
-    if (!m_customIcons && !m_customPopupPath.isNull() && !m_customLabel.isNull() && !m_customBadgeText.isNull() && !m_customEnabled)
+    if (!m_customIcons && !m_customPopupPath.isNull() && !m_customLabel.isNull() && !m_customBadgeText.isNull() && !m_customEnabled && !m_blockedResourceCount)
         return;
 
     m_customIcons = nil;
@@ -189,6 +189,14 @@ void WebExtensionAction::clearCustomizations()
     m_customLabel = nullString();
     m_customBadgeText = nullString();
     m_customEnabled = std::nullopt;
+    m_blockedResourceCount = 0;
+
+    propertiesDidChange();
+}
+
+void WebExtensionAction::clearBlockedResourceCount()
+{
+    m_blockedResourceCount = 0;
 
     propertiesDidChange();
 }
@@ -398,6 +406,9 @@ String WebExtensionAction::badgeText() const
     if (!m_customBadgeText.isNull())
         return m_customBadgeText;
 
+    if (m_blockedResourceCount)
+        return String::number(m_blockedResourceCount);
+
     if (m_tab)
         return extensionContext()->getAction(m_tab->window().get())->badgeText();
 
@@ -413,6 +424,16 @@ void WebExtensionAction::setBadgeText(String badgeText)
         return;
 
     m_customBadgeText = badgeText;
+
+    propertiesDidChange();
+}
+
+void WebExtensionAction::incrementBlockedResourceCount(ssize_t amount)
+{
+    m_blockedResourceCount += amount;
+
+    if (m_blockedResourceCount < 0)
+        m_blockedResourceCount = 0;
 
     propertiesDidChange();
 }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
@@ -45,6 +45,7 @@
 #import "WebExtensionEventListenerType.h"
 #import "WebPageProxy.h"
 #import "WebProcessPool.h"
+#import <WebCore/ContentRuleListResults.h>
 #import <wtf/FileSystem.h>
 #import <wtf/HashMap.h>
 #import <wtf/HashSet.h>
@@ -293,6 +294,25 @@ void WebExtensionController::didFailLoadForFrame(WebPageProxyIdentifier pageID, 
     for (auto& context : m_extensionContexts)
         context->didFailLoadForFrame(pageID, frameID, parentFrameID, frameURL, timestamp);
 }
+
+void WebExtensionController::handleContentRuleListNotification(WebPageProxyIdentifier pageID, URL& url, WebCore::ContentRuleListResults& results)
+{
+    for (const auto& result : results.results) {
+        auto contentRuleListIdentifier = result.first;
+        for (auto& context : m_extensionContexts) {
+            if (context->uniqueIdentifier() != contentRuleListIdentifier)
+                continue;
+
+            RefPtr tab = context->getTab(pageID);
+            if (!tab)
+                break;
+
+            context->incrementActionCountForTab(*tab, 1);
+            break;
+        }
+    }
+}
+
 
 } // namespace WebKit
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionAction.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionAction.h
@@ -70,6 +70,7 @@ public:
     WebExtensionWindow* window() { return m_window.get(); }
 
     void clearCustomizations();
+    void clearBlockedResourceCount();
 
     void propertiesDidChange();
 
@@ -81,6 +82,8 @@ public:
 
     String badgeText() const;
     void setBadgeText(String);
+
+    void incrementBlockedResourceCount(ssize_t amount);
 
     bool isEnabled() const;
     void setEnabled(std::optional<bool>);
@@ -116,6 +119,7 @@ private:
     RetainPtr<NSDictionary> m_customIcons;
     String m_customLabel;
     String m_customBadgeText;
+    ssize_t m_blockedResourceCount { 0 };
     std::optional<bool> m_customEnabled;
     bool m_popupPresented { false };
     bool m_respondsToPresentPopup { false };

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -365,6 +365,8 @@ public:
     void addInjectedContent(WebUserContentControllerProxy&);
     void removeInjectedContent(WebUserContentControllerProxy&);
 
+    void incrementActionCountForTab(WebExtensionTab&, ssize_t incrementAmount);
+
     UserStyleSheetVector& dynamicallyInjectedUserStyleSheets() { return m_dynamicallyInjectedUserStyleSheets; };
 
     std::optional<WebCore::PageIdentifier> backgroundPageIdentifier() const;
@@ -443,14 +445,24 @@ private:
     void removeInjectedContent(MatchPatternSet&);
     void removeInjectedContent(WebExtensionMatchPattern&);
 
+    // DeclarativeNetRequest methods.
+    // Loading/unloading static rules
     void loadDeclarativeNetRequestRules(CompletionHandler<void(bool)>&&);
     void compileDeclarativeNetRequestRules(NSArray *, CompletionHandler<void(bool)>&&);
-    void removeDeclarativeNetRequestRules();
-    void addDeclarativeNetRequestRulesToPrivateUserContentControllers();
     WKContentRuleListStore *declarativeNetRequestRuleStore();
+
+    // Updating user content controllers with new rules.
+    void addDeclarativeNetRequestRulesToPrivateUserContentControllers();
+    void removeDeclarativeNetRequestRules();
+
+    // Customizing static rulesets.
     void saveDeclarativeNetRequestRulesetStateToStorage(NSDictionary *rulesetState);
     void loadDeclarativeNetRequestRulesetStateFromStorage();
     void clearDeclarativeNetRequestRulesetState();
+
+    // Displaying action count as badge text.
+    bool shouldDisplayBlockedResourceCountAsBadgeText();
+    void saveShouldDisplayBlockedResourceCountAsBadgeText(bool);
 
     // Action APIs
     void actionGetTitle(std::optional<WebExtensionWindowIdentifier>, std::optional<WebExtensionTabIdentifier>, CompletionHandler<void(std::optional<String>, std::optional<String>)>&&);
@@ -481,6 +493,8 @@ private:
     // DeclarativeNetRequest APIs
     void declarativeNetRequestGetEnabledRulesets(CompletionHandler<void(const Vector<String>&)>&&);
     void declarativeNetRequestUpdateEnabledRulesets(const Vector<String>& rulesetIdentifiersToEnable, const Vector<String>& rulesetIdentifiersToDisable, CompletionHandler<void(std::optional<String>)>&&);
+    void declarativeNetRequestDisplayActionCountAsBadgeText(bool displayActionCountAsBadgeText, CompletionHandler<void(std::optional<String>)>&&);
+    void declarativeNetRequestIncrementActionCount(WebExtensionTabIdentifier, double increment, CompletionHandler<void(std::optional<String>)>&&);
     DeclarativeNetRequestValidatedRulesets declarativeNetRequestValidateRulesetIdentifiers(const Vector<String>&);
     size_t declarativeNetRequestEnabledRulesetCount();
     void declarativeNetRequestToggleRulesets(const Vector<String>& rulesetIdentifiers, bool newValue, NSMutableDictionary *rulesetIdentifiersToEnabledState);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
@@ -51,6 +51,8 @@ messages -> WebExtensionContext {
     // DeclarativeNetRequest
     DeclarativeNetRequestGetEnabledRulesets() -> (Vector<String> rulesetIdentifiers);
     DeclarativeNetRequestUpdateEnabledRulesets(Vector<String> rulesetIdentifiersToEnable, Vector<String> rulesetIdentifiersToDisable) -> (std::optional<String> error);
+    DeclarativeNetRequestDisplayActionCountAsBadgeText(bool result) -> (std::optional<String> error);
+    DeclarativeNetRequestIncrementActionCount(WebKit::WebExtensionTabIdentifier tabIdentifier, double increment) -> (std::optional<String> error);
 
     // Event APIs
     AddListener(WebKit::WebPageProxyIdentifier identifier, WebKit::WebExtensionEventListenerType type, WebKit::WebExtensionContentWorldType contentWorldType);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
@@ -123,6 +123,8 @@ public:
     void addItemsToContextMenu(WebPageProxy&, const ContextMenuContextData&, NSMenu *);
 #endif
 
+    void handleContentRuleListNotification(WebPageProxyIdentifier, URL&, WebCore::ContentRuleListResults&);
+
 #ifdef __OBJC__
     _WKWebExtensionController *wrapper() const { return (_WKWebExtensionController *)API::ObjectImpl<API::Object::Type::WebExtensionController>::wrapper(); }
     _WKWebExtensionControllerDelegatePrivate *delegate() const { return (_WKWebExtensionControllerDelegatePrivate *)wrapper().delegate; }


### PR DESCRIPTION
#### c26e66feb2aa3ac2cb62f6a15ea66c0dacef644e
<pre>
Implement declarativeNetRequest.setExtensionActionOptions
<a href="https://bugs.webkit.org/show_bug.cgi?id=265829">https://bugs.webkit.org/show_bug.cgi?id=265829</a>
<a href="https://rdar.apple.com/118476776">rdar://118476776</a>

Reviewed by Timothy Hatcher.

This API has two use cases:
1) To opt an extension into a behavior where the extension&apos;s action shows the number of blocked resources on the current page
2) To manually increment or decrement this badged number

It&apos;s a bit unfortunate that these two disparate behaviors are combined into one API, but here we are. This PR implements both of
them and adds tests for them.

* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
(WebKit::NavigationState::NavigationClient::contentRuleListNotification): Call into the WebExtensionController.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDeclarativeNetRequestCocoa.mm:
(WebKit::WebExtensionContext::shouldDisplayBlockedResourceCountAsBadgeText): Returns whether or not the blocked resource count should be the badge text.
(WebKit::WebExtensionContext::saveShouldDisplayBlockedResourceCountAsBadgeText): Sets whether or not the blocked resource count should be the badge
text, and saves to disk.
(WebKit::WebExtensionContext::incrementActionCountForTab): Get the action for the tab and increment the blocked resource count.
(WebKit::WebExtensionContext::declarativeNetRequestDisplayActionCountAsBadgeText): Call saveShouldDisplayBlockedResourceCountAsBadgeText with the new value, and
clear any blocked resource counts if the flag is turned off.
(WebKit::WebExtensionContext::declarativeNetRequestIncrementActionCount): Call into incrementActionCountForTab after finding the tab.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm:
(WebKit::WebExtensionAction::clearCustomizations): Clear the blocked resource count.
(WebKit::WebExtensionAction::clearBlockedResourceCount): Ditto.
(WebKit::WebExtensionAction::badgeText const): If we have a blocked resource count - use it as the badge text.
(WebKit::WebExtensionAction::incrementBlockedResourceCount): Modify the blocked resource count member variable.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(WebKit::WebExtensionController::handleContentRuleListNotification): Iterate over all of the actions, find the extension if it exists, and call incrementActionCountForTab.
* Source/WebKit/UIProcess/Extensions/WebExtensionAction.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in:
* Source/WebKit/UIProcess/Extensions/WebExtensionController.h:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDeclarativeNetRequestCocoa.mm:
(WebKit::WebExtensionAPIDeclarativeNetRequest::setExtensionActionOptions): Perform object validation and call into the UI process based on if flavor (1) or (2) was called.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/271561@main">https://commits.webkit.org/271561@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dfb2ff0925be7b8a927722670986d1640cdef812

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28799 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7442 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30172 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31418 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26275 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29369 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9576 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4801 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29069 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6172 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/24761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/5357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/5513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/25771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/32757 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26369 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/26212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/31748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/5478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/3649 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/29531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7099 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6885 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5950 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5996 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->