### PR TITLE
[MSE] MediaSourcePrivate::buffered() shouldn't call its client

### DIFF
--- a/Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp
@@ -94,7 +94,7 @@ bool ManagedMediaSource::isBuffered(const PlatformTimeRanges& ranges) const
 
     ASSERT(ranges.length() == 1);
 
-    auto bufferedRanges = buffered();
+    auto bufferedRanges = m_private->buffered();
     if (!bufferedRanges.length())
         return false;
     bufferedRanges.intersectWith(ranges);

--- a/Source/WebCore/Modules/mediasource/MediaSource.h
+++ b/Source/WebCore/Modules/mediasource/MediaSource.h
@@ -83,11 +83,10 @@ public:
     bool isEnded() const;
     void sourceBufferDidChangeActiveState(SourceBuffer&, bool);
     MediaTime duration() const;
+    const PlatformTimeRanges& buffered() const;
 
     enum class EndOfStreamError { Network, Decode };
     void streamEndedWithError(std::optional<EndOfStreamError>);
-
-    const PlatformTimeRanges& buffered() const final;
 
     bool attachToElement(HTMLMediaElement&);
     void detachFromElement(HTMLMediaElement&);
@@ -188,10 +187,8 @@ private:
 
     RefPtr<SourceBufferList> m_sourceBuffers;
     RefPtr<SourceBufferList> m_activeSourceBuffers;
-    PlatformTimeRanges m_buffered;
     PlatformTimeRanges m_liveSeekable;
     WeakPtr<HTMLMediaElement, WeakPtrImplWithEventTargetData> m_mediaElement;
-    MediaTime m_duration { MediaTime::invalidTime() };
     std::optional<SeekTarget> m_pendingSeekTarget;
     std::optional<MediaTimePromise::Producer> m_seekTargetPromise;
     ReadyState m_readyState { ReadyState::Closed };

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
@@ -67,16 +67,9 @@ RefPtr<MediaSourcePrivateClient> MediaSourcePrivate::client() const
     return m_client.get();
 }
 
-MediaTime MediaSourcePrivate::duration() const
+const MediaTime& MediaSourcePrivate::duration() const
 {
     return m_duration;
-}
-
-const PlatformTimeRanges& MediaSourcePrivate::buffered() const
-{
-    if (RefPtr client = this->client())
-        return client->buffered();
-    return PlatformTimeRanges::emptyRanges();
 }
 
 Ref<MediaTimePromise> MediaSourcePrivate::waitForTarget(const SeekTarget& target)
@@ -140,6 +133,16 @@ void MediaSourcePrivate::durationChanged(const MediaTime& duration)
     m_duration = duration;
     for (auto& sourceBuffer : m_sourceBuffers)
         sourceBuffer->setMediaSourceDuration(duration);
+}
+
+void MediaSourcePrivate::bufferedChanged(const PlatformTimeRanges& buffered)
+{
+    m_buffered = buffered;
+}
+
+const PlatformTimeRanges& MediaSourcePrivate::buffered() const
+{
+    return m_buffered;
 }
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.h
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.h
@@ -33,6 +33,7 @@
 #if ENABLE(MEDIA_SOURCE)
 
 #include "MediaPlayer.h"
+#include "PlatformTimeRanges.h"
 #include <wtf/Forward.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/Vector.h>
@@ -75,8 +76,8 @@ public:
     virtual void removeSourceBuffer(SourceBufferPrivate&);
     void sourceBufferPrivateDidChangeActiveState(SourceBufferPrivate&, bool active);
     virtual void notifyActiveSourceBuffersChanged() = 0;
-    virtual void durationChanged(const MediaTime&);
-    virtual void bufferedChanged(const PlatformTimeRanges&) { }
+    virtual void durationChanged(const MediaTime&); // Base class method must be called in overrides.
+    virtual void bufferedChanged(const PlatformTimeRanges&); // Base class method must be called in overrides.
 
     virtual void markEndOfStream(EndOfStreamStatus) { m_isEnded = true; }
     virtual void unmarkEndOfStream() { m_isEnded = false; }
@@ -93,7 +94,7 @@ public:
     virtual void setTimeFudgeFactor(const MediaTime& fudgeFactor) { m_timeFudgeFactor = fudgeFactor; }
     MediaTime timeFudgeFactor() const { return m_timeFudgeFactor; }
 
-    MediaTime duration() const;
+    const MediaTime& duration() const;
     const PlatformTimeRanges& buffered() const;
 
     bool hasFutureTime(const MediaTime& currentTime) const;
@@ -111,6 +112,7 @@ protected:
 
 private:
     MediaTime m_duration { MediaTime::invalidTime() };
+    PlatformTimeRanges m_buffered;
     MediaTime m_timeFudgeFactor;
     ThreadSafeWeakPtr<MediaSourcePrivateClient> m_client;
 };

--- a/Source/WebCore/platform/graphics/MediaSourcePrivateClient.h
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivateClient.h
@@ -43,7 +43,6 @@ public:
     virtual ~MediaSourcePrivateClient() = default;
 
     virtual void setPrivateAndOpen(Ref<MediaSourcePrivate>&&) = 0;
-    virtual const PlatformTimeRanges& buffered() const = 0;
     virtual Ref<MediaTimePromise> waitForTarget(const SeekTarget&) = 0;
     virtual Ref<MediaPromise> seekToTime(const MediaTime&) = 0;
 

--- a/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp
@@ -73,11 +73,6 @@ void RemoteMediaSourceProxy::setPrivateAndOpen(Ref<MediaSourcePrivate>&& mediaSo
     m_private = WTFMove(mediaSourcePrivate);
 }
 
-const PlatformTimeRanges& RemoteMediaSourceProxy::buffered() const
-{
-    return m_buffered;
-}
-
 Ref<MediaTimePromise> RemoteMediaSourceProxy::waitForTarget(const SeekTarget& target)
 {
     if (!m_connectionToWebProcess)
@@ -137,9 +132,8 @@ void RemoteMediaSourceProxy::durationChanged(const MediaTime& duration)
 
 void RemoteMediaSourceProxy::bufferedChanged(WebCore::PlatformTimeRanges&& buffered)
 {
-    m_buffered = WTFMove(buffered);
     if (m_private)
-        m_private->bufferedChanged(m_buffered);
+        m_private->bufferedChanged(WTFMove(buffered));
 }
 
 void RemoteMediaSourceProxy::markEndOfStream(WebCore::MediaSourcePrivate::EndOfStreamStatus status )

--- a/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h
@@ -62,7 +62,6 @@ public:
 
     // MediaSourcePrivateClient overrides
     void setPrivateAndOpen(Ref<WebCore::MediaSourcePrivate>&&) final;
-    const WebCore::PlatformTimeRanges& buffered() const final;
     Ref<WebCore::MediaTimePromise> waitForTarget(const WebCore::SeekTarget&) final;
     Ref<WebCore::MediaPromise> seekToTime(const MediaTime&) final;
 
@@ -94,8 +93,6 @@ private:
     bool m_webMParserEnabled { false };
     RefPtr<WebCore::MediaSourcePrivate> m_private;
     WeakPtr<RemoteMediaPlayerProxy> m_remoteMediaPlayerProxy;
-
-    WebCore::PlatformTimeRanges m_buffered;
 
     Vector<RefPtr<RemoteSourceBufferProxy>> m_sourceBuffers;
 };

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
@@ -111,6 +111,7 @@ MediaSourcePrivate::AddStatus MediaSourcePrivateRemote::addSourceBuffer(const Co
 
 void MediaSourcePrivateRemote::durationChanged(const MediaTime& duration)
 {
+    MediaSourcePrivate::durationChanged(duration);
     auto gpuProcessConnection = m_gpuProcessConnection.get();
     if (!isGPURunning())
         return;
@@ -120,6 +121,7 @@ void MediaSourcePrivateRemote::durationChanged(const MediaTime& duration)
 
 void MediaSourcePrivateRemote::bufferedChanged(const PlatformTimeRanges& buffered)
 {
+    MediaSourcePrivate::bufferedChanged(buffered);
     auto gpuProcessConnection = m_gpuProcessConnection.get();
     if (!isGPURunning())
         return;

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h
@@ -66,7 +66,6 @@ public:
     void removeSourceBuffer(WebCore::SourceBufferPrivate&) final { }
     void notifyActiveSourceBuffersChanged() final { };
     void durationChanged(const MediaTime&) final;
-    void bufferedChanged(const WebCore::PlatformTimeRanges&) final;
     void markEndOfStream(EndOfStreamStatus) final;
     void unmarkEndOfStream() final;
     WebCore::MediaPlayer::ReadyState mediaPlayerReadyState() const final;
@@ -95,6 +94,7 @@ private:
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
     void mediaSourcePrivateShuttingDown(CompletionHandler<void()>&&);
     bool isGPURunning() const { return !m_shutdown && m_gpuProcessConnection.get(); }
+    void bufferedChanged(const WebCore::PlatformTimeRanges&) final;
 
     ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;
     RemoteMediaSourceIdentifier m_identifier;


### PR DESCRIPTION
#### bf1d50b780f12c0892b309371ce94423045002a8
<pre>
[MSE] MediaSourcePrivate::buffered() shouldn&apos;t call its client
<a href="https://bugs.webkit.org/show_bug.cgi?id=266064">https://bugs.webkit.org/show_bug.cgi?id=266064</a>
<a href="https://rdar.apple.com/119369641">rdar://119369641</a>

Reviewed by Youenn Fablet.

Have MediaSourcePrivate be the owner of the buffered range and have the MediaSource
query its MediaSourcePrivate instead.
By keeping it in the MediaSourcePrivate we can remove a synchronous call which will
no longer be possible once the MediaSourcePrivate runs in a different queue than the MediaSource.

Similarly, also make MediaSource not hold its duration, but have the MediaSourcePrivate do so.

* Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp:
(WebCore::ManagedMediaSource::isBuffered const):
* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::duration const):
(WebCore::MediaSource::buffered const):
(WebCore::MediaSource::seekable):
(WebCore::MediaSource::hasBufferedTime):
(WebCore::MediaSource::monitorSourceBuffers):
(WebCore::MediaSource::setDurationInternal):
(WebCore::MediaSource::detachFromElement):
(WebCore::MediaSource::updateBufferedIfNeeded):
* Source/WebCore/Modules/mediasource/MediaSource.h:
* Source/WebCore/platform/graphics/MediaSourcePrivate.cpp:
(WebCore::MediaSourcePrivate::duration const):
(WebCore::MediaSourcePrivate::bufferedChanged):
(WebCore::MediaSourcePrivate::buffered const):
* Source/WebCore/platform/graphics/MediaSourcePrivate.h:
* Source/WebCore/platform/graphics/MediaSourcePrivateClient.h:
* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp:
(WebKit::RemoteMediaSourceProxy::bufferedChanged):
(WebKit::RemoteMediaSourceProxy::buffered const): Deleted. Implemented in the base class.
* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h:
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp:
(WebKit::MediaSourcePrivateRemote::durationChanged): ensure that the base class durationChanged is called.
(WebKit::MediaSourcePrivateRemote::bufferedChanged):
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h:

Canonical link: <a href="https://commits.webkit.org/271794@main">https://commits.webkit.org/271794@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71a444ca36838dd33d0a644e33c69d3f54e365c3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29653 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8308 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30956 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32156 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26826 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30268 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10501 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5587 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26830 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29926 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6966 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25298 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5913 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/6086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26383 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33496 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27062 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26806 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32266 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6004 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4198 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30041 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7743 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7046 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6548 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6528 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->