### PR TITLE
Port ContextMenuContextData to the new IPC serialization format

### DIFF
--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -383,6 +383,7 @@ set(WebKit_SERIALIZATION_IN_FILES
     Shared/AuxiliaryProcessCreationParameters.serialization.in
     Shared/BackgroundFetchState.serialization.in
     Shared/CallbackID.serialization.in
+    Shared/ContextMenuContextData.serialization.in
     Shared/DebuggableInfoData.serialization.in
     Shared/DisplayListArgumentCoders.serialization.in
     Shared/DocumentEditingContext.serialization.in

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -218,6 +218,7 @@ $(PROJECT_DIR)/Shared/Cocoa/DataDetectionResult.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/InsertTextOptions.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/RevealItem.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
+$(PROJECT_DIR)/Shared/ContextMenuContextData.serialization.in
 $(PROJECT_DIR)/Shared/Databases/IndexedDB/WebIDBResult.serialization.in
 $(PROJECT_DIR)/Shared/DebuggableInfoData.serialization.in
 $(PROJECT_DIR)/Shared/DisplayListArgumentCoders.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -539,6 +539,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in \
 	Shared/CallbackID.serialization.in \
 	Shared/BackgroundFetchState.serialization.in \
+	Shared/ContextMenuContextData.serialization.in \
 	Shared/DebuggableInfoData.serialization.in \
 	Shared/DisplayListArgumentCoders.serialization.in \
 	Shared/DocumentEditingContext.serialization.in \

--- a/Source/WebKit/Shared/ContextMenuContextData.cpp
+++ b/Source/WebKit/Shared/ContextMenuContextData.cpp
@@ -91,6 +91,13 @@ void ContextMenuContextData::setImage(WebCore::Image& image)
     if (auto graphicsContext = m_controlledImage->createGraphicsContext())
         graphicsContext->drawImage(image, IntPoint());
 }
+
+std::optional<ShareableBitmap::Handle> ContextMenuContextData::createControlledImageReadOnlyHandle() const
+{
+    if (!m_controlledImage)
+        return std::nullopt;
+    return m_controlledImage->createHandle(SharedMemory::Protection::ReadOnly);
+}
 #endif
 
 #if ENABLE(CONTEXT_MENU_QR_CODE_DETECTION)
@@ -109,102 +116,72 @@ void ContextMenuContextData::setPotentialQRCodeViewportSnapshotImage(WebCore::Im
         graphicsContext->drawImage(image, IntPoint());
 }
 
-#endif // ENABLE(CONTEXT_MENU_QR_CODE_DETECTION)
-
-void ContextMenuContextData::encode(IPC::Encoder& encoder) const
+std::optional<ShareableBitmap::Handle> ContextMenuContextData::createPotentialQRCodeNodeSnapshotImageReadOnlyHandle() const
 {
-    encoder << m_type;
-    encoder << m_menuLocation;
-    encoder << m_menuItems;
-    encoder << m_webHitTestResultData;
-    encoder << m_selectedText;
-    encoder << m_hasEntireImage;
-
-#if ENABLE(SERVICE_CONTROLS)
-    std::optional<ShareableBitmap::Handle> potentialControlledImageHandle;
-    if (m_controlledImage)
-        potentialControlledImageHandle = m_controlledImage->createHandle(SharedMemory::Protection::ReadOnly);
-
-    encoder << WTFMove(potentialControlledImageHandle);
-    encoder << m_controlledSelectionData;
-    encoder << m_selectedTelephoneNumbers;
-    encoder << m_selectionIsEditable;
-    encoder << m_controlledImageBounds;
-    encoder << m_controlledImageAttachmentID;
-    encoder << m_controlledImageElementContext;
-    encoder << m_controlledImageMIMEType;
-#endif
-
-#if ENABLE(CONTEXT_MENU_QR_CODE_DETECTION)
-    std::optional<ShareableBitmap::Handle> potentialQRCodeNodeSnapshotImageHandle;
-    if (m_potentialQRCodeNodeSnapshotImage) {
-        potentialQRCodeNodeSnapshotImageHandle = m_potentialQRCodeNodeSnapshotImage->createHandle(SharedMemory::Protection::ReadOnly);
-    }
-    encoder << WTFMove(potentialQRCodeNodeSnapshotImageHandle);
-
-    std::optional<ShareableBitmap::Handle> potentialQRCodeViewportSnapshotImageHandle;
-    if (m_potentialQRCodeViewportSnapshotImage) {
-        potentialQRCodeViewportSnapshotImageHandle = m_potentialQRCodeViewportSnapshotImage->createHandle(SharedMemory::Protection::ReadOnly);
-    }
-    encoder << WTFMove(potentialQRCodeViewportSnapshotImageHandle);
-#endif
+    if (!m_potentialQRCodeNodeSnapshotImage)
+        return std::nullopt;
+    return m_potentialQRCodeNodeSnapshotImage->createHandle(SharedMemory::Protection::ReadOnly);
 }
 
-bool ContextMenuContextData::decode(IPC::Decoder& decoder, ContextMenuContextData& result)
+std::optional<ShareableBitmap::Handle> ContextMenuContextData::createPotentialQRCodeViewportSnapshotImageReadOnlyHandle() const
 {
-    if (!decoder.decode(result.m_type))
-        return false;
+    if (!m_potentialQRCodeViewportSnapshotImage)
+        return std::nullopt;
+    return m_potentialQRCodeViewportSnapshotImage->createHandle(SharedMemory::Protection::ReadOnly);
+}
 
-    if (!decoder.decode(result.m_menuLocation))
-        return false;
+#endif // ENABLE(CONTEXT_MENU_QR_CODE_DETECTION)
 
-    if (!decoder.decode(result.m_menuItems))
-        return false;
-
-    if (!decoder.decode(result.m_webHitTestResultData))
-        return false;
-
-    if (!decoder.decode(result.m_selectedText))
-        return false;
-
-    if (!decoder.decode(result.m_hasEntireImage))
-        return false;
+ContextMenuContextData ContextMenuContextData::fromIPC(
+    WebCore::ContextMenuContext::Type type
+    , WebCore::IntPoint&& menuLocation
+    , Vector<WebContextMenuItemData>&& menuItems
+    , std::optional<WebKit::WebHitTestResultData>&& webHitTestResultData
+    , String&& selectedText
+#if ENABLE(SERVICE_CONTROLS)
+    , std::optional<WebKit::ShareableBitmapHandle>&& controlledImageHandle
+    , Vector<uint8_t>&& controlledSelectionData
+    , Vector<String>&& selectedTelephoneNumbers
+    , bool selectionIsEditable
+    , WebCore::IntRect&& controlledImageBounds
+    , String&& controlledImageAttachmentID
+    , std::optional<WebCore::ElementContext>&& controlledImageElementContext
+    , String&& controlledImageMIMEType
+#endif // ENABLE(SERVICE_CONTROLS)
+#if ENABLE(CONTEXT_MENU_QR_CODE_DETECTION)
+    , std::optional<WebKit::ShareableBitmapHandle>&& potentialQRCodeNodeSnapshotImageHandle
+    , std::optional<WebKit::ShareableBitmapHandle>&& potentialQRCodeViewportSnapshotImageHandle
+#endif // ENABLE(CONTEXT_MENU_QR_CODE_DETECTION)
+    , bool hasEntireImage
+) {
+    ContextMenuContextData result;
+    result.m_type = type;
+    result.m_menuLocation = WTFMove(menuLocation);
+    result.m_menuItems = WTFMove(menuItems);
+    result.m_webHitTestResultData = WTFMove(webHitTestResultData);
+    result.m_selectedText = WTFMove(selectedText);
+    result.m_hasEntireImage = hasEntireImage;
 
 #if ENABLE(SERVICE_CONTROLS)
-    auto potentialControlledImageHandle = decoder.decode<std::optional<ShareableBitmap::Handle>>();
-    if (UNLIKELY(!decoder.isValid()))
-        return false;
-    if (*potentialControlledImageHandle)
-        result.m_controlledImage = ShareableBitmap::create(WTFMove(**potentialControlledImageHandle), SharedMemory::Protection::ReadOnly);
-
-    if (!decoder.decode(result.m_controlledSelectionData))
-        return false;
-    if (!decoder.decode(result.m_selectedTelephoneNumbers))
-        return false;
-    if (!decoder.decode(result.m_selectionIsEditable))
-        return false;
-    if (!decoder.decode(result.m_controlledImageBounds))
-        return false;
-    if (!decoder.decode(result.m_controlledImageAttachmentID))
-        return false;
-    if (!decoder.decode(result.m_controlledImageElementContext))
-        return false;
-    if (!decoder.decode(result.m_controlledImageMIMEType))
-        return false;
-#endif
+    if (controlledImageHandle)
+        result.m_controlledImage = ShareableBitmap::create(WTFMove(*controlledImageHandle), SharedMemory::Protection::ReadOnly);
+    result.m_controlledSelectionData = WTFMove(controlledSelectionData);
+    result.m_selectedTelephoneNumbers = WTFMove(selectedTelephoneNumbers);
+    result.m_selectionIsEditable = selectionIsEditable;
+    result.m_controlledImageBounds = WTFMove(controlledImageBounds);
+    result.m_controlledImageAttachmentID = WTFMove(controlledImageAttachmentID);
+    result.m_controlledImageElementContext = WTFMove(controlledImageElementContext);
+    result.m_controlledImageMIMEType = WTFMove(controlledImageMIMEType);
+#endif // ENABLE(SERVICE_CONTROLS)
 
 #if ENABLE(CONTEXT_MENU_QR_CODE_DETECTION)
-    auto potentialQRCodeNodeSnapshotImageHandle = decoder.decode<std::optional<ShareableBitmap::Handle>>();
-    auto potentialQRCodeViewportSnapshotImageHandle = decoder.decode<std::optional<ShareableBitmap::Handle>>();
-    if (UNLIKELY(!decoder.isValid()))
-        return false;
-    if (*potentialQRCodeNodeSnapshotImageHandle)
-        result.m_potentialQRCodeNodeSnapshotImage = ShareableBitmap::create(WTFMove(**potentialQRCodeNodeSnapshotImageHandle), SharedMemory::Protection::ReadOnly);
-    if (*potentialQRCodeViewportSnapshotImageHandle)
-        result.m_potentialQRCodeViewportSnapshotImage = ShareableBitmap::create(WTFMove(**potentialQRCodeViewportSnapshotImageHandle), SharedMemory::Protection::ReadOnly);
+    if (potentialQRCodeNodeSnapshotImageHandle)
+        result.m_potentialQRCodeNodeSnapshotImage = ShareableBitmap::create(WTFMove(*potentialQRCodeNodeSnapshotImageHandle), SharedMemory::Protection::ReadOnly);
+    if (potentialQRCodeViewportSnapshotImageHandle)
+        result.m_potentialQRCodeViewportSnapshotImage = ShareableBitmap::create(WTFMove(*potentialQRCodeViewportSnapshotImageHandle), SharedMemory::Protection::ReadOnly);
 #endif
 
-    return true;
+    return result;
 }
 
 #if ENABLE(SERVICE_CONTROLS)

--- a/Source/WebKit/Shared/ContextMenuContextData.h
+++ b/Source/WebKit/Shared/ContextMenuContextData.h
@@ -48,6 +48,29 @@ public:
     ContextMenuContextData();
     ContextMenuContextData(const WebCore::IntPoint& menuLocation, const Vector<WebKit::WebContextMenuItemData>& menuItems, const WebCore::ContextMenuContext&);
 
+    static ContextMenuContextData fromIPC(
+        WebCore::ContextMenuContext::Type
+        , WebCore::IntPoint&& menuLocation
+        , Vector<WebContextMenuItemData>&& menuItems
+        , std::optional<WebKit::WebHitTestResultData>&&
+        , String&& selectedText
+#if ENABLE(SERVICE_CONTROLS)
+        , std::optional<WebKit::ShareableBitmapHandle>&& controlledImageHandle
+        , Vector<uint8_t>&& controlledSelectionData
+        , Vector<String>&& selectedTelephoneNumbers
+        , bool selectionIsEditable
+        , WebCore::IntRect&& controlledImageBounds
+        , String&& controlledImageAttachmentID
+        , std::optional<WebCore::ElementContext>&& controlledImageElementContext
+        , String&& controlledImageMIMEType
+#endif // ENABLE(SERVICE_CONTROLS)
+#if ENABLE(CONTEXT_MENU_QR_CODE_DETECTION)
+        , std::optional<WebKit::ShareableBitmapHandle>&& potentialQRCodeNodeSnapshotImageHandle
+        , std::optional<WebKit::ShareableBitmapHandle>&& potentialQRCodeViewportSnapshotImageHandle
+#endif // ENABLE(CONTEXT_MENU_QR_CODE_DETECTION)
+        , bool hasEntireImage
+    );
+
     Type type() const { return m_type; }
     const WebCore::IntPoint& menuLocation() const { return m_menuLocation; }
     const Vector<WebKit::WebContextMenuItemData>& menuItems() const { return m_menuItems; }
@@ -80,8 +103,12 @@ public:
     ContextMenuContextData(const WebCore::IntPoint& menuLocation, WebCore::Image&, bool isEditable, const WebCore::IntRect& imageRect, const String& attachmentID, std::optional<WebCore::ElementContext>&&, const String& sourceImageMIMEType);
 
     ShareableBitmap* controlledImage() const { return m_controlledImage.get(); }
+    std::optional<ShareableBitmap::Handle> createControlledImageReadOnlyHandle() const;
+
     const Vector<uint8_t>& controlledSelectionData() const { return m_controlledSelectionData; }
     const Vector<String>& selectedTelephoneNumbers() const { return m_selectedTelephoneNumbers; }
+
+    bool selectionIsEditable() const { return m_selectionIsEditable; }
 
     bool isServicesMenu() const { return m_type == ContextMenuContextData::Type::ServicesMenu; }
     bool controlledDataIsEditable() const;
@@ -93,14 +120,13 @@ public:
 
 #if ENABLE(CONTEXT_MENU_QR_CODE_DETECTION)
     ShareableBitmap* potentialQRCodeNodeSnapshotImage() const { return m_potentialQRCodeNodeSnapshotImage.get(); }
+    std::optional<ShareableBitmap::Handle> createPotentialQRCodeNodeSnapshotImageReadOnlyHandle() const;
     ShareableBitmap* potentialQRCodeViewportSnapshotImage() const { return m_potentialQRCodeViewportSnapshotImage.get(); }
+    std::optional<ShareableBitmap::Handle> createPotentialQRCodeViewportSnapshotImageReadOnlyHandle() const;
 
     const String& qrCodePayloadString() const { return m_qrCodePayloadString; }
     void setQRCodePayloadString(const String& string) { m_qrCodePayloadString = string; }
 #endif
-
-    void encode(IPC::Encoder&) const;
-    static WARN_UNUSED_RETURN bool decode(IPC::Decoder&, ContextMenuContextData&);
 
 private:
     Type m_type;

--- a/Source/WebKit/Shared/ContextMenuContextData.serialization.in
+++ b/Source/WebKit/Shared/ContextMenuContextData.serialization.in
@@ -1,0 +1,48 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE(CONTEXT_MENUS)
+
+[CreateUsing=fromIPC] class WebKit::ContextMenuContextData {
+    WebCore::ContextMenuContext::Type type();
+    WebCore::IntPoint menuLocation();
+    Vector<WebKit::WebContextMenuItemData> menuItems();
+    std::optional<WebKit::WebHitTestResultData> webHitTestResultData();
+    String selectedText();
+#if ENABLE(SERVICE_CONTROLS)
+    std::optional<WebKit::ShareableBitmapHandle> createControlledImageReadOnlyHandle();
+    Vector<uint8_t> controlledSelectionData();
+    Vector<String> selectedTelephoneNumbers();
+    bool selectionIsEditable();
+    WebCore::IntRect controlledImageBounds();
+    String controlledImageAttachmentID();
+    std::optional<WebCore::ElementContext> controlledImageElementContext();
+    String controlledImageMIMEType();
+#endif // ENABLE(SERVICE_CONTROLS)
+#if ENABLE(CONTEXT_MENU_QR_CODE_DETECTION)
+    std::optional<WebKit::ShareableBitmapHandle> createPotentialQRCodeNodeSnapshotImageReadOnlyHandle();
+    std::optional<WebKit::ShareableBitmapHandle> createPotentialQRCodeViewportSnapshotImageReadOnlyHandle();
+#endif // ENABLE(CONTEXT_MENU_QR_CODE_DETECTION)
+    bool hasEntireImage();
+};
+
+#endif // ENABLE(CONTEXT_MENUS)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -5112,6 +5112,7 @@
 		46DF063A1F3905E5001980BB /* NetworkCORSPreflightChecker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NetworkCORSPreflightChecker.h; sourceTree = "<group>"; };
 		46E9760A2757F6C900ACDD37 /* WebBroadcastChannelRegistry.messages.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = WebBroadcastChannelRegistry.messages.in; sourceTree = "<group>"; };
 		46E9760B2757F6C900ACDD37 /* RemoteWebLockRegistry.messages.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = RemoteWebLockRegistry.messages.in; sourceTree = "<group>"; };
+		46EA625A2B1FE13200DC5E39 /* ContextMenuContextData.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = ContextMenuContextData.serialization.in; sourceTree = "<group>"; };
 		46EE2847269E049B00DD48AB /* WebBroadcastChannelRegistry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebBroadcastChannelRegistry.cpp; sourceTree = "<group>"; };
 		46EE2848269E049B00DD48AB /* WebBroadcastChannelRegistry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebBroadcastChannelRegistry.h; sourceTree = "<group>"; };
 		46EE284A269E051700DD48AB /* NetworkBroadcastChannelRegistry.messages.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = NetworkBroadcastChannelRegistry.messages.in; sourceTree = "<group>"; };
@@ -8512,6 +8513,7 @@
 				5129EB1123D0DE7800AF1CD7 /* ContentWorldShared.h */,
 				5106D7BF18BDBE73000AB166 /* ContextMenuContextData.cpp */,
 				5106D7C018BDBE73000AB166 /* ContextMenuContextData.h */,
+				46EA625A2B1FE13200DC5E39 /* ContextMenuContextData.serialization.in */,
 				99F642D21FABE378009621E9 /* CoordinateSystem.h */,
 				5C2C6FA627C958FC00CCDA9E /* DataTaskIdentifier.h */,
 				99036AE823A970870000B06A /* DebuggableInfoData.cpp */,


### PR DESCRIPTION
#### 59815dfb996a456ea1997390304605e8d5bd2e39
<pre>
Port ContextMenuContextData to the new IPC serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=265913">https://bugs.webkit.org/show_bug.cgi?id=265913</a>

Reviewed by Brady Eidson.

* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Shared/ContextMenuContextData.cpp:
(WebKit::ContextMenuContextData::createPotentialQRCodeNodeSnapshotImageReadOnlyHandle const):
(WebKit::ContextMenuContextData::createPotentialQRCodeViewportSnapshotImageReadOnlyHandle const):
(WebKit::ContextMenuContextData::createControlledImageReadOnlyHandle const):
(WebKit::ContextMenuContextData::fromIPC):
(WebKit::ContextMenuContextData::encode const): Deleted.
(WebKit::ContextMenuContextData::decode): Deleted.
* Source/WebKit/Shared/ContextMenuContextData.h:
(WebKit::ContextMenuContextData::selectionIsEditable const):
* Source/WebKit/Shared/ContextMenuContextData.serialization.in: Added.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/271644@main">https://commits.webkit.org/271644@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bfbf9ade57a29966fdae5a422394b0783da3c0d8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29045 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7718 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30396 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31657 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26453 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9899 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5031 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26470 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29317 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6418 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24911 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5534 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/5695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/32994 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26574 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26375 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31913 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5639 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3815 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29699 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7297 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6138 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3742 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6160 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->