### PR TITLE
Add WKKeyedCoder as an alternate code path for WebKit secure coding types (and use it to serialize AVOutputContext)

### DIFF
--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -197,6 +197,7 @@ $(PROJECT_DIR)/Shared/AuxiliaryProcessCreationParameters.serialization.in
 $(PROJECT_DIR)/Shared/BackgroundFetchState.serialization.in
 $(PROJECT_DIR)/Shared/CallbackID.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CacheStoragePolicy.serialization.in
+$(PROJECT_DIR)/Shared/Cocoa/CoreIPCAVOutputContext.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCArray.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCCFType.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCColor.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -516,6 +516,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/AlternativeTextClient.serialization.in \
 	Shared/AppPrivacyReportTestingData.serialization.in \
 	Shared/Cocoa/CacheStoragePolicy.serialization.in \
+	Shared/Cocoa/CoreIPCAVOutputContext.serialization.in \
 	Shared/Cocoa/CoreIPCArray.serialization.in \
 	Shared/Cocoa/CoreIPCCFType.serialization.in \
 	Shared/Cocoa/CoreIPCColor.serialization.in \

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
@@ -57,6 +57,9 @@
 #include <WebCore/ScrollingStateFrameHostingNode.h>
 #include <WebCore/ScrollingStateFrameHostingNodeWithStuffAfterTuple.h>
 #include <WebCore/TimingFunction.h>
+#if USE(AVFOUNDATION)
+#include <pal/cocoa/AVFoundationSoftLink.h>
+#endif
 #if ENABLE(DATA_DETECTION)
 #include <pal/cocoa/DataDetectorsCoreSoftLink.h>
 #endif

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
@@ -85,6 +85,9 @@ namespace WebKit {
 class PlatformClass;
 class CustomEncoded;
 class LayerProperties;
+#if USE(AVFOUNDATION)
+class CoreIPCAVOutputContext;
+#endif
 class CoreIPCNSSomeFoundationType;
 #if ENABLE(DATA_DETECTION)
 class CoreIPCDDScannerResult;
@@ -263,6 +266,13 @@ template<> struct ArgumentCoder<RequestEncodedWithBodyRValue> {
     static void encode(Encoder&, RequestEncodedWithBodyRValue&&);
     static std::optional<RequestEncodedWithBodyRValue> decode(Decoder&);
 };
+
+#if USE(AVFOUNDATION)
+template<> struct ArgumentCoder<WebKit::CoreIPCAVOutputContext> {
+    static void encode(Encoder&, const WebKit::CoreIPCAVOutputContext&);
+    static std::optional<WebKit::CoreIPCAVOutputContext> decode(Decoder&);
+};
+#endif
 
 template<> struct ArgumentCoder<WebKit::CoreIPCNSSomeFoundationType> {
     static void encode(Encoder&, const WebKit::CoreIPCNSSomeFoundationType&);

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedWebKitSecureCoding.h
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedWebKitSecureCoding.h
@@ -27,6 +27,9 @@
 #if PLATFORM(COCOA)
 #include "CoreIPCTypes.h"
 
+#if USE(AVFOUNDATION)
+OBJC_CLASS AVOutputContext;
+#endif
 OBJC_CLASS NSSomeFoundationType;
 #if ENABLE(DATA_DETECTION)
 OBJC_CLASS DDScannerResult;
@@ -34,6 +37,29 @@ OBJC_CLASS DDScannerResult;
 
 namespace WebKit {
 
+#if USE(AVFOUNDATION)
+class CoreIPCAVOutputContext {
+public:
+    CoreIPCAVOutputContext(AVOutputContext *);
+    CoreIPCAVOutputContext(const RetainPtr<AVOutputContext>& object)
+        : CoreIPCAVOutputContext(object.get())
+    {
+    }
+
+    static bool isValidDictionary(CoreIPCDictionary&);
+    RetainPtr<id> toID() const;
+
+private:
+    friend struct IPC::ArgumentCoder<CoreIPCAVOutputContext, void>;
+
+    CoreIPCAVOutputContext(CoreIPCDictionary&& propertyList)
+        : m_propertyList(WTFMove(propertyList))
+    {
+    }
+
+    CoreIPCDictionary m_propertyList;
+};
+#endif
 class CoreIPCNSSomeFoundationType {
 public:
     CoreIPCNSSomeFoundationType(NSSomeFoundationType *);

--- a/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
@@ -58,6 +58,9 @@
 #include <WebCore/ScrollingStateFrameHostingNode.h>
 #include <WebCore/ScrollingStateFrameHostingNodeWithStuffAfterTuple.h>
 #include <WebCore/TimingFunction.h>
+#if USE(AVFOUNDATION)
+#include <pal/cocoa/AVFoundationSoftLink.h>
+#endif
 #if ENABLE(DATA_DETECTION)
 #include <pal/cocoa/DataDetectorsCoreSoftLink.h>
 #endif
@@ -314,6 +317,22 @@ Vector<SerializedTypeInfo> allSerializedTypes()
             {
                 "WebCore::ResourceRequest"_s,
                 "request"_s
+            },
+        } },
+        { "webkit_secure_coding AVOutputContext"_s, {
+            {
+                "AVOutputContextSerializationKeyContextID"_s,
+                "WebKit::CoreIPCString"_s
+            },
+            {
+                "AVOutputContextSerializationKeyContextType"_s,
+                "WebKit::CoreIPCString"_s
+            },
+        } },
+        { "WebKit::CoreIPCAVOutputContext"_s, {
+            {
+                "WebKit::CoreIPCDictionary"_s,
+                "m_propertyList"_s
             },
         } },
         { "webkit_secure_coding NSSomeFoundationType"_s, {

--- a/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
@@ -224,6 +224,14 @@ struct RequestEncodedWithBody {
     [EncodeRequestBody] WebCore::ResourceRequest request;
 };
 
+#if USE(AVFOUNDATION)
+secure_coding_header: <pal/cocoa/AVFoundationSoftLink.h>
+[WebKitSecureCodingClass=PAL::getAVOutputContextClass(), SupportWKKeyedCoder] webkit_secure_coding AVOutputContext {
+    AVOutputContextSerializationKeyContextID: String
+    AVOutputContextSerializationKeyContextType: String
+}
+#endif // USE(AVFOUNDATION)
+
 webkit_secure_coding NSSomeFoundationType {
     StringKey: String
     NumberKey: Number
@@ -235,8 +243,9 @@ webkit_secure_coding NSSomeFoundationType {
 }
 
 #if ENABLE(DATA_DETECTION)
+# Test a comment
 secure_coding_headers: <pal/cocoa/DataDetectorsCoreSoftLink.h>
-[WebKitSecureCodingClass=PAL::getDDScannerResultClass(), ] webkit_secure_coding DDScannerResult {
+[WebKitSecureCodingClass=PAL::getDDScannerResultClass()] webkit_secure_coding DDScannerResult {
     StringKey: String
     NumberKey: Number
     OptionalNumberKey: Number?

--- a/Source/WebKit/Scripts/webkit/tests/WebKitPlatformGeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/WebKitPlatformGeneratedSerializers.cpp
@@ -86,6 +86,40 @@ std::optional<WebKit::PlatformClass> ArgumentCoder<WebKit::PlatformClass>::decod
     };
 }
 
+#if USE(AVFOUNDATION)
+void ArgumentCoder<WebKit::CoreIPCAVOutputContext>::encode(Encoder& encoder, const WebKit::CoreIPCAVOutputContext& instance)
+{
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.m_propertyList)>, WebKit::CoreIPCDictionary>);
+    struct ShouldBeSameSizeAsAVOutputContext : public VirtualTableAndRefCountOverhead<std::is_polymorphic_v<WebKit::CoreIPCAVOutputContext>, false> {
+        WebKit::CoreIPCDictionary m_propertyList;
+    };
+    static_assert(sizeof(ShouldBeSameSizeAsAVOutputContext) == sizeof(WebKit::CoreIPCAVOutputContext));
+    static_assert(MembersInCorrectOrder < 0
+        , offsetof(WebKit::CoreIPCAVOutputContext, m_propertyList)
+    >::value);
+
+    encoder << instance.m_propertyList;
+}
+
+std::optional<WebKit::CoreIPCAVOutputContext> ArgumentCoder<WebKit::CoreIPCAVOutputContext>::decode(Decoder& decoder)
+{
+    auto m_propertyList = decoder.decode<WebKit::CoreIPCDictionary>();
+    if (UNLIKELY(!decoder.isValid()))
+        return std::nullopt;
+
+    if (!(WebKit::CoreIPCAVOutputContext::isValidDictionary(*m_propertyList)))
+        return std::nullopt;
+    if (UNLIKELY(!decoder.isValid()))
+        return std::nullopt;
+    return {
+        WebKit::CoreIPCAVOutputContext {
+            WTFMove(*m_propertyList)
+        }
+    };
+}
+
+#endif
+
 void ArgumentCoder<WebKit::CoreIPCNSSomeFoundationType>::encode(Encoder& encoder, const WebKit::CoreIPCNSSomeFoundationType& instance)
 {
     static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.m_propertyList)>, WebKit::CoreIPCDictionary>);

--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h
@@ -29,6 +29,7 @@
 
 #if PLATFORM(COCOA)
 
+#import "WKKeyedCoder.h"
 #import <wtf/RetainPtr.h>
 
 #if ENABLE(DATA_DETECTION)
@@ -44,6 +45,9 @@ using WKDDActionContext = DDActionContext;
 #endif // #if PLATFORM(MAC)
 #endif // #if ENABLE(DATA_DETECTION)
 
+#if USE(AVFOUNDATION)
+OBJC_CLASS AVOutputContext;
+#endif
 
 namespace IPC {
 
@@ -69,6 +73,9 @@ public:
 };
 
 enum class NSType : uint8_t {
+#if USE(AVFOUNDATION)
+    AVOutputContext,
+#endif
     Array,
     Color,
 #if ENABLE(DATA_DETECTION)
@@ -100,6 +107,9 @@ template<> Class getClass<DDScannerResult>();
 #if PLATFORM(MAC)
 template<> Class getClass<WKDDActionContext>();
 #endif
+#endif
+#if USE(AVFOUNDATION)
+template<> Class getClass<AVOutputContext>();
 #endif
 
 void encodeObjectWithWrapper(Encoder&, id);

--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
@@ -72,6 +72,9 @@
 #if ENABLE(DATA_DETECTION)
 #import <pal/mac/DataDetectorsSoftLink.h>
 #endif
+#if USE(AVFOUNDATION)
+#import <pal/cocoa/AVFoundationSoftLink.h>
+#endif
 
 @interface WKSecureCodingArchivingDelegate : NSObject <NSKeyedArchiverDelegate, NSKeyedUnarchiverDelegate>
 @property (nonatomic, assign) BOOL rewriteMutableArray;
@@ -272,22 +275,33 @@ template<> Class getClass<WKDDActionContext>()
 }
 #endif
 #endif
+#if USE(AVFOUNDATION)
+template<> Class getClass<AVOutputContext>()
+{
+    return PAL::getAVOutputContextClass();
+}
+#endif
+
 
 NSType typeFromObject(id object)
 {
     ASSERT(object);
 
     // Specific classes handled.
+#if USE(AVFOUNDATION)
+    if (PAL::isAVFoundationFrameworkAvailable() && [object isKindOfClass:PAL::getAVOutputContextClass()])
+        return NSType::AVOutputContext;
+#endif
     if ([object isKindOfClass:[NSArray class]])
         return NSType::Array;
     if ([object isKindOfClass:[WebCore::CocoaColor class]])
         return NSType::Color;
 #if ENABLE(DATA_DETECTION)
 #if PLATFORM(MAC)
-    if (PAL::isDataDetectorsCoreFrameworkAvailable() && [object isKindOfClass:[PAL::getWKDDActionContextClass() class]])
+    if (PAL::isDataDetectorsCoreFrameworkAvailable() && [object isKindOfClass:PAL::getWKDDActionContextClass()])
         return NSType::DDActionContext;
 #endif
-    if (PAL::isDataDetectorsCoreFrameworkAvailable() && [object isKindOfClass:[PAL::getDDScannerResultClass() class]])
+    if (PAL::isDataDetectorsCoreFrameworkAvailable() && [object isKindOfClass:PAL::getDDScannerResultClass()])
         return NSType::DDScannerResult;
 #endif
     if ([object isKindOfClass:[NSData class]])

--- a/Source/WebKit/Shared/Cocoa/CoreIPCAVOutputContext.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCAVOutputContext.serialization.in
@@ -1,0 +1,32 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if USE(AVFOUNDATION)
+
+# FIXME: Remove SupportWKKeyedCoder once AVOutputContext conforms to the WebKit Property List secure coding protocol, tracked by rdar://119289362
+
+secure_coding_header: <pal/cocoa/AVFoundationSoftLink.h>
+[WebKitSecureCodingClass=PAL::getAVOutputContextClass(), SupportWKKeyedCoder] webkit_secure_coding AVOutputContext {
+    AVOutputContextSerializationKeyContextID: String
+    AVOutputContextSerializationKeyContextType: String
+}
+#endif // USE(AVFOUNDATION)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h
@@ -53,6 +53,9 @@ class CoreIPCURL;
 
 using ObjectValue = std::variant<
     std::nullptr_t,
+#if USE(AVFOUNDATION)
+    CoreIPCAVOutputContext,
+#endif
     CoreIPCArray,
     CoreIPCCFType,
     CoreIPCColor,

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm
@@ -54,6 +54,10 @@ static ObjectValue valueFromID(id object)
         return nullptr;
 
     switch (IPC::typeFromObject(object)) {
+#if USE(AVFOUNDATION)
+    case IPC::NSType::AVOutputContext:
+        return CoreIPCAVOutputContext((AVOutputContext *)object);
+#endif
     case IPC::NSType::Array:
         return CoreIPCArray((NSArray *)object);
     case IPC::NSType::Color:

--- a/Source/WebKit/Shared/Cocoa/WKKeyedCoder.h
+++ b/Source/WebKit/Shared/Cocoa/WKKeyedCoder.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#ifdef __OBJC__
+
+// WKKeyedCoder is an NSCoder meant to work with `encodeWithCoder:` and `initWithCoder:` for
+// certain classes we need to serialize.
+//
+// The strategy is to accumulate an NSDictionary of key/value pairs that would normally be
+// in a WebKit secure coding property list.
+// The validation of this dictionary at decode time is exactly the same as for the property lists.
+//
+// It only supports a subset of the many encode/decode methods based on what we know is
+// actually needed by the target classes.
+// As we add more specific types that rely on it, we'll expand its feature-set.
+
+@interface WKKeyedCoder : NSCoder
+- (instancetype)init;
+- (instancetype)initWithDictionary:(NSDictionary *)dictionary;
+- (NSDictionary *)accumulatedDictionary;
+@end
+
+#endif // __OBJC__

--- a/Source/WebKit/Shared/Cocoa/WKKeyedCoder.mm
+++ b/Source/WebKit/Shared/Cocoa/WKKeyedCoder.mm
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "ArgumentCodersCocoa.h"
+
+@implementation WKKeyedCoder {
+    RetainPtr<NSMutableDictionary> m_dictionary;
+    bool m_failedDecoding;
+}
+
+- (instancetype)init
+{
+    if (!(self = [super init]))
+        return nil;
+
+    m_dictionary = adoptNS([NSMutableDictionary new]);
+    return self;
+}
+
+- (instancetype)initWithDictionary:(NSDictionary *)dictionary
+{
+    if (!(self = [super init]))
+        return nil;
+
+    m_dictionary = [dictionary mutableCopy];
+    return self;
+}
+
+- (BOOL)allowsKeyedCoding
+{
+    return YES;
+}
+
+- (BOOL)requiresSecureCoding
+{
+    return YES;
+}
+
+- (void)encodeObject:(id)object forKey:(NSString *)key
+{
+    if (!IPC::isSerializableValue(object)) {
+        ASSERT_NOT_REACHED_WITH_MESSAGE("WKKeyedCoder attempt to encode object of unsupported type %s", object_getClassName(object));
+        return;
+    }
+
+    [m_dictionary setObject:object forKey:key];
+}
+
+- (BOOL)containsValueForKey:(NSString *)key
+{
+    return !![m_dictionary objectForKey:key];
+}
+
+- (id)decodeObjectOfClass:(Class)aClass forKey:(NSString *)key
+{
+    if (m_failedDecoding)
+        return nil;
+
+    id object = [m_dictionary objectForKey:key];
+    if (![object isKindOfClass:aClass]) {
+        m_failedDecoding = YES;
+        return nil;
+    }
+
+    return object;
+}
+
+- (id)decodeObjectForKey:(NSString *)key
+{
+    return [m_dictionary objectForKey:key];
+}
+
+- (NSDictionary *)accumulatedDictionary
+{
+    return m_dictionary.get();
+}
+
+@end // @implementation WKKeyedCoder

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1257,6 +1257,8 @@
 		51DD9F2916367DA2001578E9 /* NetworkConnectionToWebProcessMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 51DD9F2716367DA2001578E9 /* NetworkConnectionToWebProcessMessages.h */; };
 		51E351CB180F2CCC00E53BE9 /* IDBUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 51E351C9180F2CCC00E53BE9 /* IDBUtilities.h */; };
 		51E481052AAA8F0A0069B158 /* WebPushDaemonConnectionConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 517B5F2D2757382A002DC22D /* WebPushDaemonConnectionConfiguration.h */; };
+		51E8284E2B21395A009119F9 /* WKKeyedCoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 51E8284C2B213954009119F9 /* WKKeyedCoder.h */; };
+		51E8284F2B213967009119F9 /* WKKeyedCoder.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51E8284D2B213955009119F9 /* WKKeyedCoder.mm */; };
 		51E9049A27BCB9D400929E7E /* LaunchServicesSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 51E9049827BCB9D100929E7E /* LaunchServicesSPI.h */; };
 		51E9049B27BCB9D400929E7E /* LaunchServicesSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 51E9049827BCB9D100929E7E /* LaunchServicesSPI.h */; };
 		51EE7B5B2A95B5820016FF78 /* PushClientConnectionMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 51EE7B5A2A95B5820016FF78 /* PushClientConnectionMessages.h */; };
@@ -5439,6 +5441,9 @@
 		51E351C8180F2CCC00E53BE9 /* IDBUtilities.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = IDBUtilities.cpp; sourceTree = "<group>"; };
 		51E351C9180F2CCC00E53BE9 /* IDBUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IDBUtilities.h; sourceTree = "<group>"; };
 		51E399051D6F54C5009C8831 /* UIGamepadProviderCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = UIGamepadProviderCocoa.mm; sourceTree = "<group>"; };
+		51E8284B2B2036DD009119F9 /* CoreIPCAVOutputContext.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoreIPCAVOutputContext.serialization.in; sourceTree = "<group>"; };
+		51E8284C2B213954009119F9 /* WKKeyedCoder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKKeyedCoder.h; sourceTree = "<group>"; };
+		51E8284D2B213955009119F9 /* WKKeyedCoder.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKKeyedCoder.mm; sourceTree = "<group>"; };
 		51E8B68D1E712873001B7132 /* WebURLSchemeTask.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebURLSchemeTask.cpp; sourceTree = "<group>"; };
 		51E9049827BCB9D100929E7E /* LaunchServicesSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LaunchServicesSPI.h; sourceTree = "<group>"; };
 		51E949961D761CC700EC9EB9 /* UIGamepadProviderIOS.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = UIGamepadProviderIOS.mm; sourceTree = "<group>"; };
@@ -10944,6 +10949,7 @@
 				5197FACD2AFD33AF009180C5 /* CoreIPCArray.h */,
 				5187BDE82AFF4A3A008A6EE5 /* CoreIPCArray.mm */,
 				5197FAD82AFD33B1009180C5 /* CoreIPCArray.serialization.in */,
+				51E8284B2B2036DD009119F9 /* CoreIPCAVOutputContext.serialization.in */,
 				5197FAE22AFD33B4009180C5 /* CoreIPCCFType.h */,
 				5197FAD62AFD33B1009180C5 /* CoreIPCCFType.serialization.in */,
 				5197FAD32AFD33B0009180C5 /* CoreIPCColor.h */,
@@ -11016,6 +11022,8 @@
 				465250E51ECF52CD002025CB /* WebKit2InitializeCocoa.mm */,
 				1DE076D92460CCBD00B211E8 /* WebPreferencesDefaultValuesCocoa.mm */,
 				517B5F98275EC600002DC22D /* WebPushMessageCocoa.mm */,
+				51E8284C2B213954009119F9 /* WKKeyedCoder.h */,
+				51E8284D2B213955009119F9 /* WKKeyedCoder.mm */,
 				37C4C0921814B3AF003688B9 /* WKNSArray.h */,
 				37C4C0911814B3AF003688B9 /* WKNSArray.mm */,
 				373CEAD4185417AE008C363D /* WKNSData.h */,
@@ -16288,6 +16296,7 @@
 				994BADF41F7D781400B571E7 /* WKInspectorViewController.h in Headers */,
 				A518B5D21FE1D55B00F9FA28 /* WKInspectorWKWebView.h in Headers */,
 				2DD5E129210ADC7B00DB6012 /* WKKeyboardScrollingAnimator.h in Headers */,
+				51E8284E2B21395A009119F9 /* WKKeyedCoder.h in Headers */,
 				51A9E10B1315CD18009E7031 /* WKKeyValueStorageManager.h in Headers */,
 				2D790A9F1AD7164900AB90B3 /* WKLayoutMode.h in Headers */,
 				5CE912142293C280005BEC78 /* WKMain.h in Headers */,
@@ -18092,6 +18101,7 @@
 				7B9FC5DC28A53C24007570E7 /* PlatformUnifiedSource5.cpp in Sources */,
 				5C9E0F992A577EDD00FC2664 /* WebKitPlatformGeneratedSerializers.mm in Sources */,
 				5192DDB92AB54ED700E88DE7 /* WebPushMessageCocoa.mm in Sources */,
+				51E8284F2B213967009119F9 /* WKKeyedCoder.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
@@ -34,6 +34,7 @@
 #import <Foundation/NSValue.h>
 #import <WebCore/FontCocoa.h>
 #import <limits.h>
+#import <pal/cocoa/AVFoundationSoftLink.h>
 #import <pal/cocoa/DataDetectorsCoreSoftLink.h>
 #import <pal/mac/DataDetectorsSoftLink.h>
 #import <wtf/RetainPtr.h>
@@ -155,6 +156,9 @@ struct ObjCHolderForTesting {
         RetainPtr<WKDDActionContext>,
 #endif
         RetainPtr<DDScannerResult>,
+#endif
+#if USE(AVFOUNDATION)
+        RetainPtr<AVOutputContext>,
 #endif
         RetainPtr<NSValue>,
         RetainPtr<NSPersonNameComponents>
@@ -638,6 +642,13 @@ TEST(IPCSerialization, SecureCoding)
     [actionContext setHighlightFrame:NSMakeRect(1, 2, 3, 4)];
 
     runTestNS({ actionContext.get() });
+
+    // AVOutputContext
+#if USE(AVFOUNDATION)
+    RetainPtr<AVOutputContext> outputContext = adoptNS([[PAL::getAVOutputContextClass() alloc] init]);
+    runTestNS({ outputContext.get() });
+#endif // USE(AVFOUNDATION)
+
 }
 
 #endif // PLATFORM(MAC)


### PR DESCRIPTION
#### 361273dff3a1320574cb743de6930e21cbea87a6
<pre>
Add WKKeyedCoder as an alternate code path for WebKit secure coding types (and use it to serialize AVOutputContext)
<a href="https://bugs.webkit.org/show_bug.cgi?id=265972">https://bugs.webkit.org/show_bug.cgi?id=265972</a>
<a href="https://rdar.apple.com/119279237">rdar://119279237</a>

Reviewed by Alex Christensen.

For some types where adopting the WebKit property list format is slow-to-happen or not possible
(e.g. older operating systems) we can gather the equivalent property list ourselves with our own NSCoder.

WKKeyedCoder fills that role. It accumulates the key/value pairs encoded into an NSDictionary which
is then treated by the CoreIPC machinery as equivalent to a WebKit secure coding property list.

On the decode side, once validated like other WebKit property lists, it is used to recreate the object.

I chose a very simple first class to use this feature on - AVOutputContext and its (2) NSString members.
As we apply this strategy to more advanced classes we will also flesh out WKKeyedCoder&apos;s feature set.

* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Scripts/generate-serializers.py:
(SerializedType.__init__):
(generate_webkit_secure_coding_impl):
(generate_webkit_secure_coding_impl.is):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h:
* Source/WebKit/Scripts/webkit/tests/GeneratedWebKitSecureCoding.cpp:
(WebKit::dictionaryForWebKitSecureCodingType):
(WebKit::CoreIPCAVOutputContext::CoreIPCAVOutputContext):
(WebKit::CoreIPCAVOutputContext::isValidDictionary):
(WebKit::CoreIPCAVOutputContext::toID const):
* Source/WebKit/Scripts/webkit/tests/GeneratedWebKitSecureCoding.h:
(WebKit::CoreIPCAVOutputContext::CoreIPCAVOutputContext):
* Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp:
(WebKit::allSerializedTypes):
* Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in:
* Source/WebKit/Scripts/webkit/tests/WebKitPlatformGeneratedSerializers.cpp:
(IPC::ArgumentCoder&lt;WebKit::CoreIPCAVOutputContext&gt;::encode):
(IPC::ArgumentCoder&lt;WebKit::CoreIPCAVOutputContext&gt;::decode):
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h:
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm:
(IPC::getClass&lt;AVOutputContext&gt;):
(IPC::typeFromObject):
* Source/WebKit/Shared/Cocoa/CoreIPCAVOutputContext.serialization.in: Added.
* Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h:
* Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm:
(WebKit::valueFromID):
* Source/WebKit/Shared/Cocoa/WKKeyedCoder.h: Added.
* Source/WebKit/Shared/Cocoa/WKKeyedCoder.mm: Added.
(-[WKKeyedCoder init]):
(-[WKKeyedCoder initWithDictionary:]):
(-[WKKeyedCoder allowsKeyedCoding]):
(-[WKKeyedCoder encodeObject:forKey:]):
(-[WKKeyedCoder containsValueForKey:]):
(-[WKKeyedCoder decodeObjectOfClass:forKey:]):
(-[WKKeyedCoder decodeObjectForKey:]):
(-[WKKeyedCoder accumulatedDictionary]):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/271664@main">https://commits.webkit.org/271664@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fce7a2689d9c56a047599946ac9391e0a28cc45e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29170 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7839 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30506 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31757 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26529 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29766 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9982 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5144 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26534 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29442 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/6497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24990 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5607 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/29323 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/5747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26026 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33094 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/26643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26459 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31973 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5712 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3892 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29757 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7387 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6961 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6223 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/6233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->