### PR TITLE
[WebGPU] Using fp16 as an override value will crash

### DIFF
--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -1036,8 +1036,10 @@ void RewriteGlobalVariables::usesOverride(AST::Variable& variable)
         constantType = Reflection::SpecializationConstantType::Boolean;
         break;
     case Types::Primitive::F32:
-    case Types::Primitive::F16: // Is this correct?
         constantType = Reflection::SpecializationConstantType::Float;
+        break;
+    case Types::Primitive::F16:
+        constantType = Reflection::SpecializationConstantType::Half;
         break;
     case Types::Primitive::I32:
         constantType = Reflection::SpecializationConstantType::Int;

--- a/Source/WebGPU/WGSL/WGSL.h
+++ b/Source/WebGPU/WGSL/WGSL.h
@@ -195,7 +195,8 @@ enum class SpecializationConstantType : uint8_t {
     Boolean,
     Float,
     Int,
-    Unsigned
+    Unsigned,
+    Half
 };
 
 struct SpecializationConstant {

--- a/Source/WebGPU/WebGPU/Pipeline.mm
+++ b/Source/WebGPU/WebGPU/Pipeline.mm
@@ -98,6 +98,11 @@ std::tuple<MTLFunctionConstantValues *, HashMap<String, WGSL::ConstantValue>> cr
             [constantValues setConstantValue:&value type:MTLDataTypeUInt withName:specializationConstant.mangledName];
             break;
         }
+        case WGSL::Reflection::SpecializationConstantType::Half: {
+            auto value = std::get<WGSL::half>(constantValue);
+            [constantValues setConstantValue:&value type:MTLDataTypeHalf withName:specializationConstant.mangledName];
+            break;
+        }
         }
     }
 
@@ -130,6 +135,12 @@ std::tuple<MTLFunctionConstantValues *, HashMap<String, WGSL::ConstantValue>> cr
             unsigned value = entry.value;
             wgslConstantValues.set(fromAPI(entry.key), value);
             [constantValues setConstantValue:&value type:MTLDataTypeUInt withName:specializationConstant.mangledName];
+            break;
+        }
+        case WGSL::Reflection::SpecializationConstantType::Half: {
+            float value = entry.value;
+            wgslConstantValues.set(fromAPI(entry.key), value);
+            [constantValues setConstantValue:&value type:MTLDataTypeHalf withName:specializationConstant.mangledName];
             break;
         }
         }


### PR DESCRIPTION
#### bf377f517c58a0fa63e1880a33606bc4b639b59a
<pre>
[WebGPU] Using fp16 as an override value will crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=265889">https://bugs.webkit.org/show_bug.cgi?id=265889</a>
&lt;radar://119199267&gt;

Reviewed by Dan Glastonbury.

std::get crashes if ConstantValue contained a WGSL::half,
add support for WGSL::half for override values.

* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::usesOverride):
* Source/WebGPU/WGSL/WGSL.h:
* Source/WebGPU/WebGPU/Pipeline.mm:
(WebGPU::createConstantValues):

Canonical link: <a href="https://commits.webkit.org/271576@main">https://commits.webkit.org/271576@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2dee35eb7eb0dc94c772fb5ba25833f8fdc8dd7a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28808 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7451 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30181 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31427 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26282 "Built successfully") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/9638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4810 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26337 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29078 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6176 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24759 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5400 "Found 1 new API test failure: /WPE/TestWebKitWebView:/webkit/WebKitWebView/notification (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5517 "Unexpected infrastructure issue, retrying build") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/32766 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26373 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26210 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31755 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5485 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3656 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29546 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7106 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6897 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5957 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6003 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->