### PR TITLE
Prepare WebKit for several new UIKit SPI class and symbol names

### DIFF
--- a/Source/WTF/wtf/PlatformHave.h
+++ b/Source/WTF/wtf/PlatformHave.h
@@ -1659,8 +1659,8 @@
 #define HAVE_UI_CONTEXT_MENU_ASYNC_CONFIGURATION 1
 #endif
 
-#if !PLATFORM(APPLETV) && !PLATFORM(WATCHOS) && __has_include(<UIKit/_UITextCursorDragAnimator.h>)
-#define HAVE_UI_TEXT_CURSOR_DRAG_ANIMATOR 1
+#if !PLATFORM(APPLETV) && !PLATFORM(WATCHOS) && __has_include(<UIKit/UITextCursorDropPositionAnimator.h>)
+#define HAVE_UI_TEXT_CURSOR_DROP_POSITION_ANIMATOR 1
 #endif
 
 #if __has_include(<UIKit/UIAsyncTextInteraction.h>)

--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -138,10 +138,6 @@
 #import <UIKit/_UIContextMenuAsyncConfiguration.h>
 #endif
 
-#if HAVE(UI_TEXT_CURSOR_DRAG_ANIMATOR)
-#import <UIKit/_UITextCursorDragAnimator.h>
-#endif
-
 #if HAVE(UIFINDINTERACTION)
 #import <UIKit/UIFindSession_Private.h>
 #import <UIKit/_UIFindInteraction.h>

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -141,7 +141,6 @@ class WebPageProxy;
 @class UIPointerRegion;
 @class UITargetedPreview;
 @class _UILookupGestureRecognizer;
-@class _UITextCursorDragAnimator;
 
 #if HAVE(PEPPER_UI_CORE)
 @class PUICQuickboardViewController;
@@ -537,9 +536,9 @@ struct ImageAnalysisContextMenuActionData {
     RetainPtr<_UITextDragCaretView> _editDropCaretView;
     BlockPtr<void()> _actionToPerformAfterReceivingEditDragSnapshot;
 #endif
-#if HAVE(UI_TEXT_CURSOR_DRAG_ANIMATOR)
+#if HAVE(UI_TEXT_CURSOR_DROP_POSITION_ANIMATOR)
     RetainPtr<UIView<UITextCursorView>> _editDropTextCursorView;
-    RetainPtr<_UITextCursorDragAnimator> _editDropCaretAnimator;
+    RetainPtr<UITextCursorDropPositionAnimator> _editDropCaretAnimator;
 #endif
 
 #if HAVE(PEPPER_UI_CORE)

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -198,7 +198,7 @@
 SOFT_LINK_FRAMEWORK(UIKit)
 SOFT_LINK_CLASS_OPTIONAL(UIKit, _UIAsyncDragInteraction)
 SOFT_LINK_CLASS_OPTIONAL(UIKit, _UIContextMenuAsyncConfiguration)
-SOFT_LINK_CLASS_OPTIONAL(UIKit, _UITextCursorDragAnimator)
+SOFT_LINK_CLASS_OPTIONAL(UIKit, UITextCursorDropPositionAnimator)
 SOFT_LINK_CLASS_OPTIONAL(UIKit, UIKeyEventContext)
 
 #if HAVE(AUTOCORRECTION_ENHANCEMENTS)
@@ -1151,12 +1151,12 @@ static WKDragSessionContext *ensureLocalDragSessionContext(id <UIDragSession> se
 
 - (BOOL)_shouldUseTextCursorDragAnimator
 {
-#if HAVE(UI_TEXT_CURSOR_DRAG_ANIMATOR)
+#if HAVE(UI_TEXT_CURSOR_DROP_POSITION_ANIMATOR)
     if (!self.shouldUseAsyncInteractions)
         return NO;
 
-    static BOOL hasTextCursorDragAnimatorClass = !!get_UITextCursorDragAnimatorClass();
-    return hasTextCursorDragAnimatorClass;
+    static BOOL hasClass = !!getUITextCursorDropPositionAnimatorClass();
+    return hasClass;
 #else
     return NO;
 #endif
@@ -9826,17 +9826,17 @@ static std::optional<WebCore::DragOperation> coreDragOperationForUIDropOperation
 
 - (void)_insertDropCaret:(CGRect)rect
 {
-#if HAVE(UI_TEXT_CURSOR_DRAG_ANIMATOR)
+#if HAVE(UI_TEXT_CURSOR_DROP_POSITION_ANIMATOR)
     if (self._shouldUseTextCursorDragAnimator) {
         _editDropTextCursorView = [adoptNS([[UITextSelectionDisplayInteraction alloc] initWithTextInput:self delegate:self]) cursorView];
         [self addSubview:_editDropTextCursorView.get()];
         [_editDropTextCursorView setFrame:rect];
-        _editDropCaretAnimator = adoptNS([alloc_UITextCursorDragAnimatorInstance() _initWithTextCursorView:_editDropTextCursorView.get() textInput:self]);
-        [_editDropCaretAnimator _setCursorVisible:YES animated:YES];
-        [_editDropCaretAnimator _updateCursorForPosition:[WKTextPosition textPositionWithRect:rect] animated:NO];
+        _editDropCaretAnimator = adoptNS([allocUITextCursorDropPositionAnimatorInstance() initWithTextCursorView:_editDropTextCursorView.get() textInput:self]);
+        [_editDropCaretAnimator setCursorVisible:YES animated:YES];
+        [_editDropCaretAnimator placeCursorAtPosition:[WKTextPosition textPositionWithRect:rect] animated:NO];
         return;
     }
-#endif // HAVE(UI_TEXT_CURSOR_DRAG_ANIMATOR)
+#endif // HAVE(UI_TEXT_CURSOR_DROP_POSITION_ANIMATOR)
     _editDropCaretView = adoptNS([[_UITextDragCaretView alloc] initWithTextInputView:self]);
     [_editDropCaretView insertAtPosition:[WKTextPosition textPositionWithRect:rect]];
 }
@@ -9844,8 +9844,8 @@ static std::optional<WebCore::DragOperation> coreDragOperationForUIDropOperation
 - (void)_removeDropCaret
 {
     [std::exchange(_editDropCaretView, nil) remove];
-#if HAVE(UI_TEXT_CURSOR_DRAG_ANIMATOR)
-    [std::exchange(_editDropCaretAnimator, nil) _setCursorVisible:NO animated:NO];
+#if HAVE(UI_TEXT_CURSOR_DROP_POSITION_ANIMATOR)
+    [std::exchange(_editDropCaretAnimator, nil) setCursorVisible:NO animated:NO];
     [std::exchange(_editDropTextCursorView, nil) removeFromSuperview];
 #endif
 }
@@ -9945,8 +9945,8 @@ static NSArray<NSItemProvider *> *extractItemProvidersFromDropSession(id <UIDrop
     }
 
     RetainPtr caretPosition = [WKTextPosition textPositionWithRect:rect];
-#if HAVE(UI_TEXT_CURSOR_DRAG_ANIMATOR)
-    [_editDropCaretAnimator _updateCursorForPosition:caretPosition.get() animated:YES];
+#if HAVE(UI_TEXT_CURSOR_DROP_POSITION_ANIMATOR)
+    [_editDropCaretAnimator placeCursorAtPosition:caretPosition.get() animated:YES];
 #endif
     [_editDropCaretView updateToPosition:caretPosition.get()];
 }

--- a/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
+++ b/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
@@ -70,6 +70,11 @@
 #import <UIKit/UIKeyEventContext.h>
 #endif
 
+#if !__has_include(<UIKit/UIAsyncTextInput_ForWebKitOnly.h>)
+#define UITextDocumentContext UIWKDocumentContext
+#define UITextDocumentRequest UIWKDocumentRequest
+#endif
+
 IGNORE_WARNINGS_BEGIN("deprecated-implementations")
 #import <UIKit/UIWebBrowserView.h>
 #import <UIKit/UIWebScrollView.h>
@@ -85,6 +90,9 @@ IGNORE_WARNINGS_END
 #endif // PLATFORM(IOS) || PLATFORM(VISION)
 
 #else // USE(APPLE_INTERNAL_SDK)
+
+#define UITextDocumentContext UIWKDocumentContext
+#define UITextDocumentRequest UIWKDocumentRequest
 
 @interface NSTextAlternatives : NSObject
 - (id)initWithPrimaryString:(NSString *)primaryString alternativeStrings:(NSArray<NSString *> *)alternativeStrings;
@@ -253,9 +261,9 @@ typedef NS_ENUM(NSInteger, UIWKGestureType) {
 - (void)applyAutocorrection:(NSString *)correction toString:(NSString *)input shouldUnderline:(BOOL)shouldUnderline withCompletionHandler:(void (^)(UIWKAutocorrectionRects *rectsForCorrection))completionHandler;
 
 #if HAVE(UI_WK_DOCUMENT_CONTEXT)
-- (void)requestDocumentContext:(UIWKDocumentRequest *)request completionHandler:(void (^)(UIWKDocumentContext *))completionHandler;
+- (void)requestDocumentContext:(UITextDocumentRequest *)request completionHandler:(void (^)(UITextDocumentContext *))completionHandler;
 - (void)adjustSelectionWithDelta:(NSRange)deltaRange completionHandler:(void (^)(void))completionHandler;
-- (void)selectPositionAtPoint:(CGPoint)point withContextRequest:(UIWKDocumentRequest *)request completionHandler:(void (^)(UIWKDocumentContext *))completionHandler;
+- (void)selectPositionAtPoint:(CGPoint)point withContextRequest:(UITextDocumentRequest *)request completionHandler:(void (^)(UITextDocumentContext *))completionHandler;
 #endif
 
 @property (nonatomic, readonly) NSString *selectedText;


### PR DESCRIPTION
#### a4064186be517400dc0829c712c87242e2f15c52
<pre>
Prepare WebKit for several new UIKit SPI class and symbol names
<a href="https://bugs.webkit.org/show_bug.cgi?id=265893">https://bugs.webkit.org/show_bug.cgi?id=265893</a>
<a href="https://rdar.apple.com/119206020">rdar://119206020</a>

Reviewed by Aditya Keerthi, Tim Horton and Megan Gardner.

In the continued effort to clean up the SPI boundaries between WebKit and UIKit, several classes
are being renamed:

```
UIWKDocumentRequest         UITextDocumentRequest
UIWKDocumentContext         UITextDocumentContext
UIWKSelectionFlags          UITextSelectionFlags
UIWKSelectionTouch          UITextSelectionTouch
UIWKGestureType             UITextGestureType
_UITextCursorDragAnimator   UITextCursorDropPositionAnimator
```

This patch prepares the WebKit stack for these changes in UIKit, by:

1.  Moving off the soon-to-be-deprecated `_UITextCursorDragAnimator`, in favor of
    `UITextCursorDropPositionAnimator`.

2.  Making our API tests compatible with the new `UITextDocument*` names, in place of
    `UIWKDocument*`.

3.  Maintaining source and binary compatibility with both the iOS 17 SDK, as well as older versions
    of the newer SDK, which don&apos;t contain these `UITextDocument*` names yet.

* Source/WTF/wtf/PlatformHave.h:
* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _shouldUseTextCursorDragAnimator]):
(-[WKContentView _insertDropCaret:]):
(-[WKContentView _removeDropCaret]):
(-[WKContentView _didChangeDragCaretRect:currentRect:]):
* Tools/TestRunnerShared/spi/UIKitSPIForTesting.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/DocumentEditingContext.mm:
(makeRequest):
(-[TestWKWebView synchronouslyRequestDocumentContext:]):
(TEST):
(-[UIWKDocumentContext markedTextRects]): Deleted.
(-[UIWKDocumentContext contextBeforeLength]): Deleted.
(-[UIWKDocumentContext markedTextLength]): Deleted.
(-[UIWKDocumentContext markedTextRange]): Deleted.
(-[UIWKDocumentContext textRects]): Deleted.
(-[UIWKDocumentContext boundingRectForCharacterRange:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/271578@main">https://commits.webkit.org/271578@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5853d92961b9df30efe7bacdcf936267379ff571

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28826 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7469 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30199 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31445 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26300 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29395 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9604 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4829 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26348 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29096 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6192 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24772 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5379 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5530 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25782 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/32784 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/24928 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26388 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26224 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31767 "Passed tests") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/28781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5500 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3670 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/29555 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7124 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/35443 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6896 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5975 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7643 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6020 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->