### PR TITLE
[WebGPU] Creating a ComputePipeline with a vertexShader module or similar should be an error

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUProgrammableStage.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUProgrammableStage.idl
@@ -30,7 +30,7 @@
 ]
 dictionary GPUProgrammableStage {
     required GPUShaderModule module;
-    required USVString entryPoint;
+    USVString entryPoint;
     record<USVString, GPUPipelineConstantValue> constants;
 };
 typedef double GPUPipelineConstantValue; // May represent WGSL’s bool, f32, i32, u32.

--- a/Source/WebGPU/WGSL/WGSLShaderModule.h
+++ b/Source/WebGPU/WGSL/WGSLShaderModule.h
@@ -57,6 +57,7 @@ public:
     const Configuration& configuration() const { return m_configuration; }
     AST::Directive::List& directives() { return m_directives; }
     AST::Function::List& functions() { return m_functions; }
+    const AST::Function::List& functions() const { return m_functions; }
     AST::Structure::List& structures() { return m_structures; }
     AST::Variable::List& variables() { return m_variables; }
     TypeStore& types() { return m_types; }

--- a/Source/WebGPU/WebGPU/ComputePipeline.mm
+++ b/Source/WebGPU/WebGPU/ComputePipeline.mm
@@ -76,7 +76,8 @@ Ref<ComputePipeline> Device::createComputePipeline(const WGPUComputePipelineDesc
 
     PipelineLayout& pipelineLayout = WebGPU::fromAPI(descriptor.layout);
     auto label = fromAPI(descriptor.label);
-    auto libraryCreationResult = createLibrary(m_device, shaderModule, &pipelineLayout, fromAPI(descriptor.compute.entryPoint), label);
+    auto entryPoint = fromAPI(descriptor.compute.entryPoint);
+    auto libraryCreationResult = createLibrary(m_device, shaderModule, &pipelineLayout, entryPoint.length() ? entryPoint : shaderModule.defaultComputeEntryPoint(), label);
     if (!libraryCreationResult)
         return ComputePipeline::createInvalid(*this);
 
@@ -89,7 +90,7 @@ Ref<ComputePipeline> Device::createComputePipeline(const WGPUComputePipelineDesc
 
     auto [constantValues, wgslConstantValues] = createConstantValues(descriptor.compute.constantCount, descriptor.compute.constants, entryPointInformation);
     auto function = createFunction(library, entryPointInformation, constantValues, label);
-    if (!function)
+    if (!function || function.functionType != MTLFunctionTypeKernel)
         return ComputePipeline::createInvalid(*this);
 
     auto size = metalSize(computeInformation.workgroupSize, wgslConstantValues);

--- a/Source/WebGPU/WebGPU/Pipeline.mm
+++ b/Source/WebGPU/WebGPU/Pipeline.mm
@@ -32,7 +32,7 @@ namespace WebGPU {
 
 std::optional<LibraryCreationResult> createLibrary(id<MTLDevice> device, const ShaderModule& shaderModule, const PipelineLayout* pipelineLayout, const String& entryPoint, NSString *label)
 {
-    if (!shaderModule.isValid())
+    if (!entryPoint.length() || !shaderModule.isValid())
         return std::nullopt;
 
     if (shaderModule.library() && pipelineLayout) {

--- a/Source/WebGPU/WebGPU/RenderPipeline.mm
+++ b/Source/WebGPU/WebGPU/RenderPipeline.mm
@@ -578,8 +578,8 @@ Ref<RenderPipeline> Device::createRenderPipeline(const WGPURenderPipelineDescrip
         if (!vertexModule.isValid())
             return RenderPipeline::createInvalid(*this);
 
-        const auto& vertexFunctionName = String::fromLatin1(descriptor.vertex.entryPoint);
-        auto libraryCreationResult = createLibrary(m_device, vertexModule, pipelineLayout, vertexFunctionName, label);
+        const auto& vertexFunctionName = fromAPI(descriptor.vertex.entryPoint);
+        auto libraryCreationResult = createLibrary(m_device, vertexModule, pipelineLayout, vertexFunctionName.length() ? vertexFunctionName : vertexModule.defaultVertexEntryPoint(), label);
         if (!libraryCreationResult)
             return RenderPipeline::createInvalid(*this);
 
@@ -588,7 +588,7 @@ Ref<RenderPipeline> Device::createRenderPipeline(const WGPURenderPipelineDescrip
             addPipelineLayouts(bindGroupEntries, entryPointInformation.defaultLayout);
         auto [constantValues, _] = createConstantValues(descriptor.vertex.constantCount, descriptor.vertex.constants, entryPointInformation);
         auto vertexFunction = createFunction(libraryCreationResult->library, entryPointInformation, constantValues, label);
-        if (!vertexFunction)
+        if (!vertexFunction || vertexFunction.functionType != MTLFunctionTypeVertex)
             return RenderPipeline::createInvalid(*this);
         mtlRenderPipelineDescriptor.vertexFunction = vertexFunction;
     }
@@ -604,9 +604,9 @@ Ref<RenderPipeline> Device::createRenderPipeline(const WGPURenderPipelineDescrip
         if (!fragmentModule.isValid())
             return RenderPipeline::createInvalid(*this);
 
-        const auto& fragmentFunctionName = String::fromLatin1(fragmentDescriptor.entryPoint);
+        const auto& fragmentFunctionName = fromAPI(fragmentDescriptor.entryPoint);
 
-        auto libraryCreationResult = createLibrary(m_device, fragmentModule, pipelineLayout, fragmentFunctionName, label);
+        auto libraryCreationResult = createLibrary(m_device, fragmentModule, pipelineLayout, fragmentFunctionName.length() ? fragmentFunctionName : fragmentModule.defaultFragmentEntryPoint(), label);
         if (!libraryCreationResult)
             return RenderPipeline::createInvalid(*this);
 
@@ -616,7 +616,7 @@ Ref<RenderPipeline> Device::createRenderPipeline(const WGPURenderPipelineDescrip
 
         auto [constantValues, _] = createConstantValues(fragmentDescriptor.constantCount, fragmentDescriptor.constants, entryPointInformation);
         auto fragmentFunction = createFunction(libraryCreationResult->library, entryPointInformation, constantValues, label);
-        if (!fragmentFunction)
+        if (!fragmentFunction || fragmentFunction.functionType != MTLFunctionTypeFragment)
             return RenderPipeline::createInvalid(*this);
         mtlRenderPipelineDescriptor.fragmentFunction = fragmentFunction;
 

--- a/Source/WebGPU/WebGPU/ShaderModule.h
+++ b/Source/WebGPU/WebGPU/ShaderModule.h
@@ -72,6 +72,9 @@ public:
     id<MTLLibrary> library() const { return m_library; }
 
     Device& device() const { return m_device; }
+    const String& defaultVertexEntryPoint() const;
+    const String& defaultFragmentEntryPoint() const;
+    const String& defaultComputeEntryPoint() const;
 
 private:
     ShaderModule(std::variant<WGSL::SuccessfulCheck, WGSL::FailedCheck>&&, HashMap<String, Ref<PipelineLayout>>&&, HashMap<String, WGSL::Reflection::EntryPointInformation>&&, id<MTLLibrary>, Device&);
@@ -87,6 +90,10 @@ private:
     const Ref<Device> m_device;
     // FIXME: https://bugs.webkit.org/show_bug.cgi?id=250441 - this needs to be populated from the compiler
     HashMap<String, String> m_constantIdentifiersToNames;
+
+    String m_defaultVertexEntryPoint;
+    String m_defaultFragmentEntryPoint;
+    String m_defaultComputeEntryPoint;
 };
 
 } // namespace WebGPU


### PR DESCRIPTION
#### ae54cd2196fe0a8ccbe5796cc913a67b8ade8e93
<pre>
[WebGPU] Creating a ComputePipeline with a vertexShader module or similar should be an error
<a href="https://bugs.webkit.org/show_bug.cgi?id=265928">https://bugs.webkit.org/show_bug.cgi?id=265928</a>
&lt;radar://119234036&gt;

Reviewed by Tadeu Zagallo.

Creating a pipeline now allows the entryPoint to be omitted
and the only suitable default will be chosen.

Also, if we attempt to create a compute pipeline with a vertex
shader or similar incorrect combinations, that should be an error.

* Source/WebCore/Modules/WebGPU/GPUProgrammableStage.idl:
* Source/WebGPU/WebGPU/ComputePipeline.mm:
(WebGPU::Device::createComputePipeline):
* Source/WebGPU/WebGPU/Pipeline.mm:
(WebGPU::createLibrary):
* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::Device::createRenderPipeline):
* Source/WebGPU/WebGPU/ShaderModule.h:
* Source/WebGPU/WebGPU/ShaderModule.mm:
(WebGPU::Device::createShaderModule):
(WebGPU::ShaderModule::ShaderModule):
(WebGPU::ShaderModule::convertPipelineLayout):
(WebGPU::ShaderModule::defaultVertexEntryPoint const):
(WebGPU::ShaderModule::defaultFragmentEntryPoint const):
(WebGPU::ShaderModule::defaultComputeEntryPoint const):

Canonical link: <a href="https://commits.webkit.org/271652@main">https://commits.webkit.org/271652@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/825268ab278690ef4a342918642756adf71092fa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29079 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7751 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30421 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31683 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26475 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29675 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9875 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5057 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26487 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29351 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6403 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24934 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5554 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5681 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25962 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33021 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26560 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26399 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31927 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5661 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3834 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29723 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7322 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6951 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6162 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6182 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->