### PR TITLE
Use WeakRef / WeakPtr to store non-stack RenderObjects

### DIFF
--- a/Source/WTF/wtf/WeakRef.h
+++ b/Source/WTF/wtf/WeakRef.h
@@ -138,6 +138,9 @@ template<typename P, typename WeakPtrImpl> struct PtrHash<WeakRef<P, WeakPtrImpl
 
 template<typename P, typename WeakPtrImpl> struct DefaultHash<WeakRef<P, WeakPtrImpl>> : PtrHash<WeakRef<P, WeakPtrImpl>> { };
 
+template<typename T> using SingleThreadWeakRef = WeakRef<T, SingleThreadWeakPtrImpl>;
+
 } // namespace WTF
 
+using WTF::SingleThreadWeakRef;
 using WTF::WeakRef;

--- a/Source/WebCore/editing/SelectionGeometryGatherer.h
+++ b/Source/WebCore/editing/SelectionGeometryGatherer.h
@@ -30,6 +30,7 @@
 #include <wtf/CheckedRef.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/Vector.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore {
 
@@ -67,7 +68,7 @@ public:
 private:
     Vector<LayoutRect> boundingRects() const;
 
-    CheckedRef<RenderView> m_renderView;
+    SingleThreadWeakRef<RenderView> m_renderView;
 
     // All rects are in RenderView coordinates.
     Vector<FloatQuad> m_quads;

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -44,6 +44,7 @@
 #include <wtf/ListHashSet.h>
 #include <wtf/OptionSet.h>
 #include <wtf/WeakHashSet.h>
+#include <wtf/WeakRef.h>
 #include <wtf/text/WTFString.h>
 
 namespace WTF {
@@ -912,7 +913,7 @@ private:
     LocalFrameViewLayoutContext m_layoutContext;
 
     HashSet<CheckedPtr<Widget>> m_widgetsInRenderTree;
-    std::unique_ptr<ListHashSet<CheckedPtr<RenderEmbeddedObject>>> m_embeddedObjectsToUpdate;
+    std::unique_ptr<ListHashSet<SingleThreadWeakRef<RenderEmbeddedObject>>> m_embeddedObjectsToUpdate;
     std::unique_ptr<SingleThreadWeakHashSet<RenderElement>> m_slowRepaintObjects;
 
     HashMap<ScrollingNodeID, WeakPtr<ScrollableArea>> m_scrollingNodeIDToPluginScrollableAreaMap;

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -610,7 +610,7 @@ inline RenderElement* RenderObject::parent() const
 
 inline CheckedPtr<RenderElement> RenderObject::checkedParent() const
 {
-    return m_parent;
+    return m_parent.get();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -118,7 +118,7 @@ struct SameSizeAsRenderObject : public CachedImageClient, public CanMakeCheckedP
 #endif
     unsigned m_bitfields;
     CheckedRef<Node> node;
-    void* pointers[2];
+    SingleThreadWeakPtr<RenderObject> pointers[2];
     PackedPtr<RenderObject> m_next;
     uint8_t m_type;
     CheckedPtr<Layout::Box> layoutBox;
@@ -184,7 +184,7 @@ RenderTheme& RenderObject::theme() const
 
 bool RenderObject::isDescendantOf(const RenderObject* ancestor) const
 {
-    for (CheckedPtr renderer = this; renderer; renderer = renderer->m_parent) {
+    for (auto* renderer = this; renderer; renderer = renderer->m_parent.get()) {
         if (renderer == ancestor)
             return true;
     }

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -1205,8 +1205,8 @@ private:
 
     CheckedRef<Node> m_node;
 
-    CheckedPtr<RenderElement> m_parent;
-    CheckedPtr<RenderObject> m_previous;
+    SingleThreadWeakPtr<RenderElement> m_parent;
+    SingleThreadWeakPtr<RenderObject> m_previous;
     PackedCheckedPtr<RenderObject> m_next;
     Type m_type;
 


### PR DESCRIPTION
#### a94d55eae68febe63e553172ddda72561a422461
<pre>
Use WeakRef / WeakPtr to store non-stack RenderObjects
<a href="https://bugs.webkit.org/show_bug.cgi?id=266040">https://bugs.webkit.org/show_bug.cgi?id=266040</a>
<a href="https://rdar.apple.com/118737861">rdar://118737861</a>

Reviewed by Darin Adler.

Use WeakRef / WeakPtr to store non-stack RenderObjects instead of CheckedRef / CheckedPtr.
Crashes generated by CheckedRef / CheckedPtr are not actionable if the smart pointer is
not on the stack.

This tested as performance neutral on the benchmarks we track on macOS and iOS, thanks
to the recent WeakPtr optimizations.

There are still a few PackedCheckedPtr&lt;RenderObject&gt; data members that should be
converted. I&apos;ll look into it in a follow-up given we don&apos;t have a drop-in replacement
at the moment.

* Source/WTF/wtf/WeakRef.h:
* Source/WebCore/editing/SelectionGeometryGatherer.h:
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::didDestroyRenderTree):
(WebCore::LocalFrameView::addEmbeddedObjectToUpdate):
(WebCore::LocalFrameView::removeEmbeddedObjectToUpdate):
(WebCore::LocalFrameView::updateEmbeddedObjects):
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::addContinuationWithOutline):
(WebCore::RenderBlock::paintContinuationOutlines):
* Source/WebCore/rendering/RenderElement.h:
(WebCore::RenderObject::checkedParent const):
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::isDescendantOf const):
* Source/WebCore/rendering/RenderObject.h:
* Source/WebCore/rendering/RenderSelection.cpp:
(WebCore::collectSelectionData):
(WebCore::RenderSelection::collectBounds const):
(WebCore::RenderSelection::apply):

Canonical link: <a href="https://commits.webkit.org/271749@main">https://commits.webkit.org/271749@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b9ac9153b8ffc8fd3b30f8905a68a5ddfaa7a746

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29509 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8177 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30836 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32052 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26747 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30110 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10325 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5469 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26751 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29782 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6834 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25217 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5843 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/5974 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26302 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33396 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/25384 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26939 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26722 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32197 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/29756 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5932 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4120 "Found 1 new test failure: fullscreen/full-screen-layer-dump.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29971 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7662 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/26103 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/36082 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6470 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7775 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3800 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6455 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->