### PR TITLE
Speed up use of WeakPtr with EventTarget objects (such as Node)

### DIFF
--- a/Source/WebCore/Modules/cookie-store/CookieStore.cpp
+++ b/Source/WebCore/Modules/cookie-store/CookieStore.cpp
@@ -76,6 +76,8 @@ public:
     void getAll(CookieStoreGetOptions&&, URL&&, Function<void(CookieStore&, ExceptionOr<Vector<Cookie>>&&)>&&);
     void set(CookieInit&& options, Cookie&&, Function<void(CookieStore&, std::optional<Exception>&&)>&&);
 
+    void detach() { m_cookieStore = nullptr; }
+
 private:
     explicit MainThreadBridge(CookieStore&);
 
@@ -221,7 +223,10 @@ CookieStore::CookieStore(ScriptExecutionContext* context)
 {
 }
 
-CookieStore::~CookieStore() = default;
+CookieStore::~CookieStore()
+{
+    m_mainThreadBridge->detach();
+}
 
 void CookieStore::get(String&& name, Ref<DeferredPromise>&& promise)
 {

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.h
@@ -45,7 +45,7 @@ class ReadableStream;
 class SimpleReadableStreamSource;
 class WritableStream;
 
-class RTCRtpSFrameTransform : public RefCounted<RTCRtpSFrameTransform>, public ActiveDOMObject, public EventTarget {
+class RTCRtpSFrameTransform : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RTCRtpSFrameTransform>, public ActiveDOMObject, public EventTarget {
     WTF_MAKE_ISO_ALLOCATED(RTCRtpSFrameTransform);
 public:
     enum class Role { Encrypt, Decrypt };
@@ -75,8 +75,8 @@ public:
 
     bool hasKey(uint64_t) const;
 
-    using RefCounted<RTCRtpSFrameTransform>::ref;
-    using RefCounted<RTCRtpSFrameTransform>::deref;
+    using ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref;
+    using ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref;
 
 private:
     RTCRtpSFrameTransform(ScriptExecutionContext&, Options);

--- a/Source/WebCore/Modules/permissions/MainThreadPermissionObserver.cpp
+++ b/Source/WebCore/Modules/permissions/MainThreadPermissionObserver.cpp
@@ -34,7 +34,7 @@
 
 namespace WebCore {
 
-MainThreadPermissionObserver::MainThreadPermissionObserver(WeakPtr<PermissionStatus, WeakPtrImplWithEventTargetData>&& permissionStatus, ScriptExecutionContextIdentifier contextIdentifier, PermissionState state, PermissionDescriptor descriptor, PermissionQuerySource source, WeakPtr<Page>&& page, ClientOrigin&& origin)
+MainThreadPermissionObserver::MainThreadPermissionObserver(ThreadSafeWeakPtr<PermissionStatus>&& permissionStatus, ScriptExecutionContextIdentifier contextIdentifier, PermissionState state, PermissionDescriptor descriptor, PermissionQuerySource source, WeakPtr<Page>&& page, ClientOrigin&& origin)
     : m_permissionStatus(WTFMove(permissionStatus))
     , m_contextIdentifier(contextIdentifier)
     , m_state(state)
@@ -57,8 +57,8 @@ void MainThreadPermissionObserver::stateChanged(PermissionState newPermissionSta
 {
     m_state = newPermissionState;
 
-    ScriptExecutionContext::ensureOnContextThread(m_contextIdentifier, [permissionStatus = m_permissionStatus, newPermissionState](auto&) {
-        if (permissionStatus)
+    ScriptExecutionContext::ensureOnContextThread(m_contextIdentifier, [weakPermissionStatus = m_permissionStatus, newPermissionState](auto&) {
+        if (RefPtr permissionStatus = weakPermissionStatus.get())
             permissionStatus->stateChanged(newPermissionState);
     });
 }

--- a/Source/WebCore/Modules/permissions/MainThreadPermissionObserver.h
+++ b/Source/WebCore/Modules/permissions/MainThreadPermissionObserver.h
@@ -42,7 +42,7 @@ class MainThreadPermissionObserver final : public PermissionObserver {
     WTF_MAKE_NONCOPYABLE(MainThreadPermissionObserver);
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    MainThreadPermissionObserver(WeakPtr<PermissionStatus, WeakPtrImplWithEventTargetData>&&, ScriptExecutionContextIdentifier, PermissionState, PermissionDescriptor, PermissionQuerySource, WeakPtr<Page>&&, ClientOrigin&&);
+    MainThreadPermissionObserver(ThreadSafeWeakPtr<PermissionStatus>&&, ScriptExecutionContextIdentifier, PermissionState, PermissionDescriptor, PermissionQuerySource, WeakPtr<Page>&&, ClientOrigin&&);
     ~MainThreadPermissionObserver();
 
 private:
@@ -54,7 +54,7 @@ private:
     PermissionQuerySource source() const final { return m_source; }
     const WeakPtr<Page>& page() const final { return m_page; }
 
-    WeakPtr<PermissionStatus, WeakPtrImplWithEventTargetData> m_permissionStatus;
+    ThreadSafeWeakPtr<PermissionStatus> m_permissionStatus;
     ScriptExecutionContextIdentifier m_contextIdentifier;
     PermissionState m_state;
     PermissionDescriptor m_descriptor;

--- a/Source/WebCore/Modules/permissions/PermissionStatus.cpp
+++ b/Source/WebCore/Modules/permissions/PermissionStatus.cpp
@@ -72,7 +72,7 @@ PermissionStatus::PermissionStatus(ScriptExecutionContext& context, PermissionSt
 
     m_mainThreadPermissionObserverIdentifier = MainThreadPermissionObserverIdentifier::generate();
 
-    ensureOnMainThread([weakThis = WeakPtr { *this }, contextIdentifier = context.identifier(), state = m_state, descriptor = m_descriptor, source, page = WTFMove(page), origin = WTFMove(clientOrigin).isolatedCopy(), identifier = m_mainThreadPermissionObserverIdentifier]() mutable {
+    ensureOnMainThread([weakThis = ThreadSafeWeakPtr { *this }, contextIdentifier = context.identifier(), state = m_state, descriptor = m_descriptor, source, page = WTFMove(page), origin = WTFMove(clientOrigin).isolatedCopy(), identifier = m_mainThreadPermissionObserverIdentifier]() mutable {
         auto mainThreadPermissionObserver = makeUnique<MainThreadPermissionObserver>(WTFMove(weakThis), contextIdentifier, state, descriptor, source, WTFMove(page), WTFMove(origin));
         allMainThreadPermissionObservers().add(identifier, WTFMove(mainThreadPermissionObserver));
     });
@@ -115,7 +115,7 @@ bool PermissionStatus::virtualHasPendingActivity() const
     if (!m_hasChangeEventListener)
         return false;
 
-    if (WeakPtr document = dynamicDowncast<Document>(scriptExecutionContext()))
+    if (auto* document = dynamicDowncast<Document>(scriptExecutionContext()))
         return document->hasBrowsingContext();
 
     return true;

--- a/Source/WebCore/Modules/permissions/PermissionStatus.h
+++ b/Source/WebCore/Modules/permissions/PermissionStatus.h
@@ -39,7 +39,7 @@ namespace WebCore {
 
 class ScriptExecutionContext;
 
-class PermissionStatus final : public ActiveDOMObject, public RefCounted<PermissionStatus>, public EventTarget  {
+class PermissionStatus final : public ActiveDOMObject, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<PermissionStatus>, public EventTarget  {
     WTF_MAKE_ISO_ALLOCATED(PermissionStatus);
 public:
     static Ref<PermissionStatus> create(ScriptExecutionContext&, PermissionState, PermissionDescriptor, PermissionQuerySource, WeakPtr<Page>&&);
@@ -50,8 +50,8 @@ public:
 
     void stateChanged(PermissionState);
 
-    using RefCounted::ref;
-    using RefCounted::deref;
+    using ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref;
+    using ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref;
 
 private:
     PermissionStatus(ScriptExecutionContext&, PermissionState, PermissionDescriptor, PermissionQuerySource, WeakPtr<Page>&&);

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.h
@@ -46,7 +46,7 @@ class WebCodecsErrorCallback;
 class WebCodecsAudioDataOutputCallback;
 
 class WebCodecsAudioDecoder
-    : public RefCounted<WebCodecsAudioDecoder>
+    : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<WebCodecsAudioDecoder>
     , public ActiveDOMObject
     , public EventTarget {
     WTF_MAKE_ISO_ALLOCATED(WebCodecsAudioDecoder);
@@ -71,8 +71,8 @@ public:
 
     static void isConfigSupported(ScriptExecutionContext&, WebCodecsAudioDecoderConfig&&, Ref<DeferredPromise>&&);
 
-    using RefCounted::ref;
-    using RefCounted::deref;
+    using ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref;
+    using ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref;
 
 private:
     WebCodecsAudioDecoder(ScriptExecutionContext&, Init&&);

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp
@@ -139,15 +139,16 @@ ExceptionOr<void> WebCodecsAudioEncoder::configure(ScriptExecutionContext&, WebC
     if (m_internalEncoder) {
         queueControlMessageAndProcess([this, config]() mutable {
             m_isMessageQueueBlocked = true;
-            m_internalEncoder->flush([this, weakedThis = WeakPtr { *this }, config = WTFMove(config)]() mutable {
-                if (!weakedThis)
+            m_internalEncoder->flush([weakThis = ThreadSafeWeakPtr { *this }, config = WTFMove(config)]() mutable {
+                RefPtr protectedThis = weakThis.get();
+                if (!protectedThis)
                     return;
 
-                if (m_state == WebCodecsCodecState::Closed || !scriptExecutionContext())
+                if (protectedThis->m_state == WebCodecsCodecState::Closed || !protectedThis->scriptExecutionContext())
                     return;
 
-                m_isMessageQueueBlocked = false;
-                processControlMessageQueue();
+                protectedThis->m_isMessageQueueBlocked = false;
+                protectedThis->processControlMessageQueue();
             });
         });
     }

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.h
@@ -46,7 +46,7 @@ class WebCodecsAudioData;
 struct WebCodecsEncodedAudioChunkMetadata;
 
 class WebCodecsAudioEncoder
-    : public RefCounted<WebCodecsAudioEncoder>
+    : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<WebCodecsAudioEncoder>
     , public ActiveDOMObject
     , public EventTarget {
     WTF_MAKE_ISO_ALLOCATED(WebCodecsAudioEncoder);
@@ -71,8 +71,8 @@ public:
 
     static void isConfigSupported(ScriptExecutionContext&, WebCodecsAudioEncoderConfig&&, Ref<DeferredPromise>&&);
 
-    using RefCounted::ref;
-    using RefCounted::deref;
+    using ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref;
+    using ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref;
 
 private:
     WebCodecsAudioEncoder(ScriptExecutionContext&, Init&&);

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.h
@@ -44,7 +44,7 @@ class WebCodecsErrorCallback;
 class WebCodecsVideoFrameOutputCallback;
 
 class WebCodecsVideoDecoder
-    : public RefCounted<WebCodecsVideoDecoder>
+    : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<WebCodecsVideoDecoder>
     , public ActiveDOMObject
     , public EventTarget {
     WTF_MAKE_ISO_ALLOCATED(WebCodecsVideoDecoder);
@@ -69,8 +69,8 @@ public:
 
     static void isConfigSupported(ScriptExecutionContext&, WebCodecsVideoDecoderConfig&&, Ref<DeferredPromise>&&);
 
-    using RefCounted::ref;
-    using RefCounted::deref;
+    using ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref;
+    using ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref;
 
 private:
     WebCodecsVideoDecoder(ScriptExecutionContext&, Init&&);

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h
@@ -45,7 +45,7 @@ struct WebCodecsEncodedVideoChunkMetadata;
 struct WebCodecsVideoEncoderEncodeOptions;
 
 class WebCodecsVideoEncoder
-    : public RefCounted<WebCodecsVideoEncoder>
+    : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<WebCodecsVideoEncoder>
     , public ActiveDOMObject
     , public EventTarget {
     WTF_MAKE_ISO_ALLOCATED(WebCodecsVideoEncoder);
@@ -70,8 +70,8 @@ public:
 
     static void isConfigSupported(ScriptExecutionContext&, WebCodecsVideoEncoderConfig&&, Ref<DeferredPromise>&&);
 
-    using RefCounted::ref;
-    using RefCounted::deref;
+    using ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref;
+    using ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref;
 
 private:
     WebCodecsVideoEncoder(ScriptExecutionContext&, Init&&);

--- a/Source/WebCore/dom/BroadcastChannel.cpp
+++ b/Source/WebCore/dom/BroadcastChannel.cpp
@@ -77,6 +77,7 @@ public:
     void registerChannel();
     void unregisterChannel();
     void postMessage(Ref<SerializedScriptValue>&&);
+    void detach() { m_broadcastChannel = nullptr; }
 
     String name() const { return m_name.isolatedCopy(); }
     BroadcastChannelIdentifier identifier() const { return m_identifier; }
@@ -168,6 +169,7 @@ BroadcastChannel::BroadcastChannel(ScriptExecutionContext& context, const String
 BroadcastChannel::~BroadcastChannel()
 {
     close();
+    m_mainThreadBridge->detach();
     {
         Locker locker { allBroadcastChannelsLock };
         allBroadcastChannels().remove(m_mainThreadBridge->identifier());

--- a/Source/WebCore/dom/EventTarget.h
+++ b/Source/WebCore/dom/EventTarget.h
@@ -68,12 +68,12 @@ public:
 };
 
 // Do not make WeakPtrImplWithEventTargetData a derived class of DefaultWeakPtrImpl to catch the bug which uses incorrect impl class.
-class WeakPtrImplWithEventTargetData final : public WTF::WeakPtrImplBase<WeakPtrImplWithEventTargetData> {
+class WeakPtrImplWithEventTargetData final : public WTF::WeakPtrImplBaseSingleThread<WeakPtrImplWithEventTargetData> {
 public:
     EventTargetData& eventTargetData() { return m_eventTargetData; }
     const EventTargetData& eventTargetData() const { return m_eventTargetData; }
 
-    template<typename T> WeakPtrImplWithEventTargetData(T* ptr) : WTF::WeakPtrImplBase<WeakPtrImplWithEventTargetData>(ptr) { }
+    template<typename T> WeakPtrImplWithEventTargetData(T* ptr) : WTF::WeakPtrImplBaseSingleThread<WeakPtrImplWithEventTargetData>(ptr) { }
 
 private:
     EventTargetData m_eventTargetData;

--- a/Source/WebCore/dom/MessagePort.h
+++ b/Source/WebCore/dom/MessagePort.h
@@ -47,12 +47,15 @@ class WebCoreOpaqueRoot;
 
 struct StructuredSerializeOptions;
 
-class MessagePort final : public ActiveDOMObject, public EventTarget {
+class MessagePort final : public ActiveDOMObject, public EventTarget, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<MessagePort> {
     WTF_MAKE_NONCOPYABLE(MessagePort);
-    WTF_MAKE_ISO_ALLOCATED(MessagePort);
+    WTF_MAKE_ISO_ALLOCATED_EXPORT(MessagePort, WEBCORE_EXPORT);
 public:
     static Ref<MessagePort> create(ScriptExecutionContext&, const MessagePortIdentifier& local, const MessagePortIdentifier& remote);
-    virtual ~MessagePort();
+    WEBCORE_EXPORT virtual ~MessagePort();
+
+    using ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref;
+    using ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref;
 
     ExceptionOr<void> postMessage(JSC::JSGlobalObject&, JSC::JSValue message, StructuredSerializeOptions&&);
 
@@ -80,9 +83,6 @@ public:
 
     const MessagePortIdentifier& identifier() const { return m_identifier; }
     const MessagePortIdentifier& remoteIdentifier() const { return m_remoteIdentifier; }
-
-    WEBCORE_EXPORT void ref() const;
-    WEBCORE_EXPORT void deref() const;
 
     // EventTarget.
     EventTargetInterface eventTargetInterface() const final { return MessagePortEventTargetInterfaceType; }
@@ -117,8 +117,6 @@ private:
 
     MessagePortIdentifier m_identifier;
     MessagePortIdentifier m_remoteIdentifier;
-
-    mutable std::atomic<unsigned> m_refCount { 1 };
 };
 
 WebCoreOpaqueRoot root(MessagePort*);

--- a/Source/WebCore/html/OffscreenCanvas.h
+++ b/Source/WebCore/html/OffscreenCanvas.h
@@ -196,7 +196,7 @@ private:
 
     bool m_hasScheduledCommit { false };
 
-    class PlaceholderData : public ThreadSafeRefCounted<PlaceholderData> {
+    class PlaceholderData : public ThreadSafeRefCounted<PlaceholderData, WTF::DestructionThread::Main> {
     public:
         static Ref<PlaceholderData> create()
         {


### PR DESCRIPTION
#### 4c56da25ced28ccc63d3d4e45c4f8451c1c67e5e
<pre>
Speed up use of WeakPtr with EventTarget objects (such as Node)
<a href="https://bugs.webkit.org/show_bug.cgi?id=265878">https://bugs.webkit.org/show_bug.cgi?id=265878</a>

Reviewed by Darin Adler.

Speed up use of WeakPtr with EventTarget objects (such as Node) by using a
single thread ref count instead of ThreadSafeRefCounted for the WeakPtr
implementation object, like we did for RenderObjects.

Most of the EventTarget didn&apos;t need a thread-safe WeakPtr impl. For the
subclasses that did, I either:
- Updated the logic to avoid ref&apos;ing / deref&apos;ing the WeakPtr on a different
  thread.
- Had the subclass inherit ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr
  and used ThreadSafeWeakPtr instead of WeakPtr.

This tested as a small Speedometer progression (~0.3% on M1 with 98%
confidence). More importantly, this will help us convert more
CheckedPtr&lt;Node&gt; into WeakPtr&lt;Node&gt; without hurting performance.

* Source/WebCore/Modules/cookie-store/CookieStore.cpp:
(WebCore::CookieStore::MainThreadBridge::detach):
(WebCore::CookieStore::~CookieStore):
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp:
(WebCore::processFrame):
(WebCore::RTCRtpSFrameTransform::initializeTransformer):
(WebCore::transformFrame):
(WebCore::RTCRtpSFrameTransform::createStreams):
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.h:
* Source/WebCore/Modules/permissions/MainThreadPermissionObserver.cpp:
(WebCore::MainThreadPermissionObserver::MainThreadPermissionObserver):
(WebCore::MainThreadPermissionObserver::stateChanged):
* Source/WebCore/Modules/permissions/MainThreadPermissionObserver.h:
* Source/WebCore/Modules/permissions/PermissionStatus.cpp:
(WebCore::PermissionStatus::PermissionStatus):
(WebCore::PermissionStatus::virtualHasPendingActivity const):
* Source/WebCore/Modules/permissions/PermissionStatus.h:
* Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp:
(WebCore::WebCodecsAudioDecoder::configure):
* Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.h:
* Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp:
(WebCore::WebCodecsAudioEncoder::configure):
* Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.h:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp:
(WebCore::WebCodecsVideoDecoder::configure):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.h:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp:
(WebCore::WebCodecsVideoEncoder::configure):
(WebCore::WebCodecsVideoEncoder::encode):
(WebCore::WebCodecsVideoEncoder::flush):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h:
* Source/WebCore/dom/BroadcastChannel.cpp:
(WebCore::BroadcastChannel::MainThreadBridge::detach):
(WebCore::BroadcastChannel::~BroadcastChannel):
* Source/WebCore/dom/EventTarget.h:
* Source/WebCore/dom/MessagePort.cpp:
(WebCore::WTF_REQUIRES_LOCK):
(WebCore::MessagePort::MessagePort):
(WebCore::MessagePort::~MessagePort):
(WebCore::MessagePort::ref const): Deleted.
(WebCore::MessagePort::deref const): Deleted.
* Source/WebCore/dom/MessagePort.h:
* Source/WebCore/html/OffscreenCanvas.h:

Canonical link: <a href="https://commits.webkit.org/271982@main">https://commits.webkit.org/271982@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dcb8e5d8a1141a08150e09a9d1e07766c0fadd72

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30212 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8880 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31678 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32717 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27329 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30890 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11081 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6117 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27316 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30516 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7457 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6380 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6552 "Passed tests") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34057 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/27562 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32709 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6484 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4647 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30521 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8235 "Built successfully") | [⏳ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/macOS-Release-WK2-Stress-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7239 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3903 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7012 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->