### PR TITLE
[web-animations] effect targeting an element with `display: none` should not schedule immediate animation resolution (affects reddit.com)

### DIFF
--- a/LayoutTests/webanimations/scheduling-of-animation-with-display-contents-expected.txt
+++ b/LayoutTests/webanimations/scheduling-of-animation-with-display-contents-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Computing the time until the next tick for an effect targeting an element with 'display: contents'.
+

--- a/LayoutTests/webanimations/scheduling-of-animation-with-display-contents.html
+++ b/LayoutTests/webanimations/scheduling-of-animation-with-display-contents.html
@@ -1,0 +1,14 @@
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<div style="display: contents"></div>
+<script>
+
+promise_test(async () => {
+    const animation = document.querySelector("div").animate({ color: "blue" }, 1000);
+    await animation.ready;
+
+    animation.currentTime = 100;
+    assert_equals(internals.timeToNextAnimationTick(animation), 0);
+}, "Computing the time until the next tick for an effect targeting an element with 'display: contents'.");
+
+</script>

--- a/LayoutTests/webanimations/scheduling-of-animation-without-renderer-expected.txt
+++ b/LayoutTests/webanimations/scheduling-of-animation-without-renderer-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Computing the time until the next tick for an effect targeting an element losing its renderer.
+

--- a/LayoutTests/webanimations/scheduling-of-animation-without-renderer.html
+++ b/LayoutTests/webanimations/scheduling-of-animation-without-renderer.html
@@ -1,0 +1,19 @@
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<div></div>
+<script>
+
+promise_test(async () => {
+    const target = document.querySelector("div");
+    const animation = document.querySelector("div").animate({ marginLeft: "100px" }, 1000);
+    await animation.ready;
+
+    animation.currentTime = 100;
+    assert_equals(internals.timeToNextAnimationTick(animation), 0, "Animation needs immediate resolution when running with a renderer.");
+
+    target.style.display = "none";
+    assert_equals(getComputedStyle(target).display, "none");
+    assert_equals(internals.timeToNextAnimationTick(animation), 900, "Animation will not need to be resolved until complete when running without a renderer.");
+}, "Computing the time until the next tick for an effect targeting an element losing its renderer.");
+
+</script>

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -2291,6 +2291,10 @@ bool KeyframeEffect::ticksContinouslyWhileActive() const
     if (doesNotAffectStyles)
         return false;
 
+    auto targetHasDisplayContents = [&]() { return m_target && m_pseudoId == PseudoId::None && m_target->hasDisplayContents(); };
+    if (!renderer() && !targetHasDisplayContents())
+        return false;
+
     if (isCompletelyAccelerated() && isRunningAccelerated())
         return false;
 


### PR DESCRIPTION
#### 452ca171058f6b23dfd986c79b8093939c9b32ce
<pre>
[web-animations] effect targeting an element with `display: none` should not schedule immediate animation resolution (affects reddit.com)
<a href="https://bugs.webkit.org/show_bug.cgi?id=265934">https://bugs.webkit.org/show_bug.cgi?id=265934</a>
<a href="https://rdar.apple.com/119191813">rdar://119191813</a>

Reviewed by Simon Fraser and Antti Koivisto.

Typically, effects that are in their active phase (ie. their current time is changing from frame
to frame (see <a href="https://drafts.csswg.org/web-animations-1/#animation-effect-active-phase">https://drafts.csswg.org/web-animations-1/#animation-effect-active-phase</a> for details)
will schedule immediate animation resolution. However there are exceptions, for instance we don&apos;t
schedule immediate animation resolution if the effect does not affect styles or if the effect is
running accelerated.

We now also handle the case where an effect&apos;s target does not have a renderer, as would be the case
if an element has a `display: none` style, making sure to also handle the `display: contents` case
where a renderer is not created for the target element, but will for its children.

This helps power usage on reddit.com which has JS-originated animations running infinitely that are
targeting elements in shadow roots that eventually lose their renderer.

* LayoutTests/webanimations/scheduling-of-animation-with-display-contents-expected.txt: Added.
* LayoutTests/webanimations/scheduling-of-animation-with-display-contents.html: Added.
* LayoutTests/webanimations/scheduling-of-animation-without-renderer-expected.txt: Added.
* LayoutTests/webanimations/scheduling-of-animation-without-renderer.html: Added.
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::ticksContinouslyWhileActive const):

Canonical link: <a href="https://commits.webkit.org/271614@main">https://commits.webkit.org/271614@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/273f68a4651fa0f8602d2abcf25d6a9b2b780778

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29002 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7674 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30358 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31616 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26426 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29594 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9807 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4990 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26446 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29274 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6352 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24883 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5507 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5635 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25908 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/32953 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26504 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26344 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31884 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5612 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3788 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29666 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7268 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/25702 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6109 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3732 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6133 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->