### PR TITLE
WebCodecs HEVC isSupported returns true but decoding failed

### DIFF
--- a/LayoutTests/http/wpt/webcodecs/hevc-decoder-annexb.https.any-expected.txt
+++ b/LayoutTests/http/wpt/webcodecs/hevc-decoder-annexb.https.any-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Test that HEVC decoder with annexb data
+

--- a/LayoutTests/http/wpt/webcodecs/hevc-decoder-annexb.https.any.html
+++ b/LayoutTests/http/wpt/webcodecs/hevc-decoder-annexb.https.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/http/wpt/webcodecs/hevc-decoder-annexb.https.any.js
+++ b/LayoutTests/http/wpt/webcodecs/hevc-decoder-annexb.https.any.js
@@ -1,0 +1,33 @@
+promise_test(t => {
+    let resolveCallback, rejectCallback;
+    const promise = new Promise((resolve, reject) => {
+        resolveCallback = resolve;
+        rejectCallback = reject;
+    });
+    const decoder = new VideoDecoder({
+        output(frame) {
+            assert_equals(frame.codedWidth, 268, "width");
+            assert_equals(frame.codedHeight, 268, "height");
+
+            frame.close();
+            resolveCallback();
+        },
+        error(e) {
+            rejectCallback(e);
+        }
+    });
+
+    decoder.configure({
+        codec: "hev1.1.6.L90.90",
+        hardwareAcceleration: "no-preference"
+    });
+
+    const data = new Uint8Array([0, 0, 0, 1, 64, 1, 12, 1, 255, 255, 1, 96, 0, 0, 3, 0, 144, 0, 0, 3, 0, 0, 3, 0, 60, 149, 152, 9, 0, 0, 0, 1, 66, 1, 1, 1, 96, 0, 0, 3, 0, 144, 0, 0, 3, 0, 0, 3, 0, 60, 160, 8, 136, 4, 71, 119, 150, 86, 105, 36, 202, 230, 128, 128, 0, 0, 3, 0, 128, 0, 0, 3, 0, 132, 0, 0, 0, 1, 68, 1, 193, 114, 180, 98, 64, 0, 0, 1, 40, 1, 175, 19, 41, 104, 147, 158, 230, 105, 128, 191, 255, 233, 135, 63, 31, 217, 0, 181, 98, 99, 182, 187, 224, 9, 0, 128, 128, 165, 239, 114, 184, 5, 192, 31, 34, 97, 21, 147, 2, 132, 42, 64, 0, 12, 104, 135, 0, 0, 3, 0, 0, 91, 64, 0, 0, 3, 0, 2, 182 ]);
+    decoder.decode(new EncodedVideoChunk({
+        timestamp: 1,
+        type: "key",
+        data,
+    }));
+    decoder.flush();
+    return promise;
+}, "Test that HEVC decoder with annexb data");

--- a/LayoutTests/http/wpt/webcodecs/hevc-decoder-annexb.https.any.worker-expected.txt
+++ b/LayoutTests/http/wpt/webcodecs/hevc-decoder-annexb.https.any.worker-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Test that HEVC decoder with annexb data
+

--- a/LayoutTests/http/wpt/webcodecs/hevc-decoder-annexb.https.any.worker.html
+++ b/LayoutTests/http/wpt/webcodecs/hevc-decoder-annexb.https.any.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1203,6 +1203,8 @@ imported/w3c/web-platform-tests/webcodecs/audio-encoder.https.any.html [ Pass Du
 
 http/tests/webcodecs/h264-reordering.html [ Failure ]
 http/tests/webcodecs/hevc-reordering.html [ Failure ]
+http/wpt/webcodecs/hevc-decoder-annexb.https.any.html [ Failure ]
+http/wpt/webcodecs/hevc-decoder-annexb.https.any.worker.html [ Failure ]
 
 # This test is flaky crashing with the current GStreamer version of the SDK (1.22), raising a
 # critical warning in GStreamer, but the issue is not happening with GStreamer 1.23. So this test is


### PR DESCRIPTION
#### 8555adfc8a29c5d85caff1f9d6c7f9c0dc8eb0b2
<pre>
WebCodecs HEVC isSupported returns true but decoding failed
<a href="https://bugs.webkit.org/show_bug.cgi?id=262950">https://bugs.webkit.org/show_bug.cgi?id=262950</a>
<a href="https://rdar.apple.com/116768196">rdar://116768196</a>

Reviewed by Jean-Yves Avenard.

Our nalu_rewriter logic was inaccurate and we were sometimes dropping data when translating annexb to hevc.
Fix the issue and add logging in error case.
Covered by added test.

* LayoutTests/http/wpt/webcodecs/hevc-decoder-annexb.https.any-expected.txt: Added.
* LayoutTests/http/wpt/webcodecs/hevc-decoder-annexb.https.any.html: Added.
* LayoutTests/http/wpt/webcodecs/hevc-decoder-annexb.https.any.js: Added.
(promise_test.t.const.promise.new.Promise):
(promise_test.t.const.decoder.new.VideoDecoder.output):
(promise_test.t.const.decoder.new.VideoDecoder.error):
* LayoutTests/http/wpt/webcodecs/hevc-decoder-annexb.https.any.worker-expected.txt: Added.
* LayoutTests/http/wpt/webcodecs/hevc-decoder-annexb.https.any.worker.html: Added.
* Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/nalu_rewriter.cc:

Canonical link: <a href="https://commits.webkit.org/271728@main">https://commits.webkit.org/271728@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c48788248ae39d831957a13f45b8ae9a5e764b8f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29466 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8133 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30791 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32011 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26718 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10275 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5424 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26719 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29739 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6779 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25177 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5812 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5943 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26260 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33352 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26893 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26686 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32167 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5902 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4087 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29939 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7623 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/26061 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7000 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6434 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6425 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->