### PR TITLE
[threaded-animation-resolution] Schedule animation updates from RemoteLayerTreeEventDispatcher on the scrolling thread.

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAcceleratedEffectStack.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAcceleratedEffectStack.h
@@ -28,6 +28,7 @@
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
 
 #include <WebCore/AcceleratedEffectStack.h>
+#include <WebCore/PlatformLayer.h>
 
 namespace WebKit {
 
@@ -35,6 +36,13 @@ class RemoteAcceleratedEffectStack final : public WebCore::AcceleratedEffectStac
     WTF_MAKE_ISO_ALLOCATED(RemoteAcceleratedEffectStack);
 public:
     static Ref<RemoteAcceleratedEffectStack> create(Seconds);
+
+#if PLATFORM(MAC)
+    void initEffectsFromMainThread(PlatformLayer*, MonotonicTime now);
+    void applyEffectsFromScrollingThread(MonotonicTime now) const;
+#endif
+
+    void clear(PlatformLayer*);
 
 private:
     explicit RemoteAcceleratedEffectStack(Seconds);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAcceleratedEffectStack.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAcceleratedEffectStack.mm
@@ -44,6 +44,20 @@ RemoteAcceleratedEffectStack::RemoteAcceleratedEffectStack(Seconds acceleratedTi
 {
 }
 
+#if PLATFORM(MAC)
+void RemoteAcceleratedEffectStack::initEffectsFromMainThread(PlatformLayer*, MonotonicTime)
+{
+}
+
+void RemoteAcceleratedEffectStack::applyEffectsFromScrollingThread(MonotonicTime) const
+{
+}
+#endif
+
+void RemoteAcceleratedEffectStack::clear(PlatformLayer*)
+{
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(THREADED_ANIMATION_RESOLUTION)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -80,6 +80,7 @@ public:
     void animationsWereAddedToNode(RemoteLayerTreeNode&);
     void animationsWereRemovedFromNode(RemoteLayerTreeNode&);
     Seconds acceleratedTimelineTimeOrigin() const { return m_acceleratedTimelineTimeOrigin; }
+    MonotonicTime animationCurrentTime() const { return m_animationCurrentTime; }
 #endif
 
     // For testing.
@@ -186,6 +187,7 @@ private:
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
     Seconds m_acceleratedTimelineTimeOrigin;
+    MonotonicTime m_animationCurrentTime;
 #endif
 };
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -290,6 +290,7 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction(IPC::Connection
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
     m_acceleratedTimelineTimeOrigin = layerTreeTransaction.acceleratedTimelineTimeOrigin();
+    m_animationCurrentTime = MonotonicTime::now();
 #endif
 
     webPageProxy->scrollingCoordinatorProxy()->willCommitLayerAndScrollingTrees();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
@@ -95,6 +95,7 @@ public:
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
     Seconds acceleratedTimelineTimeOrigin() const;
+    MonotonicTime animationCurrentTime() const;
 #endif
 
     void remotePageProcessCrashed(WebCore::ProcessIdentifier);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
@@ -481,6 +481,11 @@ Seconds RemoteLayerTreeHost::acceleratedTimelineTimeOrigin() const
 {
     return m_drawingArea->acceleratedTimelineTimeOrigin();
 }
+
+MonotonicTime RemoteLayerTreeHost::animationCurrentTime() const
+{
+    return m_drawingArea->animationCurrentTime();
+}
 #endif
 
 void RemoteLayerTreeHost::remotePageProcessCrashed(WebCore::ProcessIdentifier processIdentifier)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
@@ -135,6 +135,7 @@ public:
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
     void setAcceleratedEffectsAndBaseValues(const WebCore::AcceleratedEffects&, const WebCore::AcceleratedEffectValues&, RemoteLayerTreeHost&);
+    const RemoteAcceleratedEffectStack* effectStack() const { return m_effectStack.get(); }
     RefPtr<RemoteAcceleratedEffectStack> takeEffectStack() { return std::exchange(m_effectStack, nullptr); }
 #endif
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
@@ -89,8 +89,11 @@ public:
     void renderingUpdateComplete();
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
+    void lockForAnimationChanges() WTF_ACQUIRES_LOCK(m_effectStacksLock);
+    void unlockForAnimationChanges() WTF_RELEASES_LOCK(m_effectStacksLock);
     void animationsWereAddedToNode(RemoteLayerTreeNode&);
     void animationsWereRemovedFromNode(RemoteLayerTreeNode&);
+    void updateAnimations();
 #endif
 
 private:
@@ -166,7 +169,10 @@ private:
     std::unique_ptr<RunLoop::Timer> m_delayedRenderingUpdateDetectionTimer;
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
-    HashMap<WebCore::PlatformLayerIdentifier, Ref<RemoteAcceleratedEffectStack>> m_effectStacks;
+    // For WTF_ACQUIRES_LOCK
+    friend class RemoteScrollingCoordinatorProxyMac;
+    Lock m_effectStacksLock;
+    HashMap<WebCore::PlatformLayerIdentifier, Ref<RemoteAcceleratedEffectStack>> m_effectStacks WTF_GUARDED_BY_LOCK(m_effectStacksLock);
 #endif
 
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
@@ -27,6 +27,7 @@
 
 #if PLATFORM(MAC) && ENABLE(UI_SIDE_COMPOSITING)
 
+#include "RemoteLayerTreeEventDispatcher.h"
 #include "RemoteScrollingCoordinatorProxy.h"
 
 namespace WebKit {
@@ -65,13 +66,17 @@ private:
     void windowScreenWillChange() override;
     void windowScreenDidChange(WebCore::PlatformDisplayID, std::optional<WebCore::FramesPerSecond>) override;
 
-    void willCommitLayerAndScrollingTrees() override;
-    void didCommitLayerAndScrollingTrees() override;
     void applyScrollingTreeLayerPositionsAfterCommit() override;
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
+    void willCommitLayerAndScrollingTrees() override WTF_ACQUIRES_LOCK(m_eventDispatcher->m_effectStacksLock);
+    void didCommitLayerAndScrollingTrees() override WTF_RELEASES_LOCK(m_eventDispatcher->m_effectStacksLock);
+
     void animationsWereAddedToNode(RemoteLayerTreeNode&) override;
     void animationsWereRemovedFromNode(RemoteLayerTreeNode&) override;
+#else
+    void willCommitLayerAndScrollingTrees() override;
+    void didCommitLayerAndScrollingTrees() override;
 #endif
 
 #if ENABLE(SCROLLING_THREAD)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
@@ -273,11 +273,17 @@ void RemoteScrollingCoordinatorProxyMac::windowScreenWillChange()
 void RemoteScrollingCoordinatorProxyMac::willCommitLayerAndScrollingTrees()
 {
     scrollingTree()->lockLayersForHitTesting();
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+    m_eventDispatcher->lockForAnimationChanges();
+#endif
 }
 
 void RemoteScrollingCoordinatorProxyMac::didCommitLayerAndScrollingTrees()
 {
     scrollingTree()->unlockLayersForHitTesting();
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+    m_eventDispatcher->unlockForAnimationChanges();
+#endif
 }
 
 void RemoteScrollingCoordinatorProxyMac::applyScrollingTreeLayerPositionsAfterCommit()


### PR DESCRIPTION
#### e183df84221ef46786e71200591e6ef284ebc4d0
<pre>
[threaded-animation-resolution] Schedule animation updates from RemoteLayerTreeEventDispatcher on the scrolling thread.
<a href="https://bugs.webkit.org/show_bug.cgi?id=266026">https://bugs.webkit.org/show_bug.cgi?id=266026</a>
&lt;<a href="https://rdar.apple.com/119341112">rdar://119341112</a>&gt;

Reviewed by Simon Fraser.

RemoteLayerTreeEventDispatcher can update the current set of animations at the
same time it applies any asynchronous scrolls.

This should align them with rendering updates (when scroll synchronisation
succeeds), and make it simpler to integrate scroll-linked animations

iOS doesn&apos;t use RemoteLayerTreeEventDispatcher/scrolling thread, so will
need a separate solution to schedule animation updates.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAcceleratedEffectStack.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAcceleratedEffectStack.mm:
(WebKit::RemoteAcceleratedEffectStack::initEffectsFromMainThread):
(WebKit::RemoteAcceleratedEffectStack::applyEffectsFromScrollingThread const):
(WebKit::RemoteAcceleratedEffectStack::clear):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h:
(WebKit::RemoteLayerTreeDrawingAreaProxy::animationCurrentTime const):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm:
(WebKit::RemoteLayerTreeHost::animationCurrentTime const):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h:
(WebKit::RemoteLayerTreeNode::effectStack const):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm:
(WebKit::RemoteLayerTreeNode::~RemoteLayerTreeNode):
(WebKit::RemoteLayerTreeNode::setAcceleratedEffectsAndBaseValues):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp:
(WebKit::RemoteLayerTreeEventDispatcher::startOrStopDisplayLinkOnMainThread):
(WebKit::RemoteLayerTreeEventDispatcher::didRefreshDisplay):
(WebKit::RemoteLayerTreeEventDispatcher::delayedRenderingUpdateDetectionTimerFired):
(WebKit::RemoteLayerTreeEventDispatcher::waitForRenderingUpdateCompletionOrTimeout):
(WebKit::RemoteLayerTreeEventDispatcher::scrollingTreeWasRecentlyActive):
(WebKit::RemoteLayerTreeEventDispatcher::lockForAnimationChanges):
(WebKit::RemoteLayerTreeEventDispatcher::unlockForAnimationChanges):
(WebKit::RemoteLayerTreeEventDispatcher::animationsWereAddedToNode):
(WebKit::RemoteLayerTreeEventDispatcher::animationsWereRemovedFromNode):
(WebKit::RemoteLayerTreeEventDispatcher::updateAnimations):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h:
(WebKit::RemoteLayerTreeEventDispatcher::animationsLock):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm:
(WebKit::RemoteScrollingCoordinatorProxyMac::willCommitLayerAndScrollingTrees):
(WebKit::RemoteScrollingCoordinatorProxyMac::didCommitLayerAndScrollingTrees):

Canonical link: <a href="https://commits.webkit.org/273391@main">https://commits.webkit.org/273391@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/961cd7cdf0b396dddcb0e1af1bf353222b719f7b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35262 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14199 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37392 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38018 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31822 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16581 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11261 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30706 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35809 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12011 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31440 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10529 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10582 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39264 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32073 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31880 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36558 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10715 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8644 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34573 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12482 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8073 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11239 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11539 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->