### PR TITLE
The ContentRuleList for declarativeNetRequest is stored in the wrong location.

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDeclarativeNetRequestCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDeclarativeNetRequestCocoa.mm
@@ -268,7 +268,7 @@ void WebExtensionContext::declarativeNetRequestGetMatchedRules(std::optional<Web
 _WKWebExtensionDeclarativeNetRequestSQLiteStore *WebExtensionContext::declarativeNetRequestDynamicRulesStore()
 {
     if (!m_declarativeNetRequestDynamicRulesStore)
-        m_declarativeNetRequestDynamicRulesStore = [[_WKWebExtensionDeclarativeNetRequestSQLiteStore alloc] initWithUniqueIdentifier:uniqueIdentifier() storageType:_WKWebExtensionDeclarativeNetRequestStorageType::Dynamic directory:m_storageDirectory usesInMemoryDatabase:!storageIsPersistent()];
+        m_declarativeNetRequestDynamicRulesStore = [[_WKWebExtensionDeclarativeNetRequestSQLiteStore alloc] initWithUniqueIdentifier:uniqueIdentifier() storageType:_WKWebExtensionDeclarativeNetRequestStorageType::Dynamic directory:storageDirectory() usesInMemoryDatabase:!storageIsPersistent()];
 
     return m_declarativeNetRequestDynamicRulesStore.get();
 }
@@ -276,7 +276,7 @@ _WKWebExtensionDeclarativeNetRequestSQLiteStore *WebExtensionContext::declarativ
 _WKWebExtensionDeclarativeNetRequestSQLiteStore *WebExtensionContext::declarativeNetRequestSessionRulesStore()
 {
     if (!m_declarativeNetRequestSessionRulesStore)
-        m_declarativeNetRequestSessionRulesStore = [[_WKWebExtensionDeclarativeNetRequestSQLiteStore alloc] initWithUniqueIdentifier:uniqueIdentifier() storageType:_WKWebExtensionDeclarativeNetRequestStorageType::Session directory:m_storageDirectory usesInMemoryDatabase:YES];
+        m_declarativeNetRequestSessionRulesStore = [[_WKWebExtensionDeclarativeNetRequestSQLiteStore alloc] initWithUniqueIdentifier:uniqueIdentifier() storageType:_WKWebExtensionDeclarativeNetRequestStorageType::Session directory:storageDirectory() usesInMemoryDatabase:YES];
 
     return m_declarativeNetRequestSessionRulesStore.get();
 }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerConfigurationCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerConfigurationCocoa.mm
@@ -83,25 +83,6 @@ WKWebViewConfiguration *WebExtensionControllerConfiguration::webViewConfiguratio
     return m_webViewConfiguration.get();
 }
 
-const String& WebExtensionControllerConfiguration::declarativeNetRequestStoreDirectory()
-{
-    if (!m_declarativeNetRequestStoreDirectory.isEmpty())
-        return m_declarativeNetRequestStoreDirectory;
-
-    if (!storageIsPersistent()) {
-        m_declarativeNetRequestStoreDirectory = FileSystem::createTemporaryDirectory(@"DeclarativeNetRequest");
-        return m_declarativeNetRequestStoreDirectory;
-    }
-
-    m_declarativeNetRequestStoreDirectory = FileSystem::pathByAppendingComponent(storageDirectory(), "DeclarativeNetRequest"_s);
-    if (!FileSystem::makeAllDirectories(m_declarativeNetRequestStoreDirectory)) {
-        m_declarativeNetRequestStoreDirectory = String();
-        return m_declarativeNetRequestStoreDirectory;
-    }
-
-    return m_declarativeNetRequestStoreDirectory;
-}
-
 } // namespace WebKit
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestSQLiteStore.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestSQLiteStore.mm
@@ -244,7 +244,7 @@ static const SchemaVersion currentDatabaseSchemaVersion = 1;
     DatabaseResult result = SQLiteDatabaseExecute(database, [NSString stringWithFormat:@"INSERT INTO %@ (id, rule) VALUES (?, ?)", _tableName], ruleID.integerValue, ruleAsData);
     if (result != SQLITE_DONE) {
         RELEASE_LOG_ERROR(Extensions, "Failed to insert dynamic declarative net request rule for extension %{private}@.", _uniqueIdentifier);
-        return [NSString stringWithFormat:@"Failed to add %@ rule.", self->_storageType];
+        return [NSString stringWithFormat:@"Failed to add %@ rule.", _storageType];
     }
 
     return nil;
@@ -262,7 +262,9 @@ static const SchemaVersion currentDatabaseSchemaVersion = 1;
     if (_useInMemoryDatabase)
         return [_WKWebExtensionSQLiteDatabase inMemoryDatabaseURL];
 
-    NSString *databaseName = @"dnr-dynamic-rules.db";
+    ASSERT([_storageType isEqualToString:@"dynamic"]);
+
+    NSString *databaseName = @"DynamicRules-DeclarativeNetRequest.db";
     return [_directory URLByAppendingPathComponent:databaseName isDirectory:NO];
 }
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -211,6 +211,7 @@ public:
     NSError *createError(Error, NSString *customLocalizedDescription = nil, NSError *underlyingError = nil);
 
     bool storageIsPersistent() const { return !m_storageDirectory.isEmpty(); }
+    const String& storageDirectory() const { return m_storageDirectory; }
 
     bool load(WebExtensionController&, String storageDirectory, NSError ** = nullptr);
     bool unload(NSError ** = nullptr);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.h
@@ -64,8 +64,6 @@ public:
     const String& storageDirectory() const { return m_storageDirectory; }
     void setStorageDirectory(const String& directory) { m_storageDirectory = directory; }
 
-    const String& declarativeNetRequestStoreDirectory();
-
     WKWebViewConfiguration *webViewConfiguration();
     void setWebViewConfiguration(WKWebViewConfiguration *configuration) { m_webViewConfiguration = configuration; }
 
@@ -82,7 +80,6 @@ private:
     Markable<WTF::UUID> m_identifier;
     bool m_temporary { false };
     String m_storageDirectory;
-    String m_declarativeNetRequestStoreDirectory;
     RetainPtr<WKWebViewConfiguration> m_webViewConfiguration;
 };
 


### PR DESCRIPTION
#### de396f01ad00068f3cee230deb50104176099dc3
<pre>
The ContentRuleList for declarativeNetRequest is stored in the wrong location.
<a href="https://webkit.org/b/266074">https://webkit.org/b/266074</a>
<a href="https://rdar.apple.com/problem/119379304">rdar://problem/119379304</a>

Reviewed by Brian Weinstein.

Change the location of the ContentRuleList used by dNR. Currently the directory is DeclarativeNetRequest
at the top-level controller storage directory. This will cause compiled rules to be shared with other
contexts, from other profiles. Since dNR rules are dynamic per-context, the compiled rules need to be
stored per-context too. Also change the name of the dynamic rules DB to better match the other files.

A per-context storage directory looks like this now:

  ContentRuleList-DeclarativeNetRequest.data
  DynamicRules-DeclarativeNetRequest.db
  DynamicRules-DeclarativeNetRequest.db-shm
  DynamicRules-DeclarativeNetRequest.db-wal
  State.plist

* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDeclarativeNetRequestCocoa.mm:
(WebKit::WebExtensionContext::declarativeNetRequestDynamicRulesStore):
(WebKit::WebExtensionContext::declarativeNetRequestSessionRulesStore):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::stateFilePath const):
(WebKit::WebExtensionContext::declarativeNetRequestRuleStore):
(WebKit::WebExtensionContext::addDeclarativeNetRequestRulesToPrivateUserContentControllers):
(WebKit::WebExtensionContext::compileDeclarativeNetRequestRules):
(WebKit::WebExtensionContext::loadDeclarativeNetRequestRules):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerConfigurationCocoa.mm:
(WebKit::WebExtensionControllerConfiguration::declarativeNetRequestStoreDirectory): Deleted.
* Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestSQLiteStore.mm:
(-[_WKWebExtensionDeclarativeNetRequestSQLiteStore _insertRule:inDatabase:]):
(-[_WKWebExtensionDeclarativeNetRequestSQLiteStore _databaseURL]):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
(WebKit::WebExtensionContext::storageDirectory const): Added.
* Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.h:

Canonical link: <a href="https://commits.webkit.org/271745@main">https://commits.webkit.org/271745@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/85537d675f7a5bf426cdbb4fc05c42f89ac87b6d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29535 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8202 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30857 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/32070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/26761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10354 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5495 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/32070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29808 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/6850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/25230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/32070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/5989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/33414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/26953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/26736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/33414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/5945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/4135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/33414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/7679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/6486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3799 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/6468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->