### PR TITLE
[iOS] Maps occasionally crashes under auto layout code when presenting a date picker

### DIFF
--- a/LayoutTests/fast/forms/ios/show-date-input-in-empty-window-expected.txt
+++ b/LayoutTests/fast/forms/ios/show-date-input-in-empty-window-expected.txt
@@ -1,0 +1,10 @@
+This test verifies that presenting a date picker in a web view in an empty window does not crash.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Did not crash after showing date picker
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/ios/show-date-input-in-empty-window.html
+++ b/LayoutTests/fast/forms/ios/show-date-input-in-empty-window.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true focusStartsInputSessionPolicy=allow ] -->
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script src="../../../resources/ui-helper.js"></script>
+    <script src="../../../resources/js-test.js"></script>
+    <style>
+        body, html {
+            width: 100%;
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+
+        input {
+            width: 200px;
+            height: 44px;
+            position: absolute;
+            left: calc(50% - 100px);
+            top: calc(50% - 22px);
+        }
+    </style>
+</head>
+<body>
+    <input type="datetime-local"></input>
+    <script>
+    jsTestIsAsync = true;
+
+    addEventListener("load", async () => {
+        description("This test verifies that presenting a date picker in a web view in an empty window does not crash.");
+
+        let input = document.querySelector("input");
+        await UIHelper.resizeWindowTo(0, 100);
+        input.focus();
+        await UIHelper.delayFor(300);
+        input.blur();
+
+        testPassed("Did not crash after showing date picker");
+        finishJSTest();
+    });
+    </script>
+</body>
+</html>

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -679,6 +679,14 @@ window.UIHelper = class UIHelper {
         });
     }
 
+    static resizeWindowTo(width, height)
+    {
+        if (!this.isWebKit2())
+            return Promise.resolve();
+
+        return new Promise(resolve => testRunner.runUIScript(`uiController.resizeWindowTo(${width}, ${height})`, resolve));
+    }
+
     static activateElementAndWaitForInputSession(element)
     {
         const x = element.offsetLeft + element.offsetWidth / 2;

--- a/Source/WebKit/UIProcess/ios/forms/WKDatePickerPopoverController.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKDatePickerPopoverController.mm
@@ -227,10 +227,20 @@
 {
     auto viewBounds = self.view.bounds;
     auto originalContentFrame = [_contentView frame];
-    if (CGRectIsEmpty(originalContentFrame) || CGRectGetHeight(originalContentFrame) <= CGRectGetHeight(viewBounds))
+    if (CGRectIsEmpty(viewBounds) || CGRectIsEmpty(originalContentFrame))
         return;
 
+    if (CGRectGetHeight(originalContentFrame) <= CGRectGetHeight(viewBounds)) {
+        // The UIDatePicker content view gets clipped vertically if the containing view is too short.
+        // However, if the date picker is wider than the view bounds, the date picker will automatically
+        // shrink horizontally to fit.
+        return;
+    }
+
     auto targetScale = std::min(CGRectGetWidth(viewBounds) / CGRectGetWidth(originalContentFrame), CGRectGetHeight(viewBounds) / CGRectGetHeight(originalContentFrame));
+    if (targetScale <= CGFLOAT_EPSILON || !std::isfinite(targetScale))
+        return;
+
     auto adjustedContentSize = CGSizeMake(CGRectGetWidth(originalContentFrame) * targetScale, CGRectGetHeight(originalContentFrame) * targetScale);
 
     [_contentView setTransform:^{

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -365,6 +365,8 @@ interface UIScriptController {
     undefined removeViewFromWindow(object callback);
     undefined addViewToWindow(object callback);
 
+    undefined resizeWindowTo(unsigned long width, unsigned long height);
+
     undefined installTapGestureOnWindow(object callback);
 
     undefined overridePreference(DOMString preference, DOMString value);

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -129,6 +129,8 @@ public:
     virtual void removeViewFromWindow(JSValueRef) { notImplemented(); }
     virtual void addViewToWindow(JSValueRef) { notImplemented(); }
 
+    virtual void resizeWindowTo(unsigned /* width */, unsigned /* height */) { notImplemented(); }
+
     virtual void installTapGestureOnWindow(JSValueRef) { notImplemented(); }
 
     // Editable region

--- a/Tools/WebKitTestRunner/UIScriptControllerCommon.cpp
+++ b/Tools/WebKitTestRunner/UIScriptControllerCommon.cpp
@@ -41,4 +41,9 @@ void UIScriptControllerCommon::setWindowIsKey(bool isKey)
     TestController::singleton().mainWebView()->setWindowIsKey(isKey);
 }
 
+void UIScriptControllerCommon::resizeWindowTo(unsigned width, unsigned height)
+{
+    TestController::singleton().mainWebView()->resizeTo(width, height);
+}
+
 } // namespace WTR

--- a/Tools/WebKitTestRunner/UIScriptControllerCommon.h
+++ b/Tools/WebKitTestRunner/UIScriptControllerCommon.h
@@ -38,6 +38,8 @@ public:
 
     bool windowIsKey() const override;
     void setWindowIsKey(bool) override;
+
+    void resizeWindowTo(unsigned width, unsigned height) override;
 };
 
 } // namespace WTR


### PR DESCRIPTION
#### 5187b76b861c8ce52672b4c995045678795ee15b
<pre>
[iOS] Maps occasionally crashes under auto layout code when presenting a date picker
<a href="https://bugs.webkit.org/show_bug.cgi?id=265906">https://bugs.webkit.org/show_bug.cgi?id=265906</a>
<a href="https://rdar.apple.com/119060260">rdar://119060260</a>

Reviewed by Aditya Keerthi.

Add some extra hardening to the logic in `-_scaleDownToFitHeightIfNeeded`, to avoid ever using 0 or
a non-finite value for `targetScale` when adjusting the date picker&apos;s layout constraints and
transform to fit within the popover container view.

* LayoutTests/fast/forms/ios/show-date-input-in-empty-window-expected.txt: Added.
* LayoutTests/fast/forms/ios/show-date-input-in-empty-window.html: Added.
* LayoutTests/resources/ui-helper.js:

Add a layout test to exercise the change, as well as test infrastructure to resize the web view
along with the containing test runner window.

(window.UIHelper.resizeWindowTo):
* Source/WebKit/UIProcess/ios/forms/WKDatePickerPopoverController.mm:
(-[WKDatePickerPopoverController _scaleDownToFitHeightIfNeeded]):
* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
(WTR::UIScriptController::resizeWindowTo):
* Tools/WebKitTestRunner/UIScriptControllerCommon.cpp:
(WTR::UIScriptControllerCommon::resizeWindowTo):
* Tools/WebKitTestRunner/UIScriptControllerCommon.h:

Canonical link: <a href="https://commits.webkit.org/271610@main">https://commits.webkit.org/271610@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e0e2551fb03de7cc23a19d8f211a564d0ef1c97

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28945 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7593 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30300 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31559 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26377 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29518 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9719 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4933 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26402 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29217 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6271 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24841 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5467 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5602 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25866 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/32897 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26463 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26298 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31843 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5572 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3743 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29622 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7214 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/25660 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6923 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6057 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6093 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->