### PR TITLE
[WebGPU] GPUCanvasContext backing creation will fail if requested size exceeds max 2D texture size

### DIFF
--- a/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
+++ b/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
@@ -83,13 +83,15 @@ void PresentationContextIOSurface::configure(Device& device, const WGPUSwapChain
 
     m_device = &device;
 
+    auto width = std::min<uint32_t>(device.limits().maxTextureDimension2D, descriptor.width);
+    auto height = std::min<uint32_t>(device.limits().maxTextureDimension2D, descriptor.height);
     WGPUTextureDescriptor wgpuTextureDescriptor = {
         nullptr,
         descriptor.label,
         descriptor.usage,
         WGPUTextureDimension_2D, {
-            descriptor.width,
-            descriptor.height,
+            width,
+            height,
             1,
         },
         descriptor.format,
@@ -109,14 +111,14 @@ void PresentationContextIOSurface::configure(Device& device, const WGPUSwapChain
         1,
         WGPUTextureAspect_All,
     };
-    MTLTextureDescriptor *textureDescriptor = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:Texture::pixelFormat(descriptor.format) width:descriptor.width height:descriptor.height mipmapped:NO];
+    MTLTextureDescriptor *textureDescriptor = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:Texture::pixelFormat(descriptor.format) width:width height:height mipmapped:NO];
     textureDescriptor.usage = Texture::usage(descriptor.usage, descriptor.format);
     for (IOSurface *iosurface in m_ioSurfaces) {
         id<MTLTexture> texture = [device.device() newTextureWithDescriptor:textureDescriptor iosurface:bridge_cast(iosurface) plane:0];
         texture.label = fromAPI(descriptor.label);
         auto viewFormats = Vector<WGPUTextureFormat> { Texture::pixelFormat(descriptor.format) };
         auto parentTexture = Texture::create(texture, wgpuTextureDescriptor, WTFMove(viewFormats), device);
-        m_renderBuffers.append({ parentTexture, TextureView::create(texture, wgpuTextureViewDescriptor, { { descriptor.width, descriptor.height, 1 } }, parentTexture, device) });
+        m_renderBuffers.append({ parentTexture, TextureView::create(texture, wgpuTextureViewDescriptor, { { width, height, 1 } }, parentTexture, device) });
     }
     ASSERT(m_ioSurfaces.count == m_renderBuffers.size());
 }


### PR DESCRIPTION
#### baa2edb1774a345521499809469d648efda55024
<pre>
[WebGPU] GPUCanvasContext backing creation will fail if requested size exceeds max 2D texture size
<a href="https://bugs.webkit.org/show_bug.cgi?id=265885">https://bugs.webkit.org/show_bug.cgi?id=265885</a>
&lt;radar://119197653&gt;

Reviewed by Tadeu Zagallo.

If the GPUCanvas size exceeds the max 2D texture size, render to a smaller
canvas and upscale.

* Source/WebGPU/WebGPU/PresentationContextIOSurface.mm:
(WebGPU::PresentationContextIOSurface::configure):

Canonical link: <a href="https://commits.webkit.org/271616@main">https://commits.webkit.org/271616@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c24aa471be3e9c60cf6a0cef76add0f454491f06

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28803 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7446 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30176 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31422 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26278 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9580 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4805 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26333 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29073 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6170 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24753 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5360 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5511 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/32761 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26367 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26204 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31749 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5481 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3661 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29532 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7102 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6926 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5953 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5999 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->