### PR TITLE
Add temporary directory support to _WKWebExtensionControllerConfiguration.

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfiguration.mm
@@ -35,6 +35,8 @@
 #import "WebExtensionControllerConfiguration.h"
 
 static NSString * const persistentCodingKey = @"persistent";
+static NSString * const temporaryCodingKey = @"temporary";
+static NSString * const temporaryDirectoryCodingKey = @"temporaryDirectory";
 static NSString * const identifierCodingKey = @"identifier";
 static NSString * const webViewConfigurationCodingKey = @"webViewConfiguration";
 
@@ -63,7 +65,13 @@ static NSString * const webViewConfigurationCodingKey = @"webViewConfiguration";
 
     auto uuid = WTF::UUID::fromNSUUID(identifier);
     RELEASE_ASSERT(uuid);
+
     return WebKit::WebExtensionControllerConfiguration::create(*uuid)->wrapper();
+}
+
++ (instancetype)_temporaryConfiguration
+{
+    return WebKit::WebExtensionControllerConfiguration::createTemporary()->wrapper();
 }
 
 - (void)encodeWithCoder:(NSCoder *)coder
@@ -73,6 +81,12 @@ static NSString * const webViewConfigurationCodingKey = @"webViewConfiguration";
     [coder encodeObject:self.identifier forKey:identifierCodingKey];
     [coder encodeBool:self.persistent forKey:persistentCodingKey];
     [coder encodeObject:self.webViewConfiguration forKey:webViewConfigurationCodingKey];
+
+    if (!self._temporary)
+        return;
+
+    [coder encodeBool:YES forKey:temporaryCodingKey];
+    [coder encodeObject:self._storageDirectoryPath forKey:temporaryDirectoryCodingKey];
 }
 
 - (instancetype)initWithCoder:(NSCoder *)coder
@@ -83,12 +97,24 @@ static NSString * const webViewConfigurationCodingKey = @"webViewConfiguration";
         return nil;
 
     using IsPersistent = WebKit::WebExtensionControllerConfiguration::IsPersistent;
+    using TemporaryTag = WebKit::WebExtensionControllerConfiguration::TemporaryTag;
+
+    if ([coder containsValueForKey:temporaryCodingKey]) {
+        RELEASE_ASSERT([coder decodeBoolForKey:temporaryCodingKey]);
+
+        NSString *temporaryDirectory = [coder decodeObjectOfClass:NSString.class forKey:temporaryDirectoryCodingKey];
+        API::Object::constructInWrapper<WebKit::WebExtensionControllerConfiguration>(self, TemporaryTag::Temporary, temporaryDirectory);
+
+        // Remake the directories if needed, since they might have been cleaned up since this was last used.
+        FileSystem::makeAllDirectories(temporaryDirectory);
+
+        return self;
+    }
 
     NSUUID *identifier = [coder decodeObjectOfClass:NSUUID.class forKey:identifierCodingKey];
     BOOL persistent = [coder decodeBoolForKey:persistentCodingKey];
 
-    auto uuid = WTF::UUID::fromNSUUID(identifier);
-    if (uuid)
+    if (auto uuid = WTF::UUID::fromNSUUID(identifier))
         API::Object::constructInWrapper<WebKit::WebExtensionControllerConfiguration>(self, *uuid);
     else
         API::Object::constructInWrapper<WebKit::WebExtensionControllerConfiguration>(self, persistent ? IsPersistent::Yes : IsPersistent::No);
@@ -124,7 +150,7 @@ static NSString * const webViewConfigurationCodingKey = @"webViewConfiguration";
 
 - (NSString *)debugDescription
 {
-    return [NSString stringWithFormat:@"<%@: %p; persistent = %@; identifier = %@>", NSStringFromClass(self.class), self, self.persistent ? @"YES" : @"NO", self.identifier];
+    return [NSString stringWithFormat:@"<%@: %p; persistent = %@; temporary = %@; identifier = %@>", NSStringFromClass(self.class), self, self.persistent ? @"YES" : @"NO", self._temporary ? @"YES" : @"NO", self.identifier];
 }
 
 - (NSUUID *)identifier
@@ -147,6 +173,18 @@ static NSString * const webViewConfigurationCodingKey = @"webViewConfiguration";
 - (void)setWebViewConfiguration:(WKWebViewConfiguration *)configuration
 {
     _webExtensionControllerConfiguration->setWebViewConfiguration(configuration);
+}
+
+- (BOOL)_isTemporary
+{
+    return _webExtensionControllerConfiguration->storageIsTemporary();
+}
+
+- (NSString *)_storageDirectoryPath
+{
+    if (auto& directory = _webExtensionControllerConfiguration->storageDirectory(); !directory.isEmpty())
+        return directory;
+    return nil;
 }
 
 #pragma mark WKObject protocol implementation
@@ -174,6 +212,11 @@ static NSString * const webViewConfigurationCodingKey = @"webViewConfiguration";
 }
 
 + (instancetype)configurationWithIdentifier:(NSUUID *)identifier
+{
+    return nil;
+}
+
++ (instancetype)_temporaryConfiguration
 {
     return nil;
 }
@@ -209,6 +252,16 @@ static NSString * const webViewConfigurationCodingKey = @"webViewConfiguration";
 
 - (void)setWebViewConfiguration:(WKWebViewConfiguration *)webViewConfiguration
 {
+}
+
+- (BOOL)_isTemporary
+{
+    return NO;
+}
+
+- (NSString *)_storageDirectoryPath
+{
+    return nil;
 }
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfigurationPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfigurationPrivate.h
@@ -25,6 +25,31 @@
 
 #import <WebKit/_WKWebExtensionControllerConfiguration.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface _WKWebExtensionControllerConfiguration ()
 
+/*!
+ @abstract Returns a new configuration that is persistent and uses a temporary directory.
+ @discussion This method creates a configuration for a `WKWebExtensionController` that is persistent during the session
+ and uses a temporary directory for storage. This is ideal for scenarios that require temporary data persistence, such as testing.
+ Each instance is created with a unique temporary directory.
+*/
++ (instancetype)_temporaryConfiguration;
+
+/*!
+ @abstract A Boolean value indicating if this configuration uses a temporary directory.
+ @discussion This property indicates whether the configuration is persistent, with data stored in a temporary directory.
+*/
+@property (nonatomic, readonly, getter=_isTemporary) BOOL _temporary;
+
+/*!
+ @abstract The file path to the storage directory, if applicable.
+ @discussion This property contains the file path to the storage directory used by the configuration. It is `nil` for non-persistent
+ configurations. For persistent configurations, it provides the path where data is stored, which may be a temporary directory.
+*/
+@property (nonatomic, readonly, copy, nullable) NSString *_storageDirectoryPath;
+
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerConfigurationCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerConfigurationCocoa.mm
@@ -40,27 +40,21 @@ namespace WebKit {
 
 String WebExtensionControllerConfiguration::createStorageDirectoryPath(std::optional<WTF::UUID> identifier)
 {
-    static NeverDestroyed<String> defaultStoragePath;
-    static dispatch_once_t onceToken;
+    String libraryPath = [NSFileManager.defaultManager URLForDirectory:NSLibraryDirectory inDomain:NSUserDomainMask appropriateForURL:nil create:NO error:nullptr].path;
+    RELEASE_ASSERT(!libraryPath.isEmpty());
 
-    dispatch_once(&onceToken, ^{
-        String libraryPath = [NSFileManager.defaultManager URLForDirectory:NSLibraryDirectory inDomain:NSUserDomainMask appropriateForURL:nil create:NO error:nullptr].path;
-        if (libraryPath.isEmpty())
-            RELEASE_ASSERT_NOT_REACHED();
+    String identifierPath = identifier ? identifier->toString() : "Default"_s;
 
-        String identifierPath = identifier ? identifier->toString() : "Default"_s;
-        if (processHasContainer()) {
-            defaultStoragePath.get() = FileSystem::pathByAppendingComponents(libraryPath, { "WebKit"_s, "WebExtensions"_s, identifierPath });
-            return;
-        }
+    if (processHasContainer())
+        return FileSystem::pathByAppendingComponents(libraryPath, { "WebKit"_s, "WebExtensions"_s, identifierPath });
 
-        String appDirectoryName = [NSBundle mainBundle].bundleIdentifier ?: [NSProcessInfo processInfo].processName;
-        defaultStoragePath.get() = FileSystem::pathByAppendingComponents(libraryPath, { "WebKit"_s, appDirectoryName, "WebExtensions"_s, identifierPath });
+    String appDirectoryName = NSBundle.mainBundle.bundleIdentifier ?: NSProcessInfo.processInfo.processName;
+    return FileSystem::pathByAppendingComponents(libraryPath, { "WebKit"_s, appDirectoryName, "WebExtensions"_s, identifierPath });
+}
 
-        RELEASE_ASSERT(!defaultStoragePath->isEmpty());
-    });
-
-    return defaultStoragePath.get();
+String WebExtensionControllerConfiguration::createTemporaryStorageDirectoryPath()
+{
+    return FileSystem::createTemporaryDirectory(@"WebExtensions");
 }
 
 Ref<WebExtensionControllerConfiguration> WebExtensionControllerConfiguration::copy() const
@@ -69,11 +63,14 @@ Ref<WebExtensionControllerConfiguration> WebExtensionControllerConfiguration::co
 
     if (m_identifier)
         result = create(m_identifier.value());
+    else if (storageIsTemporary())
+        result = createTemporary();
     else if (storageIsPersistent())
         result = createDefault();
     else
         result = createNonPersistent();
 
+    result->setStorageDirectory(storageDirectory());
     result->setWebViewConfiguration([m_webViewConfiguration copy]);
 
     return result.releaseNonNull();
@@ -86,7 +83,7 @@ WKWebViewConfiguration *WebExtensionControllerConfiguration::webViewConfiguratio
     return m_webViewConfiguration.get();
 }
 
-String WebExtensionControllerConfiguration::declarativeNetRequestStoreDirectory()
+const String& WebExtensionControllerConfiguration::declarativeNetRequestStoreDirectory()
 {
     if (!m_declarativeNetRequestStoreDirectory.isEmpty())
         return m_declarativeNetRequestStoreDirectory;
@@ -96,7 +93,7 @@ String WebExtensionControllerConfiguration::declarativeNetRequestStoreDirectory(
         return m_declarativeNetRequestStoreDirectory;
     }
 
-    m_declarativeNetRequestStoreDirectory = FileSystem::pathByAppendingComponent(m_storageDirectory, "DeclarativeNetRequest"_s);
+    m_declarativeNetRequestStoreDirectory = FileSystem::pathByAppendingComponent(storageDirectory(), "DeclarativeNetRequest"_s);
     if (!FileSystem::makeAllDirectories(m_declarativeNetRequestStoreDirectory)) {
         m_declarativeNetRequestStoreDirectory = String();
         return m_declarativeNetRequestStoreDirectory;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.cpp
@@ -35,6 +35,12 @@ WebExtensionControllerConfiguration::WebExtensionControllerConfiguration(IsPersi
 {
 }
 
+WebExtensionControllerConfiguration::WebExtensionControllerConfiguration(TemporaryTag, const String& storageDirectory)
+    : m_temporary(true)
+    , m_storageDirectory(!storageDirectory.isEmpty() ? storageDirectory : createTemporaryStorageDirectoryPath())
+{
+}
+
 WebExtensionControllerConfiguration::WebExtensionControllerConfiguration(const WTF::UUID& identifier)
     : m_identifier(identifier)
     , m_storageDirectory(createStorageDirectoryPath(identifier))

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.h
@@ -43,22 +43,28 @@ class WebExtensionControllerConfiguration : public API::ObjectImpl<API::Object::
 
 public:
     enum class IsPersistent : bool { No, Yes };
+    enum TemporaryTag { Temporary };
 
     static Ref<WebExtensionControllerConfiguration> createDefault() { return adoptRef(*new WebExtensionControllerConfiguration(IsPersistent::Yes)); }
     static Ref<WebExtensionControllerConfiguration> createNonPersistent() { return adoptRef(*new WebExtensionControllerConfiguration(IsPersistent::No)); }
+    static Ref<WebExtensionControllerConfiguration> createTemporary() { return adoptRef(*new WebExtensionControllerConfiguration(Temporary)); }
     static Ref<WebExtensionControllerConfiguration> create(const WTF::UUID& identifier) { return adoptRef(*new WebExtensionControllerConfiguration(identifier)); }
 
     Ref<WebExtensionControllerConfiguration> copy() const;
 
     explicit WebExtensionControllerConfiguration(IsPersistent);
+    explicit WebExtensionControllerConfiguration(TemporaryTag, const String& storageDirectory = nullString());
     explicit WebExtensionControllerConfiguration(const WTF::UUID&);
 
     std::optional<WTF::UUID> identifier() const { return m_identifier; }
 
     bool storageIsPersistent() const { return !m_storageDirectory.isEmpty(); }
-    String storageDirectory() const { return m_storageDirectory; }
+    bool storageIsTemporary() const { return m_temporary; }
 
-    String declarativeNetRequestStoreDirectory();
+    const String& storageDirectory() const { return m_storageDirectory; }
+    void setStorageDirectory(const String& directory) { m_storageDirectory = directory; }
+
+    const String& declarativeNetRequestStoreDirectory();
 
     WKWebViewConfiguration *webViewConfiguration();
     void setWebViewConfiguration(WKWebViewConfiguration *configuration) { m_webViewConfiguration = configuration; }
@@ -71,8 +77,10 @@ public:
 
 private:
     static String createStorageDirectoryPath(std::optional<WTF::UUID> = std::nullopt);
+    static String createTemporaryStorageDirectoryPath();
 
     Markable<WTF::UUID> m_identifier;
+    bool m_temporary { false };
     String m_storageDirectory;
     String m_declarativeNetRequestStoreDirectory;
     RetainPtr<WKWebViewConfiguration> m_webViewConfiguration;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionControllerConfiguration.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionControllerConfiguration.mm
@@ -39,16 +39,20 @@ TEST(WKWebExtensionControllerConfiguration, Initialization)
 
     EXPECT_TRUE(configuration.persistent);
     EXPECT_NULL(configuration.identifier);
+    EXPECT_FALSE(configuration._temporary);
     EXPECT_NOT_NULL(configuration.webViewConfiguration);
     EXPECT_NE(configuration, _WKWebExtensionControllerConfiguration.defaultConfiguration);
     EXPECT_FALSE([configuration isEqual:_WKWebExtensionControllerConfiguration.defaultConfiguration]);
     EXPECT_FALSE([configuration.webViewConfiguration isEqual:_WKWebExtensionControllerConfiguration.defaultConfiguration.webViewConfiguration]);
+    EXPECT_NS_EQUAL(configuration._storageDirectoryPath, _WKWebExtensionControllerConfiguration.defaultConfiguration._storageDirectoryPath);
 
     configuration = _WKWebExtensionControllerConfiguration.nonPersistentConfiguration;
 
     EXPECT_FALSE(configuration.persistent);
     EXPECT_NULL(configuration.identifier);
+    EXPECT_FALSE(configuration._temporary);
     EXPECT_NOT_NULL(configuration.webViewConfiguration);
+    EXPECT_NULL(configuration._storageDirectoryPath);
     EXPECT_NE(configuration, _WKWebExtensionControllerConfiguration.nonPersistentConfiguration);
     EXPECT_FALSE([configuration isEqual:_WKWebExtensionControllerConfiguration.nonPersistentConfiguration]);
     EXPECT_FALSE([configuration.webViewConfiguration isEqual:_WKWebExtensionControllerConfiguration.nonPersistentConfiguration.webViewConfiguration]);
@@ -58,10 +62,25 @@ TEST(WKWebExtensionControllerConfiguration, Initialization)
 
     EXPECT_TRUE(configuration.persistent);
     EXPECT_NS_EQUAL(configuration.identifier, identifier);
+    EXPECT_FALSE(configuration._temporary);
     EXPECT_NOT_NULL(configuration.webViewConfiguration);
     EXPECT_NE(configuration, [_WKWebExtensionControllerConfiguration configurationWithIdentifier:identifier]);
     EXPECT_FALSE([configuration isEqual:[_WKWebExtensionControllerConfiguration configurationWithIdentifier:identifier]]);
     EXPECT_FALSE([configuration.webViewConfiguration isEqual:[_WKWebExtensionControllerConfiguration configurationWithIdentifier:identifier].webViewConfiguration]);
+    EXPECT_NS_EQUAL(configuration._storageDirectoryPath, [_WKWebExtensionControllerConfiguration configurationWithIdentifier:identifier]._storageDirectoryPath);
+
+    configuration = _WKWebExtensionControllerConfiguration._temporaryConfiguration;
+
+    EXPECT_FALSE([configuration isEqual:_WKWebExtensionControllerConfiguration._temporaryConfiguration]);
+
+    EXPECT_TRUE(configuration.persistent);
+    EXPECT_TRUE(configuration._temporary);
+    EXPECT_NULL(configuration.identifier);
+    EXPECT_NOT_NULL(configuration.webViewConfiguration);
+    EXPECT_NE(configuration, _WKWebExtensionControllerConfiguration._temporaryConfiguration);
+    EXPECT_FALSE([configuration isEqual:_WKWebExtensionControllerConfiguration._temporaryConfiguration]);
+    EXPECT_FALSE([configuration.webViewConfiguration isEqual:_WKWebExtensionControllerConfiguration.nonPersistentConfiguration.webViewConfiguration]);
+    EXPECT_FALSE([configuration._storageDirectoryPath isEqualToString:_WKWebExtensionControllerConfiguration._temporaryConfiguration._storageDirectoryPath]);
 }
 
 TEST(WKWebExtensionControllerConfiguration, SecureCoding)
@@ -74,6 +93,8 @@ TEST(WKWebExtensionControllerConfiguration, SecureCoding)
     EXPECT_NULL(error);
     EXPECT_TRUE(result.persistent);
     EXPECT_NULL(result.identifier);
+    EXPECT_FALSE(result._temporary);
+    EXPECT_NS_EQUAL(result._storageDirectoryPath, configuration._storageDirectoryPath);
     EXPECT_NOT_NULL(result.webViewConfiguration);
     EXPECT_NE(configuration, result);
     EXPECT_FALSE([result isEqual:configuration]);
@@ -86,6 +107,8 @@ TEST(WKWebExtensionControllerConfiguration, SecureCoding)
     EXPECT_NULL(error);
     EXPECT_FALSE(result.persistent);
     EXPECT_NULL(result.identifier);
+    EXPECT_FALSE(result._temporary);
+    EXPECT_NS_EQUAL(result._storageDirectoryPath, configuration._storageDirectoryPath);
     EXPECT_NOT_NULL(result.webViewConfiguration);
     EXPECT_NE(configuration, result);
     EXPECT_FALSE([result isEqual:configuration]);
@@ -98,8 +121,24 @@ TEST(WKWebExtensionControllerConfiguration, SecureCoding)
 
     EXPECT_NULL(error);
     EXPECT_TRUE(result.persistent);
+    EXPECT_FALSE(result._temporary);
+    EXPECT_NS_EQUAL(result._storageDirectoryPath, configuration._storageDirectoryPath);
     EXPECT_NOT_NULL(result.webViewConfiguration);
     EXPECT_NS_EQUAL(result.identifier, identifier);
+    EXPECT_NE(configuration, result);
+    EXPECT_FALSE([result isEqual:configuration]);
+    EXPECT_FALSE([result.webViewConfiguration isEqual:configuration.webViewConfiguration]);
+
+    configuration = _WKWebExtensionControllerConfiguration._temporaryConfiguration;
+    data = [NSKeyedArchiver archivedDataWithRootObject:configuration requiringSecureCoding:YES error:&error];
+    result = [NSKeyedUnarchiver unarchivedObjectOfClass:_WKWebExtensionControllerConfiguration.class fromData:data error:&error];
+
+    EXPECT_NULL(error);
+    EXPECT_TRUE(result.persistent);
+    EXPECT_NULL(result.identifier);
+    EXPECT_TRUE(result._temporary);
+    EXPECT_NS_EQUAL(result._storageDirectoryPath, configuration._storageDirectoryPath);
+    EXPECT_NOT_NULL(result.webViewConfiguration);
     EXPECT_NE(configuration, result);
     EXPECT_FALSE([result isEqual:configuration]);
     EXPECT_FALSE([result.webViewConfiguration isEqual:configuration.webViewConfiguration]);
@@ -112,6 +151,8 @@ TEST(WKWebExtensionControllerConfiguration, Copying)
 
     EXPECT_TRUE(copy.persistent);
     EXPECT_NULL(copy.identifier);
+    EXPECT_FALSE(copy._temporary);
+    EXPECT_NS_EQUAL(copy._storageDirectoryPath, configuration._storageDirectoryPath);
     EXPECT_NOT_NULL(copy.webViewConfiguration);
     EXPECT_NE(configuration, copy);
     EXPECT_FALSE([copy isEqual:configuration]);
@@ -122,6 +163,8 @@ TEST(WKWebExtensionControllerConfiguration, Copying)
 
     EXPECT_FALSE(copy.persistent);
     EXPECT_NULL(copy.identifier);
+    EXPECT_FALSE(copy._temporary);
+    EXPECT_NS_EQUAL(copy._storageDirectoryPath, configuration._storageDirectoryPath);
     EXPECT_NOT_NULL(copy.webViewConfiguration);
     EXPECT_NE(configuration, copy);
     EXPECT_FALSE([copy isEqual:configuration]);
@@ -133,6 +176,20 @@ TEST(WKWebExtensionControllerConfiguration, Copying)
 
     EXPECT_TRUE(copy.persistent);
     EXPECT_NS_EQUAL(copy.identifier, identifier);
+    EXPECT_FALSE(copy._temporary);
+    EXPECT_NS_EQUAL(copy._storageDirectoryPath, configuration._storageDirectoryPath);
+    EXPECT_NOT_NULL(copy.webViewConfiguration);
+    EXPECT_NE(configuration, copy);
+    EXPECT_FALSE([copy isEqual:configuration]);
+    EXPECT_FALSE([copy.webViewConfiguration isEqual:configuration.webViewConfiguration]);
+
+    configuration = _WKWebExtensionControllerConfiguration._temporaryConfiguration;
+    copy = [configuration copy];
+
+    EXPECT_TRUE(copy.persistent);
+    EXPECT_NULL(copy.identifier);
+    EXPECT_TRUE(copy._temporary);
+    EXPECT_NS_EQUAL(copy._storageDirectoryPath, configuration._storageDirectoryPath);
     EXPECT_NOT_NULL(copy.webViewConfiguration);
     EXPECT_NE(configuration, copy);
     EXPECT_FALSE([copy isEqual:configuration]);

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
@@ -41,6 +41,7 @@
 @interface TestWebExtensionManager : NSObject
 
 - (instancetype)initForExtension:(_WKWebExtension *)extension;
+- (instancetype)initForExtension:(_WKWebExtension *)extension extensionControllerConfiguration:(_WKWebExtensionControllerConfiguration *)configuration;
 
 @property (nonatomic, strong) _WKWebExtension *extension;
 @property (nonatomic, strong) _WKWebExtensionContext *context;
@@ -142,10 +143,10 @@ NSData *makePNGData(CGSize, SEL colorSelector);
 
 #endif
 
-RetainPtr<TestWebExtensionManager> loadAndRunExtension(_WKWebExtension *);
-RetainPtr<TestWebExtensionManager> loadAndRunExtension(NSDictionary *manifest, NSDictionary *resources);
-RetainPtr<TestWebExtensionManager> loadAndRunExtension(NSDictionary *resources);
-RetainPtr<TestWebExtensionManager> loadAndRunExtension(NSURL *baseURL);
+RetainPtr<TestWebExtensionManager> loadAndRunExtension(_WKWebExtension *, _WKWebExtensionControllerConfiguration * = nil);
+RetainPtr<TestWebExtensionManager> loadAndRunExtension(NSDictionary *manifest, NSDictionary *resources, _WKWebExtensionControllerConfiguration * = nil);
+RetainPtr<TestWebExtensionManager> loadAndRunExtension(NSDictionary *resources, _WKWebExtensionControllerConfiguration * = nil);
+RetainPtr<TestWebExtensionManager> loadAndRunExtension(NSURL *baseURL, _WKWebExtensionControllerConfiguration * = nil);
 
 } // namespace TestWebKitAPI::Util
 

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
@@ -48,13 +48,18 @@
 
 - (instancetype)initForExtension:(_WKWebExtension *)extension
 {
+    return [self initForExtension:extension extensionControllerConfiguration:nil];
+}
+
+- (instancetype)initForExtension:(_WKWebExtension *)extension extensionControllerConfiguration:(_WKWebExtensionControllerConfiguration *)configuration
+{
     if (!(self = [super init]))
         return nil;
 
     _yieldMessage = @"";
     _extension = extension;
     _context = [[_WKWebExtensionContext alloc] initForExtension:extension];
-    _controller = [[_WKWebExtensionController alloc] initWithConfiguration:_WKWebExtensionControllerConfiguration.nonPersistentConfiguration];
+    _controller = [[_WKWebExtensionController alloc] initWithConfiguration:configuration ?: _WKWebExtensionControllerConfiguration.nonPersistentConfiguration];
 
     _context._testingMode = YES;
 
@@ -794,26 +799,26 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
 namespace TestWebKitAPI {
 namespace Util {
 
-RetainPtr<TestWebExtensionManager> loadAndRunExtension(_WKWebExtension *extension)
+RetainPtr<TestWebExtensionManager> loadAndRunExtension(_WKWebExtension *extension, _WKWebExtensionControllerConfiguration *configuration)
 {
-    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension extensionControllerConfiguration:configuration]);
     [manager loadAndRun];
     return manager;
 }
 
-RetainPtr<TestWebExtensionManager> loadAndRunExtension(NSDictionary *manifest, NSDictionary *resources)
+RetainPtr<TestWebExtensionManager> loadAndRunExtension(NSDictionary *manifest, NSDictionary *resources, _WKWebExtensionControllerConfiguration *configuration)
 {
-    return loadAndRunExtension([[_WKWebExtension alloc] _initWithManifestDictionary:manifest resources:resources]);
+    return loadAndRunExtension([[_WKWebExtension alloc] _initWithManifestDictionary:manifest resources:resources], configuration);
 }
 
-RetainPtr<TestWebExtensionManager> loadAndRunExtension(NSDictionary *resources)
+RetainPtr<TestWebExtensionManager> loadAndRunExtension(NSDictionary *resources, _WKWebExtensionControllerConfiguration *configuration)
 {
-    return loadAndRunExtension([[_WKWebExtension alloc] _initWithResources:resources]);
+    return loadAndRunExtension([[_WKWebExtension alloc] _initWithResources:resources], configuration);
 }
 
-RetainPtr<TestWebExtensionManager> loadAndRunExtension(NSURL *baseURL)
+RetainPtr<TestWebExtensionManager> loadAndRunExtension(NSURL *baseURL, _WKWebExtensionControllerConfiguration *configuration)
 {
-    return loadAndRunExtension([[_WKWebExtension alloc] initWithResourceBaseURL:baseURL error:nullptr]);
+    return loadAndRunExtension([[_WKWebExtension alloc] initWithResourceBaseURL:baseURL error:nullptr], configuration);
 }
 
 NSData *makePNGData(CGSize size, SEL colorSelector)


### PR DESCRIPTION
#### f1350da694fea03048cedf20314aaff4bc9b28d9
<pre>
Add temporary directory support to _WKWebExtensionControllerConfiguration.
<a href="https://webkit.org/b/266041">https://webkit.org/b/266041</a>
<a href="https://rdar.apple.com/problem/119346018">rdar://problem/119346018</a>

Reviewed by Brian Weinstein.

Adds a way to run extensions with temporary storage for testing persistence features.
Also removes the caching in createStorageDirectoryPath() which would cache the path
with the identifier or default path and never return a different value.

* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfiguration.mm:
(+[_WKWebExtensionControllerConfiguration configurationWithIdentifier:]):
(+[_WKWebExtensionControllerConfiguration _temporaryConfiguration]):
(-[_WKWebExtensionControllerConfiguration encodeWithCoder:]):
(-[_WKWebExtensionControllerConfiguration initWithCoder:]):
(-[_WKWebExtensionControllerConfiguration debugDescription]):
(-[_WKWebExtensionControllerConfiguration _isTemporary]):
(-[_WKWebExtensionControllerConfiguration _storageDirectoryPath]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfigurationPrivate.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerConfigurationCocoa.mm:
(WebKit::WebExtensionControllerConfiguration::createStorageDirectoryPath): Fixed incorrect caching.
(WebKit::WebExtensionControllerConfiguration::createTemporaryStorageDirectoryPath): Added.
(WebKit::WebExtensionControllerConfiguration::copy const):
(WebKit::WebExtensionControllerConfiguration::declarativeNetRequestStoreDirectory):
* Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.cpp:
(WebKit::WebExtensionControllerConfiguration::WebExtensionControllerConfiguration):
* Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.h:
(WebKit::WebExtensionControllerConfiguration::createTemporary): Added.
(WebKit::WebExtensionControllerConfiguration::storageIsTemporary const): Added.
(WebKit::WebExtensionControllerConfiguration::storageDirectory const): Added.
(WebKit::WebExtensionControllerConfiguration::setStorageDirectory): Added.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionControllerConfiguration.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h:
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm:
(-[TestWebExtensionManager initForExtension:]):
(-[TestWebExtensionManager initForExtension:extensionControllerConfiguration:]):
(TestWebKitAPI::Util::loadAndRunExtension):

Canonical link: <a href="https://commits.webkit.org/271741@main">https://commits.webkit.org/271741@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84b3bdcdc38c52c63d636ba3ca3cf21df87bb00c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29368 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8035 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30697 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31933 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26663 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29968 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10285 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5330 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26660 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29641 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6789 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25122 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5745 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5947 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26178 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33274 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26900 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26611 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32100 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5846 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4031 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29883 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7549 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6371 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3796 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6370 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->