### PR TITLE
Port SerializedScriptValue to the new IPC serialization format

### DIFF
--- a/Source/JavaScriptCore/runtime/ArrayBuffer.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayBuffer.cpp
@@ -652,5 +652,16 @@ ASCIILiteral errorMessageForTransfer(ArrayBuffer* buffer)
     return "Cannot transfer an ArrayBuffer whose backing store has been accessed by the JavaScriptCore C API"_s;
 }
 
+std::optional<ArrayBufferContents> ArrayBufferContents::fromDataSpan(std::span<const uint8_t> data)
+{
+    void* buffer = Gigacage::tryMalloc(Gigacage::Primitive, data.size_bytes());
+    if (!buffer)
+        return std::nullopt;
+
+    memcpy(buffer, data.data(), data.size_bytes());
+
+    return ArrayBufferContents { buffer, data.size_bytes(), std::nullopt, ArrayBuffer::primitiveGigacageDestructor() };
+}
+
 } // namespace JSC
 

--- a/Source/JavaScriptCore/runtime/ArrayBuffer.h
+++ b/Source/JavaScriptCore/runtime/ArrayBuffer.h
@@ -157,6 +157,8 @@ public:
         RELEASE_ASSERT(m_sizeInBytes <= MAX_ARRAY_BUFFER_SIZE);
     }
 
+    JS_EXPORT_PRIVATE static std::optional<ArrayBufferContents> fromDataSpan(std::span<const uint8_t>);
+
     ArrayBufferContents(ArrayBufferContents&& other)
     {
         swap(other);
@@ -195,6 +197,8 @@ public:
             return m_maxByteLength;
         return std::nullopt;
     }
+
+    std::span<const uint8_t> dataSpan() const { return { static_cast<const uint8_t*>(data()), sizeInBytes() }; }
     
     bool isShared() const { return m_shared; }
     bool isResizableOrGrowableShared() const { return m_hasMaxByteLength; }

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1248,6 +1248,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     html/MediaDocument.h
     html/MediaElementSession.h
     html/MediaError.h
+    html/OffscreenCanvas.h
     html/PDFDocument.h
     html/PluginDocument.h
     html/StepRange.h
@@ -1931,6 +1932,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/ImageBufferAllocator.h
     platform/graphics/ImageBufferBackend.h
     platform/graphics/ImageBufferBackendParameters.h
+    platform/graphics/ImageBufferPipe.h
     platform/graphics/ImageBufferPlatformBackend.h
     platform/graphics/ImageDecoder.h
     platform/graphics/ImageDecoderIdentifier.h

--- a/Source/WebCore/bindings/js/SerializedScriptValue.h
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.h
@@ -101,26 +101,25 @@ public:
     WEBCORE_EXPORT static RefPtr<SerializedScriptValue> create(JSContextRef, JSValueRef, JSValueRef* exception);
     WEBCORE_EXPORT JSValueRef deserialize(JSContextRef, JSValueRef* exception);
 
-    bool hasBlobURLs() const { return !m_blobHandles.isEmpty(); }
+    bool hasBlobURLs() const { return !m_internals.blobHandles.isEmpty(); }
 
     Vector<String> blobURLs() const;
-    Vector<URLKeepingBlobAlive> blobHandles() const { return crossThreadCopy(m_blobHandles); }
+    Vector<URLKeepingBlobAlive> blobHandles() const { return crossThreadCopy(m_internals.blobHandles); }
     void writeBlobsToDiskForIndexedDB(CompletionHandler<void(IDBValue&&)>&&);
     IDBValue writeBlobsToDiskForIndexedDBSynchronously();
     static Ref<SerializedScriptValue> createFromWireBytes(Vector<uint8_t>&& data)
     {
         return adoptRef(*new SerializedScriptValue(WTFMove(data)));
     }
-    const Vector<uint8_t>& wireBytes() const { return m_data; }
+    const Vector<uint8_t>& wireBytes() const { return m_internals.data; }
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static RefPtr<SerializedScriptValue> decode(Decoder&);
-
-    size_t memoryCost() const { return m_memoryCost; }
+    size_t memoryCost() const { return m_internals.memoryCost; }
 
     WEBCORE_EXPORT ~SerializedScriptValue();
 
 private:
+    friend struct IPC::ArgumentCoder<SerializedScriptValue, void>;
+
     static ExceptionOr<Ref<SerializedScriptValue>> create(JSC::JSGlobalObject&, JSC::JSValue, Vector<JSC::Strong<JSC::JSObject>>&& transfer, Vector<RefPtr<MessagePort>>&, SerializationForStorage, SerializationErrorMode, SerializationContext);
     WEBCORE_EXPORT SerializedScriptValue(Vector<unsigned char>&&, std::unique_ptr<ArrayBufferContentsArray>&& = nullptr
 #if ENABLE(WEB_RTC)
@@ -157,160 +156,42 @@ private:
 
     size_t computeMemoryCost() const;
 
-    Vector<unsigned char> m_data;
-    std::unique_ptr<ArrayBufferContentsArray> m_arrayBufferContentsArray;
-    std::unique_ptr<ArrayBufferContentsArray> m_sharedBufferContentsArray;
-    Vector<std::optional<ImageBitmapBacking>> m_backingStores;
+    struct Internals {
+        Vector<unsigned char> data;
+        std::unique_ptr<ArrayBufferContentsArray> arrayBufferContentsArray;
+#if ENABLE(WEB_RTC)
+        Vector<std::unique_ptr<DetachedRTCDataChannel>> detachedRTCDataChannels;
+#endif
+#if ENABLE(WEB_CODECS)
+        Vector<RefPtr<WebCodecsEncodedVideoChunkStorage>> serializedVideoChunks;
+        Vector<RefPtr<WebCodecsEncodedAudioChunkStorage>> serializedAudioChunks;
+        Vector<WebCodecsVideoFrameData> serializedVideoFrames { };
+        Vector<WebCodecsAudioInternalData> serializedAudioData { };
+#endif
+        std::unique_ptr<ArrayBufferContentsArray> sharedBufferContentsArray { };
+        Vector<std::optional<ImageBitmapBacking>> backingStores { };
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
-    Vector<std::unique_ptr<DetachedOffscreenCanvas>> m_detachedOffscreenCanvases;
-    Vector<RefPtr<OffscreenCanvas>> m_inMemoryOffscreenCanvases;
+        Vector<std::unique_ptr<DetachedOffscreenCanvas>> detachedOffscreenCanvases { };
+        Vector<RefPtr<OffscreenCanvas>> inMemoryOffscreenCanvases { };
 #endif
-    Vector<RefPtr<MessagePort>> m_inMemoryMessagePorts;
-#if ENABLE(WEB_RTC)
-    Vector<std::unique_ptr<DetachedRTCDataChannel>> m_detachedRTCDataChannels;
-#endif
+        Vector<RefPtr<MessagePort>> inMemoryMessagePorts { };
 #if ENABLE(WEBASSEMBLY)
-    std::unique_ptr<WasmModuleArray> m_wasmModulesArray;
-    std::unique_ptr<WasmMemoryHandleArray> m_wasmMemoryHandlesArray;
+        std::unique_ptr<WasmModuleArray> wasmModulesArray { };
+        std::unique_ptr<WasmMemoryHandleArray> wasmMemoryHandlesArray { };
 #endif
-#if ENABLE(WEB_CODECS)
-    Vector<RefPtr<WebCodecsEncodedVideoChunkStorage>> m_serializedVideoChunks;
-    Vector<WebCodecsVideoFrameData> m_serializedVideoFrames;
-    Vector<RefPtr<WebCodecsEncodedAudioChunkStorage>> m_serializedAudioChunks;
-    Vector<WebCodecsAudioInternalData> m_serializedAudioData;
-#endif
-    Vector<URLKeepingBlobAlive> m_blobHandles;
-    size_t m_memoryCost { 0 };
+        Vector<URLKeepingBlobAlive> blobHandles { };
+        size_t memoryCost { 0 };
+    };
+    friend struct IPC::ArgumentCoder<Internals, void>;
+
+    static Ref<SerializedScriptValue> create(Internals&& internals)
+    {
+        return adoptRef(*new SerializedScriptValue(WTFMove(internals)));
+    }
+
+    WEBCORE_EXPORT explicit SerializedScriptValue(Internals&&);
+
+    Internals m_internals;
 };
-
-template<class Encoder>
-void SerializedScriptValue::encode(Encoder& encoder) const
-{
-    encoder << m_data;
-
-    auto hasArray = m_arrayBufferContentsArray && m_arrayBufferContentsArray->size();
-    encoder << hasArray;
-
-    if (hasArray) {
-        encoder << static_cast<uint64_t>(m_arrayBufferContentsArray->size());
-        for (const auto& arrayBufferContents : *m_arrayBufferContentsArray)
-            encoder << std::span(reinterpret_cast<const uint8_t*>(arrayBufferContents.data()), arrayBufferContents.sizeInBytes());
-    }
-
-#if ENABLE(WEB_RTC)
-    encoder << static_cast<uint64_t>(m_detachedRTCDataChannels.size());
-    for (const auto &channel : m_detachedRTCDataChannels)
-        encoder << *channel;
-#endif
-
-#if ENABLE(WEB_CODECS)
-    encoder << static_cast<uint64_t>(m_serializedVideoChunks.size());
-    for (const auto &videoChunk : m_serializedVideoChunks)
-        encoder << videoChunk->data();
-
-    // FIXME: encode video frames
-
-    encoder << static_cast<uint64_t>(m_serializedAudioChunks.size());
-    for (const auto& audioChunk : m_serializedAudioChunks)
-        encoder << audioChunk->data();
-
-    // FIXME: encode audio data
-#endif
-}
-
-template<class Decoder>
-RefPtr<SerializedScriptValue> SerializedScriptValue::decode(Decoder& decoder)
-{
-    Vector<uint8_t> data;
-    if (!decoder.decode(data))
-        return nullptr;
-
-    bool hasArray;
-    if (!decoder.decode(hasArray))
-        return nullptr;
-
-    std::unique_ptr<ArrayBufferContentsArray> arrayBufferContentsArray;
-    if (hasArray) {
-        uint64_t arrayLength;
-        if (!decoder.decode(arrayLength))
-            return nullptr;
-        ASSERT(arrayLength);
-
-        arrayBufferContentsArray = makeUnique<ArrayBufferContentsArray>();
-        while (arrayLength--) {
-            std::span<const uint8_t> data;
-            if (!decoder.decode(data))
-                return nullptr;
-
-            auto buffer = Gigacage::tryMalloc(Gigacage::Primitive, data.size_bytes());
-            if (!buffer)
-                return nullptr;
-
-            static_assert(sizeof(std::span<const uint8_t>::element_type) == 1);
-            memcpy(buffer, data.data(), data.size_bytes());
-            JSC::ArrayBufferDestructorFunction destructor = ArrayBuffer::primitiveGigacageDestructor();
-            arrayBufferContentsArray->append({ buffer, data.size_bytes(), std::nullopt, WTFMove(destructor) });
-        }
-    }
-
-#if ENABLE(WEB_RTC)
-    uint64_t detachedRTCDataChannelsSize;
-    if (!decoder.decode(detachedRTCDataChannelsSize))
-        return nullptr;
-
-    Vector<std::unique_ptr<DetachedRTCDataChannel>> detachedRTCDataChannels;
-    while (detachedRTCDataChannelsSize--) {
-        std::optional<DetachedRTCDataChannel> detachedRTCDataChannel;
-        decoder >> detachedRTCDataChannel;
-        if (!detachedRTCDataChannel)
-            return nullptr;
-        detachedRTCDataChannels.append(makeUnique<DetachedRTCDataChannel>(WTFMove(*detachedRTCDataChannel)));
-    }
-#endif
-#if ENABLE(WEB_CODECS)
-    uint64_t serializedVideoChunksSize;
-    if (!decoder.decode(serializedVideoChunksSize))
-        return nullptr;
-
-    Vector<RefPtr<WebCodecsEncodedVideoChunkStorage>> serializedVideoChunks;
-    while (serializedVideoChunksSize--) {
-        std::optional<WebCodecsEncodedVideoChunkData> videoChunkData;
-        decoder >> videoChunkData;
-        if (!videoChunkData)
-            return nullptr;
-        serializedVideoChunks.append(WebCodecsEncodedVideoChunkStorage::create(WTFMove(*videoChunkData)));
-    }
-    // FIXME: decode video frames
-    Vector<WebCodecsVideoFrameData> serializedVideoFrames;
-
-    uint64_t serializedAudioChunksSize;
-    if (!decoder.decode(serializedAudioChunksSize))
-        return nullptr;
-
-    Vector<RefPtr<WebCodecsEncodedAudioChunkStorage>> serializedAudioChunks;
-    while (serializedAudioChunksSize--) {
-        std::optional<WebCodecsEncodedAudioChunkData> audioChunkData;
-        decoder >> audioChunkData;
-        if (!audioChunkData)
-            return nullptr;
-        serializedAudioChunks.append(WebCodecsEncodedAudioChunkStorage::create(WTFMove(*audioChunkData)));
-    }
-    // FIXME: decode audio data
-    Vector<WebCodecsAudioInternalData> serializedAudioData;
-#endif
-
-    return adoptRef(*new SerializedScriptValue(WTFMove(data), WTFMove(arrayBufferContentsArray)
-#if ENABLE(WEB_RTC)
-        , WTFMove(detachedRTCDataChannels)
-#endif
-#if ENABLE(WEB_CODECS)
-        , WTFMove(serializedVideoChunks)
-        , WTFMove(serializedVideoFrames)
-        , WTFMove(serializedAudioChunks)
-        , WTFMove(serializedAudioData)
-#endif
-        ));
-}
-
 
 }

--- a/Source/WebCore/html/OffscreenCanvas.h
+++ b/Source/WebCore/html/OffscreenCanvas.h
@@ -102,7 +102,7 @@ private:
 };
 
 class OffscreenCanvas final : public ActiveDOMObject, public RefCounted<OffscreenCanvas>, public CanvasBase, public EventTarget {
-    WTF_MAKE_ISO_ALLOCATED(OffscreenCanvas);
+    WTF_MAKE_ISO_ALLOCATED_EXPORT(OffscreenCanvas, WEBCORE_EXPORT);
 public:
 
     struct ImageEncodeOptions {
@@ -123,7 +123,7 @@ public:
     static Ref<OffscreenCanvas> create(ScriptExecutionContext&, unsigned width, unsigned height);
     static Ref<OffscreenCanvas> create(ScriptExecutionContext&, std::unique_ptr<DetachedOffscreenCanvas>&&);
     static Ref<OffscreenCanvas> create(ScriptExecutionContext&, HTMLCanvasElement&);
-    virtual ~OffscreenCanvas();
+    WEBCORE_EXPORT virtual ~OffscreenCanvas();
 
     unsigned width() const final;
     unsigned height() const final;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -771,30 +771,6 @@ bool ArgumentCoder<MediaPlaybackTargetContext>::decode(Decoder& decoder, MediaPl
 }
 #endif
 
-void ArgumentCoder<RefPtr<WebCore::SerializedScriptValue>>::encode(Encoder& encoder, const RefPtr<WebCore::SerializedScriptValue>& instance)
-{
-    encoder << !!instance;
-    if (instance)
-        instance->encode(encoder);
-}
-
-std::optional<RefPtr<WebCore::SerializedScriptValue>> ArgumentCoder<RefPtr<WebCore::SerializedScriptValue>>::decode(Decoder& decoder)
-{
-    std::optional<bool> nonEmpty;
-    decoder >> nonEmpty;
-    if (!nonEmpty)
-        return std::nullopt;
-
-    if (!*nonEmpty)
-        return nullptr;
-
-    RefPtr<SerializedScriptValue> scriptValue = SerializedScriptValue::decode(decoder);
-    if (!scriptValue)
-        return std::nullopt;
-
-    return { scriptValue };
-}
-
 #if ENABLE(VIDEO)
 void ArgumentCoder<WebCore::SerializedPlatformDataCueValue>::encode(Encoder& encoder, const SerializedPlatformDataCueValue& value)
 {

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -162,11 +162,6 @@ template<> struct ArgumentCoder<WebCore::Image> {
     static std::optional<Ref<WebCore::Image>> decode(Decoder&);
 };
 
-template<> struct ArgumentCoder<RefPtr<WebCore::SerializedScriptValue>> {
-    static void encode(Encoder&, const RefPtr<WebCore::SerializedScriptValue>&);
-    static std::optional<RefPtr<WebCore::SerializedScriptValue>> decode(Decoder&);
-};
-
 template<> struct ArgumentCoder<WebCore::Font> {
     static void encode(Encoder&, const WebCore::Font&);
     static std::optional<Ref<WebCore::Font>> decode(Decoder&);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -5457,6 +5457,11 @@ header: <JavaScriptCore/ArrayBuffer.h>
     Vector<uint8_t> toVector();
 }
 
+header: <JavaScriptCore/ArrayBuffer.h>
+[CustomHeader, CreateUsing=fromDataSpan] class JSC::ArrayBufferContents {
+    std::span<const uint8_t> dataSpan();
+}
+
 enum class WebCore::TextIndicatorPresentationTransition : uint8_t {
     None,
     Bounce,
@@ -6787,6 +6792,50 @@ enum class WebCore::InspectorClientDeveloperPreference : uint8_t {
     PrivateClickMeasurementDebugModeEnabled,
     ITPDebugModeEnabled,
     MockCaptureDevicesEnabled,
+};
+
+#if ENABLE(WEB_CODECS)
+header: <WebCore/WebCodecsEncodedVideoChunk.h>
+[CustomHeader, RefCounted] class WebCore::WebCodecsEncodedVideoChunkStorage {
+    WebCore::WebCodecsEncodedVideoChunkData data();
+};
+
+header: <WebCore/WebCodecsEncodedAudioChunk.h>
+[CustomHeader, RefCounted] class WebCore::WebCodecsEncodedAudioChunkStorage {
+    WebCore::WebCodecsEncodedAudioChunkData data();
+};
+#endif
+
+headers: <JavaScriptCore/WasmModule.h> <WebCore/ImageBitmapBacking.h> <WebCore/MessagePort.h> <WebCore/OffscreenCanvas.h>
+[Nested] class WebCore::SerializedScriptValue::Internals {
+    Vector<uint8_t> data;
+    std::unique_ptr<Vector<JSC::ArrayBufferContents>> arrayBufferContentsArray;
+#if ENABLE(WEB_RTC)
+    Vector<std::unique_ptr<WebCore::DetachedRTCDataChannel>> detachedRTCDataChannels;
+#endif
+#if ENABLE(WEB_CODECS)
+    Vector<RefPtr<WebCore::WebCodecsEncodedVideoChunkStorage>> serializedVideoChunks;
+    Vector<RefPtr<WebCore::WebCodecsEncodedAudioChunkStorage>> serializedAudioChunks;
+    [NotSerialized] Vector<WebCore::WebCodecsVideoFrameData> serializedVideoFrames;
+    [NotSerialized] Vector<WebCore::WebCodecsAudioInternalData> serializedAudioData;
+#endif
+    [NotSerialized] std::unique_ptr<Vector<JSC::ArrayBufferContents>> sharedBufferContentsArray;
+    [NotSerialized] Vector<std::optional<WebCore::ImageBitmapBacking>> backingStores;
+#if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
+    [NotSerialized] Vector<std::unique_ptr<WebCore::DetachedOffscreenCanvas>> detachedOffscreenCanvases;
+    [NotSerialized] Vector<RefPtr<WebCore::OffscreenCanvas>> inMemoryOffscreenCanvases;
+#endif
+    [NotSerialized] Vector<RefPtr<WebCore::MessagePort>> inMemoryMessagePorts;
+#if ENABLE(WEBASSEMBLY)
+    [NotSerialized] std::unique_ptr<Vector<RefPtr<JSC::Wasm::Module>>> wasmModulesArray;
+    [NotSerialized] std::unique_ptr<Vector<RefPtr<JSC::SharedArrayBufferContents>>> wasmMemoryHandlesArray;
+#endif
+    [NotSerialized] Vector<WebCore::URLKeepingBlobAlive> blobHandles;
+    [NotSerialized] size_t memoryCost;
+};
+
+[RefCounted] class WebCore::SerializedScriptValue {
+    WebCore::SerializedScriptValue::Internals m_internals;
 };
 
 #if ENABLE(MEDIA_SOURCE)


### PR DESCRIPTION
#### 197177abbd7c527be4856a691f8f42c6c1768f8d
<pre>
Port SerializedScriptValue to the new IPC serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=265904">https://bugs.webkit.org/show_bug.cgi?id=265904</a>

Reviewed by Alex Christensen.

* Source/JavaScriptCore/runtime/ArrayBuffer.cpp:
(JSC::ArrayBufferContents::fromDataSpan):
* Source/JavaScriptCore/runtime/ArrayBuffer.h:
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::SerializedScriptValue::SerializedScriptValue):
* Source/WebCore/bindings/js/SerializedScriptValue.h:
(WebCore::SerializedScriptValue::arrayBufferContentsArray const):
(WebCore::SerializedScriptValue::detachedRTCDataChannels const):
(WebCore::SerializedScriptValue::serializedVideoChunks const):
(WebCore::SerializedScriptValue::serializedAudioChunks const):
(WebCore::SerializedScriptValue::encode const): Deleted.
(WebCore::SerializedScriptValue::decode): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;RefPtr&lt;WebCore::SerializedScriptValue&gt;&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;RefPtr&lt;WebCore::SerializedScriptValue&gt;&gt;::decode): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/271671@main">https://commits.webkit.org/271671@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/795e53c8e90e2dd24208ffeabbaaa225448859c9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29173 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7842 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30509 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31760 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26532 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29769 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9989 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5147 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26536 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29445 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6505 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24995 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5609 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5754 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26031 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33097 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/25163 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26649 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26465 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31979 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/29483 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5715 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3895 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29764 "Found 2 new API test failures: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/close-quickly, /WebKitGTK/TestWebKitUserContentFilterStore:/webkit/WebKitUserContentFilterStore/save-from-file (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7392 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/35778 "Built successfully") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/6967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6226 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7714 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3751 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6237 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->