### PR TITLE
Follow-up: Add targets for vp8 and vp9 builds of vpx_dec_fuzzer.cc

### DIFF
--- a/Source/ThirdParty/libwebrtc/Configurations/Base-libvpx.xcconfig
+++ b/Source/ThirdParty/libwebrtc/Configurations/Base-libvpx.xcconfig
@@ -9,6 +9,7 @@ ENABLE_STRICT_OBJC_MSGSEND = YES;
 
 HEADER_SEARCH_PATHS[arch=x86_64] = Source/third_party/libvpx/source/config/mac/x64 Source/third_party/libvpx/source/libvpx Source/third_party/libvpx/source/config;
 HEADER_SEARCH_PATHS[arch=arm64*] = Source/third_party/libvpx/source/config/linux/arm64-highbd Source/third_party/libvpx/source/libvpx Source/third_party/libvpx/source/config;
+USE_HEADERMAP = NO;
 
 GCC_PREPROCESSOR_DEFINITIONS[sdk=iphonesimulator*] = $(inherited) WEBRTC_WEBKIT_DISABLE_HARDWARE_ACCELERATION;
 GCC_PREPROCESSOR_DEFINITIONS[sdk=macosx*] = $(inherited) $(GCC_PREPROCESSOR_DEFINITIONS_$(WK_IS_CATALYST))

--- a/Source/ThirdParty/libwebrtc/Configurations/libvpx.xcconfig
+++ b/Source/ThirdParty/libwebrtc/Configurations/libvpx.xcconfig
@@ -4,7 +4,6 @@ PRODUCT_NAME = vpx;
 
 INSTALL_PATH = $(INSTALL_PATH_PREFIX)$(WK_LIBRARY_INSTALL_PATH);
 PUBLIC_HEADERS_FOLDER_PATH = $(INSTALL_PATH_PREFIX)$(WK_LIBRARY_HEADERS_FOLDER_PATH)/libwebrtc;
-USE_HEADERMAP = NO;
 
 ARM_FILES = *_neon.c arm_cpudetect.c *_arm.c
 X86_FILES = *_sse2.c *_ssse3.c *_sse4.c *_avx2.c *_avx2.cc *_avx.c *.asm


### PR DESCRIPTION
#### 6294044ab15ffdc962d5ed402bc207a90679c3b3
<pre>
Follow-up: Add targets for vp8 and vp9 builds of vpx_dec_fuzzer.cc
<a href="https://bugs.webkit.org/show_bug.cgi?id=261568">https://bugs.webkit.org/show_bug.cgi?id=261568</a>
&lt;<a href="https://rdar.apple.com/115515990">rdar://115515990</a>&gt;

Unreviewed follow-up fix.

* Source/ThirdParty/libwebrtc/Configurations/Base-libvpx.xcconfig:
(USE_HEADERMAP): Add.
* Source/ThirdParty/libwebrtc/Configurations/libvpx.xcconfig:
(USE_HEADERMAP): Remove.
- Move USE_HEADERMAP from libvpx.xcconfig to Base-libvpx.xcconfig.
  This matches the change made to libwebrtc.xcconfig and
  Base-libwebrtc.xcconfig in commit 269490@main.

Canonical link: <a href="https://commits.webkit.org/271731@main">https://commits.webkit.org/271731@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9bf60a9e4138073883845f6a6ad66e1787e47c89

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29250 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7920 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30589 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31833 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26599 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10061 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5224 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26599 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29523 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6580 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25059 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5667 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5813 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26098 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33172 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26713 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26530 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32033 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5779 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3959 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29818 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/close-quickly (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7461 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6292 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3791 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6304 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->