### PR TITLE
[UnifiedPDF] CGPDFPageLayoutGetAreaOfInterestAtPoint should be declared with C linkage

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cg/CoreGraphicsSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cg/CoreGraphicsSPI.h
@@ -247,7 +247,12 @@ typedef CF_OPTIONS(uint32_t, CGPDFAreaOfInterest) {
     kCGPDFAreaImage  = (1 << 1),
 };
 typedef struct CGPDFPageLayout *CGPDFPageLayoutRef;
+
+WTF_EXTERN_C_BEGIN
+
 CGPDFAreaOfInterest CGPDFPageLayoutGetAreaOfInterestAtPoint(CGPDFPageLayoutRef, CGPoint);
+
+WTF_EXTERN_C_END
 
 #endif // ENABLE(UNIFIED_PDF)
 


### PR DESCRIPTION
#### c4fc80276b733ebba34ee05c2e2abf32da4f77a8
<pre>
[UnifiedPDF] CGPDFPageLayoutGetAreaOfInterestAtPoint should be declared with C linkage
<a href="https://bugs.webkit.org/show_bug.cgi?id=266094">https://bugs.webkit.org/show_bug.cgi?id=266094</a>
<a href="https://rdar.apple.com/119394292">rdar://119394292</a>

Reviewed by Wenson Hsieh.

Since CGPDFPageLayoutGetAreaOfInterestAtPoint is a C API, it must not go
through name mangling, so we specify C linkage for it.

This patch fixes the open source macOS build with unified PDF enabled.

* Source/WebCore/PAL/pal/spi/cg/CoreGraphicsSPI.h:

Canonical link: <a href="https://commits.webkit.org/271792@main">https://commits.webkit.org/271792@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7584b265b310aafe2c48aaf1bdd68e321ceabf0e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29588 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8248 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30897 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32100 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26789 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30191 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10482 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5538 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26794 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29861 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6950 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25261 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5882 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/6073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26349 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33444 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27046 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26770 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32234 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5973 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4165 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30010 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/close-quickly (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7708 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7045 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6514 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6495 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->