### PR TITLE
[GTK][WPE] Random incorrect image displayed as the background of a div

### DIFF
--- a/Source/WebCore/platform/graphics/cairo/CairoUtilities.cpp
+++ b/Source/WebCore/platform/graphics/cairo/CairoUtilities.cpp
@@ -38,6 +38,7 @@
 #include "RefPtrCairo.h"
 #include "Region.h"
 #include <wtf/Assertions.h>
+#include <wtf/Atomics.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/UniqueArray.h>
 #include <wtf/Vector.h>
@@ -47,6 +48,9 @@
 #endif
 
 namespace WebCore {
+
+static cairo_user_data_key_t s_surfaceUniqueIDKey;
+static Atomic<uintptr_t> s_surfaceUniqueID = 1;
 
 #if USE(FREETYPE)
 RecursiveLock& cairoFontLock()
@@ -411,6 +415,16 @@ RefPtr<cairo_region_t> toCairoRegion(const Region& region)
 cairo_matrix_t toCairoMatrix(const AffineTransform& transform)
 {
     return cairo_matrix_t { transform.a(), transform.b(), transform.c(), transform.d(), transform.e(), transform.f() };
+}
+
+void attachSurfaceUniqueID(cairo_surface_t* surface)
+{
+    cairo_surface_set_user_data(surface, &s_surfaceUniqueIDKey, reinterpret_cast<void*>(s_surfaceUniqueID.exchangeAdd(1)), nullptr);
+}
+
+uintptr_t getSurfaceUniqueID(cairo_surface_t* surface)
+{
+    return reinterpret_cast<uintptr_t>(cairo_surface_get_user_data(surface, &s_surfaceUniqueIDKey));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/cairo/CairoUtilities.h
+++ b/Source/WebCore/platform/graphics/cairo/CairoUtilities.h
@@ -103,6 +103,9 @@ RefPtr<cairo_region_t> toCairoRegion(const Region&);
 
 cairo_matrix_t toCairoMatrix(const AffineTransform&);
 
+void attachSurfaceUniqueID(cairo_surface_t*);
+uintptr_t getSurfaceUniqueID(cairo_surface_t*);
+
 } // namespace WebCore
 
 #endif // USE(CAIRO)

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
@@ -26,6 +26,7 @@
 
 #if USE(COORDINATED_GRAPHICS)
 
+#include "CairoUtilities.h"
 #include "FloatQuad.h"
 #include "GraphicsContext.h"
 #include "GraphicsLayer.h"
@@ -892,7 +893,7 @@ void CoordinatedGraphicsLayer::flushCompositingStateForThisLayerOnly()
         ASSERT(m_compositedImage);
         auto& image = *m_compositedImage;
         uintptr_t imageID = reinterpret_cast<uintptr_t>(&image);
-        uintptr_t nativeImageID = reinterpret_cast<uintptr_t>(m_compositedNativeImage->platformImage().get());
+        uintptr_t nativeImageID = getSurfaceUniqueID(m_compositedNativeImage->platformImage().get());
 
         // Respawn the ImageBacking object if the underlying image changed.
         if (m_nicosia.imageBacking) {
@@ -910,7 +911,7 @@ void CoordinatedGraphicsLayer::flushCompositingStateForThisLayerOnly()
         auto& layerState = m_nicosia.imageBacking->layerState();
         layerState.imageID = imageID;
         layerState.update.isVisible = transformedVisibleRect().intersects(IntRect(contentsRect()));
-        if (layerState.update.isVisible && layerState.update.nativeImageID != nativeImageID) {
+        if (layerState.update.isVisible && (!nativeImageID || layerState.update.nativeImageID != nativeImageID)) {
             layerState.update.nativeImageID = nativeImageID;
             layerState.update.imageBackingStore = m_coordinator->imageBackingStore(nativeImageID,
                 [&] {

--- a/Source/WebCore/platform/image-decoders/cairo/ImageBackingStoreCairo.cpp
+++ b/Source/WebCore/platform/image-decoders/cairo/ImageBackingStoreCairo.cpp
@@ -24,6 +24,7 @@
  */
 
 #include "config.h"
+#include "CairoUtilities.h"
 #include "ImageBackingStore.h"
 
 #include <cairo.h>
@@ -41,6 +42,7 @@ PlatformImagePtr ImageBackingStore::image() const
         static_cast<DataSegment*>(data)->deref();
     });
 
+    attachSurfaceUniqueID(surface.get());
     return surface;
 }
 


### PR DESCRIPTION
#### fcd69249c4936e186feea896bdfe27d9be97faab
<pre>
[GTK][WPE] Random incorrect image displayed as the background of a div
<a href="https://bugs.webkit.org/show_bug.cgi?id=265990">https://bugs.webkit.org/show_bug.cgi?id=265990</a>

Reviewed by Žan Doberšek.

Add an unique ID to cairo surfaces created in ImageBackingStoreCairo. This unique ID allows us
to differentiate when the cairo surface that&apos;s backing an image has changed, so we are sure that
we&apos;re not using an incorrect value cached inside some ImageBackingStore.

* Source/WebCore/platform/graphics/cairo/CairoUtilities.cpp:
(WebCore::attachSurfaceUniqueID):
(WebCore::getSurfaceUniqueID):
* Source/WebCore/platform/graphics/cairo/CairoUtilities.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp:
(WebCore::CoordinatedGraphicsLayer::flushCompositingStateForThisLayerOnly):
* Source/WebCore/platform/image-decoders/cairo/ImageBackingStoreCairo.cpp:
(WebCore::ImageBackingStore::image const):

Canonical link: <a href="https://commits.webkit.org/272009@main">https://commits.webkit.org/272009@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6613130daef31917e9f71dfc367b2d9f7f49db4c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30278 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8948 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31756 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32784 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27396 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30977 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11145 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6184 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27384 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30585 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7526 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/26723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6436 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6595 "Passed tests") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34124 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27607 "Passed tests") | [⏳ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32786 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6549 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4731 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30594 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8299 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7187 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7308 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7078 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->