### PR TITLE
Set sandbox state flag on extension processes

### DIFF
--- a/Source/WebKit/Shared/AuxiliaryProcessExtensions/GPUProcessExtension.swift
+++ b/Source/WebKit/Shared/AuxiliaryProcessExtensions/GPUProcessExtension.swift
@@ -27,12 +27,22 @@ import ServiceExtensions
 @_spi(Private) import ServiceExtensions
 
 @main
-class GPUProcessExtension {
-    required init() {}
+class GPUProcessExtension : WKProcessExtension {
+    override required init() {
+        super.init()
+        setSharedInstance(self)
+    }
 }
 
 extension GPUProcessExtension: GPUServiceExtension {
     func handle(xpcConnection: xpc_connection_t) {
         handleNewConnection(xpcConnection)
     }
+
+    override func lockdownSandbox(_ version: String) {
+        if let lockdownVersion = _LockdownVersion(rawValue: version) {
+            self._lockdown(version: lockdownVersion)
+        }
+    }
+
 }

--- a/Source/WebKit/Shared/AuxiliaryProcessExtensions/NetworkingProcessExtension.swift
+++ b/Source/WebKit/Shared/AuxiliaryProcessExtensions/NetworkingProcessExtension.swift
@@ -69,4 +69,11 @@ extension NetworkingProcessExtension : NetworkingServiceExtension {
             return WKGrant()
         }
     }
+
+    override func lockdownSandbox(_ version: String) {
+        if let lockdownVersion = _LockdownVersion(rawValue: version) {
+            self._lockdown(version: lockdownVersion)
+        }
+    }
+
 }

--- a/Source/WebKit/Shared/AuxiliaryProcessExtensions/WebContentProcessExtension.swift
+++ b/Source/WebKit/Shared/AuxiliaryProcessExtensions/WebContentProcessExtension.swift
@@ -27,12 +27,22 @@ import ServiceExtensions
 @_spi(Private) import ServiceExtensions
 
 @main
-class WebContentProcessExtension {
-    required init() {}
+class WebContentProcessExtension : WKProcessExtension {
+    override required init() {
+        super.init()
+        setSharedInstance(self)
+    }
 }
+
 
 extension WebContentProcessExtension: ContentServiceExtension {
     func handle(xpcConnection: xpc_connection_t) {
         handleNewConnection(xpcConnection)
+    }
+
+    override func lockdownSandbox(_ version: String) {
+        if let lockdownVersion = _LockdownVersion(rawValue: version) {
+            self._lockdown(version: lockdownVersion)
+        }
     }
 }

--- a/Source/WebKit/Shared/Cocoa/WKProcessExtension.h
+++ b/Source/WebKit/Shared/Cocoa/WKProcessExtension.h
@@ -34,4 +34,5 @@ OBJC_EXPORT
 + (WKProcessExtension*) sharedInstance;
 - (void)setSharedInstance:(WKProcessExtension*)instance;
 - (id)grant:(NSString*)domain name:(NSString*)name;
+- (void)lockdownSandbox:(NSString*)version;
 @end

--- a/Source/WebKit/Shared/Cocoa/WKProcessExtension.mm
+++ b/Source/WebKit/Shared/Cocoa/WKProcessExtension.mm
@@ -52,4 +52,8 @@ static RetainPtr<WKProcessExtension>& sharedInstance()
 {
     return nil;
 }
+
+- (void)lockdownSandbox:(NSString*)version
+{
+}
 @end

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -495,12 +495,7 @@ Ref<WebPage> WebPage::create(PageIdentifier pageID, WebPageCreationParameters&& 
         injectedBundle->didCreatePage(page);
 
 #if HAVE(SANDBOX_STATE_FLAGS)
-    static bool hasSetLaunchVariable = false;
-    if (!hasSetLaunchVariable) {
-        auto auditToken = WebProcess::singleton().auditTokenForSelf();
-        sandbox_enable_state_flag("local:WebContentProcessLaunched", *auditToken);
-        hasSetLaunchVariable = true;
-    };
+    setHasLaunchedWebContentProcess();
 #endif
 
     return page;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2152,6 +2152,10 @@ private:
     void remotePostMessage(WebCore::FrameIdentifier source, const String& sourceOrigin, WebCore::FrameIdentifier target, std::optional<WebCore::SecurityOriginData>&& targetOrigin, const WebCore::MessageWithMessagePorts&);
     void renderTreeAsText(WebCore::FrameIdentifier, size_t baseIndent, OptionSet<WebCore::RenderAsTextFlag>, CompletionHandler<void(String&&)>&&);
 
+#if HAVE(SANDBOX_STATE_FLAGS)
+    static void setHasLaunchedWebContentProcess();
+#endif
+
     WebCore::PageIdentifier m_identifier;
 
     std::unique_ptr<WebCore::Page> m_page;


### PR DESCRIPTION
#### df8ea8c5ad6aa163ecffb4166760fb4f651ab61a
<pre>
Set sandbox state flag on extension processes
<a href="https://bugs.webkit.org/show_bug.cgi?id=265835">https://bugs.webkit.org/show_bug.cgi?id=265835</a>
<a href="https://rdar.apple.com/119159447">rdar://119159447</a>

Reviewed by Brent Fulgham.

Add functions to enable WebKit extension processes to set sandbox state flags. These flags can then
be used in the various sandboxes to restrict the sandbox further.

* Source/WebKit/Shared/AuxiliaryProcessExtensions/GPUProcessExtension.swift:
(GPUProcessExtension.lockdownSandbox(_:)):
* Source/WebKit/Shared/AuxiliaryProcessExtensions/NetworkingProcessExtension.swift:
(NetworkingProcessExtension.lockdownSandbox(_:)):
* Source/WebKit/Shared/AuxiliaryProcessExtensions/WebContentProcessExtension.swift:
(WebContentProcessExtension.lockdownSandbox(_:)):
* Source/WebKit/Shared/Cocoa/WKProcessExtension.h:
* Source/WebKit/Shared/Cocoa/WKProcessExtension.mm:
(-[WKProcessExtension lockdownSandbox:]):
(-[WKProcessExtension lockdownSandboxPostLaunch]):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::setHasLaunchedWebContentProcess):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::create):
* Source/WebKit/WebProcess/WebPage/WebPage.h:

Canonical link: <a href="https://commits.webkit.org/271626@main">https://commits.webkit.org/271626@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ffb35eb1b139e0922192b3788106ab7346b60ed

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29059 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7731 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30408 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31669 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/26463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9859 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5044 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29331 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/6390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/24919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/5543 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/5671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33006 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26549 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/26384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/31918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/5649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/3824 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/29701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7309 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6931 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6150 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/6170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->