### PR TITLE
Web Extensions: menuId and parentMenuId is wrong in the menus API.

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -341,6 +341,8 @@ public:
     WebExtensionMenuItem* menuItem(const String& identifier) const;
     void performMenuItem(WebExtensionMenuItem&, const WebExtensionMenuItemContextParameters&, UserTriggered = UserTriggered::No);
 
+    CocoaMenuItem *singleMenuItemOrExtensionItemWithSubmenu(const WebExtensionMenuItemContextParameters&) const;
+
 #if PLATFORM(MAC)
     void addItemsToContextMenu(WebPageProxy&, const ContextMenuContextData&, NSMenu *);
 #endif

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm
@@ -74,9 +74,9 @@ static NSString * const frameURLKey = @"frameUrl";
 static NSString * const linkTextKey = @"linkText";
 static NSString * const linkURLKey = @"linkUrl";
 static NSString * const mediaTypeKey = @"mediaType";
-static NSString * const menuIDKey = @"menuId";
+static NSString * const menuItemIDKey = @"menuItemId";
 static NSString * const pageURLKey = @"pageUrl";
-static NSString * const parentMenuIDKey = @"parentMenuId";
+static NSString * const parentMenuItemIDKey = @"parentMenuItemId";
 static NSString * const selectionTextKey = @"selectionText";
 static NSString * const srcURLKey = @"srcUrl";
 static NSString * const wasCheckedKey = @"wasChecked";
@@ -463,10 +463,10 @@ void WebExtensionContextProxy::dispatchMenusClickedEvent(const WebExtensionMenuI
 
     auto *info = [NSMutableDictionary dictionary];
 
-    info[menuIDKey] = toMenuIdentifierWebAPI(menuItemParameters.identifier);
+    info[menuItemIDKey] = toMenuIdentifierWebAPI(menuItemParameters.identifier);
 
     if (menuItemParameters.parentIdentifier)
-        info[parentMenuIDKey] = toMenuIdentifierWebAPI(menuItemParameters.parentIdentifier.value());
+        info[parentMenuItemIDKey] = toMenuIdentifierWebAPI(menuItemParameters.parentIdentifier.value());
 
     if (isCheckedType(menuItemParameters.type.value())) {
         info[checkedKey] = @(menuItemParameters.checked.value_or(false));

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIMenus.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIMenus.mm
@@ -206,8 +206,8 @@ TEST(WKWebExtensionAPIMenus, ActionMenus)
         @"  browser.test.assertEq(typeof info, 'object')",
         @"  browser.test.assertEq(typeof tab, 'object')",
 
-        @"  browser.test.assertEq(info.menuId, 'top-level-1')",
-        @"  browser.test.assertEq(info.parentMenuId, undefined)",
+        @"  browser.test.assertEq(info.menuItemId, 'top-level-1')",
+        @"  browser.test.assertEq(info.parentMenuItemId, undefined)",
 
         @"  browser.test.assertEq(typeof tab.id, 'number')",
         @"  browser.test.assertEq(typeof tab.windowId, 'number')",
@@ -271,8 +271,8 @@ TEST(WKWebExtensionAPIMenus, ActionSubmenus)
         @"  browser.test.assertEq(typeof info, 'object')",
         @"  browser.test.assertEq(typeof tab, 'object')",
 
-        @"  browser.test.assertEq(info.menuId, 'submenu-1')",
-        @"  browser.test.assertEq(info.parentMenuId, 'top-level-1')",
+        @"  browser.test.assertEq(info.menuItemId, 'submenu-1')",
+        @"  browser.test.assertEq(info.parentMenuItemId, 'top-level-1')",
 
         @"  browser.test.notifyPass()",
         @"})",
@@ -373,8 +373,8 @@ TEST(WKWebExtensionAPIMenus, ActionSubmenusUpdate)
         @"  browser.test.assertEq(typeof info, 'object')",
         @"  browser.test.assertEq(typeof tab, 'object')",
 
-        @"  browser.test.assertEq(info.menuId, 'submenu-1')",
-        @"  browser.test.assertEq(info.parentMenuId, 'top-level-1')",
+        @"  browser.test.assertEq(info.menuItemId, 'submenu-1')",
+        @"  browser.test.assertEq(info.parentMenuItemId, 'top-level-1')",
 
         @"  browser.test.notifyPass()",
         @"})",
@@ -448,7 +448,7 @@ TEST(WKWebExtensionAPIMenus, TabMenus)
         @"  browser.test.assertEq(typeof info, 'object')",
         @"  browser.test.assertEq(typeof tab, 'object')",
 
-        @"  browser.test.assertEq(info.menuId, 'tab-item-1')",
+        @"  browser.test.assertEq(info.menuItemId, 'tab-item-1')",
         @"  browser.test.assertEq(typeof tab.id, 'number')",
 
         @"  browser.test.notifyPass()",
@@ -462,6 +462,16 @@ TEST(WKWebExtensionAPIMenus, TabMenus)
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Menus Created");
 
     auto *menuItems = [manager.get().context menuItemsForTab:manager.get().defaultTab];
+    EXPECT_EQ(menuItems.count, 1lu);
+
+#if USE(APPKIT)
+    menuItems = menuItems.firstObject.submenu.itemArray;
+#else
+    auto *parentMenu = dynamic_objc_cast<UIMenu>(menuItems.firstObject);
+    menuItems = parentMenu.children;
+#endif
+
+    EXPECT_EQ(menuItems.count, 2lu);
 
     auto *expectedTitles = @[ @"Tab Item 1", @"Tab Item 2" ];
     EXPECT_EQ(menuItems.count, expectedTitles.count);
@@ -520,6 +530,14 @@ TEST(WKWebExtensionAPIMenus, MenuItemProperties)
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Menus Created");
 
     auto *menuItems = [manager.get().context menuItemsForTab:manager.get().defaultTab];
+    EXPECT_EQ(menuItems.count, 1lu);
+
+#if USE(APPKIT)
+    menuItems = menuItems.firstObject.submenu.itemArray;
+#else
+    auto *parentMenu = dynamic_objc_cast<UIMenu>(menuItems.firstObject);
+    menuItems = parentMenu.children;
+#endif
 
     EXPECT_EQ(menuItems.count, 2lu);
 
@@ -601,6 +619,14 @@ TEST(WKWebExtensionAPIMenus, MenuItemPropertiesUpdate)
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Menus Created");
 
     auto *menuItems = [manager.get().context menuItemsForTab:manager.get().defaultTab];
+    EXPECT_EQ(menuItems.count, 1lu);
+
+#if USE(APPKIT)
+    menuItems = menuItems.firstObject.submenu.itemArray;
+#else
+    auto *parentMenu = dynamic_objc_cast<UIMenu>(menuItems.firstObject);
+    menuItems = parentMenu.children;
+#endif
 
     EXPECT_EQ(menuItems.count, 2lu);
 
@@ -649,10 +675,10 @@ TEST(WKWebExtensionAPIMenus, ToggleCheckboxMenuItems)
         @"let clickCount = 0",
 
         @"browser.menus.onClicked.addListener((info) => {",
-        @"  if (info.menuId === 'checkbox-1') {",
+        @"  if (info.menuItemId === 'checkbox-1') {",
         @"    browser.test.assertTrue(info.wasChecked)",
         @"    browser.test.assertFalse(info.checked)",
-        @"  } else if (info.menuId === 'checkbox-2') {",
+        @"  } else if (info.menuItemId === 'checkbox-2') {",
         @"    browser.test.assertFalse(info.wasChecked)",
         @"    browser.test.assertTrue(info.checked)",
         @"  }",
@@ -669,6 +695,15 @@ TEST(WKWebExtensionAPIMenus, ToggleCheckboxMenuItems)
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Menus Created");
 
     auto *menuItems = [manager.get().context menuItemsForTab:manager.get().defaultTab];
+    EXPECT_EQ(menuItems.count, 1lu);
+
+#if USE(APPKIT)
+    menuItems = menuItems.firstObject.submenu.itemArray;
+#else
+    auto *parentMenu = dynamic_objc_cast<UIMenu>(menuItems.firstObject);
+    menuItems = parentMenu.children;
+#endif
+
     EXPECT_EQ(menuItems.count, 2lu);
 
     auto *checkbox1 = dynamic_objc_cast<CocoaMenuAction>(menuItems.firstObject);
@@ -687,6 +722,16 @@ TEST(WKWebExtensionAPIMenus, ToggleCheckboxMenuItems)
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Menus Clicked");
 
     auto *updatedMenuItems = [manager.get().context menuItemsForTab:manager.get().defaultTab];
+    EXPECT_EQ(updatedMenuItems.count, 1lu);
+
+#if USE(APPKIT)
+    updatedMenuItems = updatedMenuItems.firstObject.submenu.itemArray;
+#else
+    parentMenu = dynamic_objc_cast<UIMenu>(updatedMenuItems.firstObject);
+    updatedMenuItems = parentMenu.children;
+#endif
+
+    EXPECT_EQ(updatedMenuItems.count, 2lu);
 
     checkbox1 = dynamic_objc_cast<CocoaMenuAction>(updatedMenuItems.firstObject);
     checkbox2 = dynamic_objc_cast<CocoaMenuAction>(updatedMenuItems.lastObject);
@@ -744,10 +789,10 @@ TEST(WKWebExtensionAPIMenus, RadioItemGrouping)
         @"let clickCount = 0",
 
         @"browser.menus.onClicked.addListener((info) => {",
-        @"  if (info.menuId === 'radio-2-group-1') {",
+        @"  if (info.menuItemId === 'radio-2-group-1') {",
         @"    browser.test.assertTrue(info.wasChecked)",
         @"    browser.test.assertTrue(info.checked)",
-        @"  } else if (info.menuId === 'radio-2-group-2') {",
+        @"  } else if (info.menuItemId === 'radio-2-group-2') {",
         @"    browser.test.assertFalse(info.wasChecked)",
         @"    browser.test.assertTrue(info.checked)",
         @"  }",
@@ -764,6 +809,15 @@ TEST(WKWebExtensionAPIMenus, RadioItemGrouping)
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Menus Created");
 
     auto *menuItems = [manager.get().context menuItemsForTab:manager.get().defaultTab];
+    EXPECT_EQ(menuItems.count, 1lu);
+
+#if USE(APPKIT)
+    menuItems = menuItems.firstObject.submenu.itemArray;
+#else
+    auto *parentMenu = dynamic_objc_cast<UIMenu>(menuItems.firstObject);
+    menuItems = parentMenu.children;
+#endif
+
     EXPECT_EQ(menuItems.count, 6lu);
 
     auto *radio1Group1 = dynamic_objc_cast<CocoaMenuAction>(menuItems[0]);
@@ -787,6 +841,16 @@ TEST(WKWebExtensionAPIMenus, RadioItemGrouping)
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Menus Clicked");
 
     auto *updatedMenuItems = [manager.get().context menuItemsForTab:manager.get().defaultTab];
+    EXPECT_EQ(updatedMenuItems.count, 1lu);
+
+#if USE(APPKIT)
+    updatedMenuItems = updatedMenuItems.firstObject.submenu.itemArray;
+#else
+    parentMenu = dynamic_objc_cast<UIMenu>(updatedMenuItems.firstObject);
+    updatedMenuItems = parentMenu.children;
+#endif
+
+    EXPECT_EQ(updatedMenuItems.count, 6lu);
 
     radio1Group1 = dynamic_objc_cast<CocoaMenuAction>(updatedMenuItems[0]);
     radio2Group1 = dynamic_objc_cast<CocoaMenuAction>(updatedMenuItems[1]);
@@ -815,7 +879,7 @@ TEST(WKWebExtensionAPIMenus, OnClick)
         @"    browser.test.assertEq(typeof info, 'object')",
         @"    browser.test.assertEq(typeof tab, 'object')",
 
-        @"    browser.test.assertEq(info.menuId, 'click-item')",
+        @"    browser.test.assertEq(info.menuItemId, 'click-item')",
         @"    browser.test.assertEq(typeof tab.id, 'number')",
 
         @"    browser.test.notifyPass()",
@@ -828,7 +892,6 @@ TEST(WKWebExtensionAPIMenus, OnClick)
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Menu Item Created");
 
     auto *menuItems = [manager.get().context menuItemsForTab:manager.get().defaultTab];
-
     EXPECT_EQ(menuItems.count, 1lu);
 
     performMenuItemAction(menuItems.firstObject);
@@ -850,7 +913,7 @@ TEST(WKWebExtensionAPIMenus, OnClickAfterUpdate)
         @"    browser.test.assertEq(typeof info, 'object')",
         @"    browser.test.assertEq(typeof tab, 'object')",
 
-        @"    browser.test.assertEq(info.menuId, 'click-item')",
+        @"    browser.test.assertEq(info.menuItemId, 'click-item')",
         @"    browser.test.assertEq(typeof tab.id, 'number')",
 
         @"    browser.test.notifyPass()",
@@ -865,7 +928,6 @@ TEST(WKWebExtensionAPIMenus, OnClickAfterUpdate)
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Menu Item Created");
 
     auto *menuItems = [manager.get().context menuItemsForTab:manager.get().defaultTab];
-
     EXPECT_EQ(menuItems.count, 1lu);
 
     performMenuItemAction(menuItems.firstObject);
@@ -903,8 +965,8 @@ TEST(WKWebExtensionAPIMenus, MacContextMenuItems)
         @"  browser.test.assertEq(typeof info, 'object')",
         @"  browser.test.assertEq(typeof tab, 'object')",
 
-        @"  browser.test.assertEq(info.menuId, 'context-menu-1')",
-        @"  browser.test.assertEq(info.parentMenuId, undefined)",
+        @"  browser.test.assertEq(info.menuItemId, 'context-menu-1')",
+        @"  browser.test.assertEq(info.parentMenuItemId, undefined)",
         @"  browser.test.assertEq(info.selectionText, undefined)",
         @"  browser.test.assertEq(typeof info.pageUrl, 'string')",
         @"  browser.test.assertTrue(info.pageUrl.startsWith('http://localhost:'))",
@@ -998,8 +1060,8 @@ TEST(WKWebExtensionAPIMenus, MacActiveTabContextMenuItems)
         @"  browser.test.assertEq(typeof info, 'object')",
         @"  browser.test.assertEq(typeof tab, 'object')",
 
-        @"  browser.test.assertEq(info.menuId, 'context-menu')",
-        @"  browser.test.assertEq(info.parentMenuId, undefined)",
+        @"  browser.test.assertEq(info.menuItemId, 'context-menu')",
+        @"  browser.test.assertEq(info.parentMenuItemId, undefined)",
         @"  browser.test.assertEq(info.selectionText, undefined)",
         @"  browser.test.assertEq(typeof info.pageUrl, 'string')",
         @"  browser.test.assertTrue(info.pageUrl.startsWith('http://localhost:'))",
@@ -1094,8 +1156,8 @@ TEST(WKWebExtensionAPIMenus, MacURLPatternContextMenuItems)
         @"  browser.test.assertEq(typeof info, 'object')",
         @"  browser.test.assertEq(typeof tab, 'object')",
 
-        @"  browser.test.assertEq(info.menuId, 'url-pattern-menu-item')",
-        @"  browser.test.assertEq(info.parentMenuId, undefined)",
+        @"  browser.test.assertEq(info.menuItemId, 'url-pattern-menu-item')",
+        @"  browser.test.assertEq(info.parentMenuItemId, undefined)",
         @"  browser.test.assertEq(info.selectionText, 'Large Example Link')",
         @"  browser.test.assertEq(info.linkText, 'Large Example Link')",
         @"  browser.test.assertEq(info.linkUrl, 'http://example.com/test')",
@@ -1181,8 +1243,8 @@ TEST(WKWebExtensionAPIMenus, MacSelectionContextMenuItems)
         @"  browser.test.assertEq(typeof info, 'object')",
         @"  browser.test.assertEq(typeof tab, 'object')",
 
-        @"  browser.test.assertEq(info.menuId, 'selection-menu-item')",
-        @"  browser.test.assertEq(info.parentMenuId, undefined)",
+        @"  browser.test.assertEq(info.menuItemId, 'selection-menu-item')",
+        @"  browser.test.assertEq(info.parentMenuItemId, undefined)",
         @"  browser.test.assertEq(info.selectionText, 'Example ')",
         @"  browser.test.assertEq(typeof info.pageUrl, 'string')",
         @"  browser.test.assertTrue(info.pageUrl.startsWith('http://localhost:'))",
@@ -1265,8 +1327,8 @@ TEST(WKWebExtensionAPIMenus, MacLinkContextMenuItems)
         @"  browser.test.assertEq(typeof info, 'object')",
         @"  browser.test.assertEq(typeof tab, 'object')",
 
-        @"  browser.test.assertEq(info.menuId, 'link-menu-item')",
-        @"  browser.test.assertEq(info.parentMenuId, undefined)",
+        @"  browser.test.assertEq(info.menuItemId, 'link-menu-item')",
+        @"  browser.test.assertEq(info.parentMenuItemId, undefined)",
         @"  browser.test.assertEq(info.selectionText, 'Large Example Link')",
         @"  browser.test.assertEq(info.linkText, 'Large Example Link')",
         @"  browser.test.assertEq(info.linkUrl, 'http://example.com/test')",
@@ -1350,8 +1412,8 @@ TEST(WKWebExtensionAPIMenus, MacImageContextMenuItems)
         @"  browser.test.assertEq(typeof info, 'object')",
         @"  browser.test.assertEq(typeof tab, 'object')",
 
-        @"  browser.test.assertEq(info.menuId, 'image-menu-item')",
-        @"  browser.test.assertEq(info.parentMenuId, undefined)",
+        @"  browser.test.assertEq(info.menuItemId, 'image-menu-item')",
+        @"  browser.test.assertEq(info.parentMenuItemId, undefined)",
         @"  browser.test.assertEq(info.mediaType, 'image')",
         @"  browser.test.assertEq(info.srcUrl, 'http://example.com/example.png')",
         @"  browser.test.assertEq(typeof info.pageUrl, 'string')",
@@ -1434,8 +1496,8 @@ TEST(WKWebExtensionAPIMenus, MacVideoContextMenuItems)
         @"  browser.test.assertEq(typeof info, 'object')",
         @"  browser.test.assertEq(typeof tab, 'object')",
 
-        @"  browser.test.assertEq(info.menuId, 'video-menu-item')",
-        @"  browser.test.assertEq(info.parentMenuId, undefined)",
+        @"  browser.test.assertEq(info.menuItemId, 'video-menu-item')",
+        @"  browser.test.assertEq(info.parentMenuItemId, undefined)",
         @"  browser.test.assertEq(info.mediaType, 'video')",
         @"  browser.test.assertEq(info.srcUrl, 'http://example.com/example.mp4')",
         @"  browser.test.assertEq(typeof info.pageUrl, 'string')",
@@ -1518,8 +1580,8 @@ TEST(WKWebExtensionAPIMenus, MacAudioContextMenuItems)
         @"  browser.test.assertEq(typeof info, 'object')",
         @"  browser.test.assertEq(typeof tab, 'object')",
 
-        @"  browser.test.assertEq(info.menuId, 'audio-menu-item')",
-        @"  browser.test.assertEq(info.parentMenuId, undefined)",
+        @"  browser.test.assertEq(info.menuItemId, 'audio-menu-item')",
+        @"  browser.test.assertEq(info.parentMenuItemId, undefined)",
         @"  browser.test.assertEq(info.mediaType, 'audio')",
         @"  browser.test.assertEq(info.srcUrl, 'http://example.com/example.mp3')",
         @"  browser.test.assertEq(typeof info.pageUrl, 'string')",
@@ -1602,8 +1664,8 @@ TEST(WKWebExtensionAPIMenus, MacEditableContextMenuItems)
         @"  browser.test.assertEq(typeof info, 'object')",
         @"  browser.test.assertEq(typeof tab, 'object')",
 
-        @"  browser.test.assertEq(info.menuId, 'editable-menu-item')",
-        @"  browser.test.assertEq(info.parentMenuId, undefined)",
+        @"  browser.test.assertEq(info.menuItemId, 'editable-menu-item')",
+        @"  browser.test.assertEq(info.parentMenuItemId, undefined)",
         @"  browser.test.assertEq(info.selectionText, 'Area')",
         @"  browser.test.assertEq(info.editable, true)",
 
@@ -1682,8 +1744,8 @@ TEST(WKWebExtensionAPIMenus, MacFrameContextMenuItems)
         @"  browser.test.assertEq(typeof info, 'object')",
         @"  browser.test.assertEq(typeof tab, 'object')",
 
-        @"  browser.test.assertEq(info.menuId, 'frame-menu-item')",
-        @"  browser.test.assertEq(info.parentMenuId, undefined)",
+        @"  browser.test.assertEq(info.menuItemId, 'frame-menu-item')",
+        @"  browser.test.assertEq(info.parentMenuItemId, undefined)",
         @"  browser.test.assertEq(info.selectionText, undefined)",
         @"  browser.test.assertEq(typeof info.frameUrl, 'string')",
         @"  browser.test.assertTrue(info.frameUrl.endsWith('frame.html'))",


### PR DESCRIPTION
#### cec52d1f1d681336033df01c7a8f099510086fb7
<pre>
Web Extensions: menuId and parentMenuId is wrong in the menus API.
<a href="https://webkit.org/b/265843">https://webkit.org/b/265843</a>
<a href="https://rdar.apple.com/problem/119164396">rdar://problem/119164396</a>

Reviewed by Brian Weinstein.

Fix the keys we use for menuItemId and parentMenuItemId. Also make tab menu items
collapse into an extension titled submenu since these will often be next to other
extensions and should be grouped to prevent overloading menus. This can be shared
with the implementation we had for extension context menus.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::platformMenuItems const):
(WebKit::WebExtensionContext::singleMenuItemOrExtensionItemWithSubmenu const):
(WebKit::WebExtensionContext::addItemsToContextMenu):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm:
(WebKit::WebExtensionContextProxy::dispatchMenusClickedEvent):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIMenus.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/271560@main">https://commits.webkit.org/271560@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e9e142471a10c52dc9c7213bb5c982c1077de244

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28712 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7355 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30083 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31331 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26198 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29282 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9476 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4715 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26269 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28982 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6080 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24675 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5285 "Found 1 new API test failure: /WPE/TestWebKitWebView:/webkit/WebKitWebView/notification (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5436 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25679 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/32669 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26278 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26122 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31675 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5403 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3574 "Found 1 new test failure: imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-createDataChannel.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29452 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7020 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5870 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3714 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5921 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->