### PR TITLE
Generate secure coding serializer for DDActionContext (and the types it relies on)

### DIFF
--- a/Source/WebCore/PAL/pal/spi/mac/DataDetectorsSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/DataDetectorsSPI.h
@@ -61,6 +61,8 @@
 @property (assign) BOOL altMode;
 @property (assign) BOOL immediate;
 
+@property (retain) NSPersonNameComponents *authorNameComponents;
+
 @property (copy) NSArray *allowedActionUTIs;
 
 - (DDActionContext *)contextForView:(NSView *)view altMode:(BOOL)altMode interactionStartedHandler:(void (^)(void))interactionStartedHandler interactionChangedHandler:(void (^)(void))interactionChangedHandler interactionStoppedHandler:(void (^)(void))interactionStoppedHandler;

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -200,6 +200,7 @@ $(PROJECT_DIR)/Shared/Cocoa/CacheStoragePolicy.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCArray.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCCFType.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCColor.serialization.in
+$(PROJECT_DIR)/Shared/Cocoa/CoreIPCDDActionContext.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCDDScannerResult.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCData.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCDate.serialization.in
@@ -209,6 +210,7 @@ $(PROJECT_DIR)/Shared/Cocoa/CoreIPCFont.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCLocale.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCNSCFObject.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCNSValue.serialization.in
+$(PROJECT_DIR)/Shared/Cocoa/CoreIPCPersonNameComponents.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCSecureCoding.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCString.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCURL.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -519,6 +519,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/Cocoa/CoreIPCArray.serialization.in \
 	Shared/Cocoa/CoreIPCCFType.serialization.in \
 	Shared/Cocoa/CoreIPCColor.serialization.in \
+	Shared/Cocoa/CoreIPCDDActionContext.serialization.in \
 	Shared/Cocoa/CoreIPCDDScannerResult.serialization.in \
 	Shared/Cocoa/CoreIPCData.serialization.in \
 	Shared/Cocoa/CoreIPCDate.serialization.in \
@@ -528,6 +529,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/Cocoa/CoreIPCLocale.serialization.in \
 	Shared/Cocoa/CoreIPCNSCFObject.serialization.in \
 	Shared/Cocoa/CoreIPCNSValue.serialization.in \
+	Shared/Cocoa/CoreIPCPersonNameComponents.serialization.in \
 	Shared/Cocoa/CoreIPCSecureCoding.serialization.in \
 	Shared/Cocoa/CoreIPCString.serialization.in \
 	Shared/Cocoa/CoreIPCURL.serialization.in \

--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h
@@ -33,7 +33,17 @@
 
 #if ENABLE(DATA_DETECTION)
 OBJC_CLASS DDScannerResult;
-#endif
+#if PLATFORM(MAC)
+#if HAVE(SECURE_ACTION_CONTEXT)
+OBJC_CLASS DDSecureActionContext;
+using WKDDActionContext = DDSecureActionContext;
+#else
+OBJC_CLASS DDActionContext;
+using WKDDActionContext = DDActionContext;
+#endif // #if HAVE(SECURE_ACTION_CONTEXT)
+#endif // #if PLATFORM(MAC)
+#endif // #if ENABLE(DATA_DETECTION)
+
 
 namespace IPC {
 
@@ -62,6 +72,9 @@ enum class NSType : uint8_t {
     Array,
     Color,
 #if ENABLE(DATA_DETECTION)
+#if PLATFORM(MAC)
+    DDActionContext,
+#endif
     DDScannerResult,
 #endif
     Data,
@@ -71,6 +84,7 @@ enum class NSType : uint8_t {
     Font,
     Locale,
     Number,
+    PersonNameComponents,
     SecureCoding,
     String,
     URL,
@@ -83,6 +97,9 @@ bool isSerializableValue(id);
 
 #if ENABLE(DATA_DETECTION)
 template<> Class getClass<DDScannerResult>();
+#if PLATFORM(MAC)
+template<> Class getClass<WKDDActionContext>();
+#endif
 #endif
 
 void encodeObjectWithWrapper(Encoder&, id);

--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
@@ -264,6 +264,13 @@ template<> Class getClass<DDScannerResult>()
 {
     return PAL::getDDScannerResultClass();
 }
+
+#if PLATFORM(MAC)
+template<> Class getClass<WKDDActionContext>()
+{
+    return PAL::getWKDDActionContextClass();
+}
+#endif
 #endif
 
 NSType typeFromObject(id object)
@@ -276,6 +283,10 @@ NSType typeFromObject(id object)
     if ([object isKindOfClass:[WebCore::CocoaColor class]])
         return NSType::Color;
 #if ENABLE(DATA_DETECTION)
+#if PLATFORM(MAC)
+    if (PAL::isDataDetectorsCoreFrameworkAvailable() && [object isKindOfClass:[PAL::getWKDDActionContextClass() class]])
+        return NSType::DDActionContext;
+#endif
     if (PAL::isDataDetectorsCoreFrameworkAvailable() && [object isKindOfClass:[PAL::getDDScannerResultClass() class]])
         return NSType::DDScannerResult;
 #endif
@@ -295,6 +306,8 @@ NSType typeFromObject(id object)
         return NSType::Number;
     if ([object isKindOfClass:[NSValue class]])
         return NSType::NSValue;
+    if ([object isKindOfClass:[NSPersonNameComponents class]])
+        return NSType::PersonNameComponents;
     if ([object isKindOfClass:[NSString class]])
         return NSType::String;
     if ([object isKindOfClass:[NSURL class]])

--- a/Source/WebKit/Shared/Cocoa/CoreIPCDDActionContext.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCDDActionContext.serialization.in
@@ -1,0 +1,52 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE(DATA_DETECTION) && PLATFORM(MAC)
+secure_coding_header: <pal/mac/DataDetectorsSoftLink.h>
+[WebKitSecureCodingClass=PAL::getWKDDActionContextClass()] webkit_secure_coding DDActionContext {
+    highlightFrame: NSValue
+    aimFrame: NSValue
+    eventTitle: String
+    leadingText: String
+    trailingText: String
+    coreSpotlightUniqueIdentifier: String
+    referenceDate: Date
+    hostUUID: String
+    authorABUUID: String
+    authorEmailAddress: String
+    authorName: String
+    url: URL
+    matchedString: String
+
+    allResults: Array<DDScannerResult>?
+    groupAllResults: Array<DDScannerResult>
+    groupCategory: Number
+    groupTranscript: String
+    selectionString: String
+
+    mainResult: DDScannerResult?
+
+    immediate: Number
+    isRightClick: Number
+    authorNameComponents: PersonNameComponents
+}
+#endif // ENABLE(DATA_DETECTION) && PLATFORM(MAC)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCDictionary.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCDictionary.mm
@@ -55,8 +55,11 @@ bool CoreIPCDictionary::keyHasValueOfType(const String& key, IPC::NSType type) c
 {
     createNSDictionaryIfNeeded();
     id object = [m_nsDictionary.get() objectForKey:(NSString *)key];
-    if (!object)
-        return false;
+    if (!object) {
+        // Many objects have a required key that sometimes has a missing value, which is okay.
+        return true;
+    }
+
     return IPC::typeFromObject(object) == type;
 }
 

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h
@@ -57,6 +57,9 @@ using ObjectValue = std::variant<
     CoreIPCCFType,
     CoreIPCColor,
 #if ENABLE(DATA_DETECTION)
+#if PLATFORM(MAC)
+    CoreIPCDDActionContext,
+#endif
     CoreIPCDDScannerResult,
 #endif
     CoreIPCData,
@@ -67,6 +70,7 @@ using ObjectValue = std::variant<
     CoreIPCLocale,
     CoreIPCNSValue,
     CoreIPCNumber,
+    CoreIPCPersonNameComponents,
     CoreIPCSecureCoding,
     CoreIPCString,
     CoreIPCURL

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm
@@ -59,6 +59,10 @@ static ObjectValue valueFromID(id object)
     case IPC::NSType::Color:
         return CoreIPCColor((WebCore::CocoaColor *)object);
 #if ENABLE(DATA_DETECTION)
+#if PLATFORM(MAC)
+    case IPC::NSType::DDActionContext:
+        return secureCodingValueFromID<CoreIPCDDActionContext>((DDActionContext *)object);
+#endif
     case IPC::NSType::DDScannerResult:
         return secureCodingValueFromID<CoreIPCDDScannerResult>((DDScannerResult *)object);
 #endif
@@ -78,6 +82,8 @@ static ObjectValue valueFromID(id object)
         return CoreIPCNSValue((NSValue *)object);
     case IPC::NSType::Number:
         return CoreIPCNumber(bridge_cast((NSNumber *)object));
+    case IPC::NSType::PersonNameComponents:
+        return CoreIPCPersonNameComponents((NSPersonNameComponents *)object);
     case IPC::NSType::SecureCoding:
         return CoreIPCSecureCoding((NSObject<NSSecureCoding> *)object);
     case IPC::NSType::String:

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSValue.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSValue.h
@@ -52,7 +52,11 @@ public:
 private:
     friend struct IPC::ArgumentCoder<CoreIPCNSValue, void>;
 
+#if PLATFORM(MAC)
+    using WrappedNSValue = std::variant<NSRange, NSRect>;
+#else
     using WrappedNSValue = std::variant<NSRange>;
+#endif
     using Value = std::variant<WrappedNSValue, CoreIPCSecureCoding>;
 
     static Value valueFromNSValue(NSValue *);

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSValue.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSValue.mm
@@ -38,6 +38,11 @@ CoreIPCNSValue::Value CoreIPCNSValue::valueFromNSValue(NSValue *nsValue)
     if (!strcmp(nsValue.objCType, @encode(NSRange)))
         return WrappedNSValue { nsValue.rangeValue };
 
+#if PLATFORM(MAC)
+    if (!strcmp(nsValue.objCType, @encode(NSRect)))
+        return WrappedNSValue { nsValue.rectValue };
+#endif
+
     RELEASE_ASSERT_NOT_REACHED();
 }
 
@@ -55,6 +60,10 @@ RetainPtr<id> CoreIPCNSValue::toID() const
 
         WTF::switchOn(wrappedValue, [&](const NSRange& range) {
             result = [NSValue valueWithRange:range];
+#if PLATFORM(MAC)
+        }, [&](const NSRect& rect) {
+            result = [NSValue valueWithRect:rect];
+#endif
         });
 
         return result;
@@ -73,7 +82,14 @@ RetainPtr<id> CoreIPCNSValue::toID() const
 
 bool CoreIPCNSValue::shouldWrapValue(NSValue *value)
 {
-    return !strcmp(value.objCType, @encode(NSRange));
+    if (!strcmp(value.objCType, @encode(NSRange)))
+        return true;
+#if PLATFORM(MAC)
+    if (!strcmp(value.objCType, @encode(NSRect)))
+        return true;
+#endif
+
+    return false;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPersonNameComponents.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPersonNameComponents.h
@@ -25,19 +25,42 @@
 
 #pragma once
 
-#import "CoreIPCArray.h"
-#import "CoreIPCCFType.h"
-#import "CoreIPCColor.h"
-#import "CoreIPCData.h"
-#import "CoreIPCDate.h"
-#import "CoreIPCDictionary.h"
-#import "CoreIPCError.h"
-#import "CoreIPCFont.h"
-#import "CoreIPCLocale.h"
-#import "CoreIPCNSValue.h"
-#import "CoreIPCNumber.h"
-#import "CoreIPCPersonNameComponents.h"
-#import "CoreIPCSecureCoding.h"
-#import "CoreIPCString.h"
-#import "CoreIPCURL.h"
-#import "GeneratedWebKitSecureCoding.h"
+#if PLATFORM(COCOA)
+
+#include "ArgumentCodersCocoa.h"
+#include <Foundation/Foundation.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebKit {
+
+class CoreIPCPersonNameComponents {
+WTF_MAKE_FAST_ALLOCATED;
+public:
+    CoreIPCPersonNameComponents(NSPersonNameComponents *);
+
+    RetainPtr<id> toID() const;
+
+private:
+    friend struct IPC::ArgumentCoder<CoreIPCPersonNameComponents, void>;
+
+    CoreIPCPersonNameComponents(const String& namePrefix, const String& givenName, const String& middleName, const String& familyName, const String& nickname, std::unique_ptr<CoreIPCPersonNameComponents>&& phoneticRepresentation)
+        : m_namePrefix(namePrefix)
+        , m_givenName(givenName)
+        , m_middleName(middleName)
+        , m_familyName(familyName)
+        , m_nickname(nickname)
+        , m_phoneticRepresentation(WTFMove(phoneticRepresentation))
+    {
+    }
+
+    String m_namePrefix;
+    String m_givenName;
+    String m_middleName;
+    String m_familyName;
+    String m_nickname;
+    std::unique_ptr<CoreIPCPersonNameComponents> m_phoneticRepresentation;
+};
+
+} // namespace WebKit
+
+#endif // PLATFORM(COCOA)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPersonNameComponents.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPersonNameComponents.mm
@@ -23,21 +23,40 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
-
-#import "CoreIPCArray.h"
-#import "CoreIPCCFType.h"
-#import "CoreIPCColor.h"
-#import "CoreIPCData.h"
-#import "CoreIPCDate.h"
-#import "CoreIPCDictionary.h"
-#import "CoreIPCError.h"
-#import "CoreIPCFont.h"
-#import "CoreIPCLocale.h"
-#import "CoreIPCNSValue.h"
-#import "CoreIPCNumber.h"
+#import "config.h"
 #import "CoreIPCPersonNameComponents.h"
-#import "CoreIPCSecureCoding.h"
-#import "CoreIPCString.h"
-#import "CoreIPCURL.h"
-#import "GeneratedWebKitSecureCoding.h"
+
+#if PLATFORM(COCOA)
+
+#import <wtf/RetainPtr.h>
+
+namespace WebKit {
+
+CoreIPCPersonNameComponents::CoreIPCPersonNameComponents(NSPersonNameComponents *components)
+    : m_namePrefix(components.namePrefix)
+    , m_givenName(components.givenName)
+    , m_middleName(components.middleName)
+    , m_familyName(components.familyName)
+    , m_nickname(components.nickname)
+{
+    if (components.phoneticRepresentation)
+        m_phoneticRepresentation = makeUnique<CoreIPCPersonNameComponents>(components.phoneticRepresentation);
+}
+
+RetainPtr<id> CoreIPCPersonNameComponents::toID() const
+{
+    auto components = adoptNS([NSPersonNameComponents new]);
+    components.get().namePrefix = (NSString *)m_namePrefix;
+    components.get().givenName = (NSString *)m_givenName;
+    components.get().middleName = (NSString *)m_middleName;
+    components.get().familyName = (NSString *)m_familyName;
+    components.get().nickname = (NSString *)m_nickname;
+    if (m_phoneticRepresentation)
+        components.get().phoneticRepresentation = m_phoneticRepresentation->toID().get();
+
+    return components;
+}
+
+} // namespace WebKit
+
+#endif // PLATFORM(COCOA)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPersonNameComponents.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPersonNameComponents.serialization.in
@@ -1,0 +1,36 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if PLATFORM(COCOA)
+
+webkit_platform_headers: "CoreIPCPersonNameComponents.h"
+
+[WebKitPlatform, AdditionalEncoder=StreamConnectionEncoder] class WebKit::CoreIPCPersonNameComponents {
+    String m_namePrefix;
+    String m_givenName;
+    String m_middleName;
+    String m_familyName;
+    String m_nickname;
+    std::unique_ptr<WebKit::CoreIPCPersonNameComponents> m_phoneticRepresentation;
+}
+
+#endif // PLATFORM(COCOA)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -691,17 +691,17 @@ enum class WebCore::IndexedDB::RequestType : uint8_t {
 
 #if USE(CG)
 headers: <CoreGraphics/CGGeometry.h> <CoreGraphics/CGAffineTransform.h>
-[AdditionalEncoder=StreamConnectionEncoder] struct CGSize {
+[WebKitPlatform, AdditionalEncoder=StreamConnectionEncoder] struct CGSize {
     CGFloat width
     CGFloat height
 };
 
-struct CGPoint {
+[WebKitPlatform] struct CGPoint {
     CGFloat x
     CGFloat y
 };
 
-struct CGRect {
+[WebKitPlatform] struct CGRect {
     CGPoint origin
     CGSize size
 };

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1229,6 +1229,8 @@
 		51ACFFE02B048829001331A2 /* CoreIPCNSValue.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51ACFFDB2B048820001331A2 /* CoreIPCNSValue.mm */; };
 		51AD56822B1A8CF6001A0ECB /* GeneratedWebKitSecureCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = 51AD56812B1A8CF5001A0ECB /* GeneratedWebKitSecureCoding.h */; };
 		51AD56862B1AB839001A0ECB /* GeneratedWebKitSecureCoding.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51AD56832B1AA324001A0ECB /* GeneratedWebKitSecureCoding.mm */; };
+		51AD56902B1C46FE001A0ECB /* CoreIPCPersonNameComponents.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51AD568E2B1C46EF001A0ECB /* CoreIPCPersonNameComponents.mm */; };
+		51AD56912B1C4704001A0ECB /* CoreIPCPersonNameComponents.h in Headers */ = {isa = PBXBuildFile; fileRef = 51AD568D2B1C46EF001A0ECB /* CoreIPCPersonNameComponents.h */; };
 		51B15A8513843A3900321AD8 /* EnvironmentUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 51B15A8313843A3900321AD8 /* EnvironmentUtilities.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		51BE6C572AA92480001745C1 /* WebPushToolMain.mm in Sources */ = {isa = PBXBuildFile; fileRef = 517B5F64275A8D7E002DC22D /* WebPushToolMain.mm */; };
 		51BE6C5A2AA9250D001745C1 /* webpushtool.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 51BE6C582AA92503001745C1 /* webpushtool.cpp */; };
@@ -5370,9 +5372,13 @@
 		51ACFFDA2B048820001331A2 /* CoreIPCNSValue.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CoreIPCNSValue.serialization.in; sourceTree = "<group>"; };
 		51ACFFDB2B048820001331A2 /* CoreIPCNSValue.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCNSValue.mm; sourceTree = "<group>"; };
 		51ACFFDC2B048820001331A2 /* CoreIPCNSValue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CoreIPCNSValue.h; sourceTree = "<group>"; };
-		51AD56812B1A8CF5001A0ECB /* GeneratedWebKitSecureCoding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GeneratedWebKitSecureCoding.h; path = GeneratedWebKitSecureCoding.h; sourceTree = "<group>"; };
-		51AD56832B1AA324001A0ECB /* GeneratedWebKitSecureCoding.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = GeneratedWebKitSecureCoding.mm; path = GeneratedWebKitSecureCoding.mm; sourceTree = "<group>"; };
-		51AD56882B1ABFC1001A0ECB /* SerializedTypeInfo.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = SerializedTypeInfo.mm; path = SerializedTypeInfo.mm; sourceTree = "<group>"; };
+		51AD56812B1A8CF5001A0ECB /* GeneratedWebKitSecureCoding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GeneratedWebKitSecureCoding.h; sourceTree = "<group>"; };
+		51AD56832B1AA324001A0ECB /* GeneratedWebKitSecureCoding.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = GeneratedWebKitSecureCoding.mm; sourceTree = "<group>"; };
+		51AD56882B1ABFC1001A0ECB /* SerializedTypeInfo.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SerializedTypeInfo.mm; sourceTree = "<group>"; };
+		51AD56892B1C3BA1001A0ECB /* CoreIPCDDActionContext.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CoreIPCDDActionContext.serialization.in; sourceTree = "<group>"; };
+		51AD568D2B1C46EF001A0ECB /* CoreIPCPersonNameComponents.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreIPCPersonNameComponents.h; sourceTree = "<group>"; };
+		51AD568E2B1C46EF001A0ECB /* CoreIPCPersonNameComponents.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCPersonNameComponents.mm; sourceTree = "<group>"; };
+		51AD568F2B1C46F0001A0ECB /* CoreIPCPersonNameComponents.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoreIPCPersonNameComponents.serialization.in; sourceTree = "<group>"; };
 		51B15A8213843A3900321AD8 /* EnvironmentUtilities.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = EnvironmentUtilities.cpp; path = unix/EnvironmentUtilities.cpp; sourceTree = "<group>"; };
 		51B15A8313843A3900321AD8 /* EnvironmentUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = EnvironmentUtilities.h; path = unix/EnvironmentUtilities.h; sourceTree = "<group>"; };
 		51BE6C552AA92406001745C1 /* WebPushToolMain.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebPushToolMain.h; sourceTree = "<group>"; };
@@ -10934,6 +10940,7 @@
 				F48C81E52AE0E1DF00073850 /* CoreIPCData.serialization.in */,
 				F49EE2202AE87F41003E3C34 /* CoreIPCDate.h */,
 				F49EE21F2AE87ED7003E3C34 /* CoreIPCDate.serialization.in */,
+				51AD56892B1C3BA1001A0ECB /* CoreIPCDDActionContext.serialization.in */,
 				51ACFFD52B048804001331A2 /* CoreIPCDDScannerResult.serialization.in */,
 				5197FAD22AFD33B0009180C5 /* CoreIPCDictionary.h */,
 				5187BDED2B005DEE008A6EE5 /* CoreIPCDictionary.mm */,
@@ -10953,6 +10960,9 @@
 				51ACFFDC2B048820001331A2 /* CoreIPCNSValue.h */,
 				51ACFFDB2B048820001331A2 /* CoreIPCNSValue.mm */,
 				51ACFFDA2B048820001331A2 /* CoreIPCNSValue.serialization.in */,
+				51AD568D2B1C46EF001A0ECB /* CoreIPCPersonNameComponents.h */,
+				51AD568E2B1C46EF001A0ECB /* CoreIPCPersonNameComponents.mm */,
+				51AD568F2B1C46F0001A0ECB /* CoreIPCPersonNameComponents.serialization.in */,
 				5197FAD92AFD33B2009180C5 /* CoreIPCSecureCoding.h */,
 				5197FADA2AFD33B2009180C5 /* CoreIPCSecureCoding.mm */,
 				5197FAD12AFD33B0009180C5 /* CoreIPCSecureCoding.serialization.in */,
@@ -15205,6 +15215,7 @@
 				5197FAE42AFD33CF009180C5 /* CoreIPCNSCFObject.h in Headers */,
 				51ACFFDF2B048821001331A2 /* CoreIPCNSValue.h in Headers */,
 				F4EFF36D2AF0267300479AB8 /* CoreIPCNumber.h in Headers */,
+				51AD56912B1C4704001A0ECB /* CoreIPCPersonNameComponents.h in Headers */,
 				5197FAE92AFD33CF009180C5 /* CoreIPCSecureCoding.h in Headers */,
 				5197FAE52AFD33CF009180C5 /* CoreIPCString.h in Headers */,
 				51D1B6942B09723A00FEA5CB /* CoreIPCTypes.h in Headers */,
@@ -18050,6 +18061,7 @@
 				F4A30A6D2B08255B004E1F24 /* CoreIPCLocale.mm in Sources */,
 				5197FAF22AFD33FF009180C5 /* CoreIPCNSCFObject.mm in Sources */,
 				51ACFFE02B048829001331A2 /* CoreIPCNSValue.mm in Sources */,
+				51AD56902B1C46FE001A0ECB /* CoreIPCPersonNameComponents.mm in Sources */,
 				5197FAED2AFD33FF009180C5 /* CoreIPCSecureCoding.mm in Sources */,
 				5131D5462AE9D5230016EF39 /* CoreTextHelpers.mm in Sources */,
 				51AD56862B1AB839001A0ECB /* GeneratedWebKitSecureCoding.mm in Sources */,


### PR DESCRIPTION
#### 5776a8fdee1ed5230bafbb063ad15ac71d607f55
<pre>
Generate secure coding serializer for DDActionContext (and the types it relies on)
<a href="https://bugs.webkit.org/show_bug.cgi?id=265890">https://bugs.webkit.org/show_bug.cgi?id=265890</a>
<a href="https://rdar.apple.com/119203785">rdar://119203785</a>

Reviewed by Alex Christensen.

This adds the WebKit property list serialization code path for DDActionContext.
That includes the types it relies on - NSPersonNameComponents, and NSRect wrapped by NSValue.

On the surface - by looking at how our API test works - it appears almost as if we could serialize DDActionContext
directly by accessing members and recreating with setters.
Unfortunately that&apos;s not the case because not everything they need to encode/decode is directly accessible.

* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h:
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm:
(IPC::getClass&lt;WKDDActionContext&gt;):
(IPC::typeFromObject):
* Source/WebKit/Shared/Cocoa/CoreIPCDDActionContext.serialization.in: Added.
* Source/WebKit/Shared/Cocoa/CoreIPCDictionary.mm:
(WebKit::CoreIPCDictionary::keyHasValueOfType const):
* Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h:
* Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm:
(WebKit::valueFromID):
* Source/WebKit/Shared/Cocoa/CoreIPCNSValue.h:
* Source/WebKit/Shared/Cocoa/CoreIPCNSValue.mm:
(WebKit::CoreIPCNSValue::valueFromNSValue):
(WebKit::CoreIPCNSValue::toID const):
(WebKit::CoreIPCNSValue::shouldWrapValue):
* Source/WebKit/Shared/Cocoa/CoreIPCPersonNameComponents.h: Copied from Source/WebKit/Shared/Cocoa/CoreIPCNSValue.h.
(WebKit::CoreIPCPersonNameComponents::CoreIPCPersonNameComponents):
* Source/WebKit/Shared/Cocoa/CoreIPCPersonNameComponents.mm: Copied from Source/WebKit/Shared/Cocoa/CoreIPCNSValue.mm.
(WebKit::CoreIPCPersonNameComponents::CoreIPCPersonNameComponents):
(WebKit::CoreIPCPersonNameComponents::toID const):
* Source/WebKit/Shared/Cocoa/CoreIPCPersonNameComponents.serialization.in: Added.
* Source/WebKit/Shared/Cocoa/CoreIPCTypes.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm:
(isEqual):
(operator==):
(personNameComponentsForTesting):
(TEST):
(fakeDataDetectorResultForTesting):

Canonical link: <a href="https://commits.webkit.org/271585@main">https://commits.webkit.org/271585@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4873a9daf261bfb6e37706812559a7730b5cc976

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28843 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7485 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30214 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31460 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26310 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29415 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9619 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4844 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26356 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29114 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6202 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24782 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5390 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5539 "Found 5 new test failures: imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-below-viewport-partially-onscreen-new.html, imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-below-viewport-partially-onscreen-old.html, imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch.tentative.html, imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative.html, imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/readwrite-readonly.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25793 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/32798 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26398 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26235 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31779 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5510 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3678 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29560 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7137 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6901 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5987 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6031 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->