### PR TITLE
[WebGPU] MTLTextureUsagePixelFormatView needs to be specified on compressed textures

### DIFF
--- a/Source/WebGPU/WebGPU/Texture.mm
+++ b/Source/WebGPU/WebGPU/Texture.mm
@@ -1349,7 +1349,7 @@ MTLTextureUsage Texture::usage(WGPUTextureUsageFlags usage, WGPUTextureFormat fo
         result |= MTLTextureUsageShaderWrite;
     if (usage & WGPUTextureUsage_RenderAttachment)
         result |= MTLTextureUsageRenderTarget;
-    if (Texture::isDepthOrStencilFormat(format))
+    if (Texture::isDepthOrStencilFormat(format) || Texture::isCompressedFormat(format))
         result |= MTLTextureUsagePixelFormatView;
     return result;
 }


### PR DESCRIPTION
#### d7430f08e3da290d714b4e491678d4b7d9300e14
<pre>
[WebGPU] MTLTextureUsagePixelFormatView needs to be specified on compressed textures
<a href="https://bugs.webkit.org/show_bug.cgi?id=265929">https://bugs.webkit.org/show_bug.cgi?id=265929</a>
&lt;radar://119234400&gt;

Reviewed by Tadeu Zagallo.

As we do not know in advance if createView will be called on a compressed
texture, set the flag pre-emptively instead of recreating the texture.

This approach could be revisited if we see performance issues.

* Source/WebGPU/WebGPU/Texture.mm:
(WebGPU::Texture::usage):

Canonical link: <a href="https://commits.webkit.org/271619@main">https://commits.webkit.org/271619@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4c05f7739a339136d73e0252cb49539f510955c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28944 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7592 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30299 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31558 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26376 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9718 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4932 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26401 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29216 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6270 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24843 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5466 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5606 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/32896 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26462 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26300 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/31897 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5571 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3742 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29624 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7213 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6928 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6056 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6092 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->