### PR TITLE
Port Font::Attributes to the new IPC serialization format

### DIFF
--- a/Source/WebCore/platform/graphics/Font.cpp
+++ b/Source/WebCore/platform/graphics/Font.cpp
@@ -178,7 +178,7 @@ RenderingResourceIdentifier Font::renderingResourceIdentifier() const
     return m_attributes.ensureRenderingResourceIdentifier();
 }
 
-RenderingResourceIdentifier Font::Attributes::ensureRenderingResourceIdentifier() const
+RenderingResourceIdentifier FontInternalAttributes::ensureRenderingResourceIdentifier() const
 {
     if (!renderingResourceIdentifier)
         renderingResourceIdentifier = RenderingResourceIdentifier::generate();

--- a/Source/WebCore/platform/graphics/Font.h
+++ b/Source/WebCore/platform/graphics/Font.h
@@ -80,6 +80,16 @@ bool fontHasTable(CTFontRef, unsigned tableTag);
 bool fontHasEitherTable(CTFontRef, unsigned tableTag1, unsigned tableTag2);
 #endif
 
+struct FontInternalAttributes {
+    WEBCORE_EXPORT RenderingResourceIdentifier ensureRenderingResourceIdentifier() const;
+
+    mutable std::optional<RenderingResourceIdentifier> renderingResourceIdentifier;
+    FontOrigin origin : 1;
+    FontIsInterstitial isInterstitial : 1;
+    FontVisibility visibility : 1;
+    FontIsOrientationFallback isTextOrientationFallback : 1;
+};
+
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(Font);
 class Font : public RefCounted<Font>, public CanMakeWeakPtr<Font>, public CanMakeCheckedPtr {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Font);
@@ -219,16 +229,7 @@ public:
     void setIsUsedInSystemFallbackFontCache() { m_isUsedInSystemFallbackFontCache = true; }
     bool isUsedInSystemFallbackFontCache() const { return m_isUsedInSystemFallbackFontCache; }
 
-    class Attributes {
-    public:
-        WEBCORE_EXPORT RenderingResourceIdentifier ensureRenderingResourceIdentifier() const;
-
-        mutable std::optional<RenderingResourceIdentifier> renderingResourceIdentifier;
-        Font::Origin origin : 1;
-        Font::IsInterstitial isInterstitial : 1;
-        Font::Visibility visibility : 1;
-        Font::IsOrientationFallback isTextOrientationFallback : 1;
-    };
+    using Attributes = FontInternalAttributes;
     const Attributes& attributes() const { return m_attributes; }
 
     ColorGlyphType colorGlyphType(Glyph) const;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -289,45 +289,6 @@ std::optional<Ref<Font>> ArgumentCoder<Font>::decode(Decoder& decoder)
     return Font::create(*platformData, attributes->origin, attributes->isInterstitial, attributes->visibility, attributes->isTextOrientationFallback, attributes->renderingResourceIdentifier);
 }
 
-void ArgumentCoder<WebCore::Font::Attributes>::encode(Encoder& encoder, const WebCore::Font::Attributes& attributes)
-{
-    encoder << attributes.origin;
-    encoder << attributes.isInterstitial;
-    encoder << attributes.visibility;
-    encoder << attributes.isTextOrientationFallback;
-    encoder << attributes.ensureRenderingResourceIdentifier();
-}
-
-std::optional<Font::Attributes> ArgumentCoder<Font::Attributes>::decode(Decoder& decoder)
-{
-    std::optional<Font::Origin> origin;
-    decoder >> origin;
-    if (!origin)
-        return std::nullopt;
-
-    std::optional<Font::IsInterstitial> isInterstitial;
-    decoder >> isInterstitial;
-    if (!isInterstitial)
-        return std::nullopt;
-
-    std::optional<Font::Visibility> visibility;
-    decoder >> visibility;
-    if (!visibility)
-        return std::nullopt;
-
-    std::optional<Font::IsOrientationFallback> isTextOrientationFallback;
-    decoder >> isTextOrientationFallback;
-    if (!isTextOrientationFallback)
-        return std::nullopt;
-
-    std::optional<RenderingResourceIdentifier> renderingResourceIdentifier;
-    decoder >> renderingResourceIdentifier;
-    if (!renderingResourceIdentifier)
-        return std::nullopt;
-
-    return std::optional<Font::Attributes>({ renderingResourceIdentifier, origin.value(), isInterstitial.value(), visibility.value(), isTextOrientationFallback.value() });
-}
-
 void ArgumentCoder<WebCore::FontCustomPlatformData>::encode(Encoder& encoder, const WebCore::FontCustomPlatformData& customPlatformData)
 {
     std::optional<WebKit::SharedMemory::Handle> handle;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -164,11 +164,6 @@ template<> struct ArgumentCoder<WebCore::Font> {
     static std::optional<WebCore::FontPlatformData> decodePlatformData(Decoder&);
 };
 
-template<> struct ArgumentCoder<WebCore::Font::Attributes> {
-    static void encode(Encoder&, const WebCore::Font::Attributes&);
-    static std::optional<WebCore::Font::Attributes> decode(Decoder&);
-};
-
 template<> struct ArgumentCoder<WebCore::FontPlatformData::Attributes> {
     static void encode(Encoder&, const WebCore::FontPlatformData::Attributes&);
     static std::optional<WebCore::FontPlatformData::Attributes> decode(Decoder&);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6862,6 +6862,15 @@ enum class WebCore::SourceBufferAppendMode : uint8_t {
 
 #endif
 
+header: <WebCore/Font.h>
+[CustomHeader] struct WebCore::FontInternalAttributes {
+    std::optional<WebCore::RenderingResourceIdentifier> renderingResourceIdentifier;
+    [BitField] WebCore::FontOrigin origin;
+    [BitField] WebCore::FontIsInterstitial isInterstitial;
+    [BitField] WebCore::FontVisibility visibility;
+    [BitField] WebCore::FontIsOrientationFallback isTextOrientationFallback;
+};
+
 [CustomHeader, Nested] struct WebCore::Cursor::CustomCursorIPCData {
     Ref<WebCore::Image> image;
     [Validator='(*image)->rect().contains(*hotSpot)'] WebCore::IntPoint hotSpot;


### PR DESCRIPTION
#### ff2215743d202983f1eb966c1a60158480fd464c
<pre>
Port Font::Attributes to the new IPC serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=266002">https://bugs.webkit.org/show_bug.cgi?id=266002</a>

Reviewed by Brady Eidson.

* Source/WebCore/platform/graphics/Font.cpp:
(WebCore::FontInternalAttributes::ensureRenderingResourceIdentifier const):
(WebCore::Font::Attributes::ensureRenderingResourceIdentifier const): Deleted.
* Source/WebCore/platform/graphics/Font.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;WebCore::Font::Attributes&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;Font::Attributes&gt;::decode): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/271690@main">https://commits.webkit.org/271690@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce0354be0c36c1e9a37f9e8c0ed4b63e64779ba1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29232 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7903 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30572 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31820 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26588 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29830 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10091 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5207 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26592 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29505 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/6607 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25049 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5661 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/5829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26087 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33159 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/26737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26520 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32027 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5768 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3951 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29812 "Found 1 new API test failure: /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/service-worker-registrations (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7449 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6281 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3762 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6293 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->