### PR TITLE
Add support for styling grammar and spelling errors

### DIFF
--- a/LayoutTests/editing/spelling/grammar-and-spelling-error-styling-expected.html
+++ b/LayoutTests/editing/spelling/grammar-and-spelling-error-styling-expected.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+
+#editor {
+    width: 300px;
+    height: 20px;
+    border: 1px solid black;
+}
+
+.spelling-error {
+    color: red;
+    background-color: yellow;
+    text-decoration-line: underline;
+    text-decoration-style: wavy;
+    text-decoration-color: green;
+}
+
+.grammar-error {
+    color: darkred;
+    background-color: lightblue;
+    text-decoration-line: underline;
+    text-decoration-style: double;
+    text-decoration-color: red;
+}
+
+</style>
+</head>
+
+<body>
+<div id="editor" contenteditable="true">the <span class="grammar-error">the</span> <span class="spelling-error">adlj</span> <span class="spelling-error">adaasj</span> <span class="spelling-error">sdklj</span>. there <span class="grammar-error">there</span></div>
+</body>
+</html>

--- a/LayoutTests/editing/spelling/grammar-and-spelling-error-styling.html
+++ b/LayoutTests/editing/spelling/grammar-and-spelling-error-styling.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html><!-- webkit-test-runner [ spellCheckingDots=true ] -->
+<html>
+<head>
+<style>
+
+#editor {
+    width: 300px;
+    height: 20px;
+    border: 1px solid black;
+}
+
+::spelling-error {
+    color: red;
+    background-color: yellow;
+    text-decoration-line: underline;
+    text-decoration-style: wavy;
+    text-decoration-color: green;
+}
+
+::grammar-error {
+    color: darkred;
+    background-color: lightblue;
+    text-decoration-line: underline;
+    text-decoration-style: double;
+    text-decoration-color: red;
+}
+
+</style>
+</head>
+
+<body>
+<script src="../../resources/ui-helper.js"></script>
+<div id="editor" contenteditable="true"></div>
+<script>
+
+const incorrectPhrase = "the the adlj adaasj sdklj. there there";
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+if (window.internals)
+    internals.setContinuousSpellCheckingEnabled(true);
+
+function runTest()
+{
+    var editor = document.getElementById("editor");
+    editor.focus();
+
+    document.execCommand("InsertText", false, incorrectPhrase);
+
+    // Add a word separator so that both spelling and grammar markers will appear.
+    document.execCommand("InsertText", false, " ");
+
+    editor.blur();
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+UIHelper.setSpellCheckerResults({
+    "the the adlj adaasj sdklj. there there\u00A0" : [
+        { type : "spelling", from : 8, to : 12 },
+        { type : "spelling", from : 13, to : 19 },
+        { type : "spelling", from : 20, to : 25 },
+        {
+            type : "grammar",
+            from : 4,
+            to : 7,
+            details : [{ from : 0, to : 3 }]
+        },
+        {
+            type : "grammar",
+            from : 33,
+            to : 38,
+            details : [{ from : 0, to : 5 }]
+        }
+    ]
+}).then(runTest);
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/rendering/MarkedText.cpp
+++ b/Source/WebCore/rendering/MarkedText.cpp
@@ -232,6 +232,9 @@ Vector<MarkedText> MarkedText::collectForDocumentMarkers(const RenderText& rende
         switch (marker->type()) {
         case DocumentMarker::Grammar:
         case DocumentMarker::Spelling:
+            if (renderer.settings().grammarAndSpellingPseudoElementsEnabled())
+                break;
+            FALLTHROUGH;
         case DocumentMarker::CorrectionIndicator:
         case DocumentMarker::Replacement:
         case DocumentMarker::DictationAlternatives:

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -77,8 +77,9 @@ public:
     // continue even if the style isn't different from the current style.
     void setStyle(RenderStyle&&, StyleDifference minimalStyleDifference = StyleDifference::Equal);
 
-    // The pseudo element style can be cached or uncached.  Use the cached method if the pseudo element doesn't respect
-    // any pseudo classes (and therefore has no concept of changing state).
+    // The pseudo element style can be cached or uncached. Use the uncached method if the pseudo element
+    // has the concept of changing state (like ::-webkit-scrollbar-thumb:hover), or if it takes additional
+    // parameters (like ::highlight(name)).
     const RenderStyle* getCachedPseudoStyle(PseudoId, const RenderStyle* parentStyle = nullptr) const;
     std::unique_ptr<RenderStyle> getUncachedPseudoStyle(const Style::PseudoElementRequest&, const RenderStyle* parentStyle = nullptr, const RenderStyle* ownStyle = nullptr) const;
 
@@ -113,12 +114,15 @@ public:
     bool hasEligibleContainmentForSizeQuery() const;
 
     Color selectionColor(CSSPropertyID) const;
-    std::unique_ptr<RenderStyle> selectionPseudoStyle() const;
+    const RenderStyle* selectionPseudoStyle() const;
 
     // Obtains the selection colors that should be used when painting a selection.
     Color selectionBackgroundColor() const;
     Color selectionForegroundColor() const;
     Color selectionEmphasisMarkColor() const;
+
+    const RenderStyle* spellingErrorPseudoStyle() const;
+    const RenderStyle* grammarErrorPseudoStyle() const;
 
     // FIXME: Make these standalone and move to relevant files.
     bool isRenderLayerModelObject() const;
@@ -400,6 +404,8 @@ private:
     
     void updateReferencedSVGResources();
     void clearReferencedSVGResources();
+
+    const RenderStyle* textSegmentPseudoStyle(PseudoId) const;
 
     PackedCheckedPtr<RenderObject> m_firstChild;
     unsigned m_baseTypeFlags : 8;

--- a/Source/WebCore/rendering/RenderText.h
+++ b/Source/WebCore/rendering/RenderText.h
@@ -57,7 +57,10 @@ public:
     Color selectionBackgroundColor() const;
     Color selectionForegroundColor() const;
     Color selectionEmphasisMarkColor() const;
-    std::unique_ptr<RenderStyle> selectionPseudoStyle() const;
+    const RenderStyle* selectionPseudoStyle() const;
+
+    const RenderStyle* spellingErrorPseudoStyle() const;
+    const RenderStyle* grammarErrorPseudoStyle() const;
 
     virtual String originalText() const;
 
@@ -316,10 +319,24 @@ inline Color RenderText::selectionEmphasisMarkColor() const
     return Color();
 }
 
-inline std::unique_ptr<RenderStyle> RenderText::selectionPseudoStyle() const
+inline const RenderStyle* RenderText::selectionPseudoStyle() const
 {
     if (auto* ancestor = firstNonAnonymousAncestor())
         return ancestor->selectionPseudoStyle();
+    return nullptr;
+}
+
+inline const RenderStyle* RenderText::spellingErrorPseudoStyle() const
+{
+    if (auto* ancestor = firstNonAnonymousAncestor())
+        return ancestor->spellingErrorPseudoStyle();
+    return nullptr;
+}
+
+inline const RenderStyle* RenderText::grammarErrorPseudoStyle() const
+{
+    if (auto* ancestor = firstNonAnonymousAncestor())
+        return ancestor->grammarErrorPseudoStyle();
     return nullptr;
 }
 

--- a/Source/WebCore/rendering/StyledMarkedText.cpp
+++ b/Source/WebCore/rendering/StyledMarkedText.cpp
@@ -35,6 +35,34 @@
 
 namespace WebCore {
 
+static void computeStyleForPseudoElementStyle(StyledMarkedText::Style& style, const RenderStyle* pseudoElementStyle, const PaintInfo& paintInfo)
+{
+    if (!pseudoElementStyle)
+        return;
+
+    style.backgroundColor = pseudoElementStyle->colorResolvingCurrentColor(pseudoElementStyle->backgroundColor());
+    style.textStyles.fillColor = pseudoElementStyle->computedStrokeColor();
+    style.textStyles.strokeColor = pseudoElementStyle->computedStrokeColor();
+    style.textStyles.hasExplicitlySetFillColor = pseudoElementStyle->hasExplicitlySetColor();
+
+    auto color = TextDecorationPainter::decorationColor(*pseudoElementStyle, paintInfo.paintBehavior);
+    auto decorationStyle = pseudoElementStyle->textDecorationStyle();
+    auto decorations = pseudoElementStyle->textDecorationsInEffect();
+
+    if (decorations.contains(TextDecorationLine::Underline)) {
+        style.textDecorationStyles.underline.color = color;
+        style.textDecorationStyles.underline.decorationStyle = decorationStyle;
+    }
+    if (decorations.contains(TextDecorationLine::Overline)) {
+        style.textDecorationStyles.overline.color = color;
+        style.textDecorationStyles.overline.decorationStyle = decorationStyle;
+    }
+    if (decorations.contains(TextDecorationLine::LineThrough)) {
+        style.textDecorationStyles.linethrough.color = color;
+        style.textDecorationStyles.linethrough.decorationStyle = decorationStyle;
+    }
+}
+
 static StyledMarkedText resolveStyleForMarkedText(const MarkedText& markedText, const StyledMarkedText::Style& baseStyle, const RenderText& renderer, const RenderStyle& lineStyle, const PaintInfo& paintInfo)
 {
     auto style = baseStyle;
@@ -45,35 +73,23 @@ static StyledMarkedText resolveStyleForMarkedText(const MarkedText& markedText, 
     // FIXME: See <rdar://problem/8933352>. Also, remove the PLATFORM(IOS_FAMILY)-guard.
     case MarkedText::Type::DictationPhraseWithAlternatives:
 #endif
-    case MarkedText::Type::GrammarError:
-    case MarkedText::Type::SpellingError:
     case MarkedText::Type::Unmarked:
         break;
-    case MarkedText::Type::Highlight:
-        if (auto renderStyle = renderer.parent()->getUncachedPseudoStyle({ PseudoId::Highlight, markedText.highlightName }, &renderer.style())) {
-            style.backgroundColor = renderStyle->colorResolvingCurrentColor(renderStyle->backgroundColor());
-            style.textStyles.fillColor = renderStyle->computedStrokeColor();
-            style.textStyles.strokeColor = renderStyle->computedStrokeColor();
-            style.textStyles.hasExplicitlySetFillColor = renderStyle->hasExplicitlySetColor();
-
-            auto color = TextDecorationPainter::decorationColor(*renderStyle.get(), paintInfo.paintBehavior);
-            auto decorationStyle = renderStyle->textDecorationStyle();
-            auto decorations = renderStyle->textDecorationsInEffect();
-
-            if (decorations.contains(TextDecorationLine::Underline)) {
-                style.textDecorationStyles.underline.color = color;
-                style.textDecorationStyles.underline.decorationStyle = decorationStyle;
-            }
-            if (decorations.contains(TextDecorationLine::Overline)) {
-                style.textDecorationStyles.overline.color = color;
-                style.textDecorationStyles.overline.decorationStyle = decorationStyle;
-            }
-            if (decorations.contains(TextDecorationLine::LineThrough)) {
-                style.textDecorationStyles.linethrough.color = color;
-                style.textDecorationStyles.linethrough.decorationStyle = decorationStyle;
-            }
-        }
+    case MarkedText::Type::GrammarError: {
+        auto* renderStyle = renderer.grammarErrorPseudoStyle();
+        computeStyleForPseudoElementStyle(style, renderStyle, paintInfo);
         break;
+    }
+    case MarkedText::Type::Highlight: {
+        auto renderStyle = renderer.parent()->getUncachedPseudoStyle({ PseudoId::Highlight, markedText.highlightName }, &renderer.style());
+        computeStyleForPseudoElementStyle(style, renderStyle.get(), paintInfo);
+        break;
+    }
+    case MarkedText::Type::SpellingError: {
+        auto* renderStyle = renderer.spellingErrorPseudoStyle();
+        computeStyleForPseudoElementStyle(style, renderStyle, paintInfo);
+        break;
+    }
     case MarkedText::Type::FragmentHighlight: {
         OptionSet<StyleColorOptions> styleColorOptions = { StyleColorOptions::UseSystemAppearance };
         style.backgroundColor = renderer.theme().annotationHighlightColor(styleColorOptions);

--- a/Source/WebCore/rendering/TextPaintStyle.cpp
+++ b/Source/WebCore/rendering/TextPaintStyle.cpp
@@ -148,7 +148,7 @@ TextPaintStyle computeTextSelectionPaintStyle(const TextPaintStyle& textPaintSty
     if (emphasisMarkForeground.isValid() && emphasisMarkForeground != selectionPaintStyle.emphasisMarkColor)
         selectionPaintStyle.emphasisMarkColor = emphasisMarkForeground;
 
-    if (auto pseudoStyle = renderer.selectionPseudoStyle()) {
+    if (auto* pseudoStyle = renderer.selectionPseudoStyle()) {
         selectionPaintStyle.hasExplicitlySetFillColor = pseudoStyle->hasExplicitlySetColor();
         selectionShadow = ShadowData::clone(paintInfo.forceTextColor() ? nullptr : pseudoStyle->textShadow());
         auto viewportSize = renderer.frame().view() ? renderer.frame().view()->size() : IntSize();

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
@@ -59,6 +59,7 @@ struct WKAppPrivacyReportTestingData {
 - (CGFloat)_pageScale;
 
 - (void)_setContinuousSpellCheckingEnabledForTesting:(BOOL)enabled;
+- (void)_setGrammarCheckingEnabledForTesting:(BOOL)enabled;
 - (NSDictionary *)_contentsOfUserInterfaceItem:(NSString *)userInterfaceItem;
 
 - (void)_requestActiveNowPlayingSessionInfo:(void(^)(BOOL, BOOL, NSString*, double, double, NSInteger))callback;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -169,6 +169,15 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 #endif
 }
 
+- (void)_setGrammarCheckingEnabledForTesting:(BOOL)enabled
+{
+#if PLATFORM(IOS_FAMILY)
+    [_contentView setGrammarCheckingEnabled:enabled];
+#else
+    _impl->setGrammarCheckingEnabled(enabled);
+#endif
+}
+
 - (NSDictionary *)_contentsOfUserInterfaceItem:(NSString *)userInterfaceItem
 {
     if ([userInterfaceItem isEqualToString:@"validationBubble"]) {

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -820,6 +820,7 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(DECLARE_WKCONTENTVIEW_ACTION_FOR_WEB_VIEW)
 
 - (void)_didChangeLinkPreviewAvailability;
 - (void)setContinuousSpellCheckingEnabled:(BOOL)enabled;
+- (void)setGrammarCheckingEnabled:(BOOL)enabled;
 
 - (void)updateSoftwareKeyboardSuppressionStateFromWebView;
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -44,6 +44,7 @@
 #import "RevealItem.h"
 #import "SmartMagnificationController.h"
 #import "TextChecker.h"
+#import "TextCheckerState.h"
 #import "TextInputSPI.h"
 #import "TextRecognitionUpdateResult.h"
 #import "UIKitSPI.h"
@@ -11081,6 +11082,15 @@ static Vector<WebCore::IntSize> sizesOfPlaceholderElementsToInsertWhenDroppingIt
 {
     if (WebKit::TextChecker::setContinuousSpellCheckingEnabled(enabled))
         _page->process().updateTextCheckerState();
+}
+
+- (void)setGrammarCheckingEnabled:(BOOL)enabled
+{
+    if (static_cast<bool>(enabled) == WebKit::TextChecker::state().isGrammarCheckingEnabled)
+        return;
+
+    WebKit::TextChecker::setGrammarCheckingEnabled(enabled);
+    _page->process().updateTextCheckerState();
 }
 
 #if HAVE(UIKIT_WITH_MOUSE_SUPPORT)

--- a/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
@@ -422,6 +422,7 @@ void TestController::cocoaResetStateToConsistentValues(const TestOptions& option
         platformView._minimumEffectiveDeviceWidth = 0;
         platformView._editable = NO;
         [platformView _setContinuousSpellCheckingEnabledForTesting:options.shouldShowSpellCheckingDots()];
+        [platformView _setGrammarCheckingEnabledForTesting:YES];
         [platformView resetInteractionCallbacks];
         [platformView _resetNavigationGestureStateForTesting];
         [platformView.configuration.preferences setTextInteractionEnabled:options.textInteractionEnabled()];


### PR DESCRIPTION
#### dea7937dec2bc7d25ea94641cb60bdf586f6526e
<pre>
Add support for styling grammar and spelling errors
<a href="https://bugs.webkit.org/show_bug.cgi?id=265879">https://bugs.webkit.org/show_bug.cgi?id=265879</a>
<a href="https://rdar.apple.com/119190841">rdar://119190841</a>

Reviewed by Antti Koivisto.

Support the use of `::grammar-error` and `::spelling-error` to change the color,
background color, fill color, stroke color, and text decoration of grammar and
spelling errors.

Similar to `::highlight()`, support for `text-shadow` and `stroke-width` is
currently missing. To adhere to the spec, support for these properties should
be added for all highlight pseudo-elements in subsequent changes.

Spec: <a href="https://www.w3.org/TR/css-pseudo-4/#highlight-styling">https://www.w3.org/TR/css-pseudo-4/#highlight-styling</a>

* LayoutTests/editing/spelling/grammar-and-spelling-error-styling-expected.html: Added.
* LayoutTests/editing/spelling/grammar-and-spelling-error-styling.html: Added.
* Source/WebCore/rendering/MarkedText.cpp:
(WebCore::MarkedText::collectForDocumentMarkers):

Ensure grammar and spelling markers are collected for all paint phases, since
they are fully styleable.

* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::textSegmentPseudoStyle const):

Factor out pseudo-element style retrieval for text nodes into a common method.

Additionally, use `getCachedPseudoStyle` rather than `getUncachedPseudoStyle`,
since `::selection`, `::grammar-error`, and `::spelling-error` do not take
additional parameters.

(WebCore::RenderElement::selectionColor const):
(WebCore::RenderElement::selectionPseudoStyle const):
(WebCore::RenderElement::selectionBackgroundColor const):
(WebCore::RenderElement::spellingErrorPseudoStyle const):
(WebCore::RenderElement::grammarErrorPseudoStyle const):
* Source/WebCore/rendering/RenderElement.h:

Update comment describing when to use `getCachedPseudoStyle` and `getUncachedPseudoStyle`
for accuracy.

* Source/WebCore/rendering/RenderText.h:
(WebCore::RenderText::selectionPseudoStyle const):
(WebCore::RenderText::spellingErrorPseudoStyle const):
(WebCore::RenderText::grammarErrorPseudoStyle const):
* Source/WebCore/rendering/StyledMarkedText.cpp:
(WebCore::computeStyleForPseudoElementStyle):

Factor out `StyledMarkedText` generation into a common method used by highlights
and the grammar and spelling pseudo elements.

(WebCore::resolveStyleForMarkedText):
* Source/WebCore/rendering/TextBoxPainter.cpp:
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::paintForegroundAndDecorations):

Detect text decorations when grammar and spelling pseudo styles are applied to
ensure the paint phase is not skipped.

(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::paintPlatformDocumentMarkers):

Do not paint platform error underlines if a custom text decoration is specified
using the new pseudo-elements.

* Source/WebCore/rendering/TextPaintStyle.cpp:
(WebCore::computeTextSelectionPaintStyle):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _setGrammarCheckingEnabledForTesting:]):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView setGrammarCheckingEnabled:]):
* Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm:
(WTR::TestController::cocoaResetStateToConsistentValues):

Always enable grammar checking for testing. Grammar checking is already enabled
by default on most Cocoa platforms other than older macOS.

Canonical link: <a href="https://commits.webkit.org/271643@main">https://commits.webkit.org/271643@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/04e1156bbb18dc7e7c4f1864822cd498204827b4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29094 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7763 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30433 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31695 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/26483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29690 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9888 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5069 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29366 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6413 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24943 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5566 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/5689 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25973 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33033 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26569 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26409 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/31939 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/5669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3842 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/29724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7334 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/25769 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6945 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6173 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/6190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->