### PR TITLE
Failing to deserialize data from _WKWebExtensionSQLiteRow

### DIFF
--- a/Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteRow.mm
+++ b/Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteRow.mm
@@ -112,7 +112,7 @@
     RawData data = [self uncopiedRawDataAtIndex:index];
     if (data.isNull)
         return nil;
-    return [NSData dataWithBytes:(void*)&data.bytes length:data.length];
+    return [NSData dataWithBytes:data.bytes length:data.length];
 }
 
 - (NSData *)uncopiedDataAtIndex:(NSUInteger)index
@@ -120,7 +120,7 @@
     RawData data = [self uncopiedRawDataAtIndex:index];
     if (data.isNull)
         return nil;
-    return [NSData dataWithBytesNoCopy:(void*)&data.bytes length:data.length freeWhenDone:NO];
+    return [NSData dataWithBytesNoCopy:const_cast<void *>(data.bytes) length:data.length freeWhenDone:NO];
 }
 
 - (RawData)uncopiedRawDataAtIndex:(NSUInteger)index

--- a/Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteStore.mm
+++ b/Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteStore.mm
@@ -45,7 +45,7 @@ using namespace WebKit;
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
-static constexpr std::array<const char *, 3> databaseFileSuffixes { "-shm", "-wal" };
+static constexpr std::array<const char *, 2> databaseFileSuffixes { "-shm", "-wal" };
 
 @implementation _WKWebExtensionSQLiteStore
 


### PR DESCRIPTION
#### 9e36fb6ce4d50edc025be982de388581958edf03
<pre>
Failing to deserialize data from _WKWebExtensionSQLiteRow
<a href="https://bugs.webkit.org/show_bug.cgi?id=266012">https://bugs.webkit.org/show_bug.cgi?id=266012</a>

Reviewed by Brian Weinstein and Timothy Hatcher.

We should be passing data.bytes as is.
`- (NSData *)uncopiedDataAtIndex:(NSUInteger)index` needs a cast.

* Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteRow.mm:
(-[_WKWebExtensionSQLiteRow dataAtIndex:]):
(-[_WKWebExtensionSQLiteRow uncopiedDataAtIndex:]):
* Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteStore.mm:
Initialize with space for two items, not three.

Canonical link: <a href="https://commits.webkit.org/271693@main">https://commits.webkit.org/271693@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c48a187e4f7483e7ba6b875d7aba1cac629bd53

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29298 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7968 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30633 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31872 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/26625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10108 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5267 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29571 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/6621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/25082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5697 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/5842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33212 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/26751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/26561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/32065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/5807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/3987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/29849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/7496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/6323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3766 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/6331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->