### PR TITLE
REGRESSION(267629@main): create_hash_table script runs forever on i686

### DIFF
--- a/Source/JavaScriptCore/create_hash_table
+++ b/Source/JavaScriptCore/create_hash_table
@@ -24,7 +24,7 @@
  
 use strict;
 use warnings;
-use Math::BigInt;
+use bigint;
 use Getopt::Long qw(:config pass_through);
 
 my $file = shift @ARGV or die("Must provide source file as final argument.");
@@ -148,6 +148,9 @@ sub calcPerfectHashSize($)
     my ($isMac) = @_;
 tableSizeLoop:
     for ($perfectHashSize = ceilingToPowerOf2(scalar @keys); ; $perfectHashSize += $perfectHashSize) {
+        if ($perfectHashSize > 2**15) {
+            die "The hash size is far too big. This should not be reached.";
+        }
         my @table = ();
         foreach my $key (@keys) {
             my $h = hashValue($key, $isMac) % $perfectHashSize;
@@ -176,6 +179,12 @@ sub calcCompactHashSize($)
         my $depth = 0;
         my $h = hashValue($key, $isMac) % $compactHashSize;
         while (defined($table[$h])) {
+            if ($compactSize > 1000) {
+                die "The hash size is far too big. This should not be reached.";
+            }
+            if ($depth > 100) {
+                die "The depth is far too big. This should not be reached.";
+            }
             if (defined($links[$h])) {
                 $h = $links[$h];
                 $depth++;
@@ -188,7 +197,7 @@ sub calcCompactHashSize($)
         }
         $table[$h] = $i;
         $i++;
-        $maxdepth = $depth if ( $depth > $maxdepth);
+        $maxdepth = $depth if ($depth > $maxdepth);
     }
 }
 

--- a/Source/WebCore/bindings/scripts/Hasher.pm
+++ b/Source/WebCore/bindings/scripts/Hasher.pm
@@ -27,7 +27,7 @@
 package Hasher;
 
 use strict;
-use Math::BigInt;
+use bigint;
 
 my $mask64 = 2**64 - 1;
 my $mask32 = 2**32 - 1;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestConditionallyReadWrite.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestConditionallyReadWrite.cpp
@@ -110,23 +110,6 @@ STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(JSTestConditionallyReadWritePrototype, JSTes
 using JSTestConditionallyReadWriteDOMConstructor = JSDOMConstructorNotConstructable<JSTestConditionallyReadWrite>;
 
 /* Hash table */
-#if PLATFORM(MAC)
-
-static const struct CompactHashIndex JSTestConditionallyReadWriteTableIndex[4] = {
-    { -1, -1 },
-    { 0, -1 },
-    { -1, -1 },
-    { -1, -1 },
-};
-
-
-static const HashTableValue JSTestConditionallyReadWriteTableValues[] =
-{
-    { "enabledConditionallyReadWriteBySettingAttributeUnforgeable"_s, JSC::PropertyAttribute::DontDelete | JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestConditionallyReadWrite_enabledConditionallyReadWriteBySettingAttributeUnforgeable, setJSTestConditionallyReadWrite_enabledConditionallyReadWriteBySettingAttributeUnforgeable } },
-};
-
-static const HashTable JSTestConditionallyReadWriteTable = { 1, 3, static_cast<uint8_t>(JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute | JSC::PropertyAttribute::DontDelete), JSTestConditionallyReadWrite::info(), JSTestConditionallyReadWriteTableValues, JSTestConditionallyReadWriteTableIndex };
-#else
 
 static const struct CompactHashIndex JSTestConditionallyReadWriteTableIndex[4] = {
     { 0, -1 },
@@ -142,7 +125,6 @@ static const HashTableValue JSTestConditionallyReadWriteTableValues[] =
 };
 
 static const HashTable JSTestConditionallyReadWriteTable = { 1, 3, static_cast<uint8_t>(JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute | JSC::PropertyAttribute::DontDelete), JSTestConditionallyReadWrite::info(), JSTestConditionallyReadWriteTableValues, JSTestConditionallyReadWriteTableIndex };
-#endif
 template<> const ClassInfo JSTestConditionallyReadWriteDOMConstructor::s_info = { "TestConditionallyReadWrite"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSTestConditionallyReadWriteDOMConstructor) };
 
 template<> JSValue JSTestConditionallyReadWriteDOMConstructor::prototypeForStructure(JSC::VM& vm, const JSDOMGlobalObject& globalObject)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestGlobalObject.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestGlobalObject.cpp
@@ -253,7 +253,7 @@ using JSTestGlobalObjectDOMConstructor = JSDOMConstructorNotConstructable<JSTest
 /* Hash table */
 #if PLATFORM(MAC)
 
-static const struct CompactHashIndex JSTestGlobalObjectTableIndex[269] = {
+static const struct CompactHashIndex JSTestGlobalObjectTableIndex[268] = {
     { -1, -1 },
     { 43, -1 },
     { -1, -1 },
@@ -356,7 +356,7 @@ static const struct CompactHashIndex JSTestGlobalObjectTableIndex[269] = {
     { 20, -1 },
     { -1, -1 },
     { -1, -1 },
-    { -1, -1 },
+    { 50, -1 },
     { -1, -1 },
     { 38, -1 },
     { -1, -1 },
@@ -414,7 +414,7 @@ static const struct CompactHashIndex JSTestGlobalObjectTableIndex[269] = {
     { -1, -1 },
     { 67, -1 },
     { -1, -1 },
-    { 50, 267 },
+    { 68, -1 },
     { -1, -1 },
     { 29, -1 },
     { 34, -1 },
@@ -438,7 +438,7 @@ static const struct CompactHashIndex JSTestGlobalObjectTableIndex[269] = {
     { -1, -1 },
     { -1, -1 },
     { -1, -1 },
-    { 36, 268 },
+    { 36, 267 },
     { -1, -1 },
     { 18, 256 },
     { -1, -1 },
@@ -521,7 +521,6 @@ static const struct CompactHashIndex JSTestGlobalObjectTableIndex[269] = {
     { 53, -1 },
     { 58, -1 },
     { 64, -1 },
-    { 68, -1 },
     { 69, -1 },
 };
 


### PR DESCRIPTION
#### 08395c362d950165a0646c78ce89101979ba2618
<pre>
REGRESSION(267629@main): create_hash_table script runs forever on i686
<a href="https://bugs.webkit.org/show_bug.cgi?id=265554">https://bugs.webkit.org/show_bug.cgi?id=265554</a>

Reviewed by Mark Lam.

This reverts 267629@main, and also adds some additional safety checks to
the create_hash_table script.

bigint and Math::BigInt are two completely different perl modules.
bigint causes the entire script to transparently use Math::BigInt for
mathematical operations. Importing the wrong module effectively sabotaged
the script. Whoops.

bigint appears to be part of a standard perl installation, so for
upstream purposes we can expect it to be always available. However,
Fedora packages the perl interpreter separately from its modules. When I
went to install the bigint module, I tricked myself into thinking it was
already installed because Math::BigInt was installed, and another
developer suggested that the import syntax was wrong, and I improperly
went along with this because I am not very familiar with perl.

So, fix the import syntax to make this script actually use big integers
again. This fixes an infinite loop on 32-bit platforms if perl is not
compiled with 64-bit integer support. It also affects the generated hash
tables, so I had to rebase two of the bindings test results.

Also, add new safety checks to ensure the script fails if the hash
size grows too large. This will prevent the script from infinite looping
if somebody else breaks the script in the future. The guard values I
selected are arbitrary numbers that are much bigger than expected.

* Source/JavaScriptCore/create_hash_table:
* Source/WebCore/bindings/scripts/Hasher.pm:
* Source/WebCore/bindings/scripts/test/JS/JSTestConditionallyReadWrite.cpp:
(WebCore::JSTestConditionallyReadWriteDOMConstructor::prototypeForStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestGlobalObject.cpp:

Canonical link: <a href="https://commits.webkit.org/271765@main">https://commits.webkit.org/271765@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e4c236d780ae1f3a2a8739d44111fe5617c710e0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29537 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8203 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30858 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32071 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26762 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30138 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10355 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5496 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26766 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29810 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6852 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25235 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5857 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5990 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26321 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33415 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/25399 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26956 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26741 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32212 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/29771 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5946 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4137 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29986 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7680 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/36109 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7020 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6487 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7783 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6469 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->