### PR TITLE
Optimize the creation of WeakPtrs for many object types

### DIFF
--- a/Source/WTF/wtf/WeakHashMap.h
+++ b/Source/WTF/wtf/WeakHashMap.h
@@ -375,9 +375,8 @@ private:
     template <typename T>
     static WeakPtrImpl* keyImplIfExists(const T& key)
     {
-        auto& weakPtrImpl = key.weakPtrFactory().m_impl;
-        if (auto* pointer = weakPtrImpl.pointer(); pointer && *pointer)
-            return pointer;
+        if (auto* impl = key.weakPtrFactory().impl(); impl && *impl)
+            return impl;
         return nullptr;
     }
 

--- a/Source/WTF/wtf/WeakHashSet.h
+++ b/Source/WTF/wtf/WeakHashSet.h
@@ -98,8 +98,8 @@ public:
     const_iterator find(const U& value) const
     {
         increaseOperationCountSinceLastCleanup();
-        if (auto* pointer = value.weakPtrFactory().m_impl.pointer(); pointer && *pointer)
-            return WeakHashSetConstIterator(*this, m_set.find(pointer));
+        if (auto* impl = value.weakPtrFactory().impl(); impl && *impl)
+            return WeakHashSetConstIterator(*this, m_set.find(impl));
         return end();
     }
 
@@ -122,8 +122,8 @@ public:
     bool remove(const U& value)
     {
         amortizedCleanupIfNeeded();
-        if (auto* pointer = value.weakPtrFactory().m_impl.pointer(); pointer && *pointer)
-            return m_set.remove(*pointer);
+        if (auto* impl = value.weakPtrFactory().impl(); impl && *impl)
+            return m_set.remove(*impl);
         return false;
     }
 
@@ -144,8 +144,8 @@ public:
     bool contains(const U& value) const
     {
         increaseOperationCountSinceLastCleanup();
-        if (auto* pointer = value.weakPtrFactory().m_impl.pointer(); pointer && *pointer)
-            return m_set.contains(*pointer);
+        if (auto* impl = value.weakPtrFactory().impl(); impl && *impl)
+            return m_set.contains(*impl);
         return false;
     }
 

--- a/Source/WTF/wtf/WeakListHashSet.h
+++ b/Source/WTF/wtf/WeakListHashSet.h
@@ -172,9 +172,8 @@ public:
     iterator find(const U& value)
     {
         increaseOperationCountSinceLastCleanup();
-        auto& weakPtrImpl = value.weakPtrFactory().m_impl;
-        if (auto* pointer = weakPtrImpl.pointer(); pointer && *pointer)
-            return WeakListHashSetIterator(*this, m_set.find(*pointer));
+        if (auto* impl = value.weakPtrFactory().impl(); impl && *impl)
+            return WeakListHashSetIterator(*this, m_set.find(*impl));
         return end();
     }
 
@@ -182,9 +181,8 @@ public:
     const_iterator find(const U& value) const
     {
         increaseOperationCountSinceLastCleanup();
-        auto& weakPtrImpl = value.weakPtrFactory().m_impl;
-        if (auto* pointer = weakPtrImpl.pointer(); pointer && *pointer)
-            return WeakListHashSetConstIterator(*this, m_set.find(*pointer));
+        if (auto* impl = value.weakPtrFactory().impl(); impl && *impl)
+            return WeakListHashSetConstIterator(*this, m_set.find(*impl));
         return end();
     }
 
@@ -192,9 +190,8 @@ public:
     bool contains(const U& value) const
     {
         increaseOperationCountSinceLastCleanup();
-        auto& weakPtrImpl = value.weakPtrFactory().m_impl;
-        if (auto* pointer = weakPtrImpl.pointer(); pointer && *pointer)
-            return m_set.contains(*pointer);
+        if (auto* impl = value.weakPtrFactory().impl(); impl && *impl)
+            return m_set.contains(*impl);
         return false;
     }
 
@@ -245,9 +242,8 @@ public:
     bool remove(const U& value)
     {
         amortizedCleanupIfNeeded();
-        auto& weakPtrImpl = value.weakPtrFactory().m_impl;
-        if (auto* pointer = weakPtrImpl.pointer(); pointer && *pointer)
-            return m_set.remove(*pointer);
+        if (auto* impl = value.weakPtrFactory().impl(); impl && *impl)
+            return m_set.remove(*impl);
         return false;
     }
 

--- a/Source/WTF/wtf/WeakRef.h
+++ b/Source/WTF/wtf/WeakRef.h
@@ -86,7 +86,7 @@ private:
     template<typename U> static WeakPtrImpl& implForObject(const U& object)
     {
         object.weakPtrFactory().initializeIfNeeded(object);
-        return *object.weakPtrFactory().m_impl.pointer();
+        return *object.weakPtrFactory().impl();
     }
 
     Ref<WeakPtrImpl> m_impl;

--- a/Source/WebCore/dom/EventTarget.cpp
+++ b/Source/WebCore/dom/EventTarget.cpp
@@ -58,7 +58,7 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(EventTarget);
 
-struct SameSizeAsEventTarget : ScriptWrappable, CanMakeWeakPtr<EventTarget, WeakPtrFactoryInitialization::Lazy, WeakPtrImplWithEventTargetData>, CanMakeCheckedPtr {
+struct SameSizeAsEventTarget : ScriptWrappable, CanMakeWeakPtrWithBitField<EventTarget, WeakPtrFactoryInitialization::Lazy, WeakPtrImplWithEventTargetData>, CanMakeCheckedPtr {
     virtual ~SameSizeAsEventTarget() = default; // Allocate vtable pointer.
 };
 

--- a/Source/WebCore/dom/EventTarget.h
+++ b/Source/WebCore/dom/EventTarget.h
@@ -79,7 +79,7 @@ private:
     EventTargetData m_eventTargetData;
 };
 
-class EventTarget : public ScriptWrappable, public CanMakeWeakPtr<EventTarget, WeakPtrFactoryInitialization::Lazy, WeakPtrImplWithEventTargetData>, public CanMakeCheckedPtr {
+class EventTarget : public ScriptWrappable, public CanMakeWeakPtrWithBitField<EventTarget, WeakPtrFactoryInitialization::Lazy, WeakPtrImplWithEventTargetData>, public CanMakeCheckedPtr {
     WTF_MAKE_ISO_ALLOCATED(EventTarget);
 public:
     static Ref<EventTarget> create(ScriptExecutionContext&);


### PR DESCRIPTION
#### 0ea98bdecabcba02abd3154aef5a17d11f35d9ca
<pre>
Optimize the creation of WeakPtrs for many object types
<a href="https://bugs.webkit.org/show_bug.cgi?id=265981">https://bugs.webkit.org/show_bug.cgi?id=265981</a>

Reviewed by Darin Adler.

The performance of WeakPtrs is increasingly important as we adopt it
more and more in our code base. As I am working to use WeakPtr more
in rendering code, I noticed that the construction of WeakPtr was
impact by the fact that WeakPtrFactory was using a data member of
type `CompactRefPtrTuple&lt;WeakPtrImpl, uint16_t&gt;` to store a
packed WeakPtrImpl pointer in order to free up space for a bitfield.
This means that every time we want to construct a WeakPtr from an
object, the WeakPtrFactory has to extract the WeakPtrImpl pointer
from the CompactRefPtrTuple, which can be costly, especially in
Intel hardware.

The only type actually leveraging the WeakPtrFactory&apos;s bit field
is EventTarget. All the other classes (like RenderObject) are just
paying this cost without actually getting any benefit from the
pointer packing.

To address the issue, I renamed WeakPtrFactory to
WeakPtrFactoryWithBitField and had EventTarget use this one
instead. I introduced a simpler WeakPtrFactory which is using a
straight `RefPtr&lt;WeakPtrImpl&gt;` instead, which every other type
is now using.

Based on my A/B testing, this should allow us to replace
CheckedPtr / CheckedRef with WeakPtr / WeakRef in rendering code
without regressing our benchmarks.

* Source/WTF/wtf/WeakHashMap.h:
* Source/WTF/wtf/WeakHashSet.h:
* Source/WTF/wtf/WeakListHashSet.h:
* Source/WTF/wtf/WeakPtr.h:
(WTF::WeakPtr::implForObject):
(WTF::WeakPtrFactory::~WeakPtrFactory):
(WTF::WeakPtrFactory::impl const):
(WTF::WeakPtrFactory::initializeIfNeeded const):
(WTF::WeakPtrFactory::createWeakPtr const):
(WTF::WeakPtrFactory::revokeAll):
(WTF::WeakPtrFactory::weakPtrCount const):
(WTF::WeakPtrFactory::isInitialized const):
(WTF::WeakPtrFactoryWithBitField::WeakPtrFactoryWithBitField):
(WTF::WeakPtrFactoryWithBitField::~WeakPtrFactoryWithBitField):
(WTF::WeakPtrFactoryWithBitField::impl const):
(WTF::CanMakeWeakPtrBase::weakPtrFactory const):
(WTF::CanMakeWeakPtrBase::weakPtrFactory):
(WTF::CanMakeWeakPtrBase::CanMakeWeakPtrBase):
(WTF::CanMakeWeakPtrBase::operator=):
(WTF::CanMakeWeakPtrBase::initializeWeakPtrFactory):
(WTF::WeakPtrFactory::impl): Deleted.
(WTF::WeakPtrFactory::bitfield const): Deleted.
(WTF::WeakPtrFactory::setBitfield const): Deleted.
(WTF::CanMakeWeakPtr::weakPtrFactory const): Deleted.
(WTF::CanMakeWeakPtr::weakPtrFactory): Deleted.
(WTF::CanMakeWeakPtr::CanMakeWeakPtr): Deleted.
(WTF::CanMakeWeakPtr::operator=): Deleted.
(WTF::CanMakeWeakPtr::initializeWeakPtrFactory): Deleted.
* Source/WTF/wtf/WeakRef.h:
(WTF::WeakRef::implForObject):
* Source/WebCore/dom/EventTarget.h:

Canonical link: <a href="https://commits.webkit.org/271701@main">https://commits.webkit.org/271701@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/064136f2d3247f110c4c4a1327be271f3675299b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29175 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7844 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30512 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31762 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26534 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29771 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/9976 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5149 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26539 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29447 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6490 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24997 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5611 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5741 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26033 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33099 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/25165 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26637 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26467 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31977 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/29485 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5717 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3897 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29762 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7394 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/35781 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6228 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7715 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3771 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6239 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->