### PR TITLE
[UnifiedPDF] PDFs load blank/white on iOS with UnifiedPDF enabled

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -167,16 +167,22 @@ void WebPage::requestActiveNowPlayingSessionInfo(CompletionHandler<void(bool, bo
 #if ENABLE(PDF_PLUGIN)
 bool WebPage::shouldUsePDFPlugin(const String& contentType, StringView path) const
 {
-    return pdfPluginEnabled()
 #if ENABLE(PDFJS)
-        && !corePage()->settings().pdfJSViewerEnabled()
+    if (corePage()->settings().pdfJSViewerEnabled())
+        return false;
 #endif
+
+    bool pluginEnabled = false;
 #if ENABLE(LEGACY_PDFKIT_PLUGIN)
-        && PDFPlugin::pdfKitLayerControllerIsAvailable()
+    pluginEnabled |= pdfPluginEnabled() && PDFPlugin::pdfKitLayerControllerIsAvailable();
 #endif
-        && (MIMETypeRegistry::isPDFOrPostScriptMIMEType(contentType)
-            || (contentType.isEmpty()
-                && (path.endsWithIgnoringASCIICase(".pdf"_s) || path.endsWithIgnoringASCIICase(".ps"_s))));
+#if ENABLE(UNIFIED_PDF)
+    pluginEnabled |= corePage()->settings().unifiedPDFEnabled();
+#endif
+    if (!pluginEnabled)
+        return false;
+
+    return MIMETypeRegistry::isPDFOrPostScriptMIMEType(contentType) || (contentType.isEmpty() && (path.endsWithIgnoringASCIICase(".pdf"_s) || path.endsWithIgnoringASCIICase(".ps"_s)));
 }
 #endif
 


### PR DESCRIPTION
#### f0019c9e8b3dfd16b8e112fd0253ddfeb7edb0a4
<pre>
[UnifiedPDF] PDFs load blank/white on iOS with UnifiedPDF enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=265966">https://bugs.webkit.org/show_bug.cgi?id=265966</a>
<a href="https://rdar.apple.com/118522690">rdar://118522690</a>

Reviewed by Tim Horton.

The `PDFPluginEnabled` preference defaults to OFF for IOS_FAMILY
targets, so even when the `UnifiedPDFEnabled` preference is set, on iOS we
always report `shouldUsePDFPlugin==false`, which means a plugin is never
created and we never see a PDF load.

This patch fixes this bug by consulting whether or not the
`UnifiedPDFEnabled` has been set. If it has, then we should use the PDF
plugin.

* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::shouldUsePDFPlugin const):

Canonical link: <a href="https://commits.webkit.org/271660@main">https://commits.webkit.org/271660@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26bc6d940e1d2327f896324cef4402b7f1de0dc2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29140 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7808 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30477 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31734 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26513 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9937 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5114 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26518 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29412 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6448 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24970 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5587 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5716 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33073 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26602 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26437 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31955 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5698 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3869 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29739 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7367 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6958 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6206 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6219 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->