### PR TITLE
Fix depencency cycle in build

### DIFF
--- a/Source/WebKit/Modules/OSX_Private.modulemap
+++ b/Source/WebKit/Modules/OSX_Private.modulemap
@@ -944,11 +944,6 @@ framework module WebKit_Private [system] {
     export *
   }
 
-  explicit module WKProcessExtension {
-    header "WKProcessExtension.h"
-    export *
-  }
-
   explicit module WKProcessGroup {
     header "WKProcessGroup.h"
     export *

--- a/Source/WebKit/Modules/iOS_Private.modulemap
+++ b/Source/WebKit/Modules/iOS_Private.modulemap
@@ -1644,11 +1644,6 @@ framework module WebKit_Private [system] {
     export *
   }
 
-  explicit module WKProcessExtension {
-    header "WKProcessExtension.h"
-    export *
-  }
-
   explicit module WKProcessGroup {
     header "WKProcessGroup.h"
     export *

--- a/Source/WebKit/Platform/ExtraPrivateSymbolsForTAPI.h
+++ b/Source/WebKit/Platform/ExtraPrivateSymbolsForTAPI.h
@@ -38,6 +38,14 @@ void GPUServiceInitializer();
 
 void ExtensionEventHandler(xpc_connection_t);
 
+// Declared in WKProcessExtension.h for use in extension targets. Must be declared in project
+//  headers because the extension targets cannot import the entire WebKit module (rdar://119162443).
+@interface WKGrant : NSObject
+@end
+
+@interface WKProcessExtension : NSObject
+@end
+
 #ifdef __cplusplus
 }
 #endif

--- a/Source/WebKit/Shared/AuxiliaryProcessExtensions/AuxiliaryProcessExtensionBridge.h
+++ b/Source/WebKit/Shared/AuxiliaryProcessExtensions/AuxiliaryProcessExtensionBridge.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#import <Foundation/Foundation.h>
+
 #import "WKProcessExtension.h"
 
 // FIXME: forward declare xpc_connection_t to build with public SDK.

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2271,7 +2271,7 @@
 		E31869BC2B1A74A800571519 /* AuxiliaryProcessExtensionBridge.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5C139DB829DB847E00D5117B /* AuxiliaryProcessExtensionBridge.mm */; };
 		E31869BD2B1A74A900571519 /* AuxiliaryProcessExtensionBridge.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5C139DB829DB847E00D5117B /* AuxiliaryProcessExtensionBridge.mm */; };
 		E31869C42B1A7C2400571519 /* WKProcessExtension.mm in Sources */ = {isa = PBXBuildFile; fileRef = E31869C22B1A7C2400571519 /* WKProcessExtension.mm */; };
-		E31869C52B1A7C2400571519 /* WKProcessExtension.h in Headers */ = {isa = PBXBuildFile; fileRef = E31869C32B1A7C2400571519 /* WKProcessExtension.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E31869C52B1A7C2400571519 /* WKProcessExtension.h in Headers */ = {isa = PBXBuildFile; fileRef = E31869C32B1A7C2400571519 /* WKProcessExtension.h */; };
 		E326E357284E580E00157372 /* AuxiliaryProcessProxyCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = E326E356284E580E00157372 /* AuxiliaryProcessProxyCocoa.mm */; };
 		E36A00E329CF7AC000AC4E8A /* TextTrackRepresentationCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = E36A00E229CF7AC000AC4E8A /* TextTrackRepresentationCocoa.mm */; };
 		E36FF00327F36FBD004BE21A /* SandboxStateVariables.h in Headers */ = {isa = PBXBuildFile; fileRef = E36FF00127F36FBD004BE21A /* SandboxStateVariables.h */; };


### PR DESCRIPTION
#### 9610a6aafa77230e02e955bf794c16aa5ad0a46f
<pre>
Fix depencency cycle in build
<a href="https://bugs.webkit.org/show_bug.cgi?id=265870">https://bugs.webkit.org/show_bug.cgi?id=265870</a>
<a href="https://rdar.apple.com/119162443">rdar://119162443</a>

Reviewed by Per Arne Vollan.

Swift code in WebKit extension targets (really any targets that are part of
the WebKit project and depend on WebKit.framework) cannot import
WebKit&apos;s swiftmodule without causing a cycle in the internal OS build.
This is because WebKit&apos;s Swift overlay builds in a separate project.

Fix by making WKProcessExtension.h a non-modular header, so that the
extension targets can bridge it without pulling in all of WebKit.

* Source/WebKit/Modules/OSX_Private.modulemap:
* Source/WebKit/Modules/iOS_Private.modulemap:
* Source/WebKit/Platform/ExtraPrivateSymbolsForTAPI.h:
* Source/WebKit/Shared/AuxiliaryProcessExtensions/AuxiliaryProcessExtensionBridge.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/271568@main">https://commits.webkit.org/271568@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e10d458ff0332204ddf9365a79884492fd07af7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28813 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7456 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30186 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31432 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26287 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9590 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4815 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26340 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29083 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6180 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24764 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5368 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/5520 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/32771 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26376 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26215 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31758 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5490 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3660 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/29542 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7111 "Built successfully") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/6890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5962 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3717 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6008 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->