### PR TITLE
[iOS] Adopt -[AVCaptureSession initWithMediaEnvironment:]

### DIFF
--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp
@@ -424,6 +424,18 @@ bool RealtimeMediaSourceCenter::shouldInterruptAudioOnPageVisibilityChange()
 }
 #endif
 
+#if ENABLE(PROCESS_CAPABILITIES)
+const String& RealtimeMediaSourceCenter::currentMediaEnvironment() const
+{
+    return m_currentMediaEnvironment;
+}
+
+void RealtimeMediaSourceCenter::setCurrentMediaEnvironment(const String& mediaEnvironment)
+{
+    m_currentMediaEnvironment = mediaEnvironment;
+}
+#endif
+
 } // namespace WebCore
 
 #endif // ENABLE(MEDIA_STREAM)

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.h
@@ -111,6 +111,11 @@ public:
     OSObjectPtr<tcc_identity_t> identity() const { return m_identity; }
 #endif
 
+#if ENABLE(PROCESS_CAPABILITIES)
+    const String& currentMediaEnvironment() const;
+    void setCurrentMediaEnvironment(const String&);
+#endif
+
 private:
     RealtimeMediaSourceCenter();
     friend class NeverDestroyed<RealtimeMediaSourceCenter>;
@@ -144,6 +149,10 @@ private:
 
 #if ENABLE(APP_PRIVACY_REPORT)
     OSObjectPtr<tcc_identity_t> m_identity;
+#endif
+
+#if ENABLE(PROCESS_CAPABILITIES)
+    String m_currentMediaEnvironment;
 #endif
 
     bool m_useMockCaptureDevices { false };

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -220,6 +220,13 @@ private:
     }
 #endif
 
+#if ENABLE(PROCESS_CAPABILITIES)
+    void setCurrentMediaEnvironment(WebCore::PageIdentifier pageIdentifier) final
+    {
+        WebCore::RealtimeMediaSourceCenter::singleton().setCurrentMediaEnvironment(m_process.mediaEnvironment(pageIdentifier));
+    }
+#endif
+
     void startProducingData(CaptureDevice::DeviceType type) final
     {
         if (type == CaptureDevice::DeviceType::Microphone)

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
@@ -245,6 +245,11 @@ public:
     void overridePresentingApplicationPIDIfNeeded();
 #endif
 
+#if ENABLE(PROCESS_CAPABILITIES)
+    String mediaEnvironment(WebCore::PageIdentifier);
+    void setMediaEnvironment(WebCore::PageIdentifier, const String&);
+#endif
+
 private:
     GPUConnectionToWebProcess(GPUProcess&, WebCore::ProcessIdentifier, PAL::SessionID, IPC::Connection::Handle&&, GPUProcessConnectionParameters&&);
 
@@ -414,6 +419,10 @@ private:
     const bool m_isLockdownModeEnabled { false };
 #if ENABLE(MEDIA_SOURCE)
     bool m_mockMediaSourceEnabled { false };
+#endif
+
+#if ENABLE(PROCESS_CAPABILITIES)
+    HashMap<WebCore::PageIdentifier, String> m_mediaEnvironments;
 #endif
 
 #if ENABLE(ROUTING_ARBITRATION) && HAVE(AVAUDIO_ROUTING_ARBITER)

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.messages.in
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.messages.in
@@ -64,6 +64,10 @@ messages -> GPUConnectionToWebProcess WantsDispatchMessage {
 #if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
     UpdateSampleBufferDisplayLayerBoundsAndPosition(WebKit::SampleBufferDisplayLayerIdentifier identifier, WebCore::FloatRect bounds, std::optional<MachSendRight> fence);
 #endif
+
+#if ENABLE(PROCESS_CAPABILITIES)
+    SetMediaEnvironment(WebCore::PageIdentifier pageIdentifier, String mediaEnvironment);
+#endif
 }
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/GPUProcess/cocoa/GPUConnectionToWebProcessCocoa.mm
+++ b/Source/WebKit/GPUProcess/cocoa/GPUConnectionToWebProcessCocoa.mm
@@ -102,6 +102,22 @@ void GPUConnectionToWebProcess::setTCCIdentity()
 #endif // !PLATFORM(MACCATALYST)
 }
 #endif // ENABLE(APP_PRIVACY_REPORT)
+
+#if ENABLE(PROCESS_CAPABILITIES)
+String GPUConnectionToWebProcess::mediaEnvironment(WebCore::PageIdentifier pageIdentifier)
+{
+    return m_mediaEnvironments.get(pageIdentifier);
+}
+
+void GPUConnectionToWebProcess::setMediaEnvironment(WebCore::PageIdentifier pageIdentifier, const String& mediaEnvironment)
+{
+    if (mediaEnvironment.isEmpty())
+        m_mediaEnvironments.remove(pageIdentifier);
+    else
+        m_mediaEnvironments.set(pageIdentifier, mediaEnvironment);
+}
+#endif
+
 } // namespace WebKit
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
@@ -555,7 +555,7 @@ void UserMediaCaptureManagerProxy::createMediaSourceForCaptureDeviceWithConstrai
     });
 }
 
-void UserMediaCaptureManagerProxy::startProducingData(RealtimeMediaSourceIdentifier id)
+void UserMediaCaptureManagerProxy::startProducingData(RealtimeMediaSourceIdentifier id, WebCore::PageIdentifier pageIdentifier)
 {
     auto* proxy = m_proxies.get(id);
     if (!proxy)
@@ -568,6 +568,9 @@ void UserMediaCaptureManagerProxy::startProducingData(RealtimeMediaSourceIdentif
 
 #if ENABLE(APP_PRIVACY_REPORT)
     m_connectionProxy->setTCCIdentity();
+#endif
+#if ENABLE(PROCESS_CAPABILITIES)
+    m_connectionProxy->setCurrentMediaEnvironment(pageIdentifier);
 #endif
     m_connectionProxy->startProducingData(proxy->source().deviceType());
     proxy->start();

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.h
@@ -66,6 +66,9 @@ public:
 #if ENABLE(APP_PRIVACY_REPORT)
         virtual void setTCCIdentity() { }
 #endif
+#if ENABLE(PROCESS_CAPABILITIES)
+        virtual void setCurrentMediaEnvironment(WebCore::PageIdentifier) { };
+#endif
         virtual void startProducingData(WebCore::CaptureDevice::DeviceType) { }
         virtual RemoteVideoFrameObjectHeap* remoteVideoFrameObjectHeap() { return nullptr; }
     };
@@ -87,7 +90,7 @@ private:
 
     using CreateSourceCallback = CompletionHandler<void(const WebCore::CaptureSourceError&, const WebCore::RealtimeMediaSourceSettings&, const WebCore::RealtimeMediaSourceCapabilities&)>;
     void createMediaSourceForCaptureDeviceWithConstraints(WebCore::RealtimeMediaSourceIdentifier, const WebCore::CaptureDevice& deviceID, WebCore::MediaDeviceHashSalts&&, const WebCore::MediaConstraints&, bool shouldUseGPUProcessRemoteFrames, WebCore::PageIdentifier, CreateSourceCallback&&);
-    void startProducingData(WebCore::RealtimeMediaSourceIdentifier);
+    void startProducingData(WebCore::RealtimeMediaSourceIdentifier, WebCore::PageIdentifier);
     void stopProducingData(WebCore::RealtimeMediaSourceIdentifier);
     void removeSource(WebCore::RealtimeMediaSourceIdentifier);
     void capabilities(WebCore::RealtimeMediaSourceIdentifier, CompletionHandler<void(WebCore::RealtimeMediaSourceCapabilities&&)>&&);

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.messages.in
@@ -25,7 +25,7 @@
 
 messages -> UserMediaCaptureManagerProxy NotRefCounted {
     CreateMediaSourceForCaptureDeviceWithConstraints(WebCore::RealtimeMediaSourceIdentifier id, WebCore::CaptureDevice device, struct WebCore::MediaDeviceHashSalts hashSalts, struct WebCore::MediaConstraints constraints, bool shouldUseGPUProcessRemoteFrames, WebCore::PageIdentifier pageIdentifier) -> (struct WebCore::CaptureSourceError error, WebCore::RealtimeMediaSourceSettings settings, WebCore::RealtimeMediaSourceCapabilities capabilities) Async
-    StartProducingData(WebCore::RealtimeMediaSourceIdentifier id)
+    StartProducingData(WebCore::RealtimeMediaSourceIdentifier id, WebCore::PageIdentifier pageIdentifier)
     StopProducingData(WebCore::RealtimeMediaSourceIdentifier id)
     RemoveSource(WebCore::RealtimeMediaSourceIdentifier id)
     ApplyConstraints(WebCore::RealtimeMediaSourceIdentifier id, struct WebCore::MediaConstraints constraints)

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -1011,6 +1011,12 @@ void WebPageProxy::setMediaCapability(std::optional<MediaCapability>&& capabilit
         WEBPAGEPROXY_RELEASE_LOG(ProcessCapabilities, "setMediaCapability: granting (envID=%{public}s) for registrable domain '%{sensitive}s'", newCapability->environmentIdentifier().utf8().data(), newCapability->registrableDomain().string().utf8().data());
         processPool->processCapabilityGranter().grant(*newCapability);
     }
+
+    send(Messages::WebPage::SetMediaEnvironment([&]() -> String {
+        if (auto& capability = internals().mediaCapability)
+            return capability->environmentIdentifier();
+        return { };
+    }()));
 }
 
 void WebPageProxy::updateMediaCapability()

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
@@ -414,6 +414,13 @@ void GPUProcessConnection::updateMediaConfiguration(bool forceUpdate)
 #endif
 }
 
+#if ENABLE(PROCESS_CAPABILITIES)
+void GPUProcessConnection::setMediaEnvironment(WebCore::PageIdentifier pageIdentifier, const String& mediaEnvironment)
+{
+    connection().send(Messages::GPUConnectionToWebProcess::SetMediaEnvironment(pageIdentifier, mediaEnvironment), { });
+}
+#endif
+
 } // namespace WebKit
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.h
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.h
@@ -34,12 +34,15 @@
 #include "SharedMemory.h"
 #include <WebCore/AudioSession.h>
 #include <WebCore/PlatformMediaSession.h>
+#include <wtf/Forward.h>
 #include <wtf/RefCounted.h>
 #include <wtf/ThreadSafeWeakHashSet.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
 class CAAudioStreamDescription;
+struct PageIdentifierType;
+using PageIdentifier = ObjectIdentifier<PageIdentifierType>;
 }
 
 namespace IPC {
@@ -98,6 +101,10 @@ public:
 #if HAVE(VISIBILITY_PROPAGATION_VIEW)
     void createVisibilityPropagationContextForPage(WebPage&);
     void destroyVisibilityPropagationContextForPage(WebPage&);
+#endif
+
+#if ENABLE(PROCESS_CAPABILITIES)
+    void setMediaEnvironment(WebCore::PageIdentifier, const String&);
 #endif
 
     void configureLoggingChannel(const String&, WTFLogChannelState, WTFLogLevel);

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -815,6 +815,15 @@ URL WebPage::allowedQueryParametersForAdvancedPrivacyProtections(const URL& url)
 #endif
 }
 
+#if ENABLE(PROCESS_CAPABILITIES)
+void WebPage::setMediaEnvironment(const String& mediaEnvironment)
+{
+    m_mediaEnvironment = mediaEnvironment;
+    if (auto gpuProcessConnection = WebProcess::singleton().existingGPUProcessConnection())
+        gpuProcessConnection->setMediaEnvironment(identifier(), mediaEnvironment);
+}
+#endif
+
 } // namespace WebKit
 
 #endif // PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1124,10 +1124,15 @@ void WebPage::mainFrameURLChangedInAnotherProcess(const URL& newURL)
 #if ENABLE(GPU_PROCESS)
 void WebPage::gpuProcessConnectionDidBecomeAvailable(GPUProcessConnection& gpuProcessConnection)
 {
+    UNUSED_PARAM(gpuProcessConnection);
+
 #if HAVE(VISIBILITY_PROPAGATION_VIEW)
     gpuProcessConnection.createVisibilityPropagationContextForPage(*this);
-#else
-    UNUSED_PARAM(gpuProcessConnection);
+#endif
+
+#if ENABLE(PROCESS_CAPABILITIES)
+    if (!mediaEnvironment().isEmpty())
+        gpuProcessConnection.setMediaEnvironment(identifier(), mediaEnvironment());
 #endif
 }
 
@@ -1302,6 +1307,10 @@ WebPage::~WebPage()
 
     for (auto& completionHandler : std::exchange(m_markLayersAsVolatileCompletionHandlers, { }))
         completionHandler(false);
+
+#if ENABLE(PROCESS_CAPABILITIES)
+    setMediaEnvironment({ });
+#endif
 }
 
 IPC::Connection* WebPage::messageSenderConnection() const

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1671,6 +1671,11 @@ public:
     const Vector<DMABufRendererBufferFormat>& preferredBufferFormats() const { return m_preferredBufferFormats; }
 #endif
 
+#if ENABLE(PROCESS_CAPABILITIES)
+    const String& mediaEnvironment() const { return m_mediaEnvironment; }
+    void setMediaEnvironment(const String&);
+#endif
+
 private:
     WebPage(WebCore::PageIdentifier, WebPageCreationParameters&&);
 
@@ -2661,6 +2666,10 @@ private:
 
 #if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)
     WeakHashSet<WebCore::HTMLImageElement, WebCore::WeakPtrImplWithEventTargetData> m_elementsToExcludeFromRemoveBackground;
+#endif
+
+#if ENABLE(PROCESS_CAPABILITIES)
+    String m_mediaEnvironment;
 #endif
 
     mutable RefPtr<Logger> m_logger;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -747,4 +747,8 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
 
     RemotePostMessage(WebCore::FrameIdentifier source, String sourceOrigin, WebCore::FrameIdentifier target, std::optional<WebCore::SecurityOriginData> targetOrigin, struct WebCore::MessageWithMessagePorts message)
     RenderTreeAsText(WebCore::FrameIdentifier frameID, size_t baseIndent, OptionSet<WebCore::RenderAsTextFlag> behavior) -> (String renderTreeDump) Synchronous
+
+#if ENABLE(PROCESS_CAPABILITIES)
+    SetMediaEnvironment(String mediaEnvironment)
+#endif
 }

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.h
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.h
@@ -80,7 +80,7 @@ protected:
 
 private:
     // RealtimeMediaSource
-    void startProducingData() final { m_proxy.startProducingData(); }
+    void startProducingData() final { m_proxy.startProducingData(pageIdentifier()); }
     void stopProducingData() final { m_proxy.stopProducingData(); }
     bool isCaptureSource() const final { return true; }
     void applyConstraints(const WebCore::MediaConstraints&, ApplyConstraintsHandler&&) final;

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.cpp
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.cpp
@@ -74,10 +74,10 @@ void RemoteRealtimeMediaSourceProxy::updateConnection()
     m_connection = getSourceConnection(m_shouldCaptureInGPUProcess);
 }
 
-void RemoteRealtimeMediaSourceProxy::startProducingData()
+void RemoteRealtimeMediaSourceProxy::startProducingData(WebCore::PageIdentifier pageIdentifier)
 {
     m_interrupted = false;
-    m_connection->send(Messages::UserMediaCaptureManagerProxy::StartProducingData { m_identifier }, 0);
+    m_connection->send(Messages::UserMediaCaptureManagerProxy::StartProducingData { m_identifier, pageIdentifier }, 0);
 }
 
 void RemoteRealtimeMediaSourceProxy::stopProducingData()

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.h
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.h
@@ -69,7 +69,7 @@ public:
 
     bool isEnded() const { return m_isEnded; }
     void end();
-    void startProducingData();
+    void startProducingData(WebCore::PageIdentifier);
     void stopProducingData();
     void endProducingData();
     void applyConstraints(const WebCore::MediaConstraints&, WebCore::RealtimeMediaSource::ApplyConstraintsHandler&&);


### PR DESCRIPTION
#### 875ade367c7e1aac927afd76a29bc9abb53ea19d
<pre>
[iOS] Adopt -[AVCaptureSession initWithMediaEnvironment:]
<a href="https://bugs.webkit.org/show_bug.cgi?id=266084">https://bugs.webkit.org/show_bug.cgi?id=266084</a>
<a href="https://rdar.apple.com/118949622">rdar://118949622</a>

Reviewed by Tim Horton.

Adopted -[AVCaptureSession initWithMediaEnvironment:] when creating an AVCaptureSession in
AVVideoCaptureSource. This requires plumbing the associated media environment identifier
WebPage(Proxy).

* Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.h: Added a getter/setter for
m_currentMediaEnvironment.
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm:
(WebCore::AVVideoCaptureSource::setupSession): Forward-declared -initWithMediaEnvironment: and
called it if AVCaptureSession responds to it and we have a non-empty media environment.

* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h:
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.messages.in:
* Source/WebKit/GPUProcess/cocoa/GPUConnectionToWebProcessCocoa.mm:
(WebKit::GPUConnectionToWebProcess::mediaEnvironment):
(WebKit::GPUConnectionToWebProcess::setMediaEnvironment): Added a SetMediaEnvironment message that
WebPage sends to tell the GPU process the media environment for a given PageIdentifier. Stored the
media environments in a map keyed by PageIdentifier.

* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp:
(WebKit::UserMediaCaptureManagerProxy::startProducingData):
* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.h:
(WebKit::UserMediaCaptureManagerProxy::ConnectionProxy::setCurrentMediaEnvironment): Sets the
current media environment prior to calling startProducingData (which will create an
AVCaptureSession).

* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.messages.in: Included a pageIdentifier
in the StartProducingData message.

* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::setMediaCapability): Sent WebPage::SetMediaEnvironment when the media
capability changes.

* Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp:
(WebKit::GPUProcessConnection::setMediaEnvironment):
* Source/WebKit/WebProcess/GPU/GPUProcessConnection.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::setMediaEnvironment): Sent GPUConnectionToWebProcess::SetMediaEnvironment to the
GPU process.

(WebKit::WebPage::gpuProcessConnectionDidBecomeAvailable):
(WebKit::WebPage::~WebPage): Sent GPUConnectionToWebProcess::SetMediaEnvironment when the GPU
process becomes available or the WebPage is deallocated.

* Source/WebKit/WebProcess/WebPage/WebPage.h:
(WebKit::WebPage::mediaEnvironment const): Added a getter/setter for m_mediaEnvironment.

* Source/WebKit/WebProcess/WebPage/WebPage.messages.in: Defined WebPage::SetMediaEnvironment.

* Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.h:
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.cpp:
(WebKit::RemoteRealtimeMediaSourceProxy::startProducingData):
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.h: Plumbed a PageIdentifier through
startProducingData.

Canonical link: <a href="https://commits.webkit.org/271764@main">https://commits.webkit.org/271764@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dae1bcbea267b5dee2eb362f8309754c803de844

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/29632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/8288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/30931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/32137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/26815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/30246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/10432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/5566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/32137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/29905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/10432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/30931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/32137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/10432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/30931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/33477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/10432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/30931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/33477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/5993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/5566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/33477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/7731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/30931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/7025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/6537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3810 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/6517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->