### PR TITLE
[CSS] @scope invalidation

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-focus-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-focus-expected.txt
@@ -1,6 +1,6 @@
 
 FAIL :focus via :scope in subject assert_equals: expected "1" but got "auto"
-FAIL :focus via :scope in non-subject assert_equals: expected "1" but got "auto"
+PASS :focus via :scope in non-subject
 FAIL :focus in limit, :scope in subject assert_equals: expected "auto" but got "1"
-FAIL :focus in intermediate limit, :scope in subject assert_equals: expected "auto" but got "1"
+PASS :focus in intermediate limit, :scope in subject
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-hover-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-hover-expected.txt
@@ -1,6 +1,6 @@
 
 FAIL :hover via :scope in subject assert_equals: expected "1" but got "auto"
-FAIL :hover via :scope in non-subject assert_equals: expected "1" but got "auto"
+PASS :hover via :scope in non-subject
 FAIL :hover in limit, :scope in subject assert_equals: expected "auto" but got "1"
-FAIL :hover in intermediate limit, :scope in subject assert_equals: expected "auto" but got "1"
+PASS :hover in intermediate limit, :scope in subject
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-invalidation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-invalidation-expected.txt
@@ -1,25 +1,25 @@
 
-FAIL Element becoming scope root assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
-FAIL Element becoming scope root (selector list) assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS Element becoming scope root
+PASS Element becoming scope root (selector list)
 FAIL Element becoming scope root, with inner :scope rule assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
-FAIL Parent element becoming scope limit assert_equals: expected "rgb(0, 0, 0)" but got "rgb(0, 128, 0)"
+PASS Parent element becoming scope limit
 FAIL Parent element becoming scope limit (selector list) assert_equals: expected "rgb(0, 0, 0)" but got "rgb(0, 128, 0)"
-FAIL Subject element becoming scope limit assert_equals: expected "rgb(0, 0, 0)" but got "rgb(0, 128, 0)"
-FAIL Parent element affecting scope limit assert_equals: expected "rgb(0, 0, 0)" but got "rgb(0, 128, 0)"
-FAIL Sibling element affecting scope limit assert_equals: expected "rgb(0, 0, 0)" but got "rgb(0, 128, 0)"
-FAIL Toggling inner/outer scope roots assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS Subject element becoming scope limit
+PASS Parent element affecting scope limit
+PASS Sibling element affecting scope limit
+PASS Toggling inner/outer scope roots
 FAIL Element becoming root, with :scope in subject assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
-FAIL Scope root with :has() assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS Scope root with :has()
 FAIL Scope root with :has(), :scope subject assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 FAIL Scope root with :has(), :scope both subject and non-subject assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
-FAIL Scope limit with :has() assert_equals: expected "rgb(0, 0, 0)" but got "rgb(0, 128, 0)"
+PASS Scope limit with :has()
 FAIL Element becoming root, with :scope selected by ~ combinator assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
-FAIL Element becoming root via ~ combinator assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
-FAIL Element becoming root via + combinator assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
-FAIL :not(scope) in subject assert_equals: expected "rgb(0, 0, 0)" but got "rgb(0, 128, 0)"
-FAIL :not(scope) in ancestor assert_equals: expected "rgb(0, 0, 0)" but got "rgb(0, 128, 0)"
-FAIL :not(scope) in limit subject assert_equals: expected "rgb(0, 0, 0)" but got "rgb(0, 128, 0)"
+PASS Element becoming root via ~ combinator
+PASS Element becoming root via + combinator
+PASS :not(scope) in subject
+PASS :not(scope) in ancestor
+PASS :not(scope) in limit subject
 FAIL :not(scope) in limit ancestor assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 FAIL :nth-child() in scope root assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
-FAIL :nth-child() in scope limit assert_equals: expected "rgb(0, 0, 0)" but got "rgb(0, 128, 0)"
+PASS :nth-child() in scope limit
 

--- a/Source/WebCore/style/RuleFeature.h
+++ b/Source/WebCore/style/RuleFeature.h
@@ -32,6 +32,7 @@
 namespace WebCore {
 
 class StyleRule;
+class StyleRuleScope;
 
 namespace Style {
 
@@ -98,7 +99,7 @@ struct RuleFeatureSet {
     void add(const RuleFeatureSet&);
     void clear();
     void shrinkToFit();
-    void collectFeatures(const RuleData&);
+    void collectFeatures(const RuleData&, const Vector<Ref<const StyleRuleScope>>& scopeRules = { });
     void registerContentAttribute(const AtomString&);
 
     bool usesHasPseudoClass() const;

--- a/Source/WebCore/style/RuleSet.cpp
+++ b/Source/WebCore/style/RuleSet.cpp
@@ -134,7 +134,8 @@ void RuleSet::addRule(RuleData&& ruleData, CascadeLayerIdentifier cascadeLayerId
     storeIdentifier(containerQueryIdentifier, m_containerQueryIdentifierForRulePosition);
     storeIdentifier(scopeRuleIdentifier, m_scopeRuleIdentifierForRulePosition);
 
-    m_features.collectFeatures(ruleData);
+    const auto& scopeRules = scopeRulesFor(ruleData);
+    m_features.collectFeatures(ruleData, scopeRules);
 
     unsigned classBucketSize = 0;
     const CSSSelector* idSelector = nullptr;


### PR DESCRIPTION
#### 2f8a6cd85ced97a0d2f33632f3a7b11e96050b30
<pre>
[CSS] @scope invalidation
<a href="https://bugs.webkit.org/show_bug.cgi?id=265996">https://bugs.webkit.org/show_bug.cgi?id=265996</a>
<a href="https://rdar.apple.com/119313058">rdar://119313058</a>

Reviewed by Antti Koivisto.

When there is a DOM mutation in an ancestor or itself, we need to
reevaluate if the scope is matching.

* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-focus-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-hover-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-invalidation-expected.txt:
* Source/WebCore/style/RuleFeature.cpp:
(WebCore::Style::RuleFeatureSet::collectFeatures):
* Source/WebCore/style/RuleFeature.h:
(WebCore::Style::RuleFeatureSet::collectFeatures):
* Source/WebCore/style/RuleSet.cpp:
(WebCore::Style::RuleSet::addRule):

Canonical link: <a href="https://commits.webkit.org/271897@main">https://commits.webkit.org/271897@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2be174cf01c6710e04eb4ef6152bcf3fd5fcee29

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29949 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8615 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31267 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32461 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27083 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30609 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10802 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5870 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27130 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30243 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7220 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25551 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6163 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6327 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-cascade/scope-hover.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26640 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33797 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27315 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27070 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32504 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6265 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4440 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30297 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8002 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7104 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7007 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6791 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->