### PR TITLE
Getting the current tab / window from the background page or action popup should return the right tab / window.

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
@@ -74,7 +74,7 @@ void WebExtensionContext::tabsCreate(WebPageProxyIdentifier webPageProxyIdentifi
     creationOptions.shouldMute = parameters.muted.value_or(false);
     creationOptions.shouldShowReaderMode = parameters.showingReaderMode.value_or(false);
 
-    auto window = getWindow(parameters.windowIdentifier.value_or(WebExtensionWindowConstants::CurrentIdentifier), webPageProxyIdentifier);
+    RefPtr window = getWindow(parameters.windowIdentifier.value_or(WebExtensionWindowConstants::CurrentIdentifier), webPageProxyIdentifier);
     if (!window) {
         completionHandler(std::nullopt, toErrorString(apiName, nil, @"window not found"));
         return;
@@ -84,7 +84,7 @@ void WebExtensionContext::tabsCreate(WebPageProxyIdentifier webPageProxyIdentifi
     creationOptions.desiredIndex = parameters.index.value_or(window->tabs().size());
 
     if (parameters.parentTabIdentifier) {
-        auto tab = getTab(parameters.parentTabIdentifier.value());
+        RefPtr tab = getTab(parameters.parentTabIdentifier.value());
         if (!tab) {
             completionHandler(std::nullopt, toErrorString(apiName, nil, @"parent tab not found"));
             return;
@@ -126,7 +126,7 @@ void WebExtensionContext::tabsUpdate(WebExtensionTabIdentifier tabIdentifier, co
     ASSERT(!parameters.title);
     ASSERT(!parameters.windowIdentifier);
 
-    auto tab = getTab(tabIdentifier);
+    RefPtr tab = getTab(tabIdentifier);
     if (!tab) {
         completionHandler(std::nullopt, toErrorString(@"tabs.update()", nil, @"tab not found"));
         return;
@@ -246,7 +246,7 @@ void WebExtensionContext::tabsUpdate(WebExtensionTabIdentifier tabIdentifier, co
 
 void WebExtensionContext::tabsDuplicate(WebExtensionTabIdentifier tabIdentifier, const WebExtensionTabParameters& parameters, CompletionHandler<void(std::optional<WebExtensionTabParameters>, WebExtensionTab::Error)>&& completionHandler)
 {
-    auto tab = getTab(tabIdentifier);
+    RefPtr tab = getTab(tabIdentifier);
     if (!tab) {
         completionHandler(std::nullopt, toErrorString(@"tabs.duplicate()", nil, @"tab not found"));
         return;
@@ -264,7 +264,7 @@ void WebExtensionContext::tabsDuplicate(WebExtensionTabIdentifier tabIdentifier,
 
 void WebExtensionContext::tabsGet(WebExtensionTabIdentifier tabIdentifier, CompletionHandler<void(std::optional<WebExtensionTabParameters>, WebExtensionTab::Error)>&& completionHandler)
 {
-    auto tab = getTab(tabIdentifier);
+    RefPtr tab = getTab(tabIdentifier);
     if (!tab) {
         completionHandler(std::nullopt, toErrorString(@"tabs.get()", nil, @"tab not found"));
         return;
@@ -275,9 +275,9 @@ void WebExtensionContext::tabsGet(WebExtensionTabIdentifier tabIdentifier, Compl
 
 void WebExtensionContext::tabsGetCurrent(WebPageProxyIdentifier webPageProxyIdentifier, CompletionHandler<void(std::optional<WebExtensionTabParameters>, WebExtensionTab::Error)>&& completionHandler)
 {
-    auto tab = getTab(webPageProxyIdentifier);
+    RefPtr tab = getCurrentTab(webPageProxyIdentifier);
     if (!tab) {
-        // No error is reported when the page isn't a tab (e.g. the background page).
+        // No error is reported when there is no tab found.
         completionHandler(std::nullopt, std::nullopt);
         return;
     }
@@ -304,7 +304,7 @@ void WebExtensionContext::tabsQuery(WebPageProxyIdentifier webPageProxyIdentifie
 
 void WebExtensionContext::tabsReload(WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebExtensionTabIdentifier> tabIdentifier, ReloadFromOrigin reloadFromOrigin, CompletionHandler<void(WebExtensionTab::Error)>&& completionHandler)
 {
-    auto tab = getTab(webPageProxyIdentifier, tabIdentifier);
+    RefPtr tab = getTab(webPageProxyIdentifier, tabIdentifier);
     if (!tab) {
         completionHandler(toErrorString(@"tabs.reload()", nil, @"tab not found"));
         return;
@@ -318,7 +318,7 @@ void WebExtensionContext::tabsReload(WebPageProxyIdentifier webPageProxyIdentifi
 
 void WebExtensionContext::tabsGoBack(WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebExtensionTabIdentifier> tabIdentifier, CompletionHandler<void(WebExtensionTab::Error)>&& completionHandler)
 {
-    auto tab = getTab(webPageProxyIdentifier, tabIdentifier);
+    RefPtr tab = getTab(webPageProxyIdentifier, tabIdentifier);
     if (!tab) {
         completionHandler(toErrorString(@"tabs.goBack()", nil, @"tab not found"));
         return;
@@ -329,7 +329,7 @@ void WebExtensionContext::tabsGoBack(WebPageProxyIdentifier webPageProxyIdentifi
 
 void WebExtensionContext::tabsGoForward(WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebExtensionTabIdentifier> tabIdentifier, CompletionHandler<void(WebExtensionTab::Error)>&& completionHandler)
 {
-    auto tab = getTab(webPageProxyIdentifier, tabIdentifier);
+    RefPtr tab = getTab(webPageProxyIdentifier, tabIdentifier);
     if (!tab) {
         completionHandler(toErrorString(@"tabs.goForward()", nil, @"tab not found"));
         return;
@@ -340,7 +340,7 @@ void WebExtensionContext::tabsGoForward(WebPageProxyIdentifier webPageProxyIdent
 
 void WebExtensionContext::tabsDetectLanguage(WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebExtensionTabIdentifier> tabIdentifier, CompletionHandler<void(std::optional<String>, WebExtensionTab::Error)>&& completionHandler)
 {
-    auto tab = getTab(webPageProxyIdentifier, tabIdentifier);
+    RefPtr tab = getTab(webPageProxyIdentifier, tabIdentifier);
     if (!tab) {
         completionHandler(std::nullopt, toErrorString(@"tabs.detectLanguage()", nil, @"tab not found"));
         return;
@@ -373,13 +373,13 @@ static inline String toMIMEType(WebExtensionTab::ImageFormat format)
 
 void WebExtensionContext::tabsCaptureVisibleTab(WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebExtensionWindowIdentifier> windowIdentifier, WebExtensionTab::ImageFormat imageFormat, uint8_t imageQuality, CompletionHandler<void(std::optional<URL>, WebExtensionTab::Error)>&& completionHandler)
 {
-    auto window = getWindow(windowIdentifier.value_or(WebExtensionWindowConstants::CurrentIdentifier), webPageProxyIdentifier);
+    RefPtr window = getWindow(windowIdentifier.value_or(WebExtensionWindowConstants::CurrentIdentifier), webPageProxyIdentifier);
     if (!window) {
         completionHandler({ }, toErrorString(@"tabs.captureVisibleTab()", nil, @"window not found"));
         return;
     }
 
-    auto activeTab = window->activeTab();
+    RefPtr activeTab = window->activeTab();
     if (!activeTab) {
         completionHandler({ }, toErrorString(@"tabs.captureVisibleTab()", nil, @"active tab not found"));
         return;
@@ -417,7 +417,7 @@ void WebExtensionContext::tabsCaptureVisibleTab(WebPageProxyIdentifier webPagePr
 
 void WebExtensionContext::tabsToggleReaderMode(WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebExtensionTabIdentifier> tabIdentifier, CompletionHandler<void(WebExtensionTab::Error)>&& completionHandler)
 {
-    auto tab = getTab(webPageProxyIdentifier, tabIdentifier);
+    RefPtr tab = getTab(webPageProxyIdentifier, tabIdentifier);
     if (!tab) {
         completionHandler(toErrorString(@"tabs.toggleReaderMode()", nil, @"tab not found"));
         return;
@@ -428,7 +428,7 @@ void WebExtensionContext::tabsToggleReaderMode(WebPageProxyIdentifier webPagePro
 
 void WebExtensionContext::tabsSendMessage(WebExtensionTabIdentifier tabIdentifier, const String& messageJSON, std::optional<WebExtensionFrameIdentifier> frameIdentifier, const WebExtensionMessageSenderParameters& senderParameters, CompletionHandler<void(std::optional<String> replyJSON, WebExtensionTab::Error)>&& completionHandler)
 {
-    auto tab = getTab(tabIdentifier);
+    RefPtr tab = getTab(tabIdentifier);
     if (!tab) {
         completionHandler(nullString(), toErrorString(@"tabs.sendMessage()", nil, @"tab not found"));
         return;
@@ -454,7 +454,7 @@ void WebExtensionContext::tabsConnect(WebExtensionTabIdentifier tabIdentifier, W
     constexpr auto sourceContentWorldType = WebExtensionContentWorldType::Main;
     addPorts(sourceContentWorldType, channelIdentifier, 1);
 
-    auto tab = getTab(tabIdentifier);
+    RefPtr tab = getTab(tabIdentifier);
     if (!tab) {
         completionHandler(toErrorString(@"tabs.connect()", nil, @"tab not found"));
         return;
@@ -483,7 +483,7 @@ void WebExtensionContext::tabsConnect(WebExtensionTabIdentifier tabIdentifier, W
 
 void WebExtensionContext::tabsGetZoom(WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebExtensionTabIdentifier> tabIdentifier, CompletionHandler<void(std::optional<double>, WebExtensionTab::Error)>&& completionHandler)
 {
-    auto tab = getTab(webPageProxyIdentifier, tabIdentifier);
+    RefPtr tab = getTab(webPageProxyIdentifier, tabIdentifier);
     if (!tab) {
         completionHandler(std::nullopt, toErrorString(@"tabs.getZoom()", nil, @"tab not found"));
         return;
@@ -494,7 +494,7 @@ void WebExtensionContext::tabsGetZoom(WebPageProxyIdentifier webPageProxyIdentif
 
 void WebExtensionContext::tabsSetZoom(WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebExtensionTabIdentifier> tabIdentifier, double zoomFactor, CompletionHandler<void(WebExtensionTab::Error)>&& completionHandler)
 {
-    auto tab = getTab(webPageProxyIdentifier, tabIdentifier);
+    RefPtr tab = getTab(webPageProxyIdentifier, tabIdentifier);
     if (!tab) {
         completionHandler(toErrorString(@"tabs.setZoom()", nil, @"tab not found"));
         return;
@@ -506,7 +506,7 @@ void WebExtensionContext::tabsSetZoom(WebPageProxyIdentifier webPageProxyIdentif
 void WebExtensionContext::tabsRemove(Vector<WebExtensionTabIdentifier> tabIdentifiers, CompletionHandler<void(WebExtensionTab::Error)>&& completionHandler)
 {
     auto tabs = tabIdentifiers.map([&](auto& tabIdentifier) -> RefPtr<WebExtensionTab> {
-        auto tab = getTab(tabIdentifier);
+        RefPtr tab = getTab(tabIdentifier);
         if (!tab) {
             completionHandler(toErrorString(@"tabs.remove()", nil, @"tab '%llu' was not found", tabIdentifier.toUInt64()));
             return nullptr;
@@ -548,7 +548,7 @@ void WebExtensionContext::tabsRemove(Vector<WebExtensionTabIdentifier> tabIdenti
 
 void WebExtensionContext::tabsExecuteScript(WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebExtensionTabIdentifier> tabIdentifier, const WebExtensionScriptInjectionParameters& parameters, CompletionHandler<void(std::optional<InjectionResults>, WebExtensionTab::Error)>&& completionHandler)
 {
-    auto tab = getTab(webPageProxyIdentifier, tabIdentifier);
+    RefPtr tab = getTab(webPageProxyIdentifier, tabIdentifier);
     if (!tab) {
         completionHandler(std::nullopt, toErrorString(@"tabs.executeScript()", nil, @"tab not found"));
         return;
@@ -585,7 +585,7 @@ void WebExtensionContext::tabsExecuteScript(WebPageProxyIdentifier webPageProxyI
 
 void WebExtensionContext::tabsInsertCSS(WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebExtensionTabIdentifier> tabIdentifier, const WebExtensionScriptInjectionParameters& parameters, CompletionHandler<void(WebExtensionTab::Error)>&& completionHandler)
 {
-    auto tab = getTab(webPageProxyIdentifier, tabIdentifier);
+    RefPtr tab = getTab(webPageProxyIdentifier, tabIdentifier);
     if (!tab) {
         completionHandler(toErrorString(@"tabs.insertCSS()", nil, @"tab not found"));
         return;
@@ -613,7 +613,7 @@ void WebExtensionContext::tabsInsertCSS(WebPageProxyIdentifier webPageProxyIdent
 
 void WebExtensionContext::tabsRemoveCSS(WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebExtensionTabIdentifier> tabIdentifier, const WebExtensionScriptInjectionParameters& parameters, CompletionHandler<void(WebExtensionTab::Error)>&& completionHandler)
 {
-    auto tab = getTab(webPageProxyIdentifier, tabIdentifier);
+    RefPtr tab = getTab(webPageProxyIdentifier, tabIdentifier);
     if (!tab) {
         completionHandler(toErrorString(@"tabs.removeCSS()", nil, @"tab not found"));
         return;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -297,6 +297,7 @@ public:
     Ref<WebExtensionTab> getOrCreateTab(_WKWebExtensionTab *);
     RefPtr<WebExtensionTab> getTab(WebExtensionTabIdentifier, IgnoreExtensionAccess = IgnoreExtensionAccess::No);
     RefPtr<WebExtensionTab> getTab(WebPageProxyIdentifier, std::optional<WebExtensionTabIdentifier> = std::nullopt, IgnoreExtensionAccess = IgnoreExtensionAccess::No);
+    RefPtr<WebExtensionTab> getCurrentTab(WebPageProxyIdentifier, IgnoreExtensionAccess = IgnoreExtensionAccess::No);
 
     WindowVector openWindows() const;
     TabMapValueIterator openTabs() const { return m_tabMap.values(); }


### PR DESCRIPTION
#### b7f885673a25153a6285857a3a6e2c512f750040
<pre>
Getting the current tab / window from the background page or action popup should return the right tab / window.
<a href="https://webkit.org/b/260995">https://webkit.org/b/260995</a>
<a href="https://rdar.apple.com/problem/114787479">rdar://problem/114787479</a>

Reviewed by Brian Weinstein.

Make tabs.getCurrent() and windows.getCurrent() return the relevant tab and window
for the page they are called from.

* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm:
(WebKit::WebExtensionContext::tabsCreate):
(WebKit::WebExtensionContext::tabsUpdate):
(WebKit::WebExtensionContext::tabsDuplicate):
(WebKit::WebExtensionContext::tabsGet):
(WebKit::WebExtensionContext::tabsGetCurrent):
(WebKit::WebExtensionContext::tabsReload):
(WebKit::WebExtensionContext::tabsGoBack):
(WebKit::WebExtensionContext::tabsGoForward):
(WebKit::WebExtensionContext::tabsDetectLanguage):
(WebKit::WebExtensionContext::tabsCaptureVisibleTab):
(WebKit::WebExtensionContext::tabsToggleReaderMode):
(WebKit::WebExtensionContext::tabsSendMessage):
(WebKit::WebExtensionContext::tabsConnect):
(WebKit::WebExtensionContext::tabsGetZoom):
(WebKit::WebExtensionContext::tabsSetZoom):
(WebKit::WebExtensionContext::tabsRemove):
(WebKit::WebExtensionContext::tabsExecuteScript):
(WebKit::WebExtensionContext::tabsInsertCSS):
(WebKit::WebExtensionContext::tabsRemoveCSS):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::getWindow):
(WebKit::WebExtensionContext::getTab):
(WebKit::WebExtensionContext::getCurrentTab):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWindows.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/271638@main">https://commits.webkit.org/271638@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4f6e73bb3a07e1f4ab29d3673b0c4b082cec114

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29098 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7766 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30436 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31698 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/26486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29694 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9891 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5072 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29370 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6414 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24938 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5564 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/5691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25966 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33036 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26570 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26407 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/31935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/5672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3843 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/29719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7337 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6176 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3738 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/6193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->