### PR TITLE
Calling configure on WebCodecs Video Encoder triggers a new key frame each time even if the configuration is only changing the bitrate

### DIFF
--- a/LayoutTests/http/wpt/webcodecs/encode-bitrate-change-expected.txt
+++ b/LayoutTests/http/wpt/webcodecs/encode-bitrate-change-expected.txt
@@ -1,0 +1,8 @@
+
+PASS VP8 - bitrate
+PASS VP8 - framerate
+PASS VP9 - bitrate
+PASS VP9 - framerate
+PASS H.264 - bitrate
+PASS H.264 - framerate
+

--- a/LayoutTests/http/wpt/webcodecs/encode-bitrate-change.html
+++ b/LayoutTests/http/wpt/webcodecs/encode-bitrate-change.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html>
+<header>
+<script src='/resources/testharness.js'></script>
+<script src='/resources/testharnessreport.js'></script>
+</header>
+<body>
+<script>
+
+function makeOffscreenCanvas(width, height) {
+  let canvas = new OffscreenCanvas(width, height);
+  let ctx = canvas.getContext('2d');
+  ctx.fillStyle = 'rgba(50, 100, 150, 255)';
+  ctx.fillRect(0, 0, width, height);
+  return new VideoFrame(canvas, { timestamp: 1 });
+}
+
+async function doEncode(test, encoderConfig, updateConfig)
+{
+  let deltaCount = 0;
+  let decoderConfigCount = 0;
+  const encoderInit = {
+    output(chunk, metadata) {
+      if (chunk.type === "delta")
+          deltaCount++;
+
+      // In our current implementation, we create a decoderConfig once per internal encoder.
+      if (metadata.decoderConfig)
+          decoderConfigCount++;
+    },
+    error(e) {
+    }
+  };
+
+  const encoder = new VideoEncoder(encoderInit);
+
+  let actualEncoderConfig = encoderConfig;
+
+  const w = encoderConfig.width;
+  const h = encoderConfig.height;
+  const frame = makeOffscreenCanvas(w, h);
+  test.add_cleanup(() => frame.close());
+
+  encoder.configure(actualEncoderConfig);
+  encoder.encode(frame, { keyFrame: true });
+
+  let cptr;
+  for (cptr = 0; cptr < 5; cptr++) {
+    updateConfig(actualEncoderConfig);
+    encoder.configure(actualEncoderConfig);
+    encoder.encode(frame, { keyFrame: false });
+  }
+
+  await encoder.flush();
+  assert_true(deltaCount > 0 || decoderConfigCount <= 1, "before first flush");
+
+  deltaCount = 0;
+  decoderConfigCount = 0;
+
+  for (cptr = 0; cptr < 20; cptr++ && !deltaCount) {
+    updateConfig(actualEncoderConfig);
+    encoder.configure(actualEncoderConfig);
+    encoder.encode(frame, { keyFrame: false });
+    await new Promise(resolve => setTimeout(resolve, 50));
+  }
+
+  await encoder.flush();
+  encoder.close();
+
+  assert_true(deltaCount > 0 || decoderConfigCount <= 1, "after first flush");
+}
+
+function doTest(codec, title)
+{
+  const config = { codec };
+  config.width = 320;
+  config.height = 240;
+  config.bitrate = 1000000;
+  config.framerate = 10;
+
+  promise_test(async t => {
+    return doEncode(t, config, (config) => {
+        config.bitrate += 1;
+    });
+  }, title + " - bitrate");
+
+  promise_test(async t => {
+    return doEncode(t, config, (config) => {
+        config.framerate += 1;
+    });
+  }, title + " - framerate");
+}
+
+doTest('vp8', "VP8");
+doTest('vp09.00.10.08', "VP9");
+doTest('avc1.42001E', "H.264");
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1150,6 +1150,8 @@ imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.
 
 imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.any.worker.html [ Pass ]
 
+http/wpt/webcodecs/encode-bitrate-change.html [ Failure ]
+
 # Our MP3 decoder is not yet spec-compliant (reverse decoding, mostly).
 imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.html?mp3 [ Failure ]
 imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker.html?mp3 [ Failure ]

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp
@@ -113,6 +113,32 @@ static ExceptionOr<VideoEncoder::Config> createVideoEncoderConfig(const WebCodec
     return VideoEncoder::Config { config.width, config.height, useAnnexB, config.bitrate.value_or(0), config.framerate.value_or(0), config.latencyMode == LatencyMode::Realtime, scalabilityMode };
 }
 
+bool WebCodecsVideoEncoder::updateRates(const WebCodecsVideoEncoderConfig& config)
+{
+    auto bitrate = config.bitrate.value_or(0);
+    auto framerate = config.framerate.value_or(0);
+
+    m_isMessageQueueBlocked = true;
+    bool isChangingRatesSupported = m_internalEncoder->setRates(bitrate, framerate, [this, weakThis = WeakPtr { *this }, bitrate, framerate]() mutable {
+        auto protectedThis = weakThis.get();
+        if (!protectedThis)
+            return;
+
+        if (m_state == WebCodecsCodecState::Closed || !scriptExecutionContext())
+            return;
+
+        if (bitrate)
+            m_baseConfiguration.bitrate = bitrate;
+        if (framerate)
+            m_baseConfiguration.framerate = framerate;
+        m_isMessageQueueBlocked = false;
+        processControlMessageQueue();
+    });
+    if (!isChangingRatesSupported)
+        m_isMessageQueueBlocked = false;
+    return isChangingRatesSupported;
+}
+
 ExceptionOr<void> WebCodecsVideoEncoder::configure(ScriptExecutionContext& context, WebCodecsVideoEncoderConfig&& config)
 {
     if (!isValidEncoderConfig(config))
@@ -126,6 +152,9 @@ ExceptionOr<void> WebCodecsVideoEncoder::configure(ScriptExecutionContext& conte
 
     if (m_internalEncoder) {
         queueControlMessageAndProcess([this, config]() mutable {
+            if (isSameConfigurationExceptBitrateAndFramerate(m_baseConfiguration, config) && updateRates(config))
+                return;
+
             m_isMessageQueueBlocked = true;
             m_internalEncoder->flush([weakThis = ThreadSafeWeakPtr { *this }, config = WTFMove(config)]() mutable {
                 RefPtr protectedThis = weakThis.get();
@@ -143,6 +172,9 @@ ExceptionOr<void> WebCodecsVideoEncoder::configure(ScriptExecutionContext& conte
 
     bool isSupportedCodec = isSupportedEncoderCodec(config.codec, context.settingsValues());
     queueControlMessageAndProcess([this, config = WTFMove(config), isSupportedCodec, identifier = scriptExecutionContext()->identifier()]() mutable {
+        if (isSupportedCodec && isSameConfigurationExceptBitrateAndFramerate(m_baseConfiguration, config) && updateRates(config))
+            return;
+
         m_isMessageQueueBlocked = true;
         VideoEncoder::PostTaskCallback postTaskCallback = [weakThis = ThreadSafeWeakPtr { *this }, identifier](auto&& task) {
             ScriptExecutionContext::postTaskTo(identifier, [weakThis, task = WTFMove(task)](auto&) mutable {

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h
@@ -99,6 +99,7 @@ private:
     void queueControlMessageAndProcess(Function<void()>&&);
     void processControlMessageQueue();
     WebCodecsEncodedVideoChunkMetadata createEncodedChunkMetadata(std::optional<unsigned>);
+    bool updateRates(const WebCodecsVideoEncoderConfig&);
 
     WebCodecsCodecState m_state { WebCodecsCodecState::Unconfigured };
     size_t m_encodeQueueSize { 0 };

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoderConfig.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoderConfig.h
@@ -55,6 +55,22 @@ struct WebCodecsVideoEncoderConfig {
     WebCodecsVideoEncoderConfig isolatedCopy() const & { return { codec.isolatedCopy(), width, height, displayWidth, displayHeight, bitrate, framerate, hardwareAcceleration, alpha, scalabilityMode.isolatedCopy(), bitrateMode, latencyMode, avc }; }
 };
 
+inline bool isSameConfigurationExceptBitrateAndFramerate(const WebCodecsVideoEncoderConfig& a, const WebCodecsVideoEncoderConfig& b)
+{
+    return a.codec == b.codec
+        && a.width == b.width
+        && a.height == b.height
+        && a.displayWidth == b.displayWidth
+        && a.displayHeight == b.displayHeight
+        && a.hardwareAcceleration == b.hardwareAcceleration
+        && a.alpha == b.alpha
+        && a.scalabilityMode == b.scalabilityMode
+        && a.bitrateMode == b.bitrateMode
+        && a.latencyMode == b.latencyMode
+        && (!!a.avc == !!b.avc)
+        && (!a.avc || (a.avc->format == b.avc->format));
+}
+
 }
 
 #endif // ENABLE(WEB_CODECS)

--- a/Source/WebCore/platform/VideoEncoder.h
+++ b/Source/WebCore/platform/VideoEncoder.h
@@ -80,6 +80,8 @@ public:
     using EncodeCallback = Function<void(String&&)>;
     virtual void encode(RawFrame&&, bool shouldGenerateKeyFrame, EncodeCallback&&) = 0;
 
+    // FIXME: Evaluate whether we can make it virtual pure and not return a boolean.
+    virtual bool setRates(uint64_t /* bitRate */, double /* frameRate */, Function<void()>&&) { return false; }
     virtual void flush(Function<void()>&&) = 0;
     virtual void reset() = 0;
     virtual void close() = 0;

--- a/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.cpp
+++ b/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.cpp
@@ -49,6 +49,8 @@ ALLOW_UNUSED_PARAMETERS_END
 
 namespace WebCore {
 
+static constexpr double defaultFrameRate = 30.0;
+
 static WorkQueue& vpxEncoderQueue()
 {
     static NeverDestroyed<Ref<WorkQueue>> queue(WorkQueue::create("VPX VideoEncoder Queue"_s));
@@ -65,6 +67,8 @@ public:
     void postTask(Function<void()>&& task) { m_postTaskCallback(WTFMove(task)); }
     void encode(VideoEncoder::RawFrame&&, bool shouldGenerateKeyFrame, VideoEncoder::EncodeCallback&&);
     void close() { m_isClosed = true; }
+    void setRates(uint64_t bitRate, double frameRate);
+
 private:
     LibWebRTCVPXInternalVideoEncoder(LibWebRTCVPXVideoEncoder::Type, VideoEncoder::OutputCallback&&, VideoEncoder::PostTaskCallback&&);
     webrtc::EncodedImageCallback::Result OnEncodedImage(const webrtc::EncodedImage&, const webrtc::CodecSpecificInfo*) final;
@@ -77,8 +81,7 @@ private:
     int64_t m_timestampOffset { 0 };
     std::optional<uint64_t> m_duration;
     bool m_isClosed { false };
-    uint64_t m_width { 0 };
-    uint64_t m_height { 0 };
+    VideoEncoder::Config m_config;
     bool m_isInitialized { false };
     bool m_hasEncoded { false };
     bool m_hasMultipleTemporalLayers { false };
@@ -142,6 +145,15 @@ void LibWebRTCVPXVideoEncoder::close()
     m_internalEncoder->close();
 }
 
+bool LibWebRTCVPXVideoEncoder::setRates(uint64_t bitRate, double frameRate, Function<void()>&& callback)
+{
+    vpxEncoderQueue().dispatch([encoder = m_internalEncoder, bitRate, frameRate, callback = WTFMove(callback)]() mutable {
+        encoder->setRates(bitRate, frameRate);
+        encoder->postTask(WTFMove(callback));
+    });
+    return true;
+}
+
 static UniqueRef<webrtc::VideoEncoder> createInternalEncoder(LibWebRTCVPXVideoEncoder::Type type)
 {
     switch (type) {
@@ -165,10 +177,31 @@ LibWebRTCVPXInternalVideoEncoder::LibWebRTCVPXInternalVideoEncoder(LibWebRTCVPXV
 {
 }
 
+static webrtc::VideoBitrateAllocation computeAllocation(const VideoEncoder::Config& config)
+{
+    auto totalBitRate = config.bitRate ? config.bitRate : 3 * config.width * config.height;
+
+    webrtc::VideoBitrateAllocation allocation;
+    switch (config.scalabilityMode) {
+    case VideoEncoder::ScalabilityMode::L1T1:
+        allocation.SetBitrate(0, 0, totalBitRate);
+        break;
+    case VideoEncoder::ScalabilityMode::L1T2:
+        allocation.SetBitrate(0, 0, totalBitRate * 0.6);
+        allocation.SetBitrate(0, 1, totalBitRate * 0.4);
+        break;
+    case VideoEncoder::ScalabilityMode::L1T3:
+        allocation.SetBitrate(0, 0, totalBitRate * 0.5);
+        allocation.SetBitrate(0, 1, totalBitRate * 0.2);
+        allocation.SetBitrate(0, 2, totalBitRate * 0.3);
+        break;
+    }
+    return allocation;
+}
+
 int LibWebRTCVPXInternalVideoEncoder::initialize(LibWebRTCVPXVideoEncoder::Type type, const VideoEncoder::Config& config)
 {
-    m_width = config.width;
-    m_height = config.height;
+    m_config = config;
 
     const int defaultPayloadSize = 1440;
     webrtc::VideoCodec videoCodec;
@@ -176,25 +209,17 @@ int LibWebRTCVPXInternalVideoEncoder::initialize(LibWebRTCVPXVideoEncoder::Type 
     videoCodec.height = config.height;
     videoCodec.maxFramerate = 100;
 
-    webrtc::VideoBitrateAllocation allocation;
-    auto totalBitRate = config.bitRate ? config.bitRate : 3 * config.width * config.height;
     switch (config.scalabilityMode) {
     case VideoEncoder::ScalabilityMode::L1T1:
         videoCodec.SetScalabilityMode(webrtc::ScalabilityMode::kL1T1);
-        allocation.SetBitrate(0, 0, totalBitRate);
         break;
     case VideoEncoder::ScalabilityMode::L1T2:
         m_hasMultipleTemporalLayers = true;
         videoCodec.SetScalabilityMode(webrtc::ScalabilityMode::kL1T2);
-        allocation.SetBitrate(0, 0, totalBitRate * 0.6);
-        allocation.SetBitrate(0, 1, totalBitRate * 0.4);
         break;
     case VideoEncoder::ScalabilityMode::L1T3:
         m_hasMultipleTemporalLayers = true;
         videoCodec.SetScalabilityMode(webrtc::ScalabilityMode::kL1T3);
-        allocation.SetBitrate(0, 0, totalBitRate * 0.5);
-        allocation.SetBitrate(0, 1, totalBitRate * 0.2);
-        allocation.SetBitrate(0, 2, totalBitRate * 0.3);
         break;
     }
 
@@ -230,7 +255,7 @@ int LibWebRTCVPXInternalVideoEncoder::initialize(LibWebRTCVPXVideoEncoder::Type 
         return error;
 
     m_isInitialized = true;
-    m_internalEncoder->SetRates({ allocation, config.frameRate ? config.frameRate : 30.0 });
+    m_internalEncoder->SetRates({ computeAllocation(config), config.frameRate ? config.frameRate : defaultFrameRate });
 
     m_internalEncoder->RegisterEncodeCompleteCallback(this);
     return 0;
@@ -251,8 +276,8 @@ void LibWebRTCVPXInternalVideoEncoder::encode(VideoEncoder::RawFrame&& rawFrame,
 
     auto frameBuffer = webrtc::pixelBufferToFrame(rawFrame.frame->pixelBuffer());
 
-    if (m_width != static_cast<size_t>(frameBuffer->width()) || m_height != static_cast<size_t>(frameBuffer->height()))
-        frameBuffer = frameBuffer->Scale(m_width, m_height);
+    if (m_config.width != static_cast<size_t>(frameBuffer->width()) || m_config.height != static_cast<size_t>(frameBuffer->height()))
+        frameBuffer = frameBuffer->Scale(m_config.width, m_config.height);
 
     webrtc::VideoFrame frame { frameBuffer, webrtc::kVideoRotation_0, rawFrame.timestamp + m_timestampOffset };
     auto error = m_internalEncoder->Encode(frame, &frameTypes);
@@ -269,6 +294,15 @@ void LibWebRTCVPXInternalVideoEncoder::encode(VideoEncoder::RawFrame&& rawFrame,
             result = makeString("VPx encoding failed with error "_s, error);
         callback(WTFMove(result));
     });
+}
+
+void LibWebRTCVPXInternalVideoEncoder::setRates(uint64_t bitRate, double frameRate)
+{
+    if (bitRate)
+        m_config.bitRate = bitRate;
+    if (frameRate)
+        m_config.frameRate = frameRate;
+    m_internalEncoder->SetRates({ computeAllocation(m_config), m_config.frameRate ? m_config.frameRate : defaultFrameRate });
 }
 
 webrtc::EncodedImageCallback::Result LibWebRTCVPXInternalVideoEncoder::OnEncodedImage(const webrtc::EncodedImage& encodedImage, const webrtc::CodecSpecificInfo*)

--- a/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.h
+++ b/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.h
@@ -57,6 +57,7 @@ private:
     void flush(Function<void()>&&) final;
     void reset() final;
     void close() final;
+    bool setRates(uint64_t bitRate, double frameRate, Function<void()>&&) final;
 
     Ref<LibWebRTCVPXInternalVideoEncoder> m_internalEncoder;
 };

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
@@ -162,7 +162,7 @@ public:
 #if ENABLE(WEB_CODECS)
     void registerEncoderDescriptionCallback(Encoder&, DescriptionCallback&&);
 #endif
-    void setEncodeRates(Encoder&, uint32_t bitRate, uint32_t frameRate);
+    void setEncodeRates(Encoder&, uint32_t bitRateInKbps, uint32_t frameRate);
 
     CVPixelBufferPoolRef pixelBufferPool(size_t width, size_t height, OSType);
 


### PR DESCRIPTION
#### 37dfb4fa3c73132a0d3b5d90aa0cb6253cad64bb
<pre>
Calling configure on WebCodecs Video Encoder triggers a new key frame each time even if the configuration is only changing the bitrate
<a href="https://bugs.webkit.org/show_bug.cgi?id=261402">https://bugs.webkit.org/show_bug.cgi?id=261402</a>
<a href="https://rdar.apple.com/115482127">rdar://115482127</a>

Reviewed by Jean-Yves Avenard.

Check the new configuration is the same as the new one, except for bitrate and framerate.
If that is the case, we call setRate instead of recreating the encoder.
Implement setRate for VPX and remote encoders.

Covered by newly added test.

* LayoutTests/http/wpt/webcodecs/encode-bitrate-change-expected.txt: Added.
* LayoutTests/http/wpt/webcodecs/encode-bitrate-change.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp:
(WebCore::WebCodecsVideoEncoder::updateRates):
(WebCore::WebCodecsVideoEncoder::configure):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoderConfig.h:
(WebCore::isSameConfigurationExceptBitrateAndFramerate):
* Source/WebCore/platform/VideoEncoder.h:
* Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.cpp:
(WebCore::LibWebRTCVPXVideoEncoder::setRates):
(WebCore::computeAllocation):
(WebCore::LibWebRTCVPXInternalVideoEncoder::initialize):
(WebCore::LibWebRTCVPXInternalVideoEncoder::encode):
(WebCore::LibWebRTCVPXInternalVideoEncoder::setRates):
* Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.h:
* Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.cpp:
(WebKit::RemoteVideoEncoder::setRates):
(WebKit::RemoteVideoEncoder::flush):
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp:
(WebKit::setEncodeRatesCallback):
(WebKit::LibWebRTCCodecs::setEncodeRates):
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h:

Originally-landed-as: 4c9425f9126b. <a href="https://rdar.apple.com/115482127">rdar://115482127</a>
Canonical link: <a href="https://commits.webkit.org/280771@main">https://commits.webkit.org/280771@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2838a5253fdec93e0e0b5852529d817616732e57

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57578 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36906 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10053 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61200 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8023 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59706 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44539 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8211 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46621 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5689 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59608 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34623 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49742 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27487 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31400 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7040 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7026 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53357 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7312 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62880 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1491 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7405 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53881 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1498 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49761 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53986 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12736 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1268 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32735 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33820 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34905 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33566 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->