### PR TITLE
Implement declarativeNetRequest dynamic and session rules APIs

### DIFF
--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -542,7 +542,7 @@
 "Exceeded maximum number of `declarative_net_request` rulesets. Ignoring extra rulesets." = "Exceeded maximum number of `declarative_net_request` rulesets. Ignoring extra rulesets.";
 
 /* _WKWebExtensionErrorInvalidDeclarativeNetRequestEntry description for too many enabled static rulesets */
-"Exceeded maxmimum number of enabled `declarative_net_request` static rulesets. The first %lu will be applied, the remaining will be ignored." = "Exceeded maxmimum number of enabled `declarative_net_request` static rulesets. The first %lu will be applied, the remaining will be ignored.";
+"Exceeded maximum number of enabled `declarative_net_request` static rulesets. The first %lu will be applied, the remaining will be ignored." = "Exceeded maximum number of enabled `declarative_net_request` static rulesets. The first %lu will be applied, the remaining will be ignored.";
 
 /* Button for exiting full screen when in full screen media playback */
 "Exit Full Screen" = "Exit Full Screen";
@@ -907,6 +907,9 @@
 /* context menu item for PDF */
 "Open with %@" = "Open with %@";
 
+/* Open with Preview context menu item */
+"Open with Preview" = "Open with Preview";
+
 /* Label for the order with Apple Pay button. */
 "Order with Apple Pay" = "Order with Apple Pay";
 
@@ -1113,9 +1116,6 @@
 
 /* Title of the context menu item to show when PDFPlugin was used instead of a blocked plugin */
 "Show in blocked plug-in" = "Show in blocked plug-in";
-
-/* Open with Preview context menu item */
-"Open with Preview" = "Open with Preview";
 
 /* Single Page context menu item */
 "Single Page" = "Single Page";

--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -417,7 +417,6 @@ localizedStrings["Connection Closed"] = "Connection Closed";
 localizedStrings["Connection ID"] = "Connection ID";
 localizedStrings["Connection:"] = "Connection:";
 localizedStrings["Console"] = "Console";
-localizedStrings["Console:"] = "Console:";
 localizedStrings["Console Evaluation"] = "Console Evaluation";
 localizedStrings["Console Evaluation %d"] = "Console Evaluation %d";
 localizedStrings["Console Profile Recorded"] = "Console Profile Recorded";
@@ -429,6 +428,7 @@ localizedStrings["Console Tab Name"] = "Console";
 localizedStrings["Console cleared at %s"] = "Console cleared at %s";
 localizedStrings["Console opened at %s"] = "Console opened at %s";
 localizedStrings["Console prompt"] = "Console prompt";
+localizedStrings["Console:"] = "Console:";
 localizedStrings["Containing"] = "Containing";
 localizedStrings["Content Security Policy violation of directive: %s"] = "Content Security Policy violation of directive: %s";
 /* Property value for `font-variant-ligatures: contextual`. */
@@ -835,8 +835,8 @@ localizedStrings["Group Media Requests"] = "Group Media Requests";
 localizedStrings["Group by Event @ Node Event Listeners"] = "Group by Event";
 /* Group DOM event listeners by DOM node */
 localizedStrings["Group by Target @ Node Event Listeners"] = "Group by Target";
-localizedStrings["Grouping Method"] = "Grouping Method";
 localizedStrings["Group source map network errors"] = "Group source map network errors";
+localizedStrings["Grouping Method"] = "Grouping Method";
 localizedStrings["HAR Export (%s)"] = "HAR Export (%s)";
 localizedStrings["HAR Import"] = "HAR Import";
 localizedStrings["HAR Import Error: %s"] = "HAR Import Error: %s";
@@ -1578,8 +1578,8 @@ localizedStrings["Some examples of ways to use this script include (but are not 
 localizedStrings["Sort Ascending"] = "Sort Ascending";
 localizedStrings["Sort Descending"] = "Sort Descending";
 localizedStrings["Source"] = "Source";
-localizedStrings["Source Maps:"] = "Source Maps:";
 localizedStrings["Source Map loading errors"] = "Source Map loading errors";
+localizedStrings["Source Maps:"] = "Source Maps:";
 localizedStrings["Sources"] = "Sources";
 /* Name of Sources Tab */
 localizedStrings["Sources Tab Name"] = "Sources";

--- a/Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteStore.h
+++ b/Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteStore.h
@@ -52,6 +52,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)_openDatabaseIfNecessaryReturningErrorMessage:(NSString * _Nullable * _Nonnull)outErrorMessage;
 - (nullable NSString *)_deleteDatabaseIfEmpty;
 
+- (void)createSavepointWithCompletionHandler:(void (^)(NSUUID * _Nullable savepointIdentifer, NSString * _Nullable errorMessage))completionHandler;
+- (void)commitSavepoint:(NSUUID *)savepointIdentifier completionHandler:(void (^)(NSString * _Nullable errorMessage))completionHandler;
+- (void)rollbackToSavepoint:(NSUUID *)savepointIdentifier completionHandler:(void (^)(NSString * _Nullable errorMessage))completionHandler;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
@@ -1709,7 +1709,7 @@ void WebExtension::populateDeclarativeNetRequestPropertiesIfNeeded()
         }
 
         if (ruleset.enabled && ++enabledRulesetCount > webExtensionDeclarativeNetRequestMaximumNumberOfEnabledRulesets && !recordedTooManyRulesetsManifestError) {
-            recordError(createError(Error::InvalidDeclarativeNetRequest, WEB_UI_FORMAT_STRING("Exceeded maxmimum number of enabled `declarative_net_request` static rulesets. The first %lu will be applied, the remaining will be ignored.", "_WKWebExtensionErrorInvalidDeclarativeNetRequestEntry description for too many enabled static rulesets", webExtensionDeclarativeNetRequestMaximumNumberOfEnabledRulesets)));
+            recordError(createError(Error::InvalidDeclarativeNetRequest, WEB_UI_FORMAT_STRING("Exceeded maximum number of enabled `declarative_net_request` static rulesets. The first %lu will be applied, the remaining will be ignored.", "_WKWebExtensionErrorInvalidDeclarativeNetRequestEntry description for too many enabled static rulesets", webExtensionDeclarativeNetRequestMaximumNumberOfEnabledRulesets)));
             recordedTooManyRulesetsManifestError = true;
             continue;
         }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestSQLiteStore.h
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestSQLiteStore.h
@@ -27,9 +27,13 @@
 
 #import "_WKWebExtensionSQLiteStore.h"
 
+enum class _WKWebExtensionDeclarativeNetRequestStorageType : bool { Dynamic, Session };
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface _WKWebExtensionDeclarativeNetRequestSQLiteStore : _WKWebExtensionSQLiteStore
+
+- (instancetype)initWithUniqueIdentifier:(NSString *)uniqueIdentifier storageType:(_WKWebExtensionDeclarativeNetRequestStorageType)storageType directory:(NSString *)directory usesInMemoryDatabase:(BOOL)useInMemoryDatabase;
 
 - (void)getRulesWithCompletionHandler:(void (^)(NSArray<NSDictionary<NSString *, id> *> *rules, NSString *errorMessage))completionHandler;
 - (void)updateRulesByRemovingIDs:(NSArray<NSNumber *> *)ruleIDs addRules:(NSArray<NSDictionary<NSString *, id> *> *)rules completionHandler:(void (^)(NSString *errorMessage))completionHandler;

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestSQLiteStore.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestSQLiteStore.mm
@@ -48,13 +48,13 @@ static const SchemaVersion currentDatabaseSchemaVersion = 1;
     NSString *_tableName;
 }
 
-- (instancetype)initWithUniqueIdentifier:(NSString *)uniqueIdentifier directory:(NSString *)directory usesInMemoryDatabase:(BOOL)useInMemoryDatabase
+- (instancetype)initWithUniqueIdentifier:(NSString *)uniqueIdentifier storageType:(_WKWebExtensionDeclarativeNetRequestStorageType)storageType directory:(NSString *)directory usesInMemoryDatabase:(BOOL)useInMemoryDatabase
 {
     if (!(self = [super initWithUniqueIdentifier:uniqueIdentifier directory:directory usesInMemoryDatabase:useInMemoryDatabase]))
         return nil;
 
-    _storageType = _useInMemoryDatabase ? @"session" : @"dynamic";
-    _tableName = [NSString stringWithFormat:@"%@_rules", _storageType];
+    _storageType = storageType == _WKWebExtensionDeclarativeNetRequestStorageType::Dynamic ? @"dynamic" : @"session";
+    _tableName = @"rules";
     return self;
 }
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -82,6 +82,7 @@ OBJC_CLASS WKWebView;
 OBJC_CLASS WKWebViewConfiguration;
 OBJC_CLASS _WKWebExtensionContext;
 OBJC_CLASS _WKWebExtensionContextDelegate;
+OBJC_CLASS _WKWebExtensionDeclarativeNetRequestSQLiteStore;
 OBJC_PROTOCOL(_WKWebExtensionTab);
 OBJC_PROTOCOL(_WKWebExtensionWindow);
 
@@ -472,6 +473,11 @@ private:
     bool shouldDisplayBlockedResourceCountAsBadgeText();
     void saveShouldDisplayBlockedResourceCountAsBadgeText(bool);
 
+    // Session and dynamic rules.
+    _WKWebExtensionDeclarativeNetRequestSQLiteStore *declarativeNetRequestDynamicRulesStore();
+    _WKWebExtensionDeclarativeNetRequestSQLiteStore *declarativeNetRequestSessionRulesStore();
+    void updateDeclarativeNetRequestRulesInStorage(_WKWebExtensionDeclarativeNetRequestSQLiteStore *, NSString *storageType, NSArray *rulesToAdd, NSArray *ruleIDsToRemove, CompletionHandler<void(std::optional<String>)>&&);
+
     DeclarativeNetRequestMatchedRuleVector matchedRules() { return m_matchedRules; }
 
     // Action APIs
@@ -509,6 +515,10 @@ private:
     size_t declarativeNetRequestEnabledRulesetCount();
     void declarativeNetRequestToggleRulesets(const Vector<String>& rulesetIdentifiers, bool newValue, NSMutableDictionary *rulesetIdentifiersToEnabledState);
     void declarativeNetRequestGetMatchedRules(std::optional<WebExtensionTabIdentifier>, std::optional<WallTime> minTimeStamp, CompletionHandler<void(std::optional<Vector<WebExtensionMatchedRuleParameters>> matchedRules, std::optional<String>)>&&);
+    void declarativeNetRequestGetDynamicRules(CompletionHandler<void(std::optional<String>, std::optional<String>)>&&);
+    void declarativeNetRequestUpdateDynamicRules(std::optional<String> rulesToAddJSON, std::optional<Vector<double>> ruleIDsToDelete, CompletionHandler<void(std::optional<String>)>&&);
+    void declarativeNetRequestGetSessionRules(CompletionHandler<void(std::optional<String>, std::optional<String>)>&&);
+    void declarativeNetRequestUpdateSessionRules(std::optional<String> rulesToAddJSON, std::optional<Vector<double>> ruleIDsToDelete, CompletionHandler<void(std::optional<String>)>&&);
 
     // Event APIs
     void addListener(WebPageProxyIdentifier, WebExtensionEventListenerType, WebExtensionContentWorldType);
@@ -701,6 +711,8 @@ private:
 
     RetainPtr<WKContentRuleListStore> m_declarativeNetRequestRuleStore;
     DeclarativeNetRequestMatchedRuleVector m_matchedRules;
+    RetainPtr<_WKWebExtensionDeclarativeNetRequestSQLiteStore> m_declarativeNetRequestDynamicRulesStore;
+    RetainPtr<_WKWebExtensionDeclarativeNetRequestSQLiteStore> m_declarativeNetRequestSessionRulesStore;
 
     MenuItemMap m_menuItems;
     MenuItemVector m_mainMenuItems;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
@@ -54,6 +54,10 @@ messages -> WebExtensionContext {
     DeclarativeNetRequestDisplayActionCountAsBadgeText(bool result) -> (std::optional<String> error);
     DeclarativeNetRequestIncrementActionCount(WebKit::WebExtensionTabIdentifier tabIdentifier, double increment) -> (std::optional<String> error);
     DeclarativeNetRequestGetMatchedRules(std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, std::optional<WallTime> minTimeStamp) -> (std::optional<Vector<WebKit::WebExtensionMatchedRuleParameters>> matchedRules, std::optional<String> error);
+    DeclarativeNetRequestGetDynamicRules() -> (std::optional<String> rulesJSON, std::optional<String> error);
+    DeclarativeNetRequestUpdateDynamicRules(std::optional<String> rulesToAddJSON, std::optional<Vector<double>> ruleIdsToRemove) -> (std::optional<String> error);
+    DeclarativeNetRequestGetSessionRules() -> (std::optional<String> rulesJSON, std::optional<String> error);
+    DeclarativeNetRequestUpdateSessionRules(std::optional<String> rulesToAddJSON, std::optional<Vector<double>> ruleIdsToRemove) -> (std::optional<String> error);
 
     // Event APIs
     AddListener(WebKit::WebPageProxyIdentifier identifier, WebKit::WebExtensionEventListenerType type, WebKit::WebExtensionContentWorldType contentWorldType);


### PR DESCRIPTION
#### 14bd8a42717a351ebe92101b83d757311d20a07e
<pre>
Implement declarativeNetRequest dynamic and session rules APIs
<a href="https://bugs.webkit.org/show_bug.cgi?id=266016">https://bugs.webkit.org/show_bug.cgi?id=266016</a>
<a href="https://rdar.apple.com/118476702&amp">rdar://118476702&amp</a>;118476774

Reviewed by Timothy Hatcher.

This patch implements:
- declarativeNetRequest.getSessionRules()
- declarativeNetRequest.updateSessionRules()
- declarativeNetRequest.getDynamicRules()
- declarativeNetRequest.updateDynamicRules()

The big difference between these two APIs is that dynamic rules are persisted to disk and will be loaded across
quitting and relaunching the browser. Session rules will go away.

Also, while we are here, fix a typo in an error message and update the localizable strings.

* Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteStore.h:
* Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteStore.mm:
(-[_WKWebExtensionSQLiteStore _savepointNameFromUUID:]): Generate a savepoint name based on the UUID.
(-[_WKWebExtensionSQLiteStore createSavepointWithCompletionHandler:]): Create a savepoint in the database.
(-[_WKWebExtensionSQLiteStore commitSavepoint:completionHandler:]): Commit the savepoint to the database.
(-[_WKWebExtensionSQLiteStore rollbackToSavepoint:completionHandler:]): Rollback the database to a given savepoint.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDeclarativeNetRequestCocoa.mm:
(WebKit::WebExtensionContext::declarativeNetRequestDynamicRulesStore): Create and return a _WKWebExtensionDeclarativeNetRequestSQLiteStore for the
dynamic rules. This will only use the in memory database if storage isn&apos;t persistent for the extension context.
(WebKit::WebExtensionContext::declarativeNetRequestSessionRulesStore): Create and return a _WKWebExtensionDeclarativeNetRequestSQLiteStore for the
session rules. This will always use the in memory database.
(WebKit::WebExtensionContext::updateDeclarativeNetRequestRulesInStorage): Attempt to perform the given updates to the rules in the database. The flow is:
- Create a savepoint
- Update the rules by removing and adding rules.
    - If this fails, perform a rollback
    - If this succeeds, attempt to load the new rules
        - If this fails, perform a rollback, and attempt to load the old rules
        - If this succeeds, commit the savepoint
(WebKit::WebExtensionContext::declarativeNetRequestGetDynamicRules): Get the rules from the dynamic rules store.
(WebKit::WebExtensionContext::declarativeNetRequestUpdateDynamicRules): Call into updateDeclarativeNetRequestRulesInStorage.
(WebKit::WebExtensionContext::declarativeNetRequestGetSessionRules): Get the rules from the session rules store.
(WebKit::WebExtensionContext::declarativeNetRequestUpdateSessionRules): Call into updateDeclarativeNetRequestRulesInStorage.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::loadDeclarativeNetRequestRules): Chain together loading rules from the various sources, the order is:
- Session rules
- Dynamic rules
- Static rules
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDeclarativeNetRequestCocoa.mm:
(WebKit::WebExtensionAPIDeclarativeNetRequest::updateDynamicRules): Call into the UI process after performing argument validation.
(WebKit::WebExtensionAPIDeclarativeNetRequest::getDynamicRules): Call into the UI process.
(WebKit::WebExtensionAPIDeclarativeNetRequest::updateSessionRules): Call into the UI process after performing argument validation.
(WebKit::WebExtensionAPIDeclarativeNetRequest::getSessionRules): Call into the UI process.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm:
(TestWebKitAPI::TEST): Add tests for updating dynamic and session rules and verifying that they block content.

Canonical link: <a href="https://commits.webkit.org/271706@main">https://commits.webkit.org/271706@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4bd2c0d873f4b31d1255bd1536d3058dd02d6eb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29361 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8029 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30694 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31931 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/26661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29961 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10169 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5326 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29634 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6682 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/25126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5744 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/5886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26186 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33272 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26805 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/26614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/32103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/5844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/4028 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/29886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7547 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6981 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/6369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/6368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->