### PR TITLE
[WebGPU] createComputePipelineState crashes when maxTotalThreadsPerThreadgroup is greater than 65535

### DIFF
--- a/Source/WebGPU/WebGPU/ComputePipeline.mm
+++ b/Source/WebGPU/WebGPU/ComputePipeline.mm
@@ -39,8 +39,9 @@ static id<MTLComputePipelineState> createComputePipelineState(id<MTLDevice> devi
 {
     auto computePipelineDescriptor = [MTLComputePipelineDescriptor new];
     computePipelineDescriptor.computeFunction = function;
-    // FIXME: check this calculation for overflow
-    computePipelineDescriptor.maxTotalThreadsPerThreadgroup = size.width * size.height * size.depth;
+    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=265910 - [WebGPU] Investigate the appropriate way to set MTLComputePipelineDescriptor.maxTotalThreadsPerThreadgroup
+    // -[MTLComputePipelineDescriptor setMaxTotalThreadsPerThreadgroup:] will release assert if maxTotalThreadsPerThreadgroup > USHRT_MAX
+    computePipelineDescriptor.maxTotalThreadsPerThreadgroup = std::min<NSUInteger>(size.width * size.height * size.depth, USHRT_MAX);
     for (size_t i = 0; i < pipelineLayout.numberOfBindGroupLayouts(); ++i)
         computePipelineDescriptor.buffers[i].mutability = MTLMutabilityImmutable; // Argument buffers are always immutable in WebGPU.
     // FIXME: https://bugs.webkit.org/show_bug.cgi?id=249345 don't unconditionally set this to YES


### PR DESCRIPTION
#### cf2f4949e8851b4f56b7a405db6c2268d103f4f8
<pre>
[WebGPU] createComputePipelineState crashes when maxTotalThreadsPerThreadgroup is greater than 65535
<a href="https://bugs.webkit.org/show_bug.cgi?id=265892">https://bugs.webkit.org/show_bug.cgi?id=265892</a>
&lt;radar://119205356&gt;

Reviewed by Tadeu Zagallo.

I can&apos;t find where this limit originates, so I left a comment indicating
the crash will occur if a value greater than USHRT_MAX is passed in.

* Source/WebGPU/WebGPU/ComputePipeline.mm:
(WebGPU::createComputePipelineState):

Canonical link: <a href="https://commits.webkit.org/271618@main">https://commits.webkit.org/271618@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af038a5e1fc9ee4bab8819395391e187104ad441

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28868 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7508 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30233 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31485 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26326 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9640 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4863 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26372 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29139 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6212 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24799 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5412 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5547 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/32822 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26407 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26252 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31791 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5526 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3694 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29570 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7156 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6927 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6003 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6047 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->