### PR TITLE
[CSS] Mark selector as implicit to ignore them in specificity calculation

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-specificity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-specificity-expected.txt
@@ -1,10 +1,10 @@
 
-FAIL @scope (#main) { .b {  } } assert_equals: unscoped + scoped expected "2" but got "1"
-FAIL @scope (#main) to (.b) { .a {  } } assert_equals: unscoped + scoped expected "2" but got "1"
-FAIL @scope (#main, .foo, .bar) { #a {  } } assert_equals: unscoped + scoped expected "2" but got "1"
-FAIL @scope (#main) { div.b {  } } assert_equals: unscoped + scoped expected "2" but got "1"
+PASS @scope (#main) { .b {  } }
+PASS @scope (#main) to (.b) { .a {  } }
+PASS @scope (#main, .foo, .bar) { #a {  } }
+PASS @scope (#main) { div.b {  } }
 PASS @scope (#main) { :scope .b {  } }
 PASS @scope (#main) { & .b {  } }
-FAIL @scope (#main) { div .b {  } } assert_equals: unscoped + scoped expected "2" but got "1"
-FAIL @scope (#main) { @scope (.a) { .b {  } } } assert_equals: unscoped + scoped expected "2" but got "1"
+PASS @scope (#main) { div .b {  } }
+PASS @scope (#main) { @scope (.a) { .b {  } } }
 

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -336,6 +336,10 @@ struct PossiblyQuotedIdentifier {
         bool isForPage() const { return m_isForPage; }
         void setForPage() { m_isForPage = true; }
 
+        void setImplicit() { m_isImplicit = true; }
+        // Implicit means that this selector is not author/UA written.
+        bool isImplicit() const { return m_isImplicit; }
+
     private:
         unsigned m_relation : 4 { static_cast<unsigned>(RelationType::DescendantSpace) }; // enum RelationType.
         mutable unsigned m_match : 5 { static_cast<unsigned>(Match::Unknown) }; // enum Match.
@@ -348,7 +352,8 @@ struct PossiblyQuotedIdentifier {
         unsigned m_isForPage : 1 { false };
         unsigned m_tagIsForNamespaceRule : 1 { false };
         unsigned m_caseInsensitiveAttributeValueMatching : 1 { false };
-        // 24 bits
+        unsigned m_isImplicit : 1 { false };
+        // 25 bits
 #if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
         unsigned m_destructorHasBeenCalled : 1 { false };
 #endif

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -1231,6 +1231,8 @@ RefPtr<StyleRuleBase> CSSParserImpl::consumeStyleRule(CSSParserTokenRange prelud
                 if (!selector->hasExplicitNestingParent() || selectorStartWithExplicitCombinator) {
                     auto nestingParentSelector = makeUnique<CSSParserSelector>();
                     nestingParentSelector->setMatch(CSSSelector::Match::NestingParent);
+                    // https://drafts.csswg.org/css-nesting/#nesting
+                    // Spec: nested rules with relative selectors include the specificity of their implied nesting selector.
                     selector->appendTagHistoryAsRelative(WTFMove(nestingParentSelector));
                 }
             // For a rule inside a scope rule, we had the implicit ":scope" if there is no explicit & or :scope already
@@ -1239,6 +1241,7 @@ RefPtr<StyleRuleBase> CSSParserImpl::consumeStyleRule(CSSParserTokenRange prelud
                     auto scopeSelector = makeUnique<CSSParserSelector>();
                     scopeSelector->setMatch(CSSSelector::Match::PseudoClass);
                     scopeSelector->setPseudoClassType(CSSSelector::PseudoClassType::Scope);
+                    scopeSelector->selector()->setImplicit();
                     selector->appendTagHistoryAsRelative(WTFMove(scopeSelector));
                 }
             }


### PR DESCRIPTION
#### dedf708653ff64d0743e6be773311fec317cd601
<pre>
[CSS] Mark selector as implicit to ignore them in specificity calculation
<a href="https://bugs.webkit.org/show_bug.cgi?id=265992">https://bugs.webkit.org/show_bug.cgi?id=265992</a>
<a href="https://rdar.apple.com/119307433">rdar://119307433</a>

Reviewed by Antti Koivisto.

We sometimes insert non author written selectors in the selector list
(for cases like `:has(&gt; foo)` or scoped or nested selectors).
We should not count those implicit selectors in the specificity calculation.

* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-specificity-expected.txt:
* Source/WebCore/css/CSSSelector.cpp:
(WebCore::SelectorSpecificity::specificityTuple const):
(WebCore::SelectorSpecificity::debugDescription const):
(WebCore::operator&lt;&lt;):
(WebCore::selectorSpecificity):
(WebCore::maxSpecificity):
(WebCore::simpleSelectorSpecificity):
(WebCore::CSSSelector::computeSpecificityTuple const):
(WebCore::CSSSelector::CSSSelector):
* Source/WebCore/css/CSSSelector.h:
(WebCore::CSSSelector::setImplicit):
(WebCore::CSSSelector::isImplicit const):
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::consumeStyleRule):

Canonical link: <a href="https://commits.webkit.org/271675@main">https://commits.webkit.org/271675@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20373b6188dab7bbc1787453f46962a483303ec1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29204 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7873 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30542 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31792 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26564 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29801 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10015 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5178 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26568 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29477 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6538 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25027 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5636 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5779 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26064 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33129 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26675 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26497 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32005 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5744 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3926 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29791 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7422 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6968 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6257 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6267 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->