### PR TITLE
Add <input type=checkbox switch> iOS infrastructure, take 2

### DIFF
--- a/Source/WebCore/PAL/pal/ios/UIKitSoftLink.h
+++ b/Source/WebCore/PAL/pal/ios/UIKitSoftLink.h
@@ -75,6 +75,8 @@ SOFT_LINK_FUNCTION_FOR_HEADER(PAL, UIKit, UIAccessibilityIsReduceMotionEnabled, 
 #define UIAccessibilityIsReduceMotionEnabled PAL::softLink_UIKit_UIAccessibilityIsReduceMotionEnabled
 SOFT_LINK_FUNCTION_FOR_HEADER(PAL, UIKit, UIAccessibilityDarkerSystemColorsEnabled, BOOL, (void), ())
 #define UIAccessibilityDarkerSystemColorsEnabled PAL::softLink_UIKit_UIAccessibilityDarkerSystemColorsEnabled
+SOFT_LINK_FUNCTION_FOR_HEADER(PAL, UIKit, UIAccessibilityIsOnOffSwitchLabelsEnabled, BOOL, (void), ())
+#define UIAccessibilityIsOnOffSwitchLabelsEnabled PAL::softLink_UIKit_UIAccessibilityIsOnOffSwitchLabelsEnabled
 SOFT_LINK_FUNCTION_FOR_HEADER(PAL, UIKit, UIAccessibilityPostNotification, void, (UIAccessibilityNotifications n, id argument), (n, argument))
 #define UIAccessibilityPostNotification PAL::softLink_UIKit_UIAccessibilityPostNotification
 SOFT_LINK_FUNCTION_FOR_HEADER(PAL, UIKit, UIGraphicsGetCurrentContext, CGContextRef, (void), ())

--- a/Source/WebCore/PAL/pal/ios/UIKitSoftLink.mm
+++ b/Source/WebCore/PAL/pal/ios/UIKitSoftLink.mm
@@ -70,6 +70,7 @@ SOFT_LINK_FUNCTION_FOR_SOURCE(PAL, UIKit, UIAccessibilityIsGrayscaleEnabled, BOO
 SOFT_LINK_FUNCTION_FOR_SOURCE(PAL, UIKit, UIAccessibilityIsInvertColorsEnabled, BOOL, (void), ())
 SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, UIKit, UIAccessibilityIsReduceMotionEnabled, BOOL, (void), (), PAL_EXPORT)
 SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, UIKit, UIAccessibilityDarkerSystemColorsEnabled, BOOL, (void), (), PAL_EXPORT)
+SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, UIKit, UIAccessibilityIsOnOffSwitchLabelsEnabled, BOOL, (void), (), PAL_EXPORT)
 SOFT_LINK_FUNCTION_FOR_SOURCE(PAL, UIKit, UIAccessibilityPostNotification, void, (UIAccessibilityNotifications n, id argument), (n, argument))
 SOFT_LINK_FUNCTION_FOR_SOURCE(PAL, UIKit, UIGraphicsGetCurrentContext, CGContextRef, (void), ())
 SOFT_LINK_FUNCTION_FOR_SOURCE(PAL, UIKit, UIGraphicsPopContext, void, (void), ())

--- a/Source/WebCore/css/htmlSwitchControl.css
+++ b/Source/WebCore/css/htmlSwitchControl.css
@@ -33,3 +33,26 @@ input[type="checkbox"][switch]::thumb, input[type="checkbox"][switch]::track {
     appearance: inherit !important;
     grid-area: 1/1;
 }
+
+#if defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY
+input[type="checkbox"][switch] {
+    border-radius: initial;
+    width: initial;
+    height: initial;
+    padding: initial;
+    background-color: initial;
+}
+
+input[type="checkbox"][switch]:checked {
+    border-color: initial;
+}
+
+input[type="checkbox"][switch]:disabled {
+    opacity: initial;
+}
+
+input[type="checkbox"][switch]:checked:disabled {
+    opacity: initial;
+    background: initial;
+}
+#endif // defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY

--- a/Source/WebCore/html/CheckboxInputType.cpp
+++ b/Source/WebCore/html/CheckboxInputType.cpp
@@ -34,6 +34,7 @@
 
 #include "ChromeClient.h"
 #include "EventHandler.h"
+#include "EventNames.h"
 #include "HTMLInputElement.h"
 #include "InputTypeNames.h"
 #include "KeyboardEvent.h"
@@ -49,6 +50,10 @@
 #include "ShadowRoot.h"
 #include "SwitchThumbElement.h"
 #include "SwitchTrackElement.h"
+
+#if ENABLE(IOS_TOUCH_EVENTS)
+#include "TouchEvent.h"
+#endif
 
 namespace WebCore {
 
@@ -97,7 +102,6 @@ void CheckboxInputType::handleMouseDownEvent(MouseEvent& event)
 
     if (!event.isTrusted() || !isSwitch() || element()->isDisabledFormControl() || !element()->renderer())
         return;
-    m_isSwitchVisuallyOn = element()->checked();
     startSwitchPointerTracking(event.absoluteLocation());
 }
 
@@ -117,6 +121,76 @@ void CheckboxInputType::handleMouseMoveEvent(MouseEvent& event)
 
     updateIsSwitchVisuallyOnFromAbsoluteLocation(event.absoluteLocation());
 }
+
+#if ENABLE(IOS_TOUCH_EVENTS)
+// FIXME: Share this function with SliderThumbElement somehow? Some of the logic in
+// handleTouchEvent() could maybe do with some abstraction as well.
+static Touch* findTouchWithIdentifier(TouchList& list, unsigned identifier)
+{
+    unsigned length = list.length();
+    for (unsigned i = 0; i < length; ++i) {
+        RefPtr<Touch> touch = list.item(i);
+        if (touch->identifier() == identifier)
+            return touch.get();
+    }
+    return nullptr;
+}
+
+void CheckboxInputType::handleTouchEvent(TouchEvent& event)
+{
+    ASSERT(element());
+
+    if (!event.isTrusted() || !isSwitch() || element()->isDisabledFormControl() || !element()->renderer()) {
+        stopSwitchPointerTracking();
+        return;
+    }
+
+    const AtomString& eventType = event.type();
+    auto& eventNames = WebCore::eventNames();
+    if (eventType == eventNames.touchstartEvent) {
+        RefPtr<TouchList> targetTouches = event.targetTouches();
+        if (!targetTouches)
+            return;
+        if (targetTouches->length() != 1)
+            return;
+        RefPtr<Touch> touch = targetTouches->item(0);
+
+        startSwitchPointerTracking(IntPoint(touch->pageX(), touch->pageY()), touch->identifier());
+        performSwitchAnimation(SwitchAnimationType::Pressed);
+        event.setDefaultHandled();
+    } else if (eventType == eventNames.touchmoveEvent) {
+        if (!m_switchPointerTrackingTouchIdentifier || !isSwitchPointerTracking())
+            return;
+
+        RefPtr<TouchList> targetTouches = event.targetTouches();
+        if (!targetTouches)
+            return;
+
+        RefPtr<Touch> touch = findTouchWithIdentifier(*targetTouches, *m_switchPointerTrackingTouchIdentifier);
+        if (!touch)
+            return;
+
+        auto absoluteLocation = IntPoint(touch->pageX(), touch->pageY());
+        updateIsSwitchVisuallyOnFromAbsoluteLocation(absoluteLocation);
+        event.setDefaultHandled();
+    } else if (eventType == eventNames.touchendEvent || eventType == eventNames.touchcancelEvent) {
+        if (!m_switchPointerTrackingTouchIdentifier || !isSwitchPointerTracking())
+            return;
+
+        RefPtr<TouchList> targetTouches = event.targetTouches();
+        if (!targetTouches)
+            return;
+
+        // If our touch still exists, this is not our touchend/touchcancel.
+        RefPtr<Touch> touch = findTouchWithIdentifier(*targetTouches, *m_switchPointerTrackingTouchIdentifier);
+        if (touch)
+            return;
+
+        performSwitchAnimation(SwitchAnimationType::Pressed);
+        element()->dispatchSimulatedClick(&event);
+    }
+}
+#endif
 
 void CheckboxInputType::willDispatchClick(InputElementClickState& state)
 {
@@ -157,7 +231,7 @@ void CheckboxInputType::didDispatchClick(Event& event, const InputElementClickSt
     event.setDefaultHandled();
 }
 
-void CheckboxInputType::startSwitchPointerTracking(LayoutPoint absoluteLocation)
+void CheckboxInputType::startSwitchPointerTracking(LayoutPoint absoluteLocation, std::optional<unsigned> touchIdentifier)
 {
     ASSERT(element());
     ASSERT(element()->renderer());
@@ -165,6 +239,7 @@ void CheckboxInputType::startSwitchPointerTracking(LayoutPoint absoluteLocation)
         frame->eventHandler().setCapturingMouseEventsElement(element());
         m_isSwitchVisuallyOn = element()->checked();
         m_switchPointerTrackingXPositionStart = element()->renderer()->absoluteToLocal(absoluteLocation, UseTransforms).x();
+        m_switchPointerTrackingTouchIdentifier = touchIdentifier;
     }
 }
 
@@ -178,6 +253,7 @@ void CheckboxInputType::stopSwitchPointerTracking()
         frame->eventHandler().setCapturingMouseEventsElement(nullptr);
     m_hasSwitchVisuallyOnChanged = false;
     m_switchPointerTrackingXPositionStart = std::nullopt;
+    m_switchPointerTrackingTouchIdentifier = std::nullopt;
 }
 
 bool CheckboxInputType::isSwitchPointerTracking() const
@@ -196,6 +272,7 @@ void CheckboxInputType::disabledStateChanged()
     ASSERT(element());
     if (isSwitch() && element()->isDisabledFormControl()) {
         stopSwitchAnimation(SwitchAnimationType::VisuallyOn);
+        stopSwitchAnimation(SwitchAnimationType::Pressed);
         stopSwitchPointerTracking();
     }
 }
@@ -205,6 +282,7 @@ void CheckboxInputType::willUpdateCheckedness(bool, WasSetByJavaScript wasChecke
     ASSERT(element());
     if (isSwitch() && wasCheckedByJavaScript == WasSetByJavaScript::Yes) {
         stopSwitchAnimation(SwitchAnimationType::VisuallyOn);
+        stopSwitchAnimation(SwitchAnimationType::Pressed);
         stopSwitchPointerTracking();
     }
 }
@@ -218,19 +296,26 @@ static Seconds switchAnimationUpdateInterval(HTMLInputElement* element)
     return 0_s;
 }
 
-static Seconds switchAnimationDuration(SwitchAnimationType)
+static Seconds switchAnimationDuration(SwitchAnimationType type)
 {
-    return RenderTheme::singleton().switchAnimationVisuallyOnDuration();
+    if (type == SwitchAnimationType::VisuallyOn)
+        return RenderTheme::singleton().switchAnimationVisuallyOnDuration();
+    return RenderTheme::singleton().switchAnimationPressedDuration();
 }
 
-Seconds CheckboxInputType::switchAnimationStartTime(SwitchAnimationType) const
+Seconds CheckboxInputType::switchAnimationStartTime(SwitchAnimationType type) const
 {
-    return m_switchAnimationVisuallyOnStartTime;
+    if (type == SwitchAnimationType::VisuallyOn)
+        return m_switchAnimationVisuallyOnStartTime;
+    return m_switchAnimationPressedStartTime;
 }
 
-void CheckboxInputType::setSwitchAnimationStartTime(SwitchAnimationType, Seconds time)
+void CheckboxInputType::setSwitchAnimationStartTime(SwitchAnimationType type, Seconds time)
 {
-    m_switchAnimationVisuallyOnStartTime = time;
+    if (type == SwitchAnimationType::VisuallyOn)
+        m_switchAnimationVisuallyOnStartTime = time;
+    else
+        m_switchAnimationPressedStartTime = time;
 }
 
 bool CheckboxInputType::isSwitchAnimating(SwitchAnimationType type) const
@@ -290,6 +375,14 @@ float CheckboxInputType::switchAnimationVisuallyOnProgress() const
     return switchAnimationProgress(SwitchAnimationType::VisuallyOn);
 }
 
+float CheckboxInputType::switchAnimationPressedProgress() const
+{
+    ASSERT(isSwitch());
+    ASSERT(switchAnimationDuration(SwitchAnimationType::Pressed) > 0_s);
+
+    return switchAnimationProgress(SwitchAnimationType::Pressed);
+}
+
 bool CheckboxInputType::isSwitchVisuallyOn() const
 {
     ASSERT(element());
@@ -339,10 +432,15 @@ void CheckboxInputType::switchAnimationTimerFired()
 
     auto currentTime = MonotonicTime::now().secondsSinceEpoch();
     auto isVisuallyOnOngoing = currentTime - switchAnimationStartTime(SwitchAnimationType::VisuallyOn) < switchAnimationDuration(SwitchAnimationType::VisuallyOn);
-    if (isVisuallyOnOngoing)
+    auto isPressedOngoing = currentTime - switchAnimationStartTime(SwitchAnimationType::Pressed) < switchAnimationDuration(SwitchAnimationType::Pressed);
+    if (isVisuallyOnOngoing || isPressedOngoing)
         m_switchAnimationTimer->startOneShot(updateInterval);
-    else
-        stopSwitchAnimation(SwitchAnimationType::VisuallyOn);
+    else {
+        if (!isVisuallyOnOngoing)
+            stopSwitchAnimation(SwitchAnimationType::VisuallyOn);
+        if (!isPressedOngoing)
+            stopSwitchAnimation(SwitchAnimationType::Pressed);
+    }
 
     element()->renderer()->repaint();
 }

--- a/Source/WebCore/html/CheckboxInputType.h
+++ b/Source/WebCore/html/CheckboxInputType.h
@@ -36,7 +36,7 @@ namespace WebCore {
 
 enum class WasSetByJavaScript : bool;
 
-enum class SwitchAnimationType { VisuallyOn };
+enum class SwitchAnimationType : bool { VisuallyOn, Pressed };
 
 class CheckboxInputType final : public BaseCheckableInputType {
 public:
@@ -48,6 +48,7 @@ public:
     bool valueMissing(const String&) const final;
     float switchAnimationVisuallyOnProgress() const;
     bool isSwitchVisuallyOn() const;
+    float switchAnimationPressedProgress() const;
 
 private:
     explicit CheckboxInputType(HTMLInputElement& element)
@@ -61,7 +62,12 @@ private:
     void handleKeyupEvent(KeyboardEvent&) final;
     void handleMouseDownEvent(MouseEvent&) final;
     void handleMouseMoveEvent(MouseEvent&) final;
-    void startSwitchPointerTracking(LayoutPoint);
+// FIXME: It should not be iOS-specific, but it's not been tested with a non-iOS touch
+// implementation thus far.
+#if ENABLE(IOS_TOUCH_EVENTS)
+    void handleTouchEvent(TouchEvent&) final;
+#endif
+    void startSwitchPointerTracking(LayoutPoint, std::optional<unsigned> = std::nullopt);
     void stopSwitchPointerTracking();
     bool isSwitchPointerTracking() const;
     void willDispatchClick(InputElementClickState&) final;
@@ -84,7 +90,9 @@ private:
     bool m_hasSwitchVisuallyOnChanged { false };
     bool m_isSwitchVisuallyOn { false };
     Seconds m_switchAnimationVisuallyOnStartTime { 0_s };
+    Seconds m_switchAnimationPressedStartTime { 0_s };
     std::unique_ptr<Timer> m_switchAnimationTimer;
+    std::optional<unsigned> m_switchPointerTrackingTouchIdentifier { std::nullopt };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLInputElement.h
+++ b/Source/WebCore/html/HTMLInputElement.h
@@ -342,6 +342,7 @@ public:
 
     float switchAnimationVisuallyOnProgress() const;
     bool isSwitchVisuallyOn() const;
+    float switchAnimationPressedProgress() const;
 
 protected:
     HTMLInputElement(const QualifiedName&, Document&, HTMLFormElement*, bool createdByParser);
@@ -435,6 +436,10 @@ private:
     void updateType(const AtomString& typeAttributeValue);
     void runPostTypeUpdateTasks();
 
+#if ENABLE(TOUCH_EVENTS)
+    void updateTouchEventHandler();
+#endif
+
     void subtreeHasChanged() final;
     void disabledStateChanged() final;
     void readOnlyStateChanged() final;
@@ -481,7 +486,7 @@ private:
     bool m_valueAttributeWasUpdatedAfterParsing : 1 { false };
     bool m_wasModifiedByUser : 1 { false };
     bool m_canReceiveDroppedFiles : 1 { false };
-#if ENABLE(TOUCH_EVENTS) && !ENABLE(IOS_TOUCH_EVENTS)
+#if ENABLE(TOUCH_EVENTS)
     bool m_hasTouchEventHandler : 1 { false };
 #endif
     bool m_isSpellcheckDisabledExceptTextReplacement : 1 { false };

--- a/Source/WebCore/html/InputType.cpp
+++ b/Source/WebCore/html/InputType.cpp
@@ -1193,4 +1193,18 @@ void InputType::createShadowSubtreeIfNeeded()
     createShadowSubtree();
 }
 
+#if ENABLE(TOUCH_EVENTS)
+bool InputType::hasTouchEventHandler() const
+{
+#if ENABLE(IOS_TOUCH_EVENTS)
+    if (isSwitch())
+        return true;
+#else
+    if (isRangeControl())
+        return true;
+#endif
+    return false;
+}
+#endif
+
 } // namespace WebCore

--- a/Source/WebCore/html/InputType.h
+++ b/Source/WebCore/html/InputType.h
@@ -212,6 +212,10 @@ public:
     bool needsShadowSubtree() const { return !nonShadowRootTypes.contains(m_type) || isSwitch(); }
     bool hasCreatedShadowSubtree() const { return m_hasCreatedShadowSubtree; }
 
+#if ENABLE(TOUCH_EVENTS)
+    bool hasTouchEventHandler() const;
+#endif
+
     // Form value functions.
 
     virtual bool shouldSaveAndRestoreFormControlState() const;
@@ -307,10 +311,6 @@ public:
     virtual void blur();
 
     virtual void elementDidBlur() { }
-
-#if ENABLE(TOUCH_EVENTS) && !ENABLE(IOS_TOUCH_EVENTS)
-    virtual bool hasTouchEventHandler() const { return false; }
-#endif
 
     // Shadow tree handling.
 

--- a/Source/WebCore/html/RangeInputType.h
+++ b/Source/WebCore/html/RangeInputType.h
@@ -82,9 +82,6 @@ private:
 
 #if ENABLE(TOUCH_EVENTS)
     void handleTouchEvent(TouchEvent&) final;
-#if !ENABLE(IOS_TOUCH_EVENTS)
-    bool hasTouchEventHandler() const final { return true; }
-#endif
 #endif
 
     void disabledStateChanged() final;

--- a/Source/WebCore/platform/Theme.h
+++ b/Source/WebCore/platform/Theme.h
@@ -83,6 +83,7 @@ public:
 
     virtual bool userPrefersContrast() const { return false; }
     virtual bool userPrefersReducedMotion() const { return false; }
+    virtual bool userPrefersOnOffLabels() const { return false; }
 
 protected:
     Theme() = default;

--- a/Source/WebCore/platform/ios/ThemeIOS.h
+++ b/Source/WebCore/platform/ios/ThemeIOS.h
@@ -35,6 +35,7 @@ class ThemeIOS final : public ThemeCocoa {
 private:
     bool userPrefersContrast() const final;
     bool userPrefersReducedMotion() const final;
+    bool userPrefersOnOffLabels() const final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/ios/ThemeIOS.mm
+++ b/Source/WebCore/platform/ios/ThemeIOS.mm
@@ -49,6 +49,11 @@ bool ThemeIOS::userPrefersReducedMotion() const
     return PAL::softLink_UIKit_UIAccessibilityIsReduceMotionEnabled();
 }
 
+bool ThemeIOS::userPrefersOnOffLabels() const
+{
+    return PAL::softLink_UIKit_UIAccessibilityIsOnOffSwitchLabelsEnabled();
+}
+
 }
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -363,6 +363,8 @@ void RenderTheme::adjustStyle(RenderStyle& style, const Element* element, const 
         return adjustSearchFieldResultsDecorationPartStyle(style, element);
     case StyleAppearance::SearchFieldResultsButton:
         return adjustSearchFieldResultsButtonStyle(style, element);
+    case StyleAppearance::Switch:
+        return adjustSwitchStyle(style, element);
     case StyleAppearance::ProgressBar:
         return adjustProgressBarStyle(style, element);
     case StyleAppearance::Meter:
@@ -943,6 +945,12 @@ bool RenderTheme::paint(const RenderBox& box, ControlStates& controlStates, cons
         return paintSearchFieldResultsDecorationPart(box, paintInfo, integralSnappedRect);
     case StyleAppearance::SearchFieldResultsButton:
         return paintSearchFieldResultsButton(box, paintInfo, integralSnappedRect);
+    case StyleAppearance::Switch:
+        return true;
+    case StyleAppearance::SwitchThumb:
+        return paintSwitchThumb(box, paintInfo, devicePixelSnappedRect);
+    case StyleAppearance::SwitchTrack:
+        return paintSwitchTrack(box, paintInfo, devicePixelSnappedRect);
 #if ENABLE(SERVICE_CONTROLS)
     case StyleAppearance::ImageControlsButton:
         return paintImageControlsButton(box, paintInfo, integralSnappedRect);

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -264,6 +264,7 @@ public:
     virtual void paintSystemPreviewBadge(Image&, const PaintInfo&, const FloatRect&);
 #endif
     virtual Seconds switchAnimationVisuallyOnDuration() const { return 0_s; }
+    virtual Seconds switchAnimationPressedDuration() const { return 0_s; }
     float switchPointerTrackingMagnitudeProportion() const { return 0.4f; }
 
 protected:
@@ -382,6 +383,10 @@ protected:
 
     virtual void adjustSearchFieldResultsButtonStyle(RenderStyle&, const Element*) const { }
     virtual bool paintSearchFieldResultsButton(const RenderBox&, const PaintInfo&, const IntRect&) { return true; }
+
+    virtual void adjustSwitchStyle(RenderStyle&, const Element*) const { }
+    virtual bool paintSwitchThumb(const RenderObject&, const PaintInfo&, const FloatRect&) { return true; }
+    virtual bool paintSwitchTrack(const RenderObject&, const PaintInfo&, const FloatRect&) { return true; }
 
 public:
     void updateControlStatesForRenderer(const RenderBox&, ControlStates&) const;

--- a/Source/WebCore/rendering/RenderThemeIOS.h
+++ b/Source/WebCore/rendering/RenderThemeIOS.h
@@ -99,6 +99,12 @@ private:
 
     void adjustSliderThumbSize(RenderStyle&, const Element*) const override;
 
+    void adjustSwitchStyle(RenderStyle&, const Element*) const override;
+    bool paintSwitchThumb(const RenderObject&, const PaintInfo&, const FloatRect&) override;
+    bool paintSwitchTrack(const RenderObject&, const PaintInfo&, const FloatRect&) override;
+    Seconds switchAnimationVisuallyOnDuration() const final { return 300_ms; }
+    Seconds switchAnimationPressedDuration() const final { return 300_ms; }
+
     bool paintProgressBar(const RenderObject&, const PaintInfo&, const IntRect&) override;
 
 #if ENABLE(DATALIST_ELEMENT)

--- a/Source/WebCore/rendering/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/RenderThemeIOS.mm
@@ -97,6 +97,10 @@
 #include "HTMLOptionElement.h"
 #endif
 
+#if USE(APPLE_INTERNAL_SDK)
+#include <WebKitAdditions/RenderThemeIOSAdditions.mm>
+#endif
+
 #import <pal/ios/UIKitSoftLink.h>
 
 namespace WebCore {
@@ -701,6 +705,46 @@ void RenderThemeIOS::adjustSliderThumbSize(RenderStyle& style, const Element*) c
 
 constexpr auto reducedMotionProgressAnimationMinOpacity = 0.3f;
 constexpr auto reducedMotionProgressAnimationMaxOpacity = 0.6f;
+
+#if !USE(APPLE_INTERNAL_SDK)
+constexpr auto switchHeight = 31.f;
+constexpr auto switchWidth = 51.f;
+
+static bool renderThemePaintSwitchThumb(OptionSet<ControlStates::States>, const RenderObject&, const PaintInfo&, const FloatRect&)
+{
+    return true;
+}
+
+static bool renderThemePaintSwitchTrack(OptionSet<ControlStates::States>, const RenderObject&, const PaintInfo&, const FloatRect&, const Color)
+{
+    return true;
+}
+#endif
+
+void RenderThemeIOS::adjustSwitchStyle(RenderStyle& style, const Element* element) const
+{
+    RenderTheme::adjustSwitchStyle(style, element);
+
+    if (!style.width().isAuto() && !style.height().isAuto())
+        return;
+
+    auto size = std::max(style.computedFontSize(), switchHeight);
+    style.setWidth({ size * (switchWidth / switchHeight), LengthType::Fixed });
+    style.setHeight({ size, LengthType::Fixed });
+
+    if (element->isDisabledFormControl())
+        style.setOpacity(.4f);
+}
+
+bool RenderThemeIOS::paintSwitchThumb(const RenderObject& renderer, const PaintInfo& paintInfo, const FloatRect& rect)
+{
+    return renderThemePaintSwitchThumb(extractControlStatesForRenderer(renderer), renderer, paintInfo, rect);
+}
+
+bool RenderThemeIOS::paintSwitchTrack(const RenderObject& renderer, const PaintInfo& paintInfo, const FloatRect& rect)
+{
+    return renderThemePaintSwitchTrack(extractControlStatesForRenderer(renderer), renderer, paintInfo, rect, systemColor(CSSValueAppleSystemGreen, renderer.styleColorOptions()));
+}
 
 bool RenderThemeIOS::paintProgressBar(const RenderObject& renderer, const PaintInfo& paintInfo, const IntRect& rect)
 {


### PR DESCRIPTION
#### ed68bec15c81ef24f5be1e5fa7af70b9e0162361
<pre>
Add &lt;input type=checkbox switch&gt; iOS infrastructure, take 2
<a href="https://bugs.webkit.org/show_bug.cgi?id=265947">https://bugs.webkit.org/show_bug.cgi?id=265947</a>
<a href="https://rdar.apple.com/119325031">rdar://119325031</a>

Reviewed by Aditya Keerthi.

This makes the following changes:

- Resets default styling of &lt;input type=checkbox switch&gt; on iOS.
- Adds support for reading the on/off labels preference.
- Adds support for touch-based pointer tracking to CheckboxInputType as
  well as a Pressed animation that can run simultaneously with the
  VisuallyOn animation.
- Make the non-IOS_TOUCH_EVENTS code in HTMLInputElement compatible
  with IOS_TOUCH_EVENTS so events get delivered to CheckboxInputType.
- Adds the relevant hooks to RenderTheme to enable painting on iOS.

And most importantly, attempts to only enable the touch code paths for
switch controls to avoid impacting Speedometer. This was generously
contributed by Aditya and is how this patch is substantially different
from 271682@main (take 1) which was reverted in 271705@main.

* Source/WebCore/PAL/pal/ios/UIKitSoftLink.h:
* Source/WebCore/PAL/pal/ios/UIKitSoftLink.mm:
* Source/WebCore/css/htmlSwitchControl.css:
(#if defined(WTF_PLATFORM_IOS_FAMILY) &amp;&amp; WTF_PLATFORM_IOS_FAMILY):
(input[type=&quot;checkbox&quot;][switch]:checked):
(input[type=&quot;checkbox&quot;][switch]:disabled):
(input[type=&quot;checkbox&quot;][switch]:checked:disabled):
* Source/WebCore/html/CheckboxInputType.cpp:
(WebCore::CheckboxInputType::handleMouseDownEvent):
(WebCore::findTouchWithIdentifier):
(WebCore::CheckboxInputType::handleTouchEvent):
(WebCore::CheckboxInputType::startSwitchPointerTracking):
(WebCore::CheckboxInputType::stopSwitchPointerTracking):
(WebCore::CheckboxInputType::disabledStateChanged):
(WebCore::CheckboxInputType::willUpdateCheckedness):
(WebCore::switchAnimationDuration):
(WebCore::CheckboxInputType::switchAnimationStartTime const):
(WebCore::CheckboxInputType::setSwitchAnimationStartTime):
(WebCore::CheckboxInputType::switchAnimationPressedProgress const):
(WebCore::CheckboxInputType::switchAnimationTimerFired):
* Source/WebCore/html/CheckboxInputType.h:
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::~HTMLInputElement):
(WebCore::HTMLInputElement::runPostTypeUpdateTasks):
(WebCore::HTMLInputElement::updateTouchEventHandler):
(WebCore::HTMLInputElement::attributeChanged):
(WebCore::HTMLInputElement::didMoveToNewDocument):
(WebCore::HTMLInputElement::switchAnimationPressedProgress const):
* Source/WebCore/html/HTMLInputElement.h:
* Source/WebCore/html/InputType.cpp:
(WebCore::InputType::hasTouchEventHandler const):
* Source/WebCore/html/InputType.h:
(WebCore::InputType::hasTouchEventHandler const): Deleted.
* Source/WebCore/html/RangeInputType.h:
* Source/WebCore/platform/Theme.h:
(WebCore::Theme::userPrefersOnOffLabels const):
* Source/WebCore/platform/ios/ThemeIOS.h:
* Source/WebCore/platform/ios/ThemeIOS.mm:
(WebCore::ThemeIOS::userPrefersOnOffLabels const):
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::adjustStyle):
(WebCore::RenderTheme::paint):
* Source/WebCore/rendering/RenderTheme.h:
(WebCore::RenderTheme::switchAnimationPressedDuration const):
(WebCore::RenderTheme::adjustSwitchStyle const):
(WebCore::RenderTheme::paintSwitchThumb):
(WebCore::RenderTheme::paintSwitchTrack):
* Source/WebCore/rendering/RenderThemeIOS.h:
* Source/WebCore/rendering/RenderThemeIOS.mm:
(WebCore::renderThemePaintSwitchThumb):
(WebCore::renderThemePaintSwitchTrack):
(WebCore::RenderThemeIOS::adjustSwitchStyle const):
(WebCore::RenderThemeIOS::paintSwitchThumb):
(WebCore::RenderThemeIOS::paintSwitchTrack):

Canonical link: <a href="https://commits.webkit.org/271735@main">https://commits.webkit.org/271735@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f644f66630034c04368ed1cad18fa918e359eba6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29453 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8119 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30775 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31998 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26707 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30053 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10261 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5411 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26710 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29726 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6756 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25169 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5800 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5935 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26248 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33338 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26885 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26662 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32162 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5891 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4078 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29931 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7610 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7003 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6420 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6414 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->