### PR TITLE
[macOS] Occasional crash when invoking the completion handler in WebKit::requestPayloadForQRCode

### DIFF
--- a/Source/WebKit/Platform/cocoa/ImageAnalysisUtilities.mm
+++ b/Source/WebKit/Platform/cocoa/ImageAnalysisUtilities.mm
@@ -407,6 +407,8 @@ void requestPayloadForQRCode(CGImageRef image, CompletionHandler<void(NSString *
 
         auto callCompletionOnMainRunLoopWithResult = [completion = WTFMove(completion)](NSString *result) mutable {
             callOnMainRunLoop([completion = WTFMove(completion), result = retainPtr(result)]() mutable {
+                if (!completion)
+                    return;
                 completion(result.get());
             });
         };


### PR DESCRIPTION
#### b2788c65e9c925f0484298df163aa2b7fee81ede
<pre>
[macOS] Occasional crash when invoking the completion handler in WebKit::requestPayloadForQRCode
<a href="https://bugs.webkit.org/show_bug.cgi?id=266000">https://bugs.webkit.org/show_bug.cgi?id=266000</a>
<a href="https://rdar.apple.com/117083360">rdar://117083360</a>

Reviewed by Aditya Keerthi.

This is a speculative fix for <a href="https://rdar.apple.com/117083360">rdar://117083360</a>, where (on certain version of macOS), Safari crashes
underneath this QR code detection codepath, due to the completion handler being invoked more than
once. While I wasn&apos;t able to reproduce the crash locally, forcing the completion handler to be
called twice was sufficient to replicate a crash under the same stack.

It&apos;s possible that Vision has a bug wherein `-[VNImageRequestHandler performRequests:error:]` yields
a non-null `NSError` for the error outparam, yet the `VNDetectBarcodesRequest`&apos;s completion handler
is still invoked (presumably, also with an `NSError`). <a href="https://rdar.apple.com/119319173">rdar://119319173</a> tracks further investigation
here.

* Source/WebKit/Platform/cocoa/ImageAnalysisUtilities.mm:
(WebKit::requestPayloadForQRCode):

Canonical link: <a href="https://commits.webkit.org/271695@main">https://commits.webkit.org/271695@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e2e09296af210e1933b9c0420f7a5213af1d562a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29273 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7943 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30612 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31853 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26612 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10083 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5246 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26613 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29546 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6603 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25067 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5687 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/5826 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33194 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26732 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26542 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32046 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5793 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3972 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29830 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7479 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6975 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6307 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6318 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->