### PR TITLE
[WGSL] Type::alignment should return 1 for bool

### DIFF
--- a/Source/WebGPU/WGSL/Types.cpp
+++ b/Source/WebGPU/WGSL/Types.cpp
@@ -282,6 +282,7 @@ unsigned Type::size() const
             case Types::Primitive::U32:
                 return 4;
             case Types::Primitive::Bool:
+                return 1;
             case Types::Primitive::Void:
             case Types::Primitive::AbstractInt:
             case Types::Primitive::AbstractFloat:
@@ -356,6 +357,7 @@ unsigned Type::alignment() const
             case Types::Primitive::U32:
                 return 4;
             case Types::Primitive::Bool:
+                return 1;
             case Types::Primitive::Void:
             case Types::Primitive::AbstractInt:
             case Types::Primitive::AbstractFloat:


### PR DESCRIPTION
#### 4d2e7619a5200f166ad98b550233f7c534655d33
<pre>
[WGSL] Type::alignment should return 1 for bool
<a href="https://bugs.webkit.org/show_bug.cgi?id=265852">https://bugs.webkit.org/show_bug.cgi?id=265852</a>
&lt;radar://119169937&gt;

Reviewed by Tadeu Zagallo.

Per the MSL specification, size and alignment of bool is 1.

* Source/WebGPU/WGSL/Types.cpp:
(WGSL::Type::size const):
(WGSL::Type::alignment const):

Canonical link: <a href="https://commits.webkit.org/271559@main">https://commits.webkit.org/271559@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df9023e6e1cd6e68aea918969f24dc8f33375006

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28716 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7359 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30087 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31335 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26202 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9480 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4719 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26273 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28986 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6083 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24680 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5289 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5439 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/32673 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26281 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26127 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31681 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5407 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3578 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29458 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7024 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6883 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5874 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5925 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->