### PR TITLE
[WebGPU] Several limits in HardwareCapabilities.mm are not realistic

### DIFF
--- a/Source/WebGPU/WebGPU/HardwareCapabilities.mm
+++ b/Source/WebGPU/WebGPU/HardwareCapabilities.mm
@@ -34,10 +34,9 @@
 
 namespace WebGPU {
 
-static constexpr uint32_t maxUInt32Limit()
+static constexpr uint32_t largeReasonableLimit()
 {
-    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=252873
-    return std::numeric_limits<uint32_t>::max() - 1;
+    return USHRT_MAX;
 }
 
 // https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf
@@ -133,21 +132,21 @@ static HardwareCapabilities apple3(id<MTLDevice> device)
             .maxBindGroups =    maxBindGroups,
             .maxBindGroupsPlusVertexBuffers = 30,
             .maxBindingsPerBindGroup =  1000,
-            .maxDynamicUniformBuffersPerPipelineLayout =    maxUInt32Limit(),
-            .maxDynamicStorageBuffersPerPipelineLayout =    maxUInt32Limit(),
-            .maxSampledTexturesPerShaderStage =    maxBindGroups * 31,
+            .maxDynamicUniformBuffersPerPipelineLayout =    largeReasonableLimit(),
+            .maxDynamicStorageBuffersPerPipelineLayout =    largeReasonableLimit(),
+            .maxSampledTexturesPerShaderStage =    maxBindGroups * 30,
             .maxSamplersPerShaderStage =    maxBindGroups * 16,
-            .maxStorageBuffersPerShaderStage =    maxBindGroups * 31,
-            .maxStorageTexturesPerShaderStage =    maxBindGroups * 31,
-            .maxUniformBuffersPerShaderStage =    maxBindGroups * 31,
+            .maxStorageBuffersPerShaderStage =    maxBindGroups * 30,
+            .maxStorageTexturesPerShaderStage =    maxBindGroups * 30,
+            .maxUniformBuffersPerShaderStage =    maxBindGroups * 30,
             .maxUniformBufferBindingSize =    0, // To be filled in by the caller.
             .maxStorageBufferBindingSize =    0, // To be filled in by the caller.
             .minUniformBufferOffsetAlignment =    32,
             .minStorageBufferOffsetAlignment =    32,
             .maxVertexBuffers =    30,
             .maxBufferSize = device.maxBufferLength,
-            .maxVertexAttributes =    31,
-            .maxVertexBufferArrayStride =    maxUInt32Limit(),
+            .maxVertexAttributes =    30,
+            .maxVertexBufferArrayStride =    largeReasonableLimit(),
             .maxInterStageShaderComponents =    60,
             .maxInterStageShaderVariables =    124,
             .maxColorAttachments =    8,
@@ -157,7 +156,7 @@ static HardwareCapabilities apple3(id<MTLDevice> device)
             .maxComputeWorkgroupSizeX =    512,
             .maxComputeWorkgroupSizeY =    512,
             .maxComputeWorkgroupSizeZ =    512,
-            .maxComputeWorkgroupsPerDimension =    maxUInt32Limit(),
+            .maxComputeWorkgroupsPerDimension =    largeReasonableLimit(),
         },
         WTFMove(features),
         baseCapabilities,
@@ -189,8 +188,8 @@ static HardwareCapabilities apple4(id<MTLDevice> device)
             .maxBindGroups =    maxBindGroups,
             .maxBindGroupsPlusVertexBuffers = 30,
             .maxBindingsPerBindGroup =  1000,
-            .maxDynamicUniformBuffersPerPipelineLayout =    maxUInt32Limit(),
-            .maxDynamicStorageBuffersPerPipelineLayout =    maxUInt32Limit(),
+            .maxDynamicUniformBuffersPerPipelineLayout =    largeReasonableLimit(),
+            .maxDynamicStorageBuffersPerPipelineLayout =    largeReasonableLimit(),
             .maxSampledTexturesPerShaderStage =    maxBindGroups * 96,
             .maxSamplersPerShaderStage =    maxBindGroups * 16,
             .maxStorageBuffersPerShaderStage =    maxBindGroups * 96,
@@ -202,8 +201,8 @@ static HardwareCapabilities apple4(id<MTLDevice> device)
             .minStorageBufferOffsetAlignment =    32,
             .maxVertexBuffers =    30,
             .maxBufferSize =    device.maxBufferLength,
-            .maxVertexAttributes =    31,
-            .maxVertexBufferArrayStride =    maxUInt32Limit(),
+            .maxVertexAttributes =    30,
+            .maxVertexBufferArrayStride =    largeReasonableLimit(),
             .maxInterStageShaderComponents =    124,
             .maxInterStageShaderVariables =    124,
             .maxColorAttachments =    8,
@@ -213,7 +212,7 @@ static HardwareCapabilities apple4(id<MTLDevice> device)
             .maxComputeWorkgroupSizeX =    1024,
             .maxComputeWorkgroupSizeY =    1024,
             .maxComputeWorkgroupSizeZ =    1024,
-            .maxComputeWorkgroupsPerDimension =    maxUInt32Limit(),
+            .maxComputeWorkgroupsPerDimension =    largeReasonableLimit(),
         },
         WTFMove(features),
         baseCapabilities,
@@ -245,8 +244,8 @@ static HardwareCapabilities apple5(id<MTLDevice> device)
             .maxBindGroups =    maxBindGroups,
             .maxBindGroupsPlusVertexBuffers = 30,
             .maxBindingsPerBindGroup =  1000,
-            .maxDynamicUniformBuffersPerPipelineLayout =    maxUInt32Limit(),
-            .maxDynamicStorageBuffersPerPipelineLayout =    maxUInt32Limit(),
+            .maxDynamicUniformBuffersPerPipelineLayout =    largeReasonableLimit(),
+            .maxDynamicStorageBuffersPerPipelineLayout =    largeReasonableLimit(),
             .maxSampledTexturesPerShaderStage =    maxBindGroups * 96,
             .maxSamplersPerShaderStage =    maxBindGroups * 16,
             .maxStorageBuffersPerShaderStage =    maxBindGroups * 96,
@@ -258,8 +257,8 @@ static HardwareCapabilities apple5(id<MTLDevice> device)
             .minStorageBufferOffsetAlignment =    32,
             .maxVertexBuffers =    30,
             .maxBufferSize =    device.maxBufferLength,
-            .maxVertexAttributes =    31,
-            .maxVertexBufferArrayStride =    maxUInt32Limit(),
+            .maxVertexAttributes =    30,
+            .maxVertexBufferArrayStride =    largeReasonableLimit(),
             .maxInterStageShaderComponents =    124,
             .maxInterStageShaderVariables = 124,
             .maxColorAttachments = 8,
@@ -269,7 +268,7 @@ static HardwareCapabilities apple5(id<MTLDevice> device)
             .maxComputeWorkgroupSizeX =    1024,
             .maxComputeWorkgroupSizeY =    1024,
             .maxComputeWorkgroupSizeZ =    1024,
-            .maxComputeWorkgroupsPerDimension =    maxUInt32Limit(),
+            .maxComputeWorkgroupsPerDimension =    largeReasonableLimit(),
         },
         WTFMove(features),
         baseCapabilities,
@@ -301,22 +300,22 @@ static HardwareCapabilities apple6(id<MTLDevice> device)
             .maxTextureArrayLayers =    2048,
             .maxBindGroups =    maxBindGroups,
             .maxBindGroupsPlusVertexBuffers = 30,
-            .maxBindingsPerBindGroup =    500000,
-            .maxDynamicUniformBuffersPerPipelineLayout =    maxUInt32Limit(),
-            .maxDynamicStorageBuffersPerPipelineLayout =    maxUInt32Limit(),
-            .maxSampledTexturesPerShaderStage =    maxBindGroups * 500000 / 2,
-            .maxSamplersPerShaderStage =    maxBindGroups * 1024,
-            .maxStorageBuffersPerShaderStage =    maxBindGroups * 500000 / 2,
-            .maxStorageTexturesPerShaderStage =    maxBindGroups * 500000 / 2,
-            .maxUniformBuffersPerShaderStage =    maxBindGroups * 500000 / 2,
+            .maxBindingsPerBindGroup =    largeReasonableLimit(),
+            .maxDynamicUniformBuffersPerPipelineLayout =    largeReasonableLimit(),
+            .maxDynamicStorageBuffersPerPipelineLayout =    largeReasonableLimit(),
+            .maxSampledTexturesPerShaderStage =    maxBindGroups * 96,
+            .maxSamplersPerShaderStage =    maxBindGroups * 16,
+            .maxStorageBuffersPerShaderStage =    maxBindGroups * 96,
+            .maxStorageTexturesPerShaderStage =    maxBindGroups * 96,
+            .maxUniformBuffersPerShaderStage =    maxBindGroups * 96,
             .maxUniformBufferBindingSize =    0, // To be filled in by the caller.
             .maxStorageBufferBindingSize =    0, // To be filled in by the caller.
             .minUniformBufferOffsetAlignment =    32,
             .minStorageBufferOffsetAlignment =    32,
             .maxVertexBuffers =    30,
             .maxBufferSize = device.maxBufferLength,
-            .maxVertexAttributes =    31,
-            .maxVertexBufferArrayStride =    maxUInt32Limit(),
+            .maxVertexAttributes =    30,
+            .maxVertexBufferArrayStride =    largeReasonableLimit(),
             .maxInterStageShaderComponents =    124,
             .maxInterStageShaderVariables = 124,
             .maxColorAttachments = 8,
@@ -326,7 +325,7 @@ static HardwareCapabilities apple6(id<MTLDevice> device)
             .maxComputeWorkgroupSizeX =    1024,
             .maxComputeWorkgroupSizeY =    1024,
             .maxComputeWorkgroupSizeZ =    1024,
-            .maxComputeWorkgroupsPerDimension =    maxUInt32Limit(),
+            .maxComputeWorkgroupsPerDimension =    largeReasonableLimit(),
         },
         WTFMove(features),
         baseCapabilities,
@@ -357,22 +356,22 @@ static HardwareCapabilities apple7(id<MTLDevice> device)
             .maxTextureArrayLayers =    2048,
             .maxBindGroups =    maxBindGroups,
             .maxBindGroupsPlusVertexBuffers = 30,
-            .maxBindingsPerBindGroup =    500000,
-            .maxDynamicUniformBuffersPerPipelineLayout =    maxUInt32Limit(),
-            .maxDynamicStorageBuffersPerPipelineLayout =    maxUInt32Limit(),
-            .maxSampledTexturesPerShaderStage =    maxBindGroups * 500000 / 2,
-            .maxSamplersPerShaderStage =    maxBindGroups * 1024,
-            .maxStorageBuffersPerShaderStage =    maxBindGroups * 500000 / 2,
-            .maxStorageTexturesPerShaderStage =    maxBindGroups * 500000 / 2,
-            .maxUniformBuffersPerShaderStage =    maxBindGroups * 500000 / 2,
+            .maxBindingsPerBindGroup =    largeReasonableLimit(),
+            .maxDynamicUniformBuffersPerPipelineLayout =    largeReasonableLimit(),
+            .maxDynamicStorageBuffersPerPipelineLayout =    largeReasonableLimit(),
+            .maxSampledTexturesPerShaderStage =    maxBindGroups * 96,
+            .maxSamplersPerShaderStage =    maxBindGroups * 16,
+            .maxStorageBuffersPerShaderStage =    maxBindGroups * 96,
+            .maxStorageTexturesPerShaderStage =    maxBindGroups * 96,
+            .maxUniformBuffersPerShaderStage =    maxBindGroups * 96,
             .maxUniformBufferBindingSize =    0, // To be filled in by the caller.
             .maxStorageBufferBindingSize =    0, // To be filled in by the caller.
             .minUniformBufferOffsetAlignment =    32,
             .minStorageBufferOffsetAlignment =    32,
             .maxVertexBuffers =    30,
             .maxBufferSize = device.maxBufferLength,
-            .maxVertexAttributes =    31,
-            .maxVertexBufferArrayStride =    maxUInt32Limit(),
+            .maxVertexAttributes =    30,
+            .maxVertexBufferArrayStride =    largeReasonableLimit(),
             .maxInterStageShaderComponents =    124,
             .maxInterStageShaderVariables =    124,
             .maxColorAttachments = 8,
@@ -382,7 +381,7 @@ static HardwareCapabilities apple7(id<MTLDevice> device)
             .maxComputeWorkgroupSizeX =    1024,
             .maxComputeWorkgroupSizeY =    1024,
             .maxComputeWorkgroupSizeZ =    1024,
-            .maxComputeWorkgroupsPerDimension =    maxUInt32Limit(),
+            .maxComputeWorkgroupsPerDimension =    largeReasonableLimit(),
         },
         WTFMove(features),
         baseCapabilities,
@@ -404,20 +403,19 @@ static HardwareCapabilities mac2(id<MTLDevice> device)
     uint32_t buffersPerBindGroup = 0;
     uint32_t texturesPerBindGroup = 0;
     uint32_t samplersPerBindGroup = 0;
+    constexpr uint32_t maxBindGroups = 30;
     switch (baseCapabilities.argumentBuffersTier) {
     case MTLArgumentBuffersTier1:
         buffersPerBindGroup = 64;
-        texturesPerBindGroup = 128;
+        texturesPerBindGroup = 96;
         samplersPerBindGroup = 16;
         break;
     case MTLArgumentBuffersTier2:
-        buffersPerBindGroup = 500000 / 2;
-        texturesPerBindGroup = 500000 / 2;
-        samplersPerBindGroup = 1024;
+        buffersPerBindGroup = 96;
+        texturesPerBindGroup = 96;
+        samplersPerBindGroup = 16;
         break;
     }
-
-    uint32_t maxBindGroups = 30;
 
     return {
         {
@@ -428,8 +426,8 @@ static HardwareCapabilities mac2(id<MTLDevice> device)
             .maxBindGroups =    maxBindGroups,
             .maxBindGroupsPlusVertexBuffers = 30,
             .maxBindingsPerBindGroup =  1000,
-            .maxDynamicUniformBuffersPerPipelineLayout =    maxUInt32Limit(),
-            .maxDynamicStorageBuffersPerPipelineLayout =    maxUInt32Limit(),
+            .maxDynamicUniformBuffersPerPipelineLayout =    largeReasonableLimit(),
+            .maxDynamicStorageBuffersPerPipelineLayout =    largeReasonableLimit(),
             .maxSampledTexturesPerShaderStage =    maxBindGroups * texturesPerBindGroup,
             .maxSamplersPerShaderStage =    maxBindGroups * samplersPerBindGroup,
             .maxStorageBuffersPerShaderStage =    maxBindGroups * buffersPerBindGroup,
@@ -441,8 +439,8 @@ static HardwareCapabilities mac2(id<MTLDevice> device)
             .minStorageBufferOffsetAlignment =    256,
             .maxVertexBuffers =    30,
             .maxBufferSize =    device.maxBufferLength,
-            .maxVertexAttributes =    31,
-            .maxVertexBufferArrayStride =    maxUInt32Limit(),
+            .maxVertexAttributes =    30,
+            .maxVertexBufferArrayStride =    largeReasonableLimit(),
             .maxInterStageShaderComponents =    60,
             .maxInterStageShaderVariables =    32,
             .maxColorAttachments =    8,
@@ -452,7 +450,7 @@ static HardwareCapabilities mac2(id<MTLDevice> device)
             .maxComputeWorkgroupSizeX =    1024,
             .maxComputeWorkgroupSizeY =    1024,
             .maxComputeWorkgroupSizeZ =    1024,
-            .maxComputeWorkgroupsPerDimension =    maxUInt32Limit(),
+            .maxComputeWorkgroupsPerDimension =    largeReasonableLimit(),
         },
         WTFMove(features),
         baseCapabilities,


### PR DESCRIPTION
#### cbc83e590816bce3fbd0bd853d64a27b01f83427
<pre>
[WebGPU] Several limits in HardwareCapabilities.mm are not realistic
<a href="https://bugs.webkit.org/show_bug.cgi?id=265853">https://bugs.webkit.org/show_bug.cgi?id=265853</a>
&lt;radar://119171264&gt;

Reviewed by Dan Glastonbury.

Reporting such large of a limit will not work in practice as
we won&apos;t be able to allocate sufficient memory if a website
attempts to approach the reported limit, so reduce the limit
to something large yet reasonable.

* Source/WebGPU/WebGPU/HardwareCapabilities.mm:
(WebGPU::largeReasonableLimit):
(WebGPU::apple3):
(WebGPU::apple4):
(WebGPU::apple5):
(WebGPU::apple6):
(WebGPU::apple7):
(WebGPU::mac2):
(WebGPU::maxUInt32Limit): Deleted.

Canonical link: <a href="https://commits.webkit.org/271776@main">https://commits.webkit.org/271776@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45894076bd28d25420e8dc8f6fa77155238ef282

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28936 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7597 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30292 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31551 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26371 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9712 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4924 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26399 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29208 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6269 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24840 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5463 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5583 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/32888 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26461 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26297 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31838 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5566 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3738 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29621 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7208 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7030 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6051 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6087 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->