### PR TITLE
Implement layer hosting for WebKit extension processes

### DIFF
--- a/Source/WebKit/Platform/ExtraPrivateSymbolsForTAPI.h
+++ b/Source/WebKit/Platform/ExtraPrivateSymbolsForTAPI.h
@@ -38,6 +38,7 @@ void GPUServiceInitializer();
 
 void ExtensionEventHandler(xpc_connection_t);
 
+#if USE(EXTENSIONKIT)
 // Declared in WKProcessExtension.h for use in extension targets. Must be declared in project
 //  headers because the extension targets cannot import the entire WebKit module (rdar://119162443).
 @interface WKGrant : NSObject
@@ -45,6 +46,7 @@ void ExtensionEventHandler(xpc_connection_t);
 
 @interface WKProcessExtension : NSObject
 @end
+#endif
 
 #ifdef __cplusplus
 }

--- a/Source/WebKit/Platform/cocoa/LayerHostingContext.h
+++ b/Source/WebKit/Platform/cocoa/LayerHostingContext.h
@@ -27,10 +27,16 @@
 
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/OSObjectPtr.h>
 #include <wtf/RetainPtr.h>
 
 OBJC_CLASS CALayer;
 OBJC_CLASS CAContext;
+
+#if USE(EXTENSIONKIT)
+OBJC_CLASS _SEHostable;
+OBJC_CLASS _SEHostingUpdateCoordinator;
+#endif
 
 namespace WTF {
 class MachSendRight;
@@ -44,6 +50,9 @@ enum class LayerHostingMode : uint8_t;
 struct LayerHostingContextOptions {
 #if PLATFORM(IOS_FAMILY)
     bool canShowWhileLocked { false };
+#endif
+#if USE(EXTENSIONKIT)
+    bool useHostable { false };
 #endif
 };
 
@@ -96,6 +105,11 @@ public:
     void updateCachedContextID(LayerHostingContextID);
     LayerHostingContextID cachedContextID();
 
+#if USE(EXTENSIONKIT)
+    OSObjectPtr<xpc_object_t> xpcRepresentation() const;
+    void commit();
+#endif
+
 private:
     LayerHostingMode m_layerHostingMode;
     // Denotes the contextID obtained from GPU process, should be returned
@@ -103,6 +117,10 @@ private:
     // is enabled. This is done to avoid making calls to CARenderServer from webprocess
     LayerHostingContextID m_cachedContextID;
     RetainPtr<CAContext> m_context;
+#if USE(EXTENSIONKIT)
+    RetainPtr<_SEHostable> m_hostable;
+    RetainPtr<_SEHostingUpdateCoordinator> m_hostingUpdateCoordinator;
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Platform/spi/Cocoa/ExtensionKitSPI.h
+++ b/Source/WebKit/Platform/spi/Cocoa/ExtensionKitSPI.h
@@ -27,6 +27,9 @@
 
 #if USE(EXTENSIONKIT)
 
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
 #if __has_include(<ServiceExtensions/ServiceExtensions_Private.h>)
 #import <ServiceExtensions/ServiceExtensions_Private.h>
 #else
@@ -102,6 +105,8 @@ NS_ASSUME_NONNULL_END
 
 #endif
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface _SECapability (SPI)
 - (BOOL)setActive:(BOOL)active;
 + (instancetype)mediaWithWebsite:(NSString *)website;
@@ -110,5 +115,31 @@ NS_ASSUME_NONNULL_END
 + (instancetype)assertionWithDomain:(NSString *)domain name:(NSString *)name environmentIdentifier:(NSString *)environmentIdentifier willInvalidate:(void (^)())willInvalidateBlock didInvalidate:(void (^)())didInvalidateBlock;
 @property (nonatomic, readonly) NSString *mediaEnvironment;
 @end
+
+@interface _SEHostingHandle: NSObject
+-(instancetype)initFromXPCRepresentation:(xpc_object_t)xpcRepresentation;
+-(xpc_object_t)xpcRepresentation;
+@end
+
+@interface _SEHostable: NSObject
++(_SEHostable*)createHostableWithOptions:(NSDictionary*)dict error:(NSError**)error;
+@property (nonatomic, readonly) _SEHostingHandle* handle;
+@property (nonatomic, strong) CALayer *layer;
+@end
+
+@interface _SEHostingView: UIView
+@property (nonatomic, retain) _SEHostingHandle* handle;
+@end
+
+@interface _SEHostingUpdateCoordinator : NSObject
+-(instancetype)init;
+-(instancetype)initFromXPCRepresentation:(xpc_object_t)xpcRepresentation;
+-(xpc_object_t)xpcRepresentation;
+-(void)addHostable:(_SEHostable*)hostable;
+-(void)addHostingView:(_SEHostingView*)hostingView;
+-(void)commit;
+@end
+
+NS_ASSUME_NONNULL_END
 
 #endif // USE(EXTENSIONKIT)

--- a/Source/WebKit/Shared/Cocoa/ExtensionKitSoftLink.h
+++ b/Source/WebKit/Shared/Cocoa/ExtensionKitSoftLink.h
@@ -33,5 +33,9 @@
 SOFT_LINK_FRAMEWORK_FOR_HEADER(WebKit, ServiceExtensions)
 
 SOFT_LINK_CLASS_FOR_HEADER(WebKit, _SECapability)
+SOFT_LINK_CLASS_FOR_HEADER(WebKit, _SEHostable)
+SOFT_LINK_CLASS_FOR_HEADER(WebKit, _SEHostingHandle)
+SOFT_LINK_CLASS_FOR_HEADER(WebKit, _SEHostingUpdateCoordinator)
+SOFT_LINK_CLASS_FOR_HEADER(WebKit, _SEHostingView)
 
 #endif // USE(EXTENSIONKIT)

--- a/Source/WebKit/Shared/Cocoa/ExtensionKitSoftLink.mm
+++ b/Source/WebKit/Shared/Cocoa/ExtensionKitSoftLink.mm
@@ -32,5 +32,9 @@
 SOFT_LINK_FRAMEWORK_FOR_SOURCE(WebKit, ServiceExtensions)
 
 SOFT_LINK_CLASS_FOR_SOURCE(WebKit, ServiceExtensions, _SECapability)
+SOFT_LINK_CLASS_FOR_SOURCE(WebKit, ServiceExtensions, _SEHostable)
+SOFT_LINK_CLASS_FOR_SOURCE(WebKit, ServiceExtensions, _SEHostingHandle)
+SOFT_LINK_CLASS_FOR_SOURCE(WebKit, ServiceExtensions, _SEHostingUpdateCoordinator)
+SOFT_LINK_CLASS_FOR_SOURCE(WebKit, ServiceExtensions, _SEHostingView)
 
 #endif // USE(EXTENSIONKIT)

--- a/Source/WebKit/Shared/Cocoa/WKProcessExtension.mm
+++ b/Source/WebKit/Shared/Cocoa/WKProcessExtension.mm
@@ -24,6 +24,8 @@
  */
 
 #import "config.h"
+
+#if USE(EXTENSIONKIT)
 #import "WKProcessExtension.h"
 
 #import <wtf/RetainPtr.h>
@@ -57,3 +59,5 @@ static RetainPtr<WKProcessExtension>& sharedInstance()
 {
 }
 @end
+
+#endif // USE(EXTENSIONKIT)


### PR DESCRIPTION
#### b674f6c410e6fd20169eb8f8da10f143feff1073
<pre>
Implement layer hosting for WebKit extension processes
<a href="https://rdar.apple.com/119381400">rdar://119381400</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=266078">https://bugs.webkit.org/show_bug.cgi?id=266078</a>

Reviewed by Andy Estes and Brent Fulgham.

Implement layer hosting for WebKit extension processes. In this implementation, the remote context is
represented by an object of type _SEHostable. In this implementation, the _SEHostable object is created
in the GPU process. The remote context is shared by extracting the context ID from the XPC representation
of the _SEHostable object, and sent to the UI process via the WebContent process as in the former
implementation. In the UI process, a _SEHostingHandle is created from the received context ID and
attached to the new view type we create in the UI process, _SEHostingView. Fencing is implemented with
the new object type _SEHostingUpdateCoordinator. This object is created in the UI process, and shared
with the GPU process from its XPC representation, which contains a Mach send right.

* Source/WebKit/GPUProcess/media/cocoa/RemoteMediaPlayerProxyCocoa.mm:
(WebKit::RemoteMediaPlayerProxy::mediaPlayerRenderingModeChanged):
(WebKit::RemoteMediaPlayerProxy::setVideoLayerSizeFenced):
* Source/WebKit/Platform/ExtraPrivateSymbolsForTAPI.h:
* Source/WebKit/Platform/cocoa/LayerHostingContext.h:
* Source/WebKit/Platform/cocoa/LayerHostingContext.mm:
(WebKit::LayerHostingContext::createForExternalHostingProcess):
(WebKit::LayerHostingContext::~LayerHostingContext):
(WebKit::LayerHostingContext::setRootLayer):
(WebKit::LayerHostingContext::rootLayer const):
(WebKit::LayerHostingContext::contextID const):
(WebKit::LayerHostingContext::setFencePort):
(WebKit::LayerHostingContext::xpcRepresentation const):
(WebKit::LayerHostingContext::commit):
* Source/WebKit/Platform/spi/Cocoa/ExtensionKitSPI.h:
* Source/WebKit/Shared/Cocoa/ExtensionKitSoftLink.h:
* Source/WebKit/Shared/Cocoa/ExtensionKitSoftLink.mm:
* Source/WebKit/Shared/Cocoa/WKProcessExtension.mm:
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(-[WKLayerHostView dealloc]):
(WebKit::VideoPresentationManagerProxy::createLayerHostViewWithID):
(WebKit::VideoPresentationManagerProxy::setVideoLayerFrame):

Canonical link: <a href="https://commits.webkit.org/272703@main">https://commits.webkit.org/272703@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52d49aa81b66bccecb7b66b8279358e28b9940ee

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32706 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11459 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34562 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35277 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29549 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13807 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8647 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29036 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33146 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9661 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29214 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8424 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8555 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36614 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29723 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29575 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34680 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8674 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6638 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32546 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10358 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7610 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9287 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9281 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->