### PR TITLE
[css-transitions] add parsing support for the `transition-behavior` property

### DIFF
--- a/LayoutTests/fast/css/shorthand-mismatched-list-crash-expected.txt
+++ b/LayoutTests/fast/css/shorthand-mismatched-list-crash-expected.txt
@@ -1,7 +1,7 @@
 Test for WebKit bug 31559: Crash with mismatched lists and shorthands.
 
-PASS para.style.webkitTransition is "width 1s, left 1s, 1s"
-PASS para.style.webkitTransition is "width 1s, left 1s, top"
+PASS para.style.webkitTransition is "width 1s ease 0s, left 1s ease 0s, all 1s ease 0s"
+PASS para.style.webkitTransition is "width 1s ease 0s, left 1s ease 0s, top 0s ease 0s"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/css/shorthand-mismatched-list-crash.html
+++ b/LayoutTests/fast/css/shorthand-mismatched-list-crash.html
@@ -17,14 +17,14 @@
   para.style.webkitTransition = 'width 1s, left 1s, top 1s';
   para.style.webkitTransitionProperty = 'width, left';
 
-  shouldBeEqualToString("para.style.webkitTransition", "width 1s, left 1s, 1s");
+  shouldBeEqualToString("para.style.webkitTransition", "width 1s ease 0s, left 1s ease 0s, all 1s ease 0s");
 
   // Test shorter shorthand
   para.style.webkitTransition = 'width 1s, left 1s';
   para.style.webkitTransitionProperty = 'width, left, top';
 
   // the next line will crash
-  shouldBeEqualToString("para.style.webkitTransition", "width 1s, left 1s, top");
+  shouldBeEqualToString("para.style.webkitTransition", "width 1s ease 0s, left 1s ease 0s, top 0s ease 0s");
 </script>
 <script src="../../resources/js-test-post.js"></script>
 </body>

--- a/LayoutTests/fast/css/transform-inline-style-expected.txt
+++ b/LayoutTests/fast/css/transform-inline-style-expected.txt
@@ -1,6 +1,6 @@
 Tests reading inline style of transition, and -webkit-transform-origin
 https://bugs.webkit.org/show_bug.cgi?id=22594
 
-style: 1s, left 3s cubic-bezier(0.2, 0.3, 0.6, 0.8) 2s
+style: all 1s ease 0s, left 3s cubic-bezier(0.2, 0.3, 0.6, 0.8) 2s
 style: left 30%
 

--- a/LayoutTests/fast/css/transform-inline-style-remove-expected.txt
+++ b/LayoutTests/fast/css/transform-inline-style-remove-expected.txt
@@ -3,7 +3,7 @@ https://bugs.webkit.org/show_bug.cgi?id=22605
 
 All "after" results should be null/empty
 
-transition (before): 1s, left 3s cubic-bezier(0.2, 0.3, 0.6, 0.8) 2s
+transition (before): all 1s ease 0s, left 3s cubic-bezier(0.2, 0.3, 0.6, 0.8) 2s
 transition property (before): all, left
 transition duration (before): 1s, 3s
 transition timing function (before): ease, cubic-bezier(0.2, 0.3, 0.6, 0.8)

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -346,6 +346,7 @@ PASS transform
 PASS transform-box
 PASS transform-origin
 PASS transform-style
+PASS transition-behavior
 PASS transition-delay
 PASS transition-duration
 PASS transition-property

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt
@@ -331,6 +331,7 @@ PASS transform
 PASS transform-box
 PASS transform-origin
 PASS transform-style
+PASS transition-behavior
 PASS transition-delay
 PASS transition-duration
 PASS transition-property

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-behavior-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-behavior-expected.txt
@@ -1,30 +1,30 @@
 
-FAIL e.style['transition-behavior'] = "normal" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL Property transition-behavior value 'normal' assert_true: transition-behavior doesn't seem to be supported in the computed style expected true got false
-FAIL e.style['transition-behavior'] = "allow-discrete" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL Property transition-behavior value 'allow-discrete' assert_true: transition-behavior doesn't seem to be supported in the computed style expected true got false
-FAIL e.style['transition'] = "allow-discrete display" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL Property transition value 'allow-discrete display' assert_true: 'allow-discrete display' is a supported value for transition. expected true got false
-FAIL e.style['transition'] = "allow-discrete display 3s" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL Property transition value 'allow-discrete display 3s' assert_true: 'allow-discrete display 3s' is a supported value for transition. expected true got false
-FAIL e.style['transition'] = "allow-discrete display 3s 1s" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL Property transition value 'allow-discrete display 3s 1s' assert_true: 'allow-discrete display 3s 1s' is a supported value for transition. expected true got false
-FAIL e.style['transition'] = "allow-discrete display 3s ease-in-out" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL Property transition value 'allow-discrete display 3s ease-in-out' assert_true: 'allow-discrete display 3s ease-in-out' is a supported value for transition. expected true got false
-FAIL e.style['transition'] = "allow-discrete display 3s ease-in-out 1s" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL Property transition value 'allow-discrete display 3s ease-in-out 1s' assert_true: 'allow-discrete display 3s ease-in-out 1s' is a supported value for transition. expected true got false
+PASS e.style['transition-behavior'] = "normal" should set the property value
+PASS Property transition-behavior value 'normal'
+PASS e.style['transition-behavior'] = "allow-discrete" should set the property value
+PASS Property transition-behavior value 'allow-discrete'
+PASS e.style['transition'] = "allow-discrete display" should set the property value
+PASS Property transition value 'allow-discrete display'
+PASS e.style['transition'] = "allow-discrete display 3s" should set the property value
+PASS Property transition value 'allow-discrete display 3s'
+PASS e.style['transition'] = "allow-discrete display 3s 1s" should set the property value
+PASS Property transition value 'allow-discrete display 3s 1s'
+PASS e.style['transition'] = "allow-discrete display 3s ease-in-out" should set the property value
+PASS Property transition value 'allow-discrete display 3s ease-in-out'
+PASS e.style['transition'] = "allow-discrete display 3s ease-in-out 1s" should set the property value
+PASS Property transition value 'allow-discrete display 3s ease-in-out 1s'
 PASS e.style['transition'] = "asdf display" should not set the property value
 PASS e.style['transition'] = "display asdf" should not set the property value
-FAIL e.style['transition'] = "display allow-discrete 3s ease-in-out 1s" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['transition'] = "display 3s allow-discrete ease-in-out 1s" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['transition'] = "display 3s ease-in-out allow-discrete 1s" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['transition'] = "display 3s ease-in-out 1s allow-discrete" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL Property transition value 'display allow-discrete 3s ease-in-out 1s' assert_true: 'display allow-discrete 3s ease-in-out 1s' is a supported value for transition. expected true got false
-FAIL Property transition value 'display 3s allow-discrete ease-in-out 1s' assert_true: 'display 3s allow-discrete ease-in-out 1s' is a supported value for transition. expected true got false
-FAIL Property transition value 'display 3s ease-in-out allow-discrete 1s' assert_true: 'display 3s ease-in-out allow-discrete 1s' is a supported value for transition. expected true got false
-FAIL Property transition value 'display 3s ease-in-out 1s allow-discrete' assert_true: 'display 3s ease-in-out 1s allow-discrete' is a supported value for transition. expected true got false
-FAIL e.style['transition'] = "allow-discrete display, normal opacity, color" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL Property transition value 'allow-discrete display, normal opacity, color' assert_true: 'allow-discrete display, normal opacity, color' is a supported value for transition. expected true got false
-FAIL e.style['transition'] = "normal opacity, color, allow-discrete display" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL Property transition value 'normal opacity, color, allow-discrete display' assert_true: 'normal opacity, color, allow-discrete display' is a supported value for transition. expected true got false
+PASS e.style['transition'] = "display allow-discrete 3s ease-in-out 1s" should set the property value
+PASS e.style['transition'] = "display 3s allow-discrete ease-in-out 1s" should set the property value
+PASS e.style['transition'] = "display 3s ease-in-out allow-discrete 1s" should set the property value
+PASS e.style['transition'] = "display 3s ease-in-out 1s allow-discrete" should set the property value
+PASS Property transition value 'display allow-discrete 3s ease-in-out 1s'
+PASS Property transition value 'display 3s allow-discrete ease-in-out 1s'
+PASS Property transition value 'display 3s ease-in-out allow-discrete 1s'
+PASS Property transition value 'display 3s ease-in-out 1s allow-discrete'
+PASS e.style['transition'] = "allow-discrete display, normal opacity, color" should set the property value
+PASS Property transition value 'allow-discrete display, normal opacity, color'
+PASS e.style['transition'] = "normal opacity, color, allow-discrete display" should set the property value
+PASS Property transition value 'normal opacity, color, allow-discrete display'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-shorthand-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-shorthand-expected.txt
@@ -1,17 +1,17 @@
 
-FAIL e.style['transition'] = "1s -3s cubic-bezier(0, -2, 1, 3) top" should set transition-behavior assert_equals: transition-behavior should be canonical expected (string) "normal" but got (undefined) undefined
+PASS e.style['transition'] = "1s -3s cubic-bezier(0, -2, 1, 3) top" should set transition-behavior
 PASS e.style['transition'] = "1s -3s cubic-bezier(0, -2, 1, 3) top" should set transition-delay
 PASS e.style['transition'] = "1s -3s cubic-bezier(0, -2, 1, 3) top" should set transition-duration
 PASS e.style['transition'] = "1s -3s cubic-bezier(0, -2, 1, 3) top" should set transition-property
 PASS e.style['transition'] = "1s -3s cubic-bezier(0, -2, 1, 3) top" should set transition-timing-function
 PASS e.style['transition'] = "1s -3s cubic-bezier(0, -2, 1, 3) top" should not set unrelated longhands
-FAIL e.style['transition'] = "1s -3s, cubic-bezier(0, -2, 1, 3) top" should set transition-behavior assert_equals: transition-behavior should be canonical expected (string) "normal, normal" but got (undefined) undefined
+PASS e.style['transition'] = "1s -3s, cubic-bezier(0, -2, 1, 3) top" should set transition-behavior
 PASS e.style['transition'] = "1s -3s, cubic-bezier(0, -2, 1, 3) top" should set transition-delay
 PASS e.style['transition'] = "1s -3s, cubic-bezier(0, -2, 1, 3) top" should set transition-duration
 PASS e.style['transition'] = "1s -3s, cubic-bezier(0, -2, 1, 3) top" should set transition-property
 PASS e.style['transition'] = "1s -3s, cubic-bezier(0, -2, 1, 3) top" should set transition-timing-function
 PASS e.style['transition'] = "1s -3s, cubic-bezier(0, -2, 1, 3) top" should not set unrelated longhands
-FAIL e.style['transition'] = "cubic-bezier(0, -2, 1, 3) top, 1s -3s" should set transition-behavior assert_equals: transition-behavior should be canonical expected (string) "normal, normal" but got (undefined) undefined
+PASS e.style['transition'] = "cubic-bezier(0, -2, 1, 3) top, 1s -3s" should set transition-behavior
 PASS e.style['transition'] = "cubic-bezier(0, -2, 1, 3) top, 1s -3s" should set transition-delay
 PASS e.style['transition'] = "cubic-bezier(0, -2, 1, 3) top, 1s -3s" should set transition-duration
 PASS e.style['transition'] = "cubic-bezier(0, -2, 1, 3) top, 1s -3s" should set transition-property

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -346,6 +346,7 @@ PASS transform
 PASS transform-box
 PASS transform-origin
 PASS transform-style
+PASS transition-behavior
 PASS transition-delay
 PASS transition-duration
 PASS transition-property

--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -346,6 +346,7 @@ PASS transform
 PASS transform-box
 PASS transform-origin
 PASS transform-style
+PASS transition-behavior
 PASS transition-delay
 PASS transition-duration
 PASS transition-property

--- a/LayoutTests/platform/ipad/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/ipad/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -345,6 +345,7 @@ PASS transform
 PASS transform-box
 PASS transform-origin
 PASS transform-style
+PASS transition-behavior
 PASS transition-delay
 PASS transition-duration
 PASS transition-property

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -345,6 +345,7 @@ PASS transform
 PASS transform-box
 PASS transform-origin
 PASS transform-style
+PASS transition-behavior
 PASS transition-delay
 PASS transition-duration
 PASS transition-property

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt
@@ -330,6 +330,7 @@ PASS transform
 PASS transform-box
 PASS transform-origin
 PASS transform-style
+PASS transition-behavior
 PASS transition-delay
 PASS transition-duration
 PASS transition-property

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -346,6 +346,7 @@ PASS transform
 PASS transform-box
 PASS transform-origin
 PASS transform-style
+PASS transition-behavior
 PASS transition-delay
 PASS transition-duration
 PASS transition-property

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -4138,6 +4138,7 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         case CSSPropertyTextDecorationSkip:
         case CSSPropertyTextUnderlinePosition:
         case CSSPropertyTransition:
+        case CSSPropertyTransitionBehavior:
         case CSSPropertyTransitionDelay:
         case CSSPropertyTransitionDuration:
         case CSSPropertyTransitionProperty:

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -6012,12 +6012,29 @@
                     "transition-property",
                     "transition-duration",
                     "transition-timing-function",
-                    "transition-delay"
+                    "transition-delay",
+                    "transition-behavior"
                 ]
             },
             "specification": {
                 "category": "css-transitions",
                 "url": "https://www.w3.org/TR/css3-transitions/#transition-shorthand-property"
+            }
+        },
+        "transition-behavior": {
+            "values": [
+                "normal",
+                "allow-discrete"
+            ],
+            "animatable": true,
+            "codegen-properties": {
+                "name-for-methods": "AllowsDiscreteTransitions",
+                "separator": ",",
+                "parser-grammar": "<transition-behavior-value>#"
+            },
+            "specification": {
+                "category": "css-transitions",
+                "url": "https://drafts.csswg.org/css-transitions-2/#transition-behavior-property"
             }
         },
         "transition-delay": {
@@ -10661,6 +10678,14 @@
             "specification": {
                 "category": "css-animations",
                 "url": "https://www.w3.org/TR/css-animations-1/#typedef-single-animation-play-state"
+            }
+        },
+        "<transition-behavior-value>": {
+            "grammar": "normal | allow-discrete",
+            "exported": true,
+            "specification": {
+                "category": "css-transitions",
+                "url": "https://drafts.csswg.org/css-transitions-2/#typedef-transition-behavior-value"
             }
         },
         "<page-size>": {

--- a/Source/WebCore/css/CSSToStyleMap.cpp
+++ b/Source/WebCore/css/CSSToStyleMap.cpp
@@ -489,6 +489,14 @@ void CSSToStyleMap::mapAnimationCompositeOperation(Animation& animation, const C
         animation.setCompositeOperation(*compositeOperation);
 }
 
+void CSSToStyleMap::mapAnimationAllowsDiscreteTransitions(Animation& layer, const CSSValue& value)
+{
+    if (treatAsInitialValue(value, CSSPropertyTransitionBehavior))
+        layer.setAllowsDiscreteTransitions(Animation::initialAllowsDiscreteTransitions());
+    else if (is<CSSPrimitiveValue>(value))
+        layer.setAllowsDiscreteTransitions(value.valueID() == CSSValueAllowDiscrete);
+}
+
 void CSSToStyleMap::mapNinePieceImage(const CSSValue* value, NinePieceImage& image)
 {
     // If we're not a value list, then we are "none" and don't need to alter the empty image at all.

--- a/Source/WebCore/css/CSSToStyleMap.h
+++ b/Source/WebCore/css/CSSToStyleMap.h
@@ -71,6 +71,7 @@ public:
     static void mapAnimationTimeline(Animation&, const CSSValue&);
     static void mapAnimationTimingFunction(Animation&, const CSSValue&);
     static void mapAnimationCompositeOperation(Animation&, const CSSValue&);
+    static void mapAnimationAllowsDiscreteTransitions(Animation&, const CSSValue&);
 
     void mapNinePieceImage(const CSSValue*, NinePieceImage&);
     static void mapNinePieceImageSlice(const CSSValue&, NinePieceImage&);

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -1744,3 +1744,7 @@ no-autospace
 // auto
 // stable
 both-edges
+
+// transition-behavior
+// normal
+allow-discrete

--- a/Source/WebCore/css/ComputedStyleExtractor.h
+++ b/Source/WebCore/css/ComputedStyleExtractor.h
@@ -81,8 +81,6 @@ public:
 
     static Ref<CSSPrimitiveValue> currentColorOrValidColor(const RenderStyle&, const StyleColor&);
 
-    static void addValueForAnimationPropertyToList(CSSValueListBuilder&, CSSPropertyID, const Animation*);
-
     static bool updateStyleIfNeededForProperty(Element&, CSSPropertyID);
 
 private:

--- a/Source/WebCore/css/ShorthandSerializer.cpp
+++ b/Source/WebCore/css/ShorthandSerializer.cpp
@@ -641,6 +641,13 @@ String ShorthandSerializer::serializeLayered() const
         for (unsigned j = 0; j < length(); j++) {
             auto longhand = longhandProperty(j);
 
+            // We always want to force the serialization of the transition longhands,
+            // except for transition-behavior which should only serialize if non-default.
+            if (m_shorthand.id() == CSSPropertyTransition) {
+                if (longhand != CSSPropertyTransitionBehavior)
+                    layerValues.skip(j) = false;
+            }
+
             // A single box value sets both background-origin and background-clip.
             // A single geometry-box value sets both mask-origin and mask-clip.
             // A single geometry-box value sets both mask-origin and -webkit-mask-clip.

--- a/Source/WebCore/css/StylePropertyShorthand.cpp
+++ b/Source/WebCore/css/StylePropertyShorthand.cpp
@@ -31,7 +31,7 @@ StylePropertyShorthand transitionShorthandForParsing()
     // duration.
     static const CSSPropertyID transitionProperties[] = {
         CSSPropertyTransitionDuration, CSSPropertyTransitionTimingFunction,
-        CSSPropertyTransitionDelay, CSSPropertyTransitionProperty};
+        CSSPropertyTransitionDelay, CSSPropertyTransitionBehavior, CSSPropertyTransitionProperty };
     return StylePropertyShorthand(CSSPropertyTransition, transitionProperties);
 }
 

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -968,6 +968,7 @@ static constexpr InitialValue initialValueForLonghand(CSSPropertyID longhand)
     case CSSPropertyScrollSnapStop:
     case CSSPropertySpeakAs:
     case CSSPropertyTextBoxTrim:
+    case CSSPropertyTransitionBehavior:
     case CSSPropertyWordBreak:
     case CSSPropertyWordSpacing:
 #if ENABLE(VARIATION_FONTS)
@@ -1722,6 +1723,8 @@ static RefPtr<CSSValue> consumeAnimationValueForShorthand(CSSPropertyID property
     case CSSPropertyAnimationTimingFunction:
     case CSSPropertyTransitionTimingFunction:
         return consumeTimingFunction(range, context);
+    case CSSPropertyTransitionBehavior:
+        return CSSPropertyParsing::consumeTransitionBehaviorValue(range);
     default:
         ASSERT_NOT_REACHED();
         return nullptr;

--- a/Source/WebCore/platform/animation/Animation.cpp
+++ b/Source/WebCore/platform/animation/Animation.cpp
@@ -40,6 +40,7 @@ Animation::Animation()
     , m_fillMode(static_cast<unsigned>(initialFillMode()))
     , m_playState(static_cast<unsigned>(initialPlayState()))
     , m_compositeOperation(static_cast<unsigned>(initialCompositeOperation()))
+    , m_allowsDiscreteTransitions(initialAllowsDiscreteTransitions())
     , m_delaySet(false)
     , m_directionSet(false)
     , m_durationSet(false)
@@ -51,6 +52,7 @@ Animation::Animation()
     , m_timelineSet(false)
     , m_timingFunctionSet(false)
     , m_compositeOperationSet(false)
+    , m_allowsDiscreteTransitionsSet(false)
     , m_isNone(false)
     , m_delayFilled(false)
     , m_directionFilled(false)
@@ -62,6 +64,7 @@ Animation::Animation()
     , m_timelineFilled(false)
     , m_timingFunctionFilled(false)
     , m_compositeOperationFilled(false)
+    , m_allowsDiscreteTransitionsFilled(false)
 {
 }
 
@@ -78,6 +81,7 @@ Animation::Animation(const Animation& o)
     , m_fillMode(o.m_fillMode)
     , m_playState(o.m_playState)
     , m_compositeOperation(o.m_compositeOperation)
+    , m_allowsDiscreteTransitions(o.m_allowsDiscreteTransitions)
     , m_delaySet(o.m_delaySet)
     , m_directionSet(o.m_directionSet)
     , m_durationSet(o.m_durationSet)
@@ -89,6 +93,7 @@ Animation::Animation(const Animation& o)
     , m_timelineSet(o.m_timelineSet)
     , m_timingFunctionSet(o.m_timingFunctionSet)
     , m_compositeOperationSet(o.m_compositeOperationSet)
+    , m_allowsDiscreteTransitionsSet(o.m_allowsDiscreteTransitionsSet)
     , m_isNone(o.m_isNone)
     , m_delayFilled(o.m_delayFilled)
     , m_directionFilled(o.m_directionFilled)
@@ -100,6 +105,7 @@ Animation::Animation(const Animation& o)
     , m_timelineFilled(o.m_timelineFilled)
     , m_timingFunctionFilled(o.m_timingFunctionFilled)
     , m_compositeOperationFilled(o.m_compositeOperationFilled)
+    , m_allowsDiscreteTransitionsFilled(o.m_allowsDiscreteTransitionsFilled)
 {
 }
 
@@ -110,6 +116,7 @@ bool Animation::animationsMatch(const Animation& other, bool matchProperties) co
     bool result = m_name == other.m_name
         && m_playState == other.m_playState
         && m_compositeOperation == other.m_compositeOperation
+        && m_allowsDiscreteTransitions == other.m_allowsDiscreteTransitions
         && m_playStateSet == other.m_playStateSet
         && m_iterationCount == other.m_iterationCount
         && m_delay == other.m_delay
@@ -127,6 +134,7 @@ bool Animation::animationsMatch(const Animation& other, bool matchProperties) co
         && m_timelineSet == other.m_timelineSet
         && m_timingFunctionSet == other.m_timingFunctionSet
         && m_compositeOperationSet == other.m_compositeOperationSet
+        && m_allowsDiscreteTransitionsSet == other.m_allowsDiscreteTransitionsSet
         && m_isNone == other.m_isNone;
 
     if (!result)

--- a/Source/WebCore/platform/animation/Animation.h
+++ b/Source/WebCore/platform/animation/Animation.h
@@ -52,6 +52,7 @@ public:
     bool isTimelineSet() const { return m_timelineSet; }
     bool isTimingFunctionSet() const { return m_timingFunctionSet; }
     bool isCompositeOperationSet() const { return m_compositeOperationSet; }
+    bool isAllowsDiscreteTransitionsSet() const { return m_allowsDiscreteTransitionsSet; }
 
     // Flags this to be the special "none" animation (animation-name: none)
     bool isNoneAnimation() const { return m_isNone; }
@@ -65,7 +66,8 @@ public:
         return !m_directionSet && !m_durationSet && !m_fillModeSet
             && !m_nameSet && !m_playStateSet && !m_iterationCountSet
             && !m_delaySet && !m_timingFunctionSet && !m_propertySet
-            && !m_isNone && !m_compositeOperationSet && !m_timelineSet;
+            && !m_isNone && !m_compositeOperationSet && !m_timelineSet
+            && !m_allowsDiscreteTransitionsSet;
     }
 
     bool isEmptyOrZeroDuration() const
@@ -84,6 +86,7 @@ public:
     void clearTimeline() { m_timelineSet = false; m_timelineFilled = false; }
     void clearTimingFunction() { m_timingFunctionSet = false; m_timingFunctionFilled = false; }
     void clearCompositeOperation() { m_compositeOperationSet = false; m_compositeOperationFilled = false; }
+    void clearAllowsDiscreteTransitions() { m_allowsDiscreteTransitionsSet = false; m_allowsDiscreteTransitionsFilled = false; }
 
     void clearAll()
     {
@@ -98,6 +101,7 @@ public:
         clearTimeline();
         clearTimingFunction();
         clearCompositeOperation();
+        clearAllowsDiscreteTransitions();
     }
 
     double delay() const { return m_delay; }
@@ -170,6 +174,7 @@ public:
     void fillTimeline(Timeline timeline) { setTimeline(timeline); m_timelineFilled = true; }
     void fillTimingFunction(RefPtr<TimingFunction>&& timingFunction) { setTimingFunction(WTFMove(timingFunction)); m_timingFunctionFilled = true; }
     void fillCompositeOperation(CompositeOperation compositeOperation) { setCompositeOperation(compositeOperation); m_compositeOperationFilled = true; }
+    void fillAllowsDiscreteTransitions(bool allowsDiscreteTransitionsFilled) { setAllowsDiscreteTransitions(allowsDiscreteTransitionsFilled); m_allowsDiscreteTransitionsFilled = true; }
 
     bool isDelayFilled() const { return m_delayFilled; }
     bool isDirectionFilled() const { return m_directionFilled; }
@@ -181,11 +186,12 @@ public:
     bool isTimelineFilled() const { return m_timelineFilled; }
     bool isTimingFunctionFilled() const { return m_timingFunctionFilled; }
     bool isCompositeOperationFilled() const { return m_compositeOperationFilled; }
+    bool isAllowsDiscreteTransitionsFilled() const { return m_allowsDiscreteTransitionsFilled; }
 
     // return true if all members of this class match (excluding m_next)
     bool animationsMatch(const Animation&, bool matchProperties = true) const;
 
-    // return true every Animation in the chain (defined by m_next) match 
+    // return true every Animation in the chain (defined by m_next) match
     bool operator==(const Animation& o) const { return animationsMatch(o); }
 
     bool fillsBackwards() const { return m_fillModeSet && (fillMode() == AnimationFillMode::Backwards || fillMode() == AnimationFillMode::Both); }
@@ -194,10 +200,13 @@ public:
     CompositeOperation compositeOperation() const { return static_cast<CompositeOperation>(m_compositeOperation); }
     void setCompositeOperation(CompositeOperation op) { m_compositeOperation = static_cast<unsigned>(op); m_compositeOperationSet = true; }
 
+    void setAllowsDiscreteTransitions(bool allowsDiscreteTransitions) { m_allowsDiscreteTransitions = allowsDiscreteTransitions; m_allowsDiscreteTransitionsSet = true; }
+    bool allowsDiscreteTransitions() const { return m_allowsDiscreteTransitions; }
+
 private:
     WEBCORE_EXPORT Animation();
     Animation(const Animation&);
-    
+
     // Packs with m_refCount from the base class.
     TransitionProperty m_property { TransitionMode::All, CSSPropertyInvalid };
 
@@ -214,6 +223,7 @@ private:
     unsigned m_fillMode : 2; // AnimationFillMode
     unsigned m_playState : 2; // AnimationPlayState
     unsigned m_compositeOperation : 2; // CompositeOperation
+    bool m_allowsDiscreteTransitions : 1;
 
     bool m_delaySet : 1;
     bool m_directionSet : 1;
@@ -226,6 +236,7 @@ private:
     bool m_timelineSet : 1;
     bool m_timingFunctionSet : 1;
     bool m_compositeOperationSet : 1;
+    bool m_allowsDiscreteTransitionsSet : 1;
 
     bool m_isNone : 1;
 
@@ -239,6 +250,7 @@ private:
     bool m_timelineFilled : 1;
     bool m_timingFunctionFilled : 1;
     bool m_compositeOperationFilled : 1;
+    bool m_allowsDiscreteTransitionsFilled : 1;
 
 public:
     static double initialDelay() { return 0; }
@@ -252,6 +264,7 @@ public:
     static TransitionProperty initialProperty() { return { TransitionMode::All, CSSPropertyInvalid }; }
     static Timeline initialTimeline() { return TimelineKeyword::Auto; }
     static Ref<TimingFunction> initialTimingFunction() { return CubicBezierTimingFunction::create(); }
+    static bool initialAllowsDiscreteTransitions() { return false; }
 };
 
 WTF::TextStream& operator<<(WTF::TextStream&, AnimationPlayState);

--- a/Source/WebCore/platform/animation/AnimationList.cpp
+++ b/Source/WebCore/platform/animation/AnimationList.cpp
@@ -59,6 +59,7 @@ void AnimationList::fillUnsetProperties()
     FILL_UNSET_PROPERTY(isTimingFunctionSet, timingFunction, fillTimingFunction);
     FILL_UNSET_PROPERTY(isPropertySet, property, fillProperty);
     FILL_UNSET_PROPERTY(isCompositeOperationSet, compositeOperation, fillCompositeOperation);
+    FILL_UNSET_PROPERTY(isAllowsDiscreteTransitionsSet, allowsDiscreteTransitions, fillAllowsDiscreteTransitions);
 }
 
 bool AnimationList::operator==(const AnimationList& other) const

--- a/Source/WebCore/style/PropertyAllowlist.cpp
+++ b/Source/WebCore/style/PropertyAllowlist.cpp
@@ -99,6 +99,7 @@ bool isValidMarkerStyleProperty(CSSPropertyID id)
     case CSSPropertyAnimationPlayState:
     case CSSPropertyAnimationComposition:
     case CSSPropertyAnimationName:
+    case CSSPropertyTransitionBehavior:
     case CSSPropertyTransitionDuration:
     case CSSPropertyTransitionTimingFunction:
     case CSSPropertyTransitionDelay:


### PR DESCRIPTION
#### a0f7f0bc002c88904ebd534d3daa2d12d92c1545
<pre>
[css-transitions] add parsing support for the `transition-behavior` property
<a href="https://bugs.webkit.org/show_bug.cgi?id=266071">https://bugs.webkit.org/show_bug.cgi?id=266071</a>
<a href="https://rdar.apple.com/119378989">rdar://119378989</a>

Reviewed by Tim Nguyen.

We add parsing support for the new `transition-behavior` property which we represent as a simple
boolean on the backing Animation object created for each group of `transition-` properties.

We make adjustments in this patch to always serialize the previously-existing `transition-`
properties for the `transition` shorthand to pass the tests in the existing WPT tests. The
new `transition-behavior` property is handled differently where it only gets serialized if
it cannot be omitted.

An issue was filed to see if the relevant tests are indeed correct: <a href="https://github.com/web-platform-tests/wpt/issues/43574.">https://github.com/web-platform-tests/wpt/issues/43574.</a>

* LayoutTests/fast/css/shorthand-mismatched-list-crash-expected.txt:
* LayoutTests/fast/css/shorthand-mismatched-list-crash.html:
* LayoutTests/fast/css/transform-inline-style-expected.txt:
* LayoutTests/fast/css/transform-inline-style-remove-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-behavior-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-shorthand-expected.txt:
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/ipad/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap):
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/CSSToStyleMap.cpp:
(WebCore::CSSToStyleMap::mapAnimationAllowsDiscreteTransitions):
* Source/WebCore/css/CSSToStyleMap.h:
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::valueForTransitionBehavior):
(WebCore::addValueForAnimationPropertyToList):
(WebCore::valueListForAnimationOrTransitionProperty):
(WebCore::animationShorthandValue):
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle const):
(WebCore::ComputedStyleExtractor::addValueForAnimationPropertyToList): Deleted.
* Source/WebCore/css/ComputedStyleExtractor.h:
* Source/WebCore/css/ShorthandSerializer.cpp:
(WebCore::ShorthandSerializer::serializeLayered const):
* Source/WebCore/css/StylePropertyShorthand.cpp:
(WebCore::transitionShorthandForParsing):
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::initialValueForLonghand):
(WebCore::consumeAnimationValueForShorthand):
* Source/WebCore/platform/animation/Animation.cpp:
(WebCore::Animation::Animation):
(WebCore::Animation::animationsMatch const):
* Source/WebCore/platform/animation/Animation.h:
(WebCore::Animation::isAllowsDiscreteTransitionsSet const):
(WebCore::Animation::isEmpty const):
(WebCore::Animation::clearAllowsDiscreteTransitions):
(WebCore::Animation::clearAll):
(WebCore::Animation::fillAllowsDiscreteTransitions):
(WebCore::Animation::isAllowsDiscreteTransitionsFilled const):
(WebCore::Animation::setAllowsDiscreteTransitions):
(WebCore::Animation::allowsDiscreteTransitions const):
(WebCore::Animation::initialAllowsDiscreteTransitions):
* Source/WebCore/platform/animation/AnimationList.cpp:
(WebCore::AnimationList::fillUnsetProperties):
* Source/WebCore/style/PropertyAllowlist.cpp:
(WebCore::Style::isValidMarkerStyleProperty):

Canonical link: <a href="https://commits.webkit.org/271759@main">https://commits.webkit.org/271759@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab831b6bc72e96d0960dc25d9fc326339545b8ee

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29576 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8237 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30889 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32094 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/26782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30179 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10390 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5530 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29849 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6879 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/25255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5878 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/6011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26343 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33438 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/26979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/26763 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/32238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/5966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4157 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/30015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7702 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/26144 "Passed tests") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6508 "Failed to checkout and rebase branch from PR 21515") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3805 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/6489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->