### PR TITLE
Prepare <input type=checkbox switch> for multiple animation types

### DIFF
--- a/Source/WebCore/html/CheckboxInputType.h
+++ b/Source/WebCore/html/CheckboxInputType.h
@@ -36,6 +36,8 @@ namespace WebCore {
 
 enum class WasSetByJavaScript : bool;
 
+enum class SwitchAnimationType { VisuallyOn };
+
 class CheckboxInputType final : public BaseCheckableInputType {
 public:
     static Ref<CheckboxInputType> create(HTMLInputElement& element)
@@ -44,7 +46,7 @@ public:
     }
 
     bool valueMissing(const String&) const final;
-    float switchCheckedChangeAnimationProgress() const;
+    float switchAnimationVisuallyOnProgress() const;
     bool isSwitchVisuallyOn() const;
 
 private:
@@ -59,7 +61,7 @@ private:
     void handleKeyupEvent(KeyboardEvent&) final;
     void handleMouseDownEvent(MouseEvent&) final;
     void handleMouseMoveEvent(MouseEvent&) final;
-    void startSwitchPointerTracking(int);
+    void startSwitchPointerTracking(LayoutPoint);
     void stopSwitchPointerTracking();
     bool isSwitchPointerTracking() const;
     void willDispatchClick(InputElementClickState&) final;
@@ -67,17 +69,22 @@ private:
     bool matchesIndeterminatePseudoClass() const final;
     void willUpdateCheckedness(bool /* nowChecked */, WasSetByJavaScript);
     void disabledStateChanged() final;
-    void performSwitchCheckedChangeAnimation();
-    void stopSwitchCheckedChangeAnimation();
-    void switchCheckedChangeAnimationTimerFired();
+    Seconds switchAnimationStartTime(SwitchAnimationType) const;
+    void setSwitchAnimationStartTime(SwitchAnimationType, Seconds);
+    bool isSwitchAnimating(SwitchAnimationType) const;
+    void performSwitchAnimation(SwitchAnimationType);
+    void stopSwitchAnimation(SwitchAnimationType);
+    float switchAnimationProgress(SwitchAnimationType) const;
+    void updateIsSwitchVisuallyOnFromAbsoluteLocation(LayoutPoint);
+    void switchAnimationTimerFired();
 
     // FIXME: Consider moving all switch-related state (and methods?) to their own object so
     // CheckboxInputType can stay somewhat small.
     std::optional<int> m_switchPointerTrackingXPositionStart { std::nullopt };
     bool m_hasSwitchVisuallyOnChanged { false };
     bool m_isSwitchVisuallyOn { false };
-    Seconds m_switchCheckedChangeAnimationStartTime { 0_s };
-    std::unique_ptr<Timer> m_switchCheckedChangeAnimationTimer;
+    Seconds m_switchAnimationVisuallyOnStartTime { 0_s };
+    std::unique_ptr<Timer> m_switchAnimationTimer;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -2304,10 +2304,10 @@ bool HTMLInputElement::dirAutoUsesValue() const
     return m_inputType->dirAutoUsesValue();
 }
 
-float HTMLInputElement::switchCheckedChangeAnimationProgress() const
+float HTMLInputElement::switchAnimationVisuallyOnProgress() const
 {
     ASSERT(isSwitch());
-    return checkedDowncast<CheckboxInputType>(*m_inputType).switchCheckedChangeAnimationProgress();
+    return checkedDowncast<CheckboxInputType>(*m_inputType).switchAnimationVisuallyOnProgress();
 }
 
 bool HTMLInputElement::isSwitchVisuallyOn() const

--- a/Source/WebCore/html/HTMLInputElement.h
+++ b/Source/WebCore/html/HTMLInputElement.h
@@ -340,7 +340,7 @@ public:
 
     bool hasEverBeenPasswordField() const { return m_hasEverBeenPasswordField; }
 
-    float switchCheckedChangeAnimationProgress() const;
+    float switchAnimationVisuallyOnProgress() const;
     bool isSwitchVisuallyOn() const;
 
 protected:

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -601,7 +601,7 @@ static void updateSwitchThumbPartForRenderer(SwitchThumbPart& switchThumbPart, c
     ASSERT(input.isSwitch());
 
     switchThumbPart.setIsOn(input.isSwitchVisuallyOn());
-    switchThumbPart.setProgress(input.switchCheckedChangeAnimationProgress());
+    switchThumbPart.setProgress(input.switchAnimationVisuallyOnProgress());
 }
 
 static void updateSwitchTrackPartForRenderer(SwitchTrackPart& switchTrackPart, const RenderObject& renderer)
@@ -610,7 +610,7 @@ static void updateSwitchTrackPartForRenderer(SwitchTrackPart& switchTrackPart, c
     ASSERT(input.isSwitch());
 
     switchTrackPart.setIsOn(input.isSwitchVisuallyOn());
-    switchTrackPart.setProgress(input.switchCheckedChangeAnimationProgress());
+    switchTrackPart.setProgress(input.switchAnimationVisuallyOnProgress());
 }
 
 RefPtr<ControlPart> RenderTheme::createControlPart(const RenderObject& renderer) const

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -263,7 +263,7 @@ public:
 #if USE(SYSTEM_PREVIEW)
     virtual void paintSystemPreviewBadge(Image&, const PaintInfo&, const FloatRect&);
 #endif
-    virtual Seconds switchCheckedChangeAnimationDuration() const { return 0_s; }
+    virtual Seconds switchAnimationVisuallyOnDuration() const { return 0_s; }
     float switchPointerTrackingMagnitudeProportion() const { return 0.4f; }
 
 protected:

--- a/Source/WebCore/rendering/RenderThemeMac.h
+++ b/Source/WebCore/rendering/RenderThemeMac.h
@@ -91,7 +91,7 @@ public:
 
     WEBCORE_EXPORT static RetainPtr<NSImage> iconForAttachment(const String& fileName, const String& attachmentType, const String& title);
 
-    Seconds switchCheckedChangeAnimationDuration() const final { return 300_ms; }
+    Seconds switchAnimationVisuallyOnDuration() const final { return 300_ms; }
 
 private:
     RenderThemeMac();


### PR DESCRIPTION
#### 942d831672a619657a92dd1fdce617603d6543b3
<pre>
Prepare &lt;input type=checkbox switch&gt; for multiple animation types
<a href="https://bugs.webkit.org/show_bug.cgi?id=265937">https://bugs.webkit.org/show_bug.cgi?id=265937</a>

Reviewed by Aditya Keerthi.

On iOS the switch control will perform two separate types of
animations. Make it so that the infrastructure supports that in
principle.

Also prepare for supporting non-mouse events.

* Source/WebCore/html/CheckboxInputType.cpp:
(WebCore::CheckboxInputType::handleMouseDownEvent):
(WebCore::CheckboxInputType::handleMouseMoveEvent):
(WebCore::CheckboxInputType::willDispatchClick):
(WebCore::CheckboxInputType::startSwitchPointerTracking):
(WebCore::CheckboxInputType::disabledStateChanged):
(WebCore::CheckboxInputType::willUpdateCheckedness):
(WebCore::switchAnimationUpdateInterval):
(WebCore::switchAnimationDuration):
(WebCore::CheckboxInputType::switchAnimationStartTime const):
(WebCore::CheckboxInputType::setSwitchAnimationStartTime):
(WebCore::CheckboxInputType::isSwitchAnimating const):
(WebCore::CheckboxInputType::performSwitchAnimation):
(WebCore::CheckboxInputType::stopSwitchAnimation):
(WebCore::CheckboxInputType::switchAnimationProgress const):
(WebCore::CheckboxInputType::switchAnimationVisuallyOnProgress const):
(WebCore::CheckboxInputType::updateIsSwitchVisuallyOnFromAbsoluteLocation):
(WebCore::CheckboxInputType::switchAnimationTimerFired):
(WebCore::switchCheckedChangeAnimationUpdateInterval): Deleted.
(WebCore::CheckboxInputType::performSwitchCheckedChangeAnimation): Deleted.
(WebCore::CheckboxInputType::stopSwitchCheckedChangeAnimation): Deleted.
(WebCore::CheckboxInputType::switchCheckedChangeAnimationProgress const): Deleted.
(WebCore::CheckboxInputType::switchCheckedChangeAnimationTimerFired): Deleted.
* Source/WebCore/html/CheckboxInputType.h:
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::switchAnimationVisuallyOnProgress const):
(WebCore::HTMLInputElement::switchCheckedChangeAnimationProgress const): Deleted.
* Source/WebCore/html/HTMLInputElement.h:
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::updateSwitchThumbPartForRenderer):
(WebCore::updateSwitchTrackPartForRenderer):
* Source/WebCore/rendering/RenderTheme.h:
(WebCore::RenderTheme::switchAnimationVisuallyOnDuration const):
(WebCore::RenderTheme::switchCheckedChangeAnimationDuration const): Deleted.
* Source/WebCore/rendering/RenderThemeMac.h:

Canonical link: <a href="https://commits.webkit.org/271607@main">https://commits.webkit.org/271607@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b8f3234fba67c85d162b2aa18affb2ac7360f07

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28986 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7656 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30342 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31600 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26411 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29578 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9783 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4974 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26432 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29258 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6314 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24873 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5495 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/5620 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25898 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/32938 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26493 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26333 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31871 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5597 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3774 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29652 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/replaced-objects (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7253 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6922 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6094 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6118 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->