### PR TITLE
WebXROpaqueFramebuffer fails to restore textures and framebuffers

### DIFF
--- a/Source/WebCore/html/canvas/WebGLUtilities.h
+++ b/Source/WebCore/html/canvas/WebGLUtilities.h
@@ -193,10 +193,10 @@ public:
         auto* gl = m_context.graphicsContextGL();
         if (m_context.isWebGL2()) {
             auto& context2 = downcast<WebGL2RenderingContext>(m_context);
-            gl->bindFramebuffer(GraphicsContextGL::READ_FRAMEBUFFER_BINDING, objectOrZero(context2.m_readFramebufferBinding));
-            gl->bindFramebuffer(GraphicsContextGL::DRAW_FRAMEBUFFER_BINDING, objectOrZero(context2.m_framebufferBinding));
+            gl->bindFramebuffer(GraphicsContextGL::READ_FRAMEBUFFER, objectOrZero(context2.m_readFramebufferBinding));
+            gl->bindFramebuffer(GraphicsContextGL::DRAW_FRAMEBUFFER, objectOrZero(context2.m_framebufferBinding));
         } else
-            gl->bindFramebuffer(GraphicsContextGL::FRAMEBUFFER_BINDING, objectOrZero(m_context.m_framebufferBinding));
+            gl->bindFramebuffer(GraphicsContextGL::FRAMEBUFFER, objectOrZero(m_context.m_framebufferBinding));
     }
 
 private:
@@ -234,7 +234,7 @@ public:
         PlatformGLObject texture = 0;
         switch (m_target) {
         case GraphicsContextGL::TEXTURE_2D:
-            texture = objectOrZero(textureUnit.textureCubeMapBinding);
+            texture = objectOrZero(textureUnit.texture2DBinding);
             break;
         case GraphicsContextGL::TEXTURE_CUBE_MAP:
             texture = objectOrZero(textureUnit.textureCubeMapBinding);


### PR DESCRIPTION
#### 72ac84bfa36768e5f5331db494bb282ea849d51b
<pre>
WebXROpaqueFramebuffer fails to restore textures and framebuffers
<a href="https://bugs.webkit.org/show_bug.cgi?id=265855">https://bugs.webkit.org/show_bug.cgi?id=265855</a>
<a href="https://rdar.apple.com/119139935">rdar://119139935</a>

Reviewed by Dean Jackson.

Use correct binding points enums for BindFramebuffer.
Use correct texture for BindTexture.

* Source/WebCore/html/canvas/WebGLUtilities.h:
(WebCore::ScopedWebGLRestoreFramebuffer::~ScopedWebGLRestoreFramebuffer):
(WebCore::ScopedWebGLRestoreTexture::~ScopedWebGLRestoreTexture):

Canonical link: <a href="https://commits.webkit.org/271572@main">https://commits.webkit.org/271572@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/83bc1c79c061946e90cd9e15144454122f74a4d0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28724 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7367 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30095 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31343 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26208 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29294 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9490 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4727 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26277 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28994 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6093 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24689 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5295 "Found 1 new API test failure: /WPE/TestWebKitWebView:/webkit/WebKitWebView/notification (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5447 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25693 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/32681 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26291 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26136 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31687 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5414 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3586 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29463 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7032 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6895 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5882 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5932 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->