### PR TITLE
WebCoreObjCScheduleDeallocateOnMainRunLoop crashes in Web Extension ARC code.

### DIFF
--- a/Source/WebCore/platform/mac/WebCoreObjCExtras.h
+++ b/Source/WebCore/platform/mac/WebCoreObjCExtras.h
@@ -28,6 +28,10 @@
 
 #pragma once
 
+#if __has_feature(objc_arc)
+#error Do not use these functions in ARC-enabled code, as they conflict with ARC's automatic memory management.
+#endif
+
 // The class passed here is the class that implements the dealloc method that this function is called from.
 WEBCORE_EXPORT bool WebCoreObjCScheduleDeallocateOnMainThread(Class, id);
 WEBCORE_EXPORT bool WebCoreObjCScheduleDeallocateOnMainRunLoop(Class, id);

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.mm
@@ -33,7 +33,6 @@
 #import "CocoaImage.h"
 #import "WebExtension.h"
 #import "_WKWebExtensionMatchPatternInternal.h"
-#import <WebCore/WebCoreObjCExtras.h>
 
 NSErrorDomain const _WKWebExtensionErrorDomain = @"_WKWebExtensionErrorDomain";
 NSNotificationName const _WKWebExtensionErrorsWereUpdatedNotification = @"_WKWebExtensionErrorsWereUpdated";
@@ -149,8 +148,7 @@ NSNotificationName const _WKWebExtensionErrorsWereUpdatedNotification = @"_WKWeb
 
 - (void)dealloc
 {
-    if (WebCoreObjCScheduleDeallocateOnMainRunLoop(_WKWebExtension.class, self))
-        return;
+    ASSERT(isMainRunLoop());
 
     _webExtension->~WebExtension();
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionAction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionAction.mm
@@ -34,7 +34,6 @@
 #import "WebExtensionAction.h"
 #import "WebExtensionContext.h"
 #import "WebExtensionTab.h"
-#import <WebCore/WebCoreObjCExtras.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/CompletionHandler.h>
 
@@ -54,8 +53,7 @@ using CocoaMenuItem = UIMenuElement;
 
 - (void)dealloc
 {
-    if (WebCoreObjCScheduleDeallocateOnMainRunLoop(_WKWebExtensionAction.class, self))
-        return;
+    ASSERT(isMainRunLoop());
 
     _webExtensionAction->~WebExtensionAction();
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionCommand.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionCommand.mm
@@ -32,7 +32,6 @@
 
 #import "WebExtensionCommand.h"
 #import "WebExtensionContext.h"
-#import <WebCore/WebCoreObjCExtras.h>
 
 #if USE(APPKIT)
 using CocoaModifierFlags = NSEventModifierFlags;
@@ -48,8 +47,7 @@ using CocoaMenuItem = UIMenuElement;
 
 - (void)dealloc
 {
-    if (WebCoreObjCScheduleDeallocateOnMainRunLoop(_WKWebExtensionCommand.class, self))
-        return;
+    ASSERT(isMainRunLoop());
 
     _webExtensionCommand->~WebExtensionCommand();
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
@@ -41,7 +41,6 @@
 #import "_WKWebExtensionInternal.h"
 #import "_WKWebExtensionMatchPatternInternal.h"
 #import "_WKWebExtensionTab.h"
-#import <WebCore/WebCoreObjCExtras.h>
 #import <wtf/URLParser.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
@@ -91,8 +90,7 @@ using CocoaMenuItem = UIMenuElement;
 
 - (void)dealloc
 {
-    if (WebCoreObjCScheduleDeallocateOnMainRunLoop(_WKWebExtensionContext.class, self))
-        return;
+    ASSERT(isMainRunLoop());
 
     _webExtensionContext->~WebExtensionContext();
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.mm
@@ -35,7 +35,6 @@
 #import "_WKWebExtensionControllerConfigurationInternal.h"
 #import "_WKWebExtensionInternal.h"
 #import <WebCore/EventRegion.h>
-#import <WebCore/WebCoreObjCExtras.h>
 
 @implementation _WKWebExtensionController
 
@@ -65,8 +64,7 @@
 
 - (void)dealloc
 {
-    if (WebCoreObjCScheduleDeallocateOnMainRunLoop(_WKWebExtensionController.class, self))
-        return;
+    ASSERT(isMainRunLoop());
 
     _webExtensionController->~WebExtensionController();
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfiguration.mm
@@ -33,7 +33,6 @@
 #import "APIPageConfiguration.h"
 #import "WKWebViewConfigurationPrivate.h"
 #import "WebExtensionControllerConfiguration.h"
-#import <WebCore/WebCoreObjCExtras.h>
 
 static NSString * const persistentCodingKey = @"persistent";
 static NSString * const identifierCodingKey = @"identifier";
@@ -106,8 +105,7 @@ static NSString * const webViewConfigurationCodingKey = @"webViewConfiguration";
 
 - (void)dealloc
 {
-    if (WebCoreObjCScheduleDeallocateOnMainRunLoop(_WKWebExtensionControllerConfiguration.class, self))
-        return;
+    ASSERT(isMainRunLoop());
 
     _webExtensionControllerConfiguration->~WebExtensionControllerConfiguration();
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMatchPattern.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMatchPattern.mm
@@ -31,7 +31,6 @@
 #import "_WKWebExtensionMatchPatternInternal.h"
 
 #import "WebExtensionMatchPattern.h"
-#import <WebCore/WebCoreObjCExtras.h>
 #import <wtf/URLParser.h>
 
 static NSString * const stringCodingKey = @"string";
@@ -139,8 +138,7 @@ NSErrorDomain const _WKWebExtensionMatchPatternErrorDomain = @"_WKWebExtensionMa
 
 - (void)dealloc
 {
-    if (WebCoreObjCScheduleDeallocateOnMainRunLoop(_WKWebExtensionMatchPattern.class, self))
-        return;
+    ASSERT(isMainRunLoop());
 
     _webExtensionMatchPattern->~WebExtensionMatchPattern();
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMessagePort.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMessagePort.mm
@@ -31,7 +31,6 @@
 #import "_WKWebExtensionMessagePortInternal.h"
 
 #import "WebExtensionMessagePort.h"
-#import <WebCore/WebCoreObjCExtras.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/CompletionHandler.h>
 
@@ -43,8 +42,7 @@ NSErrorDomain const _WKWebExtensionMessagePortErrorDomain = @"_WKWebExtensionMes
 
 - (void)dealloc
 {
-    if (WebCoreObjCScheduleDeallocateOnMainRunLoop(_WKWebExtensionMessagePort.class, self))
-        return;
+    ASSERT(isMainRunLoop());
 
     _webExtensionMessagePort->~WebExtensionMessagePort();
 }


### PR DESCRIPTION
#### 69836763a22f493a3a2504e76c6423923bd24ce0
<pre>
WebCoreObjCScheduleDeallocateOnMainRunLoop crashes in Web Extension ARC code.
<a href="https://webkit.org/b/265888">https://webkit.org/b/265888</a>
<a href="https://rdar.apple.com/118477863">rdar://118477863</a>

Reviewed by Brian Weinstein.

Resolved a crash in the `_WKWebExtension` ARC code caused by an early return in
`dealloc`, leading to `dealloc` being incorrectly scheduled on the main thread.
This scenario resulted in access of deallocated objects and subsequent crashes.

Introduced an error in the header for `WebCoreObjCScheduleDeallocate` functions
to prevent their use in ARC-enabled code. Additionally, to catch internal misuse
of these objects, `ASSERT(isMainRunLoop())` has been added in `dealloc`.

* Source/WebCore/platform/mac/WebCoreObjCExtras.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.mm:
(-[_WKWebExtension dealloc]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionAction.mm:
(-[_WKWebExtensionAction dealloc]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionCommand.mm:
(-[_WKWebExtensionCommand dealloc]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm:
(-[_WKWebExtensionContext dealloc]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.mm:
(-[_WKWebExtensionController dealloc]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfiguration.mm:
(-[_WKWebExtensionControllerConfiguration dealloc]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMatchPattern.mm:
(-[_WKWebExtensionMatchPattern dealloc]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMessagePort.mm:
(-[_WKWebExtensionMessagePort dealloc]):

Canonical link: <a href="https://commits.webkit.org/271564@main">https://commits.webkit.org/271564@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/27a8eb52f1f5978d68a157e812dcda3cc96a4da9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28807 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7450 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30180 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31426 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26281 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29376 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9583 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4809 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29077 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6175 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24756 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5363 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/5516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25766 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/32765 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26372 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26207 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/31754 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5484 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3655 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/29538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7105 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5956 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3715 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6002 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->