### PR TITLE
Address post landing review feedback about 271644@main

### DIFF
--- a/Source/WebKit/Shared/ContextMenuContextData.cpp
+++ b/Source/WebKit/Shared/ContextMenuContextData.cpp
@@ -132,8 +132,7 @@ std::optional<ShareableBitmap::Handle> ContextMenuContextData::createPotentialQR
 
 #endif // ENABLE(CONTEXT_MENU_QR_CODE_DETECTION)
 
-ContextMenuContextData ContextMenuContextData::fromIPC(
-    WebCore::ContextMenuContext::Type type
+ContextMenuContextData::ContextMenuContextData(WebCore::ContextMenuContext::Type type
     , WebCore::IntPoint&& menuLocation
     , Vector<WebContextMenuItemData>&& menuItems
     , std::optional<WebKit::WebHitTestResultData>&& webHitTestResultData
@@ -153,35 +152,34 @@ ContextMenuContextData ContextMenuContextData::fromIPC(
     , std::optional<WebKit::ShareableBitmapHandle>&& potentialQRCodeViewportSnapshotImageHandle
 #endif // ENABLE(CONTEXT_MENU_QR_CODE_DETECTION)
     , bool hasEntireImage
-) {
-    ContextMenuContextData result;
-    result.m_type = type;
-    result.m_menuLocation = WTFMove(menuLocation);
-    result.m_menuItems = WTFMove(menuItems);
-    result.m_webHitTestResultData = WTFMove(webHitTestResultData);
-    result.m_selectedText = WTFMove(selectedText);
-    result.m_hasEntireImage = hasEntireImage;
-
+)
+    : m_type(type)
+    , m_menuLocation(WTFMove(menuLocation))
+    , m_menuItems(WTFMove(menuItems))
+    , m_webHitTestResultData(WTFMove(webHitTestResultData))
+    , m_selectedText(WTFMove(selectedText))
+    , m_hasEntireImage(hasEntireImage)
+#if ENABLE(SERVICE_CONTROLS)
+    , m_controlledSelectionData(WTFMove(controlledSelectionData))
+    , m_selectedTelephoneNumbers(WTFMove(selectedTelephoneNumbers))
+    , m_selectionIsEditable(selectionIsEditable)
+    , m_controlledImageBounds(WTFMove(controlledImageBounds))
+    , m_controlledImageAttachmentID(WTFMove(controlledImageAttachmentID))
+    , m_controlledImageElementContext(WTFMove(controlledImageElementContext))
+    , m_controlledImageMIMEType(WTFMove(controlledImageMIMEType))
+#endif
+{
 #if ENABLE(SERVICE_CONTROLS)
     if (controlledImageHandle)
-        result.m_controlledImage = ShareableBitmap::create(WTFMove(*controlledImageHandle), SharedMemory::Protection::ReadOnly);
-    result.m_controlledSelectionData = WTFMove(controlledSelectionData);
-    result.m_selectedTelephoneNumbers = WTFMove(selectedTelephoneNumbers);
-    result.m_selectionIsEditable = selectionIsEditable;
-    result.m_controlledImageBounds = WTFMove(controlledImageBounds);
-    result.m_controlledImageAttachmentID = WTFMove(controlledImageAttachmentID);
-    result.m_controlledImageElementContext = WTFMove(controlledImageElementContext);
-    result.m_controlledImageMIMEType = WTFMove(controlledImageMIMEType);
+        m_controlledImage = ShareableBitmap::create(WTFMove(*controlledImageHandle), SharedMemory::Protection::ReadOnly);
 #endif // ENABLE(SERVICE_CONTROLS)
 
 #if ENABLE(CONTEXT_MENU_QR_CODE_DETECTION)
     if (potentialQRCodeNodeSnapshotImageHandle)
-        result.m_potentialQRCodeNodeSnapshotImage = ShareableBitmap::create(WTFMove(*potentialQRCodeNodeSnapshotImageHandle), SharedMemory::Protection::ReadOnly);
+        m_potentialQRCodeNodeSnapshotImage = ShareableBitmap::create(WTFMove(*potentialQRCodeNodeSnapshotImageHandle), SharedMemory::Protection::ReadOnly);
     if (potentialQRCodeViewportSnapshotImageHandle)
-        result.m_potentialQRCodeViewportSnapshotImage = ShareableBitmap::create(WTFMove(*potentialQRCodeViewportSnapshotImageHandle), SharedMemory::Protection::ReadOnly);
+        m_potentialQRCodeViewportSnapshotImage = ShareableBitmap::create(WTFMove(*potentialQRCodeViewportSnapshotImageHandle), SharedMemory::Protection::ReadOnly);
 #endif
-
-    return result;
 }
 
 #if ENABLE(SERVICE_CONTROLS)

--- a/Source/WebKit/Shared/ContextMenuContextData.h
+++ b/Source/WebKit/Shared/ContextMenuContextData.h
@@ -48,8 +48,7 @@ public:
     ContextMenuContextData();
     ContextMenuContextData(const WebCore::IntPoint& menuLocation, const Vector<WebKit::WebContextMenuItemData>& menuItems, const WebCore::ContextMenuContext&);
 
-    static ContextMenuContextData fromIPC(
-        WebCore::ContextMenuContext::Type
+    ContextMenuContextData(WebCore::ContextMenuContext::Type
         , WebCore::IntPoint&& menuLocation
         , Vector<WebContextMenuItemData>&& menuItems
         , std::optional<WebKit::WebHitTestResultData>&&

--- a/Source/WebKit/Shared/ContextMenuContextData.serialization.in
+++ b/Source/WebKit/Shared/ContextMenuContextData.serialization.in
@@ -22,7 +22,7 @@
 
 #if ENABLE(CONTEXT_MENUS)
 
-[CreateUsing=fromIPC] class WebKit::ContextMenuContextData {
+class WebKit::ContextMenuContextData {
     WebCore::ContextMenuContext::Type type();
     WebCore::IntPoint menuLocation();
     Vector<WebKit::WebContextMenuItemData> menuItems();


### PR DESCRIPTION
#### 6685cecb32b0d340cd84ce62335b7ca2f685d3a3
<pre>
Address post landing review feedback about 271644@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=265976">https://bugs.webkit.org/show_bug.cgi?id=265976</a>

Reviewed by Alex Christensen.

Address post landing review feedback from Alex about 271644@main. Use a
ContextMenuContextData constructor on deserialization from IPC instead
of a fromIPC() static function.

* Source/WebKit/Shared/ContextMenuContextData.h:
* Source/WebKit/Shared/ContextMenuContextData.serialization.in:

Canonical link: <a href="https://commits.webkit.org/271658@main">https://commits.webkit.org/271658@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92cede4bae4f13d390556610c89cd278650dc251

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29151 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7819 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30487 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31741 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/26519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9948 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5125 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29423 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6459 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24976 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5591 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/5722 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33080 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26613 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26443 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/31968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/5704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3876 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/29753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7374 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6956 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6212 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/6225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->