### PR TITLE
Move WebFindOptions to the new serialization format

### DIFF
--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -434,6 +434,7 @@ set(WebKit_SERIALIZATION_IN_FILES
     Shared/WebCoreArgumentCoders.serialization.in
     Shared/WebCompiledContentRuleListData.serialization.in
     Shared/WebEvent.serialization.in
+    Shared/WebFindOptions.serialization.in
     Shared/WebFoundTextRange.serialization.in
     Shared/WebHitTestResultData.serialization.in
     Shared/WebNavigationDataStore.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -621,6 +621,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/WebContextMenuItemData.serialization.in \
 	Shared/WebCoreArgumentCoders.serialization.in \
 	Shared/WebEvent.serialization.in \
+	Shared/WebFindOptions.serialization.in \
 	Shared/WebFoundTextRange.serialization.in \
 	Shared/WebHitTestResultData.serialization.in \
 	Shared/WebNavigationDataStore.serialization.in \

--- a/Source/WebKit/Shared/WebFindOptions.h
+++ b/Source/WebKit/Shared/WebFindOptions.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <WebCore/FindOptions.h>
-#include <wtf/EnumTraits.h>
 
 namespace WebKit {
 
@@ -53,33 +52,3 @@ enum class FindDecorationStyle : uint8_t {
 WebCore::FindOptions core(OptionSet<FindOptions>);
 
 } // namespace WebKit
-
-namespace WTF {
-
-template<> struct EnumTraits<WebKit::FindOptions> {
-    using values = EnumValues<
-        WebKit::FindOptions,
-        WebKit::FindOptions::CaseInsensitive,
-        WebKit::FindOptions::AtWordStarts,
-        WebKit::FindOptions::TreatMedialCapitalAsWordStart,
-        WebKit::FindOptions::Backwards,
-        WebKit::FindOptions::WrapAround,
-        WebKit::FindOptions::ShowOverlay,
-        WebKit::FindOptions::ShowFindIndicator,
-        WebKit::FindOptions::ShowHighlight,
-        WebKit::FindOptions::DetermineMatchIndex,
-        WebKit::FindOptions::NoIndexChange,
-        WebKit::FindOptions::AtWordEnds
-    >;
-};
-
-template<> struct EnumTraits<WebKit::FindDecorationStyle> {
-    using values = EnumValues<
-        WebKit::FindDecorationStyle,
-        WebKit::FindDecorationStyle::Normal,
-        WebKit::FindDecorationStyle::Found,
-        WebKit::FindDecorationStyle::Highlighted
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebKit/Shared/WebFindOptions.serialization.in
+++ b/Source/WebKit/Shared/WebFindOptions.serialization.in
@@ -1,0 +1,44 @@
+# Copyright (C) 2023 Igalia S.L.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+header: "WebFindOptions.h"
+[OptionSet] enum class WebKit::FindOptions : uint16_t {
+    CaseInsensitive,
+    AtWordStarts,
+    TreatMedialCapitalAsWordStart,
+    Backwards,
+    WrapAround,
+    ShowOverlay,
+    ShowFindIndicator,
+    ShowHighlight,
+    DetermineMatchIndex,
+    NoIndexChange,
+    AtWordEnds,
+};
+
+enum class WebKit::FindDecorationStyle : uint8_t {
+    Normal,
+    Found,
+    Highlighted,
+};


### PR DESCRIPTION
#### 7ccdef5950c2cb3ff46b6664ced7976fcc218660
<pre>
Move WebFindOptions to the new serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=265877">https://bugs.webkit.org/show_bug.cgi?id=265877</a>

Reviewed by Alex Christensen.

Add a serialization file for the WebFindOptions.h enums and remove
the EnumTraits for these.

* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Shared/WebFindOptions.h:
* Source/WebKit/Shared/WebFindOptions.serialization.in: Added.

Canonical link: <a href="https://commits.webkit.org/271710@main">https://commits.webkit.org/271710@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7ed23e46a70328d252c736b82c8d26dc29f2230

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28779 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7422 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30152 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31398 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26256 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9553 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4781 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26316 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29049 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6149 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24739 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5341 "Found 1 new API test failure: /WPE/TestWebKitWebView:/webkit/WebKitWebView/notification (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5492 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/32737 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26347 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26188 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31744 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5461 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3632 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29526 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7080 "Built successfully") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/6984 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5931 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3777 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5979 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->