### PR TITLE
Generate serialization of WebImage

### DIFF
--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -437,6 +437,7 @@ set(WebKit_SERIALIZATION_IN_FILES
     Shared/WebFindOptions.serialization.in
     Shared/WebFoundTextRange.serialization.in
     Shared/WebHitTestResultData.serialization.in
+    Shared/WebImage.serialization.in
     Shared/WebNavigationDataStore.serialization.in
     Shared/WebPageCreationParameters.serialization.in
     Shared/WebPageGroupData.serialization.in

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -383,6 +383,7 @@ $(PROJECT_DIR)/Shared/WebGPU/WebGPUVertexAttribute.serialization.in
 $(PROJECT_DIR)/Shared/WebGPU/WebGPUVertexBufferLayout.serialization.in
 $(PROJECT_DIR)/Shared/WebGPU/WebGPUVertexState.serialization.in
 $(PROJECT_DIR)/Shared/WebHitTestResultData.serialization.in
+$(PROJECT_DIR)/Shared/WebImage.serialization.in
 $(PROJECT_DIR)/Shared/WebNavigationDataStore.serialization.in
 $(PROJECT_DIR)/Shared/WebPageCreationParameters.serialization.in
 $(PROJECT_DIR)/Shared/WebPageGroupData.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -624,6 +624,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/WebFindOptions.serialization.in \
 	Shared/WebFoundTextRange.serialization.in \
 	Shared/WebHitTestResultData.serialization.in \
+	Shared/WebImage.serialization.in \
 	Shared/WebNavigationDataStore.serialization.in \
 	Shared/WebPageCreationParameters.serialization.in \
 	Shared/WebPageNetworkParameters.serialization.in \

--- a/Source/WebKit/Shared/API/c/cairo/WKImageCairo.cpp
+++ b/Source/WebKit/Shared/API/c/cairo/WKImageCairo.cpp
@@ -43,7 +43,9 @@ WKImageRef WKImageCreateFromCairoSurface(cairo_surface_t* surface, WKImageOption
 {
     WebCore::IntSize imageSize(cairo_image_surface_get_width(surface), cairo_image_surface_get_height(surface));
     auto webImage = WebKit::WebImage::create(imageSize, WebKit::toImageOptions(options), WebCore::DestinationColorSpace::SRGB());
-    auto& graphicsContext = webImage->context();
+    if (!webImage->context())
+        return nullptr;
+    auto& graphicsContext = *webImage->context();
 
     cairo_t* cr = graphicsContext.platformContext()->cr();
     cairo_set_source_surface(cr, surface, 0, 0);

--- a/Source/WebKit/Shared/API/c/cg/WKImageCG.cpp
+++ b/Source/WebKit/Shared/API/c/cg/WKImageCG.cpp
@@ -57,8 +57,9 @@ WKImageRef WKImageCreateFromCGImage(CGImageRef imageRef, WKImageOptions options)
     auto nativeImage = WebCore::NativeImage::create(imageRef);
     WebCore::IntSize imageSize = nativeImage->size();
     auto webImage = WebKit::WebImage::create(imageSize, WebKit::toImageOptions(options), WebCore::DestinationColorSpace::SRGB());
-
-    auto& graphicsContext = webImage->context();
+    if (!webImage->context())
+        return nullptr;
+    auto& graphicsContext = *webImage->context();
 
     WebCore::FloatRect rect(WebCore::FloatPoint(0, 0), imageSize);
 

--- a/Source/WebKit/Shared/WebImage.cpp
+++ b/Source/WebKit/Shared/WebImage.cpp
@@ -33,7 +33,12 @@
 namespace WebKit {
 using namespace WebCore;
 
-RefPtr<WebImage> WebImage::create(const IntSize& size, ImageOptions options, const DestinationColorSpace& colorSpace, ChromeClient* client)
+Ref<WebImage> WebImage::createEmpty()
+{
+    return adoptRef(*new WebImage(nullptr));
+}
+
+Ref<WebImage> WebImage::create(const IntSize& size, ImageOptions options, const DestinationColorSpace& colorSpace, ChromeClient* client)
 {
     if (client) {
         auto purpose = (options & ImageOptionsShareable) ? RenderingPurpose::ShareableSnapshot : RenderingPurpose::Snapshot;
@@ -46,29 +51,33 @@ RefPtr<WebImage> WebImage::create(const IntSize& size, ImageOptions options, con
     if (options & ImageOptionsShareable) {
         auto buffer = ImageBuffer::create<ImageBufferShareableBitmapBackend>(size, 1, colorSpace, PixelFormat::BGRA8, RenderingPurpose::ShareableSnapshot, { });
         if (!buffer)
-            return nullptr;
+            return createEmpty();
         return WebImage::create(buffer.releaseNonNull());
     }
 
     auto buffer = ImageBuffer::create(size, RenderingPurpose::Snapshot, 1, colorSpace, PixelFormat::BGRA8);
     if (!buffer)
-        return nullptr;
+        return createEmpty();
     return WebImage::create(buffer.releaseNonNull());
 }
 
-RefPtr<WebImage> WebImage::create(ImageBufferParameters&& parameters, ShareableBitmap::Handle&& handle)
+Ref<WebImage> WebImage::create(std::optional<ParametersAndHandle>&& parametersAndHandle)
 {
+    if (!parametersAndHandle)
+        return createEmpty();
+    auto [parameters, handle] = WTFMove(*parametersAndHandle);
+
     // FIXME: These should be abstracted as a encodable image buffer handle.
     auto backendParameters = ImageBuffer::backendParameters(parameters);
     auto backend = ImageBufferShareableBitmapBackend::create(backendParameters, WTFMove(handle));
     if (!backend)
-        return nullptr;
+        return createEmpty();
     
     auto info = ImageBuffer::populateBackendInfo<ImageBufferShareableBitmapBackend>(backendParameters);
 
     auto buffer = ImageBuffer::create(WTFMove(parameters), info, WTFMove(backend));
     if (!buffer)
-        return nullptr;
+        return createEmpty();
 
     return WebImage::create(buffer.releaseNonNull());
 }
@@ -78,28 +87,45 @@ Ref<WebImage> WebImage::create(Ref<ImageBuffer>&& buffer)
     return adoptRef(*new WebImage(WTFMove(buffer)));
 }
 
-WebImage::WebImage(Ref<ImageBuffer>&& buffer)
+WebImage::WebImage(RefPtr<ImageBuffer>&& buffer)
     : m_buffer(WTFMove(buffer))
 {
 }
 
 IntSize WebImage::size() const
 {
+    if (!m_buffer)
+        return { };
     return m_buffer->backendSize();
 }
 
-const ImageBufferParameters& WebImage::parameters() const
+const ImageBufferParameters* WebImage::parameters() const
 {
-    return m_buffer->parameters();
+    if (!m_buffer)
+        return nullptr;
+    return &m_buffer->parameters();
 }
 
-GraphicsContext& WebImage::context() const
+auto WebImage::parametersAndHandle() const -> std::optional<ParametersAndHandle>
 {
-    return m_buffer->context();
+    auto handle = createHandle();
+    if (!handle)
+        return std::nullopt;
+    RELEASE_ASSERT(m_buffer);
+    return { { m_buffer->parameters(), WTFMove(*handle) } };
+}
+
+GraphicsContext* WebImage::context() const
+{
+    if (!m_buffer)
+        return nullptr;
+    return &m_buffer->context();
 }
 
 RefPtr<NativeImage> WebImage::copyNativeImage(BackingStoreCopy copyBehavior) const
 {
+    if (!m_buffer)
+        return nullptr;
     if (copyBehavior == CopyBackingStore)
         return m_buffer->copyNativeImage();
     return m_buffer->createNativeImageReference();
@@ -107,7 +133,9 @@ RefPtr<NativeImage> WebImage::copyNativeImage(BackingStoreCopy copyBehavior) con
 
 RefPtr<ShareableBitmap> WebImage::bitmap() const
 {
-    const_cast<ImageBuffer&>(*m_buffer.ptr()).flushDrawingContext();
+    if (!m_buffer)
+        return nullptr;
+    const_cast<ImageBuffer&>(*m_buffer).flushDrawingContext();
 
     auto* sharing = m_buffer->toBackendSharing();
     if (!is<ImageBufferBackendHandleSharing>(sharing))
@@ -119,13 +147,17 @@ RefPtr<ShareableBitmap> WebImage::bitmap() const
 #if USE(CAIRO)
 RefPtr<cairo_surface_t> WebImage::createCairoSurface()
 {
+    if (!m_buffer)
+        return nullptr;
     return m_buffer->createCairoSurface();
 }
 #endif
 
 std::optional<ShareableBitmap::Handle> WebImage::createHandle(SharedMemory::Protection protection) const
 {
-    const_cast<ImageBuffer&>(*m_buffer.ptr()).flushDrawingContext();
+    if (!m_buffer)
+        return std::nullopt;
+    const_cast<ImageBuffer&>(*m_buffer).flushDrawingContext();
 
     auto* sharing = m_buffer->toBackendSharing();
     if (!is<ImageBufferBackendHandleSharing>(sharing))

--- a/Source/WebKit/Shared/WebImage.h
+++ b/Source/WebKit/Shared/WebImage.h
@@ -45,14 +45,19 @@ namespace WebKit {
 
 class WebImage : public API::ObjectImpl<API::Object::Type::Image> {
 public:
-    static RefPtr<WebImage> create(const WebCore::IntSize&, ImageOptions, const WebCore::DestinationColorSpace&, WebCore::ChromeClient* = nullptr);
-    static RefPtr<WebImage> create(WebCore::ImageBufferParameters&&, ShareableBitmap::Handle&&);
+    using ParametersAndHandle = std::pair<WebCore::ImageBufferParameters, ShareableBitmap::Handle>;
+
+    static Ref<WebImage> create(const WebCore::IntSize&, ImageOptions, const WebCore::DestinationColorSpace&, WebCore::ChromeClient* = nullptr);
+    static Ref<WebImage> create(std::optional<ParametersAndHandle>&&);
     static Ref<WebImage> create(Ref<WebCore::ImageBuffer>&&);
+    static Ref<WebImage> createEmpty();
 
     WebCore::IntSize size() const;
-    const WebCore::ImageBufferParameters& parameters() const;
+    const WebCore::ImageBufferParameters* parameters() const;
+    std::optional<ParametersAndHandle> parametersAndHandle() const;
+    bool isEmpty() const { return !m_buffer; }
 
-    WebCore::GraphicsContext& context() const;
+    WebCore::GraphicsContext* context() const;
 
     RefPtr<WebCore::NativeImage> copyNativeImage(WebCore::BackingStoreCopy = WebCore::CopyBackingStore) const;
     RefPtr<ShareableBitmap> bitmap() const;
@@ -63,9 +68,9 @@ public:
     std::optional<ShareableBitmap::Handle> createHandle(SharedMemory::Protection = SharedMemory::Protection::ReadWrite) const;
 
 private:
-    WebImage(Ref<WebCore::ImageBuffer>&&);
+    WebImage(RefPtr<WebCore::ImageBuffer>&&);
 
-    Ref<WebCore::ImageBuffer> m_buffer;
+    RefPtr<WebCore::ImageBuffer> m_buffer;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebImage.serialization.in
+++ b/Source/WebKit/Shared/WebImage.serialization.in
@@ -1,0 +1,25 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+[RefCounted] class WebKit::WebImage {
+    std::optional<std::pair<WebCore::ImageBufferParameters, WebKit::ShareableBitmap::Handle>> parametersAndHandle()
+};

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -8118,12 +8118,12 @@ void WebPageProxy::didCountStringMatches(const String& string, uint32_t matchCou
 
 void WebPageProxy::didGetImageForFindMatch(ImageBufferParameters&& parameters, ShareableBitmap::Handle&& contentImageHandle, uint32_t matchIndex)
 {
-    RefPtr image = WebImage::create(WTFMove(parameters), WTFMove(contentImageHandle));
-    if (!image) {
+    Ref image = WebImage::create({ { WTFMove(parameters), WTFMove(contentImageHandle) } });
+    if (image->isEmpty()) {
         ASSERT_NOT_REACHED();
         return;
     }
-    m_findMatchesClient->didGetImageForMatchResult(this, image.get(), matchIndex);
+    m_findMatchesClient->didGetImageForMatchResult(this, image.ptr(), matchIndex);
 }
 
 void WebPageProxy::setTextIndicator(const TextIndicatorData& indicatorData, uint64_t lifetime)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -7791,6 +7791,7 @@
 		F6A90811133C1F3D0082C3F4 /* WebCookieManagerMac.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebCookieManagerMac.mm; sourceTree = "<group>"; };
 		FA1473272B06EE6200765CC1 /* SandboxExtension.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = SandboxExtension.serialization.in; sourceTree = "<group>"; };
 		FA39AE4B2B2269C4008F93CD /* APIDictionary.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = APIDictionary.serialization.in; sourceTree = "<group>"; };
+		FA39AE4C2B229187008F93CD /* WebImage.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebImage.serialization.in; sourceTree = "<group>"; };
 		FA651BA42AA3CBB500747576 /* NetworkTransportBidirectionalStream.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NetworkTransportBidirectionalStream.h; sourceTree = "<group>"; };
 		FA651BA52AA3CBB500747576 /* NetworkTransportBidirectionalStream.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = NetworkTransportBidirectionalStream.cpp; sourceTree = "<group>"; };
 		FA651BA62AA3CBB600747576 /* NetworkTransportReceiveStream.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = NetworkTransportReceiveStream.cpp; sourceTree = "<group>"; };
@@ -8734,6 +8735,7 @@
 				86AA521929264F5D0065399E /* WebHitTestResultData.serialization.in */,
 				BCCF6ABA12C91EF9008F9C35 /* WebImage.cpp */,
 				BCCF6ABB12C91EF9008F9C35 /* WebImage.h */,
+				FA39AE4C2B229187008F93CD /* WebImage.serialization.in */,
 				C0337DD2127A2A0E008FF4F4 /* WebKeyboardEvent.cpp */,
 				0F4000FF2527D6F700E91DA7 /* WebKeyboardEvent.h */,
 				BC9BA5021697C45300E44616 /* WebKit2Initialize.cpp */,

--- a/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp
@@ -169,10 +169,10 @@ static RefPtr<WebImage> imageForRect(LocalFrameView* frameView, const IntRect& p
         return nullptr;
 
     auto snapshot = WebImage::create(bitmapSize, snapshotOptionsToImageOptions(options), DestinationColorSpace::SRGB());
-    if (!snapshot)
+    if (!snapshot->context())
         return nullptr;
 
-    auto& graphicsContext = snapshot->context();
+    auto& graphicsContext = *snapshot->context();
 
     graphicsContext.clearRect(IntRect(IntPoint(), bitmapSize));
     graphicsContext.applyDeviceScaleFactor(deviceScaleFactor);

--- a/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleRangeHandle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleRangeHandle.cpp
@@ -141,10 +141,10 @@ RefPtr<WebImage> InjectedBundleRangeHandle::renderedImage(SnapshotOptions option
     backingStoreSize.scale(scaleFactor);
 
     auto snapshot = WebImage::create(backingStoreSize, snapshotOptionsToImageOptions(options | SnapshotOptionsShareable), DestinationColorSpace::SRGB());
-    if (!snapshot)
+    if (!snapshot->context())
         return nullptr;
 
-    auto& graphicsContext = snapshot->context();
+    auto& graphicsContext = *snapshot->context();
     graphicsContext.scale(scaleFactor);
 
     paintRect.move(frameView->frameRect().x(), frameView->frameRect().y());

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp
@@ -175,11 +175,11 @@ RefPtr<WebImage> InjectedBundleHitTestResult::image() const
     BitmapImage& bitmapImage = downcast<BitmapImage>(*image);
     IntSize size(bitmapImage.size());
     auto webImage = WebImage::create(size, static_cast<ImageOptions>(0), DestinationColorSpace::SRGB());
-    if (!webImage)
+    if (!webImage->context())
         return nullptr;
 
     // FIXME: need to handle EXIF rotation.
-    auto& graphicsContext = webImage->context();
+    auto& graphicsContext = *webImage->context();
     graphicsContext.drawImage(bitmapImage, { { }, size });
 
     return webImage;

--- a/Source/WebKit/WebProcess/WebPage/FindController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/FindController.cpp
@@ -369,10 +369,10 @@ void FindController::getImageForFindMatch(uint32_t matchIndex)
         return;
 
     auto handle = selectionSnapshot->createHandle();
-    if (!handle)
+    if (!handle || !selectionSnapshot->parameters())
         return;
 
-    m_webPage->send(Messages::WebPageProxy::DidGetImageForFindMatch(selectionSnapshot->parameters(), WTFMove(*handle), matchIndex));
+    m_webPage->send(Messages::WebPageProxy::DidGetImageForFindMatch(*selectionSnapshot->parameters(), WTFMove(*handle), matchIndex));
 }
 
 void FindController::selectFindMatch(uint32_t matchIndex)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -3011,10 +3011,10 @@ static ImageOptions snapshotImageOptions(LocalFrame& frame)
 RefPtr<WebImage> WebPage::snapshotAtSize(const IntRect& rect, const IntSize& bitmapSize, SnapshotOptions options, LocalFrame& frame, LocalFrameView& frameView)
 {
     auto snapshot = WebImage::create(bitmapSize, snapshotImageOptions(frame), snapshotColorSpace(options, *this), &m_page->chrome().client());
-    if (!snapshot)
+    if (!snapshot->context())
         return nullptr;
 
-    auto& graphicsContext = snapshot->context();
+    auto& graphicsContext = *snapshot->context();
     paintSnapshotAtSize(rect, bitmapSize, options, frame, frameView, graphicsContext);
 
     return snapshot;
@@ -3047,10 +3047,10 @@ RefPtr<WebImage> WebPage::snapshotNode(WebCore::Node& node, SnapshotOptions opti
     }
 
     auto snapshot = WebImage::create(snapshotSize, snapshotOptionsToImageOptions(options), snapshotColorSpace(options, *this), &m_page->chrome().client());
-    if (!snapshot)
+    if (!snapshot->context())
         return nullptr;
 
-    auto& graphicsContext = snapshot->context();
+    auto& graphicsContext = *snapshot->context();
 
     if (!(options & SnapshotOptionsExcludeDeviceScaleFactor)) {
         double deviceScaleFactor = corePage()->deviceScaleFactor();
@@ -6175,12 +6175,12 @@ void WebPage::drawRectToImage(FrameIdentifier frameID, const PrintInfo& printInf
 #endif
         
         image = WebImage::create(imageSize, ImageOptionsLocal, DestinationColorSpace::SRGB(), &m_page->chrome().client());
-        if (!image) {
+        if (!image || !image->context()) {
             ASSERT_NOT_REACHED();
             return completionHandler({ });
         }
 
-        auto& graphicsContext = image->context();
+        auto& graphicsContext = *image->context();
         float printingScale = static_cast<float>(imageSize.width()) / rect.width();
         graphicsContext.scale(printingScale);
 


### PR DESCRIPTION
#### 55786dc300a3ef373750a36e6e34f50444ee0513
<pre>
Generate serialization of WebImage
<a href="https://bugs.webkit.org/show_bug.cgi?id=266031">https://bugs.webkit.org/show_bug.cgi?id=266031</a>
<a href="https://rdar.apple.com/119343434">rdar://119343434</a>

Reviewed by Chris Dumez.

It currently has a handwritten asymmetrical decoder that can decode nullptr
when a non-null WebImage was encoded.  To correct this, I make WebImage able
to contain a null image buffer.  I updated all the checks to reflect this.

* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Shared/API/c/cg/WKImageCG.cpp:
(WKImageCreateFromCGImage):
* Source/WebKit/Shared/UserData.cpp:
(WebKit::UserData::encode):
(WebKit::UserData::decode):
* Source/WebKit/Shared/WebImage.cpp:
(WebKit::WebImage::createEmpty):
(WebKit::WebImage::create):
(WebKit::WebImage::WebImage):
(WebKit::WebImage::size const):
(WebKit::WebImage::parameters const):
(WebKit::WebImage::parametersAndHandle const):
(WebKit::WebImage::context const):
(WebKit::WebImage::copyNativeImage const):
(WebKit::WebImage::bitmap const):
(WebKit::WebImage::createCairoSurface):
(WebKit::WebImage::createHandle const):
* Source/WebKit/Shared/WebImage.h:
(WebKit::WebImage::isEmpty const):
* Source/WebKit/Shared/WebImage.serialization.in: Added.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didGetImageForFindMatch):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp:
(WebKit::imageForRect):
* Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleRangeHandle.cpp:
(WebKit::InjectedBundleRangeHandle::renderedImage):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp:
(WebKit::InjectedBundleHitTestResult::image const):
* Source/WebKit/WebProcess/WebPage/FindController.cpp:
(WebKit::FindController::getImageForFindMatch):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::snapshotAtSize):
(WebKit::WebPage::snapshotNode):
(WebKit::WebPage::drawRectToImage):

Canonical link: <a href="https://commits.webkit.org/271711@main">https://commits.webkit.org/271711@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c7f2007f3b13a60b56d94f4863821d1e03ef99a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29402 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8068 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30730 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/31956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/26678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10204 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5362 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/31956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29675 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/6701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/25138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/31956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/5897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/33298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26824 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/26628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/33298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/5861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/4041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/33298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/7570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/6387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3779 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/6385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->