### PR TITLE
Deploy more smart pointers in PlaybackSessionManagerProxy.mm

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
@@ -708,8 +708,7 @@ PlatformPlaybackSessionInterface* PlaybackSessionManagerProxy::controlsManagerIn
     if (!m_controlsManagerContextId)
         return nullptr;
 
-    auto& interface = ensureInterface(m_controlsManagerContextId);
-    return &interface;
+    return &ensureInterface(m_controlsManagerContextId);
 }
 
 bool PlaybackSessionManagerProxy::isPaused(PlaybackSessionContextIdentifier identifier) const
@@ -718,15 +717,15 @@ bool PlaybackSessionManagerProxy::isPaused(PlaybackSessionContextIdentifier iden
     if (iterator == m_contextMap.end())
         return false;
 
-    auto& model = *std::get<0>(iterator->value);
-    return !model.isPlaying() && !model.isStalled();
+    Ref model = *std::get<0>(iterator->value);
+    return !model->isPlaying() && !model->isStalled();
 }
 
 #if !RELEASE_LOG_DISABLED
 void PlaybackSessionManagerProxy::setLogIdentifier(PlaybackSessionContextIdentifier identifier, uint64_t logIdentifier)
 {
-    auto& model = ensureModel(identifier);
-    model.setLogIdentifier(reinterpret_cast<const void*>(logIdentifier));
+    Ref model = ensureModel(identifier);
+    model->setLogIdentifier(reinterpret_cast<const void*>(logIdentifier));
 }
 
 WTFLogChannel& PlaybackSessionManagerProxy::logChannel() const


### PR DESCRIPTION
#### 6f5404331306c2ffbd07c77b7a8d950ee4ccd709
<pre>
Deploy more smart pointers in PlaybackSessionManagerProxy.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=266017">https://bugs.webkit.org/show_bug.cgi?id=266017</a>
<a href="https://rdar.apple.com/119338965">rdar://119338965</a>

Reviewed by Chris Dumez.

* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm:
(WebKit::PlaybackSessionManagerProxy::controlsManagerInterface):
(WebKit::PlaybackSessionManagerProxy::isPaused const):
(WebKit::PlaybackSessionManagerProxy::setLogIdentifier):

Canonical link: <a href="https://commits.webkit.org/271753@main">https://commits.webkit.org/271753@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61a0041cf7b863c233dfad2aa67f9ec679ef0229

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29333 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8003 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30669 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31906 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26646 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10143 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5301 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26646 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29606 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6654 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25104 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5725 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5863 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33246 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26780 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26589 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32080 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5829 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4010 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29863 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7527 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7014 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6350 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6352 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->