### PR TITLE
Update LinkDecorationFilteringObserver/Controller with review feedback

### DIFF
--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h
@@ -50,22 +50,20 @@ void requestLinkDecorationFilteringData(CompletionHandler<void(Vector<WebCore::L
 
 class LinkDecorationFilteringDataObserver : public RefCounted<LinkDecorationFilteringDataObserver>, public CanMakeWeakPtr<LinkDecorationFilteringDataObserver> {
 public:
-    ~LinkDecorationFilteringDataObserver() = default;
-
-private:
-    friend class LinkDecorationFilteringController;
-
-    LinkDecorationFilteringDataObserver(Function<void()>&& callback)
-        : m_callback { WTFMove(callback) }
-    {
-    }
-
     static Ref<LinkDecorationFilteringDataObserver> create(Function<void()>&& callback)
     {
         return adoptRef(*new LinkDecorationFilteringDataObserver(WTFMove(callback)));
     }
 
+    ~LinkDecorationFilteringDataObserver() = default;
+
     void invokeCallback() { m_callback(); }
+
+private:
+    explicit LinkDecorationFilteringDataObserver(Function<void()>&& callback)
+        : m_callback { WTFMove(callback) }
+    {
+    }
 
     Function<void()> m_callback;
 };
@@ -80,7 +78,9 @@ public:
     Ref<LinkDecorationFilteringDataObserver> observeUpdates(Function<void()>&&);
 
 private:
+    friend class NeverDestroyed<LinkDecorationFilteringController, MainThreadAccessTraits>;
     LinkDecorationFilteringController() = default;
+
     void setCachedStrings(Vector<WebCore::LinkDecorationFilteringData>&&);
 
     RetainPtr<WKWebPrivacyNotificationListener> m_notificationListener;


### PR DESCRIPTION
#### 637d7cfc3cdca28c6342dd30a2788e146f10203c
<pre>
Update LinkDecorationFilteringObserver/Controller with review feedback
<a href="https://bugs.webkit.org/show_bug.cgi?id=266076">https://bugs.webkit.org/show_bug.cgi?id=266076</a>
<a href="https://rdar.apple.com/119380680">rdar://119380680</a>

Reviewed by Wenson Hsieh.

I received review feedback on some similar changes that followed how
LinkDecorationObserver/Controller is defined and implemented. This patch makes
the relevant changes that are appropriate for these classes.

We can simplify and reduce duplication in another patch.

* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h:
(WebKit::LinkDecorationFilteringDataObserver::LinkDecorationFilteringDataObserver):
* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm:
(WebKit::LinkDecorationFilteringController::shared):
(WebKit::LinkDecorationFilteringController::observeUpdates):
(WebKit::LinkDecorationFilteringController::updateStrings):

Canonical link: <a href="https://commits.webkit.org/271816@main">https://commits.webkit.org/271816@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/095191d873021b9610731b1550af1ce0a3b142b1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29527 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8194 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30849 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32063 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26756 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10345 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5487 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26758 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29800 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6842 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25224 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5850 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5981 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33407 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26946 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26730 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32204 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5940 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4130 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29978 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7672 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7058 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6479 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6463 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->