### PR TITLE
[web-animations] accelerated CSS Animation should not schedule animation resolution at iteration boundary if no CSS Animation event listener was registered (affects reddit.com)

### DIFF
--- a/LayoutTests/webanimations/scheduling-of-accelerated-css-animation-without-css-animation-event-listeners-expected.txt
+++ b/LayoutTests/webanimations/scheduling-of-accelerated-css-animation-without-css-animation-event-listeners-expected.txt
@@ -1,0 +1,3 @@
+
+PASS CSS Animations that run accelerated do not need to schedule animation resolution without CSS Animation event listeners.
+

--- a/LayoutTests/webanimations/scheduling-of-accelerated-css-animation-without-css-animation-event-listeners.html
+++ b/LayoutTests/webanimations/scheduling-of-accelerated-css-animation-without-css-animation-event-listeners.html
@@ -1,0 +1,40 @@
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="../resources/ui-helper.js"></script>
+<style>
+
+@keyframes slide {
+    from { transform: translate(100px) }
+    to { transform: translate(200px) }
+}
+
+#target {
+    width: 100px;
+    height: 100px;
+    animation-name: slide;
+    animation-duration: 1s;
+    animation-iteration-count: infinite;
+}
+
+</style>
+<div id="target"></div>
+<script>
+
+promise_test(async () => {
+    const target = document.getElementById("target");
+    const animation = target.getAnimations()[0];
+    await animation.ready;
+
+    // Wait until the animation has started with acceleration.
+    await UIHelper.animationFrame();
+    await UIHelper.animationFrame();
+    await UIHelper.animationFrame();
+
+    assert_equals(internals.timeToNextAnimationTick(animation), Infinity, "Animation does not need to schedule animation resolution if it is accelerated and does not have any CSS Animation event listeners registered.");
+
+    target.addEventListener("animationiteration", () => {});
+    animation.currentTime = 100;
+    assert_equals(internals.timeToNextAnimationTick(animation), 900, "Adding a CSS Animation event listener will make the animation require an animation resolution at the end of its current iteration.");
+}, "CSS Animations that run accelerated do not need to schedule animation resolution without CSS Animation event listeners.");
+
+</script>

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -2299,13 +2299,17 @@ bool KeyframeEffect::ticksContinouslyWhileActive() const
 
 Seconds KeyframeEffect::timeToNextTick(const BasicEffectTiming& timing) const
 {
-    if (timing.phase == AnimationEffectPhase::Active) {
-        // CSS Animations need to trigger "animationiteration" events even if there is no need to
-        // update styles while animating, so if we're dealing with one we must wait until the next iteration.
-        if (!ticksContinouslyWhileActive() && is<CSSAnimation>(animation())) {
-            if (auto iterationProgress = getComputedTiming().simpleIterationProgress)
-                return iterationDuration() * (1 - *iterationProgress);
-        }
+    // CSS Animations need to trigger "animationiteration" events even if there is no need to
+    // update styles while animating, so if we're dealing with one we must wait until the next iteration.
+    // We only do this in case any CSS Animation event was registered since, in the general case, there's
+    // a good chance that no such event listeners were registered and we can avoid some unnecessary
+    // animation resolution scheduling.
+    ASSERT(document());
+    if (timing.phase == AnimationEffectPhase::Active && is<CSSAnimation>(animation())
+        && document()->hasListenerType(Document::ListenerType::CSSAnimation)
+        && !ticksContinouslyWhileActive()) {
+        if (auto iterationProgress = getComputedTiming().simpleIterationProgress)
+            return iterationDuration() * (1 - *iterationProgress);
     }
 
     return AnimationEffect::timeToNextTick(timing);


### PR DESCRIPTION
#### 4a38bbbd7547d45a97ce02294621513d1559ce7a
<pre>
[web-animations] accelerated CSS Animation should not schedule animation resolution at iteration boundary if no CSS Animation event listener was registered (affects reddit.com)
<a href="https://bugs.webkit.org/show_bug.cgi?id=265936">https://bugs.webkit.org/show_bug.cgi?id=265936</a>
<a href="https://rdar.apple.com/119244430">rdar://119244430</a>

Reviewed by Antti Koivisto.

While we don&apos;t need to schedule animation resolution for animations that are running accelerated
to resolve styles, we do need to schedule resolution in order to dispatch `animationiteration`
events in the case of CSS Animations.

However, it is unlikely that the content will be interested in such events. As a cheap optimization,
we can detect whether any CSS Animation event listener is registered for the document to which the
effect target belongs, and if that is not the case we don&apos;t need to schedule animation resolution.

* LayoutTests/webanimations/scheduling-of-accelerated-css-animation-without-css-animation-event-listeners-expected.txt: Added.
* LayoutTests/webanimations/scheduling-of-accelerated-css-animation-without-css-animation-event-listeners.html: Added.
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::timeToNextTick const):

Canonical link: <a href="https://commits.webkit.org/271604@main">https://commits.webkit.org/271604@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7463a1e8f265deecabd7c59ec027d184e6f1e083

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28976 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7636 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30332 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31590 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26401 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29564 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9770 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4964 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26423 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29248 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6297 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24861 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5486 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/5609 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25886 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/32928 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26482 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26321 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31863 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5591 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3764 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29641 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7243 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/25680 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6084 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3727 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6112 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->