### PR TITLE
[WebXR] Transient input source for immersive AR sessions

### DIFF
--- a/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
+++ b/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		297CB483288B11D700BB7971 /* AccessibilitySoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = 297CB481288B11D700BB7971 /* AccessibilitySoftLink.mm */; };
 		2E1342CD215AA10A007199D2 /* UIKitSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2E1342CB215AA10A007199D2 /* UIKitSoftLink.mm */; };
 		31647FB0251759DD0010F8FB /* OpenGLSoftLinkCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 31647FAE251759DB0010F8FB /* OpenGLSoftLinkCocoa.mm */; };
+		3A02FE2B2B214A38001724B1 /* ARKitSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A02FE2A2B214A38001724B1 /* ARKitSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3CBEEDE928A1861D00221FAE /* BarcodeSupportSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C963637289DC1C600570DD6 /* BarcodeSupportSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		416E995323DAE6BE00E871CB /* AudioToolboxSoftLink.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 416E995123DAE6BD00E871CB /* AudioToolboxSoftLink.cpp */; };
 		4177B3DA296CB8C3009711F0 /* CoreCryptoSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 4177B3D9296CB8C3009711F0 /* CoreCryptoSPI.h */; };
@@ -549,6 +550,7 @@
 		31308B1320A21705003FB929 /* SystemPreviewSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SystemPreviewSPI.h; sourceTree = "<group>"; };
 		31647FAE251759DB0010F8FB /* OpenGLSoftLinkCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = OpenGLSoftLinkCocoa.mm; sourceTree = "<group>"; };
 		31647FAF251759DC0010F8FB /* OpenGLSoftLinkCocoa.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OpenGLSoftLinkCocoa.h; sourceTree = "<group>"; };
+		3A02FE2A2B214A38001724B1 /* ARKitSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARKitSPI.h; sourceTree = "<group>"; };
 		3C963637289DC1C600570DD6 /* BarcodeSupportSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BarcodeSupportSPI.h; sourceTree = "<group>"; };
 		411A9AC02525D4CA00807D7E /* AVAssetWriterSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AVAssetWriterSPI.h; sourceTree = "<group>"; };
 		416E995123DAE6BD00E871CB /* AudioToolboxSoftLink.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AudioToolboxSoftLink.cpp; sourceTree = "<group>"; };
@@ -772,6 +774,7 @@
 				293EE4A724154F8F0047493D /* AccessibilitySupportSoftLink.h */,
 				C037494124127CCB00D9A36E /* AccessibilitySupportSPI.h */,
 				576CA9D522B854AB0030143C /* AppSSOSPI.h */,
+				3A02FE2A2B214A38001724B1 /* ARKitSPI.h */,
 				2D02E93B2056FAA700A13797 /* AudioToolboxSPI.h */,
 				572A107722B456F500F410C8 /* AuthKitSPI.h */,
 				411A9AC02525D4CA00807D7E /* AVAssetWriterSPI.h */,
@@ -1273,6 +1276,7 @@
 				1CD50E0F2A33EA1300032F1A /* AppleJPEGXLSPI.h in Headers */,
 				DD20DD1A27BC90D60093D175 /* AppSSOSoftLink.h in Headers */,
 				DD20DDD727BC90D70093D175 /* AppSSOSPI.h in Headers */,
+				3A02FE2B2B214A38001724B1 /* ARKitSPI.h in Headers */,
 				DD20DD1527BC90D60093D175 /* AudioToolboxSoftLink.h in Headers */,
 				DD20DDD827BC90D70093D175 /* AudioToolboxSPI.h in Headers */,
 				DD20DDD927BC90D70093D175 /* AuthKitSPI.h in Headers */,

--- a/Source/WebCore/PAL/pal/spi/cocoa/ARKitSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/ARKitSPI.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,23 +23,15 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "config.h"
+#if USE(APPLE_INTERNAL_SDK)
 
-#if ((USE(SYSTEM_PREVIEW) && HAVE(ARKIT_QUICK_LOOK_PREVIEW_ITEM)) || ((PLATFORM(IOS) || PLATFORM(VISION)) && USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/ARKitSoftLinkAdditions.mm>)))
+#import <ARKit/ARKit.h>
+#import <ARKit/ARKitPrivate.h>
+
+#else // !USE(APPLE_INTERNAL_SDK)
 
 #import <simd/simd.h>
-#import <wtf/SoftLinking.h>
 
-SOFT_LINK_FRAMEWORK_FOR_SOURCE(WebKit, ARKit);
-
-SOFT_LINK_CLASS_FOR_SOURCE(WebKit, ARKit, ARQuickLookPreviewItem);
-SOFT_LINK_CLASS_FOR_SOURCE(WebKit, ARKit, ARSession);
-SOFT_LINK_CLASS_FOR_SOURCE(WebKit, ARKit, ARWorldTrackingConfiguration);
-
-SOFT_LINK_FUNCTION_FOR_SOURCE(WebKit, ARKit, ARMatrixMakeLookAt, simd_float4x4, (simd_float3 origin, simd_float3 direction), (origin, direction));
-
-#if (PLATFORM(IOS) || PLATFORM(VISION)) && USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/ARKitSoftLinkAdditions.mm>)
-#import <WebKitAdditions/ARKitSoftLinkAdditions.mm>
-#endif
+FOUNDATION_EXTERN simd_float4x4 ARMatrixMakeLookAt(simd_float3 origin, simd_float3 direction);
 
 #endif

--- a/Source/WebKit/Shared/Cocoa/ARKitSoftLink.h
+++ b/Source/WebKit/Shared/Cocoa/ARKitSoftLink.h
@@ -28,13 +28,19 @@
 #if PLATFORM(COCOA) && ((USE(SYSTEM_PREVIEW) && HAVE(ARKIT_QUICK_LOOK_PREVIEW_ITEM)) || (ENABLE(WEBXR) && USE(ARKITXR_IOS)) || (USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/ARKitSoftLinkAdditions.h>)))
 
 #import <ARKit/ARKit.h>
+#import <pal/spi/cocoa/ARKitSPI.h>
 #import <wtf/SoftLinking.h>
 
 SOFT_LINK_FRAMEWORK_FOR_HEADER(WebKit, ARKit)
 
 SOFT_LINK_CLASS_FOR_HEADER(WebKit, ARQuickLookPreviewItem);
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 SOFT_LINK_CLASS_FOR_HEADER(WebKit, ARSession);
+ALLOW_DEPRECATED_DECLARATIONS_END
 SOFT_LINK_CLASS_FOR_HEADER(WebKit, ARWorldTrackingConfiguration)
+
+SOFT_LINK_FUNCTION_FOR_HEADER(WebKit, ARKit, ARMatrixMakeLookAt, simd_float4x4, (simd_float3 origin, simd_float3 direction), (origin, direction))
+#define ARMatrixMakeLookAt WebKit::softLink_ARKit_ARMatrixMakeLookAt
 
 #if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/ARKitSoftLinkAdditions.h>)
 #import <WebKitAdditions/ARKitSoftLinkAdditions.h>

--- a/Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.mm
+++ b/Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.mm
@@ -273,6 +273,8 @@ void ARKitCoordinator::renderLoop(Box<RenderState> active)
             frameData.predictedDisplayTime = frame.timestamp;
             frameData.origin = PlatformXRPose(camera.transform).pose();
 
+            frameData.inputSources = [presentationSession collectInputSources];
+
             // Only one view
             frameData.views.append({
                 .offset = { },

--- a/Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.h
+++ b/Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.h
@@ -29,6 +29,7 @@
 
 #import <Metal/Metal.h>
 #import <UIKit/UIKit.h>
+#import <WebCore/PlatformXR.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -43,6 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @protocol WKARPresentationSession <NSObject>
+@property (nonatomic, readonly) UIView *view;
 @property (nonatomic, retain, readonly) ARFrame *currentFrame;
 @property (nonatomic, retain, readonly) ARSession *session;
 @property (nonatomic, nonnull, retain, readonly) id<MTLSharedEvent> completionEvent;
@@ -51,6 +53,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (atomic, readonly, getter=isSessionEndRequested) BOOL sessionEndRequested;
 
 - (NSUInteger)startFrame;
+- (Vector<PlatformXR::Device::FrameData::InputSource>)collectInputSources;
 - (void)present;
 - (void)terminate;
 @end


### PR DESCRIPTION
#### 3e2c8c605ad34cd3b580e438ecbc437994e9d411
<pre>
[WebXR] Transient input source for immersive AR sessions
<a href="https://bugs.webkit.org/show_bug.cgi?id=266045">https://bugs.webkit.org/show_bug.cgi?id=266045</a>
<a href="https://rdar.apple.com/119348536">rdar://119348536</a>

Reviewed by Dean Jackson.

Now that we support rendering of immersive AR sessions, we need a way to
interact with them.

This implementation of `transient-pointer`, based upon immersive VR, translates
basic touch interactions into target rays derived from shooting a ray from the
ARCamera position through the touch position in world space.

Introduce a _WKTransientGestureRecognizer that can generate `transient-pointer`
events from UITouch, and attach an instance of that gesture recognizer to the
main view for the immersive AR session.

Access to events is provided via -[WKARPresentationSession collectInputSources],
which provides transient actions suitable for passing to
PlatformXR::Device::FrameData::inputSources

* Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj:
* Source/WebCore/PAL/pal/spi/cocoa/ARKitSPI.h: Copied from Source/WebKit/Shared/Cocoa/ARKitSoftLink.h.
* Source/WebKit/Shared/Cocoa/ARKitSoftLink.h:
* Source/WebKit/Shared/Cocoa/ARKitSoftLink.mm:
* Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.mm:
(WebKit::ARKitCoordinator::renderLoop):
* Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.h:
* Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.mm:
(-[UITouch normalizedLocationInView:]):
(-[_WKARPresentationSession raycastQueryTransformFromPoint:]):
(-[_WKARPresentationSession collectInputSources]):
(-[_WKARPresentationSession gestureRecognizer:shouldReceiveTouch:]):
(-[_WKARPresentationSession loadView]):
(-[_WKTransientAction initWithTargetRay:pose:]):
(-[_WKTransientGestureRecognizer initWithSession:]):
(-[_WKTransientGestureRecognizer touchesBegan:withEvent:]):
(-[_WKTransientGestureRecognizer touchesMoved:withEvent:]):
(-[_WKTransientGestureRecognizer touchesEnded:withEvent:]):
(-[_WKTransientGestureRecognizer touchesCancelled:withEvent:]):
(-[_WKTransientGestureRecognizer _doneWithTouch:]):
(-[_WKTransientGestureRecognizer _platformXRInputSourceFromTransientAction:actionIdentifier:]):
(-[_WKTransientGestureRecognizer collectInputSources]):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e2c8c605ad34cd3b580e438ecbc437994e9d411

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29438 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8104 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/30760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/31984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/26697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30038 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/10240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5395 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/31984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29711 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/6732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/25148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/31984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/5916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/26228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/33324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/26851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/26641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/33324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/5880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/4059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/33324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/7596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/6407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3782 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/6404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->