### PR TITLE
[WebGPU] Invalid bind group should be returned if the bind group layout is not compatible with the bind group descriptor

### DIFF
--- a/LayoutTests/http/tests/webgpu/webgpu/api/validation/getBindGroupLayout-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/validation/getBindGroupLayout-expected.txt
@@ -1,1 +1,16 @@
-(Populate me when we're ready to investigate this test)
+
+PASS :index_range,explicit_layout:index=0
+PASS :index_range,explicit_layout:index=1
+PASS :index_range,explicit_layout:index=2
+PASS :index_range,explicit_layout:index=3
+PASS :index_range,explicit_layout:index=4
+PASS :index_range,explicit_layout:index=5
+PASS :index_range,auto_layout:index=0
+PASS :index_range,auto_layout:index=1
+PASS :index_range,auto_layout:index=2
+PASS :index_range,auto_layout:index=3
+PASS :index_range,auto_layout:index=4
+PASS :index_range,auto_layout:index=5
+PASS :unique_js_object,auto_layout:
+PASS :unique_js_object,explicit_layout:
+


### PR DESCRIPTION
#### f4182110bf08b0c9ac3558675aef90defbe140a4
<pre>
[WebGPU] Invalid bind group should be returned if the bind group layout is not compatible with the bind group descriptor
<a href="https://bugs.webkit.org/show_bug.cgi?id=265918">https://bugs.webkit.org/show_bug.cgi?id=265918</a>
&lt;radar://119225289&gt;

Reviewed by Tadeu Zagallo.

If the BindGroupLayout is not compatible with the BindGroup, an
invalid BindGroup should be returned.

* Source/WebGPU/WebGPU/BindGroup.mm:
(WebGPU::hasBinding):
(WebGPU::Device::createBindGroup):

* LayoutTests/http/tests/webgpu/webgpu/api/validation/getBindGroupLayout-expected.txt:
getBindGroupLayout test is now passing locally.

Canonical link: <a href="https://commits.webkit.org/271624@main">https://commits.webkit.org/271624@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20f9b2f5e8c8f1e2e287f57d77ed8af7813c2aba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29028 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7703 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30383 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31644 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26442 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9833 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5016 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26459 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29300 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6363 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24901 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5522 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5652 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25928 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/32981 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26529 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26364 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31901 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5627 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3806 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/29683 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7284 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6932 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6125 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6148 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->