### PR TITLE
[Debug] ASSERTION FAILED: m_phase == ViewTransitionPhase::Done || m_phase == ViewTransitionPhase::PendingCapture

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3731,8 +3731,6 @@ webkit.org/b/264680 media/media-source/media-managedmse-resume-after-stall.html 
 webkit.org/b/264680 media/video-page-visibility-restriction.html [ Pass Timeout ]
 webkit.org/b/264680 webgl/webgl-visible-after-context-restore.html [ ImageOnlyFailure Pass ]
 
-webkit.org/b/265868 [ Debug ] imported/w3c/web-platform-tests/css/css-view-transitions [ Skip ]
-
 webkit.org/b/265942 imported/w3c/web-platform-tests/editing/run [ Slow ]
 
 # End: Common failures between GTK and WPE.

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2598,6 +2598,3 @@ webkit.org/b/265685 [ Sonoma+ ] http/wpt/webcodecs/encoder-task-failing.html [ F
 # webkit.org/b/266168 Two wheel/mousewheel passive event listeners WPT test pass on macOS Sonoma and up
 [ Sonoma+ ] imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-mousewheel-event-listener-on-div.html [ Pass ]
 [ Sonoma+ ] imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-wheel-event-listener-on-div.html [ Pass ]
-
-# webkit.org/b/265834 ASSERTION FAILED with void WebCore::ViewTransition::ca llUpdateCallback() result of multiple tests constant crash
-[ Monterey Ventura Debug ] imported/w3c/web-platform-tests/css/css-view-transitions [ Skip ]

--- a/Source/WebCore/dom/ViewTransition.h
+++ b/Source/WebCore/dom/ViewTransition.h
@@ -41,6 +41,7 @@ class DeferredPromise;
 
 enum class ViewTransitionPhase : uint8_t {
     PendingCapture,
+    CapturingOldState, // Not part of the spec.
     UpdateCallbackCalled,
     Animating,
     Done


### PR DESCRIPTION
#### ecf63ceef8cf9afc28b7bbbd1eb7ad0582929542
<pre>
[Debug] ASSERTION FAILED: m_phase == ViewTransitionPhase::Done || m_phase == ViewTransitionPhase::PendingCapture
<a href="https://bugs.webkit.org/show_bug.cgi?id=265868">https://bugs.webkit.org/show_bug.cgi?id=265868</a>

Reviewed by Tim Nguyen.

During each invocation of `Page::updateRendering()`, the `Document`
triggers the `setupViewTransition()` method of `m_activeViewTransition`
when it&apos;s in the `ViewTransitionPhase::PendingCapture` phase.

The `ViewTransition` first updates its state within the
`callUpdateCallback()` method, which is executed asynchronously.

This can lead to a situation where the active `ViewTransition` has been
set up, but its state remains `ViewTransitionPhase::PendingCapture`
when the `Document` checks it.

In such cases, the `Document` may call `setupViewTransition()` more
than once.

To address this issue, this patch introduces a
`ViewTransitionPhase::Capturing` state, indicating that the transition
setup is complete, but the callback has not been called yet.

Note that this phase is not part of the spec [1].

1. <a href="https://drafts.csswg.org/css-view-transitions/#viewtransition-phase">https://drafts.csswg.org/css-view-transitions/#viewtransition-phase</a>

* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::callUpdateCallback):
(WebCore::ViewTransition::setupViewTransition):
* Source/WebCore/dom/ViewTransition.h:

Canonical link: <a href="https://commits.webkit.org/271959@main">https://commits.webkit.org/271959@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/216629b3186ee14abb34afe35455bf0245e57b2e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30113 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8778 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31427 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32617 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27228 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30788 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10977 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6023 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27244 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30413 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7363 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25679 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6293 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6447 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26772 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33954 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27457 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27204 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32629 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6392 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4563 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30430 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8141 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7148 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7145 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6920 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->