### PR TITLE
Fix depencency cycle in build

### DIFF
--- a/Source/WebKit/Modules/OSX_Private.modulemap
+++ b/Source/WebKit/Modules/OSX_Private.modulemap
@@ -944,11 +944,6 @@ framework module WebKit_Private [system] {
     export *
   }
 
-  explicit module WKProcessExtension {
-    header "WKProcessExtension.h"
-    export *
-  }
-
   explicit module WKProcessGroup {
     header "WKProcessGroup.h"
     export *

--- a/Source/WebKit/Modules/iOS_Private.modulemap
+++ b/Source/WebKit/Modules/iOS_Private.modulemap
@@ -1644,11 +1644,6 @@ framework module WebKit_Private [system] {
     export *
   }
 
-  explicit module WKProcessExtension {
-    header "WKProcessExtension.h"
-    export *
-  }
-
   explicit module WKProcessGroup {
     header "WKProcessGroup.h"
     export *

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -72,7 +72,7 @@ typedef struct OpaqueCFHTTPCookieStorage*  CFHTTPCookieStorageRef;
 #endif
 
 #if USE(EXTENSIONKIT)
-OBJC_CLASS WKGrant;
+OBJC_CLASS NSObject;
 #endif
 
 namespace IPC {
@@ -569,7 +569,7 @@ private:
 #if USE(RUNNINGBOARD)
     WebSQLiteDatabaseTracker m_webSQLiteDatabaseTracker;
 #if USE(EXTENSIONKIT)
-    RetainPtr<WKGrant> m_holdingLockedFileGrant;
+    RetainPtr<NSObject> m_holdingLockedFileGrant;
 #endif
     RefPtr<ProcessAssertion> m_holdingLockedFileAssertion;
 #endif

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
@@ -259,7 +259,11 @@ void NetworkProcess::setProxyConfigData(PAL::SessionID sessionID, Vector<std::pa
 #if USE(RUNNINGBOARD) && USE(EXTENSIONKIT)
 bool NetworkProcess::aqcuireLockedFileGrant()
 {
-    m_holdingLockedFileGrant = [WKProcessExtension.sharedInstance grant:@"com.apple.common" name:@"FinishTaskInterruptable"];
+    if (!processExtension())
+        return false;
+    SEL selector = NSSelectorFromString(@"grant:name:");
+    RELEASE_ASSERT([processExtension() respondsToSelector:selector]);
+    m_holdingLockedFileGrant = [processExtension() performSelector:selector withObject:@"com.apple.common" withObject:@"FinishTaskInterruptable"];
     if (m_holdingLockedFileGrant)
         RELEASE_LOG(Process, "Successfully took assertion on Network process for locked file.");
     else

--- a/Source/WebKit/Platform/ExtraPrivateSymbolsForTAPI.h
+++ b/Source/WebKit/Platform/ExtraPrivateSymbolsForTAPI.h
@@ -36,7 +36,7 @@ void NetworkServiceInitializer();
 void WebContentServiceInitializer();
 void GPUServiceInitializer();
 
-void ExtensionEventHandler(xpc_connection_t);
+void ExtensionEventHandler(xpc_connection_t, NSObject*);
 
 #ifdef __cplusplus
 }

--- a/Source/WebKit/Shared/AuxiliaryProcessExtensions/AuxiliaryProcessExtensionBridge.h
+++ b/Source/WebKit/Shared/AuxiliaryProcessExtensions/AuxiliaryProcessExtensionBridge.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#import "WKProcessExtension.h"
-
 // FIXME: forward declare xpc_connection_t to build with public SDK.
 #import <xpc/xpc.h>
 
@@ -34,7 +32,7 @@
 extern "C" {
 #endif
 
-void handleNewConnection(xpc_connection_t);
+void handleNewConnection(xpc_connection_t, NSObject*);
 
 #ifdef __cplusplus
 }

--- a/Source/WebKit/Shared/AuxiliaryProcessExtensions/AuxiliaryProcessExtensionBridge.mm
+++ b/Source/WebKit/Shared/AuxiliaryProcessExtensions/AuxiliaryProcessExtensionBridge.mm
@@ -27,7 +27,7 @@
 
 #import "ExtensionEventHandler.h"
 
-void handleNewConnection(xpc_connection_t connection)
+void handleNewConnection(xpc_connection_t connection, NSObject* process)
 {
-    ExtensionEventHandler(connection);
+    ExtensionEventHandler(connection, process);
 }

--- a/Source/WebKit/Shared/AuxiliaryProcessExtensions/GPUProcessExtension.swift
+++ b/Source/WebKit/Shared/AuxiliaryProcessExtensions/GPUProcessExtension.swift
@@ -33,6 +33,6 @@ class GPUProcessExtension {
 
 extension GPUProcessExtension: GPUServiceExtension {
     func handle(xpcConnection: xpc_connection_t) {
-        handleNewConnection(xpcConnection)
+        handleNewConnection(xpcConnection, nil)
     }
 }

--- a/Source/WebKit/Shared/AuxiliaryProcessExtensions/NetworkingProcessExtension.swift
+++ b/Source/WebKit/Shared/AuxiliaryProcessExtensions/NetworkingProcessExtension.swift
@@ -28,7 +28,7 @@ import ServiceExtensions
 
 @objc
 @_spi(Private)
-open class Grant: WKGrant {
+open class Grant: NSObject {
     let inner : _Capabilities.Grant
 
     init(inner: _Capabilities.Grant) {
@@ -49,24 +49,24 @@ open class Grant: WKGrant {
 }
 
 @main
-class NetworkingProcessExtension : WKProcessExtension {
+class NetworkingProcessExtension : NSObject {
     override required init() {
         super.init()
-        setSharedInstance(self)
     }
 }
 
 extension NetworkingProcessExtension : NetworkingServiceExtension {
     func handle(xpcConnection: xpc_connection_t) {
-        handleNewConnection(xpcConnection)
+        handleNewConnection(xpcConnection, self)
     }
 
-    override func grant(_ domain: String, name: String) -> Any {
+    @objc(grant:name:)
+    func grant(_ domain: String, name: String) -> Any {
         do {
             let grant = try self._request(capabilities: _Capabilities.assertion(domain, name))
             return Grant(inner: grant)
         } catch {
-            return WKGrant()
+            return NSObject()
         }
     }
 }

--- a/Source/WebKit/Shared/AuxiliaryProcessExtensions/WebContentProcessExtension.swift
+++ b/Source/WebKit/Shared/AuxiliaryProcessExtensions/WebContentProcessExtension.swift
@@ -33,6 +33,6 @@ class WebContentProcessExtension {
 
 extension WebContentProcessExtension: ContentServiceExtension {
     func handle(xpcConnection: xpc_connection_t) {
-        handleNewConnection(xpcConnection)
+        handleNewConnection(xpcConnection, nil)
     }
 }

--- a/Source/WebKit/Shared/Cocoa/WKProcessExtension.h
+++ b/Source/WebKit/Shared/Cocoa/WKProcessExtension.h
@@ -25,13 +25,9 @@
 
 #pragma once
 
-OBJC_EXPORT
-@interface WKGrant : NSObject
-@end
+namespace WebKit {
 
-OBJC_EXPORT
-@interface WKProcessExtension : NSObject
-+ (WKProcessExtension*) sharedInstance;
-- (void)setSharedInstance:(WKProcessExtension*)instance;
-- (id)grant:(NSString*)domain name:(NSString*)name;
-@end
+NSObject* processExtension();
+void setProcessExtension(NSObject* instance);
+
+}

--- a/Source/WebKit/Shared/Cocoa/WKProcessExtension.mm
+++ b/Source/WebKit/Shared/Cocoa/WKProcessExtension.mm
@@ -28,28 +28,22 @@
 
 #import <wtf/RetainPtr.h>
 
-static RetainPtr<WKProcessExtension>& sharedInstance()
+namespace WebKit {
+
+static RetainPtr<NSObject>& sharedProcessExtension()
 {
-    static NeverDestroyed<RetainPtr<WKProcessExtension>> instance;
+    static NeverDestroyed<RetainPtr<NSObject>> instance;
     return instance.get();
 }
 
-@implementation WKGrant
-@end
-
-@implementation WKProcessExtension
-+ (WKProcessExtension*) sharedInstance
+void setProcessExtension(NSObject* instance)
 {
-    return sharedInstance().get();
+    sharedProcessExtension() = instance;
 }
 
-- (void)setSharedInstance:(WKProcessExtension*)instance
+NSObject* processExtension()
 {
-    sharedInstance() = instance;
+    return sharedProcessExtension().get();
 }
 
-- (id)grant:(NSString*)domain name:(NSString*)name
-{
-    return nil;
 }
-@end

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/ExtensionEventHandler.h
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/ExtensionEventHandler.h
@@ -34,7 +34,7 @@
 extern "C" {
 #endif
 
-WK_EXPORT void ExtensionEventHandler(xpc_connection_t);
+WK_EXPORT void ExtensionEventHandler(xpc_connection_t, NSObject*);
 
 #ifdef __cplusplus
 }

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/ExtensionEventHandler.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/ExtensionEventHandler.mm
@@ -26,9 +26,11 @@
 #import "config.h"
 #import "ExtensionEventHandler.h"
 
+#import "WKProcessExtension.h"
 #import "XPCServiceEntryPoint.h"
 
-void ExtensionEventHandler(xpc_connection_t connection)
+void ExtensionEventHandler(xpc_connection_t connection, NSObject* processExtension)
 {
+    WebKit::setProcessExtension(processExtension);
     return WebKit::XPCServiceEventHandler(connection);
 }

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2271,7 +2271,7 @@
 		E31869BC2B1A74A800571519 /* AuxiliaryProcessExtensionBridge.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5C139DB829DB847E00D5117B /* AuxiliaryProcessExtensionBridge.mm */; };
 		E31869BD2B1A74A900571519 /* AuxiliaryProcessExtensionBridge.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5C139DB829DB847E00D5117B /* AuxiliaryProcessExtensionBridge.mm */; };
 		E31869C42B1A7C2400571519 /* WKProcessExtension.mm in Sources */ = {isa = PBXBuildFile; fileRef = E31869C22B1A7C2400571519 /* WKProcessExtension.mm */; };
-		E31869C52B1A7C2400571519 /* WKProcessExtension.h in Headers */ = {isa = PBXBuildFile; fileRef = E31869C32B1A7C2400571519 /* WKProcessExtension.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E31869C52B1A7C2400571519 /* WKProcessExtension.h in Headers */ = {isa = PBXBuildFile; fileRef = E31869C32B1A7C2400571519 /* WKProcessExtension.h */; };
 		E326E357284E580E00157372 /* AuxiliaryProcessProxyCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = E326E356284E580E00157372 /* AuxiliaryProcessProxyCocoa.mm */; };
 		E36A00E329CF7AC000AC4E8A /* TextTrackRepresentationCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = E36A00E229CF7AC000AC4E8A /* TextTrackRepresentationCocoa.mm */; };
 		E36FF00327F36FBD004BE21A /* SandboxStateVariables.h in Headers */ = {isa = PBXBuildFile; fileRef = E36FF00127F36FBD004BE21A /* SandboxStateVariables.h */; };


### PR DESCRIPTION
#### f29418a02233e6e8b9c9373660b44d4c1137ad2f
<pre>
Fix depencency cycle in build
<a href="https://bugs.webkit.org/show_bug.cgi?id=265870">https://bugs.webkit.org/show_bug.cgi?id=265870</a>
<a href="https://rdar.apple.com/119162443">rdar://119162443</a>

Reviewed by NOBODY (OOPS!).

The commit <a href="https://commits.webkit.org/271502@main">https://commits.webkit.org/271502@main</a> introduced a dependency cycle in the WebKit build.
This patch resolves this by not making Swift code in WebKit extensions depend on ObjC class definitions
in WebKit. Instead, the extensions will set a NSObject pointer in the WebKit framework. The WebKit
framework can use this pointer to access functions in the extension executable through performSelector.

* Source/WebKit/Modules/OSX_Private.modulemap:
* Source/WebKit/Modules/iOS_Private.modulemap:
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm:
(WebKit::NetworkProcess::aqcuireLockedFileGrant):
* Source/WebKit/Platform/ExtraPrivateSymbolsForTAPI.h:
* Source/WebKit/Shared/AuxiliaryProcessExtensions/AuxiliaryProcessExtensionBridge.h:
* Source/WebKit/Shared/AuxiliaryProcessExtensions/AuxiliaryProcessExtensionBridge.mm:
(handleNewConnection):
* Source/WebKit/Shared/AuxiliaryProcessExtensions/GPUProcessExtension.swift:
(GPUProcessExtension.handle(_:)):
* Source/WebKit/Shared/AuxiliaryProcessExtensions/NetworkingProcessExtension.swift:
(NetworkingProcessExtension.handle(_:)):
(NetworkingProcessExtension.grant(_:name:)):
* Source/WebKit/Shared/AuxiliaryProcessExtensions/WebContentProcessExtension.swift:
(WebContentProcessExtension.handle(_:)):
* Source/WebKit/Shared/Cocoa/WKProcessExtension.h:
* Source/WebKit/Shared/Cocoa/WKProcessExtension.mm:
(WebKit::sharedProcessExtension):
(WebKit::setProcessExtension):
(WebKit::processExtension):
(sharedInstance): Deleted.
(+[WKProcessExtension sharedInstance]): Deleted.
(-[WKProcessExtension setSharedInstance:]): Deleted.
(-[WKProcessExtension grant:name:]): Deleted.
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/ExtensionEventHandler.h:
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/ExtensionEventHandler.mm:
(ExtensionEventHandler):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f29418a02233e6e8b9c9373660b44d4c1137ad2f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28806 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7449 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30179 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31425 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26280 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9582 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4808 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26335 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29076 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6173 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24757 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5362 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5514 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/32764 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26370 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26208 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31752 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5483 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3653 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29535 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7104 "Built successfully") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/6889 "The change is no longer eligible for processing.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5955 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6001 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->