### PR TITLE
Add an (off by default) code path to crash whenever the CoreIPCSecureCoding wrapper is used

### DIFF
--- a/Source/WebKit/Shared/AuxiliaryProcess.cpp
+++ b/Source/WebKit/Shared/AuxiliaryProcess.cpp
@@ -47,6 +47,10 @@
 #include <wtf/MemoryPressureHandler.h>
 #endif
 
+#if PLATFORM(COCOA)
+#include "CoreIPCSecureCoding.h"
+#endif
+
 namespace WebKit {
 using namespace WebCore;
 
@@ -215,6 +219,9 @@ void AuxiliaryProcess::applyProcessCreationParameters(const AuxiliaryProcessCrea
     WTF::logChannels().initializeLogChannelsIfNecessary(parameters.wtfLoggingChannels);
     WebCore::logChannels().initializeLogChannelsIfNecessary(parameters.webCoreLoggingChannels);
     WebKit::logChannels().initializeLogChannelsIfNecessary(parameters.webKitLoggingChannels);
+#endif
+#if PLATFORM(COCOA)
+    SecureCoding::applyProcessCreationParameters(parameters);
 #endif
 }
 

--- a/Source/WebKit/Shared/AuxiliaryProcessCreationParameters.h
+++ b/Source/WebKit/Shared/AuxiliaryProcessCreationParameters.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <wtf/HashSet.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebKit {
@@ -34,6 +35,7 @@ struct AuxiliaryProcessCreationParameters {
     String wtfLoggingChannels;
     String webCoreLoggingChannels;
     String webKitLoggingChannels;
+    std::unique_ptr<HashSet<String>> classNamesExemptFromSecureCodingCrash;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/AuxiliaryProcessCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/AuxiliaryProcessCreationParameters.serialization.in
@@ -24,4 +24,5 @@ struct WebKit::AuxiliaryProcessCreationParameters {
     String wtfLoggingChannels;
     String webCoreLoggingChannels;
     String webKitLoggingChannels;
+    std::unique_ptr<HashSet<String>> classNamesExemptFromSecureCodingCrash;
 };

--- a/Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.h
@@ -39,6 +39,17 @@
 
 namespace WebKit {
 
+struct AuxiliaryProcessCreationParameters;
+
+namespace SecureCoding {
+
+const HashSet<String>* classNamesExemptFromSecureCodingCrash();
+void applyProcessCreationParameters(const AuxiliaryProcessCreationParameters&);
+
+} // namespace SecureCoding
+
+#ifdef __OBJC__
+
 class CoreIPCSecureCoding {
 WTF_MAKE_FAST_ALLOCATED;
 public:
@@ -60,6 +71,8 @@ private:
 
     IPC::CoreIPCRetainPtr<NSObject<NSSecureCoding>> m_secureCoding;
 };
+
+#endif // __OBJC__
 
 } // namespace WebKit
 

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
@@ -36,6 +36,7 @@
 #include <wtf/RunLoop.h>
 
 #if PLATFORM(COCOA)
+#include "CoreIPCSecureCoding.h"
 #include "SandboxUtilities.h"
 #include <sys/sysctl.h>
 #include <wtf/spi/darwin/SandboxSPI.h>
@@ -499,6 +500,13 @@ AuxiliaryProcessCreationParameters AuxiliaryProcessProxy::auxiliaryProcessParame
     parameters.webCoreLoggingChannels = UIProcess::webCoreLogLevelString();
     parameters.webKitLoggingChannels = UIProcess::webKitLogLevelString();
 #endif
+
+#if PLATFORM(COCOA)
+    auto* exemptClassNames = SecureCoding::classNamesExemptFromSecureCodingCrash();
+    if (exemptClassNames)
+        parameters.classNamesExemptFromSecureCodingCrash = WTF::makeUnique<HashSet<String>>(*exemptClassNames);
+#endif
+
     return parameters;
 }
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -5274,6 +5274,7 @@
 		515262BA1FB951310070E579 /* WebSWServerToContextConnectionMessageReceiver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebSWServerToContextConnectionMessageReceiver.cpp; sourceTree = "<group>"; };
 		515262BB1FB951310070E579 /* WebSWServerToContextConnectionMessages.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebSWServerToContextConnectionMessages.h; sourceTree = "<group>"; };
 		51578B821209ECEF00A37C4A /* APIData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APIData.h; sourceTree = "<group>"; };
+		5157ADF42B22C8F400C0E095 /* AuxiliaryProcessCreationParameters.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = AuxiliaryProcessCreationParameters.serialization.in; sourceTree = "<group>"; };
 		515BE1731D53FDDC00DD7C68 /* WebGamepadProvider.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebGamepadProvider.cpp; sourceTree = "<group>"; };
 		515BE1741D53FDDC00DD7C68 /* WebGamepadProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebGamepadProvider.h; sourceTree = "<group>"; };
 		515BE19F1D550AB000DD7C68 /* WebGamepad.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebGamepad.cpp; sourceTree = "<group>"; };
@@ -8516,6 +8517,7 @@
 				1A2D956D12848564001EB962 /* AuxiliaryProcess.h */,
 				5164C0941B05B757004F102A /* AuxiliaryProcess.messages.in */,
 				7BDDA33F275652EA0038659E /* AuxiliaryProcessCreationParameters.h */,
+				5157ADF42B22C8F400C0E095 /* AuxiliaryProcessCreationParameters.serialization.in */,
 				290F4271172A0C7400939FF0 /* AuxiliaryProcessSupplement.h */,
 				413E5C9329B0EDF3002F4987 /* BackgroundFetchChange.h */,
 				413E5C8E29B0C5F4002F4987 /* BackgroundFetchState.h */,


### PR DESCRIPTION
#### 415a49b8e806d09b279c29b35bf028a3e32fd0dd
<pre>
Add an (off by default) code path to crash whenever the CoreIPCSecureCoding wrapper is used
<a href="https://bugs.webkit.org/show_bug.cgi?id=266033">https://bugs.webkit.org/show_bug.cgi?id=266033</a>
<a href="https://rdar.apple.com/119344064">rdar://119344064</a>

Reviewed by Alex Christensen.

This &quot;crash on encountering an unspecified NSSecureCoding type&quot; mode can be turned on via NSUserDefaults.

* Source/WebKit/Shared/AuxiliaryProcess.cpp:
(WebKit::AuxiliaryProcess::applyProcessCreationParameters):
* Source/WebKit/Shared/AuxiliaryProcessCreationParameters.h:
* Source/WebKit/Shared/AuxiliaryProcessCreationParameters.serialization.in:
* Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.h:
* Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.mm:
(WebKit::SecureCoding::internalShouldCrashOnSecureCoding):
(WebKit::SecureCoding::internalClassNamesExemptFromSecureCodingCrash):
(WebKit::SecureCoding::shouldCrashOnSecureCoding):
(WebKit::SecureCoding::classNamesExemptFromSecureCodingCrash):
(WebKit::SecureCoding::applyProcessCreationParameters):
(WebKit::crashWithClassName):
(WebKit::CoreIPCSecureCoding::CoreIPCSecureCoding):
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp:
(WebKit::AuxiliaryProcessProxy::auxiliaryProcessParameters):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/271746@main">https://commits.webkit.org/271746@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/341da47e62a581f770f8992ce69a8b383ec78abf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29496 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8164 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30822 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32042 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26740 "Built successfully") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/10373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5456 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26743 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29769 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6819 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25207 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5835 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5962 "Unexpected infrastructure issue, retrying build") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33384 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26925 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26719 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32191 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5925 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4112 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29964 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7652 "Built successfully") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/7011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6462 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6448 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->