### PR TITLE
RELEASE_ASSERT(!m_ptrCount) under ~Frame()

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		3A5BCFA3298768E300E0ABB2 /* RefVector.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A5BCFA2298768E300E0ABB2 /* RefVector.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		4427C5AA21F6D6C300A612A4 /* ASCIICType.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4427C5A921F6D6C300A612A4 /* ASCIICType.cpp */; };
 		4448265228D18CA600D916E8 /* VectorCF.h in Headers */ = {isa = PBXBuildFile; fileRef = 4448265128D18CA600D916E8 /* VectorCF.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		4606FEE72B1E901800D704F1 /* WeakRef.h in Headers */ = {isa = PBXBuildFile; fileRef = 4606FEE62B1E901800D704F1 /* WeakRef.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		461229722ACF6B3100BB1CCC /* FastCharacterComparison.h in Headers */ = {isa = PBXBuildFile; fileRef = 461229712ACF6B3100BB1CCC /* FastCharacterComparison.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		46449E8B2822E5680005A8BC /* WeakHashCountedSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 46449E8A2822E5670005A8BC /* WeakHashCountedSet.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		4655743627F5FC4A002D5522 /* ASCIILiteralCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4655743527F5FC4A002D5522 /* ASCIILiteralCocoa.mm */; };
@@ -1140,6 +1141,7 @@
 		4448265128D18CA600D916E8 /* VectorCF.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VectorCF.h; sourceTree = "<group>"; };
 		4468567225094FE8008CCA05 /* ThreadSanitizerSupport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThreadSanitizerSupport.h; sourceTree = "<group>"; };
 		44CDE4D226EE6CDA009F6ACB /* TypeCastsCocoa.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TypeCastsCocoa.h; sourceTree = "<group>"; };
+		4606FEE62B1E901800D704F1 /* WeakRef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WeakRef.h; sourceTree = "<group>"; };
 		461229712ACF6B3100BB1CCC /* FastCharacterComparison.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FastCharacterComparison.h; sourceTree = "<group>"; };
 		46209A27266D543A007F8F4A /* CancellableTask.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CancellableTask.h; sourceTree = "<group>"; };
 		46449E8A2822E5670005A8BC /* WeakHashCountedSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WeakHashCountedSet.h; sourceTree = "<group>"; };
@@ -2425,6 +2427,7 @@
 				0F3501631BB258C800F0A2A3 /* WeakRandom.h */,
 				A8A472FB151A825B004123FF /* WeakRandomNumber.cpp */,
 				A8A472FC151A825B004123FF /* WeakRandomNumber.h */,
+				4606FEE62B1E901800D704F1 /* WeakRef.h */,
 				DD4901E327B4748A00D7E50D /* WindowsExtras.h */,
 				0FE4479A1B7AAA03009498EB /* WordLock.cpp */,
 				0FE4479B1B7AAA03009498EB /* WordLock.h */,
@@ -3416,6 +3419,7 @@
 				DD3DC95227A4BF8E007E5B61 /* WeakPtr.h in Headers */,
 				DD3DC91927A4BF8E007E5B61 /* WeakRandom.h in Headers */,
 				DD3DC88A27A4BF8E007E5B61 /* WeakRandomNumber.h in Headers */,
+				4606FEE72B1E901800D704F1 /* WeakRef.h in Headers */,
 				DDF3073B27C086CD006A526F /* WebCoreThread.h in Headers */,
 				DD4901EA27B4748A00D7E50D /* WindowsExtras.h in Headers */,
 				DD3DC8AE27A4BF8E007E5B61 /* WordLock.h in Headers */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -339,6 +339,7 @@ set(WTF_PUBLIC_HEADERS
     WeakPtr.h
     WeakRandom.h
     WeakRandomNumber.h
+    WeakRef.h
     WindowsExtras.h
     WordLock.h
     WorkQueue.h

--- a/Source/WTF/wtf/Forward.h
+++ b/Source/WTF/wtf/Forward.h
@@ -98,6 +98,7 @@ template<typename> class UniqueRef;
 template<typename T, class... Args> UniqueRef<T> makeUniqueRef(Args&&...);
 template<typename, size_t = 0, typename = CrashOnOverflow, size_t = 16, typename = VectorBufferMalloc> class Vector;
 template<typename, typename = DefaultWeakPtrImpl> class WeakPtr;
+template<typename, typename = DefaultWeakPtrImpl> class WeakRef;
 
 template<typename> struct DefaultHash;
 template<> struct DefaultHash<AtomString>;
@@ -187,6 +188,7 @@ using WTF::URL;
 using WTF::UniqueRef;
 using WTF::Vector;
 using WTF::WeakPtr;
+using WTF::WeakRef;
 
 template<class T, class E> using Expected = std::experimental::expected<T, E>;
 template<class E> using Unexpected = std::experimental::unexpected<E>;

--- a/Source/WTF/wtf/WeakPtr.h
+++ b/Source/WTF/wtf/WeakPtr.h
@@ -317,6 +317,7 @@ private:
     template<typename, typename, EnableWeakPtrThreadingAssertions> friend class WeakListHashSet;
     template<typename, typename, typename> friend class WeakHashMap;
     template<typename, typename> friend class WeakPtr;
+    template<typename, typename> friend class WeakRef;
 
     mutable CompactRefPtrTuple<WeakPtrImpl, uint16_t> m_impl;
 #if ASSERT_ENABLED

--- a/Source/WTF/wtf/WeakRef.h
+++ b/Source/WTF/wtf/WeakRef.h
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/WeakPtr.h>
+
+namespace WTF {
+
+// Similar to a WeakPtr but it is an error for it to become null. It is useful for hardening when replacing
+// things like `Foo& m_foo`. It is similar to CheckedRef but it generates crashes that are more actionable.
+template<typename T, typename WeakPtrImpl>
+class WeakRef {
+public:
+    template<typename = std::enable_if_t<!IsSmartPtr<T>::value && !std::is_pointer_v<T>>>
+    WeakRef(T& object, EnableWeakPtrThreadingAssertions shouldEnableAssertions = EnableWeakPtrThreadingAssertions::Yes)
+        : m_impl(implForObject(object))
+#if ASSERT_ENABLED
+        , m_shouldEnableAssertions(shouldEnableAssertions == EnableWeakPtrThreadingAssertions::Yes)
+#endif
+    {
+        UNUSED_PARAM(shouldEnableAssertions);
+    }
+
+    WeakRef(HashTableDeletedValueType) : m_impl(HashTableDeletedValue) { }
+    WeakRef(HashTableEmptyValueType) : m_impl(HashTableEmptyValue) { }
+
+    bool isHashTableDeletedValue() const { return m_impl.isHashTableDeletedValue(); }
+    bool isHashTableEmptyValue() const { return m_impl.isHashTableEmptyValue(); }
+
+    T* ptr() const
+    {
+        auto* ptr = static_cast<T*>(m_impl->template get<T>());
+        ASSERT(ptr);
+        return ptr;
+    }
+
+    T& get() const
+    {
+        auto* ptr = static_cast<T*>(m_impl->template get<T>());
+        ASSERT(ptr);
+        return *ptr;
+    }
+    operator T&() const { return get(); }
+
+    T* operator->() const
+    {
+        ASSERT(canSafelyBeUsed());
+        return ptr();
+    }
+
+private:
+#if ASSERT_ENABLED
+    inline bool canSafelyBeUsed() const
+    {
+        // FIXME: Our GC threads currently need to get opaque pointers from WeakPtrs and have to be special-cased.
+        return !m_impl
+            || !m_shouldEnableAssertions
+            || (m_impl->wasConstructedOnMainThread() && Thread::mayBeGCThread())
+            || m_impl->wasConstructedOnMainThread() == isMainThread();
+    }
+#endif
+
+    template<typename U> static WeakPtrImpl& implForObject(const U& object)
+    {
+        object.weakPtrFactory().initializeIfNeeded(object);
+        return *object.weakPtrFactory().m_impl.pointer();
+    }
+
+    Ref<WeakPtrImpl> m_impl;
+#if ASSERT_ENABLED
+    bool m_shouldEnableAssertions { true };
+#endif
+};
+
+template<class T, typename = std::enable_if_t<!IsSmartPtr<T>::value && !std::is_pointer_v<T>>>
+WeakRef(const T& value, EnableWeakPtrThreadingAssertions = EnableWeakPtrThreadingAssertions::Yes) -> WeakRef<T, typename T::WeakPtrImplType>;
+
+template <typename T, typename WeakPtrImpl>
+struct GetPtrHelper<WeakRef<T, WeakPtrImpl>> {
+    typedef T* PtrType;
+    static T* getPtr(const WeakRef<T, WeakPtrImpl>& p) { return const_cast<T*>(p.ptr()); }
+};
+
+template <typename T, typename WeakPtrImpl>
+struct IsSmartPtr<WeakRef<T, WeakPtrImpl>> {
+    static constexpr bool value = true;
+};
+
+template<typename P, typename WeakPtrImpl> struct WeakRefHashTraits : SimpleClassHashTraits<WeakRef<P, WeakPtrImpl>> {
+    static constexpr bool emptyValueIsZero = true;
+    static WeakRef<P, WeakPtrImpl> emptyValue() { return HashTableEmptyValue; }
+
+    template <typename>
+    static void constructEmptyValue(WeakRef<P, WeakPtrImpl>& slot)
+    {
+        new (NotNull, std::addressof(slot)) WeakRef<P, WeakPtrImpl>(HashTableEmptyValue);
+    }
+
+    static constexpr bool hasIsEmptyValueFunction = true;
+    static bool isEmptyValue(const WeakRef<P, WeakPtrImpl>& value) { return value.isHashTableEmptyValue(); }
+
+    using PeekType = P*;
+    static PeekType peek(const WeakRef<P, WeakPtrImpl>& value) { return const_cast<PeekType>(value.ptrAllowingHashTableEmptyValue()); }
+    static PeekType peek(P* value) { return value; }
+
+    using TakeType = WeakPtr<P, WeakPtrImpl>;
+    static TakeType take(WeakRef<P, WeakPtrImpl>&& value) { return isEmptyValue(value) ? nullptr : WeakRef<P, WeakPtrImpl>(WTFMove(value)); }
+};
+
+template<typename P, typename WeakPtrImpl> struct HashTraits<WeakRef<P, WeakPtrImpl>> : WeakRefHashTraits<P, WeakPtrImpl> { };
+
+template<typename P, typename WeakPtrImpl> struct PtrHash<WeakRef<P, WeakPtrImpl>> : PtrHashBase<WeakRef<P, WeakPtrImpl>, IsSmartPtr<WeakRef<P, WeakPtrImpl>>::value> {
+    static constexpr bool safeToCompareToEmptyOrDeleted = false;
+};
+
+template<typename P, typename WeakPtrImpl> struct DefaultHash<WeakRef<P, WeakPtrImpl>> : PtrHash<WeakRef<P, WeakPtrImpl>> { };
+
+} // namespace WTF
+
+using WTF::WeakRef;

--- a/Source/WebCore/editing/WebContentReader.h
+++ b/Source/WebCore/editing/WebContentReader.h
@@ -30,7 +30,7 @@
 #include "Pasteboard.h"
 #include "SimpleRange.h"
 #include "markup.h"
-#include <wtf/CheckedRef.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore {
 
@@ -51,7 +51,7 @@ protected:
     MSOListQuirks msoListQuirksForMarkup() const;
 
 private:
-    CheckedRef<LocalFrame> m_frame;
+    WeakRef<LocalFrame> m_frame;
 };
 
 class WebContentReader final : public FrameWebContentReader {

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -314,7 +314,7 @@ public:
     }
 
 private:
-    CheckedRef<LocalFrame> m_frame;
+    WeakRef<LocalFrame> m_frame;
     bool m_inProgress { false };
 };
 

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -53,6 +53,7 @@
 #include <wtf/UniqueRef.h>
 #include <wtf/WallTime.h>
 #include <wtf/WeakHashSet.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore {
 
@@ -446,7 +447,7 @@ private:
     void clearProvisionalLoadForPolicyCheck();
     bool hasOpenedFrames() const;
 
-    CheckedRef<LocalFrame> m_frame;
+    WeakRef<LocalFrame> m_frame;
     UniqueRef<LocalFrameLoaderClient> m_client;
 
     const std::unique_ptr<PolicyChecker> m_policyChecker;

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -44,7 +44,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/RefPtr.h>
-#include <wtf/WeakPtr.h>
+#include <wtf/WeakRef.h>
 
 #if PLATFORM(COCOA)
 OBJC_CLASS NSView;
@@ -611,7 +611,7 @@ private:
 
     Ref<LocalFrame> protectedFrame() const;
 
-    CheckedRef<LocalFrame> m_frame;
+    WeakRef<LocalFrame> m_frame;
     RefPtr<Node> m_mousePressNode;
     Timer m_hoverTimer;
 #if ENABLE(IMAGE_ANALYSIS)

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -32,7 +32,7 @@
 #include <wtf/Ref.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/UniqueRef.h>
-#include <wtf/WeakPtr.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore {
 
@@ -47,7 +47,7 @@ class Settings;
 class WeakPtrImplWithEventTargetData;
 class WindowProxy;
 
-class Frame : public ThreadSafeRefCounted<Frame, WTF::DestructionThread::Main>, public CanMakeWeakPtr<Frame>, public CanMakeCheckedPtr {
+class Frame : public ThreadSafeRefCounted<Frame, WTF::DestructionThread::Main>, public CanMakeWeakPtr<Frame> {
 public:
     virtual ~Frame();
 
@@ -107,7 +107,7 @@ private:
     mutable FrameTree m_treeNode;
     Ref<WindowProxy> m_windowProxy;
     WeakPtr<HTMLFrameOwnerElement, WeakPtrImplWithEventTargetData> m_ownerElement;
-    CheckedRef<Frame> m_mainFrame;
+    WeakRef<Frame> m_mainFrame;
     const Ref<Settings> m_settings;
     FrameType m_frameType;
     mutable UniqueRef<NavigationScheduler> m_navigationScheduler;

--- a/Source/WebCore/page/IntersectionObserver.cpp
+++ b/Source/WebCore/page/IntersectionObserver.cpp
@@ -358,7 +358,7 @@ auto IntersectionObserver::computeIntersectionState(const IntersectionObserverRe
 
         ASSERT(frameView.frame().isMainFrame());
         // FIXME: Handle the case of an implicit-root observer that has a target in a different frame tree.
-        if (targetRenderer->frame().mainFrame() != frameView.frame())
+        if (&targetRenderer->frame().mainFrame() != &frameView.frame())
             return;
 
         intersectionState.canComputeIntersection = true;

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -2962,7 +2962,7 @@ bool LocalFrameView::shouldUpdateCompositingLayersAfterScrolling() const
     if (!page)
         return true;
 
-    if (page->mainFrame() != m_frame)
+    if (&page->mainFrame() != m_frame.ptr())
         return true;
 
     auto scrollingCoordinator = this->scrollingCoordinator();

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -3818,7 +3818,7 @@ void Page::setFullscreenControlsHidden(bool hidden)
 Document* Page::outermostFullscreenDocument() const
 {
 #if ENABLE(FULLSCREEN_API)
-    CheckedPtr localMainFrame = dynamicDowncast<LocalFrame>(m_mainFrame.get());
+    RefPtr localMainFrame = dynamicDowncast<LocalFrame>(m_mainFrame.get());
     if (!localMainFrame)
         return nullptr;
 

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1064,7 +1064,7 @@ public:
     void willBeginScrolling();
     void didFinishScrolling();
 
-    const HashSet<CheckedRef<LocalFrame>>& rootFrames() const { return m_rootFrames; }
+    const HashSet<WeakRef<LocalFrame>>& rootFrames() const { return m_rootFrames; }
     WEBCORE_EXPORT void addRootFrame(LocalFrame&);
     WEBCORE_EXPORT void removeRootFrame(LocalFrame&);
 
@@ -1156,7 +1156,7 @@ private:
     UniqueRef<ProgressTracker> m_progress;
 
     UniqueRef<BackForwardController> m_backForwardController;
-    HashSet<CheckedRef<LocalFrame>> m_rootFrames;
+    HashSet<WeakRef<LocalFrame>> m_rootFrames;
     UniqueRef<EditorClient> m_editorClient;
     Ref<Frame> m_mainFrame;
     URL m_mainFrameURL;


### PR DESCRIPTION
#### 11ef5809f84211b6c4ab9155c37f66541d204582
<pre>
RELEASE_ASSERT(!m_ptrCount) under ~Frame()
<a href="https://bugs.webkit.org/show_bug.cgi?id=265833">https://bugs.webkit.org/show_bug.cgi?id=265833</a>
<a href="https://rdar.apple.com/118553828">rdar://118553828</a>

Reviewed by Darin Adler.

This crash occurs because there is still a CheckedPtr / CheckedRef pointing
to the Frame somewhere at the time where the Frame gets destroyed.

However, CheckedPtr / CheckedRef crashes are very hard to debug. Instead,
I updated Frame to stop subclassing CanMakeCheckedPtr and I used WeakPtr
instead of CheckedPtr.

I also introduced a new WeakRef class which is like a WeakPtr except that
it is not expected to ever be null. It is the replacement for CheckedRef.

This patch also updates a few comparisons between Frames instead that were
doing value comparison instead of pointer comparison. Those bad comparisons
stopped building when I dropped CanMakeCheckedPtr as a base class of Frame.

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/Forward.h:
* Source/WTF/wtf/WeakPtr.h:
* Source/WTF/wtf/WeakRef.h: Added.
(WTF::WeakRef::WeakRef):
(WTF::WeakRef::isHashTableDeletedValue const):
(WTF::WeakRef::isHashTableEmptyValue const):
(WTF::WeakRef::ptr const):
(WTF::WeakRef::get const):
(WTF::WeakRef::operator T&amp; const):
(WTF::WeakRef::operator-&gt; const):
(WTF::WeakRef::canSafelyBeUsed const):
(WTF::WeakRef::implForObject):
(WTF::WeakRefHashTraits::emptyValue):
(WTF::WeakRefHashTraits::constructEmptyValue):
(WTF::WeakRefHashTraits::isEmptyValue):
(WTF::WeakRefHashTraits::peek):
(WTF::WeakRefHashTraits::take):
* Source/WebCore/editing/WebContentReader.h:
* Source/WebCore/loader/FrameLoader.cpp:
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/page/EventHandler.h:
* Source/WebCore/page/Frame.h:
* Source/WebCore/page/IntersectionObserver.cpp:
(WebCore::IntersectionObserver::computeIntersectionState const):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::shouldUpdateCompositingLayersAfterScrolling const):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::outermostFullscreenDocument const):
* Source/WebCore/page/Page.h:
(WebCore::Page::rootFrames const):

Canonical link: <a href="https://commits.webkit.org/271551@main">https://commits.webkit.org/271551@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b72eb83832aaa1c53a9c0eae0fcb3232563719a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28674 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7317 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30045 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31295 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26167 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29184 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9434 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4678 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26252 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28944 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6050 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24650 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5266 "Found 1 new API test failure: /WPE/TestWebKitWebView:/webkit/WebKitWebView/notification (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5409 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25653 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/32632 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/24796 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26249 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26097 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31661 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/27974 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5372 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3543 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29439 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6986 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/35291 "Built successfully") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/6878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5839 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7622 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3711 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5890 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->