### PR TITLE
[threaded-animation-resolution] store accelerated effects and base values in the remote layer tree

### DIFF
--- a/Source/WebCore/platform/animation/AcceleratedEffectStack.h
+++ b/Source/WebCore/platform/animation/AcceleratedEffectStack.h
@@ -27,29 +27,29 @@
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
 
+#include "AcceleratedEffect.h"
 #include "AcceleratedEffectValues.h"
 
 namespace WebCore {
 
-class AcceleratedEffect;
-
 using AcceleratedEffects = Vector<Ref<AcceleratedEffect>>;
 
-class AcceleratedEffectStack {
-    WTF_MAKE_FAST_ALLOCATED;
+class WEBCORE_EXPORT AcceleratedEffectStack : public RefCounted<AcceleratedEffectStack> {
+    WTF_MAKE_ISO_ALLOCATED(AcceleratedEffectStack);
 public:
-    WEBCORE_EXPORT explicit AcceleratedEffectStack();
-    WEBCORE_EXPORT ~AcceleratedEffectStack();
+    static Ref<AcceleratedEffectStack> create();
 
-    WEBCORE_EXPORT bool hasEffects() const;
+    bool hasEffects() const;
     const AcceleratedEffects& primaryLayerEffects() const { return m_primaryLayerEffects; }
     const AcceleratedEffects& backdropLayerEffects() const { return m_backdropLayerEffects; }
-    WEBCORE_EXPORT void setEffects(AcceleratedEffects&&);
+    void setEffects(AcceleratedEffects&&);
 
     const AcceleratedEffectValues& baseValues() { return m_baseValues; }
-    WEBCORE_EXPORT void setBaseValues(AcceleratedEffectValues&&);
+    void setBaseValues(AcceleratedEffectValues&&);
 
-private:
+protected:
+    WEBCORE_EXPORT explicit AcceleratedEffectStack();
+
     AcceleratedEffectValues m_baseValues;
     AcceleratedEffects m_primaryLayerEffects;
     AcceleratedEffects m_backdropLayerEffects;

--- a/Source/WebCore/platform/animation/AcceleratedEffectStack.mm
+++ b/Source/WebCore/platform/animation/AcceleratedEffectStack.mm
@@ -28,15 +28,18 @@
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
 
-#include "AcceleratedEffect.h"
+#include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
 
-AcceleratedEffectStack::AcceleratedEffectStack()
+WTF_MAKE_ISO_ALLOCATED_IMPL(AcceleratedEffectStack);
+
+Ref<AcceleratedEffectStack> AcceleratedEffectStack::create()
 {
+    return adoptRef(*new AcceleratedEffectStack());
 }
 
-AcceleratedEffectStack::~AcceleratedEffectStack()
+AcceleratedEffectStack::AcceleratedEffectStack()
 {
 }
 
@@ -50,7 +53,7 @@ void AcceleratedEffectStack::setEffects(AcceleratedEffects&& effects)
     m_primaryLayerEffects.clear();
     m_backdropLayerEffects.clear();
 
-    for (auto effect : effects) {
+    for (auto& effect : effects) {
         auto& animatedProperties = effect->animatedProperties();
 
         // If we don't have a keyframe targeting backdrop-filter, we can add the effect

--- a/Source/WebCore/platform/graphics/GraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.cpp
@@ -764,7 +764,7 @@ void GraphicsLayer::setAcceleratedEffectsAndBaseValues(AcceleratedEffects&& effe
     }
 
     if (!m_effectStack)
-        m_effectStack = makeUnique<AcceleratedEffectStack>();
+        m_effectStack = AcceleratedEffectStack::create();
 
     m_effectStack->setEffects(WTFMove(effects));
     m_effectStack->setBaseValues(WTFMove(baseValues));

--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -730,7 +730,7 @@ protected:
     WEBCORE_EXPORT virtual void getDebugBorderInfo(Color&, float& width) const;
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
-    std::unique_ptr<AcceleratedEffectStack> m_effectStack;
+    RefPtr<AcceleratedEffectStack> m_effectStack;
 #endif
 
     GraphicsLayerClient* m_client; // Always non-null.

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -577,6 +577,7 @@ UIProcess/RemoteLayerTree/ios/ScrollingTreeOverflowScrollingNodeIOS.mm
 UIProcess/RemoteLayerTree/ios/ScrollingTreePluginScrollingNodeIOS.mm
 UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
 
+UIProcess/RemoteLayerTree/RemoteAcceleratedEffectStack.mm
 UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
 UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
 UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAcceleratedEffectStack.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAcceleratedEffectStack.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+
+#include <WebCore/AcceleratedEffectStack.h>
+
+namespace WebKit {
+
+class RemoteAcceleratedEffectStack final : public WebCore::AcceleratedEffectStack {
+    WTF_MAKE_ISO_ALLOCATED(RemoteAcceleratedEffectStack);
+public:
+    static Ref<RemoteAcceleratedEffectStack> create(Seconds);
+
+private:
+    explicit RemoteAcceleratedEffectStack(Seconds);
+
+    Seconds m_acceleratedTimelineTimeOrigin;
+};
+
+} // namespace WebKit
+
+#endif // ENABLE(THREADED_ANIMATION_RESOLUTION)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAcceleratedEffectStack.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAcceleratedEffectStack.mm
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "RemoteAcceleratedEffectStack.h"
+
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+
+#include <wtf/IsoMallocInlines.h>
+
+namespace WebKit {
+
+WTF_MAKE_ISO_ALLOCATED_IMPL(RemoteAcceleratedEffectStack);
+
+Ref<RemoteAcceleratedEffectStack> RemoteAcceleratedEffectStack::create(Seconds acceleratedTimelineTimeOrigin)
+{
+    return adoptRef(*new RemoteAcceleratedEffectStack(acceleratedTimelineTimeOrigin));
+}
+
+RemoteAcceleratedEffectStack::RemoteAcceleratedEffectStack(Seconds acceleratedTimelineTimeOrigin)
+    : m_acceleratedTimelineTimeOrigin(acceleratedTimelineTimeOrigin)
+{
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(THREADED_ANIMATION_RESOLUTION)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -76,6 +76,8 @@ public:
     void viewWillEndLiveResize() final;
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
+    void animationsWereAddedToNode(RemoteLayerTreeNode&);
+    void animationsWereRemovedFromNode(RemoteLayerTreeNode&);
     Seconds acceleratedTimelineTimeOrigin() const { return m_acceleratedTimelineTimeOrigin; }
 #endif
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -614,4 +614,16 @@ void RemoteLayerTreeDrawingAreaProxy::sizeToContentAutoSizeMaximumSizeDidChange(
     sendUpdateGeometry();
 }
 
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+void RemoteLayerTreeDrawingAreaProxy::animationsWereAddedToNode(RemoteLayerTreeNode& node)
+{
+    protectedWebPageProxy()->scrollingCoordinatorProxy()->animationsWereAddedToNode(node);
+}
+
+void RemoteLayerTreeDrawingAreaProxy::animationsWereRemovedFromNode(RemoteLayerTreeNode& node)
+{
+    protectedWebPageProxy()->scrollingCoordinatorProxy()->animationsWereRemovedFromNode(node);
+}
+#endif // ENABLE(THREADED_ANIMATION_RESOLUTION)
+
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
@@ -67,6 +67,11 @@ public:
     void animationDidStart(WebCore::PlatformLayerIdentifier, CAAnimation *, MonotonicTime startTime);
     void animationDidEnd(WebCore::PlatformLayerIdentifier, CAAnimation *);
 
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+    void animationsWereAddedToNode(RemoteLayerTreeNode&);
+    void animationsWereRemovedFromNode(RemoteLayerTreeNode&);
+#endif
+
     void detachFromDrawingArea();
     void clearLayers();
 
@@ -81,6 +86,7 @@ public:
 
     bool replayDynamicContentScalingDisplayListsIntoBackingStore() const;
     bool css3DTransformInteroperabilityEnabled() const;
+    bool threadedAnimationResolutionEnabled() const;
 #if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
     const HashSet<WebCore::PlatformLayerIdentifier>& overlayRegionIDs() const { return m_overlayRegionIDs; }
     void updateOverlayRegionIDs(const HashSet<WebCore::PlatformLayerIdentifier> &overlayRegionNodes) { m_overlayRegionIDs = overlayRegionNodes; }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
@@ -26,6 +26,7 @@
 #import "config.h"
 #import "RemoteLayerTreeHost.h"
 
+#import "LayerProperties.h"
 #import "Logging.h"
 #import "RemoteLayerTreeDrawingAreaProxy.h"
 #import "RemoteLayerTreePropertyApplier.h"
@@ -99,6 +100,11 @@ bool RemoteLayerTreeHost::replayDynamicContentScalingDisplayListsIntoBackingStor
 bool RemoteLayerTreeHost::css3DTransformInteroperabilityEnabled() const
 {
     return m_drawingArea->page().preferences().css3DTransformInteroperabilityEnabled();
+}
+
+bool RemoteLayerTreeHost::threadedAnimationResolutionEnabled() const
+{
+    return m_drawingArea->page().preferences().threadedAnimationResolutionEnabled();
 }
 
 #if PLATFORM(MAC)
@@ -447,6 +453,16 @@ void RemoteLayerTreeHost::mapAllIOSurfaceBackingStore()
 }
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
+void RemoteLayerTreeHost::animationsWereAddedToNode(RemoteLayerTreeNode& node)
+{
+    m_drawingArea->animationsWereAddedToNode(node);
+}
+
+void RemoteLayerTreeHost::animationsWereRemovedFromNode(RemoteLayerTreeNode& node)
+{
+    m_drawingArea->animationsWereRemovedFromNode(node);
+}
+
 Seconds RemoteLayerTreeHost::acceleratedTimelineTimeOrigin() const
 {
     return m_drawingArea->acceleratedTimelineTimeOrigin();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "RemoteAcceleratedEffectStack.h"
 #include "RemoteLayerBackingStore.h"
 #include <WebCore/EventRegion.h>
 #include <WebCore/LayerHostingContextIdentifier.h>
@@ -42,6 +43,7 @@ OBJC_CLASS UIView;
 
 namespace WebKit {
 
+class RemoteLayerTreeHost;
 class RemoteLayerTreeScrollbars;
 
 class RemoteLayerTreeNode : public CanMakeWeakPtr<RemoteLayerTreeNode> {
@@ -131,6 +133,11 @@ public:
         m_asyncContentsIdentifier = identifier;
     }
 
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+    void setAcceleratedEffectsAndBaseValues(const WebCore::AcceleratedEffects&, const WebCore::AcceleratedEffectValues&, RemoteLayerTreeHost&);
+    RefPtr<RemoteAcceleratedEffectStack> takeEffectStack() { return std::exchange(m_effectStack, nullptr); }
+#endif
+
 private:
     void initializeLayer();
 
@@ -168,6 +175,10 @@ private:
 
     Vector<CachedContentsBuffer> m_cachedContentsBuffers;
     std::optional<WebCore::RenderingResourceIdentifier> m_asyncContentsIdentifier;
+
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+    RefPtr<RemoteAcceleratedEffectStack> m_effectStack;
+#endif
 };
 
 }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -31,6 +31,7 @@
 #include "RemoteScrollingCoordinator.h"
 #include "RemoteScrollingTree.h"
 #include "RemoteScrollingUIState.h"
+#include <WebCore/PlatformLayer.h>
 #include <WebCore/PlatformLayerIdentifier.h>
 #include <WebCore/ScrollSnapOffsetsInfo.h>
 #include <WebCore/WheelEventTestMonitor.h>
@@ -49,6 +50,7 @@ namespace WebKit {
 
 class NativeWebWheelEvent;
 class RemoteLayerTreeHost;
+class RemoteLayerTreeNode;
 class RemoteScrollingCoordinatorTransaction;
 class RemoteScrollingTree;
 class WebPageProxy;
@@ -130,6 +132,11 @@ public:
     
     virtual void willCommitLayerAndScrollingTrees() { }
     virtual void didCommitLayerAndScrollingTrees() { }
+
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+    virtual void animationsWereAddedToNode(RemoteLayerTreeNode&) { }
+    virtual void animationsWereRemovedFromNode(RemoteLayerTreeNode&) { }
+#endif
 
     String scrollingTreeAsText() const;
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h
@@ -33,6 +33,8 @@ OBJC_CLASS UIScrollView;
 
 namespace WebKit {
 
+class RemoteLayerTreeNode;
+
 class RemoteScrollingCoordinatorProxyIOS final : public RemoteScrollingCoordinatorProxy {
 public:
     explicit RemoteScrollingCoordinatorProxyIOS(WebPageProxy&);
@@ -55,6 +57,11 @@ public:
     const HashSet<WebCore::PlatformLayerIdentifier>& fixedScrollingNodeLayerIDs() const { return m_fixedScrollingNodeLayerIDs; }
 #endif
 
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+    void animationsWereAddedToNode(RemoteLayerTreeNode&) override;
+    void animationsWereRemovedFromNode(RemoteLayerTreeNode&) override;
+#endif
+
 private:
     bool propagatesMainFrameScrolls() const override { return false; }
 
@@ -74,6 +81,10 @@ private:
 
 #if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
     HashSet<WebCore::PlatformLayerIdentifier> m_fixedScrollingNodeLayerIDs;
+#endif
+
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+    HashSet<WebCore::PlatformLayerIdentifier> m_animatedNodeLayerIDs;
 #endif
 };
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
@@ -368,6 +368,18 @@ CGPoint RemoteScrollingCoordinatorProxyIOS::nearestActiveContentInsetAdjustedSna
     return activePoint;
 }
 
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+void RemoteScrollingCoordinatorProxyIOS::animationsWereAddedToNode(RemoteLayerTreeNode& node)
+{
+    m_animatedNodeLayerIDs.add(node.layerID());
+}
+
+void RemoteScrollingCoordinatorProxyIOS::animationsWereRemovedFromNode(RemoteLayerTreeNode& node)
+{
+    m_animatedNodeLayerIDs.remove(node.layerID());
+}
+#endif
+
 } // namespace WebKit
 
 #endif // PLATFORM(IOS_FAMILY) && ENABLE(ASYNC_SCROLLING)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
@@ -32,6 +32,7 @@
 #include "Logging.h"
 #include "NativeWebWheelEvent.h"
 #include "RemoteLayerTreeDrawingAreaProxyMac.h"
+#include "RemoteLayerTreeNode.h"
 #include "RemoteScrollingCoordinatorProxyMac.h"
 #include "RemoteScrollingTree.h"
 #include "WebEventConversion.h"
@@ -555,6 +556,20 @@ void RemoteLayerTreeEventDispatcher::renderingUpdateComplete()
 
     m_state = SynchronizationState::Idle;
 }
+
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+void RemoteLayerTreeEventDispatcher::animationsWereAddedToNode(RemoteLayerTreeNode& node)
+{
+    auto effectStack = node.takeEffectStack();
+    ASSERT(effectStack);
+    m_effectStacks.set(node.layerID(), effectStack.releaseNonNull());
+}
+
+void RemoteLayerTreeEventDispatcher::animationsWereRemovedFromNode(RemoteLayerTreeNode& node)
+{
+    m_effectStacks.remove(node.layerID());
+}
+#endif
 
 void RemoteLayerTreeEventDispatcher::windowScreenWillChange()
 {

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
@@ -88,6 +88,11 @@ public:
 
     void renderingUpdateComplete();
 
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+    void animationsWereAddedToNode(RemoteLayerTreeNode&);
+    void animationsWereRemovedFromNode(RemoteLayerTreeNode&);
+#endif
+
 private:
     OptionSet<WebCore::WheelEventProcessingSteps> determineWheelEventProcessing(const WebCore::PlatformWheelEvent&, WebCore::RectEdges<bool> rubberBandableEdges);
 
@@ -159,6 +164,10 @@ private:
     MonotonicTime m_lastDisplayDidRefreshTime;
 
     std::unique_ptr<RunLoop::Timer> m_delayedRenderingUpdateDetectionTimer;
+
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+    HashMap<WebCore::PlatformLayerIdentifier, Ref<RemoteAcceleratedEffectStack>> m_effectStacks;
+#endif
 
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER)
     std::unique_ptr<MomentumEventDispatcher> m_momentumEventDispatcher;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
@@ -69,6 +69,11 @@ private:
     void didCommitLayerAndScrollingTrees() override;
     void applyScrollingTreeLayerPositionsAfterCommit() override;
 
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+    void animationsWereAddedToNode(RemoteLayerTreeNode&) override;
+    void animationsWereRemovedFromNode(RemoteLayerTreeNode&) override;
+#endif
+
 #if ENABLE(SCROLLING_THREAD)
     RefPtr<RemoteLayerTreeEventDispatcher> m_eventDispatcher;
 #endif

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
@@ -286,6 +286,18 @@ void RemoteScrollingCoordinatorProxyMac::applyScrollingTreeLayerPositionsAfterCo
     m_eventDispatcher->renderingUpdateComplete();
 }
 
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+void RemoteScrollingCoordinatorProxyMac::animationsWereAddedToNode(RemoteLayerTreeNode& node)
+{
+    m_eventDispatcher->animationsWereAddedToNode(node);
+}
+
+void RemoteScrollingCoordinatorProxyMac::animationsWereRemovedFromNode(RemoteLayerTreeNode& node)
+{
+    m_eventDispatcher->animationsWereRemovedFromNode(node);
+}
+#endif
+
 } // namespace WebKit
 
 #endif // PLATFORM(MAC) && ENABLE(UI_SIDE_COMPOSITING)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1516,6 +1516,7 @@
 		7137BA8025F1542000914EE3 /* ModelElementController.h in Headers */ = {isa = PBXBuildFile; fileRef = 7137BA7F25F1540C00914EE3 /* ModelElementController.h */; };
 		71A676A622C62325007D6295 /* WKTouchActionGestureRecognizer.h in Headers */ = {isa = PBXBuildFile; fileRef = 71A676A422C62318007D6295 /* WKTouchActionGestureRecognizer.h */; };
 		71BAA73325FFD09800D7CD5D /* WKModelView.h in Headers */ = {isa = PBXBuildFile; fileRef = 71BAA73125FFCCBA00D7CD5D /* WKModelView.h */; };
+		71E29A342B20610C0010F3C9 /* RemoteAcceleratedEffectStack.h in Headers */ = {isa = PBXBuildFile; fileRef = 71371D1E2B1F89C00092C32D /* RemoteAcceleratedEffectStack.h */; };
 		71FB810B2260627E00323677 /* WebsiteSimulatedMouseEventsDispatchPolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = 71FB810A2260627A00323677 /* WebsiteSimulatedMouseEventsDispatchPolicy.h */; };
 		728E86F11795188C0087879E /* WebColorPickerMac.h in Headers */ = {isa = PBXBuildFile; fileRef = 728E86EF1795188C0087879E /* WebColorPickerMac.h */; };
 		74C2F54129AC9C44006C5F97 /* DeferredPaymentRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 74C2F54029AC9C44006C5F97 /* DeferredPaymentRequest.h */; };
@@ -6009,6 +6010,8 @@
 		711725A8228D563A00018514 /* WebsiteLegacyOverflowScrollingTouchPolicy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebsiteLegacyOverflowScrollingTouchPolicy.h; sourceTree = "<group>"; };
 		7134A3D82603B80E00624BD3 /* WKModelInteractionGestureRecognizer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = WKModelInteractionGestureRecognizer.mm; path = ios/WKModelInteractionGestureRecognizer.mm; sourceTree = "<group>"; };
 		7134A3D92603B80E00624BD3 /* WKModelInteractionGestureRecognizer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WKModelInteractionGestureRecognizer.h; path = ios/WKModelInteractionGestureRecognizer.h; sourceTree = "<group>"; };
+		71371D1E2B1F89C00092C32D /* RemoteAcceleratedEffectStack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RemoteAcceleratedEffectStack.h; sourceTree = "<group>"; };
+		71371D1F2B1F89C10092C32D /* RemoteAcceleratedEffectStack.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RemoteAcceleratedEffectStack.mm; sourceTree = "<group>"; };
 		7137BA7D25F153E900914EE3 /* ModelElementControllerCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ModelElementControllerCocoa.mm; sourceTree = "<group>"; };
 		7137BA7E25F1540B00914EE3 /* ModelElementController.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ModelElementController.cpp; sourceTree = "<group>"; };
 		7137BA7F25F1540C00914EE3 /* ModelElementController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ModelElementController.h; sourceTree = "<group>"; };
@@ -9806,6 +9809,8 @@
 				2D6482482644B1AB00030335 /* cocoa */,
 				2D1551AA1F5A9BA70006E3FE /* ios */,
 				E404906F21DE65D70037F0DB /* mac */,
+				71371D1E2B1F89C00092C32D /* RemoteAcceleratedEffectStack.h */,
+				71371D1F2B1F89C10092C32D /* RemoteAcceleratedEffectStack.mm */,
 				1AB16AE01648656D00290D62 /* RemoteLayerTreeDrawingAreaProxy.h */,
 				0FF24A2F1879E4FE003ABF0C /* RemoteLayerTreeDrawingAreaProxy.messages.in */,
 				1AB16ADF1648656D00290D62 /* RemoteLayerTreeDrawingAreaProxy.mm */,
@@ -15591,6 +15596,7 @@
 				7BE9326327F5C75A00D5FEFB /* ReceiverMatcher.h in Headers */,
 				950FECF4285027200002DE4E /* RecurringPaymentRequest.h in Headers */,
 				57FD318222B3515E008D0E8B /* RedirectSOAuthorizationSession.h in Headers */,
+				71E29A342B20610C0010F3C9 /* RemoteAcceleratedEffectStack.h in Headers */,
 				9B1229D223FF2BCC008CA751 /* RemoteAudioDestinationIdentifier.h in Headers */,
 				9B1229CD23FF25F2008CA751 /* RemoteAudioDestinationManager.h in Headers */,
 				9B5BEC2A240101580070C6EF /* RemoteAudioDestinationProxy.h in Headers */,


### PR DESCRIPTION
#### c4c680697bdba4208581dc7fd40ffdd202482c08
<pre>
[threaded-animation-resolution] store accelerated effects and base values in the remote layer tree
<a href="https://bugs.webkit.org/show_bug.cgi?id=265880">https://bugs.webkit.org/show_bug.cgi?id=265880</a>

Reviewed by Simon Fraser.

While we correctly encode the `AcceleratedEffectStack` from WebCore to be sent over IPC to
the UI process whenever there is a meaningful change, we don&apos;t do anything with these effects
yet. This patch creates a `RemoteAcceleratedEffectStack` and store effects and base values on it
and lays the groundwork for the next patch for the threaded animation resolution feature where
we will schedule and resolve animations in the remote layer tree.

On iOS, the `RemoteAcceleratedEffectStack` is owned by a `RemoteLayerTreeNode` which will access
on the main thread for animation resolution.

On macOS, the `RemoteAcceleratedEffectStack` is owned by the `RemoteLayerTreeEventDispatcher` which
will allow access in a thread-safe manner for animation resolution.

* Source/WebCore/platform/animation/AcceleratedEffectStack.h:
(WebCore::AcceleratedEffectStack::primaryLayerEffects const): Deleted.
(WebCore::AcceleratedEffectStack::backdropLayerEffects const): Deleted.
(WebCore::AcceleratedEffectStack::baseValues): Deleted.
* Source/WebCore/platform/animation/AcceleratedEffectStack.mm:
(WebCore::AcceleratedEffectStack::create):
(WebCore::AcceleratedEffectStack::AcceleratedEffectStack):
(WebCore::AcceleratedEffectStack::setEffects):
(WebCore::AcceleratedEffectStack::~AcceleratedEffectStack): Deleted.
* Source/WebCore/platform/graphics/GraphicsLayer.cpp:
(WebCore::GraphicsLayer::setAcceleratedEffectsAndBaseValues):
* Source/WebCore/platform/graphics/GraphicsLayer.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(WebKit::RemoteLayerTreePropertyApplier::applyPropertiesToLayer):
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAcceleratedEffectStack.h: Added.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAcceleratedEffectStack.mm: Added.
(WebKit::RemoteAcceleratedEffectStack::create):
(WebKit::RemoteAcceleratedEffectStack::RemoteAcceleratedEffectStack):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::animationsWereAddedToNode):
(WebKit::RemoteLayerTreeDrawingAreaProxy::animationsWereRemovedFromNode):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm:
(WebKit::RemoteLayerTreeHost::threadedAnimationResolutionEnabled const):
(WebKit::RemoteLayerTreeHost::animationsWereAddedToNode):
(WebKit::RemoteLayerTreeHost::animationsWereRemovedFromNode):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h:
(WebKit::RemoteLayerTreeNode::takeEffectStack):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm:
(WebKit::RemoteLayerTreeNode::setAcceleratedEffectsAndBaseValues):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
(WebKit::RemoteScrollingCoordinatorProxy::animationsWereAddedToNode):
(WebKit::RemoteScrollingCoordinatorProxy::animationsWereRemovedFromNode):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm:
(WebKit::RemoteScrollingCoordinatorProxyIOS::animationsWereAddedToNode):
(WebKit::RemoteScrollingCoordinatorProxyIOS::animationsWereRemovedFromNode):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp:
(WebKit::RemoteLayerTreeEventDispatcher::animationsWereAddedToNode):
(WebKit::RemoteLayerTreeEventDispatcher::animationsWereRemovedFromNode):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm:
(WebKit::RemoteScrollingCoordinatorProxyMac::animationsWereAddedToNode):
(WebKit::RemoteScrollingCoordinatorProxyMac::animationsWereRemovedFromNode):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Co-authored-by: Matt Woodrow &lt;mattwoodrow@apple.com&gt;
Canonical link: <a href="https://commits.webkit.org/271692@main">https://commits.webkit.org/271692@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d381934a5ebff692d0a51da5f621caebb293875

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29286 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7956 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30624 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31864 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/26620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29885 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10096 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5258 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29559 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/6614 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/25076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5693 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/5835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/26123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33205 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26744 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26554 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/32055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/5802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/3980 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/29840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7489 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/6316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3765 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/6326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->