### PR TITLE
[WebGPU] 'alias' not supported (https://www.w3.org/TR/WGSL/#type-aliases) / error compiling shader opening https://playground.babylonjs.com/#N96NXC#106

### DIFF
--- a/Source/WebGPU/WGSL/AST/AST.h
+++ b/Source/WebGPU/WGSL/AST/AST.h
@@ -81,6 +81,7 @@
 #include "ASTStructure.h"
 #include "ASTStructureMember.h"
 #include "ASTSwitchStatement.h"
+#include "ASTTypeAlias.h"
 #include "ASTUnaryExpression.h"
 #include "ASTUnsigned32Literal.h"
 #include "ASTVariable.h"

--- a/Source/WebGPU/WGSL/AST/ASTStringDumper.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTStringDumper.cpp
@@ -198,6 +198,14 @@ void StringDumper::visit(Variable& variable)
     m_out.print(";");
 }
 
+void StringDumper::visit(TypeAlias& alias)
+{
+    m_out.print(m_indent);
+    m_out.print("alias ", alias.name(), " = ");
+    visit(alias.type());
+    m_out.print(";");
+}
+
 // Expression
 void StringDumper::visit(AbstractFloatLiteral& literal)
 {

--- a/Source/WebGPU/WGSL/AST/ASTStringDumper.h
+++ b/Source/WebGPU/WGSL/AST/ASTStringDumper.h
@@ -61,6 +61,7 @@ public:
     void visit(Function&) override;
     void visit(Structure&) override;
     void visit(Variable&) override;
+    void visit(TypeAlias&) override;
 
     // Expression
     void visit(AbstractFloatLiteral&) override;

--- a/Source/WebGPU/WGSL/AST/ASTTypeAlias.h
+++ b/Source/WebGPU/WGSL/AST/ASTTypeAlias.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ASTDeclaration.h"
+
+namespace WGSL::AST {
+
+class TypeAlias final : public Declaration {
+    WGSL_AST_BUILDER_NODE(TypeAlias);
+
+public:
+    NodeKind kind() const override;
+    Identifier& name() override { return m_name; }
+    Expression& type() { return m_type; }
+
+private:
+    TypeAlias(SourceSpan span, Identifier&& name, Expression::Ref type)
+        : Declaration(span)
+        , m_name(WTFMove(name))
+        , m_type(type)
+    { }
+
+    Identifier m_name;
+    Expression::Ref m_type;
+};
+
+} // namespace WGSL::AST
+
+SPECIALIZE_TYPE_TRAITS_WGSL_AST(TypeAlias)

--- a/Source/WebGPU/WGSL/AST/ASTVisitor.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTVisitor.cpp
@@ -82,9 +82,17 @@ void Visitor::visit(AST::Declaration& declaration)
     case AST::NodeKind::Structure:
         checkErrorAndVisit(downcast<AST::Structure>(declaration));
         break;
+    case AST::NodeKind::TypeAlias:
+        checkErrorAndVisit(downcast<AST::TypeAlias>(declaration));
+        break;
     default:
         ASSERT_NOT_REACHED("Unhandled Declaration");
     }
+}
+
+void Visitor::visit(AST::TypeAlias& alias)
+{
+    visit(alias.type());
 }
 
 // Attribute

--- a/Source/WebGPU/WGSL/AST/ASTVisitor.h
+++ b/Source/WebGPU/WGSL/AST/ASTVisitor.h
@@ -53,6 +53,7 @@ public:
     virtual void visit(AST::Function&);
     virtual void visit(AST::Variable&);
     virtual void visit(AST::Structure&);
+    virtual void visit(AST::TypeAlias&);
 
     // Attribute
     virtual void visit(AST::Attribute&);

--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -565,6 +565,9 @@ Result<AST::Declaration::Ref> Parser<Lexer>::parseDeclaration()
         PARSE(variable, Variable);
         CONSUME_TYPE(Semicolon);
         return { variable };
+    } else if (current().type == TokenType::KeywordAlias) {
+        PARSE(alias, TypeAlias);
+        return { alias };
     }
 
     PARSE(attributes, Attributes);
@@ -984,6 +987,23 @@ Result<AccessMode> Parser<Lexer>::parseAccessMode()
         return { *accessMode };
 
     FAIL("Expected one of 'read'/'write'/'read_write'"_s);
+}
+
+template<typename Lexer>
+Result<AST::TypeAlias::Ref> Parser<Lexer>::parseTypeAlias()
+{
+    START_PARSE();
+
+    CONSUME_TYPE(KeywordAlias);
+    PARSE(name, Identifier);
+
+    CONSUME_TYPE(Equal);
+
+    PARSE(type, TypeName);
+
+    CONSUME_TYPE(Semicolon);
+
+    RETURN_ARENA_NODE(TypeAlias, WTFMove(name), WTFMove(type));
 }
 
 template<typename Lexer>

--- a/Source/WebGPU/WGSL/ParserPrivate.h
+++ b/Source/WebGPU/WGSL/ParserPrivate.h
@@ -32,6 +32,7 @@
 #include "ASTFunction.h"
 #include "ASTStatement.h"
 #include "ASTStructure.h"
+#include "ASTTypeAlias.h"
 #include "ASTVariable.h"
 #include "CompilationMessage.h"
 #include "Lexer.h"
@@ -77,6 +78,7 @@ public:
     Result<AST::VariableQualifier::Ref> parseVariableQualifier();
     Result<AddressSpace> parseAddressSpace();
     Result<AccessMode> parseAccessMode();
+    Result<AST::TypeAlias::Ref> parseTypeAlias();
     Result<AST::Function::Ref> parseFunction(AST::Attribute::List&&);
     Result<std::reference_wrapper<AST::Parameter>> parseParameter();
     Result<AST::Statement::Ref> parseStatement();

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -65,6 +65,7 @@ public:
     void visit(AST::Structure&) override;
     void visit(AST::Variable&) override;
     void visit(AST::Function&) override;
+    void visit(AST::TypeAlias&) override;
 
     // Attributes
     void visit(AST::AlignAttribute&) override;
@@ -352,11 +353,16 @@ void TypeChecker::visit(AST::Variable& variable)
     visitVariable(variable, VariableKind::Global);
 }
 
+void TypeChecker::visit(AST::TypeAlias& alias)
+{
+    auto* type = resolve(alias.type());
+    introduceType(alias.name(), type);
+}
+
 void TypeChecker::visit(AST::VariableStatement& statement)
 {
     visitVariable(statement.variable(), VariableKind::Local);
 }
-
 
 void TypeChecker::visitVariable(AST::Variable& variable, VariableKind variableKind)
 {

--- a/Source/WebGPU/WGSL/tests/valid/aliases.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/aliases.wgsl
@@ -20,8 +20,18 @@ fn m7(x: mat4x2f) {}
 fn m8(x: mat4x3f) {}
 fn m9(x: mat4x4f) {}
 
+struct S {
+  x: i32,
+}
+alias v = vec2<i32>;
+alias s = S;
+
 @compute @workgroup_size(1)
 fn main() {
+
+    let x = v(0);
+    let y = s(0);
+
     _ = f1(vec2f(vec2(0u)));
     _ = f2(vec2i(vec2(0f)));
     _ = f3(vec2u(vec2(0f)));

--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -165,9 +165,10 @@
 		97BCD6AE29D7422B00A82577 /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CBAB0912718CCA0006080BB /* JavaScriptCore.framework */; };
 		97C36CFE29F1730100CFB379 /* Constraints.h in Headers */ = {isa = PBXBuildFile; fileRef = 97C36CFC29F1730000CFB379 /* Constraints.h */; };
 		97C36CFF29F1730100CFB379 /* Constraints.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 97C36CFD29F1730000CFB379 /* Constraints.cpp */; };
+		97D398E32B05106000D8C4AA /* ASTFloat16Literal.h in Headers */ = {isa = PBXBuildFile; fileRef = 97D398E22B05106000D8C4AA /* ASTFloat16Literal.h */; };
 		97D398E62B06A85B00D8C4AA /* ASTDiagnosticDirective.h in Headers */ = {isa = PBXBuildFile; fileRef = 97D398E42B06A85B00D8C4AA /* ASTDiagnosticDirective.h */; };
 		97D398E72B06A85B00D8C4AA /* ASTDiagnostic.h in Headers */ = {isa = PBXBuildFile; fileRef = 97D398E52B06A85B00D8C4AA /* ASTDiagnostic.h */; };
-		97D398E32B05106000D8C4AA /* ASTFloat16Literal.h in Headers */ = {isa = PBXBuildFile; fileRef = 97D398E22B05106000D8C4AA /* ASTFloat16Literal.h */; };
+		97D398E92B2387F300D8C4AA /* ASTTypeAlias.h in Headers */ = {isa = PBXBuildFile; fileRef = 97D398E82B2387F300D8C4AA /* ASTTypeAlias.h */; };
 		97E21C8B2A1F5DCC009CEB0E /* ASTDecrementIncrementStatement.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 97E21C8A2A1F5DCC009CEB0E /* ASTDecrementIncrementStatement.cpp */; };
 		97E21C972A2512F7009CEB0E /* ConstantValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 97E21C942A2512F7009CEB0E /* ConstantValue.cpp */; };
 		97E21C982A2512F7009CEB0E /* ConstantValue.h in Headers */ = {isa = PBXBuildFile; fileRef = 97E21C952A2512F7009CEB0E /* ConstantValue.h */; };
@@ -451,9 +452,10 @@
 		97A448A52AE3546700A4E147 /* ASTCallStatement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTCallStatement.h; sourceTree = "<group>"; };
 		97C36CFC29F1730000CFB379 /* Constraints.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Constraints.h; sourceTree = "<group>"; };
 		97C36CFD29F1730000CFB379 /* Constraints.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Constraints.cpp; sourceTree = "<group>"; };
+		97D398E22B05106000D8C4AA /* ASTFloat16Literal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTFloat16Literal.h; sourceTree = "<group>"; };
 		97D398E42B06A85B00D8C4AA /* ASTDiagnosticDirective.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTDiagnosticDirective.h; sourceTree = "<group>"; };
 		97D398E52B06A85B00D8C4AA /* ASTDiagnostic.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTDiagnostic.h; sourceTree = "<group>"; };
-		97D398E22B05106000D8C4AA /* ASTFloat16Literal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTFloat16Literal.h; sourceTree = "<group>"; };
+		97D398E82B2387F300D8C4AA /* ASTTypeAlias.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTTypeAlias.h; sourceTree = "<group>"; };
 		97E21C8A2A1F5DCC009CEB0E /* ASTDecrementIncrementStatement.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ASTDecrementIncrementStatement.cpp; sourceTree = "<group>"; };
 		97E21C942A2512F7009CEB0E /* ConstantValue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ConstantValue.cpp; sourceTree = "<group>"; };
 		97E21C952A2512F7009CEB0E /* ConstantValue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ConstantValue.h; sourceTree = "<group>"; };
@@ -759,6 +761,7 @@
 				33EA187327BC204900A1DD52 /* ASTStructure.h */,
 				3A12AEC428FCEEC400C1B975 /* ASTStructureMember.h */,
 				3A1A1EFE28FD35E800C5934A /* ASTSwitchStatement.h */,
+				97D398E82B2387F300D8C4AA /* ASTTypeAlias.h */,
 				3AD0D23A2988ED8F0080D728 /* ASTUnaryExpression.cpp */,
 				3AAE4EB328C56E9A00DA484B /* ASTUnaryExpression.h */,
 				3A12AECA28FCFA9800C1B975 /* ASTUnsigned32Literal.h */,
@@ -873,6 +876,7 @@
 				33EA187427BC204900A1DD52 /* ASTStructure.h in Headers */,
 				3A12AEC728FCEEC400C1B975 /* ASTStructureMember.h in Headers */,
 				3A1A1F0228FD35E800C5934A /* ASTSwitchStatement.h in Headers */,
+				97D398E92B2387F300D8C4AA /* ASTTypeAlias.h in Headers */,
 				3AAE4EB428C56E9A00DA484B /* ASTUnaryExpression.h in Headers */,
 				3A12AECC28FCFA9800C1B975 /* ASTUnsigned32Literal.h in Headers */,
 				33EA186427BC1A1D00A1DD52 /* ASTVariable.h in Headers */,


### PR DESCRIPTION
#### 81d65a5b16f3bf2c1bc109176ea962425b41e8c6
<pre>
[WebGPU] &apos;alias&apos; not supported (<a href="https://www.w3.org/TR/WGSL/#type-aliases)">https://www.w3.org/TR/WGSL/#type-aliases)</a> / error compiling shader opening <a href="https://playground.babylonjs.com/#N96NXC#106">https://playground.babylonjs.com/#N96NXC#106</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=265341">https://bugs.webkit.org/show_bug.cgi?id=265341</a>
<a href="https://rdar.apple.com/118796398">rdar://118796398</a>

Reviewed by Mike Wyrzykowski.

Add support for user-defined type aliases.

* Source/WebGPU/WGSL/AST/AST.h:
* Source/WebGPU/WGSL/AST/ASTStringDumper.cpp:
(WGSL::AST::StringDumper::visit):
* Source/WebGPU/WGSL/AST/ASTStringDumper.h:
* Source/WebGPU/WGSL/AST/ASTTypeAlias.h: Added.
* Source/WebGPU/WGSL/AST/ASTVisitor.cpp:
(WGSL::AST::Visitor::visit):
* Source/WebGPU/WGSL/AST/ASTVisitor.h:
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseDeclaration):
(WGSL::Parser&lt;Lexer&gt;::parseTypeAlias):
* Source/WebGPU/WGSL/ParserPrivate.h:
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
* Source/WebGPU/WGSL/tests/valid/aliases.wgsl:
* Source/WebGPU/WebGPU.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/271876@main">https://commits.webkit.org/271876@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8608422893cb7830b206577614a5e33e4be29d08

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29524 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8191 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30847 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32061 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26754 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10341 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5484 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26756 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29797 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6841 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25225 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5848 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5980 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33405 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26945 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26731 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32203 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5938 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4128 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29992 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7670 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7090 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6477 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6461 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->