### PR TITLE
[WGSL] Global declarations cannot be stored separately

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTDeclaration.h
+++ b/Source/WebGPU/WGSL/AST/ASTDeclaration.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "ASTBuilder.h"
+#include "ASTIdentifier.h"
 #include "ASTNode.h"
 #include <wtf/ReferenceWrapperVector.h>
 #include <wtf/TypeCasts.h>
@@ -35,7 +36,10 @@ namespace WGSL::AST {
 class Declaration : public Node {
     WGSL_AST_BUILDER_NODE(Declaration);
 public:
+    using Ref = std::reference_wrapper<Declaration>;
     using List = ReferenceWrapperVector<Declaration>;
+
+    virtual Identifier& name() = 0;
 
 protected:
     Declaration(SourceSpan span)

--- a/Source/WebGPU/WGSL/AST/ASTForward.h
+++ b/Source/WebGPU/WGSL/AST/ASTForward.h
@@ -30,6 +30,8 @@ namespace WGSL::AST {
 class Directive;
 class DiagnosticDirective;
 
+class Declaration;
+
 class Attribute;
 class AlignAttribute;
 class BindingAttribute;

--- a/Source/WebGPU/WGSL/AST/ASTFunction.h
+++ b/Source/WebGPU/WGSL/AST/ASTFunction.h
@@ -44,11 +44,8 @@ class Function final : public Declaration {
     friend AttributeValidator;
 
 public:
-    using Ref = std::reference_wrapper<Function>;
-    using List = ReferenceWrapperVector<Function>;
-
     NodeKind kind() const override;
-    Identifier& name() { return m_name; }
+    Identifier& name() override { return m_name; }
     Parameter::List& parameters() { return m_parameters; }
     Attribute::List& attributes() { return m_attributes; }
     Attribute::List& returnAttributes() { return m_returnAttributes; }

--- a/Source/WebGPU/WGSL/AST/ASTStringDumper.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTStringDumper.cpp
@@ -72,20 +72,10 @@ void StringDumper::visit(ShaderModule& shaderModule)
     if (!shaderModule.directives().isEmpty())
         m_out.print("\n\n");
 
-    for (auto& structure : shaderModule.structures())
-        visit(structure);
-    if (!shaderModule.structures().isEmpty())
-        m_out.printf("\n\n");
-
-    for (auto& variable : shaderModule.variables())
-        visit(variable);
-    if (!shaderModule.variables().isEmpty())
-        m_out.printf("\n\n");
-
-    for (auto& function : shaderModule.functions())
-        visit(function);
-    if (!shaderModule.functions().isEmpty())
-        m_out.printf("\n\n");
+    for (auto& declaration : shaderModule.declarations()) {
+        AST::Visitor::visit(declaration);
+        m_out.print("\n");
+    }
 }
 
 void StringDumper::visit(DiagnosticDirective&)

--- a/Source/WebGPU/WGSL/AST/ASTStructure.h
+++ b/Source/WebGPU/WGSL/AST/ASTStructure.h
@@ -60,7 +60,7 @@ public:
     NodeKind kind() const override;
     StructureRole role() const { return m_role; }
     StructureRole& role() { return m_role; }
-    Identifier& name() { return m_name; }
+    Identifier& name() override { return m_name; }
     Attribute::List& attributes() { return m_attributes; }
     StructureMember::List& members() { return m_members; }
     Structure* original() const { return m_original; }

--- a/Source/WebGPU/WGSL/AST/ASTVariable.h
+++ b/Source/WebGPU/WGSL/AST/ASTVariable.h
@@ -60,7 +60,7 @@ public:
     NodeKind kind() const override;
     VariableFlavor flavor() const { return m_flavor; };
     VariableFlavor& flavor() { return m_flavor; };
-    Identifier& name() { return m_name; }
+    Identifier& name() override { return m_name; }
     Identifier& originalName() { return m_originalName; }
     Attribute::List& attributes() { return m_attributes; }
     VariableQualifier* maybeQualifier() { return m_qualifier; }

--- a/Source/WebGPU/WGSL/AST/ASTVisitor.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTVisitor.cpp
@@ -47,12 +47,8 @@ void Visitor::visit(ShaderModule& shaderModule)
 {
     for (auto& directive : shaderModule.directives())
         checkErrorAndVisit(directive);
-    for (auto& structure : shaderModule.structures())
-        checkErrorAndVisit(structure);
-    for (auto& variable : shaderModule.variables())
-        checkErrorAndVisit(variable);
-    for (auto& function : shaderModule.functions())
-        checkErrorAndVisit(function);
+    for (auto& declaration : shaderModule.declarations())
+        checkErrorAndVisit(declaration);
 }
 
 // Directive
@@ -70,6 +66,25 @@ void Visitor::visit(AST::Directive& directive)
 
 void Visitor::visit(AST::DiagnosticDirective&)
 {
+}
+
+// Declarations
+
+void Visitor::visit(AST::Declaration& declaration)
+{
+    switch (declaration.kind()) {
+    case AST::NodeKind::Function:
+        checkErrorAndVisit(downcast<AST::Function>(declaration));
+        break;
+    case AST::NodeKind::Variable:
+        checkErrorAndVisit(downcast<AST::Variable>(declaration));
+        break;
+    case AST::NodeKind::Structure:
+        checkErrorAndVisit(downcast<AST::Structure>(declaration));
+        break;
+    default:
+        ASSERT_NOT_REACHED("Unhandled Declaration");
+    }
 }
 
 // Attribute

--- a/Source/WebGPU/WGSL/AST/ASTVisitor.h
+++ b/Source/WebGPU/WGSL/AST/ASTVisitor.h
@@ -48,6 +48,12 @@ public:
     virtual void visit(AST::Directive&);
     virtual void visit(AST::DiagnosticDirective&);
 
+    // Declaration
+    virtual void visit(AST::Declaration&);
+    virtual void visit(AST::Function&);
+    virtual void visit(AST::Variable&);
+    virtual void visit(AST::Structure&);
+
     // Attribute
     virtual void visit(AST::Attribute&);
     virtual void visit(AST::AlignAttribute&);
@@ -84,7 +90,6 @@ public:
     virtual void visit(AST::UnaryExpression&);
     virtual void visit(AST::Unsigned32Literal&);
 
-    virtual void visit(AST::Function&);
     virtual void visit(AST::Parameter&);
 
     virtual void visit(AST::Identifier&);
@@ -109,16 +114,12 @@ public:
     virtual void visit(AST::VariableStatement&);
     virtual void visit(AST::WhileStatement&);
 
-    virtual void visit(AST::Structure&);
-    virtual void visit(AST::StructureMember&);
-
     virtual void visit(AST::ArrayTypeExpression&);
     virtual void visit(AST::ElaboratedTypeExpression&);
     virtual void visit(AST::ReferenceTypeExpression&);
 
-    virtual void visit(AST::Variable&);
+    virtual void visit(AST::StructureMember&);
     virtual void visit(AST::VariableQualifier&);
-
     virtual void visit(AST::SwitchClause&);
     virtual void visit(AST::Continuing&);
 

--- a/Source/WebGPU/WGSL/CallGraph.cpp
+++ b/Source/WebGPU/WGSL/CallGraph.cpp
@@ -71,7 +71,11 @@ CallGraph CallGraphBuilder::build()
 
 void CallGraphBuilder::initializeMappings()
 {
-    for (auto& function : m_callGraph.m_ast.functions()) {
+    for (auto& declaration : m_callGraph.m_ast.declarations()) {
+        if (!is<AST::Function>(declaration))
+            continue;
+
+        auto& function = downcast<AST::Function>(declaration);
         const auto& name = function.name();
         {
             auto result = m_callGraph.m_functionsByName.add(name, &function);

--- a/Source/WebGPU/WGSL/EntryPointRewriter.cpp
+++ b/Source/WebGPU/WGSL/EntryPointRewriter.cpp
@@ -160,7 +160,7 @@ void EntryPointRewriter::checkReturnType()
                 AST::Attribute::List { },
                 role
             );
-            m_shaderModule.append(m_shaderModule.structures(), returnStruct);
+            m_shaderModule.append(m_shaderModule.declarations(), returnStruct);
             auto& returnType = m_shaderModule.astBuilder().construct<AST::IdentifierExpression>(
                 SourceSpan::empty(),
                 AST::Identifier::make(returnStructName)
@@ -200,7 +200,7 @@ void EntryPointRewriter::checkReturnType()
         AST::Attribute::List { },
         AST::StructureRole::FragmentOutputWrapper
     );
-    m_shaderModule.append(m_shaderModule.structures(), returnStruct);
+    m_shaderModule.append(m_shaderModule.declarations(), returnStruct);
     auto& returnType = m_shaderModule.astBuilder().construct<AST::IdentifierExpression>(
         SourceSpan::empty(),
         AST::Identifier::make(returnStructName)
@@ -235,14 +235,15 @@ void EntryPointRewriter::constructInputStruct()
         break;
     }
 
-    m_shaderModule.append(m_shaderModule.structures(), m_shaderModule.astBuilder().construct<AST::Structure>(
+    auto& structure = m_shaderModule.astBuilder().construct<AST::Structure>(
         SourceSpan::empty(),
         AST::Identifier::make(m_structTypeName),
         WTFMove(structMembers),
         AST::Attribute::List { },
         role
-    ));
-    m_structType = m_shaderModule.types().structType(m_shaderModule.structures().last());
+    );
+    m_shaderModule.append(m_shaderModule.declarations(), structure);
+    m_structType = m_shaderModule.types().structType(structure);
 }
 
 void EntryPointRewriter::materialize(Vector<String>& path, MemberOrParameter& data, IsBuiltin isBuiltin)

--- a/Source/WebGPU/WGSL/MangleNames.cpp
+++ b/Source/WebGPU/WGSL/MangleNames.cpp
@@ -105,27 +105,20 @@ private:
 
 void NameManglerVisitor::run()
 {
-    auto& module = m_callGraph.ast();
-    for (auto& structure : module.structures())
-        visit(structure);
-
-    for (auto& variable : module.variables())
-        visit(variable);
-
-    for (auto& function : module.functions()) {
-        String originalName = function.name();
-        introduceVariable(function.name(), MangledName::Function);
-        auto it = m_result.entryPoints.find(originalName);
-        if (it != m_result.entryPoints.end()) {
-            it->value.originalName = originalName;
-            it->value.mangledName = function.name();
-        }
-        visit(function);
-    }
+    AST::Visitor::visit(m_callGraph.ast());
 }
 
 void NameManglerVisitor::visit(AST::Function& function)
 {
+
+    String originalName = function.name();
+    introduceVariable(function.name(), MangledName::Function);
+    auto it = m_result.entryPoints.find(originalName);
+    if (it != m_result.entryPoints.end()) {
+        it->value.originalName = originalName;
+        it->value.mangledName = function.name();
+    }
+
     ContextScope functionScope(this);
     AST::Visitor::visit(function);
 }

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -158,12 +158,18 @@ void FunctionDefinitionWriter::write()
 {
     emitNecessaryHelpers();
 
-    for (auto& structure : m_callGraph.ast().structures())
-        visit(structure);
-    for (auto& structure : m_callGraph.ast().structures())
-        generatePackingHelpers(structure);
-    for (auto& variable : m_callGraph.ast().variables())
-        visitGlobal(variable);
+    for (auto& declaration : m_callGraph.ast().declarations()) {
+        if (is<AST::Structure>(declaration))
+            visit(downcast<AST::Structure>(declaration));
+        else if (is<AST::Variable>(declaration))
+            visitGlobal(downcast<AST::Variable>(declaration));
+    }
+
+    for (auto& declaration : m_callGraph.ast().declarations()) {
+        if (is<AST::Structure>(declaration))
+            generatePackingHelpers(downcast<AST::Structure>(declaration));
+    }
+
     for (auto& entryPoint : m_callGraph.entrypoints())
         visit(entryPoint.function);
 }

--- a/Source/WebGPU/WGSL/ParserPrivate.h
+++ b/Source/WebGPU/WGSL/ParserPrivate.h
@@ -29,6 +29,7 @@
 #include "ASTBuilder.h"
 #include "ASTExpression.h"
 #include "ASTForward.h"
+#include "ASTFunction.h"
 #include "ASTStatement.h"
 #include "ASTStructure.h"
 #include "ASTVariable.h"
@@ -63,7 +64,7 @@ public:
     Result<AST::Identifier> parseIdentifier();
     Result<void> parseEnableDirective();
     Result<void> parseRequireDirective();
-    Result<void> parseGlobalDecl();
+    Result<AST::Declaration::Ref> parseDeclaration();
     Result<AST::Attribute::List> parseAttributes();
     Result<AST::Attribute::Ref> parseAttribute();
     Result<AST::Structure::Ref> parseStructure(AST::Attribute::List&&);

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -76,6 +76,7 @@ public:
     void visit(AST::WorkgroupSizeAttribute&) override;
 
     // Statements
+    void visit(AST::VariableStatement&) override;
     void visit(AST::AssignmentStatement&) override;
     void visit(AST::CallStatement&) override;
     void visit(AST::CompoundAssignmentStatement&) override;
@@ -317,14 +318,7 @@ TypeChecker::TypeChecker(ShaderModule& shaderModule)
 
 std::optional<FailedCheck> TypeChecker::check()
 {
-    for (auto& structure : m_shaderModule.structures())
-        visit(structure);
-
-    for (auto& variable : m_shaderModule.variables())
-        visitVariable(variable, VariableKind::Global);
-
-    for (auto& function : m_shaderModule.functions())
-        visit(function);
+    AST::Visitor::visit(m_shaderModule);
 
     if (shouldDumpInferredTypes) {
         for (auto& error : m_errors)
@@ -355,8 +349,14 @@ void TypeChecker::visit(AST::Structure& structure)
 
 void TypeChecker::visit(AST::Variable& variable)
 {
-    visitVariable(variable, VariableKind::Local);
+    visitVariable(variable, VariableKind::Global);
 }
+
+void TypeChecker::visit(AST::VariableStatement& statement)
+{
+    visitVariable(statement.variable(), VariableKind::Local);
+}
+
 
 void TypeChecker::visitVariable(AST::Variable& variable, VariableKind variableKind)
 {

--- a/Source/WebGPU/WGSL/WGSLShaderModule.h
+++ b/Source/WebGPU/WGSL/WGSLShaderModule.h
@@ -26,11 +26,9 @@
 #pragma once
 
 #include "ASTBuilder.h"
+#include "ASTDeclaration.h"
 #include "ASTDirective.h"
-#include "ASTFunction.h"
 #include "ASTIdentityExpression.h"
-#include "ASTStructure.h"
-#include "ASTVariable.h"
 #include "TypeStore.h"
 #include "WGSL.h"
 #include "WGSLEnums.h"
@@ -55,11 +53,9 @@ public:
 
     const String& source() const { return m_source; }
     const Configuration& configuration() const { return m_configuration; }
+    AST::Declaration::List& declarations() { return m_declarations; }
+    const AST::Declaration::List& declarations() const { return m_declarations; }
     AST::Directive::List& directives() { return m_directives; }
-    AST::Function::List& functions() { return m_functions; }
-    const AST::Function::List& functions() const { return m_functions; }
-    AST::Structure::List& structures() { return m_structures; }
-    AST::Variable::List& variables() { return m_variables; }
     TypeStore& types() { return m_types; }
     AST::Builder& astBuilder() { return m_astBuilder; }
 
@@ -238,10 +234,8 @@ private:
     OptionSet<Extension> m_enabledExtensions;
     OptionSet<LanguageFeature> m_requiredFeatures;
     Configuration m_configuration;
+    AST::Declaration::List m_declarations;
     AST::Directive::List m_directives;
-    AST::Function::List m_functions;
-    AST::Structure::List m_structures;
-    AST::Variable::List m_variables;
     TypeStore m_types;
     AST::Builder m_astBuilder;
     Vector<std::function<void()>> m_replacements;

--- a/Source/WebGPU/WGSL/tests/invalid/redeclaration-reordering.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/redeclaration-reordering.wgsl
@@ -1,0 +1,9 @@
+// RUN: %not %wgslc | %check
+
+struct f {
+}
+
+// CHECK-L: redeclaration of 'f'
+override f = 1;
+
+fn f() { }

--- a/Source/WebGPU/WGSL/tests/invalid/redeclaration-type-checking.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/redeclaration-type-checking.wgsl
@@ -1,12 +1,5 @@
 // RUN: %not %wgslc | %check
 
-struct f {
-}
-
-// CHECK-L: redeclaration of 'f'
-override f = 1;
-
-// CHECK-L: redeclaration of 'f'
 fn f() {
     let x = 1;
     // CHECK-L: redeclaration of 'x'

--- a/Source/WebGPU/WGSL/tests/invalid/reordering-cycle-struct-const.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/reordering-cycle-struct-const.wgsl
@@ -1,0 +1,5 @@
+// RUN: %not %wgslc | %check
+
+// CHECK-L: encountered a dependency cycle: a -> S -> a
+const a = S(array(1));
+struct S { x: array<i32, a.x[0]> };

--- a/Source/WebGPU/WebGPU/ShaderModule.mm
+++ b/Source/WebGPU/WebGPU/ShaderModule.mm
@@ -27,6 +27,7 @@
 #import "ShaderModule.h"
 
 #import "APIConversions.h"
+#import "ASTFunction.h"
 #import "Device.h"
 #import "PipelineLayout.h"
 #import "WGSLShaderModule.h"
@@ -157,7 +158,10 @@ ShaderModule::ShaderModule(std::variant<WGSL::SuccessfulCheck, WGSL::FailedCheck
     bool allowVertexDefault = true, allowFragmentDefault = true, allowComputeDefault = true;
     if (std::holds_alternative<WGSL::SuccessfulCheck>(m_checkResult)) {
         auto& check = std::get<WGSL::SuccessfulCheck>(m_checkResult);
-        for (auto& function : check.ast->functions()) {
+        for (auto& declaration : check.ast->declarations()) {
+            if (!is<WGSL::AST::Function>(declaration))
+                continue;
+            auto& function = downcast<WGSL::AST::Function>(declaration);
             if (!function.stage())
                 continue;
             switch (*function.stage()) {

--- a/Tools/TestWebKitAPI/Tests/WGSL/ASTStringDumperTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/ASTStringDumperTests.cpp
@@ -68,7 +68,7 @@ TEST(WGSLASTDumperTests, dumpTriangleVert)
         "{\n"
         "    var pos = array<vec2<f32>, 3>(vec2<f32>(0.000000, 0.500000), vec2<f32>(-0.500000, -0.500000), vec2<f32>(0.500000, -0.500000));\n"
         "    return vec4<f32>(pos[VertexIndex], 0.000000, 1.000000);\n"
-        "}\n\n\n"_str);
+        "}\n\n"_str);
 }
 
 } // namespace TestWGSLAPI


### PR DESCRIPTION
#### de2c00fe5fb19529682712f557f044b731fff003
<pre>
[WGSL] Global declarations cannot be stored separately
<a href="https://bugs.webkit.org/show_bug.cgi?id=265960">https://bugs.webkit.org/show_bug.cgi?id=265960</a>
<a href="https://rdar.apple.com/119270455">rdar://119270455</a>

Reviewed by Mike Wyrzykowski.

We stored functions, global variables and structures in separate lists in the
AST.  That simplified a lot of things, but unfortunately breaks down when there
are dependencies between constants and structs. The fix is to move them all into
a list of global declarations.

* Source/WebGPU/WGSL/AST/ASTDeclaration.h:
* Source/WebGPU/WGSL/AST/ASTForward.h:
* Source/WebGPU/WGSL/AST/ASTFunction.h:
* Source/WebGPU/WGSL/AST/ASTStringDumper.cpp:
(WGSL::AST::StringDumper::visit):
* Source/WebGPU/WGSL/AST/ASTStructure.h:
* Source/WebGPU/WGSL/AST/ASTVariable.h:
* Source/WebGPU/WGSL/AST/ASTVisitor.cpp:
(WGSL::AST::Visitor::visit):
* Source/WebGPU/WGSL/AST/ASTVisitor.h:
* Source/WebGPU/WGSL/CallGraph.cpp:
(WGSL::CallGraphBuilder::initializeMappings):
* Source/WebGPU/WGSL/EntryPointRewriter.cpp:
(WGSL::EntryPointRewriter::checkReturnType):
(WGSL::EntryPointRewriter::constructInputStruct):
* Source/WebGPU/WGSL/GlobalSorting.cpp:
(WGSL::Graph::Node::Node):
(WGSL::Graph::Node::index const):
(WGSL::Graph::Node::astNode const):
(WGSL::Graph::Node::incomingEdges):
(WGSL::Graph::Node::outgoingEdges):
(WGSL::Graph::addNode):
(WGSL::GraphBuilder::visit):
(WGSL::GraphBuilder::GraphBuilder):
(WGSL::GraphBuilder::introduceVariable):
(WGSL::GraphBuilder::readVariable const):
(WGSL::reorder):
(WGSL::reorderGlobals):
(WGSL::Graph::Edge::remove): Deleted.
(WGSL::GraphBuilder&lt;ASTNode&gt;::visit): Deleted.
(WGSL::GraphBuilder&lt;ASTNode&gt;::GraphBuilder): Deleted.
(WGSL::GraphBuilder&lt;ASTNode&gt;::introduceVariable): Deleted.
(WGSL::GraphBuilder&lt;ASTNode&gt;::readVariable const): Deleted.
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::collectGlobals):
(WGSL::RewriteGlobalVariables::packStructType):
(WGSL::RewriteGlobalVariables::finalizeArgumentBufferStruct):
* Source/WebGPU/WGSL/MangleNames.cpp:
(WGSL::NameManglerVisitor::run):
(WGSL::NameManglerVisitor::visit):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::write):
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseShader):
(WGSL::Parser&lt;Lexer&gt;::parseDeclaration):
(WGSL::Parser&lt;Lexer&gt;::parseGlobalDecl): Deleted.
* Source/WebGPU/WGSL/ParserPrivate.h:
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::check):
(WGSL::TypeChecker::visit):
* Source/WebGPU/WGSL/WGSLShaderModule.h:
(WGSL::ShaderModule::declarations):
(WGSL::ShaderModule::directives):
(WGSL::ShaderModule::functions): Deleted.
(WGSL::ShaderModule::structures): Deleted.
(WGSL::ShaderModule::variables): Deleted.
* Source/WebGPU/WGSL/tests/invalid/redeclaration-reordering.wgsl: Added.
* Source/WebGPU/WGSL/tests/invalid/redeclaration-type-checking.wgsl: Renamed from Source/WebGPU/WGSL/tests/invalid/redeclaration.wgsl.
* Source/WebGPU/WGSL/tests/invalid/reordering-cycle-struct-const.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/271738@main">https://commits.webkit.org/271738@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9d3569c020fd3c2cdf7dd8d98bfe1dbca4295f7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29224 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7895 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30564 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31812 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26580 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29822 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10035 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5199 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26581 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29497 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6557 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25042 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5651 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5795 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26080 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33151 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26692 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26513 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32017 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5760 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3941 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29803 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7441 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7004 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6273 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6285 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->