### PR TITLE
Fix crash related to visibility propagation

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKContentView.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentView.mm
@@ -277,7 +277,7 @@ static NSArray *keyCommandsPlaceholderHackForEvernote(id self, SEL _cmd)
     if (!_visibilityPropagationInteractionForWebProcess) {
         SEL selector = NSSelectorFromString(@"createVisibilityPropagationInteraction");
         if ([_page->process().extensionProcess().get() respondsToSelector:selector])
-            _visibilityPropagationInteractionForWebProcess = adoptNS([_page->process().extensionProcess() performSelector:selector]);
+            _visibilityPropagationInteractionForWebProcess = [_page->process().extensionProcess() performSelector:selector];
         if (_visibilityPropagationInteractionForWebProcess)
             [self addInteraction:_visibilityPropagationInteractionForWebProcess.get()];
     }
@@ -313,7 +313,7 @@ static NSArray *keyCommandsPlaceholderHackForEvernote(id self, SEL _cmd)
     if (!_visibilityPropagationInteractionForGPUProcess) {
         SEL selector = NSSelectorFromString(@"createVisibilityPropagationInteraction");
         if ([_page->process().extensionProcess().get() respondsToSelector:selector])
-            _visibilityPropagationInteractionForGPUProcess = adoptNS([_page->process().extensionProcess() performSelector:selector]);
+            _visibilityPropagationInteractionForGPUProcess = [_page->process().extensionProcess() performSelector:selector];
         if (_visibilityPropagationInteractionForGPUProcess)
             [self addInteraction:_visibilityPropagationInteractionForGPUProcess.get()];
     }
@@ -337,8 +337,10 @@ static NSArray *keyCommandsPlaceholderHackForEvernote(id self, SEL _cmd)
 - (void)_removeVisibilityPropagationViewForWebProcess
 {
 #if USE(EXTENSIONKIT)
-    if (_visibilityPropagationInteractionForWebProcess)
+    if (_visibilityPropagationInteractionForWebProcess) {
         [self removeInteraction:_visibilityPropagationInteractionForWebProcess.get()];
+        _visibilityPropagationInteractionForWebProcess = nullptr;
+    }
 #endif
 
     if (!_visibilityPropagationViewForWebProcess)
@@ -352,8 +354,10 @@ static NSArray *keyCommandsPlaceholderHackForEvernote(id self, SEL _cmd)
 - (void)_removeVisibilityPropagationViewForGPUProcess
 {
 #if USE(EXTENSIONKIT)
-    if (_visibilityPropagationInteractionForGPUProcess)
+    if (_visibilityPropagationInteractionForGPUProcess) {
         [self removeInteraction:_visibilityPropagationInteractionForGPUProcess.get()];
+        _visibilityPropagationInteractionForGPUProcess = nullptr;
+    }
 #endif
 
     if (!_visibilityPropagationViewForGPUProcess)


### PR DESCRIPTION
#### b8615eb10baaf147c41e4c7817b483271ad8b413
<pre>
Fix crash related to visibility propagation
<a href="https://bugs.webkit.org/show_bug.cgi?id=266101">https://bugs.webkit.org/show_bug.cgi?id=266101</a>
<a href="https://rdar.apple.com/119398625">rdar://119398625</a>

Reviewed by Brent Fulgham.

Do not adopt the UIInteraction object, since it appears that we are currently overreleasing it.
Also set the object to null after removing it from the view.

* Source/WebKit/UIProcess/ios/WKContentView.mm:
(-[WKContentView _setupVisibilityPropagationViewForWebProcess]):
(-[WKContentView _setupVisibilityPropagationViewForGPUProcess]):
(-[WKContentView _removeVisibilityPropagationViewForWebProcess]):
(-[WKContentView _removeVisibilityPropagationViewForGPUProcess]):

Canonical link: <a href="https://commits.webkit.org/271778@main">https://commits.webkit.org/271778@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb8319b05464e29e909bba752612c52f3c3e0332

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29595 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8254 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30903 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32105 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26797 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10406 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5543 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26810 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29868 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6892 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25273 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5886 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6031 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33449 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27000 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26777 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32246 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5976 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4167 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30012 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7711 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7034 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6517 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6499 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->