### PR TITLE
Serialize canvas font families as needed

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.font.parse.family-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.font.parse.family-expected.txt
@@ -1,5 +1,5 @@
 2d.text.font.parse.family
 Actual output:
 
-FAIL Canvas test: 2d.text.font.parse.family assert_equals: ctx.font === '20px cursive, fantasy, monospace, sans-serif, serif, UnquotedFont, "QuotedFont\\\\\\","' (got 20px cursive, fantasy, monospace, sans-serif, serif, UnquotedFont, QuotedFont\",[string], expected 20px cursive, fantasy, monospace, sans-serif, serif, UnquotedFont, "QuotedFont\\\","[string]) expected "20px cursive, fantasy, monospace, sans-serif, serif, UnquotedFont, \"QuotedFont\\\\\\\",\"" but got "20px cursive, fantasy, monospace, sans-serif, serif, UnquotedFont, QuotedFont\\\","
+PASS Canvas test: 2d.text.font.parse.family
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.font.parse.family-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.font.parse.family-expected.txt
@@ -1,5 +1,5 @@
 2d.text.font.parse.family
 
 
-FAIL OffscreenCanvas test: 2d.text.font.parse.family assert_equals: ctx.font === '20px cursive, fantasy, monospace, sans-serif, serif, UnquotedFont, "QuotedFont\\\\\\","' (got 20px cursive, fantasy, monospace, sans-serif, serif, UnquotedFont, QuotedFont\",[string], expected 20px cursive, fantasy, monospace, sans-serif, serif, UnquotedFont, "QuotedFont\\\","[string]) expected "20px cursive, fantasy, monospace, sans-serif, serif, UnquotedFont, \"QuotedFont\\\\\\\",\"" but got "20px cursive, fantasy, monospace, sans-serif, serif, UnquotedFont, QuotedFont\\\","
+PASS OffscreenCanvas test: 2d.text.font.parse.family
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.font.parse.family.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.font.parse.family.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL 2d assert_equals: ctx.font === '20px cursive, fantasy, monospace, sans-serif, serif, UnquotedFont, "QuotedFont\\\\\\","' (got 20px cursive, fantasy, monospace, sans-serif, serif, UnquotedFont, QuotedFont\",[string], expected 20px cursive, fantasy, monospace, sans-serif, serif, UnquotedFont, "QuotedFont\\\","[string]) expected "20px cursive, fantasy, monospace, sans-serif, serif, UnquotedFont, \"QuotedFont\\\\\\\",\"" but got "20px cursive, fantasy, monospace, sans-serif, serif, UnquotedFont, QuotedFont\\\","
+PASS 2d
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -35,6 +35,7 @@
 
 #include "BitmapImage.h"
 #include "CSSFontSelector.h"
+#include "CSSMarkup.h"
 #include "CSSParser.h"
 #include "CSSPropertyNames.h"
 #include "CSSStyleImageValue.h"
@@ -318,8 +319,7 @@ String CanvasRenderingContext2DBase::State::fontString() const
             family = family.substring(8);
 
         auto separator = i ? ", " : " ";
-        auto quote = family.contains(' ') ? "\"" : "";
-        serializedFont.append(separator, quote, family, quote);
+        serializedFont.append(separator, serializeFontFamily(family.toString()));
     }
 
     return serializedFont.toString();


### PR DESCRIPTION
#### b94074dc23734836e49b503082cb3ab662e732a5
<pre>
Serialize canvas font families as needed
<a href="https://bugs.webkit.org/show_bug.cgi?id=265993">https://bugs.webkit.org/show_bug.cgi?id=265993</a>
<a href="https://rdar.apple.com/problem/119312574">rdar://problem/119312574</a>

Reviewed by Dean Jackson.

In a canvas rendering context, the `font` attribute contains a list of font families,
which should only contain valid CSS custom-ident&apos;s and strings (in quotes, with escaped
characters as appropriate).

The original code used to only serialize family names with spaces in them, which could
have missed some cases, such as the one in the WPT test
2d.text.drawing.style.absolute.spacing.html: `QuotedFont\&quot;,` and others.

This patch uses the CSS markup function serializeFontFamily to serialize the canvas
rendering context&apos;s `font` family names when needed.

* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.font.parse.family-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.font.parse.family-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.font.parse.family.worker-expected.txt:
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::State::fontString const):

Canonical link: <a href="https://commits.webkit.org/271804@main">https://commits.webkit.org/271804@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5253c3ce960dfe71b2b1f6ad1d372d422156252d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29278 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7948 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30616 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31856 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26614 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29876 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10138 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5250 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26611 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29551 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6646 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25069 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5683 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5858 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26114 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33197 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26773 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26545 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32050 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5795 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3973 "Found 1 new test failure: fullscreen/full-screen-layer-dump.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29834 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7481 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7048 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6309 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6320 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->