### PR TITLE
Fix file-url based tests not working with runInCrossOriginIFrame

### DIFF
--- a/Tools/Scripts/webkitpy/layout_tests/servers/aliases.json
+++ b/Tools/Scripts/webkitpy/layout_tests/servers/aliases.json
@@ -4,5 +4,6 @@
     ["/modern-media-controls", "../Source/WebCore/Modules/modern-media-controls"],
     ["/resources/testharness.css", "resources/testharness.css"],
     ["/resources/testharness.js", "resources/testharness.js"],
-    ["/resources/testharnessreport.js", "resources/testharnessreport.js"]
+    ["/resources/testharnessreport.js", "resources/testharnessreport.js"],
+    ["/root", "."]
 ]

--- a/Tools/Scripts/webkitpy/port/driver_unittest.py
+++ b/Tools/Scripts/webkitpy/port/driver_unittest.py
@@ -31,7 +31,7 @@ import optparse
 
 from webkitpy.common.system.systemhost_mock import MockSystemHost
 
-from webkitpy.port import Port, Driver, DriverOutput
+from webkitpy.port import Port, Driver, DriverInput, DriverOutput
 from webkitpy.port.server_process_mock import MockServerProcess
 from webkitpy.thirdparty.mock import patch
 
@@ -115,13 +115,15 @@ class DriverTest(unittest.TestCase):
     def test_test_to_uri(self):
         port = self.make_port()
         driver = Driver(port, None, pixel_tests=False)
-        self.assertEqual(driver.test_to_uri('foo/bar.html'), 'file://%s/foo/bar.html' % port.layout_tests_dir())
-        self.assertEqual(driver.test_to_uri('http/tests/foo.html'), 'http://127.0.0.1:8000/foo.html')
-        self.assertEqual(driver.test_to_uri('http/tests/ssl/bar.html'), 'https://127.0.0.1:8443/ssl/bar.html')
-        self.assertEqual(driver.test_to_uri('imported/w3c/web-platform-tests/foo/bar.html'), 'http://localhost:8800/foo/bar.html')
-        self.assertEqual(driver.test_to_uri('imported/w3c/web-platform-tests/foo/bar.https.html'), 'https://localhost:9443/foo/bar.https.html')
-        self.assertEqual(driver.test_to_uri('http/wpt/bar2.html'), 'http://localhost:8800/WebKit/bar2.html')
-        self.assertEqual(driver.test_to_uri('http/wpt/bar2.https.html'), 'https://localhost:9443/WebKit/bar2.https.html')
+
+        self.assertEqual(driver.test_to_uri(DriverInput('foo/bar.html', 1000, None, None)), 'file://%s/foo/bar.html' % port.layout_tests_dir())
+        self.assertEqual(driver.test_to_uri(DriverInput('foo/bar.html', 1000, None, None, self_comparison_header='runInCrossOriginIFrame=true')), 'http://127.0.0.1:8000/root/foo/bar.html')
+        self.assertEqual(driver.test_to_uri(DriverInput('http/tests/foo.html', 1000, None, None)), 'http://127.0.0.1:8000/foo.html')
+        self.assertEqual(driver.test_to_uri(DriverInput('http/tests/ssl/bar.html', 1000, None, None)), 'https://127.0.0.1:8443/ssl/bar.html')
+        self.assertEqual(driver.test_to_uri(DriverInput('imported/w3c/web-platform-tests/foo/bar.html', 1000, None, None)), 'http://localhost:8800/foo/bar.html')
+        self.assertEqual(driver.test_to_uri(DriverInput('imported/w3c/web-platform-tests/foo/bar.https.html', 1000, None, None)), 'https://localhost:9443/foo/bar.https.html')
+        self.assertEqual(driver.test_to_uri(DriverInput('http/wpt/bar2.html', 1000, None, None)), 'http://localhost:8800/WebKit/bar2.html')
+        self.assertEqual(driver.test_to_uri(DriverInput('http/wpt/bar2.https.html', 1000, None, None)), 'https://localhost:9443/WebKit/bar2.https.html')
 
     def test_uri_to_test(self):
         port = self.make_port()
@@ -133,6 +135,7 @@ class DriverTest(unittest.TestCase):
         self.assertEqual(driver.uri_to_test('http://localhost:8800/foo/bar.html'), 'imported/w3c/web-platform-tests/foo/bar.html')
         self.assertEqual(driver.uri_to_test('http://localhost:8800/WebKit/bar2.html'), 'http/wpt/bar2.html')
         self.assertEqual(driver.uri_to_test('https://localhost:9443/WebKit/bar2.https.html'), 'http/wpt/bar2.https.html')
+        self.assertEqual(driver.uri_to_test('http://127.0.0.1:8000/root/foo/bar.html'), 'foo/bar.html')
 
     def test_read_block(self):
         port = TestWebKitPort()


### PR DESCRIPTION
#### 3a9c4b78c818661e34cd0afa76f07faef656a52d
<pre>
Fix file-url based tests not working with runInCrossOriginIFrame
<a href="https://bugs.webkit.org/show_bug.cgi?id=265985">https://bugs.webkit.org/show_bug.cgi?id=265985</a>
<a href="https://rdar.apple.com/119300316">rdar://119300316</a>

Reviewed by Alex Christensen.

runInCrossOriginIFrame doesn&apos;t work with file:/// based tests as they
can&apos;t be loaded in an i-frame. This change instead runs those tests
via http whenever this option is enabled by using a new alias to the
root of the LayoutTests directory.

* Tools/Scripts/webkitpy/layout_tests/servers/aliases.json:
* Tools/Scripts/webkitpy/port/driver.py:
(Driver.is_http_test):
(Driver.test_to_uri):
(Driver.uri_to_test):
(Driver._command_from_driver_input):
(DriverProxy.is_http_test):
(DriverProxy.test_to_uri):

Canonical link: <a href="https://commits.webkit.org/272281@main">https://commits.webkit.org/272281@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e2cdfcb1f16a9f07da3187a929708834ccd3028f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31235 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/9909 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32929 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33741 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/28346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32002 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/12255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7166 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/27996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31572 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/8357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/27910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/7170 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/6/builds/31403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/7350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/27805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35082 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/28424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/28262 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/33479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/7395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/5446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/31317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/9074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/8095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4053 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/7921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->