### PR TITLE
[WebGPU] validation/query_set expectations are missing yet the tests pass locally

### DIFF
--- a/LayoutTests/http/tests/webgpu/webgpu/api/validation/query_set/create-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/validation/query_set/create-expected.txt
@@ -1,1 +1,4 @@
-(Populate me when we're ready to investigate this test)
+
+PASS :count:type="occlusion"
+PASS :count:type="timestamp"
+

--- a/LayoutTests/http/tests/webgpu/webgpu/api/validation/query_set/destroy-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/validation/query_set/destroy-expected.txt
@@ -1,3 +1,4 @@
 
 PASS :twice:
+PASS :invalid_queryset:
 


### PR DESCRIPTION
#### c93da6bc817cae6f0fa9c84a13addd83e0ee2f26
<pre>
[WebGPU] validation/query_set expectations are missing yet the tests pass locally
<a href="https://bugs.webkit.org/show_bug.cgi?id=265945">https://bugs.webkit.org/show_bug.cgi?id=265945</a>
&lt;radar://119261886&gt;

Reviewed by Dan Glastonbury.

These tests pass locally, so add their expectations.

* LayoutTests/http/tests/webgpu/webgpu/api/validation/query_set/create-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/api/validation/query_set/destroy-expected.txt:

Canonical link: <a href="https://commits.webkit.org/271654@main">https://commits.webkit.org/271654@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4941d66ef9470aabf9244c224149377547f5d21b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29043 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7717 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30395 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31656 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26452 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9845 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5030 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26469 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29315 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6369 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24910 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5533 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5655 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25937 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/32993 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26533 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26373 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31909 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5638 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3814 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29690 "Found 2 new API test failures: /WebKitGTK/TestWebKitUserContentFilterStore:/webkit/WebKitUserContentFilterStore/filter-persistence, /WebKitGTK/TestWebKitUserContentFilterStore:/webkit/WebKitUserContentFilterStore/filter-save-load (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7296 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6953 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6137 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6159 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->