### PR TITLE
[WebGPU] Crash in Buffer::getMappedRange if size is 0

### DIFF
--- a/Source/WebGPU/WebGPU/Buffer.mm
+++ b/Source/WebGPU/WebGPU/Buffer.mm
@@ -114,8 +114,7 @@ Ref<Buffer> Device::createBuffer(const WGPUBufferDescriptor& descriptor)
     if (!validateCreateBuffer(*this, descriptor)) {
         generateAValidationError("Validation failure."_s);
 
-        if (!validateCreateBuffer(*this, descriptor))
-            return Buffer::createInvalid(*this);
+        return Buffer::createInvalid(*this);
     }
 
     // FIXME(PERFORMANCE): Consider write-combining CPU cache mode.
@@ -211,7 +210,7 @@ void* Buffer::getMappedRange(size_t offset, size_t size)
 {
     // https://gpuweb.github.io/gpuweb/#dom-gpubuffer-getmappedrange
     if (!isValid()) {
-        m_emptyBuffer.resize(size);
+        m_emptyBuffer.resize(std::max<size_t>(size, 1));
         return &m_emptyBuffer[0];
     }
 


### PR DESCRIPTION
#### 53d6c3698548446f66f32ace8fdf610bd324ec78
<pre>
[WebGPU] Crash in Buffer::getMappedRange if size is 0
<a href="https://bugs.webkit.org/show_bug.cgi?id=265850">https://bugs.webkit.org/show_bug.cgi?id=265850</a>
&lt;radar://119168913&gt;

Reviewed by Dan Glastonbury.

Buffer::getMappedRange should return a valid pointer
even if validation fails, so ensure that size is &gt;= 1
otherwise the pointer will not be valid.

* Source/WebGPU/WebGPU/Buffer.mm:
(WebGPU::Device::createBuffer):
Remove redundant validation call.
(WebGPU::Buffer::getMappedRange):

Canonical link: <a href="https://commits.webkit.org/271539@main">https://commits.webkit.org/271539@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f6977186051c9b7d1570b04b77a6a3b757d6a69

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28713 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7356 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30084 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31332 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/26199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9477 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4716 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28983 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6081 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24677 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5287 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/5437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/32670 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26279 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26124 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31677 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5404 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/3575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/29454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7021 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6869 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5871 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5922 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->