### PR TITLE
Add <input type=checkbox switch> iOS infrastructure

### DIFF
--- a/Source/WebCore/PAL/pal/ios/UIKitSoftLink.h
+++ b/Source/WebCore/PAL/pal/ios/UIKitSoftLink.h
@@ -75,6 +75,8 @@ SOFT_LINK_FUNCTION_FOR_HEADER(PAL, UIKit, UIAccessibilityIsReduceMotionEnabled, 
 #define UIAccessibilityIsReduceMotionEnabled PAL::softLink_UIKit_UIAccessibilityIsReduceMotionEnabled
 SOFT_LINK_FUNCTION_FOR_HEADER(PAL, UIKit, UIAccessibilityDarkerSystemColorsEnabled, BOOL, (void), ())
 #define UIAccessibilityDarkerSystemColorsEnabled PAL::softLink_UIKit_UIAccessibilityDarkerSystemColorsEnabled
+SOFT_LINK_FUNCTION_FOR_HEADER(PAL, UIKit, UIAccessibilityIsOnOffSwitchLabelsEnabled, BOOL, (void), ())
+#define UIAccessibilityIsOnOffSwitchLabelsEnabled PAL::softLink_UIKit_UIAccessibilityIsOnOffSwitchLabelsEnabled
 SOFT_LINK_FUNCTION_FOR_HEADER(PAL, UIKit, UIAccessibilityPostNotification, void, (UIAccessibilityNotifications n, id argument), (n, argument))
 #define UIAccessibilityPostNotification PAL::softLink_UIKit_UIAccessibilityPostNotification
 SOFT_LINK_FUNCTION_FOR_HEADER(PAL, UIKit, UIGraphicsGetCurrentContext, CGContextRef, (void), ())

--- a/Source/WebCore/PAL/pal/ios/UIKitSoftLink.mm
+++ b/Source/WebCore/PAL/pal/ios/UIKitSoftLink.mm
@@ -70,6 +70,7 @@ SOFT_LINK_FUNCTION_FOR_SOURCE(PAL, UIKit, UIAccessibilityIsGrayscaleEnabled, BOO
 SOFT_LINK_FUNCTION_FOR_SOURCE(PAL, UIKit, UIAccessibilityIsInvertColorsEnabled, BOOL, (void), ())
 SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, UIKit, UIAccessibilityIsReduceMotionEnabled, BOOL, (void), (), PAL_EXPORT)
 SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, UIKit, UIAccessibilityDarkerSystemColorsEnabled, BOOL, (void), (), PAL_EXPORT)
+SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, UIKit, UIAccessibilityIsOnOffSwitchLabelsEnabled, BOOL, (void), (), PAL_EXPORT)
 SOFT_LINK_FUNCTION_FOR_SOURCE(PAL, UIKit, UIAccessibilityPostNotification, void, (UIAccessibilityNotifications n, id argument), (n, argument))
 SOFT_LINK_FUNCTION_FOR_SOURCE(PAL, UIKit, UIGraphicsGetCurrentContext, CGContextRef, (void), ())
 SOFT_LINK_FUNCTION_FOR_SOURCE(PAL, UIKit, UIGraphicsPopContext, void, (void), ())

--- a/Source/WebCore/css/htmlSwitchControl.css
+++ b/Source/WebCore/css/htmlSwitchControl.css
@@ -33,3 +33,26 @@ input[type="checkbox"][switch]::thumb, input[type="checkbox"][switch]::track {
     appearance: inherit !important;
     grid-area: 1/1;
 }
+
+#if defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY
+input[type="checkbox"][switch] {
+    border-radius: initial;
+    width: initial;
+    height: initial;
+    padding: initial;
+    background-color: initial;
+}
+
+input[type="checkbox"][switch]:checked {
+    border-color: initial;
+}
+
+input[type="checkbox"][switch]:disabled {
+    opacity: initial;
+}
+
+input[type="checkbox"][switch]:checked:disabled {
+    opacity: initial;
+    background: initial;
+}
+#endif // defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY

--- a/Source/WebCore/html/CheckboxInputType.h
+++ b/Source/WebCore/html/CheckboxInputType.h
@@ -36,7 +36,7 @@ namespace WebCore {
 
 enum class WasSetByJavaScript : bool;
 
-enum class SwitchAnimationType { VisuallyOn };
+enum class SwitchAnimationType : bool { VisuallyOn, Pressed };
 
 class CheckboxInputType final : public BaseCheckableInputType {
 public:
@@ -48,6 +48,7 @@ public:
     bool valueMissing(const String&) const final;
     float switchAnimationVisuallyOnProgress() const;
     bool isSwitchVisuallyOn() const;
+    float switchAnimationPressedProgress() const;
 
 private:
     explicit CheckboxInputType(HTMLInputElement& element)
@@ -61,7 +62,12 @@ private:
     void handleKeyupEvent(KeyboardEvent&) final;
     void handleMouseDownEvent(MouseEvent&) final;
     void handleMouseMoveEvent(MouseEvent&) final;
-    void startSwitchPointerTracking(LayoutPoint);
+// FIXME: It should not be iOS-specific, but it's not been tested with a non-iOS touch
+// implementation thus far.
+#if ENABLE(IOS_TOUCH_EVENTS)
+    void handleTouchEvent(TouchEvent&) final;
+#endif
+    void startSwitchPointerTracking(LayoutPoint, std::optional<unsigned> = std::nullopt);
     void stopSwitchPointerTracking();
     bool isSwitchPointerTracking() const;
     void willDispatchClick(InputElementClickState&) final;
@@ -84,7 +90,12 @@ private:
     bool m_hasSwitchVisuallyOnChanged { false };
     bool m_isSwitchVisuallyOn { false };
     Seconds m_switchAnimationVisuallyOnStartTime { 0_s };
+    Seconds m_switchAnimationPressedStartTime { 0_s };
     std::unique_ptr<Timer> m_switchAnimationTimer;
+    std::optional<unsigned> m_switchPointerTrackingTouchIdentifier { std::nullopt };
+#if ENABLE(IOS_TOUCH_EVENTS)
+    bool hasTouchEventHandler() const final { return true; }
+#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLInputElement.h
+++ b/Source/WebCore/html/HTMLInputElement.h
@@ -342,6 +342,7 @@ public:
 
     float switchAnimationVisuallyOnProgress() const;
     bool isSwitchVisuallyOn() const;
+    float switchAnimationPressedProgress() const;
 
 protected:
     HTMLInputElement(const QualifiedName&, Document&, HTMLFormElement*, bool createdByParser);
@@ -481,7 +482,7 @@ private:
     bool m_valueAttributeWasUpdatedAfterParsing : 1 { false };
     bool m_wasModifiedByUser : 1 { false };
     bool m_canReceiveDroppedFiles : 1 { false };
-#if ENABLE(TOUCH_EVENTS) && !ENABLE(IOS_TOUCH_EVENTS)
+#if ENABLE(TOUCH_EVENTS)
     bool m_hasTouchEventHandler : 1 { false };
 #endif
     bool m_isSpellcheckDisabledExceptTextReplacement : 1 { false };

--- a/Source/WebCore/html/InputType.h
+++ b/Source/WebCore/html/InputType.h
@@ -308,7 +308,7 @@ public:
 
     virtual void elementDidBlur() { }
 
-#if ENABLE(TOUCH_EVENTS) && !ENABLE(IOS_TOUCH_EVENTS)
+#if ENABLE(TOUCH_EVENTS)
     virtual bool hasTouchEventHandler() const { return false; }
 #endif
 

--- a/Source/WebCore/platform/Theme.h
+++ b/Source/WebCore/platform/Theme.h
@@ -83,6 +83,7 @@ public:
 
     virtual bool userPrefersContrast() const { return false; }
     virtual bool userPrefersReducedMotion() const { return false; }
+    virtual bool userPrefersOnOffLabels() const { return false; }
 
 protected:
     Theme() = default;

--- a/Source/WebCore/platform/ios/ThemeIOS.h
+++ b/Source/WebCore/platform/ios/ThemeIOS.h
@@ -35,6 +35,7 @@ class ThemeIOS final : public ThemeCocoa {
 private:
     bool userPrefersContrast() const final;
     bool userPrefersReducedMotion() const final;
+    bool userPrefersOnOffLabels() const final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/ios/ThemeIOS.mm
+++ b/Source/WebCore/platform/ios/ThemeIOS.mm
@@ -49,6 +49,11 @@ bool ThemeIOS::userPrefersReducedMotion() const
     return PAL::softLink_UIKit_UIAccessibilityIsReduceMotionEnabled();
 }
 
+bool ThemeIOS::userPrefersOnOffLabels() const
+{
+    return PAL::softLink_UIKit_UIAccessibilityIsOnOffSwitchLabelsEnabled();
+}
+
 }
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -363,6 +363,8 @@ void RenderTheme::adjustStyle(RenderStyle& style, const Element* element, const 
         return adjustSearchFieldResultsDecorationPartStyle(style, element);
     case StyleAppearance::SearchFieldResultsButton:
         return adjustSearchFieldResultsButtonStyle(style, element);
+    case StyleAppearance::Switch:
+        return adjustSwitchStyle(style, element);
     case StyleAppearance::ProgressBar:
         return adjustProgressBarStyle(style, element);
     case StyleAppearance::Meter:
@@ -943,6 +945,12 @@ bool RenderTheme::paint(const RenderBox& box, ControlStates& controlStates, cons
         return paintSearchFieldResultsDecorationPart(box, paintInfo, integralSnappedRect);
     case StyleAppearance::SearchFieldResultsButton:
         return paintSearchFieldResultsButton(box, paintInfo, integralSnappedRect);
+    case StyleAppearance::Switch:
+        return true;
+    case StyleAppearance::SwitchThumb:
+        return paintSwitchThumb(box, paintInfo, devicePixelSnappedRect);
+    case StyleAppearance::SwitchTrack:
+        return paintSwitchTrack(box, paintInfo, devicePixelSnappedRect);
 #if ENABLE(SERVICE_CONTROLS)
     case StyleAppearance::ImageControlsButton:
         return paintImageControlsButton(box, paintInfo, integralSnappedRect);

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -264,6 +264,7 @@ public:
     virtual void paintSystemPreviewBadge(Image&, const PaintInfo&, const FloatRect&);
 #endif
     virtual Seconds switchAnimationVisuallyOnDuration() const { return 0_s; }
+    virtual Seconds switchAnimationPressedDuration() const { return 0_s; }
     float switchPointerTrackingMagnitudeProportion() const { return 0.4f; }
 
 protected:
@@ -382,6 +383,10 @@ protected:
 
     virtual void adjustSearchFieldResultsButtonStyle(RenderStyle&, const Element*) const { }
     virtual bool paintSearchFieldResultsButton(const RenderBox&, const PaintInfo&, const IntRect&) { return true; }
+
+    virtual void adjustSwitchStyle(RenderStyle&, const Element*) const { }
+    virtual bool paintSwitchThumb(const RenderObject&, const PaintInfo&, const FloatRect&) { return true; }
+    virtual bool paintSwitchTrack(const RenderObject&, const PaintInfo&, const FloatRect&) { return true; }
 
 public:
     void updateControlStatesForRenderer(const RenderBox&, ControlStates&) const;

--- a/Source/WebCore/rendering/RenderThemeIOS.h
+++ b/Source/WebCore/rendering/RenderThemeIOS.h
@@ -99,6 +99,12 @@ private:
 
     void adjustSliderThumbSize(RenderStyle&, const Element*) const override;
 
+    void adjustSwitchStyle(RenderStyle&, const Element*) const override;
+    bool paintSwitchThumb(const RenderObject&, const PaintInfo&, const FloatRect&) override;
+    bool paintSwitchTrack(const RenderObject&, const PaintInfo&, const FloatRect&) override;
+    Seconds switchAnimationVisuallyOnDuration() const final { return 300_ms; }
+    Seconds switchAnimationPressedDuration() const final { return 300_ms; }
+
     bool paintProgressBar(const RenderObject&, const PaintInfo&, const IntRect&) override;
 
 #if ENABLE(DATALIST_ELEMENT)

--- a/Source/WebCore/rendering/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/RenderThemeIOS.mm
@@ -97,6 +97,10 @@
 #include "HTMLOptionElement.h"
 #endif
 
+#if USE(APPLE_INTERNAL_SDK)
+#include <WebKitAdditions/RenderThemeIOSAdditions.mm>
+#endif
+
 #import <pal/ios/UIKitSoftLink.h>
 
 namespace WebCore {
@@ -701,6 +705,46 @@ void RenderThemeIOS::adjustSliderThumbSize(RenderStyle& style, const Element*) c
 
 constexpr auto reducedMotionProgressAnimationMinOpacity = 0.3f;
 constexpr auto reducedMotionProgressAnimationMaxOpacity = 0.6f;
+
+#if !USE(APPLE_INTERNAL_SDK)
+constexpr auto switchHeight = 31.f;
+constexpr auto switchWidth = 51.f;
+
+static bool renderThemePaintSwitchThumb(OptionSet<ControlStates::States>, const RenderObject&, const PaintInfo&, const FloatRect&)
+{
+    return true;
+}
+
+static bool renderThemePaintSwitchTrack(OptionSet<ControlStates::States>, const RenderObject&, const PaintInfo&, const FloatRect&, const Color)
+{
+    return true;
+}
+#endif
+
+void RenderThemeIOS::adjustSwitchStyle(RenderStyle& style, const Element* element) const
+{
+    RenderTheme::adjustSwitchStyle(style, element);
+
+    if (!style.width().isAuto() && !style.height().isAuto())
+        return;
+
+    auto size = std::max(style.computedFontSize(), switchHeight);
+    style.setWidth({ size * (switchWidth / switchHeight), LengthType::Fixed });
+    style.setHeight({ size, LengthType::Fixed });
+
+    if (element->isDisabledFormControl())
+        style.setOpacity(.4f);
+}
+
+bool RenderThemeIOS::paintSwitchThumb(const RenderObject& renderer, const PaintInfo& paintInfo, const FloatRect& rect)
+{
+    return renderThemePaintSwitchThumb(extractControlStatesForRenderer(renderer), renderer, paintInfo, rect);
+}
+
+bool RenderThemeIOS::paintSwitchTrack(const RenderObject& renderer, const PaintInfo& paintInfo, const FloatRect& rect)
+{
+    return renderThemePaintSwitchTrack(extractControlStatesForRenderer(renderer), renderer, paintInfo, rect, systemColor(CSSValueAppleSystemGreen, renderer.styleColorOptions()));
+}
 
 bool RenderThemeIOS::paintProgressBar(const RenderObject& renderer, const PaintInfo& paintInfo, const IntRect& rect)
 {


### PR DESCRIPTION
#### 26a483b2248d43fe8f7b77ce47c847f698d97da7
<pre>
Add &lt;input type=checkbox switch&gt; iOS infrastructure
<a href="https://bugs.webkit.org/show_bug.cgi?id=265947">https://bugs.webkit.org/show_bug.cgi?id=265947</a>

Reviewed by Aditya Keerthi.

This makes the following changes:

- Resets default styling of &lt;input type=checkbox switch&gt; on iOS.
- Adds support for reading the on/off labels preference.
- Adds support for touch-based pointer tracking to CheckboxInputType as
  well as a Pressed animation that can run simultaneously with the
  VisuallyOn animation.
- Make the non-IOS_TOUCH_EVENTS code in HTMLInputElement compatible
  with IOS_TOUCH_EVENTS so events get delivered to CheckboxInputType.
- Adds the relevant hooks to RenderTheme to enable painting on iOS.

* Source/WebCore/PAL/pal/ios/UIKitSoftLink.h:
* Source/WebCore/PAL/pal/ios/UIKitSoftLink.mm:
* Source/WebCore/css/htmlSwitchControl.css:
(#if defined(WTF_PLATFORM_IOS_FAMILY) &amp;&amp; WTF_PLATFORM_IOS_FAMILY):
(input[type=&quot;checkbox&quot;][switch]:checked):
(input[type=&quot;checkbox&quot;][switch]:disabled):
(input[type=&quot;checkbox&quot;][switch]:checked:disabled):
* Source/WebCore/html/CheckboxInputType.cpp:
(WebCore::CheckboxInputType::handleMouseDownEvent):
(WebCore::findTouchWithIdentifier):
(WebCore::CheckboxInputType::handleTouchEvent):
(WebCore::CheckboxInputType::startSwitchPointerTracking):
(WebCore::CheckboxInputType::stopSwitchPointerTracking):
(WebCore::CheckboxInputType::disabledStateChanged):
(WebCore::CheckboxInputType::willUpdateCheckedness):
(WebCore::switchAnimationDuration):
(WebCore::CheckboxInputType::switchAnimationStartTime const):
(WebCore::CheckboxInputType::setSwitchAnimationStartTime):
(WebCore::CheckboxInputType::switchAnimationPressedProgress const):
(WebCore::CheckboxInputType::switchAnimationTimerFired):
* Source/WebCore/html/CheckboxInputType.h:
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::~HTMLInputElement):
(WebCore::HTMLInputElement::runPostTypeUpdateTasks):
(WebCore::HTMLInputElement::didMoveToNewDocument):
(WebCore::HTMLInputElement::switchAnimationPressedProgress const):
* Source/WebCore/html/HTMLInputElement.h:
* Source/WebCore/html/InputType.h:
* Source/WebCore/platform/Theme.h:
(WebCore::Theme::userPrefersOnOffLabels const):
* Source/WebCore/platform/ios/ThemeIOS.h:
* Source/WebCore/platform/ios/ThemeIOS.mm:
(WebCore::ThemeIOS::userPrefersOnOffLabels const):
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::adjustStyle):
(WebCore::RenderTheme::paint):
* Source/WebCore/rendering/RenderTheme.h:
(WebCore::RenderTheme::switchAnimationPressedDuration const):
(WebCore::RenderTheme::adjustSwitchStyle const):
(WebCore::RenderTheme::paintSwitchThumb):
(WebCore::RenderTheme::paintSwitchTrack):
* Source/WebCore/rendering/RenderThemeIOS.h:
* Source/WebCore/rendering/RenderThemeIOS.mm:
(WebCore::renderThemePaintSwitchThumb):
(WebCore::renderThemePaintSwitchTrack):
(WebCore::RenderThemeIOS::adjustSwitchStyle const):
(WebCore::RenderThemeIOS::paintSwitchThumb):
(WebCore::RenderThemeIOS::paintSwitchTrack):

Canonical link: <a href="https://commits.webkit.org/271682@main">https://commits.webkit.org/271682@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25a2947b2756f04fd3a34e20d4a08b57c7671812

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29227 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7898 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30567 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31815 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26583 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29825 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10038 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5202 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26588 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29500 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6560 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25044 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5657 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/5798 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26082 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33154 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26695 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26515 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/32022 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5763 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/3945 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29807 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7444 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6969 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6276 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6288 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->