### PR TITLE
[threaded-animation-resolution] rename `RemoteLayerTreeEventDispatcher` member on `RemoteScrollingCoordinatorProxyMac`

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
@@ -70,7 +70,7 @@ private:
     void applyScrollingTreeLayerPositionsAfterCommit() override;
 
 #if ENABLE(SCROLLING_THREAD)
-    RefPtr<RemoteLayerTreeEventDispatcher> m_wheelEventDispatcher;
+    RefPtr<RemoteLayerTreeEventDispatcher> m_eventDispatcher;
 #endif
 };
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
@@ -50,23 +50,23 @@ using namespace WebCore;
 RemoteScrollingCoordinatorProxyMac::RemoteScrollingCoordinatorProxyMac(WebPageProxy& webPageProxy)
     : RemoteScrollingCoordinatorProxy(webPageProxy)
 #if ENABLE(SCROLLING_THREAD)
-    , m_wheelEventDispatcher(RemoteLayerTreeEventDispatcher::create(*this, webPageProxy.webPageID()))
+    , m_eventDispatcher(RemoteLayerTreeEventDispatcher::create(*this, webPageProxy.webPageID()))
 #endif
 {
-    m_wheelEventDispatcher->setScrollingTree(scrollingTree());
+    m_eventDispatcher->setScrollingTree(scrollingTree());
 }
 
 RemoteScrollingCoordinatorProxyMac::~RemoteScrollingCoordinatorProxyMac()
 {
 #if ENABLE(SCROLLING_THREAD)
-    m_wheelEventDispatcher->invalidate();
+    m_eventDispatcher->invalidate();
 #endif
 }
 
 void RemoteScrollingCoordinatorProxyMac::cacheWheelEventScrollingAccelerationCurve(const NativeWebWheelEvent& nativeWheelEvent)
 {
 #if ENABLE(SCROLLING_THREAD)
-    m_wheelEventDispatcher->cacheWheelEventScrollingAccelerationCurve(nativeWheelEvent);
+    m_eventDispatcher->cacheWheelEventScrollingAccelerationCurve(nativeWheelEvent);
 #else
     UNUSED_PARAM(nativeWheelEvent);
 #endif
@@ -75,7 +75,7 @@ void RemoteScrollingCoordinatorProxyMac::cacheWheelEventScrollingAccelerationCur
 void RemoteScrollingCoordinatorProxyMac::handleWheelEvent(const WebWheelEvent& wheelEvent, RectEdges<bool> rubberBandableEdges)
 {
 #if ENABLE(SCROLLING_THREAD)
-    m_wheelEventDispatcher->handleWheelEvent(wheelEvent, rubberBandableEdges);
+    m_eventDispatcher->handleWheelEvent(wheelEvent, rubberBandableEdges);
 #else
     UNUSED_PARAM(wheelEvent);
     UNUSED_PARAM(rubberBandableEdges);
@@ -85,7 +85,7 @@ void RemoteScrollingCoordinatorProxyMac::handleWheelEvent(const WebWheelEvent& w
 void RemoteScrollingCoordinatorProxyMac::wheelEventHandlingCompleted(const PlatformWheelEvent& wheelEvent, ScrollingNodeID scrollingNodeID, std::optional<WheelScrollGestureState> gestureState, bool wasHandled)
 {
 #if ENABLE(SCROLLING_THREAD)
-    m_wheelEventDispatcher->wheelEventHandlingCompleted(wheelEvent, scrollingNodeID, gestureState, wasHandled);
+    m_eventDispatcher->wheelEventHandlingCompleted(wheelEvent, scrollingNodeID, gestureState, wasHandled);
 #else
     UNUSED_PARAM(wheelEvent);
     UNUSED_PARAM(scrollingNodeID);
@@ -109,7 +109,7 @@ bool RemoteScrollingCoordinatorProxyMac::scrollingTreeNodeRequestsKeyboardScroll
 void RemoteScrollingCoordinatorProxyMac::hasNodeWithAnimatedScrollChanged(bool hasAnimatedScrolls)
 {
 #if ENABLE(SCROLLING_THREAD)
-    m_wheelEventDispatcher->hasNodeWithAnimatedScrollChanged(hasAnimatedScrolls);
+    m_eventDispatcher->hasNodeWithAnimatedScrollChanged(hasAnimatedScrolls);
 #else
     auto* drawingArea = dynamicDowncast<RemoteLayerTreeDrawingAreaProxy>(webPageProxy().drawingArea());
     if (!drawingArea)
@@ -252,21 +252,21 @@ void RemoteScrollingCoordinatorProxyMac::establishLayerTreeScrollingRelations(co
 void RemoteScrollingCoordinatorProxyMac::displayDidRefresh(PlatformDisplayID displayID)
 {
 #if ENABLE(SCROLLING_THREAD)
-    m_wheelEventDispatcher->mainThreadDisplayDidRefresh(displayID);
+    m_eventDispatcher->mainThreadDisplayDidRefresh(displayID);
 #endif
 }
 
 void RemoteScrollingCoordinatorProxyMac::windowScreenDidChange(PlatformDisplayID displayID, std::optional<FramesPerSecond> nominalFramesPerSecond)
 {
 #if ENABLE(SCROLLING_THREAD)
-    m_wheelEventDispatcher->windowScreenDidChange(displayID, nominalFramesPerSecond);
+    m_eventDispatcher->windowScreenDidChange(displayID, nominalFramesPerSecond);
 #endif
 }
 
 void RemoteScrollingCoordinatorProxyMac::windowScreenWillChange()
 {
 #if ENABLE(SCROLLING_THREAD)
-    m_wheelEventDispatcher->windowScreenWillChange();
+    m_eventDispatcher->windowScreenWillChange();
 #endif
 }
 
@@ -283,7 +283,7 @@ void RemoteScrollingCoordinatorProxyMac::didCommitLayerAndScrollingTrees()
 void RemoteScrollingCoordinatorProxyMac::applyScrollingTreeLayerPositionsAfterCommit()
 {
     RemoteScrollingCoordinatorProxy::applyScrollingTreeLayerPositionsAfterCommit();
-    m_wheelEventDispatcher->renderingUpdateComplete();
+    m_eventDispatcher->renderingUpdateComplete();
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### b03871bf9700c6ddad028d499d46e3cda5e3f4e3
<pre>
[threaded-animation-resolution] rename `RemoteLayerTreeEventDispatcher` member on `RemoteScrollingCoordinatorProxyMac`
<a href="https://bugs.webkit.org/show_bug.cgi?id=265959">https://bugs.webkit.org/show_bug.cgi?id=265959</a>
<a href="https://rdar.apple.com/119269904">rdar://119269904</a>

Reviewed by Matt Woodrow.

For the threaded animation resolution work we will use the `RemoteLayerTreeEventDispatcher` member
of `RemoteScrollingCoordinatorProxyMac` for purposes beyond wheel events, so we rename the variable
from `m_wheelEventDispatcher` to the more generic `m_eventDispatcher`.

* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm:
(WebKit::RemoteScrollingCoordinatorProxyMac::RemoteScrollingCoordinatorProxyMac):
(WebKit::RemoteScrollingCoordinatorProxyMac::~RemoteScrollingCoordinatorProxyMac):
(WebKit::RemoteScrollingCoordinatorProxyMac::cacheWheelEventScrollingAccelerationCurve):
(WebKit::RemoteScrollingCoordinatorProxyMac::handleWheelEvent):
(WebKit::RemoteScrollingCoordinatorProxyMac::wheelEventHandlingCompleted):
(WebKit::RemoteScrollingCoordinatorProxyMac::hasNodeWithAnimatedScrollChanged):
(WebKit::RemoteScrollingCoordinatorProxyMac::displayDidRefresh):
(WebKit::RemoteScrollingCoordinatorProxyMac::windowScreenDidChange):
(WebKit::RemoteScrollingCoordinatorProxyMac::windowScreenWillChange):
(WebKit::RemoteScrollingCoordinatorProxyMac::applyScrollingTreeLayerPositionsAfterCommit):

Canonical link: <a href="https://commits.webkit.org/271661@main">https://commits.webkit.org/271661@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5fec1bb7ac633fbef93128db67b3b96c2cfd6fd2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29093 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7762 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30432 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31694 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26482 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9887 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5068 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26495 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29365 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6412 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24941 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5562 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5688 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33032 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26568 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26406 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31936 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5668 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3840 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29720 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7333 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6172 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3747 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6189 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->