### PR TITLE
[MSE] add track id test for MSE

### DIFF
--- a/LayoutTests/media/track/media-audio-track-expected.txt
+++ b/LayoutTests/media/track/media-audio-track-expected.txt
@@ -1,0 +1,9 @@
+
+RUN(mediaElement.src = "../content/short--1-track.webm")
+
+EVENT(loadedmetadata)
+EXPECTED (video.audioTracks.length == '1') OK
+EXPECTED (video.audioTracks[0].enabled == 'true') OK
+EXPECTED (video.audioTracks[0].id == '18446744073709551615') OK
+END OF TEST
+

--- a/LayoutTests/media/track/media-audio-track.html
+++ b/LayoutTests/media/track/media-audio-track.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <script src=media-file.js></script>
-        <script src=video-test.js></script>
+        <script src=../media-file.js></script>
+        <script src=../video-test.js></script>
         <script>
             function loadedmetadata()
             {
@@ -16,7 +16,7 @@
             {
                 findMediaElement();
                 mediaElement.onerror = () => { failTest("error occurred."); }
-                run('mediaElement.src = "content/short--1-track.webm"');
+                run('mediaElement.src = "../content/short--1-track.webm"');
                 waitForEventOnce('loadedmetadata', loadedmetadata);
                 consoleWrite("");
             }

--- a/LayoutTests/media/track/media-source-audio-track-expected.txt
+++ b/LayoutTests/media/track/media-source-audio-track-expected.txt
@@ -1,7 +1,4 @@
 
-RUN(mediaElement.src = "content/short--1-track.webm")
-
-EVENT(loadedmetadata)
 EXPECTED (video.audioTracks.length == '1') OK
 EXPECTED (video.audioTracks[0].enabled == 'true') OK
 EXPECTED (video.audioTracks[0].id == '18446744073709551615') OK

--- a/LayoutTests/media/track/media-source-audio-track.html
+++ b/LayoutTests/media/track/media-source-audio-track.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <script src="../video-test.js"></script>
+        <script src="../utilities.js"></script>
+        <script>
+
+        async function start() {
+            findMediaElement();
+    
+            mediaElement.onerror = () => { failTest("error occurred."); }
+            let fetchResult = await fetch('../content/short--1-track.webm');
+            let arrayBuffer = await fetchResult.arrayBuffer();
+            video.disableRemotePlayback = true;
+            source = new ManagedMediaSource();
+            video.src = URL.createObjectURL(source);
+            await once(source, 'sourceopen');
+            sourceBuffer = source.addSourceBuffer('audio/webm; codecs="opus"');
+            sourceBuffer.appendBuffer(arrayBuffer);
+            await once(video, 'loadedmetadata');
+            testExpected('video.audioTracks.length', '1');
+            testExpected('video.audioTracks[0].enabled', true);
+            testExpected('video.audioTracks[0].id', "18446744073709551615");
+            endTest();
+        };
+        </script>
+    </head>
+
+    <body onload="start()">
+        <video></video>
+    </body>
+</html>

--- a/LayoutTests/media/track/media-video-audio-track-expected.txt
+++ b/LayoutTests/media/track/media-video-audio-track-expected.txt
@@ -2,7 +2,7 @@
 1) Disable and enable an audio track in a run loop will enable the audio track.
 2) Deselect and select a video track in a run loop will select the video track.
 
-RUN(mediaElement.src = findMediaFile("video", "content/test"))
+RUN(mediaElement.src = findMediaFile("video", "../content/test"))
 
 EVENT(canplaythrough)
 EXPECTED (video.audioTracks.length == '1') OK

--- a/LayoutTests/media/track/media-video-audio-track.html
+++ b/LayoutTests/media/track/media-video-audio-track.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <script src=media-file.js></script>
-        <script src=video-test.js></script>
+        <script src=../media-file.js></script>
+        <script src=../video-test.js></script>
         <script>
             function canplaythrough()
             {
@@ -27,7 +27,7 @@
             function start()
             {
                 findMediaElement();
-                run('mediaElement.src = findMediaFile("video", "content/test")');
+                run('mediaElement.src = findMediaFile("video", "../content/test")');
                 waitForEventOnce('canplaythrough', canplaythrough);
                 consoleWrite("");
             }

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1052,7 +1052,8 @@ webkit.org/b/218317 media/media-source/media-source-trackid-change.html [ Failur
 webkit.org/b/238201 media/media-source/media-mp4-hevc-bframes.html [ Failure ]
 
 # GStreamer doesn't set the track's id to the container's value.
-webkit.org/b/265919 media/media-audio-track.html [ Failure ]
+webkit.org/b/265919 media/track/media-audio-track.html [ Failure ]
+webkit.org/b/265919 media/track/media-source-audio-track.html [ Failure ]
 
 # WebProcess's MemoryPressureHandler are disabled, test is nonfunctional
 media/media-source/media-managedmse-memorypressure.html [ Timeout ]

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1019,7 +1019,7 @@ media/W3C/video/canPlayType/canPlayType_supported_but_no_codecs_parameter_1.html
 media/W3C/video/canPlayType/canPlayType_two_implies_one_1.html [ Failure ]
 media/W3C/video/canPlayType/canPlayType_two_implies_one_2.html [ Failure ]
 media/media-can-play-webm.html [ Failure ]
-media/media-audio-track.html [ Failure ]
+media/track/media-audio-track.html [ Failure ]
 
 # VP9/VP8 are not supported on WK1 and turned off by default
 media/media-source/media-source-webm-configuration-change.html [ Failure ]

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
@@ -33,7 +33,6 @@
 #include <wtf/Box.h>
 #include <wtf/CancellableTask.h>
 #include <wtf/Deque.h>
-#include <wtf/HashMap.h>
 #include <wtf/LoggerHelper.h>
 #include <wtf/MediaTime.h>
 #include <wtf/OSObjectPtr.h>
@@ -195,8 +194,8 @@ ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
 ALLOW_NEW_API_WITHOUT_GUARDS_END
 
     RefPtr<MediaPlayerPrivateMediaSourceAVFObjC> player() const;
-    bool canEnqueueSample(uint64_t trackID, const MediaSampleAVFObjC&);
-    bool trackIsBlocked(uint64_t track) const;
+    bool canEnqueueSample(TrackID, const MediaSampleAVFObjC&);
+    bool trackIsBlocked(TrackID) const;
 
 #if ENABLE(ENCRYPTED_MEDIA) && HAVE(AVCONTENTKEYSESSION)
     void keyStatusesChanged();
@@ -204,17 +203,17 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 
     void setTrackChangeCallbacks(const InitializationSegment&, bool initialized);
 
-    HashMap<TrackID, RefPtr<VideoTrackPrivate>, DefaultHash<TrackID>, WTF::UnsignedWithZeroKeyHashTraits<TrackID>> m_videoTracks;
-    HashMap<TrackID, RefPtr<AudioTrackPrivate>, DefaultHash<TrackID>, WTF::UnsignedWithZeroKeyHashTraits<TrackID>> m_audioTracks;
+    StdUnorderedMap<TrackID, RefPtr<VideoTrackPrivate>> m_videoTracks;
+    StdUnorderedMap<TrackID, RefPtr<AudioTrackPrivate>> m_audioTracks;
     Vector<SourceBufferPrivateAVFObjCErrorClient*> m_errorClients;
 
     const Ref<SourceBufferParser> m_parser;
     Vector<Function<void()>> m_pendingTrackChangeTasks;
-    Deque<std::pair<uint64_t, Ref<MediaSampleAVFObjC>>> m_blockedSamples;
+    Deque<std::pair<TrackID, Ref<MediaSampleAVFObjC>>> m_blockedSamples;
 
     RetainPtr<AVSampleBufferDisplayLayer> m_displayLayer;
 ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
-    HashMap<uint64_t, RetainPtr<AVSampleBufferAudioRenderer>, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>> m_audioRenderers;
+    StdUnorderedMap<TrackID, RetainPtr<AVSampleBufferAudioRenderer>> m_audioRenderers;
 ALLOW_NEW_API_WITHOUT_GUARDS_END
     RetainPtr<WebAVSampleBufferListener> m_listener;
 #if PLATFORM(IOS_FAMILY)
@@ -236,11 +235,11 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
         RefPtr<SharedBuffer> initData;
         KeyIDs keyIDs;
     };
-    using TrackInitDataMap = HashMap<uint64_t, TrackInitData>;
+    using TrackInitDataMap = StdUnorderedMap<TrackID, TrackInitData>;
     TrackInitDataMap m_pendingProtectedTrackInitDataMap;
     TrackInitDataMap m_protectedTrackInitDataMap;
 
-    using TrackKeyIDsMap = HashMap<uint64_t, KeyIDs>;
+    using TrackKeyIDsMap = StdUnorderedMap<TrackID, KeyIDs>;
     TrackKeyIDsMap m_currentTrackIDs;
 
     RefPtr<CDMInstanceFairPlayStreamingAVFObjC> m_cdmInstance;


### PR DESCRIPTION
#### 65d8c44cce8612965ea93adb40dc64bf1c965cf4
<pre>
[MSE] add track id test for MSE
<a href="https://bugs.webkit.org/show_bug.cgi?id=265935">https://bugs.webkit.org/show_bug.cgi?id=265935</a>
<a href="https://rdar.apple.com/119244009">rdar://119244009</a>

Reviewed by Youenn Fablet.

Test exposed bug missed by bug 265718, where HashMap&lt;uint64_t&gt; where left in the code,
which caused an assertion due to the use of forbidden value. Replace them with StdUnorderedMap.

Fly-by: move track tests from media to media/track

* LayoutTests/media/track/media-audio-track-expected.txt: Copied from LayoutTests/media/media-audio-track-expected.txt.
* LayoutTests/media/track/media-audio-track.html: Renamed from LayoutTests/media/media-audio-track.html.
* LayoutTests/media/track/media-source-audio-track-expected.txt: Renamed from LayoutTests/media/media-audio-track-expected.txt.
* LayoutTests/media/track/media-source-audio-track.html: Added.
* LayoutTests/media/track/media-video-audio-track-expected.txt: Renamed from LayoutTests/media/media-video-audio-track-expected.txt.
* LayoutTests/media/track/media-video-audio-track.html: Renamed from LayoutTests/media/media-video-audio-track.html.
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(WebCore::SourceBufferPrivateAVFObjC::precheckInitialisationSegment):
(WebCore::SourceBufferPrivateAVFObjC::didProvideMediaDataForTrackId):
(WebCore::SourceBufferPrivateAVFObjC::processFormatDescriptionForTrackId):
(WebCore::SourceBufferPrivateAVFObjC::didProvideContentKeyRequestInitializationDataForTrackID):
(WebCore::SourceBufferPrivateAVFObjC::appendInternal):
(WebCore::SourceBufferPrivateAVFObjC::destroyRenderers):
(WebCore::SourceBufferPrivateAVFObjC::clearTracks):
(WebCore::SourceBufferPrivateAVFObjC::trackDidChangeEnabled):
(WebCore::SourceBufferPrivateAVFObjC::setCDMInstance):
(WebCore::SourceBufferPrivateAVFObjC::flush):
(WebCore::SourceBufferPrivateAVFObjC::rendererWasAutomaticallyFlushed):
(WebCore::SourceBufferPrivateAVFObjC::trackIsBlocked const):
(WebCore::SourceBufferPrivateAVFObjC::canEnqueueSample):
(WebCore::SourceBufferPrivateAVFObjC::enqueueSample):
(WebCore::SourceBufferPrivateAVFObjC::isReadyForMoreSamples):
(WebCore::SourceBufferPrivateAVFObjC::didBecomeReadyForMoreSamples):
(WebCore::SourceBufferPrivateAVFObjC::notifyClientWhenReadyForMoreSamples):

Canonical link: <a href="https://commits.webkit.org/271655@main">https://commits.webkit.org/271655@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/06838efc72565ac3ce6ec284cad51f99bc14fee2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29104 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7772 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30441 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31703 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26491 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29700 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9953 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5078 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26501 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29376 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/6462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24942 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5568 "Found 1 new API test failure: /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/service-worker-registrations (failure)") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/5723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25971 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33042 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26616 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26408 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31938 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5677 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3845 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29722 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7342 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/25767 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6955 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6181 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6198 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->