### PR TITLE
[MSE] Provide ability for the MediaSourcePrivate and SourceBufferPrivate to run on different thread than their client

### DIFF
--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -408,7 +408,7 @@ void MediaSource::monitorSourceBuffers()
     }
 
     // ↳ If the HTMLMediaElement.readyState attribute equals HAVE_NOTHING:
-    if (mediaElement()->readyState() == HTMLMediaElement::HAVE_NOTHING) {
+    if (m_private->mediaPlayerReadyState() == MediaPlayer::ReadyState::HaveNothing) {
         // 1. Abort these steps.
         return;
     }

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.h
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.h
@@ -106,6 +106,10 @@ public:
 #endif
 
 protected:
+    WEBCORE_EXPORT void ensureOnClientDispatcher(Function<void()>&&);
+    WEBCORE_EXPORT void ensureOnDispatcher(Function<void()>&&);
+    RefCountedSerialFunctionDispatcher& clientDispatcher() const; // SerialFunctionDispatcher the client needs to be called on.
+
     Vector<RefPtr<SourceBufferPrivate>> m_sourceBuffers;
     Vector<SourceBufferPrivate*> m_activeSourceBuffers;
     bool m_isEnded { false };
@@ -115,6 +119,7 @@ private:
     PlatformTimeRanges m_buffered;
     MediaTime m_timeFudgeFactor;
     ThreadSafeWeakPtr<MediaSourcePrivateClient> m_client;
+    const Ref<RefCountedSerialFunctionDispatcher> m_clientDispatcher;
 };
 
 String convertEnumerationToString(MediaSourcePrivate::AddStatus);

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.h
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.h
@@ -166,6 +166,11 @@ protected:
     MediaTime currentMediaTime() const;
     MediaTime mediaSourceDuration() const;
 
+    WEBCORE_EXPORT void ensureOnClientDispatcher(Function<void()>&&) const;
+    WEBCORE_EXPORT void ensureOnDispatcher(Function<void()>&&) const;
+    RefCountedSerialFunctionDispatcher& clientDispatcher() const { return m_clientDispatcher.get(); } // SerialFunctionDispatcher the client needs to be called on.
+    RefCountedSerialFunctionDispatcher& dispatcher() const { return m_dispatcher.get(); } // SerialFunctionDispatcher the SourceBufferPrivate/MediaSourcePrivate needs to be called on.
+
     using InitializationSegment = SourceBufferPrivateClient::InitializationSegment;
     WEBCORE_EXPORT void didReceiveInitializationSegment(InitializationSegment&&);
     WEBCORE_EXPORT void didUpdateFormatDescriptionForTrackId(Ref<TrackInfo>&&, uint64_t);
@@ -255,6 +260,8 @@ private:
     MediaTime m_groupEndTimestamp { MediaTime::zeroTime() };
 
     bool m_isMediaSourceEnded { false };
+    const Ref<RefCountedSerialFunctionDispatcher> m_clientDispatcher;
+    const Ref<RefCountedSerialFunctionDispatcher> m_dispatcher;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -279,14 +279,14 @@ set(WebKit_MESSAGES_IN_FILES
 
     WebProcess/GPU/media/RemoteAudioHardwareListener
     WebProcess/GPU/media/MediaPlayerPrivateRemote
-    WebProcess/GPU/media/MediaSourcePrivateRemote
+    WebProcess/GPU/media/MediaSourcePrivateRemoteMessageReceiver
     WebProcess/GPU/media/RemoteAudioSession
     WebProcess/GPU/media/RemoteAudioSourceProviderManager
     WebProcess/GPU/media/RemoteCDMInstance
     WebProcess/GPU/media/RemoteCDMInstanceSession
     WebProcess/GPU/media/RemoteLegacyCDMSession
     WebProcess/GPU/media/RemoteRemoteCommandListener
-    WebProcess/GPU/media/SourceBufferPrivateRemote
+    WebProcess/GPU/media/SourceBufferPrivateRemoteMessageReceiver
 
     WebProcess/GPU/webrtc/LibWebRTCCodecs
     WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -506,6 +506,7 @@ $(PROJECT_DIR)/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.messages.in
 $(PROJECT_DIR)/WebProcess/GPU/media/MediaOverridesForTesting.serialization.in
 $(PROJECT_DIR)/WebProcess/GPU/media/MediaPlayerPrivateRemote.messages.in
 $(PROJECT_DIR)/WebProcess/GPU/media/MediaSourcePrivateRemote.messages.in
+$(PROJECT_DIR)/WebProcess/GPU/media/MediaSourcePrivateRemoteMessageReceiver.messages.in
 $(PROJECT_DIR)/WebProcess/GPU/media/RemoteAudioHardwareListener.messages.in
 $(PROJECT_DIR)/WebProcess/GPU/media/RemoteAudioSession.messages.in
 $(PROJECT_DIR)/WebProcess/GPU/media/RemoteAudioSessionConfiguration.serialization.in
@@ -522,6 +523,7 @@ $(PROJECT_DIR)/WebProcess/GPU/media/RemoteMediaPlayerState.serialization.in
 $(PROJECT_DIR)/WebProcess/GPU/media/RemoteRemoteCommandListener.messages.in
 $(PROJECT_DIR)/WebProcess/GPU/media/RemoteVideoFrameProxyProperties.serialization.in
 $(PROJECT_DIR)/WebProcess/GPU/media/SourceBufferPrivateRemote.messages.in
+$(PROJECT_DIR)/WebProcess/GPU/media/SourceBufferPrivateRemoteMessageReceiver.messages.in
 $(PROJECT_DIR)/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.messages.in
 $(PROJECT_DIR)/WebProcess/GPU/webrtc/LibWebRTCCodecs.messages.in
 $(PROJECT_DIR)/WebProcess/GPU/webrtc/LibWebRTCRemoteCodecs.messages.in

--- a/Source/WebKit/DerivedSources-output.xcfilelist
+++ b/Source/WebKit/DerivedSources-output.xcfilelist
@@ -100,8 +100,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/LibWebRTCRemoteCodecsMessageReceiver
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/LibWebRTCRemoteCodecsMessages.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/MediaPlayerPrivateRemoteMessageReceiver.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/MediaPlayerPrivateRemoteMessages.h
-$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/MediaSourcePrivateRemoteMessageReceiver.cpp
-$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/MediaSourcePrivateRemoteMessages.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/MediaSourcePrivateRemoteMessageReceiverMessageReceiver.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/MediaSourcePrivateRemoteMessageReceiverMessages.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/MessageArgumentDescriptions.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/MessageNames.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/MessageNames.h
@@ -359,7 +359,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/ServiceWorkerFetchTaskMessages.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/SmartMagnificationControllerMessageReceiver.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/SmartMagnificationControllerMessages.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/SourceBufferPrivateRemoteMessageReceiver.cpp
-$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/SourceBufferPrivateRemoteMessages.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/SourceBufferPrivateRemoteMessageReceiverMessageReceiver.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/SourceBufferPrivateRemoteMessageReceiverMessages.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/SpeechRecognitionRealtimeMediaSourceManagerMessageReceiver.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/SpeechRecognitionRealtimeMediaSourceManagerMessages.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/SpeechRecognitionRemoteRealtimeMediaSourceManagerMessageReceiver.cpp

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -200,7 +200,7 @@ MESSAGE_RECEIVERS = \
 	WebProcess/GPU/webrtc/LibWebRTCCodecs \
 	WebProcess/GPU/webrtc/SampleBufferDisplayLayer \
 	WebProcess/GPU/media/MediaPlayerPrivateRemote \
-	WebProcess/GPU/media/MediaSourcePrivateRemote \
+	WebProcess/GPU/media/MediaSourcePrivateRemoteMessageReceiver \
 	WebProcess/GPU/media/RemoteAudioHardwareListener \
 	WebProcess/GPU/media/RemoteAudioSession \
 	WebProcess/GPU/media/RemoteAudioSourceProviderManager \
@@ -209,7 +209,7 @@ MESSAGE_RECEIVERS = \
 	WebProcess/GPU/media/RemoteImageDecoderAVFManager \
 	WebProcess/GPU/media/RemoteLegacyCDMSession \
 	WebProcess/GPU/media/RemoteRemoteCommandListener \
-	WebProcess/GPU/media/SourceBufferPrivateRemote \
+	WebProcess/GPU/media/SourceBufferPrivateRemoteMessageReceiver \
 	WebProcess/GPU/media/ios/RemoteMediaSessionHelper \
 	WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor \
 	WebProcess/WebStorage/StorageAreaMap \

--- a/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp
@@ -29,7 +29,7 @@
 #if ENABLE(GPU_PROCESS) && ENABLE(MEDIA_SOURCE)
 
 #include "GPUConnectionToWebProcess.h"
-#include "MediaSourcePrivateRemoteMessages.h"
+#include "MediaSourcePrivateRemoteMessageReceiverMessages.h"
 #include "RemoteMediaPlayerProxy.h"
 #include "RemoteMediaSourceProxyMessages.h"
 #include "RemoteSourceBufferProxy.h"
@@ -78,7 +78,7 @@ Ref<MediaTimePromise> RemoteMediaSourceProxy::waitForTarget(const SeekTarget& ta
     if (!m_connectionToWebProcess)
         return MediaTimePromise::createAndReject(PlatformMediaError::IPCError);
 
-    return m_connectionToWebProcess->connection().sendWithPromisedReply(Messages::MediaSourcePrivateRemote::ProxyWaitForTarget(target), m_identifier)->whenSettled(RunLoop::current(), [](auto&& result) {
+    return m_connectionToWebProcess->connection().sendWithPromisedReply(Messages::MediaSourcePrivateRemoteMessageReceiver::ProxyWaitForTarget(target), m_identifier)->whenSettled(RunLoop::current(), [](auto&& result) {
         return result ? MediaTimePromise::createAndSettle(WTFMove(*result)) : MediaTimePromise::createAndReject(PlatformMediaError::IPCError);
     });
 }
@@ -88,7 +88,7 @@ Ref<MediaPromise> RemoteMediaSourceProxy::seekToTime(const MediaTime& time)
     if (!m_connectionToWebProcess)
         return MediaPromise::createAndReject(PlatformMediaError::IPCError);
 
-    return m_connectionToWebProcess->connection().sendWithPromisedReply(Messages::MediaSourcePrivateRemote::ProxySeekToTime(time), m_identifier)->whenSettled(RunLoop::current(), [](auto&& result) {
+    return m_connectionToWebProcess->connection().sendWithPromisedReply(Messages::MediaSourcePrivateRemoteMessageReceiver::ProxySeekToTime(time), m_identifier)->whenSettled(RunLoop::current(), [](auto&& result) {
         return result ? MediaPromise::createAndSettle(WTFMove(*result)) : MediaPromise::createAndReject(PlatformMediaError::IPCError);
     });
 }
@@ -166,7 +166,7 @@ void RemoteMediaSourceProxy::shutdown()
     if (!m_connectionToWebProcess)
         return;
 
-    m_connectionToWebProcess->connection().sendWithAsyncReply(Messages::MediaSourcePrivateRemote::MediaSourcePrivateShuttingDown(), [this, protectedThis = Ref { *this }, protectedConnection = Ref { *m_connectionToWebProcess }] {
+    m_connectionToWebProcess->connection().sendWithAsyncReply(Messages::MediaSourcePrivateRemoteMessageReceiver::MediaSourcePrivateShuttingDown(), [this, protectedThis = Ref { *this }, protectedConnection = Ref { *m_connectionToWebProcess }] {
         disconnect();
     }, m_identifier);
 }

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp
@@ -33,7 +33,7 @@
 #include "RemoteMediaPlayerProxy.h"
 #include "RemoteSourceBufferProxyMessages.h"
 #include "SharedBufferReference.h"
-#include "SourceBufferPrivateRemoteMessages.h"
+#include "SourceBufferPrivateRemoteMessageReceiverMessages.h"
 #include <WebCore/AudioTrackPrivate.h>
 #include <WebCore/ContentType.h>
 #include <WebCore/MediaDescription.h>
@@ -108,7 +108,7 @@ Ref<MediaPromise> RemoteSourceBufferProxy::sourceBufferPrivateDidReceiveInitiali
     if (!m_connectionToWebProcess)
         return MediaPromise::createAndReject(PlatformMediaError::IPCError);
 
-    return m_connectionToWebProcess->connection().sendWithPromisedReply(Messages::SourceBufferPrivateRemote::SourceBufferPrivateDidReceiveInitializationSegment(segmentInfo), m_identifier)->whenSettled(RunLoop::current(), [](auto&& result) {
+    return m_connectionToWebProcess->connection().sendWithPromisedReply(Messages::SourceBufferPrivateRemoteMessageReceiver::SourceBufferPrivateDidReceiveInitializationSegment(segmentInfo), m_identifier)->whenSettled(RunLoop::current(), [](auto&& result) {
         return MediaPromise::createAndSettle(!result ? makeUnexpected(PlatformMediaError::IPCError) : WTFMove(*result));
     });
 }
@@ -118,7 +118,7 @@ void RemoteSourceBufferProxy::sourceBufferPrivateHighestPresentationTimestampCha
     if (!m_connectionToWebProcess)
         return;
 
-    m_connectionToWebProcess->connection().send(Messages::SourceBufferPrivateRemote::SourceBufferPrivateHighestPresentationTimestampChanged(timestamp), m_identifier);
+    m_connectionToWebProcess->connection().send(Messages::SourceBufferPrivateRemoteMessageReceiver::SourceBufferPrivateHighestPresentationTimestampChanged(timestamp), m_identifier);
 }
 
 Ref<MediaPromise> RemoteSourceBufferProxy::sourceBufferPrivateDurationChanged(const MediaTime& duration)
@@ -126,7 +126,7 @@ Ref<MediaPromise> RemoteSourceBufferProxy::sourceBufferPrivateDurationChanged(co
     if (!m_connectionToWebProcess)
         return MediaPromise::createAndReject(PlatformMediaError::IPCError);
 
-    return m_connectionToWebProcess->connection().sendWithPromisedReply(Messages::SourceBufferPrivateRemote::SourceBufferPrivateDurationChanged(duration), m_identifier)->whenSettled(RunLoop::current(), [](auto&& result) {
+    return m_connectionToWebProcess->connection().sendWithPromisedReply(Messages::SourceBufferPrivateRemoteMessageReceiver::SourceBufferPrivateDurationChanged(duration), m_identifier)->whenSettled(RunLoop::current(), [](auto&& result) {
         return result ? MediaPromise::createAndResolve() : MediaPromise::createAndReject(PlatformMediaError::IPCError);
     });
 }
@@ -136,7 +136,7 @@ Ref<MediaPromise> RemoteSourceBufferProxy::sourceBufferPrivateBufferedChanged(co
     if (!m_connectionToWebProcess)
         return MediaPromise::createAndResolve();
 
-    return m_connectionToWebProcess->connection().sendWithPromisedReply(Messages::SourceBufferPrivateRemote::SourceBufferPrivateBufferedChanged(trackRanges, totalMemorySize), m_identifier)->whenSettled(RunLoop::current(), [](auto&& result) {
+    return m_connectionToWebProcess->connection().sendWithPromisedReply(Messages::SourceBufferPrivateRemoteMessageReceiver::SourceBufferPrivateBufferedChanged(trackRanges, totalMemorySize), m_identifier)->whenSettled(RunLoop::current(), [](auto&& result) {
         return result ? MediaPromise::createAndResolve() : MediaPromise::createAndReject(PlatformMediaError::IPCError);
     });
 }
@@ -146,7 +146,7 @@ void RemoteSourceBufferProxy::sourceBufferPrivateDidParseSample(double sampleDur
     if (!m_connectionToWebProcess)
         return;
 
-    m_connectionToWebProcess->connection().send(Messages::SourceBufferPrivateRemote::SourceBufferPrivateDidParseSample(sampleDuration), m_identifier);
+    m_connectionToWebProcess->connection().send(Messages::SourceBufferPrivateRemoteMessageReceiver::SourceBufferPrivateDidParseSample(sampleDuration), m_identifier);
 }
 
 void RemoteSourceBufferProxy::sourceBufferPrivateDidDropSample()
@@ -154,7 +154,7 @@ void RemoteSourceBufferProxy::sourceBufferPrivateDidDropSample()
     if (!m_connectionToWebProcess)
         return;
 
-    m_connectionToWebProcess->connection().send(Messages::SourceBufferPrivateRemote::SourceBufferPrivateDidDropSample(), m_identifier);
+    m_connectionToWebProcess->connection().send(Messages::SourceBufferPrivateRemoteMessageReceiver::SourceBufferPrivateDidDropSample(), m_identifier);
 }
 
 void RemoteSourceBufferProxy::sourceBufferPrivateDidReceiveRenderingError(int64_t errorCode)
@@ -162,7 +162,7 @@ void RemoteSourceBufferProxy::sourceBufferPrivateDidReceiveRenderingError(int64_
     if (!m_connectionToWebProcess)
         return;
 
-    m_connectionToWebProcess->connection().send(Messages::SourceBufferPrivateRemote::SourceBufferPrivateDidReceiveRenderingError(errorCode), m_identifier);
+    m_connectionToWebProcess->connection().send(Messages::SourceBufferPrivateRemoteMessageReceiver::SourceBufferPrivateDidReceiveRenderingError(errorCode), m_identifier);
 }
 
 void RemoteSourceBufferProxy::append(IPC::SharedBufferReference&& buffer, CompletionHandler<void(MediaPromise::Result, const MediaTime&)>&& completionHandler)
@@ -173,7 +173,7 @@ void RemoteSourceBufferProxy::append(IPC::SharedBufferReference&& buffer, Comple
 
     auto handle = sharedMemory->createHandle(SharedMemory::Protection::ReadOnly);
     if (handle && m_connectionToWebProcess)
-        m_connectionToWebProcess->connection().send(Messages::SourceBufferPrivateRemote::TakeOwnershipOfMemory(WTFMove(*handle)), m_identifier);
+        m_connectionToWebProcess->connection().send(Messages::SourceBufferPrivateRemoteMessageReceiver::TakeOwnershipOfMemory(WTFMove(*handle)), m_identifier);
 
     m_sourceBufferPrivate->append(sharedMemory->createSharedBuffer(buffer.size()))->whenSettled(RunLoop::current(), [this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](auto&& result) mutable {
         completionHandler(WTFMove(result), m_sourceBufferPrivate->timestampOffset());

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -568,10 +568,8 @@
 		1DB01944211CF005009FB3E8 /* WKShareSheet.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1DBBB061211CC3CB00502ECC /* WKShareSheet.mm */; };
 		1DD2A6632561246F00FF7B6F /* RemoteMediaSourceProxyMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1DD2A662256122F100FF7B6F /* RemoteMediaSourceProxyMessageReceiver.cpp */; };
 		1DD2A66E2562021E00FF7B6F /* RemoteSourceBufferProxyMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1DD2A66B2562021E00FF7B6F /* RemoteSourceBufferProxyMessageReceiver.cpp */; };
-		1DD2A674256232A100FF7B6F /* SourceBufferPrivateRemoteMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1DD2A6722562324F00FF7B6F /* SourceBufferPrivateRemoteMessageReceiver.cpp */; };
 		1DD2A68525633C6700FF7B6F /* RemoteMediaSourceProxyMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 1DD2A660256122F100FF7B6F /* RemoteMediaSourceProxyMessages.h */; };
 		1DD2A68625633C7200FF7B6F /* RemoteSourceBufferProxyMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 1DD2A6692562021E00FF7B6F /* RemoteSourceBufferProxyMessages.h */; };
-		1DF29E64257F37A3003C28AF /* MediaSourcePrivateRemoteMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1DF29E61257F3794003C28AF /* MediaSourcePrivateRemoteMessageReceiver.cpp */; };
 		1F335BC0185B84F0001A201A /* WKWebProcessPlugInLoadDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F335BBF185B84D8001A201A /* WKWebProcessPlugInLoadDelegate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1F604BAA1889FBB800EE0395 /* _WKRenderingProgressEventsInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F604BA71889FA7400EE0395 /* _WKRenderingProgressEventsInternal.h */; };
 		1F7506B11859163700EC0FF7 /* WKWebProcessPlugInFrame.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F0181691858DC1500F92884 /* WKWebProcessPlugInFrame.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1114,6 +1112,8 @@
 		5106D7C418BDBE73000AB166 /* ContextMenuContextData.h in Headers */ = {isa = PBXBuildFile; fileRef = 5106D7C018BDBE73000AB166 /* ContextMenuContextData.h */; };
 		5109099723DACBF2003B1E4C /* WKScriptMessageHandlerWithReply.h in Headers */ = {isa = PBXBuildFile; fileRef = 5109099423D41F13003B1E4C /* WKScriptMessageHandlerWithReply.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		510AFFBA16542048001BA05E /* WebResourceLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 510AFFB816542048001BA05E /* WebResourceLoader.h */; };
+		510C52D32B241019008EABED /* MediaSourcePrivateRemoteMessageReceiverMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 510C52D22B240FD2008EABED /* MediaSourcePrivateRemoteMessageReceiverMessageReceiver.cpp */; };
+		510C52D52B241055008EABED /* SourceBufferPrivateRemoteMessageReceiverMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 510C52D42B241048008EABED /* SourceBufferPrivateRemoteMessageReceiverMessageReceiver.cpp */; };
 		510F59101DDE296900412FF5 /* _WKIconLoadingDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 5143B25E1DDCDFD10014FAC6 /* _WKIconLoadingDelegate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		510F59111DDE297000412FF5 /* _WKLinkIconParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = 51C0C9791DDD78540032CAD3 /* _WKLinkIconParameters.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		510FBB9B1288C95E00AFFDF4 /* WebContextMenuItemData.h in Headers */ = {isa = PBXBuildFile; fileRef = 510FBB991288C95E00AFFDF4 /* WebContextMenuItemData.h */; };
@@ -4164,15 +4164,11 @@
 		1DD2A6682561F68400FF7B6F /* RemoteSourceBufferIdentifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteSourceBufferIdentifier.h; sourceTree = "<group>"; };
 		1DD2A6692562021E00FF7B6F /* RemoteSourceBufferProxyMessages.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RemoteSourceBufferProxyMessages.h; sourceTree = "<group>"; };
 		1DD2A66B2562021E00FF7B6F /* RemoteSourceBufferProxyMessageReceiver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteSourceBufferProxyMessageReceiver.cpp; sourceTree = "<group>"; };
-		1DD2A66F25622F1100FF7B6F /* SourceBufferPrivateRemote.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = SourceBufferPrivateRemote.messages.in; sourceTree = "<group>"; };
-		1DD2A6722562324F00FF7B6F /* SourceBufferPrivateRemoteMessageReceiver.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SourceBufferPrivateRemoteMessageReceiver.cpp; sourceTree = "<group>"; };
-		1DD2A6732562324F00FF7B6F /* SourceBufferPrivateRemoteMessages.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SourceBufferPrivateRemoteMessages.h; sourceTree = "<group>"; };
+		1DD2A66F25622F1100FF7B6F /* SourceBufferPrivateRemoteMessageReceiver.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = SourceBufferPrivateRemoteMessageReceiver.messages.in; sourceTree = "<group>"; };
 		1DE076D92460CCBD00B211E8 /* WebPreferencesDefaultValuesCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebPreferencesDefaultValuesCocoa.mm; sourceTree = "<group>"; };
 		1DE0D095211CC21300439B5F /* WKShareSheet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKShareSheet.h; sourceTree = "<group>"; };
 		1DE2DFAC23A959F8003E013A /* RemoteMediaResourceIdentifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteMediaResourceIdentifier.h; sourceTree = "<group>"; };
-		1DF29018257F202F003C28AF /* MediaSourcePrivateRemote.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = MediaSourcePrivateRemote.messages.in; sourceTree = "<group>"; };
-		1DF29E61257F3794003C28AF /* MediaSourcePrivateRemoteMessageReceiver.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MediaSourcePrivateRemoteMessageReceiver.cpp; sourceTree = "<group>"; };
-		1DF29E63257F3795003C28AF /* MediaSourcePrivateRemoteMessages.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MediaSourcePrivateRemoteMessages.h; sourceTree = "<group>"; };
+		1DF29018257F202F003C28AF /* MediaSourcePrivateRemoteMessageReceiver.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = MediaSourcePrivateRemoteMessageReceiver.messages.in; sourceTree = "<group>"; };
 		1DFDD0DF23F60E1E00E9B490 /* VideoLayerRemoteCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = VideoLayerRemoteCocoa.mm; sourceTree = "<group>"; };
 		1DFDD0E023F60E1F00E9B490 /* VideoLayerRemoteCocoa.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VideoLayerRemoteCocoa.h; sourceTree = "<group>"; };
 		1DFDD0E223F610F000E9B490 /* VideoLayerRemote.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VideoLayerRemote.h; sourceTree = "<group>"; };
@@ -5192,6 +5188,8 @@
 		510AFFB716542048001BA05E /* WebResourceLoader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = WebResourceLoader.cpp; path = Network/WebResourceLoader.cpp; sourceTree = "<group>"; };
 		510AFFB816542048001BA05E /* WebResourceLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WebResourceLoader.h; path = Network/WebResourceLoader.h; sourceTree = "<group>"; };
 		510AFFCE16542CBD001BA05E /* WebResourceLoader.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; name = WebResourceLoader.messages.in; path = Network/WebResourceLoader.messages.in; sourceTree = "<group>"; };
+		510C52D22B240FD2008EABED /* MediaSourcePrivateRemoteMessageReceiverMessageReceiver.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MediaSourcePrivateRemoteMessageReceiverMessageReceiver.cpp; sourceTree = "<group>"; };
+		510C52D42B241048008EABED /* SourceBufferPrivateRemoteMessageReceiverMessageReceiver.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SourceBufferPrivateRemoteMessageReceiverMessageReceiver.cpp; sourceTree = "<group>"; };
 		510CC7DF16138E2900D03ED3 /* NetworkProcess.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = NetworkProcess.cpp; sourceTree = "<group>"; };
 		510CC7E016138E2900D03ED3 /* NetworkProcess.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NetworkProcess.h; sourceTree = "<group>"; };
 		510CC7EA16138E7200D03ED3 /* NetworkProcessProxy.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = NetworkProcessProxy.cpp; sourceTree = "<group>"; };
@@ -5265,6 +5263,8 @@
 		513FFB8F201459C2002596EA /* WebMessagePortChannelProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebMessagePortChannelProvider.h; sourceTree = "<group>"; };
 		514129911C6428100059E714 /* WebIDBConnectionToServer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebIDBConnectionToServer.cpp; sourceTree = "<group>"; };
 		514129921C6428100059E714 /* WebIDBConnectionToServer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebIDBConnectionToServer.h; sourceTree = "<group>"; };
+		514245142B215BE9001A3A2E /* SourceBufferPrivateRemoteMessageReceiver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SourceBufferPrivateRemoteMessageReceiver.h; sourceTree = "<group>"; };
+		514245152B215C27001A3A2E /* MediaSourcePrivateRemoteMessageReceiver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MediaSourcePrivateRemoteMessageReceiver.h; sourceTree = "<group>"; };
 		5143B25E1DDCDFD10014FAC6 /* _WKIconLoadingDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKIconLoadingDelegate.h; sourceTree = "<group>"; };
 		5143B2611DDD0DA00014FAC6 /* APIIconLoadingClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APIIconLoadingClient.h; sourceTree = "<group>"; };
 		514526EB271E1626000467B6 /* NetworkNotificationManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NetworkNotificationManager.h; sourceTree = "<group>"; };
@@ -8055,7 +8055,8 @@
 				07B1D04B23D38FCE00399A6E /* MediaPlayerPrivateRemote.messages.in */,
 				1DD2A636255DE67500FF7B6F /* MediaSourcePrivateRemote.cpp */,
 				1DD2A637255DE67500FF7B6F /* MediaSourcePrivateRemote.h */,
-				1DF29018257F202F003C28AF /* MediaSourcePrivateRemote.messages.in */,
+				514245152B215C27001A3A2E /* MediaSourcePrivateRemoteMessageReceiver.h */,
+				1DF29018257F202F003C28AF /* MediaSourcePrivateRemoteMessageReceiver.messages.in */,
 				9B5BEC29240101580070C6EF /* RemoteAudioDestinationProxy.cpp */,
 				9B5BEC28240101580070C6EF /* RemoteAudioDestinationProxy.h */,
 				CD20CE6F25CC90510069B542 /* RemoteAudioHardwareListener.cpp */,
@@ -8129,7 +8130,8 @@
 				460A4BA02AFEC9CC00240DB8 /* RemoteVideoFrameProxyProperties.serialization.in */,
 				1DD2A63A255DE6D100FF7B6F /* SourceBufferPrivateRemote.cpp */,
 				1DD2A639255DE6D100FF7B6F /* SourceBufferPrivateRemote.h */,
-				1DD2A66F25622F1100FF7B6F /* SourceBufferPrivateRemote.messages.in */,
+				514245142B215BE9001A3A2E /* SourceBufferPrivateRemoteMessageReceiver.h */,
+				1DD2A66F25622F1100FF7B6F /* SourceBufferPrivateRemoteMessageReceiver.messages.in */,
 				07E19F0823D533B90094FFB4 /* TextTrackPrivateRemote.cpp */,
 				07E19F0923D533BA0094FFB4 /* TextTrackPrivateRemote.h */,
 				1DFDD0E223F610F000E9B490 /* VideoLayerRemote.h */,
@@ -14278,8 +14280,7 @@
 				51F060DD1654317500F3281C /* LibWebRTCNetworkMessageReceiver.cpp */,
 				07E19EF823D401F00094FFB4 /* MediaPlayerPrivateRemoteMessageReceiver.cpp */,
 				07E19EF923D401F00094FFB4 /* MediaPlayerPrivateRemoteMessages.h */,
-				1DF29E61257F3794003C28AF /* MediaSourcePrivateRemoteMessageReceiver.cpp */,
-				1DF29E63257F3795003C28AF /* MediaSourcePrivateRemoteMessages.h */,
+				510C52D22B240FD2008EABED /* MediaSourcePrivateRemoteMessageReceiverMessageReceiver.cpp */,
 				9B4790902531563200EC11AB /* MessageArgumentDescriptions.cpp */,
 				0F5562E927EE28D200953585 /* MessageNames.cpp */,
 				0F5562E227EE28D100953585 /* MessageNames.h */,
@@ -14425,8 +14426,7 @@
 				51AD56882B1ABFC1001A0ECB /* SerializedTypeInfo.mm */,
 				2DE6943B18BD2A68005C15E5 /* SmartMagnificationControllerMessageReceiver.cpp */,
 				2DE6943C18BD2A68005C15E5 /* SmartMagnificationControllerMessages.h */,
-				1DD2A6722562324F00FF7B6F /* SourceBufferPrivateRemoteMessageReceiver.cpp */,
-				1DD2A6732562324F00FF7B6F /* SourceBufferPrivateRemoteMessages.h */,
+				510C52D42B241048008EABED /* SourceBufferPrivateRemoteMessageReceiverMessageReceiver.cpp */,
 				93AB9B4F257589110098B10E /* SpeechRecognitionRealtimeMediaSourceManagerMessageReceiver.cpp */,
 				93AB9B54257589120098B10E /* SpeechRecognitionRealtimeMediaSourceManagerMessages.h */,
 				93AB9B51257589110098B10E /* SpeechRecognitionRemoteRealtimeMediaSourceManagerMessageReceiver.cpp */,
@@ -18308,7 +18308,7 @@
 				449D90DA21FDC30B00F677C0 /* LocalAuthenticationSoftLink.mm in Sources */,
 				A141DF502B06ED0F00E80B2D /* MediaCapability.mm in Sources */,
 				07E19EFB23D401F10094FFB4 /* MediaPlayerPrivateRemoteMessageReceiver.cpp in Sources */,
-				1DF29E64257F37A3003C28AF /* MediaSourcePrivateRemoteMessageReceiver.cpp in Sources */,
+				510C52D32B241019008EABED /* MediaSourcePrivateRemoteMessageReceiverMessageReceiver.cpp in Sources */,
 				9B4790912531563200EC11AB /* MessageArgumentDescriptions.cpp in Sources */,
 				EBA8D3B627A5E33F00CB7900 /* MockPushServiceConnection.mm in Sources */,
 				57B826452304F14000B72EB0 /* NearFieldSoftLink.mm in Sources */,
@@ -18369,7 +18369,7 @@
 				93468E6D2714AF88009983E3 /* SharedFileHandleCocoa.cpp in Sources */,
 				575B1BB923CE9C0B0020639A /* SimulatedInputDispatcher.cpp in Sources */,
 				2DE6943D18BD2A68005C15E5 /* SmartMagnificationControllerMessageReceiver.cpp in Sources */,
-				1DD2A674256232A100FF7B6F /* SourceBufferPrivateRemoteMessageReceiver.cpp in Sources */,
+				510C52D52B241055008EABED /* SourceBufferPrivateRemoteMessageReceiverMessageReceiver.cpp in Sources */,
 				93AB9B552575A2760098B10E /* SpeechRecognitionRealtimeMediaSourceManagerMessageReceiver.cpp in Sources */,
 				93AB9B562575A28B0098B10E /* SpeechRecognitionRemoteRealtimeMediaSourceManagerMessageReceiver.cpp in Sources */,
 				93D6B782254CCCF40058DD3A /* SpeechRecognitionServerMessageReceiver.cpp in Sources */,

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
@@ -39,7 +39,7 @@
 #include "Logging.h"
 #include "MediaOverridesForTesting.h"
 #include "MediaPlayerPrivateRemoteMessages.h"
-#include "MediaSourcePrivateRemoteMessages.h"
+#include "MediaSourcePrivateRemoteMessageReceiverMessages.h"
 #include "RemoteAudioHardwareListenerMessages.h"
 #include "RemoteAudioSourceProviderManager.h"
 #include "RemoteCDMFactory.h"
@@ -49,7 +49,7 @@
 #include "RemoteRemoteCommandListenerMessages.h"
 #include "SampleBufferDisplayLayerManager.h"
 #include "SampleBufferDisplayLayerMessages.h"
-#include "SourceBufferPrivateRemoteMessages.h"
+#include "SourceBufferPrivateRemoteMessageReceiverMessages.h"
 #include "WebCoreArgumentCoders.h"
 #include "WebPage.h"
 #include "WebPageCreationParameters.h"
@@ -263,12 +263,12 @@ bool GPUProcessConnection::dispatchMessage(IPC::Connection& connection, IPC::Dec
 #endif
 
 #if ENABLE(MEDIA_SOURCE)
-    if (decoder.messageReceiverName() == Messages::MediaSourcePrivateRemote::messageReceiverName()) {
+    if (decoder.messageReceiverName() == Messages::MediaSourcePrivateRemoteMessageReceiver::messageReceiverName()) {
         RELEASE_LOG_ERROR(Media, "The MediaSourcePrivateRemote object has beed destroyed");
         return true;
     }
 
-    if (decoder.messageReceiverName() == Messages::SourceBufferPrivateRemote::messageReceiverName()) {
+    if (decoder.messageReceiverName() == Messages::SourceBufferPrivateRemoteMessageReceiver::messageReceiverName()) {
         RELEASE_LOG_ERROR(Media, "The SourceBufferPrivateRemote object has beed destroyed");
         return true;
     }

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h
@@ -28,13 +28,15 @@
 #if ENABLE(GPU_PROCESS) && ENABLE(MEDIA_SOURCE)
 
 #include "GPUProcessConnection.h"
-#include "MessageReceiver.h"
 #include "RemoteMediaPlayerMIMETypeCache.h"
 #include "RemoteMediaSourceIdentifier.h"
+#include "WorkQueueMessageReceiver.h"
 #include <WebCore/ContentType.h>
 #include <WebCore/MediaSourcePrivate.h>
 #include <WebCore/MediaSourcePrivateClient.h>
 #include <WebCore/SourceBufferPrivate.h>
+#include <atomic>
+#include <wtf/Forward.h>
 #include <wtf/LoggerHelper.h>
 #include <wtf/RefPtr.h>
 #include <wtf/Vector.h>
@@ -51,7 +53,6 @@ class SourceBufferPrivateRemote;
 
 class MediaSourcePrivateRemote final
     : public WebCore::MediaSourcePrivate
-    , public IPC::MessageReceiver
 #if !RELEASE_LOG_DISABLED
     , private LoggerHelper
 #endif
@@ -79,30 +80,48 @@ public:
         return { };
     }
 
+    static WorkQueue& queue();
+
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
     const void* nextSourceBufferLogIdentifier() { return childLogIdentifier(m_logIdentifier, ++m_nextSourceBufferID); }
 #endif
 
-    // IPC Methods
-    void proxyWaitForTarget(const WebCore::SeekTarget&, CompletionHandler<void(WebCore::MediaTimePromise::Result&&)>&&);
-    void proxySeekToTime(const MediaTime&, CompletionHandler<void(WebCore::MediaPromise::Result&&)>&&);
+    class MessageReceiver : public IPC::WorkQueueMessageReceiver {
+    public:
+        static Ref<MessageReceiver> create(MediaSourcePrivateRemote& parent)
+        {
+            return adoptRef(*new MessageReceiver(parent));
+        }
 
+    private:
+        MessageReceiver(MediaSourcePrivateRemote&);
+        void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+        void proxyWaitForTarget(const WebCore::SeekTarget&, CompletionHandler<void(WebCore::MediaTimePromise::Result&&)>&&);
+        void proxySeekToTime(const MediaTime&, CompletionHandler<void(WebCore::MediaPromise::Result&&)>&&);
+        void mediaSourcePrivateShuttingDown(CompletionHandler<void()>&&);
+        ThreadSafeWeakPtr<MediaSourcePrivateRemote> m_parent;
+    };
 private:
+    friend class MessageReceiver;
     MediaSourcePrivateRemote(GPUProcessConnection&, RemoteMediaSourceIdentifier, RemoteMediaPlayerMIMETypeCache&, const MediaPlayerPrivateRemote&, WebCore::MediaSourcePrivateClient&);
 
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    void mediaSourcePrivateShuttingDown(CompletionHandler<void()>&&);
-    bool isGPURunning() const { return !m_shutdown && m_gpuProcessConnection.get(); }
     void bufferedChanged(const WebCore::PlatformTimeRanges&) final;
 
+    void ensureOnDispatcherSync(Function<void()>&&) const;
+    void ensureOnDispatcher(Function<void()>&&) const;
+
+    bool isGPURunning() const { return !m_shutdown; }
+
     ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;
+    Ref<MessageReceiver> m_receiver;
+    const Ref<RefCountedSerialFunctionDispatcher> m_dispatcher;
     RemoteMediaSourceIdentifier m_identifier;
     RemoteMediaPlayerMIMETypeCache& m_mimeTypeCache;
     WeakPtr<MediaPlayerPrivateRemote> m_mediaPlayerPrivate;
     Vector<RefPtr<SourceBufferPrivateRemote>> m_sourceBuffers;
-    bool m_shutdown { false };
-    WebCore::MediaPlayer::ReadyState m_readyState { WebCore::MediaPlayer::ReadyState::HaveNothing };
+    std::atomic<bool> m_shutdown { false };
+    std::atomic<WebCore::MediaPlayer::ReadyState> m_readyState { WebCore::MediaPlayer::ReadyState::HaveNothing };
 
 #if !RELEASE_LOG_DISABLED
     const char* logClassName() const override { return "MediaSourcePrivateRemote"; }

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemoteMessageReceiver.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemoteMessageReceiver.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "MediaSourcePrivateRemote.h"
+
+namespace WebKit {
+
+using MediaSourcePrivateRemoteMessageReceiver = MediaSourcePrivateRemote::MessageReceiver;
+
+} // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemoteMessageReceiver.messages.in
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemoteMessageReceiver.messages.in
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2020 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if ENABLE(GPU_PROCESS) && ENABLE(MEDIA_SOURCE)
+
+messages -> MediaSourcePrivateRemoteMessageReceiver NotRefCounted {
+    ProxyWaitForTarget(struct WebCore::SeekTarget target) -> (WebCore::MediaTimePromise::Result seekedTime);
+    ProxySeekToTime(MediaTime time) -> (WebCore::MediaPromise::Result result);
+    MediaSourcePrivateShuttingDown() -> ();
+}
+
+#endif

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
@@ -28,12 +28,13 @@
 #if ENABLE(GPU_PROCESS) && ENABLE(MEDIA_SOURCE)
 
 #include "GPUProcessConnection.h"
-#include "MessageReceiver.h"
 #include "RemoteSourceBufferIdentifier.h"
+#include "WorkQueueMessageReceiver.h"
 #include <WebCore/ContentType.h>
 #include <WebCore/MediaSample.h>
 #include <WebCore/SourceBufferPrivate.h>
 #include <WebCore/SourceBufferPrivateClient.h>
+#include <atomic>
 #include <wtf/LoggerHelper.h>
 #include <wtf/MediaTime.h>
 #include <wtf/Ref.h>
@@ -57,8 +58,8 @@ class MediaSourcePrivateRemote;
 
 class SourceBufferPrivateRemote final
     : public WebCore::SourceBufferPrivate
-    , public IPC::MessageReceiver
 {
+    WTF_MAKE_FAST_ALLOCATED;
 public:
     static Ref<SourceBufferPrivateRemote> create(GPUProcessConnection&, RemoteSourceBufferIdentifier, MediaSourcePrivateRemote&, const MediaPlayerPrivateRemote&);
     virtual ~SourceBufferPrivateRemote();
@@ -66,6 +67,31 @@ public:
     constexpr WebCore::MediaPlatformType platformType() const final { return WebCore::MediaPlatformType::Remote; }
 
     void disconnect() { m_disconnected = true; }
+
+    static WorkQueue& queue();
+
+    class MessageReceiver : public IPC::WorkQueueMessageReceiver {
+    public:
+        static Ref<MessageReceiver> create(SourceBufferPrivateRemote& parent)
+        {
+            return adoptRef(*new MessageReceiver(parent));
+        }
+
+    private:
+        MessageReceiver(SourceBufferPrivateRemote&);
+        void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+        void sourceBufferPrivateDidReceiveInitializationSegment(InitializationSegmentInfo&&, CompletionHandler<void(WebCore::MediaPromise::Result&&)>&&);
+        void takeOwnershipOfMemory(WebKit::SharedMemory::Handle&&);
+        void sourceBufferPrivateHighestPresentationTimestampChanged(const MediaTime&);
+        void sourceBufferPrivateBufferedChanged(Vector<WebCore::PlatformTimeRanges>&&, uint64_t, CompletionHandler<void()>&&);
+        void sourceBufferPrivateTrackBuffersChanged(Vector<WebCore::PlatformTimeRanges>&&);
+        void sourceBufferPrivateDurationChanged(const MediaTime&, CompletionHandler<void()>&&);
+        void sourceBufferPrivateDidParseSample(double sampleDuration);
+        void sourceBufferPrivateDidDropSample();
+        void sourceBufferPrivateDidReceiveRenderingError(int64_t errorCode);
+        void sourceBufferPrivateReportExtraMemoryCost(uint64_t extraMemory);
+        ThreadSafeWeakPtr<SourceBufferPrivateRemote> m_parent;
+    };
 
 private:
     SourceBufferPrivateRemote(GPUProcessConnection&, RemoteSourceBufferIdentifier, MediaSourcePrivateRemote&, const MediaPlayerPrivateRemote&);
@@ -108,26 +134,20 @@ private:
     // Internals Utility methods
     Ref<SamplesPromise> bufferedSamplesForTrackId(TrackID) final;
     Ref<SamplesPromise> enqueuedSamplesForTrackID(TrackID) final;
+    MediaTime minimumUpcomingPresentationTimeForTrackID(TrackID) final;
+    void setMaximumQueueDepthForTrackID(TrackID, uint64_t) final;
 
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    void sourceBufferPrivateDidReceiveInitializationSegment(InitializationSegmentInfo&&, CompletionHandler<void(WebCore::MediaPromise::Result&&)>&&);
-    void takeOwnershipOfMemory(WebKit::SharedMemory::Handle&&);
-    void sourceBufferPrivateHighestPresentationTimestampChanged(const MediaTime&);
-    void sourceBufferPrivateBufferedChanged(Vector<WebCore::PlatformTimeRanges>&&, uint64_t, CompletionHandler<void()>&&);
-    void sourceBufferPrivateDurationChanged(const MediaTime&, CompletionHandler<void()>&&);
-    void sourceBufferPrivateDidParseSample(double sampleDuration);
-    void sourceBufferPrivateDidDropSample();
-    void sourceBufferPrivateDidReceiveRenderingError(int64_t errorCode);
-    MediaTime minimumUpcomingPresentationTimeForTrackID(TrackID) override;
-    void setMaximumQueueDepthForTrackID(TrackID, uint64_t) override;
+    void ensureOnDispatcherSync(Function<void()>&&);
 
+    friend class MessageReceiver;
     ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;
+    Ref<MessageReceiver> m_receiver;
     RemoteSourceBufferIdentifier m_remoteSourceBufferIdentifier;
     WeakPtr<MediaPlayerPrivateRemote> m_mediaPlayerPrivate;
 
-    uint64_t m_totalTrackBufferSizeInBytes = { 0 };
+    std::atomic<uint64_t> m_totalTrackBufferSizeInBytes = { 0 };
 
-    bool isGPURunning() const { return !m_disconnected && m_gpuProcessConnection.get(); }
+    bool isGPURunning() const { return !m_disconnected; }
     bool m_disconnected { false };
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemoteMessageReceiver.h
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemoteMessageReceiver.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,17 +23,12 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#if ENABLE(GPU_PROCESS) && ENABLE(MEDIA_SOURCE)
+#pragma once
 
-messages -> SourceBufferPrivateRemote NotRefCounted {
-    SourceBufferPrivateDidReceiveInitializationSegment(struct WebKit::InitializationSegmentInfo segmentConfiguration) -> (WebCore::MediaPromise::Result result)
-    TakeOwnershipOfMemory(WebKit::SharedMemory::Handle remoteData)
-    SourceBufferPrivateHighestPresentationTimestampChanged(MediaTime timestamp)
-    SourceBufferPrivateBufferedChanged(Vector<WebCore::PlatformTimeRanges> trackBuffers, uint64_t extraMemory) -> ()
-    SourceBufferPrivateDurationChanged(MediaTime duration) -> ()
-    SourceBufferPrivateDidParseSample(double sampleDuration)
-    SourceBufferPrivateDidDropSample()
-    SourceBufferPrivateDidReceiveRenderingError(int64_t errorCode)
-}
+#include "SourceBufferPrivateRemote.h"
 
-#endif
+namespace WebKit {
+
+using SourceBufferPrivateRemoteMessageReceiver = SourceBufferPrivateRemote::MessageReceiver;
+
+} // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemoteMessageReceiver.messages.in
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemoteMessageReceiver.messages.in
@@ -25,10 +25,15 @@
 
 #if ENABLE(GPU_PROCESS) && ENABLE(MEDIA_SOURCE)
 
-messages -> MediaSourcePrivateRemote NotRefCounted {
-    ProxyWaitForTarget(struct WebCore::SeekTarget target) -> (WebCore::MediaTimePromise::Result seekedTime);
-    ProxySeekToTime(MediaTime time) -> (WebCore::MediaPromise::Result result);
-    MediaSourcePrivateShuttingDown() -> ();
+messages -> SourceBufferPrivateRemoteMessageReceiver NotRefCounted {
+    SourceBufferPrivateDidReceiveInitializationSegment(struct WebKit::InitializationSegmentInfo segmentConfiguration) -> (WebCore::MediaPromise::Result result)
+    TakeOwnershipOfMemory(WebKit::SharedMemory::Handle remoteData)
+    SourceBufferPrivateHighestPresentationTimestampChanged(MediaTime timestamp)
+    SourceBufferPrivateBufferedChanged(Vector<WebCore::PlatformTimeRanges> trackBuffers, uint64_t extraMemory) -> ()
+    SourceBufferPrivateDurationChanged(MediaTime duration) -> ()
+    SourceBufferPrivateDidParseSample(double sampleDuration)
+    SourceBufferPrivateDidDropSample()
+    SourceBufferPrivateDidReceiveRenderingError(int64_t errorCode)
 }
 
 #endif


### PR DESCRIPTION
#### 03b1e046a365b679b06574d4741241bc7382ab6e
<pre>
[MSE] Provide ability for the MediaSourcePrivate and SourceBufferPrivate to run on different thread than their client
<a href="https://bugs.webkit.org/show_bug.cgi?id=266075">https://bugs.webkit.org/show_bug.cgi?id=266075</a>
<a href="https://rdar.apple.com/119380172">rdar://119380172</a>

Reviewed by NOBODY (OOPS!).

Set a clientDispatcher and call all clients&apos; methods on this dispatcher.
This lets define alternative RefCountedSerialFunctionDispatcher on which
the SourceBufferPrivate and MediaSourcePrivate could run on (and that would be different to their
respective client: SourceBufferPrivateClient and MediaSourcePrivateClient).

For now, all are set to be the main thread so that there&apos;s no changes in
observable behaviour; but it provides the infrastructure to later change
it so that both the SourceBufferPrivate and MediaSourcePrivate could use
a dedicated work queue while the SourceBuffer and MediaSource run on a
worker thread.

The code is still non-functional should the objects run on different queues.

Covered by existing tests, no change in observable behaviour.

* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::monitorSourceBuffers):
* Source/WebCore/platform/graphics/MediaSourcePrivate.cpp:
(WebCore::MediaSourcePrivate::MediaSourcePrivate):
(WebCore::MediaSourcePrivate::waitForTarget):
(WebCore::MediaSourcePrivate::seekToTime):
(WebCore::MediaSourcePrivate::clientDispatcher const):
(WebCore::MediaSourcePrivate::ensureOnClientDispatcher):
* Source/WebCore/platform/graphics/MediaSourcePrivate.h:
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::SourceBufferPrivate):
(WebCore::SourceBufferPrivate::updateBuffered):
(WebCore::SourceBufferPrivate::removeCodedFrames):
(WebCore::SourceBufferPrivate::didReceiveInitializationSegment):
(WebCore::SourceBufferPrivate::didUpdateFormatDescriptionForTrackId):
(WebCore::SourceBufferPrivate::append):
(WebCore::SourceBufferPrivate::processPendingMediaSamples):
(WebCore::SourceBufferPrivate::processMediaSample):
(WebCore::SourceBufferPrivate::resetParserState):
(WebCore::SourceBufferPrivate::memoryPressure):
(WebCore::SourceBufferPrivate::ensureOnClientDispatcher const):
(WebCore::SourceBufferPrivate::ensureOnDispatcher const):
* Source/WebCore/platform/graphics/SourceBufferPrivate.h:
(WebCore::SourceBufferPrivate::clientDispatcher const):
(WebCore::SourceBufferPrivate::dispatcher const):
* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources-output.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp:
(WebKit::RemoteMediaSourceProxy::waitForTarget):
(WebKit::RemoteMediaSourceProxy::seekToTime):
(WebKit::RemoteMediaSourceProxy::shutdown):
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp:
(WebKit::RemoteSourceBufferProxy::sourceBufferPrivateDidReceiveInitializationSegment):
(WebKit::RemoteSourceBufferProxy::sourceBufferPrivateHighestPresentationTimestampChanged):
(WebKit::RemoteSourceBufferProxy::sourceBufferPrivateDurationChanged):
(WebKit::RemoteSourceBufferProxy::sourceBufferPrivateBufferedChanged):
(WebKit::RemoteSourceBufferProxy::sourceBufferPrivateDidParseSample):
(WebKit::RemoteSourceBufferProxy::sourceBufferPrivateDidDropSample):
(WebKit::RemoteSourceBufferProxy::sourceBufferPrivateDidReceiveRenderingError):
(WebKit::RemoteSourceBufferProxy::append):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp:
(WebKit::GPUProcessConnection::dispatchMessage):
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp:
(WebKit::MediaSourcePrivateRemote::queue):
(WebKit::MediaSourcePrivateRemote::ensureOnDispatcherSync const):
(WebKit::MediaSourcePrivateRemote::ensureOnDispatcher const):
(WebKit::MediaSourcePrivateRemote::MediaSourcePrivateRemote):
(WebKit::MediaSourcePrivateRemote::~MediaSourcePrivateRemote):
(WebKit::MediaSourcePrivateRemote::addSourceBuffer):
(WebKit::MediaSourcePrivateRemote::durationChanged):
(WebKit::MediaSourcePrivateRemote::bufferedChanged):
(WebKit::MediaSourcePrivateRemote::markEndOfStream):
(WebKit::MediaSourcePrivateRemote::unmarkEndOfStream):
(WebKit::MediaSourcePrivateRemote::mediaPlayerReadyState const):
(WebKit::MediaSourcePrivateRemote::setMediaPlayerReadyState):
(WebKit::MediaSourcePrivateRemote::setTimeFudgeFactor):
(WebKit::MediaSourcePrivateRemote::MessageReceiver::proxyWaitForTarget):
(WebKit::MediaSourcePrivateRemote::MessageReceiver::proxySeekToTime):
(WebKit::MediaSourcePrivateRemote::MessageReceiver::mediaSourcePrivateShuttingDown):
(WebKit::MediaSourcePrivateRemote::MessageReceiver::MessageReceiver):
(WebKit::MediaSourcePrivateRemote::proxyWaitForTarget): Deleted.
(WebKit::MediaSourcePrivateRemote::proxySeekToTime): Deleted.
(WebKit::MediaSourcePrivateRemote::mediaSourcePrivateShuttingDown): Deleted.
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemoteMessageReceiver.h: Copied from Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.messages.in.
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemoteMessageReceiver.messages.in: Copied from Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.messages.in.
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp:
(WebKit::SourceBufferPrivateRemote::queue):
(WebKit::SourceBufferPrivateRemote::ensureOnDispatcherSync):
(WebKit::SourceBufferPrivateRemote::SourceBufferPrivateRemote):
(WebKit::SourceBufferPrivateRemote::~SourceBufferPrivateRemote):
(WebKit::SourceBufferPrivateRemote::append):
(WebKit::SourceBufferPrivateRemote::abort):
(WebKit::SourceBufferPrivateRemote::resetParserState):
(WebKit::SourceBufferPrivateRemote::removedFromMediaSource):
(WebKit::SourceBufferPrivateRemote::setActive):
(WebKit::SourceBufferPrivateRemote::canSwitchToType):
(WebKit::SourceBufferPrivateRemote::setMediaSourceEnded):
(WebKit::SourceBufferPrivateRemote::setMode):
(WebKit::SourceBufferPrivateRemote::removeCodedFrames):
(WebKit::SourceBufferPrivateRemote::evictCodedFrames):
(WebKit::SourceBufferPrivateRemote::addTrackBuffer):
(WebKit::SourceBufferPrivateRemote::resetTrackBuffers):
(WebKit::SourceBufferPrivateRemote::clearTrackBuffers):
(WebKit::SourceBufferPrivateRemote::setAllTrackBuffersNeedRandomAccess):
(WebKit::SourceBufferPrivateRemote::setGroupStartTimestamp):
(WebKit::SourceBufferPrivateRemote::setGroupStartTimestampToEndTimestamp):
(WebKit::SourceBufferPrivateRemote::setShouldGenerateTimestamps):
(WebKit::SourceBufferPrivateRemote::reenqueueMediaIfNeeded):
(WebKit::SourceBufferPrivateRemote::resetTimestampOffsetInTrackBuffers):
(WebKit::SourceBufferPrivateRemote::startChangingType):
(WebKit::SourceBufferPrivateRemote::setTimestampOffset):
(WebKit::SourceBufferPrivateRemote::setAppendWindowStart):
(WebKit::SourceBufferPrivateRemote::setAppendWindowEnd):
(WebKit::SourceBufferPrivateRemote::computeSeekTime):
(WebKit::SourceBufferPrivateRemote::seekToTime):
(WebKit::SourceBufferPrivateRemote::updateTrackIds):
(WebKit::SourceBufferPrivateRemote::bufferedSamplesForTrackId):
(WebKit::SourceBufferPrivateRemote::enqueuedSamplesForTrackID):
(WebKit::SourceBufferPrivateRemote::MessageReceiver::takeOwnershipOfMemory):
(WebKit::SourceBufferPrivateRemote::MessageReceiver::sourceBufferPrivateDidReceiveInitializationSegment):
(WebKit::SourceBufferPrivateRemote::MessageReceiver::sourceBufferPrivateHighestPresentationTimestampChanged):
(WebKit::SourceBufferPrivateRemote::MessageReceiver::sourceBufferPrivateDurationChanged):
(WebKit::SourceBufferPrivateRemote::MessageReceiver::sourceBufferPrivateBufferedChanged):
(WebKit::SourceBufferPrivateRemote::MessageReceiver::sourceBufferPrivateDidParseSample):
(WebKit::SourceBufferPrivateRemote::MessageReceiver::sourceBufferPrivateDidDropSample):
(WebKit::SourceBufferPrivateRemote::MessageReceiver::sourceBufferPrivateDidReceiveRenderingError):
(WebKit::SourceBufferPrivateRemote::memoryPressure):
(WebKit::SourceBufferPrivateRemote::minimumUpcomingPresentationTimeForTrackID):
(WebKit::SourceBufferPrivateRemote::setMaximumQueueDepthForTrackID):
(WebKit::SourceBufferPrivateRemote::MessageReceiver::MessageReceiver):
(WebKit::SourceBufferPrivateRemote::takeOwnershipOfMemory): Deleted.
(WebKit::SourceBufferPrivateRemote::sourceBufferPrivateDidReceiveInitializationSegment): Deleted.
(WebKit::SourceBufferPrivateRemote::sourceBufferPrivateHighestPresentationTimestampChanged): Deleted.
(WebKit::SourceBufferPrivateRemote::sourceBufferPrivateDurationChanged): Deleted.
(WebKit::SourceBufferPrivateRemote::sourceBufferPrivateBufferedChanged): Deleted.
(WebKit::SourceBufferPrivateRemote::sourceBufferPrivateDidParseSample): Deleted.
(WebKit::SourceBufferPrivateRemote::sourceBufferPrivateDidDropSample): Deleted.
(WebKit::SourceBufferPrivateRemote::sourceBufferPrivateDidReceiveRenderingError): Deleted.
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemoteMessageReceiver.h: Renamed from Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.messages.in.
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemoteMessageReceiver.messages.in: Renamed from Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.messages.in.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/03b1e046a365b679b06574d4741241bc7382ab6e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29899 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8565 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31217 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32411 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27039 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30559 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10749 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5821 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27099 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30193 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7176 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25508 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6121 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6308 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26596 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33747 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27272 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27021 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32469 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6218 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4404 "Found 1 new test failure: fullscreen/full-screen-layer-dump.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30258 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7956 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6962 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6745 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->