### PR TITLE
Teach package-root to include auxiliary process extension bundles

### DIFF
--- a/Tools/Scripts/package-root
+++ b/Tools/Scripts/package-root
@@ -76,10 +76,12 @@ setConfiguration();
 
 my @privateFrameworks = qw(WebCore WebGPU WebKitLegacy);
 my @publicFrameworks = qw(JavaScriptCore WebKit);
+my @extensions = qw(GPUExtension NetworkingExtension WebContentCaptivePortalExtension WebContentExtension);
 my $packagedRootBasePath = usesCryptexPath() ? "/System/Cryptexes/OS/" : "/";
 $packagedRootBasePath = "$packagedRootBasePath" . "System/iOSSupport/" if isMacCatalystWebKit();
 my $privateInstallPath = "$packagedRootBasePath" . "System/Library/PrivateFrameworks";
 my $publicInstallPath = "$packagedRootBasePath" . "System/Library/Frameworks";
+my $extensionsInstallPath = "/System/Library/ExtensionKit/Extensions";
 
 my $configuration = configuration();
 my $platform = xcodeSDKPlatformName();
@@ -87,12 +89,14 @@ my $productDir = productDir();
 my $stagingRoot = tempdir(CLEANUP => 1);
 my $stagingPrivatePath = "$stagingRoot$privateInstallPath";
 my $stagingPublicPath = "$stagingRoot$publicInstallPath";
+my $stagingExtensionsPath = "$stagingRoot$extensionsInstallPath";
 my $archiveName = "webkit-$configuration-$platform";
 my $archivePath = "$productDir/$archiveName.tar.gz";
 my ($fh, $tempArchiveName) = tempfile( "/tmp/$archiveName-XXXXXXX");
 
 system 'mkdir', '-p', $stagingPrivatePath;
 system 'mkdir', '-p', $stagingPublicPath;
+system 'mkdir', '-p', $stagingExtensionsPath;
 
 foreach my $framework (@privateFrameworks) {
     print "Copying Private $framework from $productDir ...\n";
@@ -104,6 +108,12 @@ foreach my $framework (@publicFrameworks) {
     print "Copying Public $framework from $productDir ...\n";
     system 'cp', '-LpR', $productDir . "/$framework.framework", "$stagingPublicPath/";
     die "Check to see that you have built $framework for $configuration-$platform" if $?;
+}
+
+foreach my $extension (@extensions) {
+    print "Copying extension $extension from $productDir ...\n";
+    system 'cp', '-LpR', $productDir . "/$extension.appex", "$stagingExtensionsPath/";
+    die "Check to see that you have built $extension for $configuration-$platform" if $?;
 }
 
 system 'ditto', "$productDir/usr", "$stagingRoot" . "$packagedRootBasePath" . "usr";


### PR DESCRIPTION
#### 5aab6fe8ccf6483ea9f8dbc03768089380f1522b
<pre>
Teach package-root to include auxiliary process extension bundles
<a href="https://bugs.webkit.org/show_bug.cgi?id=266019">https://bugs.webkit.org/show_bug.cgi?id=266019</a>
<a href="https://rdar.apple.com/119339487">rdar://119339487</a>

Reviewed by Per Arne Vollan.

The GPU, Networking, and WebContent app extensions expect to be installed in
/System/Library/ExtensionKit/Extensions. Teach package-root to package them in this location.

* Tools/Scripts/package-root:

Canonical link: <a href="https://commits.webkit.org/271698@main">https://commits.webkit.org/271698@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/067f114021ba3a70e4a039cbe1b7f66b445227e2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29312 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7982 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30648 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31886 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/26634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29912 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10122 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5281 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29585 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/6635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/25088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/5712 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/5850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/26136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/33226 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/26763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/26569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/33226 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/5817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/3997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/33226 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/7509 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/6334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3768 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/6340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->