### PR TITLE
Convert `DocumentMarker::MarkerType` into an enum class

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -5506,7 +5506,7 @@ void Document::textInserted(Node& text, unsigned offset, unsigned length)
 
 #if ENABLE(PLATFORM_DRIVEN_TEXT_CHECKING)
     // Freshly inserted text is expected to not inherit PlatformTextChecking markers.
-    m_markers->removeMarkers(text, { offset, offset + length }, DocumentMarker::PlatformTextChecking);
+    m_markers->removeMarkers(text, { offset, offset + length }, DocumentMarker::Type::PlatformTextChecking);
 #endif
 }
 

--- a/Source/WebCore/dom/DocumentMarker.h
+++ b/Source/WebCore/dom/DocumentMarker.h
@@ -38,7 +38,7 @@ namespace WebCore {
 // It optionally includes a description that could be displayed in the user interface.
 class DocumentMarker : public CanMakeWeakPtr<DocumentMarker> {
 public:
-    enum MarkerType {
+    enum class Type : uint16_t {
         Spelling = 1 << 0,
         Grammar = 1 << 1,
         TextMatch = 1 << 2,
@@ -84,7 +84,7 @@ public:
 #endif
     };
 
-    static constexpr OptionSet<MarkerType> allMarkers();
+    static constexpr OptionSet<Type> allMarkers();
 
     struct DictationData {
         DictationContext context;
@@ -110,9 +110,9 @@ public:
 #endif
     >;
 
-    DocumentMarker(MarkerType, OffsetRange, Data&& = { });
+    DocumentMarker(Type, OffsetRange, Data&& = { });
 
-    MarkerType type() const { return m_type; }
+    Type type() const { return m_type; }
     unsigned startOffset() const { return m_range.start; }
     unsigned endOffset() const { return m_range.end; }
 
@@ -128,40 +128,40 @@ public:
     void shiftOffsets(int delta);
 
 private:
-    MarkerType m_type;
+    Type m_type;
     OffsetRange m_range;
     Data m_data;
 };
 
-constexpr auto DocumentMarker::allMarkers() -> OptionSet<MarkerType>
+constexpr auto DocumentMarker::allMarkers() -> OptionSet<Type>
 {
     return {
-        AcceptedCandidate,
-        Autocorrected,
-        CorrectionIndicator,
-        DeletedAutocorrection,
-        DictationAlternatives,
-        DraggedContent,
-        Grammar,
-        RejectedCorrection,
-        Replacement,
-        SpellCheckingExemption,
-        Spelling,
-        TextMatch,
+        Type::AcceptedCandidate,
+        Type::Autocorrected,
+        Type::CorrectionIndicator,
+        Type::DeletedAutocorrection,
+        Type::DictationAlternatives,
+        Type::DraggedContent,
+        Type::Grammar,
+        Type::RejectedCorrection,
+        Type::Replacement,
+        Type::SpellCheckingExemption,
+        Type::Spelling,
+        Type::TextMatch,
 #if ENABLE(TELEPHONE_NUMBER_DETECTION)
-        TelephoneNumber,
+        Type::TelephoneNumber,
 #endif
 #if PLATFORM(IOS_FAMILY)
-        DictationPhraseWithAlternatives,
-        DictationResult,
+        Type::DictationPhraseWithAlternatives,
+        Type::DictationResult,
 #endif
 #if ENABLE(PLATFORM_DRIVEN_TEXT_CHECKING)
-        PlatformTextChecking
+        Type::PlatformTextChecking,
 #endif
     };
 }
 
-inline DocumentMarker::DocumentMarker(MarkerType type, OffsetRange range, Data&& data)
+inline DocumentMarker::DocumentMarker(Type type, OffsetRange range, Data&& data)
     : m_type(type)
     , m_range(range)
     , m_data(WTFMove(data))

--- a/Source/WebCore/dom/DocumentMarkerController.h
+++ b/Source/WebCore/dom/DocumentMarkerController.h
@@ -54,41 +54,41 @@ public:
 
     void detach();
 
-    WEBCORE_EXPORT void addMarker(const SimpleRange&, DocumentMarker::MarkerType, const DocumentMarker::Data& = { });
-    void addMarker(Text&, unsigned startOffset, unsigned length, DocumentMarker::MarkerType, DocumentMarker::Data&& = { });
+    WEBCORE_EXPORT void addMarker(const SimpleRange&, DocumentMarker::Type, const DocumentMarker::Data& = { });
+    void addMarker(Text&, unsigned startOffset, unsigned length, DocumentMarker::Type, DocumentMarker::Data&& = { });
     void addDraggedContentMarker(const SimpleRange&);
 
     void copyMarkers(Node& source, OffsetRange, Node& destination);
     bool hasMarkers() const;
-    WEBCORE_EXPORT bool hasMarkers(const SimpleRange&, OptionSet<DocumentMarker::MarkerType> = DocumentMarker::allMarkers());
+    WEBCORE_EXPORT bool hasMarkers(const SimpleRange&, OptionSet<DocumentMarker::Type> = DocumentMarker::allMarkers());
 
     // When a marker partially overlaps with range, if removePartiallyOverlappingMarkers is true, we completely
     // remove the marker. If the argument is false, we will adjust the span of the marker so that it retains
     // the portion that is outside of the range.
-    WEBCORE_EXPORT void removeMarkers(const SimpleRange&, OptionSet<DocumentMarker::MarkerType> = DocumentMarker::allMarkers(), RemovePartiallyOverlappingMarker = RemovePartiallyOverlappingMarker::No);
-    void removeMarkers(Node&, OffsetRange, OptionSet<DocumentMarker::MarkerType> = DocumentMarker::allMarkers(), const Function<FilterMarkerResult(const DocumentMarker&)>& filterFunction = nullptr, RemovePartiallyOverlappingMarker = RemovePartiallyOverlappingMarker::No);
+    WEBCORE_EXPORT void removeMarkers(const SimpleRange&, OptionSet<DocumentMarker::Type> = DocumentMarker::allMarkers(), RemovePartiallyOverlappingMarker = RemovePartiallyOverlappingMarker::No);
+    void removeMarkers(Node&, OffsetRange, OptionSet<DocumentMarker::Type> = DocumentMarker::allMarkers(), const Function<FilterMarkerResult(const DocumentMarker&)>& filterFunction = nullptr, RemovePartiallyOverlappingMarker = RemovePartiallyOverlappingMarker::No);
 
-    WEBCORE_EXPORT void filterMarkers(const SimpleRange&, const Function<FilterMarkerResult(const DocumentMarker&)>& filterFunction, OptionSet<DocumentMarker::MarkerType> = DocumentMarker::allMarkers(), RemovePartiallyOverlappingMarker = RemovePartiallyOverlappingMarker::No);
+    WEBCORE_EXPORT void filterMarkers(const SimpleRange&, const Function<FilterMarkerResult(const DocumentMarker&)>& filterFunction, OptionSet<DocumentMarker::Type> = DocumentMarker::allMarkers(), RemovePartiallyOverlappingMarker = RemovePartiallyOverlappingMarker::No);
 
-    WEBCORE_EXPORT void removeMarkers(OptionSet<DocumentMarker::MarkerType> = DocumentMarker::allMarkers());
-    void removeMarkers(Node&, OptionSet<DocumentMarker::MarkerType> = DocumentMarker::allMarkers());
-    void repaintMarkers(OptionSet<DocumentMarker::MarkerType> = DocumentMarker::allMarkers());
+    WEBCORE_EXPORT void removeMarkers(OptionSet<DocumentMarker::Type> = DocumentMarker::allMarkers());
+    void removeMarkers(Node&, OptionSet<DocumentMarker::Type> = DocumentMarker::allMarkers());
+    void repaintMarkers(OptionSet<DocumentMarker::Type> = DocumentMarker::allMarkers());
     void shiftMarkers(Node&, unsigned startOffset, int delta);
 
-    void dismissMarkers(OptionSet<DocumentMarker::MarkerType> = DocumentMarker::allMarkers());
+    void dismissMarkers(OptionSet<DocumentMarker::Type> = DocumentMarker::allMarkers());
 
-    WEBCORE_EXPORT Vector<WeakPtr<RenderedDocumentMarker>> markersFor(Node&, OptionSet<DocumentMarker::MarkerType> = DocumentMarker::allMarkers());
-    WEBCORE_EXPORT Vector<WeakPtr<RenderedDocumentMarker>> markersInRange(const SimpleRange&, OptionSet<DocumentMarker::MarkerType>);
-    WEBCORE_EXPORT Vector<SimpleRange> rangesForMarkersInRange(const SimpleRange&, OptionSet<DocumentMarker::MarkerType>);
-    void clearDescriptionOnMarkersIntersectingRange(const SimpleRange&, OptionSet<DocumentMarker::MarkerType>);
+    WEBCORE_EXPORT Vector<WeakPtr<RenderedDocumentMarker>> markersFor(Node&, OptionSet<DocumentMarker::Type> = DocumentMarker::allMarkers());
+    WEBCORE_EXPORT Vector<WeakPtr<RenderedDocumentMarker>> markersInRange(const SimpleRange&, OptionSet<DocumentMarker::Type>);
+    WEBCORE_EXPORT Vector<SimpleRange> rangesForMarkersInRange(const SimpleRange&, OptionSet<DocumentMarker::Type>);
+    void clearDescriptionOnMarkersIntersectingRange(const SimpleRange&, OptionSet<DocumentMarker::Type>);
 
-    WEBCORE_EXPORT void updateRectsForInvalidatedMarkersOfType(DocumentMarker::MarkerType);
+    WEBCORE_EXPORT void updateRectsForInvalidatedMarkersOfType(DocumentMarker::Type);
 
     void invalidateRectsForAllMarkers();
     void invalidateRectsForMarkersInNode(Node&);
 
-    WeakPtr<DocumentMarker> markerContainingPoint(const LayoutPoint&, DocumentMarker::MarkerType);
-    WEBCORE_EXPORT Vector<FloatRect> renderedRectsForMarkers(DocumentMarker::MarkerType);
+    WeakPtr<DocumentMarker> markerContainingPoint(const LayoutPoint&, DocumentMarker::Type);
+    WEBCORE_EXPORT Vector<FloatRect> renderedRectsForMarkers(DocumentMarker::Type);
 
 #if ENABLE(TREE_DEBUGGING)
     void showMarkers() const;
@@ -103,14 +103,14 @@ private:
     };
     Vector<TextRange> collectTextRanges(const SimpleRange&);
 
-    void forEach(const SimpleRange&, OptionSet<DocumentMarker::MarkerType>, const Function<bool(Node&, RenderedDocumentMarker&)>);
-    void forEachOfTypes(OptionSet<DocumentMarker::MarkerType>, const Function<bool(Node&, RenderedDocumentMarker&)>);
+    void forEach(const SimpleRange&, OptionSet<DocumentMarker::Type>, const Function<bool(Node&, RenderedDocumentMarker&)>);
+    void forEachOfTypes(OptionSet<DocumentMarker::Type>, const Function<bool(Node&, RenderedDocumentMarker&)>);
 
     using MarkerMap = HashMap<Ref<Node>, std::unique_ptr<Vector<RenderedDocumentMarker>>>;
 
-    bool possiblyHasMarkers(OptionSet<DocumentMarker::MarkerType>);
-    void removeMarkers(OptionSet<DocumentMarker::MarkerType>, const Function<FilterMarkerResult(const RenderedDocumentMarker&)>& filterFunction);
-    OptionSet<DocumentMarker::MarkerType> removeMarkersFromList(MarkerMap::iterator, OptionSet<DocumentMarker::MarkerType>, const Function<FilterMarkerResult(const RenderedDocumentMarker&)>& filterFunction = nullptr);
+    bool possiblyHasMarkers(OptionSet<DocumentMarker::Type>);
+    void removeMarkers(OptionSet<DocumentMarker::Type>, const Function<FilterMarkerResult(const RenderedDocumentMarker&)>& filterFunction);
+    OptionSet<DocumentMarker::Type> removeMarkersFromList(MarkerMap::iterator, OptionSet<DocumentMarker::Type>, const Function<FilterMarkerResult(const RenderedDocumentMarker&)>& filterFunction = nullptr);
 
     void fadeAnimationTimerFired();
 
@@ -118,15 +118,15 @@ private:
 
     MarkerMap m_markers;
     // Provide a quick way to determine whether a particular marker type is absent without going through the map.
-    OptionSet<DocumentMarker::MarkerType> m_possiblyExistingMarkerTypes;
+    OptionSet<DocumentMarker::Type> m_possiblyExistingMarkerTypes;
     CheckedRef<Document> m_document;
 
     Timer m_fadeAnimationTimer;
 };
 
-WEBCORE_EXPORT void addMarker(const SimpleRange&, DocumentMarker::MarkerType, const DocumentMarker::Data& = { });
-void addMarker(Text&, unsigned startOffset, unsigned length, DocumentMarker::MarkerType, DocumentMarker::Data&& = { });
-void removeMarkers(const SimpleRange&, OptionSet<DocumentMarker::MarkerType> = DocumentMarker::allMarkers(), RemovePartiallyOverlappingMarker = RemovePartiallyOverlappingMarker::No);
+WEBCORE_EXPORT void addMarker(const SimpleRange&, DocumentMarker::Type, const DocumentMarker::Data& = { });
+void addMarker(Text&, unsigned startOffset, unsigned length, DocumentMarker::Type, DocumentMarker::Data&& = { });
+void removeMarkers(const SimpleRange&, OptionSet<DocumentMarker::Type> = DocumentMarker::allMarkers(), RemovePartiallyOverlappingMarker = RemovePartiallyOverlappingMarker::No);
 
 WEBCORE_EXPORT SimpleRange makeSimpleRange(Node&, const DocumentMarker&);
 

--- a/Source/WebCore/editing/AlternativeTextController.cpp
+++ b/Source/WebCore/editing/AlternativeTextController.cpp
@@ -55,23 +55,23 @@ namespace WebCore {
 
 #if USE(DICTATION_ALTERNATIVES) || USE(AUTOCORRECTION_PANEL)
 
-constexpr OptionSet<DocumentMarker::MarkerType> markerTypesForAppliedDictationAlternative()
+constexpr OptionSet<DocumentMarker::Type> markerTypesForAppliedDictationAlternative()
 {
-    return DocumentMarker::SpellCheckingExemption;
+    return DocumentMarker::Type::SpellCheckingExemption;
 }
 
 #endif
 
 #if USE(AUTOCORRECTION_PANEL)
 
-static inline OptionSet<DocumentMarker::MarkerType> markerTypesForAutocorrection()
+static inline OptionSet<DocumentMarker::Type> markerTypesForAutocorrection()
 {
-    return { DocumentMarker::Autocorrected, DocumentMarker::CorrectionIndicator, DocumentMarker::Replacement, DocumentMarker::SpellCheckingExemption };
+    return { DocumentMarker::Type::Autocorrected, DocumentMarker::Type::CorrectionIndicator, DocumentMarker::Type::Replacement, DocumentMarker::Type::SpellCheckingExemption };
 }
 
-static inline OptionSet<DocumentMarker::MarkerType> markerTypesForReplacement()
+static inline OptionSet<DocumentMarker::Type> markerTypesForReplacement()
 {
-    return { DocumentMarker::Replacement, DocumentMarker::SpellCheckingExemption };
+    return { DocumentMarker::Type::Replacement, DocumentMarker::Type::SpellCheckingExemption };
 }
 
 static bool markersHaveIdenticalDescription(const Vector<WeakPtr<RenderedDocumentMarker>>& markers)
@@ -165,7 +165,7 @@ bool AlternativeTextController::hasPendingCorrection() const
 
 bool AlternativeTextController::isSpellingMarkerAllowed(const SimpleRange& misspellingRange) const
 {
-    return !protectedDocument()->markers().hasMarkers(misspellingRange, DocumentMarker::SpellCheckingExemption);
+    return !protectedDocument()->markers().hasMarkers(misspellingRange, DocumentMarker::Type::SpellCheckingExemption);
 }
 
 void AlternativeTextController::show(const SimpleRange& rangeToReplace, const String& replacement)
@@ -244,9 +244,9 @@ void AlternativeTextController::respondToUnappliedSpellCorrection(const VisibleS
     auto range = document->selection().selection().firstRange();
     if (!range)
         return;
-    removeMarkers(*range, OptionSet<DocumentMarker::MarkerType> { DocumentMarker::Spelling, DocumentMarker::Autocorrected }, RemovePartiallyOverlappingMarker::Yes);
-    addMarker(*range, DocumentMarker::Replacement);
-    addMarker(*range, DocumentMarker::SpellCheckingExemption);
+    removeMarkers(*range, OptionSet<DocumentMarker::Type> { DocumentMarker::Type::Spelling, DocumentMarker::Type::Autocorrected }, RemovePartiallyOverlappingMarker::Yes);
+    addMarker(*range, DocumentMarker::Type::Replacement);
+    addMarker(*range, DocumentMarker::Type::SpellCheckingExemption);
 }
 
 void AlternativeTextController::timerFired()
@@ -274,7 +274,7 @@ void AlternativeTextController::timerFired()
         auto boundingBox = rootViewRectForRange(*m_rangeWithAlternative);
         if (!boundingBox.isEmpty()) {
             if (CheckedPtr client = alternativeTextClient()) {
-                removeMarkers(*m_rangeWithAlternative, { DocumentMarker::CorrectionIndicator });
+                removeMarkers(*m_rangeWithAlternative, { DocumentMarker::Type::CorrectionIndicator });
                 client->showCorrectionAlternative(m_type, boundingBox, m_originalText, replacementString, { });
             }
         }
@@ -347,7 +347,7 @@ void AlternativeTextController::handleAlternativeTextUIResult(const String& resu
         if (result.length())
             applyAlternativeTextToRange(*m_rangeWithAlternative, result, m_type, markerTypesForAutocorrection());
         else if (!m_isDismissedByEditing)
-            addMarker(*m_rangeWithAlternative, DocumentMarker::RejectedCorrection, m_originalText);
+            addMarker(*m_rangeWithAlternative, DocumentMarker::Type::RejectedCorrection, m_originalText);
         break;
     case AlternativeTextType::Reversion:
     case AlternativeTextType::SpellingSuggestions:
@@ -435,8 +435,8 @@ void AlternativeTextController::respondToUnappliedEditing(EditCommandComposition
     auto range = command->startingSelection().firstRange();
     if (!range)
         return;
-    addMarker(*range, DocumentMarker::Replacement);
-    addMarker(*range, DocumentMarker::SpellCheckingExemption);
+    addMarker(*range, DocumentMarker::Type::Replacement);
+    addMarker(*range, DocumentMarker::Type::SpellCheckingExemption);
 }
 
 EditorClient* AlternativeTextController::editorClient()
@@ -459,14 +459,14 @@ void AlternativeTextController::recordAutocorrectionResponse(AutocorrectionRespo
 
 void AlternativeTextController::markReversed(const SimpleRange& changedRange)
 {
-    removeMarkers(changedRange, DocumentMarker::Autocorrected, RemovePartiallyOverlappingMarker::Yes);
-    addMarker(changedRange, DocumentMarker::SpellCheckingExemption);
+    removeMarkers(changedRange, DocumentMarker::Type::Autocorrected, RemovePartiallyOverlappingMarker::Yes);
+    addMarker(changedRange, DocumentMarker::Type::SpellCheckingExemption);
 }
 
 void AlternativeTextController::markCorrection(const SimpleRange& replacedRange, const String& replacedString)
 {
     for (auto markerType : markerTypesForAutocorrection()) {
-        if (markerType == DocumentMarker::Replacement || markerType == DocumentMarker::Autocorrected)
+        if (markerType == DocumentMarker::Type::Replacement || markerType == DocumentMarker::Type::Autocorrected)
             addMarker(replacedRange, markerType, replacedString);
         else
             addMarker(replacedRange, markerType);
@@ -476,7 +476,7 @@ void AlternativeTextController::markCorrection(const SimpleRange& replacedRange,
 void AlternativeTextController::recordSpellcheckerResponseForModifiedCorrection(const SimpleRange& rangeOfCorrection, const String& corrected, const String& correction)
 {
     DocumentMarkerController& markers = rangeOfCorrection.startContainer().document().markers();
-    auto correctedOnceMarkers = markers.markersInRange(rangeOfCorrection, DocumentMarker::Autocorrected);
+    auto correctedOnceMarkers = markers.markersInRange(rangeOfCorrection, DocumentMarker::Type::Autocorrected);
     if (correctedOnceMarkers.isEmpty())
         return;
 
@@ -489,7 +489,7 @@ void AlternativeTextController::recordSpellcheckerResponseForModifiedCorrection(
             client->recordAutocorrectionResponse(AutocorrectionResponse::Edited, corrected, correction);
     }
 
-    removeMarkers(rangeOfCorrection, DocumentMarker::Autocorrected, RemovePartiallyOverlappingMarker::Yes);
+    removeMarkers(rangeOfCorrection, DocumentMarker::Type::Autocorrected, RemovePartiallyOverlappingMarker::Yes);
 }
 
 void AlternativeTextController::deletedAutocorrectionAtPosition(const Position& position, const String& originalString)
@@ -518,30 +518,30 @@ void AlternativeTextController::markPrecedingWhitespaceForDeletedAutocorrectionA
     // Mark this whitespace to indicate we have deleted an autocorrection following this
     // whitespace. So if the user types the same original word again at this position, we
     // won't autocorrect it again.
-    addMarker(*precedingCharacterRange, DocumentMarker::DeletedAutocorrection, m_originalStringForLastDeletedAutocorrection);
+    addMarker(*precedingCharacterRange, DocumentMarker::Type::DeletedAutocorrection, m_originalStringForLastDeletedAutocorrection);
 }
 
 bool AlternativeTextController::processMarkersOnTextToBeReplacedByResult(const TextCheckingResult& result, const SimpleRange& rangeWithAlternative, const String& stringToBeReplaced)
 {
     auto document = protectedDocument();
     auto& markers = document->markers();
-    if (markers.hasMarkers(rangeWithAlternative, DocumentMarker::Replacement)) {
+    if (markers.hasMarkers(rangeWithAlternative, DocumentMarker::Type::Replacement)) {
         if (result.type == TextCheckingType::Correction)
             recordSpellcheckerResponseForModifiedCorrection(rangeWithAlternative, stringToBeReplaced, result.replacement);
         return false;
     }
 
-    if (markers.hasMarkers(rangeWithAlternative, DocumentMarker::RejectedCorrection))
+    if (markers.hasMarkers(rangeWithAlternative, DocumentMarker::Type::RejectedCorrection))
         return false;
 
-    if (markers.hasMarkers(rangeWithAlternative, DocumentMarker::AcceptedCandidate))
+    if (markers.hasMarkers(rangeWithAlternative, DocumentMarker::Type::AcceptedCandidate))
         return false;
 
     auto precedingCharacterRange = makeSimpleRange(makeDeprecatedLegacyPosition(rangeWithAlternative.start).previous(), rangeWithAlternative.start);
     if (!precedingCharacterRange)
         return false;
 
-    for (auto& marker : markers.markersInRange(*precedingCharacterRange, DocumentMarker::DeletedAutocorrection)) {
+    for (auto& marker : markers.markersInRange(*precedingCharacterRange, DocumentMarker::Type::DeletedAutocorrection)) {
         if (marker->description() == stringToBeReplaced)
             return false;
     }
@@ -555,11 +555,11 @@ bool AlternativeTextController::shouldStartTimerFor(const WebCore::DocumentMarke
         return false;
 
     switch (marker.type()) {
-    case DocumentMarker::Spelling:
-    case DocumentMarker::Grammar:
-    case DocumentMarker::DictationAlternatives:
+    case DocumentMarker::Type::Spelling:
+    case DocumentMarker::Type::Grammar:
+    case DocumentMarker::Type::DictationAlternatives:
         return true;
-    case DocumentMarker::Replacement:
+    case DocumentMarker::Type::Replacement:
         return !marker.description().isNull();
     default:
         return false;
@@ -577,18 +577,18 @@ bool AlternativeTextController::respondToMarkerAtEndOfWord(const DocumentMarker&
         return false;
     m_originalText = currentWord;
     switch (marker.type()) {
-    case DocumentMarker::Spelling:
-    case DocumentMarker::Grammar:
+    case DocumentMarker::Type::Spelling:
+    case DocumentMarker::Type::Grammar:
         m_rangeWithAlternative = WTFMove(wordRange);
         m_details = emptyString();
-        startAlternativeTextUITimer((marker.type() == DocumentMarker::Spelling) ? AlternativeTextType::SpellingSuggestions : AlternativeTextType::GrammarSuggestions);
+        startAlternativeTextUITimer((marker.type() == DocumentMarker::Type::Spelling) ? AlternativeTextType::SpellingSuggestions : AlternativeTextType::GrammarSuggestions);
         break;
-    case DocumentMarker::Replacement:
+    case DocumentMarker::Type::Replacement:
         m_rangeWithAlternative = WTFMove(wordRange);
         m_details = marker.description();
         startAlternativeTextUITimer(AlternativeTextType::Reversion);
         break;
-    case DocumentMarker::DictationAlternatives: {
+    case DocumentMarker::Type::DictationAlternatives: {
         auto& markerData = std::get<DocumentMarker::DictationData>(marker.data());
         if (currentWord != markerData.originalText)
             return false;
@@ -613,10 +613,10 @@ AlternativeTextClient* AlternativeTextController::alternativeTextClient()
     return m_document->frame() && m_document->page() ? m_document->page()->alternativeTextClient() : nullptr;
 }
 
-String AlternativeTextController::markerDescriptionForAppliedAlternativeText(AlternativeTextType alternativeTextType, DocumentMarker::MarkerType markerType)
+String AlternativeTextController::markerDescriptionForAppliedAlternativeText(AlternativeTextType alternativeTextType, DocumentMarker::Type markerType)
 {
 #if USE(AUTOCORRECTION_PANEL)
-    if (alternativeTextType != AlternativeTextType::Reversion && alternativeTextType != AlternativeTextType::DictationAlternatives && (markerType == DocumentMarker::Replacement || markerType == DocumentMarker::Autocorrected))
+    if (alternativeTextType != AlternativeTextType::Reversion && alternativeTextType != AlternativeTextType::DictationAlternatives && (markerType == DocumentMarker::Type::Replacement || markerType == DocumentMarker::Type::Autocorrected))
         return m_originalText;
 #else
     UNUSED_PARAM(alternativeTextType);
@@ -625,7 +625,7 @@ String AlternativeTextController::markerDescriptionForAppliedAlternativeText(Alt
     return emptyString();
 }
 
-void AlternativeTextController::applyAlternativeTextToRange(const SimpleRange& range, const String& alternative, AlternativeTextType alternativeType, OptionSet<DocumentMarker::MarkerType> markerTypesToAdd)
+void AlternativeTextController::applyAlternativeTextToRange(const SimpleRange& range, const String& alternative, AlternativeTextType alternativeType, OptionSet<DocumentMarker::Type> markerTypesToAdd)
 {
     // After we replace the word at range rangeWithAlternative, we need to add markers to that range.
     // So before we carry out the replacement,store the start position relative to the start position
@@ -662,9 +662,9 @@ void AlternativeTextController::applyAlternativeTextToRange(const SimpleRange& r
 void AlternativeTextController::removeCorrectionIndicatorMarkers()
 {
 #if HAVE(AUTOCORRECTION_ENHANCEMENTS)
-    protectedDocument()->markers().dismissMarkers(DocumentMarker::CorrectionIndicator);
+    protectedDocument()->markers().dismissMarkers(DocumentMarker::Type::CorrectionIndicator);
 #else
-    protectedDocument()->markers().removeMarkers(DocumentMarker::CorrectionIndicator);
+    protectedDocument()->markers().removeMarkers(DocumentMarker::Type::CorrectionIndicator);
 #endif
 }
 
@@ -735,7 +735,7 @@ void AlternativeTextController::applyDictationAlternative(const String& alternat
     auto selection = editor.selectedRange();
     if (!selection || !editor.shouldInsertText(alternativeString, *selection, EditorInsertAction::Pasted))
         return;
-    for (auto& marker : selection->startContainer().document().markers().markersInRange(*selection, DocumentMarker::DictationAlternatives))
+    for (auto& marker : selection->startContainer().document().markers().markersInRange(*selection, DocumentMarker::Type::DictationAlternatives))
         removeDictationAlternativesForMarker(*marker);
     applyAlternativeTextToRange(*selection, alternativeString, AlternativeTextType::DictationAlternatives, markerTypesForAppliedDictationAlternative());
 #else

--- a/Source/WebCore/editing/AlternativeTextController.h
+++ b/Source/WebCore/editing/AlternativeTextController.h
@@ -131,8 +131,8 @@ private:
     Position m_positionForLastDeletedAutocorrection;
 #endif
 #if USE(DICTATION_ALTERNATIVES) || USE(AUTOCORRECTION_PANEL)
-    String markerDescriptionForAppliedAlternativeText(AlternativeTextType, DocumentMarker::MarkerType);
-    void applyAlternativeTextToRange(const SimpleRange&, const String&, AlternativeTextType, OptionSet<DocumentMarker::MarkerType>);
+    String markerDescriptionForAppliedAlternativeText(AlternativeTextType, DocumentMarker::Type);
+    void applyAlternativeTextToRange(const SimpleRange&, const String&, AlternativeTextType, OptionSet<DocumentMarker::Type>);
     AlternativeTextClient* alternativeTextClient();
 #endif
     Ref<Document> protectedDocument() const { return m_document.get(); }

--- a/Source/WebCore/editing/DeleteSelectionCommand.cpp
+++ b/Source/WebCore/editing/DeleteSelectionCommand.cpp
@@ -947,7 +947,7 @@ String DeleteSelectionCommand::originalStringForAutocorrectionAtBeginningOfSelec
         return String();
 
     ScriptDisallowedScope::InMainThread scriptDisallowedScope;
-    for (auto& marker : protectedDocument()->markers().markersInRange(*rangeOfFirstCharacter, DocumentMarker::Autocorrected)) {
+    for (auto& marker : protectedDocument()->markers().markersInRange(*rangeOfFirstCharacter, DocumentMarker::Type::Autocorrected)) {
         int startOffset = marker->startOffset();
         if (startOffset == startOfSelection.deepEquivalent().offsetInContainerNode())
             return marker->description();

--- a/Source/WebCore/editing/DictationCommand.cpp
+++ b/Source/WebCore/editing/DictationCommand.cpp
@@ -69,8 +69,8 @@ public:
         auto& markerController = document->markers();
         for (auto& alternative : m_alternatives) {
             DocumentMarker::DictationData data { alternative.context, textToBeInserted.substring(alternative.range.location, alternative.range.length) };
-            markerController.addMarker(textNode, alternative.range.location + offsetOfInsertion, alternative.range.length, DocumentMarker::DictationAlternatives, WTFMove(data));
-            markerController.addMarker(textNode, alternative.range.location + offsetOfInsertion, alternative.range.length, DocumentMarker::SpellCheckingExemption);
+            markerController.addMarker(textNode, alternative.range.location + offsetOfInsertion, alternative.range.length, DocumentMarker::Type::DictationAlternatives, WTFMove(data));
+            markerController.addMarker(textNode, alternative.range.location + offsetOfInsertion, alternative.range.length, DocumentMarker::Type::SpellCheckingExemption);
         }
     }
 

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -1173,7 +1173,7 @@ static inline bool didApplyAutocorrection(Document& document, AlternativeTextCon
     auto wordEnd = endOfWord(startOfSelection, WordSide::LeftWordIfOnBoundary);
 
     if (auto range = makeSimpleRange(wordStart, wordEnd)) {
-        if (document.markers().hasMarkers(*range, DocumentMarker::CorrectionIndicator))
+        if (document.markers().hasMarkers(*range, DocumentMarker::Type::CorrectionIndicator))
             autocorrectionWasApplied = true;
     }
 
@@ -1184,10 +1184,10 @@ static inline bool didApplyAutocorrection(Document& document, AlternativeTextCon
 #endif
 }
 
-static inline void adjustMarkerTypesToRemoveForWordsAffectedByEditing(OptionSet<DocumentMarker::MarkerType>& markerTypes)
+static inline void adjustMarkerTypesToRemoveForWordsAffectedByEditing(OptionSet<DocumentMarker::Type>& markerTypes)
 {
 #if HAVE(AUTOCORRECTION_ENHANCEMENTS) && PLATFORM(IOS_FAMILY)
-    markerTypes.remove(DocumentMarker::CorrectionIndicator);
+    markerTypes.remove(DocumentMarker::Type::CorrectionIndicator);
 #else
     UNUSED_PARAM(markerTypes);
 #endif
@@ -2375,7 +2375,7 @@ void Editor::ignoreSpelling()
         return;
 
     if (auto selectedRange = document().selection().selection().toNormalizedRange())
-        removeMarkers(*selectedRange, DocumentMarker::Spelling);
+        removeMarkers(*selectedRange, DocumentMarker::Type::Spelling);
 
     String text = selectedText();
     ASSERT(text.length());
@@ -2390,7 +2390,7 @@ void Editor::learnSpelling()
     // FIXME: On Mac OS X, when use "learn" button on "Spelling and Grammar" panel, we don't call this function. It should remove misspelling markers around the learned word, see <rdar://problem/5396072>.
 
     if (auto selectedRange = document().selection().selection().toNormalizedRange())
-        removeMarkers(*selectedRange, DocumentMarker::Spelling);
+        removeMarkers(*selectedRange, DocumentMarker::Type::Spelling);
 
     String text = selectedText();
     ASSERT(text.length());
@@ -2535,7 +2535,7 @@ void Editor::advanceToNextMisspelling(bool startBeforeSelection)
         document->selection().revealSelection();
         
         client()->updateSpellingUIWithGrammarString(ungrammaticalPhrase.phrase, ungrammaticalPhrase.detail);
-        addMarker(badGrammarRange, DocumentMarker::Grammar, ungrammaticalPhrase.detail.userDescription);
+        addMarker(badGrammarRange, DocumentMarker::Type::Grammar, ungrammaticalPhrase.detail.userDescription);
     } else if (!misspelledWord.word.isEmpty()) {
         // We found a misspelling, but not any earlier bad grammar. Select the misspelling, update the spelling panel, and store
         // a marker so we draw the red squiggle later.
@@ -2545,7 +2545,7 @@ void Editor::advanceToNextMisspelling(bool startBeforeSelection)
         document->selection().revealSelection();
         
         client()->updateSpellingUIWithMisspelledWord(misspelledWord.word);
-        addMarker(misspellingRange, DocumentMarker::Spelling);
+        addMarker(misspellingRange, DocumentMarker::Type::Spelling);
     }
 }
 
@@ -2667,7 +2667,7 @@ bool Editor::spellingPanelIsShowing()
 void Editor::clearMisspellingsAndBadGrammar(const VisibleSelection& movingSelection)
 {
     if (auto selectedRange = movingSelection.toNormalizedRange())
-        removeMarkers(*selectedRange, { DocumentMarker::Spelling, DocumentMarker::Grammar });
+        removeMarkers(*selectedRange, { DocumentMarker::Type::Spelling, DocumentMarker::Type::Grammar });
 }
 
 void Editor::markMisspellingsAndBadGrammar(const VisibleSelection &movingSelection)
@@ -2792,8 +2792,8 @@ void Editor::markMisspellingsAfterTypingToWord(const VisiblePosition& wordStart,
         // cause any other part of the current sentence to lose or gain spelling correction markers, due to
         // sentence retro correction. As such, we expand the spell checking range to encompass as much of the
         // full sentence as we can, respecting boundaries where spellchecking is disabled.
-        removeMarkers(*fullSentenceRange, DocumentMarker::Grammar);
-        removeMarkers(*spellCheckingRange, DocumentMarker::Spelling);
+        removeMarkers(*fullSentenceRange, DocumentMarker::Type::Grammar);
+        removeMarkers(*spellCheckingRange, DocumentMarker::Type::Spelling);
         markAllMisspellingsAndBadGrammarInRanges(textCheckingOptions, spellCheckingRange, adjacentWordRange, fullSentenceRange);
         return;
     }
@@ -3056,14 +3056,14 @@ void Editor::markAndReplaceFor(const SpellCheckRequest& request, const Vector<Te
             auto misspellingRange = paragraph.subrange({ resultLocation, resultLength });
             if (!m_alternativeTextController->isSpellingMarkerAllowed(misspellingRange))
                 continue;
-            addMarker(misspellingRange, DocumentMarker::Spelling, replacement);
+            addMarker(misspellingRange, DocumentMarker::Type::Spelling, replacement);
         } else if (shouldMarkGrammar && resultType == TextCheckingType::Grammar && paragraph.checkingRangeCovers({ resultLocation, resultLength })) {
             ASSERT(resultLength > 0);
             for (auto& detail : results[i].details) {
                 ASSERT(detail.range.length > 0);
                 if (paragraph.checkingRangeCovers({ resultLocation + detail.range.location, detail.range.length })) {
                     auto badGrammarRange = paragraph.subrange({ resultLocation + detail.range.location, detail.range.length });
-                    addMarker(badGrammarRange, DocumentMarker::Grammar, detail.userDescription);
+                    addMarker(badGrammarRange, DocumentMarker::Type::Grammar, detail.userDescription);
                     previousGrammarRanges.append(CharacterRange(resultLocation + detail.range.location, detail.range.length));
                 }
             }
@@ -3178,7 +3178,7 @@ void Editor::changeBackToReplacedString(const String& replacedString)
     TextCheckingParagraph paragraph(*selection);
     replaceSelectionWithText(replacedString, SelectReplacement::No, SmartReplace::No, EditAction::Insert);
     auto changedRange = paragraph.subrange(CharacterRange(paragraph.checkingStart(), replacedString.length()));
-    addMarker(changedRange, DocumentMarker::Replacement, String());
+    addMarker(changedRange, DocumentMarker::Type::Replacement, String());
     m_alternativeTextController->markReversed(changedRange);
 #else
     ASSERT_NOT_REACHED();
@@ -3287,22 +3287,22 @@ void Editor::updateMarkersForWordsAffectedByEditing(bool doNotRemoveIfSelectionA
     // of marker that contains the word in question, and remove marker on that whole range.
     auto wordRange = *makeSimpleRange(startOfFirstWord, endOfLastWord);
 
-    for (auto& marker : document->markers().markersInRange(wordRange, DocumentMarker::DictationAlternatives))
+    for (auto& marker : document->markers().markersInRange(wordRange, DocumentMarker::Type::DictationAlternatives))
         m_alternativeTextController->removeDictationAlternativesForMarker(*marker);
 
-    OptionSet<DocumentMarker::MarkerType> markerTypesToRemove {
-        DocumentMarker::CorrectionIndicator,
-        DocumentMarker::DictationAlternatives,
-        DocumentMarker::SpellCheckingExemption,
-        DocumentMarker::Spelling,
+    OptionSet<DocumentMarker::Type> markerTypesToRemove {
+        DocumentMarker::Type::CorrectionIndicator,
+        DocumentMarker::Type::DictationAlternatives,
+        DocumentMarker::Type::SpellCheckingExemption,
+        DocumentMarker::Type::Spelling,
 #if !PLATFORM(IOS_FAMILY)
-        DocumentMarker::Grammar,
+        DocumentMarker::Type::Grammar,
 #endif
     };
     adjustMarkerTypesToRemoveForWordsAffectedByEditing(markerTypesToRemove);
 
     removeMarkers(wordRange, markerTypesToRemove, RemovePartiallyOverlappingMarker::Yes);
-    document->markers().clearDescriptionOnMarkersIntersectingRange(wordRange, DocumentMarker::Replacement);
+    document->markers().clearDescriptionOnMarkersIntersectingRange(wordRange, DocumentMarker::Type::Replacement);
 }
 
 void Editor::deletedAutocorrectionAtPosition(const Position& position, const String& originalString)
@@ -3831,7 +3831,7 @@ unsigned Editor::countMatchesForText(const String& target, const std::optional<S
             matches->append(resultRange);
 
         if (markMatches)
-            addMarker(resultRange, DocumentMarker::TextMatch);
+            addMarker(resultRange, DocumentMarker::Type::TextMatch);
 
         // Stop looking if we hit the specified limit. A limit of 0 means no limit.
         if (limit > 0 && matchCount >= limit)
@@ -3856,7 +3856,7 @@ void Editor::setMarkedTextMatchesAreHighlighted(bool flag)
         return;
 
     m_areMarkedTextMatchesHighlighted = flag;
-    document().markers().repaintMarkers(DocumentMarker::TextMatch);
+    document().markers().repaintMarkers(DocumentMarker::Type::TextMatch);
 }
 
 #if !PLATFORM(MAC)
@@ -3968,7 +3968,7 @@ void Editor::scanSelectionForTelephoneNumbers()
 
     for (auto& range : scanForTelephoneNumbers(*extendedRange)) {
         // FIXME: Why do we do this unconditionally instead of when only when it overlaps the selection?
-        addMarker(range, DocumentMarker::TelephoneNumber);
+        addMarker(range, DocumentMarker::Type::TelephoneNumber);
 
         // Only consider ranges with a detected telephone number if they overlap with the selection.
         if (intersects<ComposedTree>(range, *selectedRange))
@@ -4036,19 +4036,19 @@ void Editor::editorUIUpdateTimerFired()
 
         if (!textChecker() || textChecker()->shouldEraseMarkersAfterChangeSelection(TextCheckingType::Spelling)) {
             if (auto wordRange = newAdjacentWords.toNormalizedRange())
-                removeMarkers(*wordRange, DocumentMarker::Spelling);
+                removeMarkers(*wordRange, DocumentMarker::Type::Spelling);
         }
         if (!textChecker() || textChecker()->shouldEraseMarkersAfterChangeSelection(TextCheckingType::Grammar)) {
             if (auto sentenceRange = newSelectedSentence.toNormalizedRange())
-                removeMarkers(*sentenceRange, DocumentMarker::Grammar);
+                removeMarkers(*sentenceRange, DocumentMarker::Type::Grammar);
         }
     }
 
     // When continuous spell checking is off, existing markers disappear after the selection changes.
     if (!isContinuousSpellCheckingEnabled)
-        document->markers().removeMarkers(DocumentMarker::Spelling);
+        document->markers().removeMarkers(DocumentMarker::Type::Spelling);
     if (!isContinuousGrammarCheckingEnabled)
-        document->markers().removeMarkers(DocumentMarker::Grammar);
+        document->markers().removeMarkers(DocumentMarker::Type::Grammar);
 
     if (!m_editorUIUpdateTimerWasTriggeredByDictation)
         m_alternativeTextController->respondToChangedSelection(oldSelection);
@@ -4082,7 +4082,7 @@ static RefPtr<Node> findFirstMarkable(Node* startingNode)
     return nullptr;
 }
 
-bool Editor::selectionStartHasMarkerFor(DocumentMarker::MarkerType markerType, int from, int length) const
+bool Editor::selectionStartHasMarkerFor(DocumentMarker::Type markerType, int from, int length) const
 {
     auto node = findFirstMarkable(document().selection().selection().start().protectedDeprecatedNode().get());
     if (!node)
@@ -4498,7 +4498,7 @@ void Editor::handleAcceptedCandidate(TextCheckingResult acceptedCandidate)
         insertText(acceptedCandidate.replacement, nullptr);
 
     if (auto insertedCandidateRange = rangeExpandedByCharactersInDirectionAtWordBoundary(selection.visibleStart(), acceptedCandidate.replacement.length(), SelectionDirection::Backward))
-        addMarker(*insertedCandidateRange, DocumentMarker::AcceptedCandidate, acceptedCandidate.replacement);
+        addMarker(*insertedCandidateRange, DocumentMarker::Type::AcceptedCandidate, acceptedCandidate.replacement);
 
     m_isHandlingAcceptedCandidate = false;
 }

--- a/Source/WebCore/editing/Editor.h
+++ b/Source/WebCore/editing/Editor.h
@@ -504,7 +504,7 @@ public:
     enum class MatchStyle : bool { No, Yes };
     WEBCORE_EXPORT void replaceSelectionWithFragment(DocumentFragment&, SelectReplacement, SmartReplace, MatchStyle, EditAction = EditAction::Insert, MailBlockquoteHandling = MailBlockquoteHandling::RespectBlockquote);
     WEBCORE_EXPORT void replaceSelectionWithText(const String&, SelectReplacement, SmartReplace, EditAction = EditAction::Insert);
-    WEBCORE_EXPORT bool selectionStartHasMarkerFor(DocumentMarker::MarkerType, int from, int length) const;
+    WEBCORE_EXPORT bool selectionStartHasMarkerFor(DocumentMarker::Type, int from, int length) const;
     void updateMarkersForWordsAffectedByEditing(bool doNotRemoveIfSelectionAtWordBoundary);
     void deletedAutocorrectionAtPosition(const Position&, const String& originalString);
     

--- a/Source/WebCore/editing/SpellChecker.cpp
+++ b/Source/WebCore/editing/SpellChecker.cpp
@@ -220,11 +220,11 @@ void SpellChecker::didCheckSucceed(TextCheckingRequestIdentifier identifier, con
 {
     TextCheckingRequestData requestData = m_processingRequest->data();
     if (requestData.identifier() == identifier) {
-        OptionSet<DocumentMarker::MarkerType> markerTypes;
+        OptionSet<DocumentMarker::Type> markerTypes;
         if (requestData.checkingTypes().contains(TextCheckingType::Spelling))
-            markerTypes.add(DocumentMarker::Spelling);
+            markerTypes.add(DocumentMarker::Type::Spelling);
         if (requestData.checkingTypes().contains(TextCheckingType::Grammar))
-            markerTypes.add(DocumentMarker::Grammar);
+            markerTypes.add(DocumentMarker::Type::Grammar);
         if (!markerTypes.isEmpty())
             removeMarkers(m_processingRequest->checkingRange(), markerTypes);
     }

--- a/Source/WebCore/editing/TextCheckingHelper.cpp
+++ b/Source/WebCore/editing/TextCheckingHelper.cpp
@@ -260,7 +260,7 @@ auto TextCheckingHelper::findMisspelledWords(Operation operation) const -> std::
         auto misspellingRange = resolveCharacterRange(m_range, CharacterRange(currentChunkOffset + misspellingLocation, misspellingLength));
 
         if (operation == Operation::MarkAll)
-            addMarker(misspellingRange, DocumentMarker::Spelling);
+            addMarker(misspellingRange, DocumentMarker::Type::Spelling);
 
         if (first.first.word.isNull()) {
             first = {
@@ -432,7 +432,7 @@ int TextCheckingHelper::findUngrammaticalPhrases(Operation operation, const Vect
         
         if (operation == Operation::MarkAll) {
             auto badGrammarRange = resolveCharacterRange(m_range, { badGrammarPhraseLocation - startOffset + detail->range.location, detail->range.length });
-            addMarker(badGrammarRange, DocumentMarker::Grammar, detail->userDescription);
+            addMarker(badGrammarRange, DocumentMarker::Type::Grammar, detail->userDescription);
         }
         
         // Remember this detail only if it's earlier than our current candidate (the details aren't in a guaranteed order)

--- a/Source/WebCore/editing/ios/DictationCommandIOS.cpp
+++ b/Source/WebCore/editing/ios/DictationCommandIOS.cpp
@@ -61,7 +61,7 @@ void DictationCommandIOS::doApply()
         if (interpretations.size() > 1) {
             auto alternatives = interpretations;
             alternatives.remove(0);
-            addMarker(*endingSelection().toNormalizedRange(), DocumentMarker::DictationPhraseWithAlternatives, WTFMove(alternatives));
+            addMarker(*endingSelection().toNormalizedRange(), DocumentMarker::Type::DictationPhraseWithAlternatives, WTFMove(alternatives));
         }
 
         setEndingSelection(VisibleSelection(endingSelection().visibleEnd()));
@@ -80,7 +80,7 @@ void DictationCommandIOS::doApply()
         return;
 
     auto resultRange = resolveCharacterRange(makeRangeSelectingNodeContents(*root), { endOffset - resultLength, endOffset });
-    addMarker(resultRange, DocumentMarker::DictationResult, m_metadata);
+    addMarker(resultRange, DocumentMarker::Type::DictationResult, m_metadata);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/editing/ios/EditorIOS.mm
+++ b/Source/WebCore/editing/ios/EditorIOS.mm
@@ -296,12 +296,12 @@ void Editor::setDictationPhrasesAsChildOfElement(const Vector<Vector<String>>& d
         if (interpretations.size() > 1) {
             auto alternatives = interpretations;
             alternatives.remove(0);
-            addMarker(textNode, previousDictationPhraseStart, dictationPhraseLength, DocumentMarker::DictationPhraseWithAlternatives, WTFMove(alternatives));
+            addMarker(textNode, previousDictationPhraseStart, dictationPhraseLength, DocumentMarker::Type::DictationPhraseWithAlternatives, WTFMove(alternatives));
         }
         previousDictationPhraseStart += dictationPhraseLength;
     }
 
-    addMarker(textNode, 0, textNode.length(), DocumentMarker::DictationResult, retainPtr(metadata));
+    addMarker(textNode, 0, textNode.length(), DocumentMarker::Type::DictationResult, retainPtr(metadata));
 
     client()->respondToChangedContents();
 }

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -4123,7 +4123,7 @@ void EventHandler::invalidateDataTransfer()
 static void removeDraggedContentDocumentMarkersFromAllFramesInPage(Page& page)
 {
     page.forEachDocument([] (Document& document) {
-        document.markers().removeMarkers(DocumentMarker::DraggedContent);
+        document.markers().removeMarkers(DocumentMarker::Type::DraggedContent);
     });
 
     if (auto* localMainFrame = dynamicDowncast<LocalFrame>(page.mainFrame())) {

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1134,7 +1134,7 @@ uint32_t Page::replaceSelectionWithText(const String& replacementText)
 void Page::unmarkAllTextMatches()
 {
     forEachDocument([] (Document& document) {
-        document.markers().removeMarkers(DocumentMarker::TextMatch);
+        document.markers().removeMarkers(DocumentMarker::Type::TextMatch);
     });
 }
 

--- a/Source/WebCore/page/ios/FrameIOS.mm
+++ b/Source/WebCore/page/ios/FrameIOS.mm
@@ -726,7 +726,7 @@ NSArray *LocalFrame::interpretationsForCurrentRoot() const
     auto* root = selection().isNone() ? document()->bodyOrFrameset() : selection().selection().rootEditableElement();
     auto rangeOfRootContents = makeRangeSelectingNodeContents(*root);
 
-    auto markersInRoot = document()->markers().markersInRange(rangeOfRootContents, DocumentMarker::DictationPhraseWithAlternatives);
+    auto markersInRoot = document()->markers().markersInRange(rangeOfRootContents, DocumentMarker::Type::DictationPhraseWithAlternatives);
 
     // There are no phrases with alternatives, so there is just one interpretation.
     if (markersInRoot.isEmpty())
@@ -746,7 +746,7 @@ NSArray *LocalFrame::interpretationsForCurrentRoot() const
     unsigned combinationsSoFar = 1;
 
     for (auto& node : intersectingNodes(rangeOfRootContents)) {
-        for (auto& marker : document()->markers().markersFor(node, DocumentMarker::DictationPhraseWithAlternatives)) {
+        for (auto& marker : document()->markers().markersFor(node, DocumentMarker::Type::DictationPhraseWithAlternatives)) {
             auto& alternatives = std::get<Vector<String>>(marker->data());
 
             auto rangeForMarker = makeSimpleRange(node, *marker);

--- a/Source/WebCore/rendering/HitTestResult.cpp
+++ b/Source/WebCore/rendering/HitTestResult.cpp
@@ -247,7 +247,7 @@ String HitTestResult::spellingToolTip(TextDirection& dir) const
     if (!m_innerNonSharedNode)
         return String();
     
-    WeakPtr marker = m_innerNonSharedNode->document().markers().markerContainingPoint(m_hitTestLocation.point(), DocumentMarker::Grammar);
+    WeakPtr marker = m_innerNonSharedNode->document().markers().markerContainingPoint(m_hitTestLocation.point(), DocumentMarker::Type::Grammar);
     if (!marker)
         return String();
 
@@ -263,7 +263,7 @@ String HitTestResult::replacedString() const
     if (!m_innerNonSharedNode)
         return String();
     
-    WeakPtr marker = m_innerNonSharedNode->document().markers().markerContainingPoint(m_hitTestLocation.point(), DocumentMarker::Replacement);
+    WeakPtr marker = m_innerNonSharedNode->document().markers().markerContainingPoint(m_hitTestLocation.point(), DocumentMarker::Type::Replacement);
     if (!marker)
         return String();
     
@@ -782,7 +782,7 @@ Vector<String> HitTestResult::dictationAlternatives() const
     if (!m_innerNonSharedNode)
         return Vector<String>();
 
-    WeakPtr marker = m_innerNonSharedNode->document().markers().markerContainingPoint(pointInInnerNodeFrame(), DocumentMarker::DictationAlternatives);
+    WeakPtr marker = m_innerNonSharedNode->document().markers().markerContainingPoint(pointInInnerNodeFrame(), DocumentMarker::Type::DictationAlternatives);
     if (!marker)
         return Vector<String>();
 

--- a/Source/WebCore/rendering/MarkedText.cpp
+++ b/Source/WebCore/rendering/MarkedText.cpp
@@ -201,20 +201,20 @@ Vector<MarkedText> MarkedText::collectForDocumentMarkers(const RenderText& rende
 
     auto markers = renderer.document().markers().markersFor(*renderer.textNode());
 
-    auto markedTextTypeForMarkerType = [] (DocumentMarker::MarkerType type) {
+    auto markedTextTypeForMarkerType = [] (DocumentMarker::Type type) {
         switch (type) {
-        case DocumentMarker::Spelling:
+        case DocumentMarker::Type::Spelling:
             return MarkedText::Type::SpellingError;
-        case DocumentMarker::Grammar:
+        case DocumentMarker::Type::Grammar:
             return MarkedText::Type::GrammarError;
-        case DocumentMarker::CorrectionIndicator:
+        case DocumentMarker::Type::CorrectionIndicator:
             return MarkedText::Type::Correction;
-        case DocumentMarker::TextMatch:
+        case DocumentMarker::Type::TextMatch:
             return MarkedText::Type::TextMatch;
-        case DocumentMarker::DictationAlternatives:
+        case DocumentMarker::Type::DictationAlternatives:
             return MarkedText::Type::DictationAlternatives;
 #if PLATFORM(IOS_FAMILY)
-        case DocumentMarker::DictationPhraseWithAlternatives:
+        case DocumentMarker::Type::DictationPhraseWithAlternatives:
             return MarkedText::Type::DictationPhraseWithAlternatives;
 #endif
         default:
@@ -230,29 +230,29 @@ Vector<MarkedText> MarkedText::collectForDocumentMarkers(const RenderText& rende
     for (auto& marker : markers) {
         // Collect either the background markers or the foreground markers, but not both
         switch (marker->type()) {
-        case DocumentMarker::Grammar:
-        case DocumentMarker::Spelling:
+        case DocumentMarker::Type::Grammar:
+        case DocumentMarker::Type::Spelling:
             if (renderer.settings().grammarAndSpellingPseudoElementsEnabled())
                 break;
             FALLTHROUGH;
-        case DocumentMarker::CorrectionIndicator:
-        case DocumentMarker::Replacement:
-        case DocumentMarker::DictationAlternatives:
+        case DocumentMarker::Type::CorrectionIndicator:
+        case DocumentMarker::Type::Replacement:
+        case DocumentMarker::Type::DictationAlternatives:
 #if PLATFORM(IOS_FAMILY)
         // FIXME: Remove the PLATFORM(IOS_FAMILY)-guard.
-        case DocumentMarker::DictationPhraseWithAlternatives:
+        case DocumentMarker::Type::DictationPhraseWithAlternatives:
 #endif
             if (phase != MarkedText::PaintPhase::Decoration)
                 continue;
             break;
-        case DocumentMarker::TextMatch:
+        case DocumentMarker::Type::TextMatch:
             if (!renderer.frame().editor().markedTextMatchesAreHighlighted())
                 continue;
             if (phase == MarkedText::PaintPhase::Decoration)
                 continue;
             break;
 #if ENABLE(TELEPHONE_NUMBER_DETECTION)
-        case DocumentMarker::TelephoneNumber:
+        case DocumentMarker::Type::TelephoneNumber:
             if (!renderer.frame().editor().markedTextMatchesAreHighlighted())
                 continue;
             if (phase != MarkedText::PaintPhase::Background)
@@ -276,23 +276,23 @@ Vector<MarkedText> MarkedText::collectForDocumentMarkers(const RenderText& rende
 
         // Marker intersects this run. Collect it.
         switch (marker->type()) {
-        case DocumentMarker::Spelling:
-        case DocumentMarker::CorrectionIndicator:
-        case DocumentMarker::DictationAlternatives:
-        case DocumentMarker::Grammar:
+        case DocumentMarker::Type::Spelling:
+        case DocumentMarker::Type::CorrectionIndicator:
+        case DocumentMarker::Type::DictationAlternatives:
+        case DocumentMarker::Type::Grammar:
 #if PLATFORM(IOS_FAMILY)
         // FIXME: See <rdar://problem/8933352>. Also, remove the PLATFORM(IOS_FAMILY)-guard.
-        case DocumentMarker::DictationPhraseWithAlternatives:
+        case DocumentMarker::Type::DictationPhraseWithAlternatives:
 #endif
-        case DocumentMarker::TextMatch: {
+        case DocumentMarker::Type::TextMatch: {
             auto [clampedStart, clampedEnd] = selectableRange.clamp(marker->startOffset(), marker->endOffset());
             markedTexts.append({ clampedStart, clampedEnd, markedTextTypeForMarkerType(marker->type()), marker.get() });
             break;
         }
-        case DocumentMarker::Replacement:
+        case DocumentMarker::Type::Replacement:
             break;
 #if ENABLE(TELEPHONE_NUMBER_DETECTION)
-        case DocumentMarker::TelephoneNumber:
+        case DocumentMarker::Type::TelephoneNumber:
             break;
 #endif
         default:

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -240,7 +240,7 @@ void RenderReplaced::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
     if (element() && element()->parentOrShadowHostElement()) {
         auto* parentContainer = element()->parentOrShadowHostElement();
         ASSERT(parentContainer);
-        if (draggedContentContainsReplacedElement(document().markers().markersFor(*parentContainer, DocumentMarker::DraggedContent), *element())) {
+        if (draggedContentContainsReplacedElement(document().markers().markersFor(*parentContainer, DocumentMarker::Type::DraggedContent), *element())) {
             savedGraphicsContext.save();
             paintInfo.context().setAlpha(0.25);
         }

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -1425,7 +1425,7 @@ Vector<std::pair<unsigned, unsigned>> RenderText::draggedContentRangesBetweenOff
     if (!textNode())
         return { };
 
-    auto markers = document().markers().markersFor(*textNode(), DocumentMarker::DraggedContent);
+    auto markers = document().markers().markersFor(*textNode(), DocumentMarker::Type::DraggedContent);
     if (markers.isEmpty())
         return { };
 

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -473,31 +473,31 @@ void InspectorStubFrontend::sendMessageToFrontend(const String& message)
     frontendAPIDispatcher().dispatchMessageAsync(message);
 }
 
-static bool markerTypeFrom(const String& markerType, DocumentMarker::MarkerType& result)
+static bool markerTypeFrom(const String& markerType, DocumentMarker::Type& result)
 {
     if (equalLettersIgnoringASCIICase(markerType, "spelling"_s))
-        result = DocumentMarker::Spelling;
+        result = DocumentMarker::Type::Spelling;
     else if (equalLettersIgnoringASCIICase(markerType, "grammar"_s))
-        result = DocumentMarker::Grammar;
+        result = DocumentMarker::Type::Grammar;
     else if (equalLettersIgnoringASCIICase(markerType, "textmatch"_s))
-        result = DocumentMarker::TextMatch;
+        result = DocumentMarker::Type::TextMatch;
     else if (equalLettersIgnoringASCIICase(markerType, "replacement"_s))
-        result = DocumentMarker::Replacement;
+        result = DocumentMarker::Type::Replacement;
     else if (equalLettersIgnoringASCIICase(markerType, "correctionindicator"_s))
-        result = DocumentMarker::CorrectionIndicator;
+        result = DocumentMarker::Type::CorrectionIndicator;
     else if (equalLettersIgnoringASCIICase(markerType, "rejectedcorrection"_s))
-        result = DocumentMarker::RejectedCorrection;
+        result = DocumentMarker::Type::RejectedCorrection;
     else if (equalLettersIgnoringASCIICase(markerType, "autocorrected"_s))
-        result = DocumentMarker::Autocorrected;
+        result = DocumentMarker::Type::Autocorrected;
     else if (equalLettersIgnoringASCIICase(markerType, "spellcheckingexemption"_s))
-        result = DocumentMarker::SpellCheckingExemption;
+        result = DocumentMarker::Type::SpellCheckingExemption;
     else if (equalLettersIgnoringASCIICase(markerType, "deletedautocorrection"_s))
-        result = DocumentMarker::DeletedAutocorrection;
+        result = DocumentMarker::Type::DeletedAutocorrection;
     else if (equalLettersIgnoringASCIICase(markerType, "dictationalternatives"_s))
-        result = DocumentMarker::DictationAlternatives;
+        result = DocumentMarker::Type::DictationAlternatives;
 #if ENABLE(TELEPHONE_NUMBER_DETECTION)
     else if (equalLettersIgnoringASCIICase(markerType, "telephonenumber"_s))
-        result = DocumentMarker::TelephoneNumber;
+        result = DocumentMarker::Type::TelephoneNumber;
 #endif
     else
         return false;
@@ -505,9 +505,9 @@ static bool markerTypeFrom(const String& markerType, DocumentMarker::MarkerType&
     return true;
 }
 
-static bool markerTypesFrom(const String& markerType, OptionSet<DocumentMarker::MarkerType>& result)
+static bool markerTypesFrom(const String& markerType, OptionSet<DocumentMarker::Type>& result)
 {
-    DocumentMarker::MarkerType singularResult;
+    DocumentMarker::Type singularResult;
 
     if (markerType.isEmpty() || equalLettersIgnoringASCIICase(markerType, "all"_s))
         result = DocumentMarker::allMarkers();
@@ -1906,7 +1906,7 @@ ExceptionOr<unsigned> Internals::inspectorPaintRectCount()
 
 ExceptionOr<unsigned> Internals::markerCountForNode(Node& node, const String& markerType)
 {
-    OptionSet<DocumentMarker::MarkerType> markerTypes;
+    OptionSet<DocumentMarker::Type> markerTypes;
     if (!markerTypesFrom(markerType, markerTypes))
         return Exception { ExceptionCode::SyntaxError };
 
@@ -1918,7 +1918,7 @@ ExceptionOr<RenderedDocumentMarker*> Internals::markerAt(Node& node, const Strin
 {
     node.document().updateLayout(LayoutOptions::IgnorePendingStylesheets);
 
-    OptionSet<DocumentMarker::MarkerType> markerTypes;
+    OptionSet<DocumentMarker::Type> markerTypes;
     if (!markerTypesFrom(markerType, markerTypes))
         return Exception { ExceptionCode::SyntaxError };
 
@@ -1954,7 +1954,7 @@ ExceptionOr<String> Internals::markerDescriptionForNode(Node& node, const String
 
 ExceptionOr<String> Internals::dumpMarkerRects(const String& markerTypeString)
 {
-    DocumentMarker::MarkerType markerType;
+    DocumentMarker::Type markerType;
     if (!markerTypeFrom(markerTypeString, markerType))
         return Exception { ExceptionCode::SyntaxError };
 
@@ -2685,7 +2685,7 @@ void Internals::updateEditorUINowIfScheduled()
     }
 }
 
-bool Internals::hasMarkerFor(DocumentMarker::MarkerType type, int from, int length)
+bool Internals::hasMarkerFor(DocumentMarker::Type type, int from, int length)
 {
     Document* document = contextDocument();
     if (!document || !document->frame())
@@ -2698,27 +2698,27 @@ bool Internals::hasMarkerFor(DocumentMarker::MarkerType type, int from, int leng
 
 bool Internals::hasSpellingMarker(int from, int length)
 {
-    return hasMarkerFor(DocumentMarker::Spelling, from, length);
+    return hasMarkerFor(DocumentMarker::Type::Spelling, from, length);
 }
 
 bool Internals::hasGrammarMarker(int from, int length)
 {
-    return hasMarkerFor(DocumentMarker::Grammar, from, length);
+    return hasMarkerFor(DocumentMarker::Type::Grammar, from, length);
 }
 
 bool Internals::hasAutocorrectedMarker(int from, int length)
 {
-    return hasMarkerFor(DocumentMarker::Autocorrected, from, length);
+    return hasMarkerFor(DocumentMarker::Type::Autocorrected, from, length);
 }
 
 bool Internals::hasDictationAlternativesMarker(int from, int length)
 {
-    return hasMarkerFor(DocumentMarker::DictationAlternatives, from, length);
+    return hasMarkerFor(DocumentMarker::Type::DictationAlternatives, from, length);
 }
 
 bool Internals::hasCorrectionIndicatorMarker(int from, int length)
 {
-    return hasMarkerFor(DocumentMarker::CorrectionIndicator, from, length);
+    return hasMarkerFor(DocumentMarker::Type::CorrectionIndicator, from, length);
 }
 
 void Internals::setContinuousSpellCheckingEnabled(bool enabled)

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1442,7 +1442,7 @@ private:
 
     CachedResource* resourceFromMemoryCache(const String& url);
 
-    bool hasMarkerFor(DocumentMarker::MarkerType, int from, int length);
+    bool hasMarkerFor(DocumentMarker::Type, int from, int length);
 
 #if ENABLE(MEDIA_STREAM)
     // RealtimeMediaSource::Observer API

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -359,7 +359,7 @@ void WebPage::addDictationAlternative(const String& text, DictationContext conte
         return;
     }
 
-    document->markers().addMarker(matchRange, DocumentMarker::DictationAlternatives, { DocumentMarker::DictationData { context, text } });
+    document->markers().addMarker(matchRange, DocumentMarker::Type::DictationAlternatives, { DocumentMarker::DictationData { context, text } });
     completion(true);
 }
 
@@ -379,7 +379,7 @@ void WebPage::dictationAlternativesAtSelection(CompletionHandler<void(Vector<Dic
         return;
     }
 
-    auto markers = document->markers().markersInRange(*expandedSelectionRange, DocumentMarker::DictationAlternatives);
+    auto markers = document->markers().markersInRange(*expandedSelectionRange, DocumentMarker::Type::DictationAlternatives);
     auto contexts = WTF::compactMap(markers, [](auto& marker) -> std::optional<DictationContext> {
         if (std::holds_alternative<DocumentMarker::DictationData>(marker->data()))
             return std::get<DocumentMarker::DictationData>(marker->data()).context;
@@ -405,7 +405,7 @@ void WebPage::clearDictationAlternatives(Vector<DictationContext>&& contexts)
         if (!std::holds_alternative<DocumentMarker::DictationData>(marker.data()))
             return FilterMarkerResult::Keep;
         return setOfContextsToRemove.contains(std::get<WebCore::DocumentMarker::DictationData>(marker.data()).context) ? FilterMarkerResult::Remove : FilterMarkerResult::Keep;
-    }, DocumentMarker::DictationAlternatives);
+    }, DocumentMarker::Type::DictationAlternatives);
 }
 
 void WebPage::accessibilityTransferRemoteToken(RetainPtr<NSData> remoteToken)

--- a/Source/WebKit/WebProcess/WebPage/FindController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/FindController.cpp
@@ -532,7 +532,7 @@ Vector<FloatRect> FindController::rectsForTextMatchesInRect(IntRect clipRect)
         if (!document)
             continue;
 
-        for (FloatRect rect : document->markers().renderedRectsForMarkers(DocumentMarker::TextMatch)) {
+        for (FloatRect rect : document->markers().renderedRectsForMarkers(DocumentMarker::Type::TextMatch)) {
             if (!localFrame->isMainFrame())
                 rect = mainFrameView->windowToContents(localFrame->view()->contentsToWindow(enclosingIntRect(rect)));
 

--- a/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
@@ -130,9 +130,9 @@ void WebFoundTextRangeController::decorateTextRangeWithStyle(const WebFoundTextR
     }
 
     if (style == FindDecorationStyle::Normal)
-        simpleRange->start.document().markers().removeMarkers(*simpleRange, WebCore::DocumentMarker::TextMatch);
+        simpleRange->start.document().markers().removeMarkers(*simpleRange, WebCore::DocumentMarker::Type::TextMatch);
     else if (style == FindDecorationStyle::Found)
-        simpleRange->start.document().markers().addMarker(*simpleRange, WebCore::DocumentMarker::TextMatch);
+        simpleRange->start.document().markers().addMarker(*simpleRange, WebCore::DocumentMarker::Type::TextMatch);
     else if (style == FindDecorationStyle::Highlighted) {
         m_highlightedRange = range;
 
@@ -363,7 +363,7 @@ Vector<WebCore::FloatRect> WebFoundTextRangeController::rectsForTextMatchesInRec
         if (!document)
             continue;
 
-        for (auto rect : document->markers().renderedRectsForMarkers(WebCore::DocumentMarker::TextMatch)) {
+        for (auto rect : document->markers().renderedRectsForMarkers(WebCore::DocumentMarker::Type::TextMatch)) {
             if (!localFrame->isMainFrame())
                 rect = mainFrameView->windowToContents(localFrame->view()->contentsToWindow(enclosingIntRect(rect)));
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5577,7 +5577,7 @@ void WebPage::unmarkAllMisspellings()
         if (!localFrame)
             continue;
         if (RefPtr document = localFrame->document())
-            document->markers().removeMarkers(DocumentMarker::Spelling);
+            document->markers().removeMarkers(DocumentMarker::Type::Spelling);
     }
 }
 
@@ -5588,7 +5588,7 @@ void WebPage::unmarkAllBadGrammar()
         if (!localFrame)
             continue;
         if (RefPtr document = localFrame->document())
-            document->markers().removeMarkers(DocumentMarker::Grammar);
+            document->markers().removeMarkers(DocumentMarker::Type::Grammar);
     }
 }
 

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -219,7 +219,7 @@ static void adjustCandidateAutocorrectionInFrame(const String& correction, Local
     if (correctedRange.collapsed())
         return;
 
-    addMarker(correctedRange, WebCore::DocumentMarker::CorrectionIndicator);
+    addMarker(correctedRange, WebCore::DocumentMarker::Type::CorrectionIndicator);
 #else
     UNUSED_PARAM(frame);
 #endif
@@ -391,7 +391,7 @@ void WebPage::getPlatformEditorState(LocalFrame& frame, EditorState& result) con
 
 #if USE(DICTATION_ALTERNATIVES)
     if (selectedRange) {
-        auto markers = frame.document()->markers().markersInRange(*selectedRange, DocumentMarker::MarkerType::DictationAlternatives);
+        auto markers = frame.document()->markers().markersInRange(*selectedRange, DocumentMarker::Type::DictationAlternatives);
         postLayoutData.dictationContextsForSelection = WTF::map(markers, [] (auto& marker) {
             return std::get<DocumentMarker::DictationData>(marker->data()).context;
         });
@@ -408,7 +408,7 @@ void WebPage::getPlatformEditorState(LocalFrame& frame, EditorState& result) con
                 auto& style = editableRoot->renderer()->style();
                 postLayoutData.caretColor = CaretBase::computeCaretColor(style, editableRoot.get());
                 postLayoutData.hasCaretColorAuto = style.hasAutoCaretColor();
-                postLayoutData.hasGrammarDocumentMarkers = editableRoot->document().markers().hasMarkers(makeRangeSelectingNodeContents(*editableRoot), DocumentMarker::Grammar);
+                postLayoutData.hasGrammarDocumentMarkers = editableRoot->document().markers().hasMarkers(makeRangeSelectingNodeContents(*editableRoot), DocumentMarker::Type::Grammar);
             }
         }
 
@@ -1904,7 +1904,7 @@ void WebPage::extendSelectionForReplacement(CompletionHandler<void()>&& completi
     if (!container)
         return;
 
-    auto markerRanges = document->markers().markersFor(*container, { DocumentMarker::DictationAlternatives, DocumentMarker::CorrectionIndicator }).map([&](auto& marker) {
+    auto markerRanges = document->markers().markersFor(*container, { DocumentMarker::Type::DictationAlternatives, DocumentMarker::Type::CorrectionIndicator }).map([&](auto& marker) {
         return makeSimpleRange(*container, *marker);
     });
 
@@ -5019,7 +5019,7 @@ void WebPage::requestDocumentEditingContext(DocumentEditingContextRequest reques
 
     if (request.options.contains(DocumentEditingContextRequest::Options::AutocorrectedRanges)) {
         if (auto contextRange = makeSimpleRange(contextBeforeStart, contextAfterEnd)) {
-            auto ranges = frame->document()->markers().rangesForMarkersInRange(*contextRange, DocumentMarker::MarkerType::CorrectionIndicator);
+            auto ranges = frame->document()->markers().rangesForMarkersInRange(*contextRange, DocumentMarker::Type::CorrectionIndicator);
             context.autocorrectedRanges = ranges.map([&] (auto& range) {
                 auto characterRangeInContext = characterRange(*contextRange, range);
                 return DocumentEditingContext::Range { characterRangeInContext.location, characterRangeInContext.length };

--- a/Source/WebKitLegacy/ios/WebCoreSupport/WebVisiblePosition.mm
+++ b/Source/WebKitLegacy/ios/WebCoreSupport/WebVisiblePosition.mm
@@ -413,7 +413,7 @@ static inline SelectionDirection toSelectionDirection(WebTextAdjustmentDirection
 
     unsigned offset = position.deepEquivalent().deprecatedEditingOffset();
     auto& document = node->document();
-    for (auto& marker : document.markers().markersFor(*node, DocumentMarker::DictationPhraseWithAlternatives)) {
+    for (auto& marker : document.markers().markersFor(*node, DocumentMarker::Type::DictationPhraseWithAlternatives)) {
         if (marker->startOffset() <= offset && marker->endOffset() >= offset) {
             *alternatives = createNSArray(std::get<Vector<String>>(marker->data())).autorelease();
             return kit(makeSimpleRange(*node, *marker));
@@ -431,7 +431,7 @@ static inline SelectionDirection toSelectionDirection(WebTextAdjustmentDirection
 
     unsigned offset = position.deepEquivalent().deprecatedEditingOffset();
     auto& document = node->document();
-    for (auto& marker : document.markers().markersFor(*node, DocumentMarker::Spelling)) {
+    for (auto& marker : document.markers().markersFor(*node, DocumentMarker::Type::Spelling)) {
         if (marker->startOffset() <= offset && marker->endOffset() >= offset)
             return kit(makeSimpleRange(*node, *marker));
     }

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -485,7 +485,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         if (!frame)
             continue;
         if (auto* document = frame->document())
-            document->markers().removeMarkers(WebCore::DocumentMarker::Grammar);
+            document->markers().removeMarkers(WebCore::DocumentMarker::Type::Grammar);
     }
 }
 
@@ -498,7 +498,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         if (!frame)
             continue;
         if (auto* document = frame->document())
-            document->markers().removeMarkers(WebCore::DocumentMarker::Spelling);
+            document->markers().removeMarkers(WebCore::DocumentMarker::Type::Spelling);
     }
 #endif
 }
@@ -1706,7 +1706,7 @@ static WebFrameLoadType toWebFrameLoadType(WebCore::FrameLoadType frameLoadType)
     for (WebCore::Node* node = root; node; node = WebCore::NodeTraversal::next(*node)) {
         auto markers = document->markers().markersFor(*node);
         for (auto& marker : markers) {
-            if (marker->type() != WebCore::DocumentMarker::DictationResult)
+            if (marker->type() != WebCore::DocumentMarker::Type::DictationResult)
                 continue;
 
             id metadata = std::get<RetainPtr<id>>(marker->data()).get();
@@ -1747,7 +1747,7 @@ static WebFrameLoadType toWebFrameLoadType(WebCore::FrameLoadType frameLoadType)
     if (!range)
         return nil;
 
-    auto markers = core(self)->document()->markers().markersInRange(makeSimpleRange(*core(range)), WebCore::DocumentMarker::DictationResult);
+    auto markers = core(self)->document()->markers().markersInRange(makeSimpleRange(*core(range)), WebCore::DocumentMarker::Type::DictationResult);
 
     // UIKit should only ever give us a DOMRange for a phrase with alternatives, which should not be part of more than one result.
     ASSERT(markers.size() <= 1);

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
@@ -4625,8 +4625,8 @@ static RefPtr<WebCore::KeyboardEvent> currentKeyboardEvent(WebCore::LocalFrame* 
 
 #if PLATFORM(IOS_FAMILY)
         if (auto* document = coreFrame->document()) {
-            document->markers().removeMarkers(WebCore::DocumentMarker::DictationPhraseWithAlternatives);
-            document->markers().removeMarkers(WebCore::DocumentMarker::DictationResult);
+            document->markers().removeMarkers(WebCore::DocumentMarker::Type::DictationPhraseWithAlternatives);
+            document->markers().removeMarkers(WebCore::DocumentMarker::Type::DictationResult);
         }
 #endif
 
@@ -7110,7 +7110,7 @@ static CGImageRef selectionImage(WebCore::LocalFrame* frame, bool forceBlackText
     auto* document = coreFrame->document();
     if (!document)
         return;
-    document->markers().removeMarkers(WebCore::DocumentMarker::TextMatch);
+    document->markers().removeMarkers(WebCore::DocumentMarker::Type::TextMatch);
 }
 
 - (NSArray *)rectsForTextMatches
@@ -7122,7 +7122,7 @@ static CGImageRef selectionImage(WebCore::LocalFrame* frame, bool forceBlackText
     if (!document)
         return @[];
 
-    return createNSArray(document->markers().renderedRectsForMarkers(WebCore::DocumentMarker::TextMatch)).autorelease();
+    return createNSArray(document->markers().renderedRectsForMarkers(WebCore::DocumentMarker::Type::TextMatch)).autorelease();
 }
 
 - (BOOL)_findString:(NSString *)string options:(WebFindOptions)options

--- a/Tools/TestWebKitAPI/Tests/WebCore/MarkedText.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/MarkedText.cpp
@@ -96,7 +96,7 @@ TEST(MarkedText, SubdivideSimple)
 
 TEST(MarkedText, SubdivideSpellingAndGrammarSimple)
 {
-    RenderedDocumentMarker grammarErrorMarker { DocumentMarker { DocumentMarker::Grammar, { 7, 8 } } };
+    RenderedDocumentMarker grammarErrorMarker { DocumentMarker { DocumentMarker::Type::Grammar, { 7, 8 } } };
     Vector<MarkedText> expectedMarkedTexts {
         MarkedText { grammarErrorMarker.startOffset(), grammarErrorMarker.endOffset(), MarkedText::Type::GrammarError, &grammarErrorMarker },
         MarkedText { 22, 32, MarkedText::Type::SpellingError },


### PR DESCRIPTION
#### a14f713bae8f1a64b79d58bbe87bfabd43745d79
<pre>
Convert `DocumentMarker::MarkerType` into an enum class
<a href="https://bugs.webkit.org/show_bug.cgi?id=266003">https://bugs.webkit.org/show_bug.cgi?id=266003</a>
<a href="https://rdar.apple.com/119322183">rdar://119322183</a>

Reviewed by Aditya Keerthi.

Changes `DocumentMarker::MarkerType` into a `uint16_t` backed enum class, `DocumentMarker::Type`.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::textInserted):
* Source/WebCore/dom/DocumentMarker.h:
(WebCore::DocumentMarker::DocumentMarker):
(WebCore::DocumentMarker::type const):
(WebCore::DocumentMarker::allMarkers):
(): Deleted.
* Source/WebCore/dom/DocumentMarkerController.cpp:
(WebCore::DocumentMarkerController::possiblyHasMarkers):
(WebCore::DocumentMarkerController::addMarker):
(WebCore::DocumentMarkerController::addDraggedContentMarker):
(WebCore::DocumentMarkerController::removeMarkers):
(WebCore::DocumentMarkerController::filterMarkers):
(WebCore::DocumentMarkerController::updateRectsForInvalidatedMarkersOfType):
(WebCore::DocumentMarkerController::renderedRectsForMarkers):
(WebCore::shouldInsertAsSeparateMarker):
(WebCore::DocumentMarkerController::markerContainingPoint):
(WebCore::DocumentMarkerController::markersFor):
(WebCore::DocumentMarkerController::forEach):
(WebCore::DocumentMarkerController::forEachOfTypes):
(WebCore::DocumentMarkerController::markersInRange):
(WebCore::DocumentMarkerController::rangesForMarkersInRange):
(WebCore::DocumentMarkerController::removeMarkersFromList):
(WebCore::DocumentMarkerController::repaintMarkers):
(WebCore::DocumentMarkerController::dismissMarkers):
(WebCore::DocumentMarkerController::hasMarkers):
(WebCore::DocumentMarkerController::clearDescriptionOnMarkersIntersectingRange):
(WebCore::addMarker):
(WebCore::removeMarkers):
* Source/WebCore/dom/DocumentMarkerController.h:
(WebCore::DocumentMarkerController::addMarker):
(WebCore::addMarker):
* Source/WebCore/editing/AlternativeTextController.cpp:
(WebCore::markerTypesForAppliedDictationAlternative):
(WebCore::markerTypesForAutocorrection):
(WebCore::markerTypesForReplacement):
(WebCore::AlternativeTextController::respondToUnappliedSpellCorrection):
(WebCore::AlternativeTextController::shouldStartTimerFor const):
(WebCore::AlternativeTextController::respondToMarkerAtEndOfWord):
(WebCore::AlternativeTextController::markerDescriptionForAppliedAlternativeText):
(WebCore::AlternativeTextController::applyAlternativeTextToRange):
(WebCore::AlternativeTextController::removeCorrectionIndicatorMarkers):
(WebCore::AlternativeTextController::applyDictationAlternative):
* Source/WebCore/editing/AlternativeTextController.h:
* Source/WebCore/editing/DeleteSelectionCommand.cpp:
(WebCore::DeleteSelectionCommand::originalStringForAutocorrectionAtBeginningOfSelection):
* Source/WebCore/editing/DictationCommand.cpp:
* Source/WebCore/editing/Editor.cpp:
(WebCore::didApplyAutocorrection):
(WebCore::adjustMarkerTypesToRemoveForWordsAffectedByEditing):
(WebCore::Editor::ignoreSpelling):
(WebCore::Editor::learnSpelling):
(WebCore::Editor::clearMisspellingsAndBadGrammar):
(WebCore::Editor::markAndReplaceFor):
(WebCore::Editor::updateMarkersForWordsAffectedByEditing):
(WebCore::Editor::countMatchesForText):
(WebCore::Editor::setMarkedTextMatchesAreHighlighted):
(WebCore::Editor::editorUIUpdateTimerFired):
(WebCore::Editor::selectionStartHasMarkerFor const):
(WebCore::Editor::handleAcceptedCandidate):
* Source/WebCore/editing/Editor.h:
* Source/WebCore/editing/SpellChecker.cpp:
(WebCore::SpellChecker::didCheckSucceed):
* Source/WebCore/editing/TextCheckingHelper.cpp:
(WebCore::TextCheckingHelper::findMisspelledWords const):
(WebCore::TextCheckingHelper::findUngrammaticalPhrases const):
* Source/WebCore/editing/ios/DictationCommandIOS.cpp:
(WebCore::DictationCommandIOS::doApply):
* Source/WebCore/editing/ios/EditorIOS.mm:
(WebCore::Editor::setDictationPhrasesAsChildOfElement):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::removeDraggedContentDocumentMarkersFromAllFramesInPage):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::unmarkAllTextMatches):
* Source/WebCore/page/ios/FrameIOS.mm:
(WebCore::LocalFrame::interpretationsForCurrentRoot const):
* Source/WebCore/rendering/HitTestResult.cpp:
(WebCore::HitTestResult::spellingToolTip const):
(WebCore::HitTestResult::replacedString const):
(WebCore::HitTestResult::dictationAlternatives const):
* Source/WebCore/rendering/MarkedText.cpp:
(WebCore::MarkedText::collectForDocumentMarkers):
* Source/WebCore/rendering/RenderReplaced.cpp:
(WebCore::RenderReplaced::paint):
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::RenderText::draggedContentRangesBetweenOffsets const):
* Source/WebCore/testing/Internals.cpp:
(WebCore::markerTypeFrom):
(WebCore::markerTypesFrom):
(WebCore::Internals::markerCountForNode):
(WebCore::Internals::dumpMarkerRects):
(WebCore::Internals::hasMarkerFor):
(WebCore::Internals::hasSpellingMarker):
(WebCore::Internals::hasGrammarMarker):
(WebCore::Internals::hasAutocorrectedMarker):
(WebCore::Internals::hasDictationAlternativesMarker):
(WebCore::Internals::hasCorrectionIndicatorMarker):
* Source/WebCore/testing/Internals.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.mm:
(WebKit::relevantMarkerTypes):
(WebKit::TextCheckingControllerProxy::replaceRelativeToSelection):
(WebKit::TextCheckingControllerProxy::removeAnnotationRelativeToSelection):
(WebKit::TextCheckingControllerProxy::annotatedSubstringBetweenPositions):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::addDictationAlternative):
(WebKit::WebPage::dictationAlternativesAtSelection):
(WebKit::WebPage::clearDictationAlternatives):
* Source/WebKit/WebProcess/WebPage/FindController.cpp:
(WebKit::FindController::rectsForTextMatchesInRect):
* Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp:
(WebKit::WebFoundTextRangeController::decorateTextRangeWithStyle):
(WebKit::WebFoundTextRangeController::rectsForTextMatchesInRect):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::unmarkAllMisspellings):
(WebKit::WebPage::unmarkAllBadGrammar):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::adjustCandidateAutocorrectionInFrame):
(WebKit::WebPage::getPlatformEditorState const):
(WebKit::WebPage::extendSelectionForReplacement):
(WebKit::WebPage::requestDocumentEditingContext):
* Source/WebKitLegacy/ios/WebCoreSupport/WebVisiblePosition.mm:
(-[WebVisiblePosition enclosingRangeWithDictationPhraseAlternatives:]):
(-[WebVisiblePosition enclosingRangeWithCorrectionIndicator]):
* Source/WebKitLegacy/mac/WebView/WebFrame.mm:
(-[WebFrame _unmarkAllBadGrammar]):
(-[WebFrame getDictationResultRanges:andMetadatas:]):
(-[WebFrame dictationResultMetadataForRange:]):
* Source/WebKitLegacy/mac/WebView/WebHTMLView.mm:
(-[WebHTMLView resignFirstResponder]):
(-[WebHTMLView unmarkAllTextMatches]):
(-[WebHTMLView rectsForTextMatches]):
* Tools/TestWebKitAPI/Tests/WebCore/MarkedText.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/271781@main">https://commits.webkit.org/271781@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3d8de4a656a2023e2aa2ea96122cfb5bd733d1f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29541 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8207 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30862 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32075 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26764 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30142 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10440 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5500 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26771 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29814 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6915 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25241 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5862 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/6040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26327 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33419 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27013 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26748 "Found 1 new test failure: imported/w3c/web-platform-tests/preload/preload-in-data-doc.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32216 "Found 5 new test failures: imported/w3c/web-platform-tests/html/cross-origin-opener-policy/iframe-popup-same-origin-to-unsafe-none.https.html?1-2, imported/w3c/web-platform-tests/html/cross-origin-opener-policy/iframe-popup-same-origin-to-unsafe-none.https.html?5-6, imported/w3c/web-platform-tests/html/cross-origin-opener-policy/popup-meta-http-equiv.https.html, imported/w3c/web-platform-tests/html/cross-origin-opener-policy/tentative/restrict-properties/iframe-popup-to-soap.https.html?7-8, imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/audioworklet-suspend.https.html (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5948 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4140 "Found 2 new test failures: fullscreen/full-screen-layer-dump.html, imported/w3c/web-platform-tests/requestidlecallback/callback-multiple-calls.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29990 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7683 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7031 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6490 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6471 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->