### PR TITLE
Hook up storage for persistent registered content scripts.

### DIFF
--- a/Source/WebKit/Shared/Extensions/_WKWebExtensionRegisteredScriptsSQLiteStore.h
+++ b/Source/WebKit/Shared/Extensions/_WKWebExtensionRegisteredScriptsSQLiteStore.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#import "_WKWebExtensionSQLiteStore.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface _WKWebExtensionRegisteredScriptsSQLiteStore : _WKWebExtensionSQLiteStore
+
+- (void)addScripts:(NSArray *)scripts completionHandler:(void (^)(NSString *errorMessage))completionHandler;
+- (void)deleteScriptsWithIDs:(NSArray *)ids completionHandler:(void (^)(NSString *errorMessage))completionHandler;
+- (void)getScriptsWithCompletionHandler:(void (^)(NSArray *scripts, NSString *errorMessage))completionHandler;
+- (void)updateScripts:(NSArray *)scripts completionHandler:(void (^)(NSString *errorMessage))completionHandler;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/WebKit/Shared/Extensions/_WKWebExtensionRegisteredScriptsSQLiteStore.mm
+++ b/Source/WebKit/Shared/Extensions/_WKWebExtensionRegisteredScriptsSQLiteStore.mm
@@ -1,0 +1,295 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#import "config.h"
+#import "_WKWebExtensionRegisteredScriptsSQLiteStore.h"
+
+#import "CocoaHelpers.h"
+#import "Logging.h"
+#import "WebExtensionDynamicScripts.h"
+#import "_WKWebExtensionSQLiteDatabase.h"
+#import "_WKWebExtensionSQLiteHelpers.h"
+#import "_WKWebExtensionSQLiteRow.h"
+#import <wtf/BlockPtr.h>
+#import <wtf/WeakObjCPtr.h>
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+using namespace WebKit;
+
+static const SchemaVersion currentDatabaseSchemaVersion = 1;
+
+static NSString * const persistAcrossSessionsKey = @"persistAcrossSessions";
+static NSString * const idKey = @"id";
+
+static NSString *rowFilterStringFromRowKeys(NSArray *keys)
+{
+    NSMutableArray<NSString *> *escapedAndQuotedKeys = [NSMutableArray arrayWithCapacity:keys.count];
+
+    for (NSString *key in keys) {
+        NSString *keyWithSingleQuotesEscaped = [key stringByReplacingOccurrencesOfString:@"'" withString:@"''"];
+        [escapedAndQuotedKeys addObject:[NSString stringWithFormat:@"'%@'", keyWithSingleQuotesEscaped]];
+    }
+
+    return [escapedAndQuotedKeys componentsJoinedByString:@","];
+}
+
+@implementation _WKWebExtensionRegisteredScriptsSQLiteStore
+
+- (instancetype)initWithUniqueIdentifier:(NSString *)uniqueIdentifier directory:(NSString *)directory usesInMemoryDatabase:(BOOL)useInMemoryDatabase
+{
+    if (!(self = [super initWithUniqueIdentifier:uniqueIdentifier directory:directory usesInMemoryDatabase:useInMemoryDatabase]))
+        return nil;
+
+    return self;
+}
+
+- (void)updateScripts:(NSArray *)scripts completionHandler:(void (^)(NSString *errorMessage))completionHandler
+{
+    NSArray *ids = mapObjects(scripts, ^(id key, NSDictionary *script) {
+        return script[idKey];
+    });
+
+    auto weakSelf = WeakObjCPtr<_WKWebExtensionRegisteredScriptsSQLiteStore> { self };
+    [self deleteScriptsWithIDs:ids completionHandler:^(NSString *errorMessage) {
+        auto strongSelf = weakSelf.get();
+        if (!strongSelf)
+            return;
+
+        if (errorMessage.length) {
+            completionHandler(errorMessage);
+            return;
+        }
+
+        [strongSelf addScripts:scripts completionHandler:^(NSString *errorMessage) {
+            completionHandler(errorMessage);
+        }];
+    }];
+}
+
+- (void)deleteScriptsWithIDs:(NSArray *)ids completionHandler:(void (^)(NSString *errorMessage))completionHandler
+{
+    if (!ids.count) {
+        completionHandler(nil);
+        return;
+    }
+
+    auto weakSelf = WeakObjCPtr<_WKWebExtensionRegisteredScriptsSQLiteStore> { self };
+    dispatch_async(_databaseQueue, ^{
+        auto strongSelf = weakSelf.get();
+        if (!strongSelf)
+            return;
+
+        NSString *errorMessage;
+        if (![strongSelf _openDatabaseIfNecessaryReturningErrorMessage:&errorMessage]) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                completionHandler(errorMessage);
+            });
+
+            return;
+        }
+
+        ASSERT(!errorMessage.length);
+        ASSERT(strongSelf->_database);
+
+        auto result = SQLiteDatabaseExecute(strongSelf->_database, [NSString stringWithFormat:@"DELETE FROM registered_scripts WHERE key in (%@)", rowFilterStringFromRowKeys(ids)]);
+        if (result != SQLITE_DONE) {
+            RELEASE_LOG_ERROR(Extensions, "Failed to delete scripts for extension %{private}@.", strongSelf->_uniqueIdentifier);
+            errorMessage = @"Failed to delete scripts from registered content scripts storage.";
+        }
+
+        NSString *deleteDatabaseErrorMessage = [strongSelf _deleteDatabaseIfEmpty];
+
+        dispatch_async(dispatch_get_main_queue(), ^{
+            // Errors from opening the database or deleting keys take precedence over an error deleting the database.
+            completionHandler(errorMessage.length ? errorMessage : deleteDatabaseErrorMessage);
+        });
+    });
+}
+
+- (void)addScripts:(NSArray *)scripts completionHandler:(void (^)(NSString *errorMessage))completionHandler
+{
+    // Only save persistent scripts to storage.
+    scripts = filterObjects(scripts, ^(id key, NSDictionary *script) {
+        return boolForKey(script, persistAcrossSessionsKey , false);
+    });
+
+    if (!scripts.count) {
+        completionHandler(nil);
+        return;
+    }
+
+    auto weakSelf = WeakObjCPtr<_WKWebExtensionRegisteredScriptsSQLiteStore> { self };
+    dispatch_async(_databaseQueue, ^{
+        auto strongSelf = weakSelf.get();
+        if (!strongSelf)
+            return;
+
+        NSString *errorMessage;
+
+        if (![strongSelf _openDatabaseIfNecessaryReturningErrorMessage:&errorMessage]) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                completionHandler(errorMessage);
+            });
+
+            return;
+        }
+
+        ASSERT(!errorMessage.length);
+        ASSERT(strongSelf->_database);
+
+        for (NSDictionary *script in scripts)
+            [strongSelf _insertScript:script inDatabase:strongSelf->_database errorMessage:&errorMessage];
+
+        dispatch_async(dispatch_get_main_queue(), ^{
+            completionHandler(errorMessage);
+        });
+    });
+}
+
+- (void)getScriptsWithCompletionHandler:(void (^)(NSArray *, NSString *))completionHandler
+{
+    auto weakSelf = WeakObjCPtr<_WKWebExtensionRegisteredScriptsSQLiteStore> { self };
+    dispatch_async(_databaseQueue, ^{
+        NSString *errorMessage;
+        auto strongSelf = weakSelf.get();
+        auto* scripts = [strongSelf _getScriptsWithOutErrorMessage:&errorMessage];
+
+        dispatch_async(dispatch_get_main_queue(), ^{
+            completionHandler(scripts, errorMessage);
+        });
+    });
+}
+
+- (NSArray *)_getScriptsWithOutErrorMessage:(NSString **)outErrorMessage
+{
+    dispatch_assert_queue(_databaseQueue);
+
+    if (![self _openDatabaseIfNecessaryReturningErrorMessage:outErrorMessage])
+        return @[ ];
+
+    ASSERT(!(*outErrorMessage).length);
+    ASSERT(_database);
+
+    _WKWebExtensionSQLiteRowEnumerator *rows = SQLiteDatabaseFetch(_database, @"SELECT * FROM registered_scripts");
+    return [self _getKeysAndValuesFromRowEnumerator:rows];
+}
+
+- (NSArray *)_getKeysAndValuesFromRowEnumerator:(_WKWebExtensionSQLiteRowEnumerator *)rows
+{
+    static NSSet *allowedClasses = [NSSet setWithObjects:NSString.class, NSArray.class, NSMutableDictionary.class, nil];
+
+    NSMutableArray<NSDictionary<NSString *, id> *> *scripts = [NSMutableArray array];
+
+    for (_WKWebExtensionSQLiteRow *row in rows) {
+        NSError *error;
+        NSDictionary<NSString *, id> *script = [NSKeyedUnarchiver unarchivedObjectOfClasses:allowedClasses fromData:[row dataAtIndex:1] error:&error];
+
+        if (error)
+            RELEASE_LOG_ERROR(Extensions, "Failed to deserialize registered content script for extension %{private}@.", _uniqueIdentifier);
+        else
+            [scripts addObject:script];
+    }
+
+    return scripts;
+}
+
+- (void)_insertScript:(NSDictionary *)script inDatabase:(_WKWebExtensionSQLiteDatabase *)database errorMessage:(NSString **)errorMessage
+{
+    dispatch_assert_queue(_databaseQueue);
+    ASSERT(_database);
+
+    NSData *scriptAsData = [NSKeyedArchiver archivedDataWithRootObject:script requiringSecureCoding:YES error:nil];
+    NSString *scriptID = script[idKey];
+    ASSERT(scriptID);
+
+    auto result = SQLiteDatabaseExecute(database, @"INSERT INTO registered_scripts (key, script) VALUES (?, ?)", scriptID, scriptAsData);
+    if (result != SQLITE_DONE) {
+        RELEASE_LOG_ERROR(Extensions, "Failed to insert registered content script for extension %{private}@.", _uniqueIdentifier);
+        *errorMessage =  @"Failed to add content script.";
+        return;
+    }
+}
+
+// MARK: Database Schema
+
+- (SchemaVersion)_currentDatabaseSchemaVersion
+{
+    return currentDatabaseSchemaVersion;
+}
+
+- (NSURL *)_databaseURL
+{
+    if (_useInMemoryDatabase)
+        return [_WKWebExtensionSQLiteDatabase inMemoryDatabaseURL];
+
+    ASSERT(_directory);
+
+    NSString *databaseName = @"RegisteredContentScripts.db";
+
+    return [_directory URLByAppendingPathComponent:databaseName isDirectory:NO];
+}
+
+- (DatabaseResult)_createFreshDatabaseSchema
+{
+    dispatch_assert_queue(_databaseQueue);
+    ASSERT(_database);
+
+    auto result = SQLiteDatabaseExecute(_database, @"CREATE TABLE registered_scripts (key TEXT PRIMARY KEY NOT NULL, script BLOB NOT NULL)");
+    if (result != SQLITE_DONE)
+        RELEASE_LOG_ERROR(Extensions, "Failed to create registered_scripts database for extension %{private}@: %{public}@ (%d)", _uniqueIdentifier, _database.lastErrorMessage, result);
+
+    return result;
+}
+
+- (DatabaseResult)_resetDatabaseSchema
+{
+    dispatch_assert_queue(_databaseQueue);
+    ASSERT(_database);
+
+    auto result = SQLiteDatabaseExecute(_database, @"DROP TABLE IF EXISTS registered_scripts");
+    if (result != SQLITE_DONE)
+        RELEASE_LOG_ERROR(Extensions, "Failed to reset registered_scripts database schema for extension %{private}@: %{public}@ (%d)", _uniqueIdentifier, _database.lastErrorMessage, result);
+
+    return result;
+}
+
+- (BOOL)_isDatabaseEmpty
+{
+    dispatch_assert_queue(_databaseQueue);
+    ASSERT(_database);
+
+    _WKWebExtensionSQLiteRowEnumerator *rows = SQLiteDatabaseFetch(_database, @"SELECT COUNT(*) FROM registered_scripts");
+    return ![[rows nextObject] int64AtIndex:0];
+}
+
+@end
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)
+

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -83,6 +83,7 @@ OBJC_CLASS WKWebViewConfiguration;
 OBJC_CLASS _WKWebExtensionContext;
 OBJC_CLASS _WKWebExtensionContextDelegate;
 OBJC_CLASS _WKWebExtensionDeclarativeNetRequestSQLiteStore;
+OBJC_CLASS _WKWebExtensionRegisteredScriptsSQLiteStore;
 OBJC_PROTOCOL(_WKWebExtensionTab);
 OBJC_PROTOCOL(_WKWebExtensionWindow);
 
@@ -420,6 +421,8 @@ private:
 
     void moveLocalStorageIfNeeded(const URL& previousBaseURL, CompletionHandler<void()>&&);
 
+    void invalidateStorage();
+
     void postAsyncNotification(NSString *notificationName, PermissionsSet&);
     void postAsyncNotification(NSString *notificationName, MatchPatternSet&);
 
@@ -480,6 +483,10 @@ private:
     void updateDeclarativeNetRequestRulesInStorage(_WKWebExtensionDeclarativeNetRequestSQLiteStore *, NSString *storageType, NSArray *rulesToAdd, NSArray *ruleIDsToRemove, CompletionHandler<void(std::optional<String>)>&&);
 
     DeclarativeNetRequestMatchedRuleVector matchedRules() { return m_matchedRules; }
+
+    // Registered content scripts methods.
+    void loadRegisteredContentScripts();
+    RetainPtr<_WKWebExtensionRegisteredScriptsSQLiteStore> registeredContentScriptsStore();
 
     // Action APIs
     void actionGetTitle(std::optional<WebExtensionWindowIdentifier>, std::optional<WebExtensionTabIdentifier>, CompletionHandler<void(std::optional<String>, std::optional<String>)>&&);
@@ -574,7 +581,7 @@ private:
     void scriptingUpdateRegisteredScripts(const Vector<WebExtensionRegisteredScriptParameters>& scripts, CompletionHandler<void(WebExtensionDynamicScripts::Error)>&&);
     void scriptingGetRegisteredScripts(const Vector<String>&, CompletionHandler<void(Vector<WebExtensionRegisteredScriptParameters> scripts)>&&);
     void scriptingUnregisterContentScripts(const Vector<String>&, CompletionHandler<void(WebExtensionDynamicScripts::Error)>&&);
-    bool parseRegisteredContentScripts(const Vector<WebExtensionRegisteredScriptParameters>&, WebExtensionDynamicScripts::WebExtensionRegisteredScript::FirstTimeRegistration, InjectedContentVector&, NSString *callingAPIName, NSString **errorMessage);
+    bool createInjectedContentForScripts(const Vector<WebExtensionRegisteredScriptParameters>&, WebExtensionDynamicScripts::WebExtensionRegisteredScript::FirstTimeRegistration, InjectedContentVector&, NSString *callingAPIName, NSString **errorMessage);
 
     // Tabs APIs
     void tabsCreate(WebPageProxyIdentifier, const WebExtensionTabParameters&, CompletionHandler<void(std::optional<WebExtensionTabParameters>, WebExtensionTab::Error)>&&);
@@ -689,6 +696,7 @@ private:
     HashMap<Ref<WebExtensionMatchPattern>, UserStyleSheetVector> m_injectedStyleSheetsPerPatternMap;
 
     HashMap<String, Ref<WebExtensionDynamicScripts::WebExtensionRegisteredScript>> m_registeredScriptsMap;
+    RetainPtr<_WKWebExtensionRegisteredScriptsSQLiteStore> m_registeredContentScriptsStorage;
 
     UserStyleSheetVector m_dynamicallyInjectedUserStyleSheets;
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1933,6 +1933,8 @@
 		B6D031052AC1F241006C8E0B /* WebExtensionDynamicScripts.h in Headers */ = {isa = PBXBuildFile; fileRef = B6D031032AC1F240006C8E0B /* WebExtensionDynamicScripts.h */; };
 		B6D031062AC1F241006C8E0B /* WebExtensionDynamicScriptsCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = B6D031042AC1F241006C8E0B /* WebExtensionDynamicScriptsCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B6D0310A2AC1F631006C8E0B /* WebExtensionScriptInjectionParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = B6D031082AC1F631006C8E0B /* WebExtensionScriptInjectionParameters.h */; };
+		B6D75B1D2B1FD0BF00BC932E /* _WKWebExtensionRegisteredScriptsSQLiteStore.mm in Sources */ = {isa = PBXBuildFile; fileRef = B6D75B1B2B1FD0BE00BC932E /* _WKWebExtensionRegisteredScriptsSQLiteStore.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		B6D75B1E2B1FD0BF00BC932E /* _WKWebExtensionRegisteredScriptsSQLiteStore.h in Headers */ = {isa = PBXBuildFile; fileRef = B6D75B1C2B1FD0BE00BC932E /* _WKWebExtensionRegisteredScriptsSQLiteStore.h */; };
 		B6E5F2A5299C105500DBCEA3 /* WebExtensionAPILocalization.h in Headers */ = {isa = PBXBuildFile; fileRef = B6E5F2A4299C105500DBCEA3 /* WebExtensionAPILocalization.h */; };
 		B6E5F2A7299C10B100DBCEA3 /* WebExtensionAPILocalizationCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = B6E5F2A6299C10B100DBCEA3 /* WebExtensionAPILocalizationCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B6F6CA172AA91EC300DC14B5 /* WebExtensionAPIScriptingCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = B6F6CA162AA91EC200DC14B5 /* WebExtensionAPIScriptingCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
@@ -6839,6 +6841,8 @@
 		B6D031032AC1F240006C8E0B /* WebExtensionDynamicScripts.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionDynamicScripts.h; sourceTree = "<group>"; };
 		B6D031042AC1F241006C8E0B /* WebExtensionDynamicScriptsCocoa.mm */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp.preprocessed; fileEncoding = 4; path = WebExtensionDynamicScriptsCocoa.mm; sourceTree = "<group>"; };
 		B6D031082AC1F631006C8E0B /* WebExtensionScriptInjectionParameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionScriptInjectionParameters.h; sourceTree = "<group>"; };
+		B6D75B1B2B1FD0BE00BC932E /* _WKWebExtensionRegisteredScriptsSQLiteStore.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKWebExtensionRegisteredScriptsSQLiteStore.mm; sourceTree = "<group>"; };
+		B6D75B1C2B1FD0BE00BC932E /* _WKWebExtensionRegisteredScriptsSQLiteStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionRegisteredScriptsSQLiteStore.h; sourceTree = "<group>"; };
 		B6E5F2A3299C0FFB00DBCEA3 /* WebExtensionAPILocalization.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebExtensionAPILocalization.idl; sourceTree = "<group>"; };
 		B6E5F2A4299C105500DBCEA3 /* WebExtensionAPILocalization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WebExtensionAPILocalization.h; path = WebProcess/Extensions/API/WebExtensionAPILocalization.h; sourceTree = SOURCE_ROOT; };
 		B6E5F2A6299C10B100DBCEA3 /* WebExtensionAPILocalizationCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionAPILocalizationCocoa.mm; sourceTree = "<group>"; };
@@ -12736,6 +12740,8 @@
 			children = (
 				B6217BB0299C39F000498BF8 /* _WKWebExtensionLocalization.h */,
 				B6217BB1299C3AE300498BF8 /* _WKWebExtensionLocalization.mm */,
+				B6D75B1C2B1FD0BE00BC932E /* _WKWebExtensionRegisteredScriptsSQLiteStore.h */,
+				B6D75B1B2B1FD0BE00BC932E /* _WKWebExtensionRegisteredScriptsSQLiteStore.mm */,
 				B6A2923B2B193ED40061930E /* _WKWebExtensionSQLiteDatabase.h */,
 				B6A2923C2B193ED50061930E /* _WKWebExtensionSQLiteDatabase.mm */,
 				B6BF18412B1A8F8A00FA39D3 /* _WKWebExtensionSQLiteDatatypeTraits.h */,
@@ -15095,6 +15101,7 @@
 				1C7316792AC1DFED007FADA4 /* _WKWebExtensionMessagePortPrivate.h in Headers */,
 				1C8B2363289AE89400020CDC /* _WKWebExtensionPermission.h in Headers */,
 				1C3BEB712888842A00E66E38 /* _WKWebExtensionPrivate.h in Headers */,
+				B6D75B1E2B1FD0BF00BC932E /* _WKWebExtensionRegisteredScriptsSQLiteStore.h in Headers */,
 				B6A2923D2B193ED50061930E /* _WKWebExtensionSQLiteDatabase.h in Headers */,
 				B6BF18422B1A8F8B00FA39D3 /* _WKWebExtensionSQLiteDatatypeTraits.h in Headers */,
 				B6BF18402B1A8C3600FA39D3 /* _WKWebExtensionSQLiteHelpers.h in Headers */,
@@ -18177,6 +18184,7 @@
 				1C1CE972288DF5030098D3A1 /* _WKWebExtensionMatchPattern.mm in Sources */,
 				1C7316752AC1D658007FADA4 /* _WKWebExtensionMessagePort.mm in Sources */,
 				1C049838289AF5AD0010308B /* _WKWebExtensionPermission.mm in Sources */,
+				B6D75B1D2B1FD0BF00BC932E /* _WKWebExtensionRegisteredScriptsSQLiteStore.mm in Sources */,
 				B6A2923E2B193ED50061930E /* _WKWebExtensionSQLiteDatabase.mm in Sources */,
 				B6BF18392B1A510500FA39D3 /* _WKWebExtensionSQLiteRow.mm in Sources */,
 				B6BF18352B1A49EF00FA39D3 /* _WKWebExtensionSQLiteStatement.mm in Sources */,

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIScripting.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIScripting.h
@@ -55,6 +55,8 @@ public:
     void unregisterContentScripts(NSDictionary *filter, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
 private:
+    friend class WebExtensionContext;
+
     bool hasValidExecutionWorld(NSDictionary *script, NSString **outExceptionString);
 
     bool validateScript(NSDictionary *, NSString **outExceptionString);
@@ -67,7 +69,7 @@ private:
     void parseCSSInjectionOptions(NSDictionary *, WebExtensionScriptInjectionParameters&);
     void parseTargetInjectionOptions(NSDictionary *, WebExtensionScriptInjectionParameters&, NSString **outExceptionString);
     void parseScriptInjectionOptions(NSDictionary *, WebExtensionScriptInjectionParameters&);
-    void parseRegisteredContentScripts(NSArray *, FirstTimeRegistration, Vector<WebExtensionRegisteredScriptParameters>&);
+    static void parseRegisteredContentScripts(NSArray *, FirstTimeRegistration, Vector<WebExtensionRegisteredScriptParameters>&);
 
 #endif
 };


### PR DESCRIPTION
#### 4485c484a89d836f7ddac832426ddfae1ea14fad
<pre>
Hook up storage for persistent registered content scripts.
<a href="https://bugs.webkit.org/show_bug.cgi?id=265899">https://bugs.webkit.org/show_bug.cgi?id=265899</a>

Reviewed by Timothy Hatcher.

This is the final work for scripting API. This patch creates a _WKWebExtensionRegisteredScriptsSQLiteStore
which will be used to manage storage for registered scripts. This patch also loads these scripts
from storage when an extension loads.

When an extension updates, we will need to remove these scripts from storage since they shouldn&apos;t
persist in this case. This is being tracked in <a href="https://bugs.webkit.org/show_bug.cgi?id=249266.">https://bugs.webkit.org/show_bug.cgi?id=249266.</a>

* Source/WebKit/Shared/Extensions/_WKWebExtensionRegisteredScriptsSQLiteStore.h: Added.
* Source/WebKit/Shared/Extensions/_WKWebExtensionRegisteredScriptsSQLiteStore.mm: Added.
(rowFilterStringFromRowKeys):
(-[_WKWebExtensionRegisteredScriptsSQLiteStore initWithUniqueIdentifier:directory:usesInMemoryDatabase:]):
(-[_WKWebExtensionRegisteredScriptsSQLiteStore updateScripts:completionHandler:]):
(-[_WKWebExtensionRegisteredScriptsSQLiteStore deleteScriptsWithIDs:completionHandler:]):
(-[_WKWebExtensionRegisteredScriptsSQLiteStore addScripts:completionHandler:]):
(-[_WKWebExtensionRegisteredScriptsSQLiteStore getScriptsWithCompletionHandler:]):
(-[_WKWebExtensionRegisteredScriptsSQLiteStore _getScriptsWithOutErrorMessage:]):
(-[_WKWebExtensionRegisteredScriptsSQLiteStore _getKeysAndValuesFromRowEnumerator:]):
(-[_WKWebExtensionRegisteredScriptsSQLiteStore _insertScript:inDatabase:errorMessage:]):
(-[_WKWebExtensionRegisteredScriptsSQLiteStore _currentDatabaseSchemaVersion]):
(-[_WKWebExtensionRegisteredScriptsSQLiteStore _databaseURL]):
(-[_WKWebExtensionRegisteredScriptsSQLiteStore _createFreshDatabaseSchema]):
(-[_WKWebExtensionRegisteredScriptsSQLiteStore _resetDatabaseSchema]):
(-[_WKWebExtensionRegisteredScriptsSQLiteStore _isDatabaseEmpty]):
* Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteStore.mm:
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm:
(WebKit::WebExtensionContext::scriptingRegisterContentScripts):
(WebKit::WebExtensionContext::scriptingUpdateRegisteredScripts):
(WebKit::WebExtensionContext::scriptingGetRegisteredScripts):
(WebKit::WebExtensionContext::scriptingUnregisterContentScripts):
(WebKit::WebExtensionContext::loadRegisteredContentScripts):
(WebKit::WebExtensionContext::createInjectedContentForScripts):
Renamed from parseRegisteredContentScripts. Parse scripts and create injected content data.
(WebKit::WebExtensionContext::parseRegisteredContentScripts): Deleted.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::load):
(WebKit::WebExtensionContext::unload):
(WebKit::WebExtensionContext::invalidateStorage):
Invalidate all references to extension storage.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerConfigurationCocoa.mm:
(WebKit::WebExtensionControllerConfiguration::registeredContentScriptsDirectory):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIScriptingCocoa.mm:
(WebKit::parseRegisteredContentScripts):
(WebKit::WebExtensionAPIScripting::parseRegisteredContentScripts): Deleted.
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIScripting.h:

Canonical link: <a href="https://commits.webkit.org/271758@main">https://commits.webkit.org/271758@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7775752954c276cc1176705913fb87b2f5716c4a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29580 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8241 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30891 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/32096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/26784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10392 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5532 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/32096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29853 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/6878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/25257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/32096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/6010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/33440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/26978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/26766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/33440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/5968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/4159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/33440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/7704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/6510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3804 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/6491 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->