### PR TITLE
[WebGPU] float32-filterable is not properly validated in bind group creation

### DIFF
--- a/LayoutTests/http/tests/webgpu/webgpu/api/validation/texture/float32_filterable-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/validation/texture/float32_filterable-expected.txt
@@ -1,0 +1,4 @@
+
+PASS :create_bind_group:enabled=true
+PASS :create_bind_group:enabled=false
+

--- a/Source/WebCore/Modules/WebGPU/GPUFeatureName.h
+++ b/Source/WebCore/Modules/WebGPU/GPUFeatureName.h
@@ -41,6 +41,7 @@ enum class GPUFeatureName : uint8_t {
     ShaderF16,
     Rg11b10ufloatRenderable,
     Bgra8unormStorage,
+    Float32Filterable,
 };
 
 inline WebGPU::FeatureName convertToBacking(GPUFeatureName featureName)
@@ -66,6 +67,8 @@ inline WebGPU::FeatureName convertToBacking(GPUFeatureName featureName)
         return WebGPU::FeatureName::ShaderF16;
     case GPUFeatureName::Rg11b10ufloatRenderable:
         return WebGPU::FeatureName::Rg11b10ufloatRenderable;
+    case GPUFeatureName::Float32Filterable:
+        return WebGPU::FeatureName::Float32Filterable;
     }
     RELEASE_ASSERT_NOT_REACHED();
 }

--- a/Source/WebCore/Modules/WebGPU/GPUFeatureName.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUFeatureName.idl
@@ -39,4 +39,5 @@ enum GPUFeatureName {
     "shader-f16",
     "rg11b10ufloat-renderable",
     "bgra8unorm-storage",
+    "float32-filterable",
 };

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUConvertToBackingContext.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUConvertToBackingContext.cpp
@@ -193,7 +193,7 @@ WGPUFeatureName ConvertToBackingContext::convertToBacking(FeatureName featureNam
 {
     switch (featureName) {
     case FeatureName::DepthClipControl:
-        return static_cast<WGPUFeatureName>(WGPUFeatureName_DepthClipControl);
+        return WGPUFeatureName_DepthClipControl;
     case FeatureName::Depth32floatStencil8:
         return WGPUFeatureName_Depth32FloatStencil8;
     case FeatureName::TextureCompressionBc:
@@ -205,13 +205,15 @@ WGPUFeatureName ConvertToBackingContext::convertToBacking(FeatureName featureNam
     case FeatureName::TimestampQuery:
         return WGPUFeatureName_TimestampQuery;
     case FeatureName::IndirectFirstInstance:
-        return static_cast<WGPUFeatureName>(WGPUFeatureName_IndirectFirstInstance);
+        return WGPUFeatureName_IndirectFirstInstance;
     case FeatureName::Bgra8unormStorage:
-        return static_cast<WGPUFeatureName>(WGPUFeatureName_BGRA8UnormStorage);
+        return WGPUFeatureName_BGRA8UnormStorage;
     case FeatureName::ShaderF16:
-        return static_cast<WGPUFeatureName>(WGPUFeatureName_ShaderF16);
+        return WGPUFeatureName_ShaderF16;
     case FeatureName::Rg11b10ufloatRenderable:
-        return static_cast<WGPUFeatureName>(WGPUFeatureName_RG11B10UfloatRenderable);
+        return WGPUFeatureName_RG11B10UfloatRenderable;
+    case FeatureName::Float32Filterable:
+        return WGPUFeatureName_Float32Filterable;
     }
 }
 

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUFeatureName.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUFeatureName.h
@@ -41,6 +41,7 @@ enum class FeatureName : uint8_t {
     ShaderF16,
     Rg11b10ufloatRenderable,
     Bgra8unormStorage,
+    Float32Filterable,
 };
 
 } // namespace WebCore::WebGPU

--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -924,7 +924,7 @@ static BindGroupLayoutEntry::BindingMember bindingMemberForGlobal(auto& global)
         }
 
         return TextureBindingLayout {
-            .sampleType = TextureSampleType::Float,
+            .sampleType = TextureSampleType::UnfilterableFloat,
             .viewDimension = viewDimension,
             .multisampled = multisampled
         };

--- a/Source/WebGPU/WebGPU/HardwareCapabilities.mm
+++ b/Source/WebGPU/WebGPU/HardwareCapabilities.mm
@@ -98,7 +98,9 @@ static Vector<WGPUFeatureName> baseFeatures(id<MTLDevice> device, const Hardware
     features.append(WGPUFeatureName_IndirectFirstInstance);
     features.append(WGPUFeatureName_RG11B10UfloatRenderable);
     features.append(WGPUFeatureName_ShaderF16);
-    features.append(static_cast<WGPUFeatureName>(WGPUFeatureName_BGRA8UnormStorage));
+    features.append(WGPUFeatureName_BGRA8UnormStorage);
+    if (device.supports32BitFloatFiltering)
+        features.append(WGPUFeatureName_Float32Filterable);
 
     return features;
 }

--- a/Source/WebKit/Shared/WebGPU/WebGPUFeatureName.serialization.in
+++ b/Source/WebKit/Shared/WebGPU/WebGPUFeatureName.serialization.in
@@ -32,5 +32,6 @@ enum class WebCore::WebGPU::FeatureName : uint8_t {
     ShaderF16,
     Rg11b10ufloatRenderable,
     Bgra8unormStorage,
+    Float32Filterable,
 };
 #endif


### PR DESCRIPTION
#### 0a661a76704f9b1e330821ea1203a10b8094da6a
<pre>
[WebGPU] float32-filterable is not properly validated in bind group creation
<a href="https://bugs.webkit.org/show_bug.cgi?id=265921">https://bugs.webkit.org/show_bug.cgi?id=265921</a>
&lt;radar://119227113&gt;

Reviewed by Tadeu Zagallo.

We can only use float32 filtering textures in bind groups if the float32-filterable
feature is enabled.

* LayoutTests/http/tests/webgpu/webgpu/api/validation/texture/float32_filterable-expected.txt: Added.
Add passing expectation.

* Source/WebGPU/WebGPU/BindGroup.mm:
(WebGPU::hasBinding):
(WebGPU::is32bppFloatFormat):
(WebGPU::valid32bppFloatSampleType):
(WebGPU::Device::createBindGroup):

* Source/WebCore/Modules/WebGPU/GPUFeatureName.h:
(WebCore::convertToBacking):

* Source/WebCore/Modules/WebGPU/GPUFeatureName.idl:
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUConvertToBackingContext.cpp:
(WebCore::WebGPU::ConvertToBackingContext::convertToBacking):

* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUFeatureName.h:
Add missing float32-filterable feature.

* Source/WebGPU/WebGPU/HardwareCapabilities.mm:
(WebGPU::baseFeatures):
Add feature if the device supports it.

Canonical link: <a href="https://commits.webkit.org/271653@main">https://commits.webkit.org/271653@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3942b601096218e2f15ce3bcb60316bb57667e24

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29096 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7764 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30434 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31696 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26484 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29692 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9889 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5070 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26498 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29368 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6415 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24944 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5565 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5692 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25974 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33034 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26571 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26410 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31937 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5670 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3841 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29721 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7335 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6952 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6174 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6191 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->