### PR TITLE
Generate serialization of audit_token_t

### DIFF
--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -207,6 +207,7 @@ $(PROJECT_DIR)/Shared/CallbackID.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CacheStoragePolicy.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCAVOutputContext.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCArray.serialization.in
+$(PROJECT_DIR)/Shared/Cocoa/CoreIPCAuditToken.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCCFType.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCColor.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCDDActionContext.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -526,6 +526,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/Cocoa/CacheStoragePolicy.serialization.in \
 	Shared/Cocoa/CoreIPCAVOutputContext.serialization.in \
 	Shared/Cocoa/CoreIPCArray.serialization.in \
+	Shared/Cocoa/CoreIPCAuditToken.serialization.in \
 	Shared/Cocoa/CoreIPCCFType.serialization.in \
 	Shared/Cocoa/CoreIPCColor.serialization.in \
 	Shared/Cocoa/CoreIPCDDActionContext.serialization.in \

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -276,7 +276,7 @@ GPUConnectionToWebProcess::GPUConnectionToWebProcess(GPUProcess& gpuProcess, Web
     , m_libWebRTCCodecsProxy(LibWebRTCCodecsProxy::create(*this))
 #endif
 #if HAVE(AUDIT_TOKEN)
-    , m_presentingApplicationAuditToken(WTFMove(parameters.presentingApplicationAuditToken))
+    , m_presentingApplicationAuditToken(parameters.presentingApplicationAuditToken ? std::optional(parameters.presentingApplicationAuditToken->auditToken()) : std::nullopt)
 #endif
     , m_isLockdownModeEnabled(parameters.isLockdownModeEnabled)
 #if ENABLE(ROUTING_ARBITRATION) && HAVE(AVAUDIO_ROUTING_ARBITER)

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -105,6 +105,7 @@ class WebSWServerToContextConnection;
 class WebSharedWorkerServerConnection;
 class WebSharedWorkerServerToContextConnection;
 
+struct CoreIPCAuditToken;
 struct NetworkProcessConnectionParameters;
 struct WebTransportSessionIdentifierType;
 
@@ -317,8 +318,8 @@ private:
     void setCORSDisablingPatterns(WebCore::PageIdentifier, Vector<String>&&);
 
 #if PLATFORM(MAC)
-    void updateActivePages(const String& name, const Vector<String>& activePagesOrigins, audit_token_t);
-    void getProcessDisplayName(audit_token_t, CompletionHandler<void(const String&)>&&);
+    void updateActivePages(const String& name, const Vector<String>& activePagesOrigins, CoreIPCAuditToken&&);
+    void getProcessDisplayName(CoreIPCAuditToken&&, CompletionHandler<void(const String&)>&&);
 #endif
 
 #if USE(LIBWEBRTC)

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
@@ -107,8 +107,8 @@ messages -> NetworkConnectionToWebProcess LegacyReceiver {
     RegisterURLSchemesAsCORSEnabled(Vector<String> schemes);
     SetCORSDisablingPatterns(WebCore::PageIdentifier pageIdentifier, Vector<String> patterns)
 #if PLATFORM(MAC)
-    GetProcessDisplayName(audit_token_t auditToken) -> (String displayName)
-    UpdateActivePages(String name, Vector<String> activePagesOrigins, audit_token_t auditToken)
+    GetProcessDisplayName(struct WebKit::CoreIPCAuditToken auditToken) -> (String displayName)
+    UpdateActivePages(String name, Vector<String> activePagesOrigins, struct WebKit::CoreIPCAuditToken auditToken)
 #endif
     SetResourceLoadSchedulingMode(WebCore::PageIdentifier webPageID, enum:uint8_t WebCore::LoadSchedulingMode mode)
     PrioritizeResourceLoads(Vector<WebCore::ResourceLoaderIdentifier> loadIdentifiers)

--- a/Source/WebKit/Platform/IPC/ArgumentCoders.cpp
+++ b/Source/WebKit/Platform/IPC/ArgumentCoders.cpp
@@ -155,23 +155,4 @@ void ArgumentCoder<StringView>::encode<Encoder>(Encoder&, StringView);
 template
 void ArgumentCoder<StringView>::encode<StreamConnectionEncoder>(StreamConnectionEncoder&, StringView);
 
-#if HAVE(AUDIT_TOKEN)
-
-void ArgumentCoder<audit_token_t>::encode(Encoder& encoder, const audit_token_t& auditToken)
-{
-    for (unsigned i = 0; i < std::size(auditToken.val); i++)
-        encoder << auditToken.val[i];
-}
-
-WARN_UNUSED_RETURN bool ArgumentCoder<audit_token_t>::decode(Decoder& decoder, audit_token_t& auditToken)
-{
-    for (unsigned i = 0; i < std::size(auditToken.val); i++) {
-        if (!decoder.decode(auditToken.val[i]))
-            return false;
-    }
-    return true;
-}
-
-#endif // HAVE(AUDIT_TOKEN)
-
 } // namespace IPC

--- a/Source/WebKit/Shared/Cocoa/CoreIPCAuditToken.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCAuditToken.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,17 +25,28 @@
 
 #pragma once
 
-#include <wtf/ArgumentCoder.h>
+#include <array>
+#include <mach/mach.h>
 
-namespace WTF {
-class MachSendRight;
-}
+namespace WebKit {
 
-namespace IPC {
+struct CoreIPCAuditToken {
+    CoreIPCAuditToken(audit_token_t input)
+    {
+        memcpy(token.data(), &input, sizeof(token));
+    }
+    CoreIPCAuditToken(std::array<int, 8> token)
+        : token(token) { }
 
-template<> struct ArgumentCoder<WTF::MachSendRight> {
-    static void encode(Encoder&, WTF::MachSendRight&&);
-    static std::optional<WTF::MachSendRight> decode(Decoder&);
+    audit_token_t auditToken() const
+    {
+        audit_token_t result;
+        memcpy(&result, token.data(), sizeof(token));
+        return result;
+    }
+
+    std::array<int, 8> token;
+    static_assert(sizeof(token) == sizeof(audit_token_t));
 };
 
-}
+} // namespace WebKit

--- a/Source/WebKit/Shared/Cocoa/CoreIPCAuditToken.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCAuditToken.serialization.in
@@ -20,10 +20,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-[RValue] struct WebKit::NetworkProcessConnectionInfo {
-    IPC::Connection::Handle connection;
-    WebCore::HTTPCookieAcceptPolicy cookieAcceptPolicy;
-#if HAVE(AUDIT_TOKEN)
-    std::optional<WebKit::CoreIPCAuditToken> auditToken;
-#endif
-};
+struct WebKit::CoreIPCAuditToken {
+    std::array<int, 8> token
+}

--- a/Source/WebKit/Shared/GPUProcessConnectionParameters.h
+++ b/Source/WebKit/Shared/GPUProcessConnectionParameters.h
@@ -32,6 +32,10 @@
 #include <WebCore/ProcessIdentity.h>
 #include <wtf/MachSendRight.h>
 
+#if HAVE(AUDIT_TOKEN)
+#include "CoreIPCAuditToken.h"
+#endif
+
 namespace WebKit {
 
 struct GPUProcessConnectionParameters {
@@ -42,7 +46,7 @@ struct GPUProcessConnectionParameters {
     bool ignoreInvalidMessageForTesting { false };
 #endif
 #if HAVE(AUDIT_TOKEN)
-    std::optional<audit_token_t> presentingApplicationAuditToken;
+    std::optional<CoreIPCAuditToken> presentingApplicationAuditToken;
 #endif
 #if ENABLE(VP9)
     std::optional<bool> hasVP9HardwareDecoder;

--- a/Source/WebKit/Shared/GPUProcessConnectionParameters.serialization.in
+++ b/Source/WebKit/Shared/GPUProcessConnectionParameters.serialization.in
@@ -30,7 +30,7 @@
     bool ignoreInvalidMessageForTesting;
 #endif
 #if HAVE(AUDIT_TOKEN)
-    std::optional<audit_token_t> presentingApplicationAuditToken;
+    std::optional<WebKit::CoreIPCAuditToken> presentingApplicationAuditToken;
 #endif
 #if ENABLE(VP9)
     std::optional<bool> hasVP9HardwareDecoder;

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm
@@ -28,6 +28,7 @@
 
 #import "AccessibilitySupportSPI.h"
 #import "CodeSigning.h"
+#import "CoreIPCAuditToken.h"
 #import "DefaultWebBrowserChecks.h"
 #import "HighPerformanceGPUManager.h"
 #import "Logging.h"
@@ -246,9 +247,9 @@ void WebProcessProxy::unblockAccessibilityServerIfNeeded()
 }
 
 #if PLATFORM(MAC)
-void WebProcessProxy::isAXAuthenticated(audit_token_t auditToken, CompletionHandler<void(bool)>&& completionHandler)
+void WebProcessProxy::isAXAuthenticated(CoreIPCAuditToken&& auditToken, CompletionHandler<void(bool)>&& completionHandler)
 {
-    auto authenticated = TCCAccessCheckAuditToken(get_TCC_kTCCServiceAccessibility(), auditToken, nullptr);
+    auto authenticated = TCCAccessCheckAuditToken(get_TCC_kTCCServiceAccessibility(), auditToken.auditToken(), nullptr);
     completionHandler(authenticated);
 }
 #endif

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -113,6 +113,7 @@ class WebProcessPool;
 class WebUserContentControllerProxy;
 class WebsiteDataStore;
 struct BackForwardListItemState;
+struct CoreIPCAuditToken;
 struct GPUProcessConnectionParameters;
 struct UserMessage;
 struct WebNavigationDataStore;
@@ -597,7 +598,7 @@ private:
     void systemBeep();
     
 #if PLATFORM(MAC)
-    void isAXAuthenticated(audit_token_t, CompletionHandler<void(bool)>&&);
+    void isAXAuthenticated(CoreIPCAuditToken&&, CompletionHandler<void(bool)>&&);
 #endif
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/UIProcess/WebProcessProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebProcessProxy.messages.in
@@ -76,7 +76,7 @@ messages -> WebProcessProxy LegacyReceiver {
     SystemBeep()
     
 #if PLATFORM(MAC)
-    IsAXAuthenticated(audit_token_t auditToken) -> (bool authenticated) Synchronous
+    IsAXAuthenticated(struct WebKit::CoreIPCAuditToken auditToken) -> (bool authenticated) Synchronous
 #endif
 
 #if HAVE(MEDIA_ACCESSIBILITY_FRAMEWORK)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2425,6 +2425,7 @@
 		F6113E25126CE1820057D0A7 /* APIUserContentURLPattern.h in Headers */ = {isa = PBXBuildFile; fileRef = F6113E24126CE1820057D0A7 /* APIUserContentURLPattern.h */; };
 		F6113E29126CE19B0057D0A7 /* WKUserContentURLPattern.h in Headers */ = {isa = PBXBuildFile; fileRef = F6113E27126CE19B0057D0A7 /* WKUserContentURLPattern.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F634445612A885C8000612D8 /* APISecurityOrigin.h in Headers */ = {isa = PBXBuildFile; fileRef = F634445512A885C8000612D8 /* APISecurityOrigin.h */; };
+		FA39AE682B23972B008F93CD /* CoreIPCAuditToken.h in Headers */ = {isa = PBXBuildFile; fileRef = FA39AE662B23972A008F93CD /* CoreIPCAuditToken.h */; };
 		FAA4E3012A1575A5003F5E50 /* WebFrameLoaderClient.h in Headers */ = {isa = PBXBuildFile; fileRef = FAA4E2FF2A1575A4003F5E50 /* WebFrameLoaderClient.h */; };
 		FEDBDCD61E68D20000A59F8F /* WebInspectorInterruptDispatcherMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FEDBDCD41E68D19C00A59F8F /* WebInspectorInterruptDispatcherMessageReceiver.cpp */; };
 		FEDBDCD71E68D20500A59F8F /* WebInspectorInterruptDispatcherMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = FEDBDCD51E68D19C00A59F8F /* WebInspectorInterruptDispatcherMessages.h */; };
@@ -7813,6 +7814,8 @@
 		FA39AE4C2B229187008F93CD /* WebImage.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebImage.serialization.in; sourceTree = "<group>"; };
 		FA39AE4D2B22D766008F93CD /* APIObject.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = APIObject.serialization.in; sourceTree = "<group>"; };
 		FA39AE4E2B22DA68008F93CD /* UserData.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = UserData.serialization.in; sourceTree = "<group>"; };
+		FA39AE662B23972A008F93CD /* CoreIPCAuditToken.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CoreIPCAuditToken.h; sourceTree = "<group>"; };
+		FA39AE672B23972A008F93CD /* CoreIPCAuditToken.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CoreIPCAuditToken.serialization.in; sourceTree = "<group>"; };
 		FA651BA42AA3CBB500747576 /* NetworkTransportBidirectionalStream.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NetworkTransportBidirectionalStream.h; sourceTree = "<group>"; };
 		FA651BA52AA3CBB500747576 /* NetworkTransportBidirectionalStream.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = NetworkTransportBidirectionalStream.cpp; sourceTree = "<group>"; };
 		FA651BA62AA3CBB600747576 /* NetworkTransportReceiveStream.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = NetworkTransportReceiveStream.cpp; sourceTree = "<group>"; };
@@ -10987,6 +10990,8 @@
 				5197FACD2AFD33AF009180C5 /* CoreIPCArray.h */,
 				5187BDE82AFF4A3A008A6EE5 /* CoreIPCArray.mm */,
 				5197FAD82AFD33B1009180C5 /* CoreIPCArray.serialization.in */,
+				FA39AE662B23972A008F93CD /* CoreIPCAuditToken.h */,
+				FA39AE672B23972A008F93CD /* CoreIPCAuditToken.serialization.in */,
 				51E8284B2B2036DD009119F9 /* CoreIPCAVOutputContext.serialization.in */,
 				5197FAE22AFD33B4009180C5 /* CoreIPCCFType.h */,
 				5197FAD62AFD33B1009180C5 /* CoreIPCCFType.serialization.in */,
@@ -15286,6 +15291,7 @@
 				5129EB1223D0DE7B00AF1CD7 /* ContentWorldShared.h in Headers */,
 				5106D7C418BDBE73000AB166 /* ContextMenuContextData.h in Headers */,
 				5197FAEB2AFD33CF009180C5 /* CoreIPCArray.h in Headers */,
+				FA39AE682B23972B008F93CD /* CoreIPCAuditToken.h in Headers */,
 				5197FAE72AFD33CF009180C5 /* CoreIPCCFType.h in Headers */,
 				5197FAE82AFD33CF009180C5 /* CoreIPCColor.h in Headers */,
 				F48C81E42AE0BA8E00073850 /* CoreIPCData.h in Headers */,

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnectionInfo.h
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnectionInfo.h
@@ -29,11 +29,15 @@
 
 #include <optional>
 
+#if HAVE(AUDIT_TOKEN)
+#include "CoreIPCAuditToken.h"
+#endif
+
 namespace WebKit {
 
 struct GPUProcessConnectionInfo {
 #if HAVE(AUDIT_TOKEN)
-    std::optional<audit_token_t> auditToken;
+    std::optional<CoreIPCAuditToken> auditToken;
 #endif
 #if ENABLE(VP9)
     bool hasVP9HardwareDecoder { false };

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnectionInfo.serialization.in
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnectionInfo.serialization.in
@@ -25,7 +25,7 @@
 struct WebKit::GPUProcessConnectionInfo {
 
 #if HAVE(AUDIT_TOKEN)
-    std::optional<audit_token_t> auditToken;
+    std::optional<WebKit::CoreIPCAuditToken> auditToken;
 #endif
 
 #if ENABLE(VP9)

--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnectionInfo.h
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnectionInfo.h
@@ -28,13 +28,17 @@
 #include "Connection.h"
 #include <WebCore/HTTPCookieAcceptPolicy.h>
 
+#if HAVE(AUDIT_TOKEN)
+#include "CoreIPCAuditToken.h"
+#endif
+
 namespace WebKit {
 
 struct NetworkProcessConnectionInfo {
     IPC::Connection::Handle connection;
     WebCore::HTTPCookieAcceptPolicy cookieAcceptPolicy;
 #if HAVE(AUDIT_TOKEN)
-    std::optional<audit_token_t> auditToken;
+    std::optional<CoreIPCAuditToken> auditToken;
 #endif
 };
 

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1185,7 +1185,7 @@ NetworkProcessConnection& WebProcess::ensureNetworkProcessConnection()
 
         m_networkProcessConnection = NetworkProcessConnection::create(IPC::Connection::Identifier { WTFMove(connectionInfo.connection) }, connectionInfo.cookieAcceptPolicy);
 #if HAVE(AUDIT_TOKEN)
-        m_networkProcessConnection->setNetworkProcessAuditToken(WTFMove(connectionInfo.auditToken));
+        m_networkProcessConnection->setNetworkProcessAuditToken(connectionInfo.auditToken ? std::optional(connectionInfo.auditToken->auditToken()) : std::nullopt);
 #endif
         setNetworkProcessConnectionID(m_networkProcessConnection->connection().uniqueID());
         m_networkProcessConnection->connection().send(Messages::NetworkConnectionToWebProcess::RegisterURLSchemesAsCORSEnabled(WebCore::LegacySchemeRegistry::allURLSchemesRegisteredAsCORSEnabled()), 0);

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -28,6 +28,7 @@
 
 #import "AccessibilitySupportSPI.h"
 #import "ArgumentCodersCocoa.h"
+#import "CoreIPCAuditToken.h"
 #import "DefaultWebBrowserChecks.h"
 #import "LegacyCustomProtocolManager.h"
 #import "LogInitialization.h"


### PR DESCRIPTION
#### 9937d7e71b2222daf9b2dbf3261a892ce796cb8a
<pre>
Generate serialization of audit_token_t
<a href="https://bugs.webkit.org/show_bug.cgi?id=266086">https://bugs.webkit.org/show_bug.cgi?id=266086</a>
<a href="https://rdar.apple.com/119386640">rdar://119386640</a>

Reviewed by Brady Eidson.

* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in:
* Source/WebKit/NetworkProcess/mac/NetworkConnectionToWebProcessMac.mm:
(WebKit::NetworkConnectionToWebProcess::updateActivePages):
(WebKit::NetworkConnectionToWebProcess::getProcessDisplayName):
* Source/WebKit/Platform/IPC/ArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;audit_token_t&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;audit_token_t&gt;::decode): Deleted.
* Source/WebKit/Platform/IPC/darwin/ArgumentCodersDarwin.h:
* Source/WebKit/Shared/Cocoa/CoreIPCAuditToken.h: Copied from Source/WebKit/Platform/IPC/darwin/ArgumentCodersDarwin.h.
(WebKit::CoreIPCAuditToken::CoreIPCAuditToken):
(WebKit::CoreIPCAuditToken::auditToken const):
* Source/WebKit/Shared/Cocoa/CoreIPCAuditToken.serialization.in: Copied from Source/WebKit/WebProcess/Network/NetworkProcessConnectionInfo.serialization.in.
* Source/WebKit/Shared/GPUProcessConnectionParameters.h:
* Source/WebKit/Shared/GPUProcessConnectionParameters.serialization.in:
* Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm:
(WebKit::WebProcessProxy::isAXAuthenticated):
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/UIProcess/WebProcessProxy.messages.in:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/GPU/GPUProcessConnectionInfo.h:
* Source/WebKit/WebProcess/GPU/GPUProcessConnectionInfo.serialization.in:
* Source/WebKit/WebProcess/Network/NetworkProcessConnectionInfo.h:
* Source/WebKit/WebProcess/Network/NetworkProcessConnectionInfo.serialization.in:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::ensureNetworkProcessConnection):
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:

Canonical link: <a href="https://commits.webkit.org/271779@main">https://commits.webkit.org/271779@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9263711a3fc5721a46b62c561f82547fa70320b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29650 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8305 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30954 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32154 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/26824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10454 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5585 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29923 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/6928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/25292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/5910 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/6051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33494 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/27024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/26799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/32264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/6002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/4196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/30040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7741 "Failed to checkout and rebase branch from PR 21518") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/6546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3817 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/6526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->