### PR TITLE
[MSE] Remove SourceBufferPrivate::setReadyState/readyState

### DIFF
--- a/Source/WebCore/Modules/mediasource/MediaSource.h
+++ b/Source/WebCore/Modules/mediasource/MediaSource.h
@@ -36,6 +36,7 @@
 #include "EventTarget.h"
 #include "ExceptionOr.h"
 #include "HTMLMediaElement.h"
+#include "MediaPlayer.h"
 #include "MediaPromiseTypes.h"
 #include "MediaSourcePrivateClient.h"
 #include "URLRegistry.h"
@@ -113,8 +114,6 @@ public:
 
     ScriptExecutionContext* scriptExecutionContext() const final;
 
-    void sourceBufferBufferedChanged();
-
     using MediaSourcePrivateClient::ref;
     using MediaSourcePrivateClient::deref;
 
@@ -138,6 +137,12 @@ public:
 #endif
 
     void setAsSrcObject(bool);
+
+    // Called by SourceBuffer.
+    void sourceBufferBufferedChanged();
+    void sourceBufferReceivedFirstInitializationSegmentChanged();
+    void sourceBufferActiveTrackFlagChanged(bool);
+    void setMediaPlayerReadyState(MediaPlayer::ReadyState);
 
 protected:
     explicit MediaSource(ScriptExecutionContext&);

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -908,23 +908,12 @@ Ref<MediaPromise> SourceBuffer::sourceBufferPrivateDidReceiveInitializationSegme
     m_pendingInitializationSegmentForChangeType = false;
 
     // 6. If the HTMLMediaElement.readyState attribute is HAVE_NOTHING, then run the following steps:
-    if (m_private->readyState() == MediaPlayer::ReadyState::HaveNothing) {
-        // 6.1 If one or more objects in sourceBuffers have first initialization segment flag set to false, then abort these steps.
-        for (auto& sourceBuffer : *m_source->sourceBuffers()) {
-            if (!sourceBuffer->m_receivedFirstInitializationSegment)
-                return MediaPromise::createAndResolve();
-        }
-
-        // 6.2 Set the HTMLMediaElement.readyState attribute to HAVE_METADATA.
-        // 6.3 Queue a task to fire a simple event named loadedmetadata at the media element.
-        m_private->setReadyState(MediaPlayer::ReadyState::HaveMetadata);
-    }
+    m_source->sourceBufferReceivedFirstInitializationSegmentChanged();
 
     // 7. If the active track flag equals true and the HTMLMediaElement.readyState
     // attribute is greater than HAVE_CURRENT_DATA, then set the HTMLMediaElement.readyState
     // attribute to HAVE_METADATA.
-    if (activeTrackFlag && m_private->readyState() > MediaPlayer::ReadyState::HaveCurrentData)
-        m_private->setReadyState(MediaPlayer::ReadyState::HaveMetadata);
+    m_source->sourceBufferActiveTrackFlagChanged(activeTrackFlag);
 
     return MediaPromise::createAndResolve();
 }

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.h
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.h
@@ -135,6 +135,7 @@ public:
     size_t memoryCost() const;
 
     void setMediaSourceEnded(bool isEnded);
+    bool receivedFirstInitializationSegment() const { return m_receivedFirstInitializationSegment; }
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.h
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.h
@@ -82,8 +82,9 @@ public:
     virtual void unmarkEndOfStream() { m_isEnded = false; }
     bool isEnded() const { return m_isEnded; }
 
-    virtual MediaPlayer::ReadyState readyState() const = 0;
-    virtual void setReadyState(MediaPlayer::ReadyState) = 0;
+    virtual MediaPlayer::ReadyState mediaPlayerReadyState() const = 0;
+    virtual void setMediaPlayerReadyState(MediaPlayer::ReadyState) = 0;
+
     virtual MediaTime currentMediaTime() const = 0;
 
     Ref<MediaTimePromise> waitForTarget(const SeekTarget&);

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.h
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.h
@@ -94,9 +94,6 @@ public:
     virtual void resetParserState();
     virtual void removedFromMediaSource();
 
-    virtual MediaPlayer::ReadyState readyState() const = 0;
-    virtual void setReadyState(MediaPlayer::ReadyState) = 0;
-
     virtual bool canSwitchToType(const ContentType&) { return false; }
 
     WEBCORE_EXPORT virtual void setMediaSourceEnded(bool);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
@@ -70,8 +70,8 @@ public:
     void durationChanged(const MediaTime&) final;
     void markEndOfStream(EndOfStreamStatus) final;
 
-    MediaPlayer::ReadyState readyState() const final;
-    void setReadyState(MediaPlayer::ReadyState) final;
+    MediaPlayer::ReadyState mediaPlayerReadyState() const final;
+    void setMediaPlayerReadyState(MediaPlayer::ReadyState) final;
 
     bool hasSelectedVideo() const;
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm
@@ -128,14 +128,14 @@ void MediaSourcePrivateAVFObjC::markEndOfStream(EndOfStreamStatus status)
     MediaSourcePrivate::markEndOfStream(status);
 }
 
-MediaPlayer::ReadyState MediaSourcePrivateAVFObjC::readyState() const
+MediaPlayer::ReadyState MediaSourcePrivateAVFObjC::mediaPlayerReadyState() const
 {
     if (auto* player = this->player())
         return player->readyState();
     return MediaPlayer::ReadyState::HaveNothing;
 }
 
-void MediaSourcePrivateAVFObjC::setReadyState(MediaPlayer::ReadyState readyState)
+void MediaSourcePrivateAVFObjC::setMediaPlayerReadyState(MediaPlayer::ReadyState readyState)
 {
     if (auto* player = this->player())
         player->setReadyState(readyState);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
@@ -160,8 +160,6 @@ private:
     void abort() final;
     void resetParserStateInternal() final;
     void removedFromMediaSource() final;
-    MediaPlayer::ReadyState readyState() const final;
-    void setReadyState(MediaPlayer::ReadyState) final;
     void flush(TrackID) final;
     void enqueueSample(Ref<MediaSample>&&, TrackID) final;
     bool isReadyForMoreSamples(TrackID) final;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
@@ -765,21 +765,6 @@ void SourceBufferPrivateAVFObjC::removedFromMediaSource()
     SourceBufferPrivate::removedFromMediaSource();
 }
 
-MediaPlayer::ReadyState SourceBufferPrivateAVFObjC::readyState() const
-{
-    if (auto player = this->player())
-        return player->readyState();
-    return MediaPlayer::ReadyState::HaveNothing;
-}
-
-void SourceBufferPrivateAVFObjC::setReadyState(MediaPlayer::ReadyState readyState)
-{
-    ALWAYS_LOG(LOGIDENTIFIER, readyState);
-
-    if (auto player = this->player())
-        player->setReadyState(readyState);
-}
-
 bool SourceBufferPrivateAVFObjC::hasSelectedVideo() const
 {
     return !!m_enabledVideoTrackID;

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
@@ -128,12 +128,12 @@ void MediaSourcePrivateGStreamer::markEndOfStream(EndOfStreamStatus endOfStreamS
     MediaSourcePrivate::markEndOfStream(endOfStreamStatus);
 }
 
-MediaPlayer::ReadyState MediaSourcePrivateGStreamer::readyState() const
+MediaPlayer::ReadyState MediaSourcePrivateGStreamer::mediaPlayerReadyState() const
 {
     return m_playerPrivate.readyState();
 }
 
-void MediaSourcePrivateGStreamer::setReadyState(MediaPlayer::ReadyState state)
+void MediaSourcePrivateGStreamer::setMediaPlayerReadyState(MediaPlayer::ReadyState state)
 {
     m_playerPrivate.setReadyState(state);
 }

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h
@@ -63,8 +63,8 @@ public:
     void durationChanged(const MediaTime&) override;
     void markEndOfStream(EndOfStreamStatus) override;
 
-    MediaPlayer::ReadyState readyState() const override;
-    void setReadyState(MediaPlayer::ReadyState) override;
+    MediaPlayer::ReadyState mediaPlayerReadyState() const override;
+    void setMediaPlayerReadyState(MediaPlayer::ReadyState) override;
 
     MediaTime currentMediaTime() const final;
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
@@ -130,19 +130,6 @@ void SourceBufferPrivateGStreamer::removedFromMediaSource()
     SourceBufferPrivate::removedFromMediaSource();
 }
 
-MediaPlayer::ReadyState SourceBufferPrivateGStreamer::readyState() const
-{
-    if (RefPtr mediaSource = m_mediaSource.get())
-        return mediaSource->readyState();
-    return MediaPlayer::ReadyState::HaveNothing;
-}
-
-void SourceBufferPrivateGStreamer::setReadyState(MediaPlayer::ReadyState state)
-{
-    if (RefPtr mediaSource = m_mediaSource.get())
-        mediaSource->setReadyState(state);
-}
-
 void SourceBufferPrivateGStreamer::flush(TrackID trackId)
 {
     ASSERT(isMainThread());

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h
@@ -63,8 +63,6 @@ public:
     Ref<MediaPromise> appendInternal(Ref<SharedBuffer>&&) final;
     void resetParserStateInternal() final;
     void removedFromMediaSource() final;
-    MediaPlayer::ReadyState readyState() const final;
-    void setReadyState(MediaPlayer::ReadyState) final;
 
     void flush(TrackID) final;
     void enqueueSample(Ref<MediaSample>&&, TrackID) final;

--- a/Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.cpp
@@ -85,12 +85,12 @@ void MockMediaSourcePrivate::markEndOfStream(EndOfStreamStatus status)
     MediaSourcePrivate::markEndOfStream(status);
 }
 
-MediaPlayer::ReadyState MockMediaSourcePrivate::readyState() const
+MediaPlayer::ReadyState MockMediaSourcePrivate::mediaPlayerReadyState() const
 {
     return m_player.readyState();
 }
 
-void MockMediaSourcePrivate::setReadyState(MediaPlayer::ReadyState readyState)
+void MockMediaSourcePrivate::setMediaPlayerReadyState(MediaPlayer::ReadyState readyState)
 {
     m_player.setReadyState(readyState);
 }

--- a/Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.h
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.h
@@ -76,8 +76,8 @@ private:
     void durationChanged(const MediaTime&) override;
     void markEndOfStream(EndOfStreamStatus) override;
 
-    MediaPlayer::ReadyState readyState() const override;
-    void setReadyState(MediaPlayer::ReadyState) override;
+    MediaPlayer::ReadyState mediaPlayerReadyState() const override;
+    void setMediaPlayerReadyState(MediaPlayer::ReadyState) override;
 
     void notifyActiveSourceBuffersChanged() final;
 

--- a/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.cpp
@@ -203,19 +203,6 @@ void MockSourceBufferPrivate::resetParserStateInternal()
 {
 }
 
-MediaPlayer::ReadyState MockSourceBufferPrivate::readyState() const
-{
-    if (RefPtr mediaSource = mediaSourcePrivate())
-        return mediaSource->player().readyState();
-    return MediaPlayer::ReadyState::HaveNothing;
-}
-
-void MockSourceBufferPrivate::setReadyState(MediaPlayer::ReadyState readyState)
-{
-    if (RefPtr mediaSource = mediaSourcePrivate())
-        mediaSource->player().setReadyState(readyState);
-}
-
 Ref<SourceBufferPrivate::SamplesPromise> MockSourceBufferPrivate::enqueuedSamplesForTrackID(TrackID)
 {
     return SamplesPromise::createAndResolve(copyToVector(m_enqueuedSamples));

--- a/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.h
+++ b/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.h
@@ -52,8 +52,6 @@ private:
     // SourceBufferPrivate overrides
     Ref<MediaPromise> appendInternal(Ref<SharedBuffer>&&) final;
     void resetParserStateInternal() final;
-    MediaPlayer::ReadyState readyState() const final;
-    void setReadyState(MediaPlayer::ReadyState) final;
     bool canSetMinimumUpcomingPresentationTime(TrackID) const final;
     void setMinimumUpcomingPresentationTime(TrackID, const MediaTime&) final;
     void clearMinimumUpcomingPresentationTime(TrackID) final;

--- a/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp
@@ -155,10 +155,10 @@ void RemoteMediaSourceProxy::unmarkEndOfStream()
 }
 
 
-void RemoteMediaSourceProxy::setReadyState(WebCore::MediaPlayerEnums::ReadyState readyState)
+void RemoteMediaSourceProxy::setMediaPlayerReadyState(WebCore::MediaPlayerEnums::ReadyState readyState)
 {
     if (m_private)
-        m_private->setReadyState(readyState);
+        m_private->setMediaPlayerReadyState(readyState);
 }
 
 void RemoteMediaSourceProxy::setTimeFudgeFactor(const MediaTime& fudgeFactor)

--- a/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h
@@ -85,7 +85,7 @@ private:
     void bufferedChanged(WebCore::PlatformTimeRanges&&);
     void markEndOfStream(WebCore::MediaSourcePrivate::EndOfStreamStatus);
     void unmarkEndOfStream();
-    void setReadyState(WebCore::MediaPlayerEnums::ReadyState);
+    void setMediaPlayerReadyState(WebCore::MediaPlayerEnums::ReadyState);
     void setTimeFudgeFactor(const MediaTime&);
     void disconnect();
 

--- a/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.messages.in
@@ -29,7 +29,7 @@ messages -> RemoteMediaSourceProxy NotRefCounted {
     AddSourceBuffer(WebCore::ContentType contentType) -> (enum:uint8_t WebCore::MediaSourcePrivate::AddStatus status, std::optional<WebKit::RemoteSourceBufferIdentifier> remoteSourceBufferIdentifier) Synchronous
     DurationChanged(MediaTime duration)
     BufferedChanged(WebCore::PlatformTimeRanges buffered)
-    SetReadyState(WebCore::MediaPlayerEnums::ReadyState readyState)
+    SetMediaPlayerReadyState(WebCore::MediaPlayerEnums::ReadyState readyState)
     SetTimeFudgeFactor(MediaTime fudgeFactor)
     MarkEndOfStream(WebCore::MediaSourcePrivate::EndOfStreamStatus status)
     UnmarkEndOfStream()

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp
@@ -230,11 +230,6 @@ void RemoteSourceBufferProxy::setMode(WebCore::SourceBufferAppendMode appendMode
     m_sourceBufferPrivate->setMode(appendMode);
 }
 
-void RemoteSourceBufferProxy::setReadyState(WebCore::MediaPlayer::ReadyState state)
-{
-    m_sourceBufferPrivate->setReadyState(state);
-}
-
 void RemoteSourceBufferProxy::startChangingType()
 {
     m_sourceBufferPrivate->startChangingType();

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h
@@ -90,7 +90,6 @@ private:
     void resetParserState();
     void removedFromMediaSource();
     void setMediaSourceEnded(bool);
-    void setReadyState(WebCore::MediaPlayer::ReadyState);
     void startChangingType();
     void removeCodedFrames(const MediaTime& start, const MediaTime& end, const MediaTime& currentTime, CompletionHandler<void(WebCore::PlatformTimeRanges&&, uint64_t)>&&);
     void evictCodedFrames(uint64_t newDataSize, uint64_t maximumBufferSize, const MediaTime& currentTime, CompletionHandler<void(WebCore::PlatformTimeRanges&&, uint64_t)>&&);

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.messages.in
@@ -34,7 +34,6 @@ messages -> RemoteSourceBufferProxy NotRefCounted {
     ResetParserState()
     RemovedFromMediaSource()
     SetMediaSourceEnded(bool isEnded)
-    SetReadyState(WebCore::MediaPlayer::ReadyState state)
     StartChangingType()
     AddTrackBuffer(WebCore::TrackID trackID)
     ResetTrackBuffers()

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
@@ -142,18 +142,19 @@ void MediaSourcePrivateRemote::unmarkEndOfStream()
     MediaSourcePrivate::unmarkEndOfStream();
 }
 
-MediaPlayer::ReadyState MediaSourcePrivateRemote::readyState() const
+MediaPlayer::ReadyState MediaSourcePrivateRemote::mediaPlayerReadyState() const
 {
-    return m_mediaPlayerPrivate ? m_mediaPlayerPrivate->readyState() : MediaPlayer::ReadyState::HaveNothing;
+    return m_readyState;
 }
 
-void MediaSourcePrivateRemote::setReadyState(MediaPlayer::ReadyState readyState)
+void MediaSourcePrivateRemote::setMediaPlayerReadyState(MediaPlayer::ReadyState readyState)
 {
     auto gpuProcessConnection = m_gpuProcessConnection.get();
     if (!isGPURunning())
         return;
 
-    gpuProcessConnection->connection().send(Messages::RemoteMediaSourceProxy::SetReadyState(readyState), m_identifier);
+    m_readyState = readyState;
+    gpuProcessConnection->connection().send(Messages::RemoteMediaSourceProxy::SetMediaPlayerReadyState(readyState), m_identifier);
 }
 
 void MediaSourcePrivateRemote::setTimeFudgeFactor(const MediaTime& fudgeFactor)
@@ -185,6 +186,8 @@ void MediaSourcePrivateRemote::proxySeekToTime(const MediaTime& time, Completion
 void MediaSourcePrivateRemote::mediaSourcePrivateShuttingDown(CompletionHandler<void()>&& completionHandler)
 {
     m_shutdown = true;
+    m_readyState = MediaPlayer::ReadyState::HaveNothing;
+
     for (auto& sourceBuffer : m_sourceBuffers)
         sourceBuffer->disconnect();
     completionHandler();

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h
@@ -69,8 +69,8 @@ public:
     void bufferedChanged(const WebCore::PlatformTimeRanges&) final;
     void markEndOfStream(EndOfStreamStatus) final;
     void unmarkEndOfStream() final;
-    WebCore::MediaPlayer::ReadyState readyState() const final;
-    void setReadyState(WebCore::MediaPlayer::ReadyState) final;
+    WebCore::MediaPlayer::ReadyState mediaPlayerReadyState() const final;
+    void setMediaPlayerReadyState(WebCore::MediaPlayer::ReadyState) final;
 
     void setTimeFudgeFactor(const MediaTime&) final;
 
@@ -102,6 +102,7 @@ private:
     WeakPtr<MediaPlayerPrivateRemote> m_mediaPlayerPrivate;
     Vector<RefPtr<SourceBufferPrivateRemote>> m_sourceBuffers;
     bool m_shutdown { false };
+    WebCore::MediaPlayer::ReadyState m_readyState { WebCore::MediaPlayer::ReadyState::HaveNothing };
 
 #if !RELEASE_LOG_DISABLED
     const char* logClassName() const override { return "MediaSourcePrivateRemote"; }

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp
@@ -146,27 +146,6 @@ void SourceBufferPrivateRemote::removedFromMediaSource()
     gpuProcessConnection->connection().send(Messages::RemoteSourceBufferProxy::RemovedFromMediaSource(), m_remoteSourceBufferIdentifier);
 }
 
-MediaPlayer::ReadyState SourceBufferPrivateRemote::readyState() const
-{
-    return m_mediaPlayerPrivate ? m_mediaPlayerPrivate->readyState() : MediaPlayer::ReadyState::HaveNothing;
-}
-
-void SourceBufferPrivateRemote::setReadyState(MediaPlayer::ReadyState state)
-{
-    auto mediaSource = m_mediaSource.get();
-    if (!mediaSource)
-        return;
-
-    if (m_mediaPlayerPrivate)
-        m_mediaPlayerPrivate->setReadyState(state);
-
-    auto gpuProcessConnection = m_gpuProcessConnection.get();
-    if (!isGPURunning())
-        return;
-
-    gpuProcessConnection->connection().send(Messages::RemoteSourceBufferProxy::SetReadyState(state), m_remoteSourceBufferIdentifier);
-}
-
 void SourceBufferPrivateRemote::setActive(bool active)
 {
     SourceBufferPrivate::setActive(active);

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
@@ -78,8 +78,6 @@ private:
     void abort() final;
     void resetParserState() final;
     void removedFromMediaSource() final;
-    WebCore::MediaPlayer::ReadyState readyState() const final;
-    void setReadyState(WebCore::MediaPlayer::ReadyState) final;
     bool canSwitchToType(const WebCore::ContentType&) final;
     void setMediaSourceEnded(bool) final;
     void setMode(WebCore::SourceBufferAppendMode) final;


### PR DESCRIPTION
#### 3fb906ab19a805864b35ba645514fbc24285d5fb
<pre>
[MSE] Remove SourceBufferPrivate::setReadyState/readyState
<a href="https://bugs.webkit.org/show_bug.cgi?id=266042">https://bugs.webkit.org/show_bug.cgi?id=266042</a>
<a href="https://rdar.apple.com/119346093">rdar://119346093</a>

Reviewed by Youenn Fablet.

By removing the SourceBufferPrivate&apos;s readyState method we can stop having
the SourceBufferPrivate query the MediaPlayer directly.
We move the responsibility of calculating the MediaPlayer&apos;s readyState to the
MediaSource.
By caching the MediaPlayer&apos;s readyState in the MediaSourcePrivateRemote we will
avoid unnecessarily crossing threads once the MediaSource runs in a worker thread.

We rename setReadyState to setMediaPlayerReadyState to avoid confusion
as we have two type of readyState. The MediaSource&apos;s one and the media element one.

Covered by existing tests, no change in existing behaviour.

* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::waitForTarget):
(WebCore::MediaSource::monitorSourceBuffers):
(WebCore::MediaSource::sourceBufferReceivedFirstInitializationSegmentChanged):
(WebCore::MediaSource::sourceBufferActiveTrackFlagChanged):
(WebCore::MediaSource::setMediaPlayerReadyState):
* Source/WebCore/Modules/mediasource/MediaSource.h:
* Source/WebCore/Modules/mediasource/SourceBuffer.cpp:
(WebCore::SourceBuffer::sourceBufferPrivateDidReceiveInitializationSegment):
* Source/WebCore/Modules/mediasource/SourceBuffer.h:
(WebCore::SourceBuffer::receivedFirstInitializationSegment const):
* Source/WebCore/platform/graphics/MediaSourcePrivate.h:
* Source/WebCore/platform/graphics/SourceBufferPrivate.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm:
(WebCore::MediaSourcePrivateAVFObjC::mediaPlayerReadyState const):
(WebCore::MediaSourcePrivateAVFObjC::setMediaPlayerReadyState):
(WebCore::MediaSourcePrivateAVFObjC::readyState const): Deleted.
(WebCore::MediaSourcePrivateAVFObjC::setReadyState): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(WebCore::SourceBufferPrivateAVFObjC::readyState const): Deleted.
(WebCore::SourceBufferPrivateAVFObjC::setReadyState): Deleted.
* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp:
(WebCore::SourceBufferPrivateGStreamer::readyState const): Deleted.
(WebCore::SourceBufferPrivateGStreamer::setReadyState): Deleted.
* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h:
* Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.cpp:
(WebCore::MockMediaSourcePrivate::mediaPlayerReadyState const):
(WebCore::MockMediaSourcePrivate::setMediaPlayerReadyState):
(WebCore::MockMediaSourcePrivate::readyState const): Deleted.
(WebCore::MockMediaSourcePrivate::setReadyState): Deleted.
* Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.h:
* Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.cpp:
(WebCore::MockSourceBufferPrivate::readyState const): Deleted.
(WebCore::MockSourceBufferPrivate::setReadyState): Deleted.
* Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.h:
* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp:
(WebKit::RemoteMediaSourceProxy::setMediaPlayerReadyState):
(WebKit::RemoteMediaSourceProxy::setReadyState): Deleted.
* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h:
* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.messages.in:
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp:
(WebKit::RemoteSourceBufferProxy::setReadyState): Deleted.
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h:
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.messages.in:
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp:
(WebKit::MediaSourcePrivateRemote::mediaPlayerReadyState const):
(WebKit::MediaSourcePrivateRemote::setMediaPlayerReadyState):
(WebKit::MediaSourcePrivateRemote::mediaSourcePrivateShuttingDown):
(WebKit::MediaSourcePrivateRemote::readyState const): Deleted.
(WebKit::MediaSourcePrivateRemote::setReadyState): Deleted.
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp:
(WebKit::SourceBufferPrivateRemote::readyState const): Deleted.
(WebKit::SourceBufferPrivateRemote::setReadyState): Deleted.
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h:

Canonical link: <a href="https://commits.webkit.org/271771@main">https://commits.webkit.org/271771@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5544e194b4cb5b961be499d35f6edb56e68bd91d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29462 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8129 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30788 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32007 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26714 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30062 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10319 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5420 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26741 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29735 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6824 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25173 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5808 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5978 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26256 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33348 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26929 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26675 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32164 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5898 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4084 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29933 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7619 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7022 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6430 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6421 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->