### PR TITLE
[Wasm-GC] Fix missing write barrier in BBQJIT struct.set

### DIFF
--- a/JSTests/wasm/gc/bug266043.js
+++ b/JSTests/wasm/gc/bug266043.js
@@ -1,0 +1,34 @@
+//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+
+import * as assert from "../assert.js";
+import { compile, instantiate } from "./wast-wrapper.js";
+
+const m1 = instantiate(`
+  (module
+    (type (struct (field i32)))
+    (type (struct (field (mut (ref null 0)))))
+    (func (export "f") (result (ref any))
+      (struct.new 1 (ref.null 0)))
+  )
+`);
+
+// GC to ensure struct is an old object.
+const struct = m1.exports.f()
+gc();
+
+const m2 = instantiate(`
+  (module
+    (type (struct (field i32)))
+    (type (struct (field (mut (ref null 0)))))
+    (func (export "g") (param (ref 1))
+      (struct.set 1 0 (local.get 0) (struct.new 0 (i32.const 42))))
+    (func (export "h") (param (ref 1)) (result i32)
+      (struct.get 0 0 (struct.get 1 0 (local.get 0))))
+  )
+`);
+
+// Do an eden GC for the new struct allocated in m2. Write barriers
+// should ensure that the object will be kept live.
+m2.exports.g(struct);
+edenGC();
+assert.eq(m2.exports.h(struct), 42);


### PR DESCRIPTION
#### 50def56d35577644e656719dba0e81bee8f571ac
<pre>
[Wasm-GC] Fix missing write barrier in BBQJIT struct.set
<a href="https://bugs.webkit.org/show_bug.cgi?id=266043">https://bugs.webkit.org/show_bug.cgi?id=266043</a>

Reviewed by Yusuke Suzuki.

Adds a missing write barrier for struct.set in BBQJIT. Also optimize how struct
mutation is done for initialization (e.g., struct.new), because the old approach
was compiling duplicate loads for the payload pointer.

* JSTests/wasm/gc/bug266043.js: Added.
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJIT::emitStructSet):
(JSC::Wasm::BBQJIT::emitStructPayloadSet):
(JSC::Wasm::BBQJIT::addStructNewDefault):
(JSC::Wasm::BBQJIT::addStructNew):

Canonical link: <a href="https://commits.webkit.org/271740@main">https://commits.webkit.org/271740@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37196993f70a326588096b42fcca96c975c57aba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29372 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8039 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30700 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31936 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26666 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10174 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5333 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26662 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29645 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6680 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25123 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5747 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5884 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26179 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33277 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/25306 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26803 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26609 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32102 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/29628 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5849 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4032 "Found 1 new test failure: fullscreen/full-screen-layer-dump.html (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29885 "Found 1 new API test failure: /WebKitGTK/TestResources:/webkit/WebKitWebView/sync-request-on-max-conns (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7552 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/35967 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7005 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6374 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7748 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6373 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->