### PR TITLE
[Wasm-GC] BBQJIT crashes compiling Wasm GC program with ASSERTION FAILED: !currentLocation.isRegister()

### DIFF
--- a/JSTests/wasm/gc/bug265742.js
+++ b/JSTests/wasm/gc/bug265742.js
@@ -1,0 +1,23 @@
+//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+
+import { instantiate } from "./wast-wrapper.js";
+
+instantiate(`
+  (module
+    (type (struct (field (mut i32))))
+    (func (result i32)
+      (local $19 (ref 0))
+      (local $22 i32)
+      (local.set $19 (struct.new_default 0))
+      (i32.const 1)
+      if (result i32)
+        (local.get $19)
+        (block (result i32)
+          (i32.const 1)
+          (br 0))
+        (struct.set 0 0)
+        (i32.const 1)
+      else
+        (i32.const 0)
+      end))
+`);

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -4162,11 +4162,14 @@ public:
             return { };
         }
 
-        Location structLocation = allocate(structValue);
+        Location structLocation = loadIfNecessary(structValue);
         emitThrowOnNullReference(ExceptionType::NullStructSet, structLocation);
 
         emitStructSet(structLocation.asGPR(), structType, fieldIndex, value);
         LOG_INSTRUCTION("StructSet", structValue, fieldIndex, value);
+
+        consume(structValue);
+
         return { };
     }
 


### PR DESCRIPTION
#### 7489f1848c5327a916b95b34c967d41950c03a89
<pre>
[Wasm-GC] BBQJIT crashes compiling Wasm GC program with ASSERTION FAILED: !currentLocation.isRegister()
<a href="https://bugs.webkit.org/show_bug.cgi?id=265742">https://bugs.webkit.org/show_bug.cgi?id=265742</a>

Reviewed by Justin Michaud.

There was a missing `consume` for struct.set, resulting in a bad state for the
register allocator. Also switches an `allocate` to `loadIfNecessary` (don&apos;t have
a minimal test case for this, but it caused a crash in Kotlin code).

* JSTests/wasm/gc/bug265742.js: Added.
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJIT::addStructSet):

Canonical link: <a href="https://commits.webkit.org/271633@main">https://commits.webkit.org/271633@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6211891ca194b32c1a96a9291656d9770caaf2e0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29013 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7687 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30369 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31627 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26434 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9817 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5000 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26450 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29285 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6346 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24889 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5512 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5644 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25915 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/32963 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/25048 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26513 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26352 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31888 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/29366 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5620 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3796 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29670 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7276 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/35627 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6942 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6117 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7683 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6141 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->