### PR TITLE
[iOS] <select> UI is not updated if options are changed

### DIFF
--- a/LayoutTests/fast/forms/ios/select-option-removed-update-expected.txt
+++ b/LayoutTests/fast/forms/ios/select-option-removed-update-expected.txt
@@ -1,0 +1,13 @@
+This test verifies that a <select> element's menu is updated if options are removed while it is visible.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS select.value is "Option 1"
+PASS areArraysEqual(items, ["Option 1", "Option 2", "Option 3"]) is true
+PASS areArraysEqual(items, ["Option 2", "Option 3"]) is true
+PASS select.value is "Option 3"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/ios/select-option-removed-update.html
+++ b/LayoutTests/fast/forms/ios/select-option-removed-update.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+        <script src="../../../resources/js-test.js"></script>
+        <script src="../../../resources/ui-helper.js"></script>
+    </head>
+<body>
+<select id="select">
+    <option>Option 1</option>
+    <option>Option 2</option>
+    <option>Option 3</option>
+</select>
+</body>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("This test verifies that a &lt;select&gt; element's menu is updated if options are removed while it is visible.");
+
+    shouldBeEqualToString("select.value", "Option 1");
+    await UIHelper.activateElement(select);
+
+    items = await UIHelper.selectMenuItems();
+    shouldBeTrue("areArraysEqual(items, " + '["Option 1", "Option 2", "Option 3"]' + ")");
+
+    select.remove(0);
+    await UIHelper.ensurePresentationUpdate();
+
+    items = await UIHelper.selectMenuItems();
+    shouldBeTrue("areArraysEqual(items, " + '["Option 2", "Option 3"]' + ")");
+
+    await UIHelper.selectFormAccessoryPickerRow(1);
+    await UIHelper.waitForContextMenuToHide();
+    shouldBeEqualToString("select.value", "Option 3");
+
+    finishJSTest();
+});
+</script>
+</html>

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -1096,9 +1096,13 @@ window.UIHelper = class UIHelper {
         return new Promise(resolve => {
             testRunner.runUIScript(`
             (function() {
-                uiController.didShowContextMenuCallback = function() {
+                if (!uiController.isShowingContextMenu) {
+                    uiController.didShowContextMenuCallback = function() {
+                        uiController.uiScriptComplete(JSON.stringify(uiController.contentsOfUserInterfaceItem('selectMenu')));
+                    };
+                } else {
                     uiController.uiScriptComplete(JSON.stringify(uiController.contentsOfUserInterfaceItem('selectMenu')));
-                };
+                }
             })();`, result => resolve(JSON.parse(result).selectMenu));
         });
     }

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -29,6 +29,8 @@
 #include "HTMLSelectElement.h"
 
 #include "AXObjectCache.h"
+#include "Chrome.h"
+#include "ChromeClient.h"
 #include "DOMFormData.h"
 #include "DocumentInlines.h"
 #include "ElementChildIteratorInlines.h"
@@ -812,6 +814,11 @@ void HTMLSelectElement::setRecalcListItems()
         invalidateSelectedItems();
     if (auto* cache = document().existingAXObjectCache())
         cache->childrenChanged(this);
+
+    if (Ref document = this->document(); this == document->focusedElement()) {
+        if (CheckedPtr page = document->page())
+            page->chrome().client().focusedSelectElementDidChangeOptions(*this);
+    }
 }
 
 void HTMLSelectElement::recalcListItems(bool updateSelectedStates, AllowStyleInvalidation allowStyleInvalidation) const

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -116,6 +116,7 @@ class GraphicsLayerFactory;
 class HTMLImageElement;
 class HTMLInputElement;
 class HTMLMediaElement;
+class HTMLSelectElement;
 class HTMLVideoElement;
 class HitTestResult;
 class IntRect;
@@ -364,6 +365,7 @@ public:
     virtual void elementDidRefocus(Element&, const FocusOptions&) { }
 
     virtual void focusedElementDidChangeInputMode(Element&, InputMode) { }
+    virtual void focusedSelectElementDidChangeOptions(const HTMLSelectElement&) { }
 
     virtual bool shouldPaintEntireContents() const { return false; }
     virtual bool hasStablePageScaleFactor() const { return true; }

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -489,6 +489,7 @@ public:
 
     virtual void elementDidFocus(const FocusedElementInformation&, bool userIsInteracting, bool blurPreviousNode, OptionSet<WebCore::ActivityState> activityStateChanges, API::Object* userData) = 0;
     virtual void updateInputContextAfterBlurringAndRefocusingElement() = 0;
+    virtual void updateFocusedElementInformation(const FocusedElementInformation&) = 0;
     virtual void elementDidBlur() = 0;
     virtual void focusedElementDidChangeInputMode(WebCore::InputMode) = 0;
     virtual void didUpdateEditorState() = 0;

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2686,6 +2686,7 @@ private:
     void elementDidFocus(const FocusedElementInformation&, bool userIsInteracting, bool blurPreviousNode, OptionSet<WebCore::ActivityState> activityStateChanges, const UserData&);
     void elementDidBlur();
     void updateInputContextAfterBlurringAndRefocusingElement();
+    void updateFocusedElementInformation(const FocusedElementInformation&);
     void focusedElementDidChangeInputMode(WebCore::InputMode);
     void didReleaseAllTouchPoints();
 

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -384,6 +384,7 @@ messages -> WebPageProxy {
     ElementDidFocus(struct WebKit::FocusedElementInformation information, bool userIsInteracting, bool blurPreviousNode, OptionSet<WebCore::ActivityState> activityStateChanges, WebKit::UserData userData)
     ElementDidBlur()
     UpdateInputContextAfterBlurringAndRefocusingElement()
+    UpdateFocusedElementInformation(struct WebKit::FocusedElementInformation information)
     FocusedElementDidChangeInputMode(enum:uint8_t WebCore::InputMode mode)
     ScrollingNodeScrollWillStartScroll(uint64_t nodeID)
     ScrollingNodeScrollDidEndScroll(uint64_t nodeID)

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -182,6 +182,7 @@ private:
 
     void elementDidFocus(const FocusedElementInformation&, bool userIsInteracting, bool blurPreviousNode, OptionSet<WebCore::ActivityState> activityStateChanges, API::Object* userData) override;
     void updateInputContextAfterBlurringAndRefocusingElement() final;
+    void updateFocusedElementInformation(const FocusedElementInformation&) final;
     void elementDidBlur() override;
     void focusedElementDidChangeInputMode(WebCore::InputMode) override;
     void didUpdateEditorState() override;

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -657,6 +657,11 @@ void PageClientImpl::updateInputContextAfterBlurringAndRefocusingElement()
     [contentView() _updateInputContextAfterBlurringAndRefocusingElement];
 }
 
+void PageClientImpl::updateFocusedElementInformation(const FocusedElementInformation& information)
+{
+    [contentView() _updateFocusedElementInformation:information];
+}
+
 bool PageClientImpl::isFocusingElement()
 {
     return [contentView() isFocusingElement];

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -703,6 +703,7 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(DECLARE_WKCONTENTVIEW_ACTION_FOR_WEB_VIEW)
 - (void)_handleSmartMagnificationInformationForPotentialTap:(WebKit::TapIdentifier)requestID renderRect:(const WebCore::FloatRect&)renderRect fitEntireRect:(BOOL)fitEntireRect viewportMinimumScale:(double)viewportMinimumScale viewportMaximumScale:(double)viewportMaximumScale nodeIsRootLevel:(BOOL)nodeIsRootLevel;
 - (void)_elementDidFocus:(const WebKit::FocusedElementInformation&)information userIsInteracting:(BOOL)userIsInteracting blurPreviousNode:(BOOL)blurPreviousNode activityStateChanges:(OptionSet<WebCore::ActivityState>)activityStateChanges userObject:(NSObject <NSSecureCoding> *)userObject;
 - (void)_updateInputContextAfterBlurringAndRefocusingElement;
+- (void)_updateFocusedElementInformation:(const WebKit::FocusedElementInformation&)information;
 - (void)_elementDidBlur;
 - (void)_didUpdateInputMode:(WebCore::InputMode)mode;
 - (void)_didUpdateEditorState;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -8024,6 +8024,18 @@ static RetainPtr<NSObject <WKFormPeripheral>> createInputPeripheralWithView(WebK
         [UIKeyboardImpl.activeInstance updateForChangedSelection];
 }
 
+- (void)_updateFocusedElementInformation:(const WebKit::FocusedElementInformation&)information
+{
+    if (!self._hasFocusedElement)
+        return;
+
+    if (!_focusedElementInformation.elementContext.isSameElement(information.elementContext))
+        return;
+
+    _focusedElementInformation = information;
+    [_inputPeripheral updateEditing];
+}
+
 - (BOOL)shouldIgnoreKeyboardWillHideNotification
 {
     // Ignore keyboard will hide notifications sent during rotation. They're just there for

--- a/Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.mm
@@ -298,6 +298,10 @@ void WebDataListSuggestionsDropdownIOS::didSelectOption(const String& selectedOp
 {
 }
 
+- (void)controlUpdateEditing
+{
+}
+
 - (void)controlEndEditing
 {
     [self.control didSelectOptionAtIndex:[self selectedRowInComponent:0]];

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -943,6 +943,11 @@ void WebPageProxy::elementDidBlur()
     pageClient().elementDidBlur();
 }
 
+void WebPageProxy::updateFocusedElementInformation(const FocusedElementInformation& information)
+{
+    pageClient().updateFocusedElementInformation(information);
+}
+
 void WebPageProxy::focusedElementDidChangeInputMode(WebCore::InputMode mode)
 {
 #if ENABLE(TOUCH_EVENTS)

--- a/Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.mm
@@ -250,6 +250,10 @@ static constexpr auto yearAndMonthDatePickerMode = static_cast<UIDatePickerMode>
     [self showDateTimePicker];
 }
 
+- (void)controlUpdateEditing
+{
+}
+
 - (void)controlEndEditing
 {
     [_view stopRelinquishingFirstResponderToFocusedElement];

--- a/Source/WebKit/UIProcess/ios/forms/WKFormColorControl.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormColorControl.mm
@@ -123,6 +123,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [presentingViewController presentViewController:_colorPickerViewController.get() animated:YES completion:nil];
 }
 
+- (void)controlUpdateEditing
+{
+}
+
 - (void)controlEndEditing
 {
     [_view stopRelinquishingFirstResponderToFocusedElement];

--- a/Source/WebKit/UIProcess/ios/forms/WKFormPeripheral.h
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormPeripheral.h
@@ -29,6 +29,7 @@
 @protocol WKFormPeripheral
 - (BOOL)isEditing;
 - (void)beginEditing;
+- (void)updateEditing;
 - (void)endEditing;
 - (UIView *)assistantView;
 @optional
@@ -39,6 +40,7 @@
 @protocol WKFormControl
 - (UIView *)controlView;
 - (void)controlBeginEditing;
+- (void)controlUpdateEditing;
 - (void)controlEndEditing;
 @optional
 - (BOOL)controlHandleKeyEvent:(UIEvent *)event;

--- a/Source/WebKit/UIProcess/ios/forms/WKFormPeripheralBase.h
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormPeripheralBase.h
@@ -37,6 +37,7 @@
 - (instancetype)initWithView:(WKContentView *)view control:(RetainPtr<NSObject <WKFormControl>>&&)control NS_DESIGNATED_INITIALIZER;
 
 - (void)beginEditing;
+- (void)updateEditing;
 - (void)endEditing;
 - (UIView *)assistantView;
 - (BOOL)handleKeyEvent:(UIEvent *)event;

--- a/Source/WebKit/UIProcess/ios/forms/WKFormPeripheralBase.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormPeripheralBase.mm
@@ -55,6 +55,14 @@
     [_control controlBeginEditing];
 }
 
+- (void)updateEditing
+{
+    if (!_editing)
+        return;
+
+    [_control controlUpdateEditing];
+}
+
 - (void)endEditing
 {
     if (!_editing)

--- a/Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm
@@ -208,6 +208,11 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 {
 }
 
+- (void)controlUpdateEditing
+{
+    [self reloadAllComponents];
+}
+
 - (void)controlEndEditing
 {
 }
@@ -394,6 +399,11 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 {
 }
 
+- (void)controlUpdateEditing
+{
+    [self reloadAllComponents];
+}
+
 - (void)controlEndEditing
 {
     if (_selectedIndex == NSNotFound)
@@ -521,6 +531,19 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #if USE(UICONTEXTMENU)
     _selectMenu = [self createMenu];
     [self showSelectPicker];
+#endif
+}
+
+- (void)controlUpdateEditing
+{
+#if USE(UICONTEXTMENU)
+    if (!_selectContextMenuPresenter)
+        return;
+
+    _selectMenu = [self createMenu];
+    _selectContextMenuPresenter->updateVisibleMenu(^UIMenu *(UIMenu *) {
+        return _selectMenu.get();
+    });
 #endif
 }
 
@@ -1239,6 +1262,11 @@ static NSString *optionCellReuseIdentifier = @"WKSelectPickerTableViewCell";
     [self configurePresentation];
     auto presentingViewController = _view._wk_viewControllerForFullScreenPresentation;
     [presentingViewController presentViewController:_navigationController.get() animated:YES completion:nil];
+}
+
+- (void)controlUpdateEditing
+{
+    [[_tableViewController tableView] reloadData];
 }
 
 - (void)controlEndEditing

--- a/Source/WebKit/UIProcess/ios/forms/WKFormSelectPopover.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormSelectPopover.mm
@@ -415,6 +415,11 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [self presentPopoverAnimated:NO];
 }
 
+- (void)controlUpdateEditing
+{
+    [[_tableViewController tableView] reloadData];
+}
+
 - (void)controlEndEditing
 {
     [self dismissPopoverAnimated:[_tableViewController shouldDismissWithAnimation]];

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -254,6 +254,11 @@ void WebChromeClient::focusedElementDidChangeInputMode(Element& element, InputMo
     protectedPage()->focusedElementDidChangeInputMode(element, mode);
 }
 
+void WebChromeClient::focusedSelectElementDidChangeOptions(const WebCore::HTMLSelectElement& element)
+{
+    protectedPage()->focusedSelectElementDidChangeOptions(element);
+}
+
 void WebChromeClient::makeFirstResponder()
 {
     protectedPage()->send(Messages::WebPageProxy::MakeFirstResponder());

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -328,6 +328,7 @@ private:
     void elementDidBlur(WebCore::Element&) final;
     void elementDidRefocus(WebCore::Element&, const WebCore::FocusOptions&) final;
     void focusedElementDidChangeInputMode(WebCore::Element&, WebCore::InputMode) final;
+    void focusedSelectElementDidChangeOptions(const WebCore::HTMLSelectElement&) final;
 
     void makeFirstResponder() final;
     void assistiveTechnologyMakeFirstResponder() final;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -6904,6 +6904,22 @@ void WebPage::focusedElementDidChangeInputMode(WebCore::Element& element, WebCor
 #endif
 }
 
+void WebPage::focusedSelectElementDidChangeOptions(const WebCore::HTMLSelectElement& element)
+{
+#if PLATFORM(IOS_FAMILY)
+    if (m_focusedElement != &element)
+        return;
+
+    auto information = focusedElementInformation();
+    if (!information)
+        return;
+
+    send(Messages::WebPageProxy::UpdateFocusedElementInformation(*information));
+#else
+    UNUSED_PARAM(element);
+#endif
+}
+
 void WebPage::didUpdateComposition()
 {
     sendEditorStateUpdate();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -206,6 +206,7 @@ class GraphicsContext;
 class HTMLElement;
 class HTMLImageElement;
 class HTMLPlugInElement;
+class HTMLSelectElement;
 class HTMLVideoElement;
 class HandleUserInputEventResult;
 class IgnoreSelectionChangeForScope;
@@ -815,6 +816,7 @@ public:
     void elementDidRefocus(WebCore::Element&, const WebCore::FocusOptions&);
     void elementDidBlur(WebCore::Element&);
     void focusedElementDidChangeInputMode(WebCore::Element&, WebCore::InputMode);
+    void focusedSelectElementDidChangeOptions(const WebCore::HTMLSelectElement&);
     void resetFocusedElementForFrame(WebFrame*);
     void updateInputContextAfterBlurringAndRefocusingElementIfNeeded(WebCore::Element&);
 


### PR DESCRIPTION
#### cb12141f93d167c38953a9b7071439f7225d08e9
<pre>
[iOS] &lt;select&gt; UI is not updated if options are changed
<a href="https://bugs.webkit.org/show_bug.cgi?id=235911">https://bugs.webkit.org/show_bug.cgi?id=235911</a>
<a href="https://rdar.apple.com/88292987">rdar://88292987</a>

Reviewed by Wenson Hsieh.

On iOS, &lt;select&gt; UI is driven by `FocusedElementInformation`, which is sent to
the UI process each time a control is focused. However, if the control is already
focused, there are currently no mechanisms for changes to element information to
be sent to the UI process. Consequently, any changes to options while a &lt;select&gt;
element is focused are not reflected in the UI process.

Fix by adding a general mechanism to update `FocusedElementInformation` for
controls that are already focused, and adopt it for &lt;select&gt; option changes.

In the future, this mechanism could be used for updates to other control types.

* LayoutTests/fast/forms/ios/select-option-removed-update-expected.txt: Added.
* LayoutTests/fast/forms/ios/select-option-removed-update.html: Added.
* LayoutTests/resources/ui-helper.js:
* Source/WebCore/html/HTMLSelectElement.cpp:
(WebCore::HTMLSelectElement::setRecalcListItems):
* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::focusedSelectElementDidChangeOptions):
* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::updateFocusedElementInformation):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _updateFocusedElementInformation:]):

Ensure updates are made only if they are referencing the same element.

* Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.mm:
(-[WKDataListSuggestionsPickerView controlUpdateEditing]):
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::updateFocusedElementInformation):
* Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.mm:
(-[WKDateTimePicker controlUpdateEditing]):
* Source/WebKit/UIProcess/ios/forms/WKFormColorControl.mm:
(-[WKColorPicker controlUpdateEditing]):
* Source/WebKit/UIProcess/ios/forms/WKFormPeripheral.h:
* Source/WebKit/UIProcess/ios/forms/WKFormPeripheralBase.h:
* Source/WebKit/UIProcess/ios/forms/WKFormPeripheralBase.mm:
(-[WKFormPeripheralBase updateEditing]):
* Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm:
(-[WKMultipleSelectPicker controlUpdateEditing]):
(-[WKSelectSinglePicker controlUpdateEditing]):
(-[WKSelectPicker controlUpdateEditing]):
(-[WKSelectMultiplePicker controlUpdateEditing]):
* Source/WebKit/UIProcess/ios/forms/WKFormSelectPopover.mm:
(-[WKSelectPopover controlUpdateEditing]):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::focusedSelectElementDidChangeOptions):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::focusedSelectElementDidChangeOptions):
* Source/WebKit/WebProcess/WebPage/WebPage.h:

Canonical link: <a href="https://commits.webkit.org/271805@main">https://commits.webkit.org/271805@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/193255df4f0d61a9fa7682a7c7ec3fd33a32bacf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29600 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8259 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30942 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32109 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26798 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30213 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10532 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5547 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26811 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29873 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6993 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25277 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5889 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/6116 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26361 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33453 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27089 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26783 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32249 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5977 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4179 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30022 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7712 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/26160 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7049 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6522 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6500 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->