### PR TITLE
[Flatpak SDK] Fix run-minibrowser for python 3.12

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
@@ -58,7 +58,7 @@ else:
     if platform.system() == 'Windows':
         AutoInstall.register(Package('win_inet_pton', Version(1, 1, 0), pypi_name='win-inet-pton'))
 
-if sys.version_info >= (3, 12):
+if sys.version_info >= (3, 13):
     AutoInstall.register(Package('setuptools', Version(68, 1, 2)))
 elif sys.version_info >= (3, 0):
     AutoInstall.register(Package('setuptools', Version(56, 0, 0)))


### PR DESCRIPTION
#### 1e25664760f6e1570a920801a95a2cde388379b0
<pre>
[Flatpak SDK] Fix run-minibrowser for python 3.12
<a href="https://bugs.webkit.org/show_bug.cgi?id=265931">https://bugs.webkit.org/show_bug.cgi?id=265931</a>

Reviewed by NOBODY (OOPS!).

When the host&apos;s Python version is 3.12 or higher, Flatpak SDK&apos;s run-minibrowser fails
due to conflicting setuptools versions (68.1.2 for Python &gt;= 3.12 and 56.0.0 for
Python &gt;= 3.0). To resolve, ensure matching setuptools versions between host and
Flatpak Pythons. The current SDK&apos;s Python version is 3.11.5, limited to setuptools-56.0.0
due to a beautifulsoup4 dependency since commit 267461@main. A similar adjustment
is made for Python 3.12.

* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py:
</pre>