### PR TITLE
Move GraphicsContextGLSimulatedEventForTesting enum class to new serialization format

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsContextGLEnums.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGLEnums.h
@@ -29,7 +29,7 @@
 
 namespace WebCore {
 
-enum class GraphicsContextGLSimulatedEventForTesting {
+enum class GraphicsContextGLSimulatedEventForTesting : uint8_t {
     GPUStatusFailure,
     Timeout,
     DisplayBufferAllocationFailure

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -473,14 +473,4 @@ template <> struct EnumTraits<WebCore::CDMInstance::HDCPStatus> {
 };
 #endif
 
-#if ENABLE(GPU_PROCESS) && ENABLE(WEBGL)
-template <> struct EnumTraits<WebCore::GraphicsContextGLSimulatedEventForTesting> {
-    using values = EnumValues<
-    WebCore::GraphicsContextGLSimulatedEventForTesting,
-    WebCore::GraphicsContextGLSimulatedEventForTesting::GPUStatusFailure,
-    WebCore::GraphicsContextGLSimulatedEventForTesting::Timeout
-    >;
-};
-#endif
-
 } // namespace WTF

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2734,6 +2734,13 @@ struct WebCore::GraphicsContextGLAttributes {
 #endif
     WebCore::GraphicsContextGLSimulatedCreationFailure failContextCreationForTesting;
 };
+
+enum class WebCore::GraphicsContextGLSimulatedEventForTesting : uint8_t {
+    GPUStatusFailure,
+    Timeout,
+    DisplayBufferAllocationFailure
+};
+
 #endif // ENABLE(GPU_PROCESS) && ENABLE(WEBGL)
 
 [RefCounted] class WebCore::TimingFunction subclasses {


### PR DESCRIPTION
#### 5beaf2534b4b8efb459a132cc4a94ad2c285f784
<pre>
Move GraphicsContextGLSimulatedEventForTesting enum class to new serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=265875">https://bugs.webkit.org/show_bug.cgi?id=265875</a>

Reviewed by Chris Dumez.

This enum can be trivially moved to the new serialization format,
remove the EnumTraits bits for it.

* Source/WebCore/platform/graphics/GraphicsContextGLEnums.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/271634@main">https://commits.webkit.org/271634@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c9d9925fcda8797166bc7ec5cf9229eb30d5b11

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28774 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7417 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30146 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31393 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26251 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29344 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9546 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4776 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26315 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29044 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6143 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24733 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5352 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5487 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25740 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/32732 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26341 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26182 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31732 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5456 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3627 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29511 "Found 2 new API test failures: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/close-quickly, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/mediaKeySystem-permission-requests (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7075 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6941 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5926 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5974 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->