### PR TITLE
[CSS] Implement @scope rule nested inside style rule

### DIFF
--- a/LayoutTests/fast/css/scope-at-rule-expected.html
+++ b/LayoutTests/fast/css/scope-at-rule-expected.html
@@ -18,10 +18,6 @@
   </div>
 </div>
 
-<div class="a">
-  <span class="green-3">should not be green</span>
-</div>
-
 <div>
   <span class="green-4">should not be green</span>
 </div>
@@ -36,6 +32,12 @@
 
 <div>
   <span class="">should not be green</span>
+</div>
+<div>
+  <span class="green">should be green</span>
+</div>
+<div>
+  <span class="green">should be green</span>
 </div>
 <div>
   <span class="green">should be green</span>

--- a/LayoutTests/fast/css/scope-at-rule.html
+++ b/LayoutTests/fast/css/scope-at-rule.html
@@ -39,6 +39,22 @@ video {
   .green-9 { color: red; }
 }
 
+div {
+  @scope (&.a) to (&.foo) {
+    & {
+      .green-10 { color:green; }
+    }
+  }
+}
+
+div {
+  @scope (&) {
+    & {
+      .green-11 { color:green; }
+    }
+  }
+}
+
 </style>
 
 <div class="a">
@@ -55,10 +71,6 @@ video {
   <div class="b">
     <span class="green-2">should be green</span>
   </div>
-</div>
-
-<div class="a">
-  <span class="green-3">should not be green</span>
 </div>
 
 <div>
@@ -93,4 +105,15 @@ video {
   <div class="b">
     <span class="green-9">should be green</span>
   </div>
+
+<div>
+  <div class="a b">
+    <div class="a b">
+      <div class="a b green-10">should be green</span>
+    </div>
+  </div>
+</div>
+
+<div>
+  <div class="green-11">should be green</span>
 </div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-nesting-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-nesting-expected.txt
@@ -2,13 +2,13 @@
 FAIL Nesting-selector in <scope-end> assert_equals: expected "auto" but got "1"
 FAIL Implicit :scope in <scope-end> assert_equals: expected "1" but got "42"
 PASS Relative selectors in <scope-end>
-FAIL Nesting-selector in the scope's <stylesheet> assert_equals: expected "1" but got "auto"
+PASS Nesting-selector in the scope's <stylesheet>
 PASS Nesting-selector within :scope rule
 PASS Nesting-selector within :scope rule (double nested)
-FAIL @scope nested within style rule assert_equals: expected "1" but got "auto"
-FAIL Parent pseudo class within scope-start assert_equals: expected "1" but got "auto"
-FAIL Parent pseudo class within scope-end assert_equals: expected "1" but got "auto"
-FAIL Parent pseudo class within body of nested @scope assert_equals: matching: DIVa b c expected "1" but got "auto"
+PASS @scope nested within style rule
+PASS Parent pseudo class within scope-start
+FAIL Parent pseudo class within scope-end assert_equals: limit element is not in scope expected "auto" but got "1"
+FAIL Parent pseudo class within body of nested @scope assert_equals: non-matching: DIVb c expected "auto" but got "1"
 FAIL Implicit rule within nested @scope  assert_equals: expected "1" but got "auto"
 FAIL Implicit rule within nested @scope (proximity) assert_equals: expected "1" but got "2"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-specificity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-specificity-expected.txt
@@ -4,7 +4,7 @@ FAIL @scope (#main) to (.b) { .a {  } } assert_equals: unscoped + scoped expecte
 FAIL @scope (#main, .foo, .bar) { #a {  } } assert_equals: unscoped + scoped expected "2" but got "1"
 FAIL @scope (#main) { div.b {  } } assert_equals: unscoped + scoped expected "2" but got "1"
 PASS @scope (#main) { :scope .b {  } }
-FAIL @scope (#main) { & .b {  } } assert_equals: scoped + unscoped expected "1" but got "2"
+PASS @scope (#main) { & .b {  } }
 FAIL @scope (#main) { div .b {  } } assert_equals: unscoped + scoped expected "2" but got "1"
 FAIL @scope (#main) { @scope (.a) { .b {  } } } assert_equals: unscoped + scoped expected "2" but got "1"
 

--- a/Source/WebCore/css/CSSScopeRule.cpp
+++ b/Source/WebCore/css/CSSScopeRule.cpp
@@ -62,7 +62,7 @@ String CSSScopeRule::cssText() const
 
 String CSSScopeRule::start() const
 {
-    auto& scope = styleRuleScope().scopeStart();
+    auto& scope = styleRuleScope().originalScopeStart();
     if (scope.isEmpty())
         return { };
 
@@ -71,7 +71,7 @@ String CSSScopeRule::start() const
 
 String CSSScopeRule::end() const
 {
-    auto& scope = styleRuleScope().scopeEnd();
+    auto& scope = styleRuleScope().originalScopeEnd();
     if (scope.isEmpty())
         return { };
 

--- a/Source/WebCore/css/StyleRule.cpp
+++ b/Source/WebCore/css/StyleRule.cpp
@@ -558,19 +558,9 @@ Ref<StyleRuleScope> StyleRuleScope::copy() const
 
 StyleRuleScope::StyleRuleScope(CSSSelectorList&& scopeStart, CSSSelectorList&& scopeEnd, Vector<Ref<StyleRuleBase>>&& rules)
     : StyleRuleGroup(StyleRuleType::Scope, WTFMove(rules))
-    , m_scopeStart(WTFMove(scopeStart))
-    , m_scopeEnd(WTFMove(scopeEnd))
+    , m_originalScopeStart(WTFMove(scopeStart))
+    , m_originalScopeEnd(WTFMove(scopeEnd))
 {
-}
-
-const CSSSelectorList& StyleRuleScope::scopeStart() const
-{
-    return m_scopeStart;
-}
-
-const CSSSelectorList& StyleRuleScope::scopeEnd() const
-{
-    return m_scopeEnd;
 }
 
 StyleRuleScope::StyleRuleScope(const StyleRuleScope&) = default;

--- a/Source/WebCore/css/StyleRule.h
+++ b/Source/WebCore/css/StyleRule.h
@@ -389,15 +389,23 @@ public:
     ~StyleRuleScope();
     Ref<StyleRuleScope> copy() const;
 
-    const CSSSelectorList& scopeStart() const;
-    const CSSSelectorList& scopeEnd() const;
+    const CSSSelectorList& scopeStart() const { return m_scopeStart; }
+    const CSSSelectorList& scopeEnd() const { return m_scopeEnd; }
+    const CSSSelectorList& originalScopeStart() const { return m_originalScopeStart; }
+    const CSSSelectorList& originalScopeEnd() const { return m_originalScopeEnd; }
+    void setScopeStart(CSSSelectorList&& scopeStart) { m_scopeStart = WTFMove(scopeStart); }
+    void setScopeEnd(CSSSelectorList&& scopeEnd) { m_scopeEnd = WTFMove(scopeEnd); }
 
 private:
     StyleRuleScope(CSSSelectorList&&, CSSSelectorList&&, Vector<Ref<StyleRuleBase>>&&);
     StyleRuleScope(const StyleRuleScope&);
 
+    // Resolved selector lists
     CSSSelectorList m_scopeStart;
     CSSSelectorList m_scopeEnd;
+    // Author written selector lists
+    CSSSelectorList m_originalScopeStart;
+    CSSSelectorList m_originalScopeEnd;
 };
 
 // This is only used by the CSS parser.

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -951,11 +951,6 @@ RefPtr<StyleRuleScope> CSSParserImpl::consumeScopeRule(CSSParserTokenRange prelu
     if (!m_context.cssScopeAtRuleEnabled)
         return nullptr;
 
-    // FIXME: implement mixing style nesting and scope nesting
-    // https://bugs.webkit.org/show_bug.cgi?id=265368
-    if (isStyleNestedContext())
-        return nullptr;
-
     auto preludeRangeCopy = prelude;
     CSSSelectorList scopeStart;
     CSSSelectorList scopeEnd;

--- a/Source/WebCore/style/RuleSetBuilder.h
+++ b/Source/WebCore/style/RuleSetBuilder.h
@@ -85,7 +85,7 @@ private:
     CascadeLayerName m_resolvedCascadeLayerName;
     HashMap<CascadeLayerName, RuleSet::CascadeLayerIdentifier> m_cascadeLayerIdentifierMap;
     RuleSet::CascadeLayerIdentifier m_currentCascadeLayerIdentifier { 0 };
-    Vector<const CSSSelectorList*> m_styleRuleStack;
+    Vector<const CSSSelectorList*> m_selectorListStack;
     const ShouldResolveNesting m_shouldResolveNesting { ShouldResolveNesting::No };
 
     RuleSet::ContainerQueryIdentifier m_currentContainerQueryIdentifier { 0 };


### PR DESCRIPTION
#### ef4eef3a7abb2e62ca9a69f8c7b81d2659db5a80
<pre>
[CSS] Implement @scope rule nested inside style rule
<a href="https://bugs.webkit.org/show_bug.cgi?id=265368">https://bugs.webkit.org/show_bug.cgi?id=265368</a>
<a href="https://rdar.apple.com/103147385">rdar://103147385</a>

Reviewed by Antti Koivisto.

Spec: <a href="https://drafts.csswg.org/css-nesting/#nesting-at-scope">https://drafts.csswg.org/css-nesting/#nesting-at-scope</a>

* LayoutTests/fast/css/scope-at-rule-expected.html:
* LayoutTests/fast/css/scope-at-rule.html:

Example removed because unsure about the actual spec expectation for this:
div {
  @scope (.a) {
    .green { color: green; }
  }
}
Should the inner rule be translated to &quot;:scope .green&quot; ? &quot;:is(div) .green&quot; ? &quot;:is(div) :scope .green&quot; ?

* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-nesting-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-specificity-expected.txt:
* Source/WebCore/css/CSSScopeRule.cpp:
(WebCore::CSSScopeRule::start const):
(WebCore::CSSScopeRule::end const):
* Source/WebCore/css/StyleRule.cpp:
(WebCore::StyleRuleScope::StyleRuleScope):
(WebCore::StyleRuleScope::scopeStart const): Deleted.
(WebCore::StyleRuleScope::scopeEnd const): Deleted.
* Source/WebCore/css/StyleRule.h:
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::consumeScopeRule):
* Source/WebCore/style/RuleSetBuilder.cpp:
(WebCore::Style::RuleSetBuilder::addChildRule):
(WebCore::Style::RuleSetBuilder::resolveSelectorListWithNesting):
(WebCore::Style::RuleSetBuilder::addStyleRule):
* Source/WebCore/style/RuleSetBuilder.h:

Canonical link: <a href="https://commits.webkit.org/271632@main">https://commits.webkit.org/271632@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0dc4cafe065a4d4231bf3b323233567244d86ed6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29050 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7723 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30401 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31662 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26458 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29641 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9851 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5036 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26473 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29322 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6384 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24922 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5538 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5666 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25949 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/32999 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26544 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26387 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31915 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5644 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3820 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/29696 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7302 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/25744 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6939 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6143 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6165 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->