### PR TITLE
[web-animations] the AnimationEffect::ticksContinouslyWhileActive() method has a typo in its name

### DIFF
--- a/Source/WebCore/animation/AnimationEffect.cpp
+++ b/Source/WebCore/animation/AnimationEffect.cpp
@@ -321,7 +321,7 @@ Seconds AnimationEffect::timeToNextTick(const BasicEffectTiming& timing) const
         // The effect is in its "before" phase, in this case we can wait until it enters its "active" phase.
         return delay() - *timing.localTime;
     case AnimationEffectPhase::Active: {
-        if (!ticksContinouslyWhileActive())
+        if (!ticksContinuouslyWhileActive())
             return endTime() - *timing.localTime;
         if (auto iterationProgress = getComputedTiming().simpleIterationProgress) {
             // In case we're in a range that uses a steps() timing function, we can compute the time until the next step starts.

--- a/Source/WebCore/animation/AnimationEffect.h
+++ b/Source/WebCore/animation/AnimationEffect.h
@@ -110,7 +110,7 @@ public:
 protected:
     explicit AnimationEffect();
 
-    virtual bool ticksContinouslyWhileActive() const { return false; }
+    virtual bool ticksContinuouslyWhileActive() const { return false; }
     virtual std::optional<double> progressUntilNextStep(double) const;
 
 private:

--- a/Source/WebCore/animation/CustomEffect.h
+++ b/Source/WebCore/animation/CustomEffect.h
@@ -44,7 +44,7 @@ private:
     // AnimationEffect
     bool isCustomEffect() const final { return true; }
     void animationDidTick() final;
-    bool ticksContinouslyWhileActive() const final { return true; }
+    bool ticksContinuouslyWhileActive() const final { return true; }
 
     Ref<CustomEffectCallback> m_callback;
 };

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -2285,7 +2285,7 @@ std::optional<double> KeyframeEffect::progressUntilNextStep(double iterationProg
     return std::nullopt;
 }
 
-bool KeyframeEffect::ticksContinouslyWhileActive() const
+bool KeyframeEffect::ticksContinuouslyWhileActive() const
 {
     auto doesNotAffectStyles = m_blendingKeyframes.isEmpty() || m_blendingKeyframes.properties().isEmpty();
     if (doesNotAffectStyles)
@@ -2311,7 +2311,7 @@ Seconds KeyframeEffect::timeToNextTick(const BasicEffectTiming& timing) const
     ASSERT(document());
     if (timing.phase == AnimationEffectPhase::Active && is<CSSAnimation>(animation())
         && document()->hasListenerType(Document::ListenerType::CSSAnimation)
-        && !ticksContinouslyWhileActive()) {
+        && !ticksContinuouslyWhileActive()) {
         if (auto iterationProgress = getComputedTiming().simpleIterationProgress)
             return iterationDuration() * (1 - *iterationProgress);
     }

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -261,7 +261,7 @@ private:
     void animationDidFinish() final;
     void setAnimation(WebAnimation*) final;
     Seconds timeToNextTick(const BasicEffectTiming&) const final;
-    bool ticksContinouslyWhileActive() const final;
+    bool ticksContinuouslyWhileActive() const final;
     std::optional<double> progressUntilNextStep(double) const final;
     bool preventsAnimationReadiness() const final;
 


### PR DESCRIPTION
#### cf6a98dec70cfea88402bc45d23a13e873d43743
<pre>
[web-animations] the AnimationEffect::ticksContinouslyWhileActive() method has a typo in its name
<a href="https://bugs.webkit.org/show_bug.cgi?id=265955">https://bugs.webkit.org/show_bug.cgi?id=265955</a>
<a href="https://rdar.apple.com/119265944">rdar://119265944</a>

Reviewed by Aditya Keerthi.

The correct spelling is ticksContinuouslyWhileActive.

* Source/WebCore/animation/AnimationEffect.cpp:
(WebCore::AnimationEffect::timeToNextTick const):
* Source/WebCore/animation/AnimationEffect.h:
(WebCore::AnimationEffect::ticksContinuouslyWhileActive const):
(WebCore::AnimationEffect::ticksContinouslyWhileActive const): Deleted.
* Source/WebCore/animation/CustomEffect.h:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::ticksContinuouslyWhileActive const):
(WebCore::KeyframeEffect::timeToNextTick const):
(WebCore::KeyframeEffect::ticksContinouslyWhileActive const): Deleted.
* Source/WebCore/animation/KeyframeEffect.h:

Canonical link: <a href="https://commits.webkit.org/271681@main">https://commits.webkit.org/271681@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b241a1b624e213811ddeef61e06ebbe7d950355b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29084 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7754 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30424 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31686 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26477 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29680 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9879 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5060 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26491 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29356 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6406 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24940 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5558 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5684 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25968 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33024 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26563 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26405 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31929 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5663 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3835 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29712 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7325 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6164 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3758 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6184 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->