### PR TITLE
Add visibility propagation for WebKit extension processes

### DIFF
--- a/Source/WebKit/Platform/spi/Cocoa/ExtensionKitSPI.h
+++ b/Source/WebKit/Platform/spi/Cocoa/ExtensionKitSPI.h
@@ -25,6 +25,8 @@
 
 #if USE(EXTENSIONKIT)
 
+@protocol UIInteraction;
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface _SEServiceConfiguration: NSObject
@@ -60,10 +62,12 @@ NS_REFINED_FOR_SWIFT
 
 NS_REFINED_FOR_SWIFT
 @interface _SEContentProcess: _SEExtensionProcess
+-(id<UIInteraction>)createVisibilityPropagationInteraction;
 @end
 
 NS_REFINED_FOR_SWIFT
 @interface _SEGPUProcess: _SEExtensionProcess
+-(id<UIInteraction>)createVisibilityPropagationInteraction;
 @end
 
 NS_REFINED_FOR_SWIFT


### PR DESCRIPTION
#### baab62554de5053810fa34fc9dbe06a50c9df8a5
<pre>
Add visibility propagation for WebKit extension processes
<a href="https://bugs.webkit.org/show_bug.cgi?id=265995">https://bugs.webkit.org/show_bug.cgi?id=265995</a>
<a href="https://rdar.apple.com/119313066">rdar://119313066</a>

Reviewed by Brent Fulgham.

Add visibility propagation for WebKit extension processes. This only applies to
the WebContent and GPU process.

* Source/WebKit/Platform/spi/Cocoa/ExtensionKitSPI.h:
* Source/WebKit/UIProcess/ios/WKContentView.mm:
(-[WKContentView _setupVisibilityPropagationViewForWebProcess]):
(-[WKContentView _setupVisibilityPropagationViewForGPUProcess]):
(-[WKContentView _removeVisibilityPropagationViewForWebProcess]):
(-[WKContentView _removeVisibilityPropagationViewForGPUProcess]):

Canonical link: <a href="https://commits.webkit.org/271697@main">https://commits.webkit.org/271697@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/86d80f083ee50ef3de58d2b204ee2bcb0f72fc41

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29206 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7875 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30544 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31794 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26565 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10017 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5180 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26569 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29479 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6539 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25032 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5637 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5780 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33131 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26676 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26503 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32003 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5745 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3929 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29789 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7424 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6258 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3767 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6268 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->