### PR TITLE
Move HistoryController ownership from FrameLoader to Frame

### DIFF
--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -322,7 +322,6 @@ FrameLoader::FrameLoader(LocalFrame& frame, UniqueRef<LocalFrameLoaderClient>&& 
     : m_frame(frame)
     , m_client(WTFMove(client))
     , m_policyChecker(makeUnique<PolicyChecker>(frame))
-    , m_history(makeUnique<HistoryController>(frame))
     , m_notifier(frame)
     , m_subframeLoader(makeUnique<SubframeLoader>(frame))
     , m_state(FrameState::Provisional)
@@ -4555,6 +4554,11 @@ RefPtr<DocumentLoader> FrameLoader::protectedDocumentLoader() const
 RefPtr<DocumentLoader> FrameLoader::protectedProvisionalDocumentLoader() const
 {
     return m_provisionalDocumentLoader;
+}
+
+HistoryController& FrameLoader::history() const
+{
+    return m_frame->history();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -116,7 +116,7 @@ public:
     class PolicyChecker;
     PolicyChecker& policyChecker() const { return *m_policyChecker; }
 
-    HistoryController& history() const { return *m_history; }
+    WEBCORE_EXPORT HistoryController& history() const;
     ResourceLoadNotifier& notifier() const { return m_notifier; }
 
     class SubframeLoader;
@@ -451,7 +451,6 @@ private:
     UniqueRef<LocalFrameLoaderClient> m_client;
 
     const std::unique_ptr<PolicyChecker> m_policyChecker;
-    const std::unique_ptr<HistoryController> m_history;
     mutable ResourceLoadNotifier m_notifier;
     const std::unique_ptr<SubframeLoader> m_subframeLoader;
     mutable FrameLoaderStateMachine m_stateMachine;

--- a/Source/WebCore/loader/HistoryController.h
+++ b/Source/WebCore/loader/HistoryController.h
@@ -48,7 +48,7 @@ class HistoryController {
 public:
     enum HistoryUpdateType { UpdateAll, UpdateAllExceptBackForwardList };
 
-    explicit HistoryController(LocalFrame&);
+    explicit HistoryController(Frame&);
     ~HistoryController();
 
     WEBCORE_EXPORT void saveScrollPositionAndViewStateToItem(HistoryItem*);
@@ -98,7 +98,7 @@ private:
 
     void initializeItem(HistoryItem&);
     Ref<HistoryItem> createItem(HistoryItemClient&);
-    Ref<HistoryItem> createItemTree(HistoryItemClient&, LocalFrame& targetFrame, bool clipAtTarget);
+    Ref<HistoryItem> createItemTree(HistoryItemClient&, Frame& targetFrame, bool clipAtTarget);
 
     void recursiveSetProvisionalItem(HistoryItem&, HistoryItem*);
     void recursiveGoToItem(HistoryItem&, HistoryItem*, FrameLoadType, ShouldTreatAsContinuingLoad);
@@ -111,7 +111,7 @@ private:
     void updateBackForwardListClippedAtTarget(bool doClip);
     void updateCurrentItem();
 
-    LocalFrame& m_frame;
+    Frame& m_frame;
 
     RefPtr<HistoryItem> m_currentItem;
     RefPtr<HistoryItem> m_previousItem;

--- a/Source/WebCore/page/Frame.cpp
+++ b/Source/WebCore/page/Frame.cpp
@@ -27,6 +27,7 @@
 #include "Frame.h"
 
 #include "HTMLFrameOwnerElement.h"
+#include "HistoryController.h"
 #include "NavigationScheduler.h"
 #include "Page.h"
 #include "RemoteFrame.h"
@@ -45,6 +46,7 @@ Frame::Frame(Page& page, FrameIdentifier frameID, FrameType frameType, HTMLFrame
     , m_settings(page.settings())
     , m_frameType(frameType)
     , m_navigationScheduler(makeUniqueRef<NavigationScheduler>(*this))
+    , m_history(makeUniqueRef<HistoryController>(*this))
 {
     if (parent)
         parent->tree().appendChild(*this);

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -40,6 +40,7 @@ class DOMWindow;
 class FrameView;
 class FrameLoadRequest;
 class HTMLFrameOwnerElement;
+class HistoryController;
 class NavigationScheduler;
 class Page;
 class RenderWidget;
@@ -66,6 +67,7 @@ public:
     WEBCORE_EXPORT std::optional<PageIdentifier> pageID() const;
     Settings& settings() const { return m_settings.get(); }
     Frame& mainFrame() const { return m_mainFrame.get(); }
+    HistoryController& history() { return m_history.get(); }
     bool isMainFrame() const { return this == m_mainFrame.ptr(); }
     WEBCORE_EXPORT bool isRootFrame() const;
 
@@ -111,6 +113,7 @@ private:
     const Ref<Settings> m_settings;
     FrameType m_frameType;
     mutable UniqueRef<NavigationScheduler> m_navigationScheduler;
+    mutable UniqueRef<HistoryController> m_history;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### ced15ca50f998e138d02513b54bfaa89098c7536
<pre>
Move HistoryController ownership from FrameLoader to Frame
<a href="https://bugs.webkit.org/show_bug.cgi?id=265973">https://bugs.webkit.org/show_bug.cgi?id=265973</a>
<a href="https://rdar.apple.com/119281064">rdar://119281064</a>

Reviewed by NOBODY (OOPS!).

LocalFrame and FrameLoader have the same lifetime, so this doesn&apos;t change behavior.
This makes it so that RemoteFrames can have a HistoryController.

* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::FrameLoader):
(WebCore::FrameLoader::history const):
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::HistoryController):
(WebCore::HistoryController::saveScrollPositionAndViewStateToItem):
(WebCore::HistoryController::restoreScrollPositionAndViewState):
(WebCore::HistoryController::saveDocumentState):
(WebCore::HistoryController::restoreDocumentState):
(WebCore::HistoryController::invalidateCurrentItemCachedPage):
(WebCore::HistoryController::goToItem):
(WebCore::HistoryController::updateForBackForwardNavigation):
(WebCore::HistoryController::updateForReload):
(WebCore::HistoryController::updateForStandardLoad):
(WebCore::HistoryController::updateForRedirectWithLockedBackForwardList):
(WebCore::HistoryController::updateForClientRedirect):
(WebCore::HistoryController::updateForCommit):
(WebCore::HistoryController::recursiveUpdateForCommit):
(WebCore::HistoryController::updateForSameDocumentNavigation):
(WebCore::HistoryController::initializeItem):
(WebCore::HistoryController::createItemTree):
(WebCore::HistoryController::recursiveGoToItem):
(WebCore::HistoryController::updateBackForwardListClippedAtTarget):
(WebCore::HistoryController::updateCurrentItem):
(WebCore::HistoryController::pushState):
(WebCore::HistoryController::replaceState):
* Source/WebCore/loader/HistoryController.h:
* Source/WebCore/page/Frame.cpp:
(WebCore::Frame::Frame):
* Source/WebCore/page/Frame.h:
(WebCore::Frame::history):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ced15ca50f998e138d02513b54bfaa89098c7536

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29138 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7807 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30476 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31733 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26512 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29734 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9936 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5113 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26517 "Found 57 new test failures: fast/history/form-submit-in-frame-via-onclick.html, fast/history/form-submit-in-frame.html, fast/history/history-back-forward-within-subframe-hash.html, fast/history/history-back-twice-with-subframes-assert.html, fast/history/history-subframe-with-name.html, fast/loader/frame-src-change-added-to-history.html, fast/loader/navigate-with-post-to-new-target-after-back-forward-navigation.html, fast/loader/remove-iframe-during-history-navigation-different.html, http/tests/misc/resource-timing-navigation-in-restored-iframe-2.html, http/tests/navigation/forward-and-cancel.html ... (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29410 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6447 "Found 9 new test failures: fast/forms/state-restore-broken-state.html, fast/history/history-back-forward-within-subframe-hash.html, fast/history/history-back-twice-with-subframes-assert.html, fast/history/saves-state-after-frame-nav.html, fast/loader/navigate-with-post-to-new-target-after-back-forward-navigation.html, fast/loader/remove-iframe-during-history-navigation-different.html, http/tests/misc/resource-timing-navigation-in-restored-iframe-2.html, http/tests/navigation/post-frames.html, http/tests/navigation/postredirect-frames.html (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24977 "Found 6 new API test failures: TestWebKitAPI.SOAuthorizationSubFrame.InterceptionErrorMessageOrder, TestWebKitAPI.SOAuthorizationSubFrame.InterceptionSucceedWithOtherHttpStatusCode, TestWebKitAPI.SiteIsolation.ShutDownFrameProcessesAfterNavigation, TestWebKitAPI.SiteIsolation.NavigationWithIFrames, TestWebKitAPI.SOAuthorizationSubFrame.InterceptionCancel, TestWebKitAPI.SOAuthorizationSubFrame.InterceptionError (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5586 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5715 "Found 60 new test failures: imported/w3c/web-platform-tests/content-security-policy/inheritance/iframe-srcdoc-history-inheritance.html, imported/w3c/web-platform-tests/content-security-policy/script-src/worker-data-set-timeout.sub.html, imported/w3c/web-platform-tests/content-security-policy/worker-src/shared-child.sub.html, imported/w3c/web-platform-tests/content-security-policy/worker-src/shared-fallback.sub.html, imported/w3c/web-platform-tests/content-security-policy/worker-src/shared-list.sub.html, imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-animation-and-scroll.html, imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-below-viewport-partially-onscreen-new.html, imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-below-viewport-partially-onscreen-old.html, imported/w3c/web-platform-tests/css/css-will-change/parsing/will-change-computed.html, imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-allowed-for-all.https.sub.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25997 "Found 60 new test failures: compositing/repaint/become-overlay-composited-layer.html, fast/forms/state-restore-broken-state.html, fast/frames/frame-navigation.html, fast/history/form-submit-in-frame-via-onclick.html, fast/history/form-submit-in-frame.html, fast/history/history-back-forward-within-subframe-hash.html, fast/history/history-back-twice-with-subframes-assert.html, fast/history/history-back-within-subframe-hash.html, fast/history/history-subframe-with-name.html, fast/history/saves-state-after-frame-nav.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33072 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26601 "Found 6 new API test failures: TestWebKitAPI.SOAuthorizationSubFrame.InterceptionErrorMessageOrder, TestWebKitAPI.SOAuthorizationSubFrame.InterceptionSucceedWithOtherHttpStatusCode, TestWebKitAPI.SiteIsolation.ShutDownFrameProcessesAfterNavigation, TestWebKitAPI.SiteIsolation.NavigationWithIFrames, TestWebKitAPI.SOAuthorizationSubFrame.InterceptionCancel, TestWebKitAPI.SOAuthorizationSubFrame.InterceptionError (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26431 "Found 60 new test failures: compositing/clipping/border-radius-async-overflow-non-stacking.html, fast/forms/state-restore-broken-state.html, fast/history/form-submit-in-frame-via-onclick.html, fast/history/form-submit-in-frame.html, fast/history/history-back-forward-within-subframe-hash.html, fast/history/history-back-twice-with-subframes-assert.html, fast/history/history-back-within-subframe-hash.html, fast/history/history-subframe-with-name.html, fast/history/saves-state-after-frame-nav.html, fast/loader/frame-src-change-added-to-history.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31958 "Found 54 new test failures: fast/forms/state-restore-broken-state.html, fast/history/form-submit-in-frame-via-onclick.html, fast/history/form-submit-in-frame.html, fast/history/history-back-forward-within-subframe-hash.html, fast/history/history-back-twice-with-subframes-assert.html, fast/history/history-subframe-with-name.html, fast/loader/frame-src-change-added-to-history.html, fast/loader/navigate-with-post-to-new-target-after-back-forward-navigation.html, fast/loader/remove-iframe-during-history-navigation-different.html, http/tests/misc/resource-timing-navigation-in-restored-iframe-2.html ... (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5697 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3868 "Found 60 new test failures: animations/stop-animation-on-suspend.html, compositing/layer-creation/scale-rotation-animation-overlap.html, fast/css/aspect-ratio-min-height-replaced.html, fast/forms/state-restore-broken-state.html, fast/history/form-submit-in-frame-via-onclick.html, fast/history/form-submit-in-frame.html, fast/history/history-back-forward-within-subframe-hash.html, fast/history/history-back-twice-with-subframes-assert.html, fast/history/history-back-within-subframe-hash.html, fast/history/history-subframe-with-name.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29743 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7366 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6205 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6218 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->