### PR TITLE
Remove `PKPaymentRequest.userAgent` staging code

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/PassKitSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/PassKitSPI.h
@@ -299,6 +299,12 @@ typedef NS_ENUM(NSInteger, PKPaymentSetupFeatureType) {
 @end
 #endif
 
+#if HAVE(PKPAYMENTREQUEST_USERAGENT)
+@interface PKPaymentRequest ()
+@property (nonatomic, copy) NSString *userAgent;
+@end
+#endif
+
 NS_ASSUME_NONNULL_END
 
 #endif // USE(APPLE_INTERNAL_SDK)
@@ -334,13 +340,6 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 typedef void(^PKCanMakePaymentsCompletion)(BOOL isValid, NSError *);
-
-#if HAVE(PKPAYMENTREQUEST_USERAGENT)
-// FIXME: <rdar://116640656> Remove `PKPaymentRequest.userAgent` staging code
-@interface PKPaymentRequest (Staging_110687914)
-@property (nonatomic, copy) NSString *userAgent;
-@end
-#endif
 
 NS_ASSUME_NONNULL_END
 

--- a/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
@@ -396,9 +396,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
             return page->userAgent();
         return WebPageProxy::standardUserAgent();
     }();
-    // FIXME: <rdar://116640656> Remove this selector check when its corresponding staging declaration is removed.
-    if ([result respondsToSelector:@selector(setUserAgent:)])
-        [result setUserAgent:userAgent];
+    [result setUserAgent:userAgent];
 #else
     UNUSED_PARAM(webPageProxyID);
 #endif // HAVE(PKPAYMENTREQUEST_USERAGENT)


### PR DESCRIPTION
#### 4e5442c8e38bdaba66cbfe6b64d63658afb8cf13
<pre>
Remove `PKPaymentRequest.userAgent` staging code
<a href="https://bugs.webkit.org/show_bug.cgi?id=265916">https://bugs.webkit.org/show_bug.cgi?id=265916</a>
<a href="https://rdar.apple.com/116640656">rdar://116640656</a>

Reviewed by Wenson Hsieh.

`PKPaymentRequest.userAgent` has been in builds for long enough, so I&apos;m
supplanting the staging code as a declaration for building with
non-Internal SDKs. Also, removed the selector check that is now
unnecessary.

* Source/WebCore/PAL/pal/spi/cocoa/PassKitSPI.h:
* Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm:
(WebKit::WebPaymentCoordinatorProxy::platformPaymentRequest):

Canonical link: <a href="https://commits.webkit.org/271595@main">https://commits.webkit.org/271595@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4292d2274aa49a2b08a4a08473f64efc2bc4946c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28905 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7548 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30261 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31520 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26351 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29478 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9673 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4894 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26390 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29177 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6240 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24818 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5439 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5570 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25836 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/32857 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26433 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26274 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31815 "layout-tests (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5548 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3716 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29596 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7184 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6913 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6029 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6069 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->