### PR TITLE
[WebAuthn] Implement condition assertions using modern AuthenticationServices API

### DIFF
--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticationServicesForwardDeclarations.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticationServicesForwardDeclarations.h
@@ -87,7 +87,6 @@ typedef NSString *ASAuthorizationPublicKeyCredentialAttestationKind;
 @interface ASAuthorizationController : NSObject
 @property (nonatomic, weak, nullable) id<ASAuthorizationControllerDelegate> delegate;
 @property (nonatomic, weak, nullable) id<ASAuthorizationControllerPresentationContextProviding> presentationContextProvider;
-- (void)performRequests;
 
 - (void)cancel;
 
@@ -95,6 +94,9 @@ typedef NSString *ASAuthorizationPublicKeyCredentialAttestationKind;
 
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithAuthorizationRequests:(NSArray<ASAuthorizationRequest *> *)authorizationRequests;
+
+- (void)performRequests;
+- (void)performAutoFillAssistedRequests;
 @end
 
 @protocol ASAuthorizationPublicKeyCredentialRegistrationRequest <NSObject, NSSecureCoding, NSCopying>

--- a/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.h
@@ -77,6 +77,11 @@ public:
     explicit WebAuthenticatorCoordinatorProxy(WebPageProxy&);
     ~WebAuthenticatorCoordinatorProxy();
 
+#if HAVE(WEB_AUTHN_AS_MODERN)
+    void pauseConditionalAssertion();
+    void unpauseConditionalAssertion();
+#endif
+
 private:
     using QueryCompletionHandler = CompletionHandler<void(bool)>;
 
@@ -113,6 +118,8 @@ private:
     RequestCompletionHandler m_completionHandler;
     RetainPtr<_WKASDelegate> m_delegate;
     RetainPtr<ASAuthorizationController> m_controller;
+    bool m_paused { false };
+    bool m_isConditionalAssertion { false };
 #endif
 
     RetainPtr<ASCAuthorizationRemotePresenter> m_presenter;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2658,6 +2658,15 @@ void WebPageProxy::dispatchActivityStateChange()
             viewDidLeaveWindow();
     }
 
+#if ENABLE(WEB_AUTHN) && HAVE(WEB_AUTHN_AS_MODERN)
+    if ((changed & ActivityState::WindowIsActive) && m_credentialsMessenger) {
+        if (pageClient().isViewWindowActive())
+            m_credentialsMessenger->unpauseConditionalAssertion();
+        else
+            m_credentialsMessenger->pauseConditionalAssertion();
+    }
+#endif
+
     updateBackingStoreDiscardableState();
 
     if (activityStateChangeID != ActivityStateChangeAsynchronous)


### PR DESCRIPTION
#### a883b11930236ca5627ecce3162380bbaa76f517
<pre>
[WebAuthn] Implement condition assertions using modern AuthenticationServices API
<a href="https://bugs.webkit.org/show_bug.cgi?id=265838">https://bugs.webkit.org/show_bug.cgi?id=265838</a>
<a href="https://rdar.apple.com/113571152">rdar://113571152</a>

Reviewed by Brent Fulgham.

This patch implements conditional assertions using the modern AuthenticationServices
framework. AuthenticationServices only allows one ongoing autofill request per process,
so this patch cancels and restarts conditional assertion requests as necessary depending on
the active page.

* Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticationServicesForwardDeclarations.h:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm:
(WebKit::WebAuthenticatorCoordinatorProxy::pauseConditionalAssertion):
(WebKit::WebAuthenticatorCoordinatorProxy::unpauseConditionalAssertion):
(WebKit::WebAuthenticatorCoordinatorProxy::performRequest):
* Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::dispatchActivityStateChange):

Canonical link: <a href="https://commits.webkit.org/271662@main">https://commits.webkit.org/271662@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22ce9f3f505bf5ac318d14ee63561113136e0763

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29146 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7814 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30482 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31737 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26516 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9943 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5119 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26520 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29418 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6451 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24969 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5589 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5719 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33076 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26606 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26436 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31969 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5701 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3883 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29754 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7370 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6959 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6209 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6222 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->