### PR TITLE
Rewrite TestWebKitAPI.AutocorrectionTests.FontAtCaretWhenUsingUICTFontTextStyle to not use fontForCaretSelection.

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -4264,8 +4264,6 @@ WEBCORE_COMMAND_FOR_WEBVIEW(pasteAndMatchStyle);
     if (!_page->editorState().postLayoutData)
         return result;
 
-    [result setObject:[UIColor blackColor] forKey:NSForegroundColorAttributeName];
-
     auto typingAttributes = _page->editorState().postLayoutData->typingAttributes;
     
     UIFont *font = _autocorrectionData.font.get();

--- a/Tools/TestWebKitAPI/Tests/ios/AutocorrectionTestsIOS.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/AutocorrectionTestsIOS.mm
@@ -97,14 +97,18 @@ TEST(AutocorrectionTests, FontAtCaretWhenUsingUICTFontTextStyle)
     checkCGRectIsNotEmpty([autocorrectionRects lastRect]);
 
     auto contentView = [webView textInputContentView];
-    UIFont *fontBeforeScaling = [contentView fontForCaretSelection];
+    auto selectedTextRangeBeforeScaling = contentView.selectedTextRange;
+    auto stylingDictionaryBeforeScaling = [contentView textStylingAtPosition:selectedTextRangeBeforeScaling.start inDirection:UITextStorageDirectionForward];
+    UIFont *fontBeforeScaling = [stylingDictionaryBeforeScaling objectForKey:NSFontAttributeName];
     UIFont *size16SystemFont = [UIFont systemFontOfSize:16];
     EXPECT_WK_STREQ(size16SystemFont.fontName, fontBeforeScaling.fontName);
     EXPECT_WK_STREQ(size16SystemFont.familyName, fontBeforeScaling.familyName);
     EXPECT_EQ(16, fontBeforeScaling.pointSize);
 
     [webView scrollView].zoomScale = 2;
-    UIFont *fontAfterScaling = [contentView fontForCaretSelection];
+    auto selectedTextRangeAfterScaling = contentView.selectedTextRange;
+    auto stylingDictionaryAfterScaling = [contentView textStylingAtPosition:selectedTextRangeAfterScaling.start inDirection:UITextStorageDirectionForward];
+    UIFont *fontAfterScaling = [stylingDictionaryAfterScaling objectForKey:NSFontAttributeName];
     UIFont *size32SystemFont = [UIFont systemFontOfSize:32];
     EXPECT_WK_STREQ(size32SystemFont.fontName, fontAfterScaling.fontName);
     EXPECT_WK_STREQ(size32SystemFont.familyName, fontAfterScaling.familyName);


### PR DESCRIPTION
#### f75c4800598c8a9cdbcd31c970d0b381cc952370
<pre>
Rewrite TestWebKitAPI.AutocorrectionTests.FontAtCaretWhenUsingUICTFontTextStyle to not use fontForCaretSelection.
<a href="https://bugs.webkit.org/show_bug.cgi?id=266055">https://bugs.webkit.org/show_bug.cgi?id=266055</a>
<a href="https://rdar.apple.com/119344370">rdar://119344370</a>

Reviewed by Tim Horton.

After <a href="https://commits.webkit.org/271515@main">https://commits.webkit.org/271515@main</a> TestWebKitAPI.AutocorrectionTests.FontAtCaretWhenUsingUICTFontTextStyle
was failing because it used a method that no longer existed. The test needed to be re-written to use the API that
now gives the font information.

I also removed a duplicate line from the previous patch, no need to set the default black color twice.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView textStylingAtPosition:inDirection:]):
* Tools/TestWebKitAPI/Tests/ios/AutocorrectionTestsIOS.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/271724@main">https://commits.webkit.org/271724@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/422d8e2d418e3e21b3a42e418cc99c1e34f4dc16

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29421 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8086 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30743 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31969 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26686 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30021 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10222 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5378 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26681 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29694 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6717 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25141 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5777 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5921 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26216 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33309 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26839 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26631 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32128 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5869 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4050 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29907 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7581 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6998 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6396 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6393 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->