### PR TITLE
Implement and Apply TZone Allocation Macros

### DIFF
--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -1247,6 +1247,7 @@
 		65303D641447B9E100D3F904 /* ParserTokens.h in Headers */ = {isa = PBXBuildFile; fileRef = 65303D631447B9E100D3F904 /* ParserTokens.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		653BC43F26D013A600D8BE20 /* YarrJITRegisters.h in Headers */ = {isa = PBXBuildFile; fileRef = 653BC43E26D013A600D8BE20 /* YarrJITRegisters.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		65570F5A1AA4C3EA009B3C23 /* Regress141275.mm in Sources */ = {isa = PBXBuildFile; fileRef = 65570F591AA4C00A009B3C23 /* Regress141275.mm */; };
+		6571E9822B23F4D0009DF224 /* JITTZoneImpls.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6571E9812B23F4D0009DF224 /* JITTZoneImpls.cpp */; };
 		657CF45919BF6662004ACBF2 /* JSCallee.h in Headers */ = {isa = PBXBuildFile; fileRef = 657CF45719BF6662004ACBF2 /* JSCallee.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		658824AF1E5CFDB000FB7359 /* ConfigFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 658824AE1E5CFDB000FB7359 /* ConfigFile.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		658D3A5619638268003C45D6 /* VMEntryRecord.h in Headers */ = {isa = PBXBuildFile; fileRef = 658D3A5519638268003C45D6 /* VMEntryRecord.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -4374,6 +4375,14 @@
 		6560A4CF04B3B3E7008AE952 /* CoreFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreFoundation.framework; path = /System/Library/Frameworks/CoreFoundation.framework; sourceTree = "<absolute>"; };
 		65621E6B089E859700760F35 /* PropertySlot.cpp */ = {isa = PBXFileReference; fileEncoding = 30; indentWidth = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PropertySlot.cpp; sourceTree = "<group>"; tabWidth = 8; };
 		65621E6C089E859700760F35 /* PropertySlot.h */ = {isa = PBXFileReference; fileEncoding = 30; indentWidth = 4; lastKnownFileType = sourcecode.c.h; path = PropertySlot.h; sourceTree = "<group>"; tabWidth = 8; };
+		6571E94C2AF2E769009DF224 /* RuntimeTZoneImpls.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RuntimeTZoneImpls.cpp; sourceTree = "<group>"; };
+		6571E94E2AF315A7009DF224 /* B3TZoneImpls.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = B3TZoneImpls.cpp; path = b3/B3TZoneImpls.cpp; sourceTree = "<group>"; };
+		6571E9502AF31C34009DF224 /* AirTZoneImpls.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = AirTZoneImpls.cpp; path = b3/air/AirTZoneImpls.cpp; sourceTree = "<group>"; };
+		6571E9542AF320AE009DF224 /* DFGTZoneImpls.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DFGTZoneImpls.cpp; path = dfg/DFGTZoneImpls.cpp; sourceTree = "<group>"; };
+		6571E9562AF3495A009DF224 /* WasmTZoneImpls.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WasmTZoneImpls.cpp; sourceTree = "<group>"; };
+		6571E9582AF35AA2009DF224 /* YarrTZoneImpls.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = YarrTZoneImpls.cpp; path = yarr/YarrTZoneImpls.cpp; sourceTree = "<group>"; };
+		6571E95A2AF9B98D009DF224 /* ProfilerTZoneImpls.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ProfilerTZoneImpls.cpp; path = profiler/ProfilerTZoneImpls.cpp; sourceTree = "<group>"; };
+		6571E9812B23F4D0009DF224 /* JITTZoneImpls.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JITTZoneImpls.cpp; sourceTree = "<group>"; };
 		657CF45619BF6662004ACBF2 /* JSCallee.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSCallee.cpp; sourceTree = "<group>"; };
 		657CF45719BF6662004ACBF2 /* JSCallee.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSCallee.h; sourceTree = "<group>"; };
 		65860177185A8F5E00030EEE /* MaxFrameExtentForSlowPathCall.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MaxFrameExtentForSlowPathCall.h; sourceTree = "<group>"; };
@@ -6547,6 +6556,7 @@
 				0FEC84F11BDACDAC0080FF74 /* B3Type.cpp */,
 				0FEC84F21BDACDAC0080FF74 /* B3Type.h */,
 				DCFDFBD81D1F5D9800FE3D72 /* B3TypeMap.h */,
+				6571E94E2AF315A7009DF224 /* B3TZoneImpls.cpp */,
 				0FEC84F31BDACDAC0080FF74 /* B3UpsilonValue.cpp */,
 				0FEC84F41BDACDAC0080FF74 /* B3UpsilonValue.h */,
 				0FEC84F51BDACDAC0080FF74 /* B3UseCounts.cpp */,
@@ -6691,6 +6701,7 @@
 				0FE0E4AB1C24C94A002E17B6 /* AirTmpWidth.cpp */,
 				0FE0E4AC1C24C94A002E17B6 /* AirTmpWidth.h */,
 				0FEC858F2BDACDC70080FF74 /* AirTmpWidthInlines.h */,
+				6571E9502AF31C34009DF224 /* AirTZoneImpls.cpp */,
 				0F3730921C0D67EE00052BFA /* AirUseCounts.h */,
 				0FEC856B1BDACDC70080FF74 /* AirValidate.cpp */,
 				0FEC856C1BDACDC70080FF74 /* AirValidate.h */,
@@ -6900,6 +6911,7 @@
 				0F5EF91C16878F78003E5C25 /* JITThunks.h */,
 				0FC712E017CD878F008CC93C /* JITToDFGDeferredCompilationCallback.cpp */,
 				0FC712E117CD878F008CC93C /* JITToDFGDeferredCompilationCallback.h */,
+				6571E9812B23F4D0009DF224 /* JITTZoneImpls.cpp */,
 				DC0184171D10C1870057B053 /* JITWorklist.cpp */,
 				DC0184181D10C1870057B053 /* JITWorklist.h */,
 				72131BFB26587EFA007114CF /* JITWorklistInlines.h */,
@@ -7779,6 +7791,7 @@
 				AD7438BE1E04579200FD0C2A /* WasmTypeDefinition.cpp */,
 				AD7438BF1E04579200FD0C2A /* WasmTypeDefinition.h */,
 				30A5F403F11C4F599CD596D5 /* WasmTypeDefinitionInlines.h */,
+				6571E9562AF3495A009DF224 /* WasmTZoneImpls.cpp */,
 				863FBC5725B093B800F6C930 /* WasmValueLocation.cpp */,
 				863FBC5825B093B900F6C930 /* WasmValueLocation.h */,
 				530FB3031E7A1146003C19DD /* WasmWorklist.cpp */,
@@ -8618,6 +8631,7 @@
 				70B0A9D01A9B66200001306A /* RuntimeFlags.h */,
 				527773DD1AAF83AC00BDE7E8 /* RuntimeType.cpp */,
 				52C0611D1AA51E1B00B4ADBA /* RuntimeType.h */,
+				6571E94C2AF2E769009DF224 /* RuntimeTZoneImpls.cpp */,
 				0F7700911402FF280078EB39 /* SamplingCounter.cpp */,
 				0F77008E1402FDD60078EB39 /* SamplingCounter.h */,
 				79D5CD581C1106A900CECA07 /* SamplingProfiler.cpp */,
@@ -8904,6 +8918,7 @@
 				86704B8312DBA33700A9FE7B /* YarrPattern.h */,
 				86704B4012DB8A8100A9FE7B /* YarrSyntaxChecker.cpp */,
 				86704B4112DB8A8100A9FE7B /* YarrSyntaxChecker.h */,
+				6571E9582AF35AA2009DF224 /* YarrTZoneImpls.cpp */,
 				659CDA591F67509800D3E53F /* YarrUnicodeProperties.cpp */,
 				659CDA5A1F67509800D3E53F /* YarrUnicodeProperties.h */,
 			);
@@ -9195,6 +9210,7 @@
 				0FE7211C193B9C590031F6ED /* DFGTransition.h */,
 				0F63943C15C75F14006A597C /* DFGTypeCheckHoistingPhase.cpp */,
 				0F63943D15C75F14006A597C /* DFGTypeCheckHoistingPhase.h */,
+				6571E9542AF320AE009DF224 /* DFGTZoneImpls.cpp */,
 				0FBE0F6F16C1DB010082C5E8 /* DFGUnificationPhase.cpp */,
 				0FBE0F7016C1DB010082C5E8 /* DFGUnificationPhase.h */,
 				0F34B14716D4200E001CDA5A /* DFGUseKind.cpp */,
@@ -9270,6 +9286,7 @@
 				0FB1058A1675482E00F8AB6E /* ProfilerOSRExitSite.h */,
 				0F13912616771C30009CCB07 /* ProfilerProfiledBytecodes.cpp */,
 				0F13912716771C30009CCB07 /* ProfilerProfiledBytecodes.h */,
+				6571E95A2AF9B98D009DF224 /* ProfilerTZoneImpls.cpp */,
 				DC605B5B1CE26E9800593718 /* ProfilerUID.cpp */,
 				DC605B5C1CE26E9800593718 /* ProfilerUID.h */,
 			);
@@ -13143,6 +13160,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				44F93E0E2AE71FBD00FFA37C /* JavaScriptCoreFramework.cpp in Sources */,
+				6571E9822B23F4D0009DF224 /* JITTZoneImpls.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -109,6 +109,7 @@ b3/air/AirStackSlot.cpp
 b3/air/AirStackSlotKind.cpp
 b3/air/AirTmp.cpp
 b3/air/AirTmpWidth.cpp
+b3/air/AirTZoneImpls.cpp
 b3/air/AirValidate.cpp
 
 b3/B3ArgumentRegValue.cpp
@@ -176,6 +177,7 @@ b3/B3StackmapSpecial.cpp
 b3/B3StackmapValue.cpp
 b3/B3SwitchCase.cpp
 b3/B3SwitchValue.cpp
+b3/B3TZoneImpls.cpp
 b3/B3Type.cpp
 b3/B3UpsilonValue.cpp
 b3/B3UseCounts.cpp
@@ -436,6 +438,7 @@ dfg/DFGToFTLDeferredCompilationCallback.cpp
 dfg/DFGToFTLForOSREntryDeferredCompilationCallback.cpp
 dfg/DFGTransition.cpp
 dfg/DFGTypeCheckHoistingPhase.cpp
+dfg/DFGTZoneImpls.cpp
 dfg/DFGUnificationPhase.cpp
 dfg/DFGUseKind.cpp
 dfg/DFGValidate.cpp
@@ -701,6 +704,7 @@ jit/SIMDInfo.cpp
 jit/SlowPathCall.cpp
 jit/TagRegistersMode.cpp
 jit/ThunkGenerators.cpp
+jit/JITTZoneImpls.cpp
 jit/Width.cpp
 
 llint/InPlaceInterpreter.cpp
@@ -738,6 +742,7 @@ profiler/ProfilerOrigin.cpp
 profiler/ProfilerOriginStack.cpp
 profiler/ProfilerProfiledBytecodes.cpp
 profiler/ProfilerUID.cpp
+profiler/ProfilerTZoneImpls.cpp
 
 runtime/AbstractModuleRecord.cpp
 runtime/AggregateError.cpp
@@ -1016,6 +1021,7 @@ runtime/RegExpObject.cpp
 runtime/RegExpPrototype.cpp
 runtime/RegExpStringIteratorPrototype.cpp
 runtime/ResourceExhaustion.cpp
+runtime/RuntimeTZoneImpls.cpp
 runtime/RuntimeType.cpp
 runtime/SamplingCounter.cpp
 runtime/SamplingProfiler.cpp
@@ -1155,6 +1161,7 @@ wasm/WasmTable.cpp
 wasm/WasmTag.cpp
 wasm/WasmThunks.cpp
 wasm/WasmTierUpCount.cpp
+wasm/WasmTZoneImpls.cpp
 wasm/WasmValueLocation.cpp
 wasm/WasmWorklist.cpp
 
@@ -1216,6 +1223,7 @@ yarr/YarrJIT.cpp
 yarr/YarrPattern.cpp
 yarr/YarrSyntaxChecker.cpp
 yarr/YarrUnicodeProperties.cpp
+yarr/YarrTZoneImpls.cpp
 
 // Derived Sources
 yarr/YarrCanonicalizeUnicode.cpp

--- a/Source/JavaScriptCore/assembler/AbstractMacroAssembler.h
+++ b/Source/JavaScriptCore/assembler/AbstractMacroAssembler.h
@@ -40,6 +40,7 @@
 #include <wtf/Noncopyable.h>
 #include <wtf/SharedTask.h>
 #include <wtf/StringPrintStream.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakRandom.h>
 
@@ -60,7 +61,7 @@ struct OSRExit;
 #define JIT_COMMENT(jit, ...) do { if (UNLIKELY(Options::needDisassemblySupport())) { (jit).comment(__VA_ARGS__); } else { (void) jit; } } while (0)
 
 class AbstractMacroAssemblerBase {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(AbstractMacroAssemblerBase);
 public:
     enum StatusCondition {
         Success,

--- a/Source/JavaScriptCore/assembler/AssemblyComments.cpp
+++ b/Source/JavaScriptCore/assembler/AssemblyComments.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,10 +27,13 @@
 #include "AssemblyComments.h"
 
 #include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
 
 static LazyNeverDestroyed<AssemblyCommentRegistry> commentsRegistry;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AssemblyCommentRegistry);
 
 void AssemblyCommentRegistry::initialize()
 {

--- a/Source/JavaScriptCore/assembler/AssemblyComments.h
+++ b/Source/JavaScriptCore/assembler/AssemblyComments.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,12 +31,13 @@
 #include <wtf/HashMap.h>
 #include <wtf/Lock.h>
 #include <wtf/StdMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace JSC {
 
 class AssemblyCommentRegistry {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(AssemblyCommentRegistry);
     WTF_MAKE_NONCOPYABLE(AssemblyCommentRegistry);
 public:
     static AssemblyCommentRegistry& singleton();

--- a/Source/JavaScriptCore/assembler/LinkBuffer.cpp
+++ b/Source/JavaScriptCore/assembler/LinkBuffer.cpp
@@ -33,11 +33,14 @@
 #include "JITCode.h"
 #include "Options.h"
 #include "PerfLog.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
 
 size_t LinkBuffer::s_profileCummulativeLinkedSizes[LinkBuffer::numberOfProfiles];
 size_t LinkBuffer::s_profileCummulativeLinkedCounts[LinkBuffer::numberOfProfiles];
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(LinkBuffer);
 
 LinkBuffer::CodeRef<LinkBufferPtrTag> LinkBuffer::finalizeCodeWithoutDisassemblyImpl()
 {

--- a/Source/JavaScriptCore/assembler/LinkBuffer.h
+++ b/Source/JavaScriptCore/assembler/LinkBuffer.h
@@ -38,7 +38,7 @@
 #include "MacroAssembler.h"
 #include "MacroAssemblerCodeRef.h"
 #include <wtf/DataLog.h>
-#include <wtf/FastMalloc.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -57,7 +57,8 @@ namespace JSC {
 //   * The value referenced by a DataLabel may be set.
 //
 class LinkBuffer {
-    WTF_MAKE_NONCOPYABLE(LinkBuffer); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_NONCOPYABLE(LinkBuffer);
+    WTF_MAKE_TZONE_ALLOCATED(LinkBuffer);
     
     template<PtrTag tag> using CodeRef = MacroAssemblerCodeRef<tag>;
     typedef MacroAssembler::Label Label;

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.cpp
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.cpp
@@ -31,6 +31,7 @@
 #include "JSCPtrTag.h"
 #include "ProbeContext.h"
 #include <wtf/InlineASM.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if OS(LINUX)
 #include <asm/hwcap.h>
@@ -56,6 +57,8 @@ static unsigned long getauxval(unsigned long type)
 #endif
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(MacroAssemblerARM64);
 
 JSC_DECLARE_JIT_OPERATION(ctiMasmProbeTrampoline, void, ());
 JSC_ANNOTATE_JIT_OPERATION_PROBE(ctiMasmProbeTrampoline);

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -32,6 +32,7 @@
 #include "JITOperationValidation.h"
 #include <wtf/MathExtras.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -39,6 +40,7 @@ using Assembler = TARGET_ASSEMBLER;
 class Reg;
 
 class MacroAssemblerARM64 : public AbstractMacroAssembler<Assembler> {
+    WTF_MAKE_TZONE_ALLOCATED(MacroAssemblerARM64);
 public:
     static constexpr unsigned numGPRs = 32;
     static constexpr unsigned numFPRs = 32;

--- a/Source/JavaScriptCore/assembler/PerfLog.cpp
+++ b/Source/JavaScriptCore/assembler/PerfLog.cpp
@@ -41,6 +41,7 @@
 #include <wtf/MonotonicTime.h>
 #include <wtf/PageBlock.h>
 #include <wtf/ProcessID.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
 
@@ -124,6 +125,8 @@ struct CodeLoadRecord {
 };
 
 } // namespace JITDump
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PerfLog);
 
 PerfLog& PerfLog::singleton()
 {

--- a/Source/JavaScriptCore/assembler/PerfLog.h
+++ b/Source/JavaScriptCore/assembler/PerfLog.h
@@ -31,12 +31,13 @@
 #include <stdio.h>
 #include <wtf/Lock.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/CString.h>
 
 namespace JSC {
 
 class PerfLog {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PerfLog);
     WTF_MAKE_NONCOPYABLE(PerfLog);
     friend class LazyNeverDestroyed<PerfLog>;
 public:

--- a/Source/JavaScriptCore/assembler/ProbeContext.cpp
+++ b/Source/JavaScriptCore/assembler/ProbeContext.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,10 +28,14 @@
 
 #if ENABLE(ASSEMBLER)
 
+#include <wtf/TZoneMallocInlines.h>
+
 namespace JSC {
 namespace Probe {
 
 static void flushDirtyStackPages(State*);
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Context);
 
 void executeJSCJITProbe(State* state)
 {

--- a/Source/JavaScriptCore/assembler/ProbeContext.h
+++ b/Source/JavaScriptCore/assembler/ProbeContext.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,6 +27,7 @@
 
 #include "MacroAssembler.h"
 #include "ProbeStack.h"
+#include <wtf/TZoneMalloc.h>
 
 #if ENABLE(ASSEMBLER)
 
@@ -220,7 +221,7 @@ struct State {
 };
 
 class Context {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Context);
 public:
     using RegisterID = MacroAssembler::RegisterID;
     using SPRegisterID = MacroAssembler::SPRegisterID;

--- a/Source/JavaScriptCore/assembler/ProbeStack.cpp
+++ b/Source/JavaScriptCore/assembler/ProbeStack.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,6 +28,7 @@
 
 #include <memory>
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(ASSEMBLER)
 
@@ -53,6 +54,8 @@ static void copyStackPage(void* dst, void* src, size_t size)
 #else
 #define copyStackPage(dst, src, size) std::memcpy(dst, src, size)
 #endif
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Page);
 
 Page::Page(void* baseAddress)
     : m_baseLogicalAddress(baseAddress)
@@ -98,6 +101,8 @@ void* Page::lowWatermarkFromVisitingDirtyChunks()
     }
     return maxLowWatermark;
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Stack);
 
 Stack::Stack(Stack&& other)
     : m_stackBounds(WTFMove(other.m_stackBounds))

--- a/Source/JavaScriptCore/assembler/ProbeStack.h
+++ b/Source/JavaScriptCore/assembler/ProbeStack.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,6 +28,7 @@
 #include "CPU.h"
 #include <wtf/HashMap.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Threading.h>
 
 #if ENABLE(ASSEMBLER)
@@ -37,7 +38,7 @@ namespace JSC {
 namespace Probe {
 
 class Page {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Page);
 public:
     Page(void* baseAddress);
 
@@ -143,7 +144,7 @@ private:
 };
 
 class Stack {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Stack);
 public:
     Stack()
         : m_stackBounds(Thread::current().stack())

--- a/Source/JavaScriptCore/b3/B3BackwardsCFG.h
+++ b/Source/JavaScriptCore/b3/B3BackwardsCFG.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,12 +29,13 @@
 
 #include "B3CFG.h"
 #include <wtf/BackwardsGraph.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC { namespace B3 {
 
 class BackwardsCFG : public BackwardsGraph<CFG> {
     WTF_MAKE_NONCOPYABLE(BackwardsCFG);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(BackwardsCFG);
 public:
     BackwardsCFG(Procedure& proc)
         : BackwardsGraph<CFG>(proc.cfg())

--- a/Source/JavaScriptCore/b3/B3BackwardsDominators.h
+++ b/Source/JavaScriptCore/b3/B3BackwardsDominators.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,12 +29,13 @@
 
 #include "B3BackwardsCFG.h"
 #include <wtf/Dominators.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC { namespace B3 {
 
 class BackwardsDominators : public WTF::Dominators<BackwardsCFG> {
     WTF_MAKE_NONCOPYABLE(BackwardsDominators);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(BackwardsDominators);
 public:
     BackwardsDominators(Procedure& proc)
         : WTF::Dominators<BackwardsCFG>(proc.backwardsCFG())

--- a/Source/JavaScriptCore/b3/B3BasicBlock.cpp
+++ b/Source/JavaScriptCore/b3/B3BasicBlock.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,10 +33,13 @@
 #include "B3Procedure.h"
 #include "B3ValueInlines.h"
 #include <wtf/ListDump.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC { namespace B3 {
 
 const char* const BasicBlock::dumpPrefix = "#";
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(BasicBlock);
 
 BasicBlock::BasicBlock(unsigned index, double frequency)
     : m_index(index)

--- a/Source/JavaScriptCore/b3/B3BasicBlock.h
+++ b/Source/JavaScriptCore/b3/B3BasicBlock.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,6 +32,7 @@
 #include "B3Origin.h"
 #include "B3SuccessorCollection.h"
 #include "B3Type.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace JSC { namespace B3 {
@@ -44,7 +45,7 @@ template<typename> class GenericBlockInsertionSet;
 
 class BasicBlock {
     WTF_MAKE_NONCOPYABLE(BasicBlock);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(BasicBlock);
 public:
     typedef Vector<Value*> ValueList;
     typedef Vector<BasicBlock*, 2> PredecessorList;

--- a/Source/JavaScriptCore/b3/B3CFG.h
+++ b/Source/JavaScriptCore/b3/B3CFG.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,12 +31,13 @@
 #include "B3Procedure.h"
 #include <wtf/IndexMap.h>
 #include <wtf/IndexSet.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC { namespace B3 {
 
 class CFG {
     WTF_MAKE_NONCOPYABLE(CFG);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(CFG);
 public:
     typedef BasicBlock* Node;
     typedef IndexSet<BasicBlock*> Set;

--- a/Source/JavaScriptCore/b3/B3CheckSpecial.cpp
+++ b/Source/JavaScriptCore/b3/B3CheckSpecial.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,8 +33,11 @@
 #include "B3StackmapGenerationParams.h"
 #include "B3ValueInlines.h"
 #include "CCallHelpers.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC { namespace B3 {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CheckSpecial);
 
 using Inst = Air::Inst;
 using Arg = Air::Arg;

--- a/Source/JavaScriptCore/b3/B3CheckSpecial.h
+++ b/Source/JavaScriptCore/b3/B3CheckSpecial.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,6 +30,7 @@
 #include "AirKind.h"
 #include "B3StackmapSpecial.h"
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC { namespace B3 {
 
@@ -49,6 +50,7 @@ struct Inst;
 // - CheckMul(a, b), which turns into Mul32 b, a but we pass Any for a's ValueRep.
 
 class CheckSpecial final : public StackmapSpecial {
+    WTF_MAKE_TZONE_ALLOCATED(CheckSpecial);
 public:
     // Support for hash consing these things.
     class Key {

--- a/Source/JavaScriptCore/b3/B3DataSection.cpp
+++ b/Source/JavaScriptCore/b3/B3DataSection.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,7 +28,11 @@
 
 #if ENABLE(B3_JIT)
 
+#include <wtf/TZoneMallocInlines.h>
+
 namespace JSC { namespace B3 {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(DataSection);
 
 DataSection::DataSection(size_t size)
     : m_data(fastZeroedMalloc(size))

--- a/Source/JavaScriptCore/b3/B3DataSection.h
+++ b/Source/JavaScriptCore/b3/B3DataSection.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,10 +28,12 @@
 #if ENABLE(B3_JIT)
 
 #include "JITOpaqueByproduct.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC { namespace B3 {
 
 class DataSection final : public OpaqueByproduct {
+    WTF_MAKE_TZONE_ALLOCATED(DataSection);
 public:
     DataSection(size_t size);
     ~DataSection() final;

--- a/Source/JavaScriptCore/b3/B3Dominators.h
+++ b/Source/JavaScriptCore/b3/B3Dominators.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,14 +30,14 @@
 #include "B3CFG.h"
 #include "B3Procedure.h"
 #include <wtf/Dominators.h>
-#include <wtf/FastMalloc.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC { namespace B3 {
 
 class Dominators : public WTF::Dominators<CFG> {
     WTF_MAKE_NONCOPYABLE(Dominators);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Dominators);
 public:
     Dominators(Procedure& proc)
         : WTF::Dominators<CFG>(proc.cfg())

--- a/Source/JavaScriptCore/b3/B3NaturalLoops.h
+++ b/Source/JavaScriptCore/b3/B3NaturalLoops.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,6 +29,7 @@
 
 #include "B3Dominators.h"
 #include <wtf/NaturalLoops.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC { namespace B3 {
 
@@ -36,7 +37,7 @@ typedef WTF::NaturalLoop<CFG> NaturalLoop;
 
 class NaturalLoops : public WTF::NaturalLoops<CFG> {
     WTF_MAKE_NONCOPYABLE(NaturalLoops);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(NaturalLoops);
 public:
     NaturalLoops(Procedure& proc)
         : WTF::NaturalLoops<CFG>(proc.cfg(), proc.dominators())

--- a/Source/JavaScriptCore/b3/B3PhiChildren.cpp
+++ b/Source/JavaScriptCore/b3/B3PhiChildren.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,8 +29,11 @@
 #if ENABLE(B3_JIT)
 
 #include "B3ValueInlines.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC { namespace B3 {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PhiChildren);
 
 PhiChildren::PhiChildren(Procedure& proc)
     : m_upsilons(proc.values().size())

--- a/Source/JavaScriptCore/b3/B3PhiChildren.h
+++ b/Source/JavaScriptCore/b3/B3PhiChildren.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,11 +31,12 @@
 #include "B3UpsilonValue.h"
 #include <wtf/GraphNodeWorklist.h>
 #include <wtf/IndexMap.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC { namespace B3 {
 
 class PhiChildren {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PhiChildren);
 public:
     PhiChildren(Procedure&);
     ~PhiChildren();

--- a/Source/JavaScriptCore/b3/B3Procedure.cpp
+++ b/Source/JavaScriptCore/b3/B3Procedure.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -41,8 +41,11 @@
 #include "B3ValueInlines.h"
 #include "B3Variable.h"
 #include "JITOpaqueByproducts.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC { namespace B3 {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Procedure);
 
 Procedure::Procedure(bool usesSIMD)
     : m_cfg(new CFG(*this))

--- a/Source/JavaScriptCore/b3/B3Procedure.h
+++ b/Source/JavaScriptCore/b3/B3Procedure.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -42,6 +42,7 @@
 #include <wtf/Noncopyable.h>
 #include <wtf/PrintStream.h>
 #include <wtf/SharedTask.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/TriState.h>
 #include <wtf/Vector.h>
 
@@ -78,7 +79,7 @@ typedef SharedTask<WasmBoundsCheckGeneratorFunction> WasmBoundsCheckGenerator;
 
 class Procedure {
     WTF_MAKE_NONCOPYABLE(Procedure);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Procedure);
 public:
 
     JS_EXPORT_PRIVATE Procedure(bool usesSIMD = false);

--- a/Source/JavaScriptCore/b3/B3StackmapSpecial.cpp
+++ b/Source/JavaScriptCore/b3/B3StackmapSpecial.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,8 +31,11 @@
 #include "AirCode.h"
 #include "AirGenerationContext.h"
 #include "B3ValueInlines.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC { namespace B3 {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(StackmapSpecial);
 
 using Arg = Air::Arg;
 using Inst = Air::Inst;

--- a/Source/JavaScriptCore/b3/B3StackmapSpecial.h
+++ b/Source/JavaScriptCore/b3/B3StackmapSpecial.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,6 +30,7 @@
 #include "AirArg.h"
 #include "AirSpecial.h"
 #include "B3ValueRep.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC { namespace B3 {
 
@@ -40,6 +41,7 @@ namespace Air { class Code; }
 // Stackmap.
 
 class StackmapSpecial : public Air::Special {
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(StackmapSpecial, JS_EXPORT_PRIVATE);
 public:
     StackmapSpecial();
     ~StackmapSpecial() override;

--- a/Source/JavaScriptCore/b3/B3TZoneImpls.cpp
+++ b/Source/JavaScriptCore/b3/B3TZoneImpls.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#if ENABLE(B3_JIT)
+
+#include "B3BackwardsCFG.h"
+#include "B3BackwardsDominators.h"
+#include "B3CFG.h"
+#include "B3Dominators.h"
+#include "B3NaturalLoops.h"
+#include <wtf/TZoneMallocInlines.h>
+
+namespace JSC { namespace B3 {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(BackwardsCFG);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(BackwardsDominators);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CFG);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Dominators);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(NaturalLoops);
+
+} } // namespace JSC::B3
+
+#endif // ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/b3/B3Value.cpp
+++ b/Source/JavaScriptCore/b3/B3Value.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -45,9 +45,12 @@
 #include <wtf/ListDump.h>
 #include <wtf/StackTrace.h>
 #include <wtf/StringPrintStream.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 
 namespace JSC { namespace B3 {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Value);
 
 #if ASSERT_ENABLED
 namespace B3ValueInternal {

--- a/Source/JavaScriptCore/b3/B3Value.h
+++ b/Source/JavaScriptCore/b3/B3Value.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -37,9 +37,9 @@
 #include "B3ValueKey.h"
 #include "B3Width.h"
 #include <wtf/CommaPrinter.h>
-#include <wtf/FastMalloc.h>
 #include <wtf/IteratorRange.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/TriState.h>
 
 namespace JSC { namespace B3 {
@@ -52,7 +52,7 @@ class PhiChildren;
 class Procedure;
 
 class JS_EXPORT_PRIVATE Value {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Value);
 public:
     static const char* const dumpPrefix;
 

--- a/Source/JavaScriptCore/b3/B3ValueRep.cpp
+++ b/Source/JavaScriptCore/b3/B3ValueRep.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,8 +30,11 @@
 
 #include "AssemblyHelpers.h"
 #include "JSCJSValueInlines.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC { namespace B3 {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ValueRep);
 
 void ValueRep::addUsedRegistersTo(bool isSIMDContext, RegisterSetBuilder& set) const
 {

--- a/Source/JavaScriptCore/b3/B3ValueRep.h
+++ b/Source/JavaScriptCore/b3/B3ValueRep.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,6 +34,7 @@
 #include "RegisterSet.h"
 #include "ValueRecovery.h"
 #include <wtf/PrintStream.h>
+#include <wtf/TZoneMalloc.h>
 #if ENABLE(WEBASSEMBLY)
 #include "WasmValueLocation.h"
 #endif
@@ -50,7 +51,7 @@ namespace B3 {
 // output.
 
 class ValueRep {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ValueRep);
 public:
     enum Kind : uint8_t {
         // As an input representation, this means that B3 can pick any representation. As an output

--- a/Source/JavaScriptCore/b3/B3Variable.cpp
+++ b/Source/JavaScriptCore/b3/B3Variable.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,7 +28,11 @@
 
 #if ENABLE(B3_JIT)
 
+#include <wtf/TZoneMallocInlines.h>
+
 namespace JSC { namespace B3 {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Variable);
 
 Variable::~Variable()
 {

--- a/Source/JavaScriptCore/b3/B3Variable.h
+++ b/Source/JavaScriptCore/b3/B3Variable.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,9 +31,9 @@
 #include "B3SparseCollection.h"
 #include "B3Type.h"
 #include "B3Width.h"
-#include <wtf/FastMalloc.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/PrintStream.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC { namespace B3 {
 
@@ -41,7 +41,7 @@ class Procedure;
 
 class Variable {
     WTF_MAKE_NONCOPYABLE(Variable);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Variable);
 
 public:
     ~Variable();

--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackAndGenerateCode.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackAndGenerateCode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -39,12 +39,15 @@
 #include "DisallowMacroScratchRegisterUsage.h"
 #include "Reg.h"
 #include <wtf/ListDump.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC { namespace B3 { namespace Air {
 
 namespace GenerateAndAllocateRegistersInternal {
 static bool verbose = false;
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(GenerateAndAllocateRegisters);
 
 GenerateAndAllocateRegisters::GenerateAndAllocateRegisters(Code& code)
     : m_code(code)

--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackAndGenerateCode.h
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackAndGenerateCode.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,6 +30,7 @@
 #include "AirLiveness.h"
 #include "AirTmpMap.h"
 #include <wtf/Nonmovable.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC { 
 
@@ -40,7 +41,7 @@ namespace B3 { namespace Air {
 class Code;
 
 class GenerateAndAllocateRegisters {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(GenerateAndAllocateRegisters);
     WTF_MAKE_NONMOVABLE(GenerateAndAllocateRegisters);
 
     struct TmpData {

--- a/Source/JavaScriptCore/b3/air/AirBasicBlock.cpp
+++ b/Source/JavaScriptCore/b3/air/AirBasicBlock.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,10 +30,13 @@
 
 #include "B3BasicBlockUtils.h"
 #include <wtf/ListDump.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC { namespace B3 { namespace Air {
 
 const char* const BasicBlock::dumpPrefix = "#";
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(BasicBlock);
 
 void BasicBlock::setSuccessors(FrequentedBlock target)
 {

--- a/Source/JavaScriptCore/b3/air/AirBasicBlock.h
+++ b/Source/JavaScriptCore/b3/air/AirBasicBlock.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,8 +30,8 @@
 #include "AirFrequentedBlock.h"
 #include "AirInst.h"
 #include "B3SuccessorCollection.h"
-#include <wtf/FastMalloc.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC { namespace B3 {
 
@@ -46,7 +46,7 @@ class PhaseInsertionSet;
 
 class BasicBlock {
     WTF_MAKE_NONCOPYABLE(BasicBlock);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(BasicBlock);
 public:
     static const char* const dumpPrefix;
     static constexpr unsigned uninsertedIndex = UINT_MAX;

--- a/Source/JavaScriptCore/b3/air/AirCCallSpecial.cpp
+++ b/Source/JavaScriptCore/b3/air/AirCCallSpecial.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,8 +29,11 @@
 #if ENABLE(B3_JIT)
 
 #include "CCallHelpers.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC { namespace B3 { namespace Air {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CCallSpecial);
 
 CCallSpecial::CCallSpecial(bool isSIMDContext)
     : m_isSIMDContext(isSIMDContext)

--- a/Source/JavaScriptCore/b3/air/AirCCallSpecial.h
+++ b/Source/JavaScriptCore/b3/air/AirCCallSpecial.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,6 +29,7 @@
 
 #include "AirSpecial.h"
 #include "RegisterSet.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC { namespace B3 { namespace Air {
 
@@ -43,6 +44,7 @@ namespace JSC { namespace B3 { namespace Air {
 // the prologue, whichever happened sooner.
 
 class CCallSpecial final : public Special {
+    WTF_MAKE_TZONE_ALLOCATED(CCallSpecial);
 public:
     CCallSpecial(bool isSIMDContext);
     ~CCallSpecial() final;

--- a/Source/JavaScriptCore/b3/air/AirCFG.h
+++ b/Source/JavaScriptCore/b3/air/AirCFG.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,12 +31,13 @@
 #include "AirCode.h"
 #include <wtf/IndexMap.h>
 #include <wtf/IndexSet.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC { namespace B3 { namespace Air {
 
 class CFG {
     WTF_MAKE_NONCOPYABLE(CFG);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(CFG);
 public:
     typedef BasicBlock* Node;
     typedef IndexSet<BasicBlock*> Set;

--- a/Source/JavaScriptCore/b3/air/AirCode.cpp
+++ b/Source/JavaScriptCore/b3/air/AirCode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -37,10 +37,14 @@
 #include "CCallHelpers.h"
 #include <wtf/ListDump.h>
 #include <wtf/MathExtras.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC { namespace B3 { namespace Air {
 
 const char* const tierName = "Air ";
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CFG);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Code);
 
 static void defaultPrologueGenerator(CCallHelpers& jit, Code& code)
 {

--- a/Source/JavaScriptCore/b3/air/AirCode.h
+++ b/Source/JavaScriptCore/b3/air/AirCode.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -41,6 +41,7 @@
 #include <wtf/HashSet.h>
 #include <wtf/IndexMap.h>
 #include <wtf/SmallSet.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakRandom.h>
 
 namespace JSC {
@@ -78,7 +79,7 @@ extern const char* const tierName;
 
 class Code {
     WTF_MAKE_NONCOPYABLE(Code);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Code);
 public:
     ~Code();
 

--- a/Source/JavaScriptCore/b3/air/AirDisassembler.cpp
+++ b/Source/JavaScriptCore/b3/air/AirDisassembler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,8 +34,11 @@
 #include "CCallHelpers.h"
 #include "Disassembler.h"
 #include "LinkBuffer.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC { namespace B3 { namespace Air {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Disassembler);
 
 void Disassembler::startEntrypoint(CCallHelpers& jit)
 {

--- a/Source/JavaScriptCore/b3/air/AirDisassembler.h
+++ b/Source/JavaScriptCore/b3/air/AirDisassembler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,8 +28,9 @@
 #if ENABLE(B3_JIT)
 
 #include "MacroAssembler.h"
+#include <wtf/TZoneMalloc.h>
 
-namespace JSC { 
+namespace JSC {
 
 class CCallHelpers;
 class LinkBuffer;
@@ -41,7 +42,7 @@ class Code;
 struct Inst;
 
 class Disassembler {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Disassembler);
 public:
     Disassembler() = default;
 

--- a/Source/JavaScriptCore/b3/air/AirLiveness.h
+++ b/Source/JavaScriptCore/b3/air/AirLiveness.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,12 +31,13 @@
 #include "CompilerTimingScope.h"
 #include "SuperSampler.h"
 #include <wtf/Liveness.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC { namespace B3 { namespace Air {
 
 template<typename Adapter>
 class Liveness : public WTF::Liveness<Adapter> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Liveness);
 public:
     Liveness(Code& code)
         : WTF::Liveness<Adapter>(code.cfg(), code)

--- a/Source/JavaScriptCore/b3/air/AirLivenessAdapter.h
+++ b/Source/JavaScriptCore/b3/air/AirLivenessAdapter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,7 +33,9 @@
 #include "AirInstInlines.h"
 #include "AirStackSlot.h"
 #include "AirTmpInlines.h"
+#include <wtf/ForbidHeapAllocation.h>
 #include <wtf/IndexMap.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC { namespace B3 { namespace Air {
 
@@ -43,6 +45,8 @@ static constexpr bool verbose = false;
 
 template<typename Adapter>
 struct LivenessAdapter {
+    WTF_FORBID_HEAP_ALLOCATION;
+public:
     typedef Air::CFG CFG;
 
     typedef Vector<unsigned, 4> ActionsList;
@@ -145,6 +149,8 @@ struct LivenessAdapter {
 
 template<Bank adapterBank, Arg::Temperature minimumTemperature = Arg::Cold>
 struct TmpLivenessAdapter : LivenessAdapter<TmpLivenessAdapter<adapterBank, minimumTemperature>> {
+    WTF_MAKE_TZONE_ALLOCATED(TmpLivenessAdapter);
+public:
     typedef LivenessAdapter<TmpLivenessAdapter<adapterBank, minimumTemperature>> Base;
 
     static constexpr const char* name = "TmpLiveness";
@@ -166,6 +172,8 @@ struct TmpLivenessAdapter : LivenessAdapter<TmpLivenessAdapter<adapterBank, mini
 };
 
 struct UnifiedTmpLivenessAdapter : LivenessAdapter<UnifiedTmpLivenessAdapter> {
+    WTF_MAKE_TZONE_ALLOCATED(UnifiedTmpLivenessAdapter);
+public:
     typedef LivenessAdapter<UnifiedTmpLivenessAdapter> Base;
 
     static constexpr const char* name = "UnifiedTmpLiveness";
@@ -189,6 +197,8 @@ struct UnifiedTmpLivenessAdapter : LivenessAdapter<UnifiedTmpLivenessAdapter> {
 };
 
 struct StackSlotLivenessAdapter : LivenessAdapter<StackSlotLivenessAdapter> {
+    WTF_MAKE_TZONE_ALLOCATED(StackSlotLivenessAdapter);
+public:
     static constexpr const char* name = "StackSlotLiveness";
     typedef StackSlot* Thing;
 

--- a/Source/JavaScriptCore/b3/air/AirPrintSpecial.cpp
+++ b/Source/JavaScriptCore/b3/air/AirPrintSpecial.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,8 +30,11 @@
 
 #include "CCallHelpers.h"
 #include "MacroAssemblerPrinter.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC { namespace B3 { namespace Air {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PrintSpecial);
 
 PrintSpecial::PrintSpecial(Printer::PrintRecordList* list)
     : m_printRecordList(list)

--- a/Source/JavaScriptCore/b3/air/AirPrintSpecial.h
+++ b/Source/JavaScriptCore/b3/air/AirPrintSpecial.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,6 +30,7 @@
 #include "AirInst.h"
 #include "AirSpecial.h"
 #include "MacroAssemblerPrinter.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -92,6 +93,7 @@ struct Printer<Reg> : public PrintRecord {
 namespace B3 { namespace Air {
 
 class PrintSpecial final : public Special {
+    WTF_MAKE_TZONE_ALLOCATED(PrintSpecial);
 public:
     PrintSpecial(Printer::PrintRecordList*);
     ~PrintSpecial() final;

--- a/Source/JavaScriptCore/b3/air/AirSpecial.cpp
+++ b/Source/JavaScriptCore/b3/air/AirSpecial.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,10 +30,13 @@
 
 #include <limits.h>
 #include <wtf/StringPrintStream.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC { namespace B3 { namespace Air {
 
 const char* const Special::dumpPrefix = "&";
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Special);
 
 Special::Special()
 {

--- a/Source/JavaScriptCore/b3/air/AirSpecial.h
+++ b/Source/JavaScriptCore/b3/air/AirSpecial.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,6 +32,7 @@
 #include <wtf/FastMalloc.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/ScopedLambda.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/CString.h>
 
 namespace JSC { namespace B3 { namespace Air {
@@ -41,7 +42,7 @@ struct GenerationContext;
 
 class Special {
     WTF_MAKE_NONCOPYABLE(Special);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(Special, JS_EXPORT_PRIVATE);
 public:
     static const char* const dumpPrefix;
     

--- a/Source/JavaScriptCore/b3/air/AirStackSlot.cpp
+++ b/Source/JavaScriptCore/b3/air/AirStackSlot.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,7 +28,11 @@
 
 #if ENABLE(B3_JIT)
 
+#include <wtf/TZoneMallocInlines.h>
+
 namespace JSC { namespace B3 { namespace Air {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(StackSlot);
 
 void StackSlot::setOffsetFromFP(intptr_t value)
 {

--- a/Source/JavaScriptCore/b3/air/AirStackSlot.h
+++ b/Source/JavaScriptCore/b3/air/AirStackSlot.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,6 +33,7 @@
 #include <wtf/FastMalloc.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/PrintStream.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC { namespace B3 {
 
@@ -42,7 +43,7 @@ namespace Air {
 
 class StackSlot {
     WTF_MAKE_NONCOPYABLE(StackSlot);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(StackSlot);
 public:
     unsigned byteSize() const { return m_byteSize; }
     StackSlotKind kind() const { return m_kind; }

--- a/Source/JavaScriptCore/b3/air/AirTZoneImpls.cpp
+++ b/Source/JavaScriptCore/b3/air/AirTZoneImpls.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "AirLiveness.h"
+#include "AirLivenessAdapter.h"
+#include <wtf/TZoneMallocInlines.h>
+
+namespace JSC { namespace B3 { namespace Air {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL_TEMPLATE(GPLiveness);
+WTF_MAKE_TZONE_ALLOCATED_IMPL_TEMPLATE(FPLiveness);
+WTF_MAKE_TZONE_ALLOCATED_IMPL_TEMPLATE(StackSlotLiveness);
+WTF_MAKE_TZONE_ALLOCATED_IMPL_TEMPLATE(UnifiedTmpLiveness);
+
+
+} } } // namespace JSC::B3::Air

--- a/Source/JavaScriptCore/builtins/BuiltinExecutables.cpp
+++ b/Source/JavaScriptCore/builtins/BuiltinExecutables.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,8 +31,11 @@
 #include "JSCJSValueInlines.h"
 #include "Parser.h"
 #include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(BuiltinExecutables);
 
 BuiltinExecutables::BuiltinExecutables(VM& vm)
     : m_vm(vm)

--- a/Source/JavaScriptCore/builtins/BuiltinExecutables.h
+++ b/Source/JavaScriptCore/builtins/BuiltinExecutables.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,6 +31,7 @@
 #include "SourceCode.h"
 #include "Weak.h"
 #include "WeakHandleOwner.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -46,7 +47,7 @@ enum class BuiltinCodeIndex {
 #undef BUILTIN_NAME_ONLY
 
 class BuiltinExecutables {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(BuiltinExecutables);
 public:
     explicit BuiltinExecutables(VM&);
 

--- a/Source/JavaScriptCore/builtins/BuiltinNames.cpp
+++ b/Source/JavaScriptCore/builtins/BuiltinNames.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2017 Yusuke Suzuki <utatane.tea@gmail.com>.
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,6 +28,7 @@
 #include "BuiltinNames.h"
 
 #include "IdentifierInlines.h"
+#include <wtf/TZoneMallocInlines.h>
 
 #if COMPILER(MSVC)
 #pragma warning(push)
@@ -70,6 +71,8 @@ SymbolImpl::StaticSymbolImpl polyProtoPrivateName { "PolyProto", SymbolImpl::s_f
         SymbolImpl* symbol = static_cast<SymbolImpl*>(m_##name##Symbol.impl()); \
         m_wellKnownSymbolsMap.add(m_##name##SymbolPrivateIdentifier.impl(), symbol); \
     } while (0);
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(BuiltinNames);
 
 // We treat the dollarVM name as a special case below for $vm (because CommonIdentifiers does not
 // yet support the $ character).

--- a/Source/JavaScriptCore/builtins/BuiltinNames.h
+++ b/Source/JavaScriptCore/builtins/BuiltinNames.h
@@ -31,6 +31,7 @@
 #include "JSCBuiltins.h"
 #include <wtf/RobinHoodHashMap.h>
 #include <wtf/RobinHoodHashSet.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -225,7 +226,8 @@ extern JS_EXPORT_PRIVATE SymbolImpl::StaticSymbolImpl polyProtoPrivateName;
 }
 
 class BuiltinNames {
-    WTF_MAKE_NONCOPYABLE(BuiltinNames); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_NONCOPYABLE(BuiltinNames);
+    WTF_MAKE_TZONE_ALLOCATED(BuiltinNames);
     
 public:
     using PrivateNameSet = MemoryCompactLookupOnlyRobinHoodHashSet<String>;

--- a/Source/JavaScriptCore/bytecode/AccessCaseSnippetParams.cpp
+++ b/Source/JavaScriptCore/bytecode/AccessCaseSnippetParams.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/Source/JavaScriptCore/bytecode/AccessCaseSnippetParams.h
+++ b/Source/JavaScriptCore/bytecode/AccessCaseSnippetParams.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,6 +30,7 @@
 #if ENABLE(JIT)
 
 #include "SnippetParams.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/bytecode/AdaptiveInferredPropertyValueWatchpointBase.cpp
+++ b/Source/JavaScriptCore/bytecode/AdaptiveInferredPropertyValueWatchpointBase.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,8 +27,11 @@
 #include "AdaptiveInferredPropertyValueWatchpointBase.h"
 
 #include "JSCInlines.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AdaptiveInferredPropertyValueWatchpointBase);
 
 AdaptiveInferredPropertyValueWatchpointBase::AdaptiveInferredPropertyValueWatchpointBase(const ObjectPropertyCondition& key)
     : m_key(key)

--- a/Source/JavaScriptCore/bytecode/AdaptiveInferredPropertyValueWatchpointBase.h
+++ b/Source/JavaScriptCore/bytecode/AdaptiveInferredPropertyValueWatchpointBase.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,8 +27,8 @@
 
 #include "ObjectPropertyCondition.h"
 #include "Watchpoint.h"
-#include <wtf/FastMalloc.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -36,7 +36,7 @@ namespace JSC {
 // https://bugs.webkit.org/show_bug.cgi?id=202381
 class AdaptiveInferredPropertyValueWatchpointBase {
     WTF_MAKE_NONCOPYABLE(AdaptiveInferredPropertyValueWatchpointBase);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(AdaptiveInferredPropertyValueWatchpointBase);
 
 public:
     AdaptiveInferredPropertyValueWatchpointBase(const ObjectPropertyCondition&);

--- a/Source/JavaScriptCore/bytecode/BytecodeBasicBlock.h
+++ b/Source/JavaScriptCore/bytecode/BytecodeBasicBlock.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013, 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -43,7 +43,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(BytecodeBasicBlock);
 
 template<typename OpcodeTraits>
 class BytecodeBasicBlock {
-    WTF_MAKE_FAST_ALLOCATED(BytecodeBasicBlock);
+    WTF_MAKE_TZONE_ALLOCATED(BytecodeBasicBlock);
     WTF_MAKE_NONCOPYABLE(BytecodeBasicBlock);
     friend class BytecodeGraph;
 public:

--- a/Source/JavaScriptCore/bytecode/BytecodeGraph.h
+++ b/Source/JavaScriptCore/bytecode/BytecodeGraph.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2016 Yusuke Suzuki <utatane.tea@gmail.com>
- * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,13 +30,14 @@
 #include "BytecodeDumper.h"
 #include <wtf/IndexedContainerIterator.h>
 #include <wtf/IteratorRange.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace JSC {
 
 class BytecodeGraph {
-    WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(BytecodeGraph);
+    WTF_MAKE_TZONE_ALLOCATED(BytecodeGraph);
 public:
     using BasicBlockType = JSBytecodeBasicBlock;
     using BasicBlocksVector = typename BasicBlockType::BasicBlockVector;

--- a/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.cpp
+++ b/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2015 Yusuke Suzuki <utatane.tea@gmail.com>.
- * Copyright (C) 2016-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -45,8 +45,11 @@
 #include "LinkTimeConstant.h"
 #include "Nodes.h"
 #include "StrongInlines.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(BytecodeIntrinsicRegistry);
 
 #define INITIALIZE_BYTECODE_INTRINSIC_NAMES_TO_SET(name) m_bytecodeIntrinsicMap.add(vm.propertyNames->builtinNames().name##PrivateName().impl(), Entry(&BytecodeIntrinsicNode::emit_intrinsic_##name));
 #define INITIALIZE_BYTECODE_INTRINSIC_NAMES_TO_SET_FOR_LINK_TIME_CONSTANT(name, code) m_bytecodeIntrinsicMap.add(vm.propertyNames->builtinNames().name##PrivateName().impl(), JSC::LinkTimeConstant::name);

--- a/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.h
+++ b/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2015 Yusuke Suzuki <utatane.tea@gmail.com>.
- * Copyright (C) 2016-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,6 +29,7 @@
 #include "Identifier.h"
 #include <wtf/Noncopyable.h>
 #include <wtf/RobinHoodHashMap.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -173,8 +174,8 @@ enum class LinkTimeConstant : int32_t;
     macro(sentinelSetBucket) \
 
 class BytecodeIntrinsicRegistry {
-    WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(BytecodeIntrinsicRegistry);
+    WTF_MAKE_TZONE_ALLOCATED(BytecodeIntrinsicRegistry);
 public:
     explicit BytecodeIntrinsicRegistry(VM&);
 

--- a/Source/JavaScriptCore/bytecode/BytecodeLivenessAnalysis.cpp
+++ b/Source/JavaScriptCore/bytecode/BytecodeLivenessAnalysis.cpp
@@ -31,8 +31,12 @@
 #include "CodeBlock.h"
 #include "FullBytecodeLiveness.h"
 #include "JSCJSValueInlines.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(BytecodeLivenessAnalysis);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FullBytecodeLiveness);
 
 BytecodeLivenessAnalysis::BytecodeLivenessAnalysis(CodeBlock* codeBlock)
     : m_graph(codeBlock, codeBlock->instructions())

--- a/Source/JavaScriptCore/bytecode/BytecodeLivenessAnalysis.h
+++ b/Source/JavaScriptCore/bytecode/BytecodeLivenessAnalysis.h
@@ -77,7 +77,7 @@ public:
 };
 
 class BytecodeLivenessAnalysis : private BytecodeLivenessPropagation {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(BytecodeLivenessAnalysis);
     WTF_MAKE_NONCOPYABLE(BytecodeLivenessAnalysis);
 public:
     friend class BytecodeLivenessPropagation;

--- a/Source/JavaScriptCore/bytecode/CallLinkStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/CallLinkStatus.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,6 +32,7 @@
 #include "JSCInlines.h"
 #include <wtf/CommaPrinter.h>
 #include <wtf/ListDump.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
 
@@ -40,6 +41,8 @@ namespace CallLinkStatusInternal {
 static constexpr bool verbose = false;
 }
 #endif
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CallLinkStatus);
 
 CallLinkStatus::CallLinkStatus(JSValue value)
     : m_couldTakeSlowPath(false)

--- a/Source/JavaScriptCore/bytecode/CallLinkStatus.h
+++ b/Source/JavaScriptCore/bytecode/CallLinkStatus.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,6 +32,7 @@
 #include "ExitFlag.h"
 #include "ICStatusMap.h"
 #include "JSCJSValue.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -42,7 +43,7 @@ class Structure;
 class CallLinkInfo;
 
 class CallLinkStatus final {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(CallLinkStatus);
 public:
     CallLinkStatus()
     {

--- a/Source/JavaScriptCore/bytecode/CallVariant.h
+++ b/Source/JavaScriptCore/bytecode/CallVariant.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,6 +30,7 @@
 #include "JSCast.h"
 #include "JSFunction.h"
 #include "NativeExecutable.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -61,7 +62,7 @@ namespace JSC {
 // cannot use WriteBarrier<> here because this gets used inside the compiler.
 
 class CallVariant {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(CallVariant);
 public:
     explicit CallVariant(JSCell* callee = nullptr)
         : m_callee(callee)

--- a/Source/JavaScriptCore/bytecode/CheckPrivateBrandStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/CheckPrivateBrandStatus.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2021 Igalia S.A. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -33,8 +33,11 @@
 #include "InlineCacheCompiler.h"
 #include "StructureStubInfo.h"
 #include <wtf/ListDump.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CheckPrivateBrandStatus);
 
 bool CheckPrivateBrandStatus::appendVariant(const CheckPrivateBrandVariant& variant)
 {

--- a/Source/JavaScriptCore/bytecode/CheckPrivateBrandStatus.h
+++ b/Source/JavaScriptCore/bytecode/CheckPrivateBrandStatus.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2021 Igalia S.A. All rights reserved.
  *
  *
@@ -34,6 +34,7 @@
 #include "ExitFlag.h"
 #include "ICStatusMap.h"
 #include "StubInfoSummary.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -42,7 +43,7 @@ class CodeBlock;
 class StructureStubInfo;
 
 class CheckPrivateBrandStatus final {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(CheckPrivateBrandStatus);
 public:
     enum State : uint8_t {
         // It's uncached so we have no information.

--- a/Source/JavaScriptCore/bytecode/CheckPrivateBrandVariant.h
+++ b/Source/JavaScriptCore/bytecode/CheckPrivateBrandVariant.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2021 Igalia S.A. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,13 +29,14 @@
 #include "CacheableIdentifier.h"
 #include "StructureSet.h"
 #include <wtf/Box.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
 class CheckPrivateBrandStatus;
 
 class CheckPrivateBrandVariant {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(CheckPrivateBrandVariant);
 public:
     CheckPrivateBrandVariant(CacheableIdentifier, const StructureSet& = StructureSet());
 

--- a/Source/JavaScriptCore/bytecode/CodeOrigin.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeOrigin.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,8 +28,11 @@
 
 #include "CodeBlock.h"
 #include "InlineCallFrame.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(CodeOriginOutOfLineCodeOrigin, CodeOrigin::OutOfLineCodeOrigin);
 
 unsigned CodeOrigin::inlineDepth() const
 {

--- a/Source/JavaScriptCore/bytecode/CodeOrigin.h
+++ b/Source/JavaScriptCore/bytecode/CodeOrigin.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,6 +32,7 @@
 #include <wtf/MathExtras.h>
 #include <wtf/PrintStream.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 #if OS(DARWIN)
@@ -204,7 +205,7 @@ private:
     static constexpr uintptr_t s_maskIsBytecodeIndexInvalid = 2;
 
     struct OutOfLineCodeOrigin {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED(OutOfLineCodeOrigin);
     public:
         InlineCallFrame* inlineCallFrame;
         BytecodeIndex bytecodeIndex;

--- a/Source/JavaScriptCore/bytecode/DeferredSourceDump.h
+++ b/Source/JavaScriptCore/bytecode/DeferredSourceDump.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,13 +27,14 @@
 
 #include "JITCode.h"
 #include "Strong.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
 class CodeBlock;
 
 class DeferredSourceDump {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(DeferredSourceDump);
 public:
     DeferredSourceDump(CodeBlock*);
     DeferredSourceDump(CodeBlock*, CodeBlock* rootCodeBlock, JITType rootJITType, BytecodeIndex callerBytecodeIndex);

--- a/Source/JavaScriptCore/bytecode/DeleteByStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/DeleteByStatus.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,8 +32,11 @@
 #include "InlineCacheCompiler.h"
 #include "StructureStubInfo.h"
 #include <wtf/ListDump.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(DeleteByStatus);
 
 bool DeleteByStatus::appendVariant(const DeleteByVariant& variant)
 {

--- a/Source/JavaScriptCore/bytecode/DeleteByStatus.h
+++ b/Source/JavaScriptCore/bytecode/DeleteByStatus.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,6 +33,7 @@
 #include "ExitFlag.h"
 #include "ICStatusMap.h"
 #include "StubInfoSummary.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -41,7 +42,7 @@ class CodeBlock;
 class StructureStubInfo;
 
 class DeleteByStatus final {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(DeleteByStatus);
 public:
     enum State : uint8_t {
         // It's uncached so we have no information.

--- a/Source/JavaScriptCore/bytecode/DeleteByVariant.h
+++ b/Source/JavaScriptCore/bytecode/DeleteByVariant.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,6 +31,7 @@
 #include "PropertyOffset.h"
 #include "StructureSet.h"
 #include <wtf/Box.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -39,7 +40,7 @@ class DeleteByStatus;
 struct DumpContext;
 
 class DeleteByVariant {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(DeleteByVariant);
 public:
     DeleteByVariant(
         CacheableIdentifier, bool result,

--- a/Source/JavaScriptCore/bytecode/ExecutionCounter.cpp
+++ b/Source/JavaScriptCore/bytecode/ExecutionCounter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012, 2014, 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,6 +29,7 @@
 #include "CodeBlock.h"
 #include "ExecutableAllocator.h"
 #include "VMInlines.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
 
@@ -211,6 +212,9 @@ void ExecutionCounter<countingVariant>::dump(PrintStream& out) const
 
 template class ExecutionCounter<CountingForBaseline>;
 template class ExecutionCounter<CountingForUpperTiers>;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL_TEMPLATE(BaselineExecutionCounter);
+WTF_MAKE_TZONE_ALLOCATED_IMPL_TEMPLATE(UpperTierExecutionCounter);
 
 } // namespace JSC
 

--- a/Source/JavaScriptCore/bytecode/ExecutionCounter.h
+++ b/Source/JavaScriptCore/bytecode/ExecutionCounter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,6 +28,7 @@
 #include "Options.h"
 #include <wtf/Nonmovable.h>
 #include <wtf/PrintStream.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -54,7 +55,7 @@ inline int32_t formattedTotalExecutionCount(float value)
 
 template<CountingVariant countingVariant>
 class ExecutionCounter {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ExecutionCounter);
     WTF_MAKE_NONMOVABLE(ExecutionCounter);
 public:
     ExecutionCounter();

--- a/Source/JavaScriptCore/bytecode/FullBytecodeLiveness.h
+++ b/Source/JavaScriptCore/bytecode/FullBytecodeLiveness.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013, 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,6 +29,7 @@
 #include "Operands.h"
 #include <wtf/FastBitVector.h>
 #include <wtf/FixedVector.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -38,7 +39,7 @@ class CodeBlock;
 // Note: Full bytecode liveness does not track any information about the liveness of temps.
 // If you want tmp liveness for a checkpoint ask tmpLivenessForCheckpoint.
 class FullBytecodeLiveness {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(FullBytecodeLiveness);
 public:
     explicit FullBytecodeLiveness(size_t size)
         : m_usesBefore(size)

--- a/Source/JavaScriptCore/bytecode/GetByVariant.h
+++ b/Source/JavaScriptCore/bytecode/GetByVariant.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,6 +31,7 @@
 #include "PropertyOffset.h"
 #include "StructureSet.h"
 #include <wtf/Box.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 namespace DOMJIT {
@@ -42,7 +43,7 @@ class GetByStatus;
 struct DumpContext;
 
 class GetByVariant {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(GetByVariant);
 public:
     GetByVariant(
         CacheableIdentifier,

--- a/Source/JavaScriptCore/bytecode/InByStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/InByStatus.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2018 Yusuke Suzuki <utatane.tea@gmail.com>.
- * Copyright (C) 2018-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,8 +34,11 @@
 #include "InlineCacheCompiler.h"
 #include "StructureStubInfo.h"
 #include <wtf/ListDump.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InByStatus);
 
 bool InByStatus::appendVariant(const InByVariant& variant)
 {

--- a/Source/JavaScriptCore/bytecode/InByStatus.h
+++ b/Source/JavaScriptCore/bytecode/InByStatus.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2018 Yusuke Suzuki <utatane.tea@gmail.com>.
- * Copyright (C) 2018-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,6 +32,7 @@
 #include "ICStatusMap.h"
 #include "InByVariant.h"
 #include "StubInfoSummary.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -40,7 +41,7 @@ class CodeBlock;
 class StructureStubInfo;
 
 class InByStatus final {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(InByStatus);
 public:
     enum State {
         // It's uncached so we have no information.

--- a/Source/JavaScriptCore/bytecode/InByVariant.h
+++ b/Source/JavaScriptCore/bytecode/InByVariant.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2018 Yusuke Suzuki <utatane.tea@gmail.com>.
- * Copyright (C) 2018-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,6 +30,7 @@
 #include "ObjectPropertyConditionSet.h"
 #include "PropertyOffset.h"
 #include "StructureSet.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 namespace DOMJIT {
@@ -40,7 +41,7 @@ class InByStatus;
 struct DumpContext;
 
 class InByVariant {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(InByVariant);
 public:
     InByVariant(CacheableIdentifier, const StructureSet& = StructureSet(), PropertyOffset = invalidOffset, const ObjectPropertyConditionSet& = ObjectPropertyConditionSet());
 

--- a/Source/JavaScriptCore/bytecode/InstanceOfStatus.h
+++ b/Source/JavaScriptCore/bytecode/InstanceOfStatus.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,6 +29,7 @@
 #include "ICStatusMap.h"
 #include "InstanceOfVariant.h"
 #include "StubInfoSummary.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -37,7 +38,7 @@ class CodeBlock;
 class StructureStubInfo;
 
 class InstanceOfStatus final {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(InstanceOfStatus);
 public:
     enum State {
         // It's uncached so we have no information.

--- a/Source/JavaScriptCore/bytecode/InstanceOfVariant.h
+++ b/Source/JavaScriptCore/bytecode/InstanceOfVariant.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,13 +27,14 @@
 
 #include "ObjectPropertyConditionSet.h"
 #include "StructureSet.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
 class InstanceOfStatus;
 
 class InstanceOfVariant {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(InstanceOfVariant);
 public:
     InstanceOfVariant() = default;
     InstanceOfVariant(const StructureSet&, const ObjectPropertyConditionSet&, JSObject* prototype, bool isHit);

--- a/Source/JavaScriptCore/bytecode/MetadataTable.h
+++ b/Source/JavaScriptCore/bytecode/MetadataTable.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,6 +30,7 @@
 #include "UnlinkedMetadataTable.h"
 #include "ValueProfile.h"
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -40,7 +41,7 @@ class CodeBlock;
 //                                                   ^
 //                 The pointer of MetadataTable points at this address.
 class MetadataTable {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(MetadataTable);
     WTF_MAKE_NONCOPYABLE(MetadataTable);
     friend class LLIntOffsetsExtractor;
     friend class UnlinkedMetadataTable;

--- a/Source/JavaScriptCore/bytecode/PutByVariant.h
+++ b/Source/JavaScriptCore/bytecode/PutByVariant.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,11 +30,12 @@
 #include "ObjectPropertyConditionSet.h"
 #include "PropertyOffset.h"
 #include "StructureSet.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
 class PutByVariant {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PutByVariant);
 public:
     enum Kind {
         NotSet,

--- a/Source/JavaScriptCore/bytecode/SetPrivateBrandStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/SetPrivateBrandStatus.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2021 Igalia S.A. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -33,8 +33,11 @@
 #include "InlineCacheCompiler.h"
 #include "StructureStubInfo.h"
 #include <wtf/ListDump.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SetPrivateBrandStatus);
 
 bool SetPrivateBrandStatus::appendVariant(const SetPrivateBrandVariant& variant)
 {

--- a/Source/JavaScriptCore/bytecode/SetPrivateBrandStatus.h
+++ b/Source/JavaScriptCore/bytecode/SetPrivateBrandStatus.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2021 Igalia S.A. All rights reserved.
  *
  *
@@ -34,6 +34,7 @@
 #include "ICStatusMap.h"
 #include "SetPrivateBrandVariant.h"
 #include "StubInfoSummary.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -43,7 +44,7 @@ class StructureSet;
 class StructureStubInfo;
 
 class SetPrivateBrandStatus final {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SetPrivateBrandStatus);
 public:
     enum State : uint8_t {
         // It's uncached so we have no information.

--- a/Source/JavaScriptCore/bytecode/SetPrivateBrandVariant.h
+++ b/Source/JavaScriptCore/bytecode/SetPrivateBrandVariant.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2021 Igalia S.A. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,13 +29,14 @@
 #include "CacheableIdentifier.h"
 #include "SlotVisitorMacros.h"
 #include <wtf/Box.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
 class SetPrivateBrandStatus;
 
 class SetPrivateBrandVariant {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SetPrivateBrandVariant);
 public:
     SetPrivateBrandVariant(CacheableIdentifier, Structure* oldStructure, Structure* newStructure);
 

--- a/Source/JavaScriptCore/bytecode/StructureStubClearingWatchpoint.cpp
+++ b/Source/JavaScriptCore/bytecode/StructureStubClearingWatchpoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012, 2015-2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,8 +31,13 @@
 #include "CodeBlock.h"
 #include "JSCellInlines.h"
 #include "StructureStubInfo.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AdaptiveValueStructureStubClearingWatchpoint);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(StructureTransitionStructureStubClearingWatchpoint);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WatchpointsOnStructureStubInfo);
 
 void StructureTransitionStructureStubClearingWatchpoint::fireInternal(VM& vm, const FireDetail&)
 {

--- a/Source/JavaScriptCore/bytecode/StructureStubClearingWatchpoint.h
+++ b/Source/JavaScriptCore/bytecode/StructureStubClearingWatchpoint.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,8 +31,8 @@
 #include "ObjectPropertyCondition.h"
 #include "Watchpoint.h"
 #include <wtf/Bag.h>
-#include <wtf/FastMalloc.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -42,7 +42,7 @@ class WatchpointsOnStructureStubInfo;
 
 class StructureTransitionStructureStubClearingWatchpoint final : public Watchpoint {
     WTF_MAKE_NONCOPYABLE(StructureTransitionStructureStubClearingWatchpoint);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(StructureTransitionStructureStubClearingWatchpoint);
 public:
     StructureTransitionStructureStubClearingWatchpoint(const ObjectPropertyCondition& key, WatchpointsOnStructureStubInfo& holder)
         : Watchpoint(Watchpoint::Type::StructureTransitionStructureStubClearing)
@@ -61,7 +61,7 @@ private:
 class AdaptiveValueStructureStubClearingWatchpoint final : public AdaptiveInferredPropertyValueWatchpointBase {
     using Base = AdaptiveInferredPropertyValueWatchpointBase;
     WTF_MAKE_NONCOPYABLE(AdaptiveValueStructureStubClearingWatchpoint);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(AdaptiveValueStructureStubClearingWatchpoint);
 
     void handleFire(VM&, const FireDetail&) final;
 
@@ -80,7 +80,7 @@ private:
 
 class WatchpointsOnStructureStubInfo final {
     WTF_MAKE_NONCOPYABLE(WatchpointsOnStructureStubInfo);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WatchpointsOnStructureStubInfo);
 public:
     WatchpointsOnStructureStubInfo(CodeBlock* codeBlock, StructureStubInfo* stubInfo)
         : m_codeBlock(codeBlock)

--- a/Source/JavaScriptCore/bytecode/StructureStubInfo.h
+++ b/Source/JavaScriptCore/bytecode/StructureStubInfo.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -40,6 +40,7 @@
 #include "StubInfoSummary.h"
 #include <wtf/Box.h>
 #include <wtf/Lock.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -112,7 +113,7 @@ struct BaselineUnlinkedStructureStubInfo;
 
 class StructureStubInfo {
     WTF_MAKE_NONCOPYABLE(StructureStubInfo);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(StructureStubInfo);
 public:
     StructureStubInfo(AccessType accessType, CodeOrigin codeOrigin)
         : codeOrigin(codeOrigin)

--- a/Source/JavaScriptCore/bytecode/UnlinkedCodeBlockGenerator.cpp
+++ b/Source/JavaScriptCore/bytecode/UnlinkedCodeBlockGenerator.cpp
@@ -31,8 +31,11 @@
 #include "JSCJSValueInlines.h"
 #include "PreciseJumpTargets.h"
 #include "UnlinkedMetadataTableInlines.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(UnlinkedCodeBlockGenerator);
 
 void UnlinkedCodeBlockGenerator::addExpressionInfo(unsigned instructionOffset, unsigned divot, unsigned startOffset, unsigned endOffset, unsigned line, unsigned column)
 {

--- a/Source/JavaScriptCore/bytecode/UnlinkedCodeBlockGenerator.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedCodeBlockGenerator.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include "UnlinkedCodeBlock.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace JSC {
@@ -34,7 +35,7 @@ namespace JSC {
 // FIXME: Create UnlinkedCodeBlock inside UnlinkedCodeBlockGenerator.
 // https://bugs.webkit.org/show_bug.cgi?id=207212
 class UnlinkedCodeBlockGenerator {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(UnlinkedCodeBlockGenerator);
     WTF_MAKE_NONCOPYABLE(UnlinkedCodeBlockGenerator)
 public:
     UnlinkedCodeBlockGenerator(VM& vm, UnlinkedCodeBlock* codeBlock)

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2008 Cameron Zwarich <cwzwarich@uwaterloo.ca>
  * Copyright (C) 2012 Igalia, S.L.
  *
@@ -59,9 +59,13 @@
 #include <wtf/BitVector.h>
 #include <wtf/HashSet.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/WTFString.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(BytecodeGenerator);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ForInContext);
 
 template<typename CallOp, typename = std::true_type>
 struct VarArgsOp;

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
@@ -55,6 +55,7 @@
 #include <wtf/HashFunctions.h>
 #include <wtf/SegmentedVector.h>
 #include <wtf/SetForScope.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace JSC {
@@ -243,7 +244,7 @@ namespace JSC {
     };
 
     class ForInContext : public RefCounted<ForInContext> {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED(ForInContext);
         WTF_MAKE_NONCOPYABLE(ForInContext);
     public:
         using GetInst = std::tuple<unsigned, int>;
@@ -337,7 +338,7 @@ namespace JSC {
     };
 
     class BytecodeGenerator : public BytecodeGeneratorBase<JSGeneratorTraits> {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED(BytecodeGenerator);
         WTF_MAKE_NONCOPYABLE(BytecodeGenerator);
 
         friend class FinallyContext;

--- a/Source/JavaScriptCore/config.h
+++ b/Source/JavaScriptCore/config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2006 Samuel Weinig <sam.weinig@gmail.com>
  *
  * This library is free software; you can redistribute it and/or
@@ -37,6 +37,7 @@
 #undef new
 #undef delete
 #include <wtf/FastMalloc.h>
+#include <wtf/TZoneMalloc.h>
 #endif
 
 #include <wtf/DisallowCType.h>

--- a/Source/JavaScriptCore/debugger/Breakpoint.h
+++ b/Source/JavaScriptCore/debugger/Breakpoint.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,10 +26,10 @@
 #pragma once
 
 #include "DebuggerPrimitives.h"
-#include <wtf/FastMalloc.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
@@ -40,7 +40,7 @@ class JSGlobalObject;
 
 class Breakpoint : public RefCounted<Breakpoint> {
     WTF_MAKE_NONCOPYABLE(Breakpoint);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Breakpoint);
 public:
     struct Action {
         enum class Type : uint8_t {

--- a/Source/JavaScriptCore/debugger/Debugger.cpp
+++ b/Source/JavaScriptCore/debugger/Debugger.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2008-2022 Apple Inc. All rights reserved.
+ *  Copyright (C) 2008-2023 Apple Inc. All rights reserved.
  *  Copyright (C) 1999-2001 Harri Porten (porten@kde.org)
  *  Copyright (C) 2001 Peter Kelly (pmk@post.com)
  *
@@ -31,15 +31,20 @@
 #include "Microtask.h"
 #include "VMEntryScopeInlines.h"
 #include "VMTrapsInlines.h"
+#include <wtf/ForbidHeapAllocation.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 #include <wtf/text/TextPosition.h>
 
 namespace JSC {
 
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Debugger);
+
 class DebuggerPausedScope {
+    WTF_FORBID_HEAP_ALLOCATION;
 public:
     DebuggerPausedScope(Debugger& debugger)
         : m_debugger(debugger)

--- a/Source/JavaScriptCore/debugger/Debugger.h
+++ b/Source/JavaScriptCore/debugger/Debugger.h
@@ -1,7 +1,7 @@
 /*
  *  Copyright (C) 1999-2001 Harri Porten (porten@kde.org)
  *  Copyright (C) 2001 Peter Kelly (pmk@post.com)
- *  Copyright (C) 2008, 2009, 2013, 2014 Apple Inc. All rights reserved.
+ *  Copyright (C) 2008-2023 Apple Inc. All rights reserved.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
@@ -30,6 +30,7 @@
 #include <wtf/DoublyLinkedList.h>
 #include <wtf/Forward.h>
 #include <wtf/ListHashSet.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -42,7 +43,7 @@ class SourceProvider;
 class VM;
 
 class Debugger : public DoublyLinkedListNode<Debugger> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(Debugger, JS_EXPORT_PRIVATE);
 public:
     JS_EXPORT_PRIVATE Debugger(VM&);
     JS_EXPORT_PRIVATE virtual ~Debugger();

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreter.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,13 +32,14 @@
 #include "DFGNode.h"
 #include "DFGNodeFlowProjection.h"
 #include "DFGPhiChildren.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/TriState.h>
 
 namespace JSC { namespace DFG {
 
 template<typename AbstractStateType>
 class AbstractInterpreter {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(AbstractInterpreter);
 public:
     AbstractInterpreter(Graph&, AbstractStateType&);
     ~AbstractInterpreter();

--- a/Source/JavaScriptCore/dfg/DFGAdaptiveInferredPropertyValueWatchpoint.cpp
+++ b/Source/JavaScriptCore/dfg/DFGAdaptiveInferredPropertyValueWatchpoint.cpp
@@ -30,8 +30,11 @@
 
 #include "CodeBlock.h"
 #include "DFGCommon.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC { namespace DFG {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AdaptiveInferredPropertyValueWatchpoint);
 
 AdaptiveInferredPropertyValueWatchpoint::AdaptiveInferredPropertyValueWatchpoint(const ObjectPropertyCondition& key, CodeBlock* codeBlock)
     : Base(key)

--- a/Source/JavaScriptCore/dfg/DFGAdaptiveInferredPropertyValueWatchpoint.h
+++ b/Source/JavaScriptCore/dfg/DFGAdaptiveInferredPropertyValueWatchpoint.h
@@ -28,10 +28,12 @@
 #if ENABLE(DFG_JIT)
 
 #include "AdaptiveInferredPropertyValueWatchpointBase.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC { namespace DFG {
 
 class AdaptiveInferredPropertyValueWatchpoint final : public AdaptiveInferredPropertyValueWatchpointBase {
+    WTF_MAKE_TZONE_ALLOCATED(AdaptiveInferredPropertyValueWatchpoint);
 public:
     typedef AdaptiveInferredPropertyValueWatchpointBase Base;
     AdaptiveInferredPropertyValueWatchpoint(const ObjectPropertyCondition&, CodeBlock*);

--- a/Source/JavaScriptCore/dfg/DFGArrayifySlowPathGenerator.h
+++ b/Source/JavaScriptCore/dfg/DFGArrayifySlowPathGenerator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,11 +32,13 @@
 #include "DFGOperations.h"
 #include "DFGSlowPathGenerator.h"
 #include "DFGSpeculativeJIT.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 
 namespace JSC { namespace DFG {
 
 class ArrayifySlowPathGenerator final : public JumpingSlowPathGenerator<MacroAssembler::JumpList> {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(ArrayifySlowPathGenerator);
 public:
     ArrayifySlowPathGenerator(
         const MacroAssembler::JumpList& from, SpeculativeJIT* jit, Node* node, GPRReg baseGPR,

--- a/Source/JavaScriptCore/dfg/DFGBackwardsCFG.h
+++ b/Source/JavaScriptCore/dfg/DFGBackwardsCFG.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,12 +29,13 @@
 
 #include "DFGCFG.h"
 #include <wtf/BackwardsGraph.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC { namespace DFG {
 
 class BackwardsCFG : public BackwardsGraph<SSACFG> {
     WTF_MAKE_NONCOPYABLE(BackwardsCFG);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(BackwardsCFG);
 public:
     BackwardsCFG(Graph& graph)
         : BackwardsGraph<SSACFG>(selectCFG<SSACFG>(graph))

--- a/Source/JavaScriptCore/dfg/DFGBackwardsDominators.h
+++ b/Source/JavaScriptCore/dfg/DFGBackwardsDominators.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,14 +29,14 @@
 
 #include "DFGBackwardsCFG.h"
 #include <wtf/Dominators.h>
-#include <wtf/FastMalloc.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC { namespace DFG {
 
 class BackwardsDominators : public WTF::Dominators<BackwardsCFG> {
     WTF_MAKE_NONCOPYABLE(BackwardsDominators);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(BackwardsDominators);
 public:
     BackwardsDominators(Graph& graph)
         : WTF::Dominators<BackwardsCFG>(graph.ensureBackwardsCFG())

--- a/Source/JavaScriptCore/dfg/DFGBasicBlock.cpp
+++ b/Source/JavaScriptCore/dfg/DFGBasicBlock.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,8 +29,13 @@
 #if ENABLE(DFG_JIT)
 
 #include "JSCJSValueInlines.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC { namespace DFG {
+
+using BasicBlockSSAData = BasicBlock::SSAData;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(BasicBlockSSAData);
 
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(BasicBlock);
 

--- a/Source/JavaScriptCore/dfg/DFGBasicBlock.h
+++ b/Source/JavaScriptCore/dfg/DFGBasicBlock.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011, 2013-2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,6 +34,7 @@
 #include "DFGNodeAbstractValuePair.h"
 #include "DFGStructureClobberState.h"
 #include "Operands.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace JSC { namespace DFG {
@@ -233,7 +234,7 @@ struct BasicBlock : RefCounted<BasicBlock> {
     float executionCount;
     
     struct SSAData {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED(SSAData);
     public:
         void invalidate()
         {

--- a/Source/JavaScriptCore/dfg/DFGBlockMap.h
+++ b/Source/JavaScriptCore/dfg/DFGBlockMap.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014, 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,7 +35,7 @@ class Graph;
 
 template<typename T>
 class BlockMap {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(BlockMap);
 public:
     BlockMap()
     {

--- a/Source/JavaScriptCore/dfg/DFGCFG.h
+++ b/Source/JavaScriptCore/dfg/DFGCFG.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,12 +32,13 @@
 #include "DFGBlockSet.h"
 #include "DFGGraph.h"
 #include <wtf/SingleRootGraph.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC { namespace DFG {
 
 class CFG {
     WTF_MAKE_NONCOPYABLE(CFG);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(CFG);
 public:
     typedef BasicBlock* Node;
     typedef BlockSet Set;

--- a/Source/JavaScriptCore/dfg/DFGCSEPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGCSEPhase.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,6 +36,7 @@
 #include "DFGDominators.h"
 #include "DFGGraph.h"
 #include "DFGPhase.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC { namespace DFG {
 
@@ -52,7 +53,7 @@ static constexpr bool verbose = false;
 
 class ImpureDataSlot {
     WTF_MAKE_NONCOPYABLE(ImpureDataSlot);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ImpureDataSlot);
 public:
     ImpureDataSlot(HeapLocation key, LazyNode value, unsigned hash)
         : key(key), value(value), hash(hash)
@@ -62,6 +63,8 @@ public:
     LazyNode value;
     unsigned hash;
 };
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ImpureDataSlot);
 
 struct ImpureDataSlotHash : public DefaultHash<std::unique_ptr<ImpureDataSlot>> {
     static unsigned hash(const std::unique_ptr<ImpureDataSlot>& key)
@@ -100,7 +103,7 @@ struct ImpureDataTranslator {
 };
 
 class ImpureMap {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ImpureMap);
     WTF_MAKE_NONCOPYABLE(ImpureMap);
 public:
     ImpureMap() = default;

--- a/Source/JavaScriptCore/dfg/DFGCallArrayAllocatorSlowPathGenerator.h
+++ b/Source/JavaScriptCore/dfg/DFGCallArrayAllocatorSlowPathGenerator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,11 +29,13 @@
 
 #include "DFGSlowPathGenerator.h"
 #include "DFGSpeculativeJIT.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 
 namespace JSC { namespace DFG {
 
 class CallArrayAllocatorSlowPathGenerator final : public JumpingSlowPathGenerator<MacroAssembler::JumpList> {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(CallArrayAllocatorSlowPathGenerator);
 public:
     CallArrayAllocatorSlowPathGenerator(
         MacroAssembler::JumpList from, SpeculativeJIT* jit, P_JITOperation_VmStZB function,
@@ -72,6 +74,7 @@ private:
 };
 
 class CallArrayAllocatorWithVariableSizeSlowPathGenerator final : public JumpingSlowPathGenerator<MacroAssembler::JumpList> {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(CallArrayAllocatorWithVariableSizeSlowPathGenerator);
 public:
     CallArrayAllocatorWithVariableSizeSlowPathGenerator(
         MacroAssembler::JumpList from, SpeculativeJIT* jit, P_JITOperation_GStZB function,
@@ -122,6 +125,7 @@ private:
 };
 
 class CallArrayAllocatorWithVariableStructureVariableSizeSlowPathGenerator final : public JumpingSlowPathGenerator<MacroAssembler::JumpList> {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(CallArrayAllocatorWithVariableStructureVariableSizeSlowPathGenerator);
 public:
     CallArrayAllocatorWithVariableStructureVariableSizeSlowPathGenerator(
         MacroAssembler::JumpList from, SpeculativeJIT* jit, P_JITOperation_GStZB function,

--- a/Source/JavaScriptCore/dfg/DFGCallCreateDirectArgumentsSlowPathGenerator.h
+++ b/Source/JavaScriptCore/dfg/DFGCallCreateDirectArgumentsSlowPathGenerator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,11 +31,13 @@
 #include "DFGSlowPathGenerator.h"
 #include "DFGSpeculativeJIT.h"
 #include "DirectArguments.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC { namespace DFG {
 
 // This calls operationCreateDirectArguments but then restores the value of lengthGPR.
 class CallCreateDirectArgumentsSlowPathGenerator final : public JumpingSlowPathGenerator<MacroAssembler::JumpList> {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(CallCreateDirectArgumentsSlowPathGenerator);
 public:
     CallCreateDirectArgumentsSlowPathGenerator(
         MacroAssembler::JumpList from, SpeculativeJIT* jit, GPRReg resultGPR, RegisteredStructure structure,

--- a/Source/JavaScriptCore/dfg/DFGCombinedLiveness.cpp
+++ b/Source/JavaScriptCore/dfg/DFGCombinedLiveness.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,8 +31,11 @@
 #include "DFGAvailabilityMap.h"
 #include "DFGBlockMapInlines.h"
 #include "JSCJSValueInlines.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC { namespace DFG {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED_TEMPLATE(CombinedLivenessNodeLivenessMap, CombinedLiveness::NodeLivenessMap);
 
 static void addBytecodeLiveness(Graph& graph, AvailabilityMap& availabilityMap, NodeSet& seen, Node* node)
 {

--- a/Source/JavaScriptCore/dfg/DFGCombinedLiveness.h
+++ b/Source/JavaScriptCore/dfg/DFGCombinedLiveness.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -44,9 +44,11 @@ struct CombinedLiveness {
     CombinedLiveness() { }
     
     CombinedLiveness(Graph&);
-    
-    BlockMap<NodeSet> liveAtHead;
-    BlockMap<NodeSet> liveAtTail;
+
+    using NodeLivenessMap = BlockMap<NodeSet>;
+
+    NodeLivenessMap liveAtHead;
+    NodeLivenessMap liveAtTail;
 };
 
 } } // namespace JSC::DFG

--- a/Source/JavaScriptCore/dfg/DFGControlEquivalenceAnalysis.h
+++ b/Source/JavaScriptCore/dfg/DFGControlEquivalenceAnalysis.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,12 +29,13 @@
 
 #include "DFGBackwardsDominators.h"
 #include "DFGDominators.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC { namespace DFG {
 
 class ControlEquivalenceAnalysis {
     WTF_MAKE_NONCOPYABLE(ControlEquivalenceAnalysis);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ControlEquivalenceAnalysis);
 public:
     ControlEquivalenceAnalysis(Graph& graph)
         : m_dominators(graph.ensureSSADominators())

--- a/Source/JavaScriptCore/dfg/DFGDisassembler.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDisassembler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,8 +33,11 @@
 #include "Disassembler.h"
 #include "JSCJSValueInlines.h"
 #include "LinkBuffer.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC { namespace DFG {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Disassembler);
 
 Disassembler::Disassembler(Graph& graph)
     : m_graph(graph)

--- a/Source/JavaScriptCore/dfg/DFGDisassembler.h
+++ b/Source/JavaScriptCore/dfg/DFGDisassembler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012, 2013 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,6 +34,7 @@
 #include "ProfilerCompilation.h"
 #include <wtf/HashMap.h>
 #include <wtf/StringPrintStream.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace JSC {
@@ -45,7 +46,7 @@ namespace DFG {
 class Graph;
 
 class Disassembler {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Disassembler);
 public:
     Disassembler(Graph&);
     

--- a/Source/JavaScriptCore/dfg/DFGDominators.h
+++ b/Source/JavaScriptCore/dfg/DFGDominators.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,15 +30,15 @@
 #include "DFGCFG.h"
 #include "DFGGraph.h"
 #include <wtf/Dominators.h>
-#include <wtf/FastMalloc.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC { namespace DFG {
 
 template <typename CFGKind>
 class Dominators : public WTF::Dominators<CFGKind> {
     WTF_MAKE_NONCOPYABLE(Dominators);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Dominators);
 public:
     Dominators(Graph& graph)
         : WTF::Dominators<CFGKind>(selectCFG<CFGKind>(graph))

--- a/Source/JavaScriptCore/dfg/DFGFailedFinalizer.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFailedFinalizer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,10 +25,13 @@
 
 #include "config.h"
 #include "DFGFailedFinalizer.h"
+#include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(DFG_JIT)
 
 namespace JSC { namespace DFG {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FailedFinalizer);
 
 FailedFinalizer::FailedFinalizer(Plan& plan)
     : Finalizer(plan)

--- a/Source/JavaScriptCore/dfg/DFGFailedFinalizer.h
+++ b/Source/JavaScriptCore/dfg/DFGFailedFinalizer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,10 +28,12 @@
 #if ENABLE(DFG_JIT)
 
 #include "DFGFinalizer.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC { namespace DFG {
 
 class FailedFinalizer final : public Finalizer {
+    WTF_MAKE_TZONE_ALLOCATED(FailedFinalizer);
 public:
     FailedFinalizer(Plan&);
     ~FailedFinalizer() final;

--- a/Source/JavaScriptCore/dfg/DFGFinalizer.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFinalizer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,10 +25,13 @@
 
 #include "config.h"
 #include "DFGFinalizer.h"
+#include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(DFG_JIT)
 
 namespace JSC { namespace DFG {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Finalizer);
 
 Finalizer::Finalizer(Plan& plan)
     : m_plan(plan)

--- a/Source/JavaScriptCore/dfg/DFGFinalizer.h
+++ b/Source/JavaScriptCore/dfg/DFGFinalizer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,15 +27,16 @@
 
 #if ENABLE(DFG_JIT)
 
-#include <wtf/FastMalloc.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC { namespace DFG {
 
 class Plan;
 
 class Finalizer {
-    WTF_MAKE_NONCOPYABLE(Finalizer); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_NONCOPYABLE(Finalizer);
+    WTF_MAKE_TZONE_ALLOCATED(Finalizer);
 public:
     Finalizer(Plan&);
     virtual ~Finalizer();

--- a/Source/JavaScriptCore/dfg/DFGFlowIndexing.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFlowIndexing.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,8 +29,11 @@
 #if ENABLE(DFG_JIT)
 
 #include "JSCJSValueInlines.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC { namespace DFG {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FlowIndexing);
 
 FlowIndexing::FlowIndexing(Graph& graph)
     : m_graph(graph)

--- a/Source/JavaScriptCore/dfg/DFGFlowIndexing.h
+++ b/Source/JavaScriptCore/dfg/DFGFlowIndexing.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,6 +29,7 @@
 
 #include "DFGGraph.h"
 #include "DFGNodeFlowProjection.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC { namespace DFG {
 
@@ -36,7 +37,7 @@ namespace JSC { namespace DFG {
 // Node-keyed maps. The special part is that it also allocated indices for the shadow values of Phi
 // nodes, which is needed for any flow-sensitive analysis.
 class FlowIndexing {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(FlowIndexing);
 public:
     FlowIndexing(Graph&);
     ~FlowIndexing();

--- a/Source/JavaScriptCore/dfg/DFGFlowMap.h
+++ b/Source/JavaScriptCore/dfg/DFGFlowMap.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,6 +30,7 @@
 #include "DFGFlowIndexing.h"
 #include "DFGGraph.h"
 #include "DFGNode.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC { namespace DFG {
 
@@ -38,7 +39,7 @@ namespace JSC { namespace DFG {
 // values of Phis. This makes it easy to do both of those things.
 template<typename T>
 class FlowMap {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(FlowMap);
 public:
     FlowMap(Graph& graph)
         : m_graph(graph)

--- a/Source/JavaScriptCore/dfg/DFGInPlaceAbstractState.cpp
+++ b/Source/JavaScriptCore/dfg/DFGInPlaceAbstractState.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,8 +30,11 @@
 
 #include "DFGBasicBlock.h"
 #include "JSCJSValueInlines.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC { namespace DFG {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InPlaceAbstractState);
 
 namespace DFGInPlaceAbstractStateInternal {
 static constexpr bool verbose = false;

--- a/Source/JavaScriptCore/dfg/DFGInPlaceAbstractState.h
+++ b/Source/JavaScriptCore/dfg/DFGInPlaceAbstractState.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,11 +33,12 @@
 #include "DFGFlowMap.h"
 #include "DFGGraph.h"
 #include "DFGNode.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC { namespace DFG {
 
 class InPlaceAbstractState {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(InPlaceAbstractState);
 public:
     InPlaceAbstractState(Graph&);
     

--- a/Source/JavaScriptCore/dfg/DFGJITCompiler.cpp
+++ b/Source/JavaScriptCore/dfg/DFGJITCompiler.cpp
@@ -42,8 +42,11 @@
 #include "ProbeContext.h"
 #include "ThunkGenerators.h"
 #include "VM.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC { namespace DFG {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(JITCompiler);
 
 JITCompiler::JITCompiler(Graph& dfg)
     : CCallHelpers(dfg.m_codeBlock)

--- a/Source/JavaScriptCore/dfg/DFGJITCompiler.h
+++ b/Source/JavaScriptCore/dfg/DFGJITCompiler.h
@@ -42,6 +42,7 @@
 #include "LinkBuffer.h"
 #include "MacroAssembler.h"
 #include "PCToCodeOriginMap.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -86,6 +87,7 @@ struct CallLinkRecord {
 // compilation, and also records information used in linking (e.g. a list of all
 // call to be linked).
 class JITCompiler : public CCallHelpers {
+    WTF_MAKE_TZONE_ALLOCATED(JITCompiler);
 public:
     friend class SpeculativeJIT;
 

--- a/Source/JavaScriptCore/dfg/DFGJITFinalizer.cpp
+++ b/Source/JavaScriptCore/dfg/DFGJITFinalizer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,8 +33,11 @@
 #include "DFGPlan.h"
 #include "HeapInlines.h"
 #include "ProfilerDatabase.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC { namespace DFG {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(JITFinalizer);
 
 JITFinalizer::JITFinalizer(Plan& plan, Ref<JITCode>&& jitCode, std::unique_ptr<LinkBuffer> linkBuffer, CodePtr<JSEntryPtrTag> withArityCheck)
     : Finalizer(plan)

--- a/Source/JavaScriptCore/dfg/DFGJITFinalizer.h
+++ b/Source/JavaScriptCore/dfg/DFGJITFinalizer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,10 +30,12 @@
 #include "DFGFinalizer.h"
 #include "DFGJITCode.h"
 #include "LinkBuffer.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC { namespace DFG {
 
 class JITFinalizer final : public Finalizer {
+    WTF_MAKE_TZONE_ALLOCATED(JITFinalizer);
 public:
     JITFinalizer(Plan&, Ref<JITCode>&&, std::unique_ptr<LinkBuffer>, CodePtr<JSEntryPtrTag> withArityCheck = CodePtr<JSEntryPtrTag>(CodePtr<JSEntryPtrTag>::EmptyValue));
     ~JITFinalizer() final;

--- a/Source/JavaScriptCore/dfg/DFGNaturalLoops.h
+++ b/Source/JavaScriptCore/dfg/DFGNaturalLoops.h
@@ -28,16 +28,16 @@
 #if ENABLE(DFG_JIT)
 
 #include "DFGDominators.h"
-#include <wtf/FastMalloc.h>
 #include <wtf/NaturalLoops.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC { namespace DFG {
 
 template <typename CFGKind>
 class NaturalLoops : public WTF::NaturalLoops<CFGKind> {
     WTF_MAKE_NONCOPYABLE(NaturalLoops);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(NaturalLoops);
 public:
     NaturalLoops(Graph& graph)
         : WTF::NaturalLoops<CFGKind>(selectCFG<CFGKind>(graph), ensureDominatorsForCFG<CFGKind>(graph), validationEnabled())

--- a/Source/JavaScriptCore/dfg/DFGNullAbstractState.h
+++ b/Source/JavaScriptCore/dfg/DFGNullAbstractState.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -37,7 +37,7 @@ struct Node;
 // to not pass any abstract state. This works if the templatized code also does a check (using the
 // operator bool) to see if the state is valid.
 class NullAbstractState {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(NullAbstractState);
 public:
     NullAbstractState() { }
     

--- a/Source/JavaScriptCore/dfg/DFGPhiChildren.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPhiChildren.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,8 +30,11 @@
 
 #include "DFGGraph.h"
 #include "JSCJSValueInlines.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC { namespace DFG {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PhiChildren);
 
 PhiChildren::PhiChildren()
 {

--- a/Source/JavaScriptCore/dfg/DFGPhiChildren.h
+++ b/Source/JavaScriptCore/dfg/DFGPhiChildren.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,6 +29,7 @@
 
 #include "DFGNode.h"
 #include <wtf/HashSet.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace JSC { namespace DFG {
@@ -36,7 +37,7 @@ namespace JSC { namespace DFG {
 class Graph;
 
 class PhiChildren {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PhiChildren);
 public:
     typedef Vector<Node*, 3> List;
     

--- a/Source/JavaScriptCore/dfg/DFGSaneStringGetByValSlowPathGenerator.h
+++ b/Source/JavaScriptCore/dfg/DFGSaneStringGetByValSlowPathGenerator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,11 +30,13 @@
 #include "DFGOperations.h"
 #include "DFGSlowPathGenerator.h"
 #include "DFGSpeculativeJIT.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 
 namespace JSC { namespace DFG {
 
 class SaneStringGetByValSlowPathGenerator final : public JumpingSlowPathGenerator<MacroAssembler::Jump> {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(SaneStringGetByValSlowPathGenerator);
 public:
     SaneStringGetByValSlowPathGenerator(
         const MacroAssembler::Jump& from, SpeculativeJIT* jit, JSValueRegs resultRegs, JITCompiler::LinkableConstant globalObject, GPRReg baseReg, GPRReg propertyReg)

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -77,10 +77,29 @@
 #include <wtf/BitVector.h>
 #include <wtf/Box.h>
 #include <wtf/MathExtras.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC { namespace DFG {
 
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(SpeculativeJIT);
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FPRTemporary);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(GPRTemporary);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(JSValueRegsFlushedCallResult);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(JSValueRegsTemporary);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SpeculateInt32Operand);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SpeculateStrictInt32Operand);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SpeculateInt52Operand);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SpeculateStrictInt52Operand);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SpeculateWhicheverInt52Operand);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SpeculateDoubleOperand);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SpeculateCellOperand);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SpeculateBooleanOperand);
+#if USE(BIGINT32)
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SpeculateBigInt32Operand);
+#endif
+WTF_MAKE_TZONE_ALLOCATED_IMPL(JSValueOperand);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(StorageOperand);
 
 SpeculativeJIT::SpeculativeJIT(Graph& dfg)
     : Base(dfg)

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -42,6 +42,7 @@
 #include "StructureStubInfo.h"
 #include "ValueRecovery.h"
 #include "VirtualRegister.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC { namespace DFG {
 
@@ -1912,7 +1913,7 @@ public:
 // in order to make space available for another.
 
 class JSValueOperand {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(JSValueOperand);
 public:
     explicit JSValueOperand(SpeculativeJIT* jit, Edge edge, OperandSpeculationMode mode = AutomaticOperandSpeculation)
         : m_jit(jit)
@@ -2070,7 +2071,7 @@ private:
 };
 
 class StorageOperand {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(StorageOperand);
 public:
     StorageOperand() = default;
 
@@ -2138,7 +2139,7 @@ private:
 enum ReuseTag { Reuse };
 
 class GPRTemporary {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(GPRTemporary);
 public:
     GPRTemporary();
     GPRTemporary(SpeculativeJIT*);
@@ -2209,7 +2210,7 @@ private:
 };
 
 class JSValueRegsTemporary {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(JSValueRegsTemporary);
 public:
     JSValueRegsTemporary();
     JSValueRegsTemporary(SpeculativeJIT*);
@@ -2258,7 +2259,7 @@ JSValueRegsTemporary::JSValueRegsTemporary(SpeculativeJIT* jit, ReuseTag, T& ope
 #endif
 
 class FPRTemporary {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(FPRTemporary);
 public:
     FPRTemporary(FPRTemporary&&);
     FPRTemporary(SpeculativeJIT*);
@@ -2330,7 +2331,7 @@ private:
 };
 
 class JSValueRegsFlushedCallResult {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(JSValueRegsFlushedCallResult);
 public:
     JSValueRegsFlushedCallResult(SpeculativeJIT* jit)
 #if USE(JSVALUE64)
@@ -2372,7 +2373,7 @@ private:
 // a bail-out to the non-speculative path will be taken.
 
 class SpeculateInt32Operand {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SpeculateInt32Operand);
 public:
     explicit SpeculateInt32Operand(SpeculativeJIT* jit, Edge edge, OperandSpeculationMode mode = AutomaticOperandSpeculation)
         : m_jit(jit)
@@ -2431,7 +2432,7 @@ private:
 };
 
 class SpeculateStrictInt32Operand {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SpeculateStrictInt32Operand);
 public:
     explicit SpeculateStrictInt32Operand(SpeculativeJIT* jit, Edge edge, OperandSpeculationMode mode = AutomaticOperandSpeculation)
         : m_jit(jit)
@@ -2480,7 +2481,7 @@ private:
 
 // Gives you a canonical Int52 (i.e. it's left-shifted by 12, low bits zero).
 class SpeculateInt52Operand {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SpeculateInt52Operand);
 public:
     explicit SpeculateInt52Operand(SpeculativeJIT* jit, Edge edge)
         : m_jit(jit)
@@ -2528,7 +2529,7 @@ private:
 
 // Gives you a strict Int52 (i.e. the payload is in the low 52 bits, high 12 bits are sign-extended).
 class SpeculateStrictInt52Operand {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SpeculateStrictInt52Operand);
 public:
     explicit SpeculateStrictInt52Operand(SpeculativeJIT* jit, Edge edge)
         : m_jit(jit)
@@ -2577,7 +2578,7 @@ private:
 enum OppositeShiftTag { OppositeShift };
 
 class SpeculateWhicheverInt52Operand {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SpeculateWhicheverInt52Operand);
 public:
     explicit SpeculateWhicheverInt52Operand(SpeculativeJIT* jit, Edge edge)
         : m_jit(jit)
@@ -2655,7 +2656,7 @@ private:
 };
 
 class SpeculateDoubleOperand {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SpeculateDoubleOperand);
 public:
     explicit SpeculateDoubleOperand(SpeculativeJIT* jit, Edge edge)
         : m_jit(jit)
@@ -2703,7 +2704,7 @@ private:
 };
 
 class SpeculateCellOperand {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SpeculateCellOperand);
 
 public:
     explicit SpeculateCellOperand(SpeculativeJIT* jit, Edge edge, OperandSpeculationMode mode = AutomaticOperandSpeculation)
@@ -2768,7 +2769,7 @@ private:
 };
 
 class SpeculateBooleanOperand {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SpeculateBooleanOperand);
 public:
     explicit SpeculateBooleanOperand(SpeculativeJIT* jit, Edge edge, OperandSpeculationMode mode = AutomaticOperandSpeculation)
         : m_jit(jit)
@@ -2817,7 +2818,7 @@ private:
 
 #if USE(BIGINT32)
 class SpeculateBigInt32Operand {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SpeculateBigInt32Operand);
 public:
     explicit SpeculateBigInt32Operand(SpeculativeJIT* jit, Edge edge, OperandSpeculationMode mode = AutomaticOperandSpeculation)
         : m_jit(jit)

--- a/Source/JavaScriptCore/dfg/DFGTZoneImpls.cpp
+++ b/Source/JavaScriptCore/dfg/DFGTZoneImpls.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#if ENABLE(DFG_JIT)
+
+#include "DFGAbstractInterpreter.h"
+#include "DFGAbstractValue.h"
+#include "DFGBackwardsDominators.h"
+#include "DFGCFG.h"
+#include "DFGControlEquivalenceAnalysis.h"
+#include "DFGDominators.h"
+#include "DFGFlowMap.h"
+#include "DFGInPlaceAbstractState.h"
+#include "DFGNaturalLoops.h"
+#include "DFGSlowPathGenerator.h"
+#include <wtf/TZoneMallocInlines.h>
+
+namespace JSC { namespace DFG {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(BackwardsCFG);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(BackwardsDominators);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CFG);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ControlEquivalenceAnalysis);
+
+using AbstractInterpreterInPlaceAbstractState = AbstractInterpreter<InPlaceAbstractState>;
+using DominatorsCFG = Dominators<CFG>;
+using DominatorsCPSCFG = Dominators<CPSCFG>;
+using FlowMapAbstractValue = FlowMap<AbstractValue>;
+using NaturalLoopsCFG = NaturalLoops<CFG>;
+using NaturalLoopsCPSCFG = NaturalLoops<CPSCFG>;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL_TEMPLATE(AbstractInterpreterInPlaceAbstractState);
+WTF_MAKE_TZONE_ALLOCATED_IMPL_TEMPLATE(DominatorsCFG);
+WTF_MAKE_TZONE_ALLOCATED_IMPL_TEMPLATE(DominatorsCPSCFG);
+WTF_MAKE_TZONE_ALLOCATED_IMPL_TEMPLATE(FlowMapAbstractValue);
+WTF_MAKE_TZONE_ALLOCATED_IMPL_TEMPLATE(NaturalLoopsCFG);
+WTF_MAKE_TZONE_ALLOCATED_IMPL_TEMPLATE(NaturalLoopsCPSCFG);
+
+} } // namespace JSC::DFG
+
+#endif // ENABLE(DFG_JIT)

--- a/Source/JavaScriptCore/dfg/DFGVariableAccessData.h
+++ b/Source/JavaScriptCore/dfg/DFGVariableAccessData.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -44,7 +44,7 @@ struct Node;
 enum DoubleBallot { VoteValue, VoteDouble };
 
 class VariableAccessData : public UnionFind<VariableAccessData> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(VariableAccessData);
     WTF_MAKE_NONCOPYABLE(VariableAccessData);
 public:
     VariableAccessData();

--- a/Source/JavaScriptCore/disassembler/ARM64/A64DOpcode.cpp
+++ b/Source/JavaScriptCore/disassembler/ARM64/A64DOpcode.cpp
@@ -42,8 +42,11 @@
 #include <stdio.h>
 #include <wtf/PtrTag.h>
 #include <wtf/Range.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC { namespace ARM64Disassembler {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(A64DOpcodeOpcodeGroup, A64DOpcode::OpcodeGroup);
 
 A64DOpcode::OpcodeGroup* A64DOpcode::opcodeTable[32];
 

--- a/Source/JavaScriptCore/disassembler/ARM64/A64DOpcode.h
+++ b/Source/JavaScriptCore/disassembler/ARM64/A64DOpcode.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,14 +28,14 @@
 #include <stdint.h>
 #include <wtf/Assertions.h>
 #include <wtf/DataLog.h>
-#include <wtf/FastMalloc.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC { namespace ARM64Disassembler {
 
 class A64DOpcode {
 private:
     class OpcodeGroup {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED(OpcodeGroup);
     public:
         OpcodeGroup(uint32_t opcodeMask, uint32_t opcodePattern, const char* (*format)(A64DOpcode*))
             : m_opcodeMask(opcodeMask)

--- a/Source/JavaScriptCore/disassembler/Disassembler.cpp
+++ b/Source/JavaScriptCore/disassembler/Disassembler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,6 +33,7 @@
 #include <wtf/Deque.h>
 #include <wtf/Lock.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Threading.h>
 
 namespace JSC {
@@ -69,7 +70,7 @@ namespace {
 // expect.
 class DisassemblyTask {
     WTF_MAKE_NONCOPYABLE(DisassemblyTask);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(DisassemblyTask);
 public:
     DisassemblyTask()
     {
@@ -137,6 +138,8 @@ private:
 };
 
 bool hadAnyAsynchronousDisassembly = false;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(DisassemblyTask);
 
 AsynchronousDisassembler& asynchronousDisassembler()
 {

--- a/Source/JavaScriptCore/ftl/FTLAbstractHeap.cpp
+++ b/Source/JavaScriptCore/ftl/FTLAbstractHeap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013, 2015-2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,8 +34,11 @@
 #include "JSCJSValueInlines.h"
 #include "Options.h"
 #include "StructureRareDataInlines.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC { namespace FTL {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AbstractHeap);
 
 AbstractHeap::AbstractHeap(AbstractHeap* parent, const char* heapName, ptrdiff_t offset)
     : m_offset(offset)

--- a/Source/JavaScriptCore/ftl/FTLAbstractHeap.h
+++ b/Source/JavaScriptCore/ftl/FTLAbstractHeap.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013, 2015-2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,9 +31,9 @@
 #include "FTLAbbreviatedTypes.h"
 #include "JSCJSValue.h"
 #include <array>
-#include <wtf/FastMalloc.h>
 #include <wtf/HashMap.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/text/CString.h>
 
@@ -44,7 +44,8 @@ class Output;
 class TypedPointer;
 
 class AbstractHeap {
-    WTF_MAKE_NONCOPYABLE(AbstractHeap); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_NONCOPYABLE(AbstractHeap);
+    WTF_MAKE_TZONE_ALLOCATED(AbstractHeap);
 public:
     AbstractHeap()
     {

--- a/Source/JavaScriptCore/ftl/FTLJITFinalizer.cpp
+++ b/Source/JavaScriptCore/ftl/FTLJITFinalizer.cpp
@@ -33,8 +33,11 @@
 #include "FTLState.h"
 #include "ProfilerDatabase.h"
 #include "ThunkGenerators.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC { namespace FTL {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(JITFinalizer);
 
 JITFinalizer::JITFinalizer(DFG::Plan& plan)
     : Finalizer(plan)

--- a/Source/JavaScriptCore/ftl/FTLJITFinalizer.h
+++ b/Source/JavaScriptCore/ftl/FTLJITFinalizer.h
@@ -32,6 +32,7 @@
 #include "FTLJITCode.h"
 #include "LinkBuffer.h"
 #include "MacroAssembler.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC { namespace FTL {
 
@@ -48,6 +49,7 @@ public:
 };
 
 class JITFinalizer final : public DFG::Finalizer {
+    WTF_MAKE_TZONE_ALLOCATED(JITFinalizer);
 public:
     JITFinalizer(DFG::Plan&);
     ~JITFinalizer() final;

--- a/Source/JavaScriptCore/ftl/FTLLazySlowPath.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLazySlowPath.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,8 +29,11 @@
 #if ENABLE(FTL_JIT)
 
 #include "LinkBuffer.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC { namespace FTL {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(LazySlowPath);
 
 LazySlowPath::~LazySlowPath()
 {

--- a/Source/JavaScriptCore/ftl/FTLLazySlowPath.h
+++ b/Source/JavaScriptCore/ftl/FTLLazySlowPath.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,6 +35,7 @@
 #include "RegisterSet.h"
 #include "ScratchRegisterAllocator.h"
 #include <wtf/SharedTask.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC { namespace FTL {
 
@@ -45,7 +46,7 @@ namespace JSC { namespace FTL {
 // which registers hold the inputs or outputs.
 class LazySlowPath {
     WTF_MAKE_NONCOPYABLE(LazySlowPath);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(LazySlowPath);
 public:
     struct GenerationParams {
         // Extra parameters to the GeneratorFunction are made into fields of this struct, so that if

--- a/Source/JavaScriptCore/ftl/FTLThunks.cpp
+++ b/Source/JavaScriptCore/ftl/FTLThunks.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,8 +35,11 @@
 #include "FTLSaveRestore.h"
 #include "GPRInfo.h"
 #include "LinkBuffer.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC { namespace FTL {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Thunks);
 
 using namespace DFG;
 

--- a/Source/JavaScriptCore/ftl/FTLThunks.h
+++ b/Source/JavaScriptCore/ftl/FTLThunks.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,6 +31,7 @@
 #include "FTLSlowPathCallKey.h"
 #include "MacroAssemblerCodeRef.h"
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -75,7 +76,7 @@ typename MapType::KeyType keyForThunk(MapType& map, CodePtr<JITThunkPtrTag> ptr)
 }
 
 class Thunks {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Thunks);
     WTF_MAKE_NONCOPYABLE(Thunks);
 public:
     Thunks() = default;

--- a/Source/JavaScriptCore/heap/AbstractSlotVisitor.h
+++ b/Source/JavaScriptCore/heap/AbstractSlotVisitor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,6 +31,7 @@
 #include "VisitRaceKey.h"
 #include <wtf/ConcurrentPtrHashSet.h>
 #include <wtf/SharedTask.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/CString.h>
 
 namespace JSC {
@@ -52,7 +53,7 @@ class WriteBarrierStructureID;
 
 class AbstractSlotVisitor {
     WTF_MAKE_NONCOPYABLE(AbstractSlotVisitor);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(AbstractSlotVisitor);
 public:
     enum OpaqueRootTag { OpaqueRoot };
 

--- a/Source/JavaScriptCore/heap/AlignedMemoryAllocator.cpp
+++ b/Source/JavaScriptCore/heap/AlignedMemoryAllocator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/Source/JavaScriptCore/heap/BlockDirectoryBits.h
+++ b/Source/JavaScriptCore/heap/BlockDirectoryBits.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,6 +27,7 @@
 
 #include <array>
 #include <wtf/FastBitVector.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace JSC {
@@ -59,7 +60,7 @@ namespace JSC {
 // https://bugs.webkit.org/show_bug.cgi?id=162121
 
 class BlockDirectoryBits {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(BlockDirectoryBits);
 public:
     static constexpr unsigned bitsPerSegment = 32;
     static constexpr unsigned segmentShift = 5;
@@ -85,7 +86,7 @@ public:
 
     template<Kind kind>
     class BlockDirectoryBitVectorWordView {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED(BlockDirectoryBitVectorWordView);
     public:
         using ViewType = BlockDirectoryBitVectorWordView;
 

--- a/Source/JavaScriptCore/heap/CodeBlockSet.cpp
+++ b/Source/JavaScriptCore/heap/CodeBlockSet.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,8 +29,11 @@
 #include "CodeBlock.h"
 #include "HeapInlines.h"
 #include <wtf/CommaPrinter.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CodeBlockSet);
 
 CodeBlockSet::CodeBlockSet()
 {

--- a/Source/JavaScriptCore/heap/CodeBlockSet.h
+++ b/Source/JavaScriptCore/heap/CodeBlockSet.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,6 +30,7 @@
 #include <wtf/Lock.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/PrintStream.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -43,7 +44,7 @@ class VM;
 // once they hasOneRef() and nobody is running code from that CodeBlock.
 
 class CodeBlockSet {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(CodeBlockSet);
     WTF_MAKE_NONCOPYABLE(CodeBlockSet);
 public:
     CodeBlockSet();

--- a/Source/JavaScriptCore/heap/GCSegmentedArray.cpp
+++ b/Source/JavaScriptCore/heap/GCSegmentedArray.cpp
@@ -25,10 +25,16 @@
 
 #include "config.h"
 #include "GCSegmentedArray.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
 
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(GCSegmentedArray);
+
+using GCSegmentedArrayJSCell = GCSegmentedArray<const JSCell*>;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL_TEMPLATE(GCSegmentedArrayJSCell);
+
 
 } // namespace JSC
 

--- a/Source/JavaScriptCore/heap/GCSegmentedArray.h
+++ b/Source/JavaScriptCore/heap/GCSegmentedArray.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,6 +29,7 @@
 #include <wtf/DoublyLinkedList.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -67,7 +68,7 @@ template <typename T> class GCSegmentedArrayIterator;
 
 template <typename T>
 class GCSegmentedArray {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(GCSegmentedArray);
     WTF_MAKE_NONCOPYABLE(GCSegmentedArray);
     friend class GCSegmentedArrayIterator<T>;
     friend class GCSegmentedArrayIterator<const T>;

--- a/Source/JavaScriptCore/heap/HeapCellType.h
+++ b/Source/JavaScriptCore/heap/HeapCellType.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,12 +26,13 @@
 #pragma once
 
 #include "MarkedBlock.h"
+#include <wtf/ForbidHeapAllocation.h>
 
 namespace JSC {
 
 class HeapCellType {
     WTF_MAKE_NONCOPYABLE(HeapCellType);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_FORBID_HEAP_ALLOCATION;
 public:
     JS_EXPORT_PRIVATE HeapCellType(CellAttributes);
     JS_EXPORT_PRIVATE virtual ~HeapCellType();

--- a/Source/JavaScriptCore/heap/HeapProfiler.cpp
+++ b/Source/JavaScriptCore/heap/HeapProfiler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,8 +28,11 @@
 
 #include "HeapSnapshot.h"
 #include "VM.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(HeapProfiler);
 
 HeapProfiler::HeapProfiler(VM& vm)
     : m_vm(vm)

--- a/Source/JavaScriptCore/heap/HeapProfiler.h
+++ b/Source/JavaScriptCore/heap/HeapProfiler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace JSC {
@@ -34,7 +35,7 @@ class HeapAnalyzer;
 class VM;
 
 class HeapProfiler {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(HeapProfiler);
 public:
     HeapProfiler(VM&);
     ~HeapProfiler();

--- a/Source/JavaScriptCore/heap/HeapSnapshot.cpp
+++ b/Source/JavaScriptCore/heap/HeapSnapshot.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,8 +27,11 @@
 #include "HeapSnapshot.h"
 
 #include <wtf/DataLog.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(HeapSnapshot);
 
 HeapSnapshot::HeapSnapshot(HeapSnapshot* previousSnapshot)
     : m_previous(previousSnapshot)

--- a/Source/JavaScriptCore/heap/HeapSnapshot.h
+++ b/Source/JavaScriptCore/heap/HeapSnapshot.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,11 +27,12 @@
 
 #include "HeapSnapshotBuilder.h"
 #include "TinyBloomFilter.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
 class HeapSnapshot {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(HeapSnapshot);
 public:
     HeapSnapshot(HeapSnapshot*);
     ~HeapSnapshot();

--- a/Source/JavaScriptCore/heap/HeapSnapshotBuilder.cpp
+++ b/Source/JavaScriptCore/heap/HeapSnapshotBuilder.cpp
@@ -35,9 +35,12 @@
 #include "PreventCollectionScope.h"
 #include "VM.h"
 #include <wtf/HexNumber.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/StringBuilder.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(HeapSnapshotBuilder);
 
 NodeIdentifier HeapSnapshotBuilder::nextAvailableObjectIdentifier = 1;
 NodeIdentifier HeapSnapshotBuilder::getNextObjectIdentifier() { return nextAvailableObjectIdentifier++; }

--- a/Source/JavaScriptCore/heap/HeapSnapshotBuilder.h
+++ b/Source/JavaScriptCore/heap/HeapSnapshotBuilder.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,6 +30,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/Lock.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace JSC {
@@ -103,7 +104,7 @@ struct HeapSnapshotEdge {
 };
 
 class JS_EXPORT_PRIVATE HeapSnapshotBuilder final : public HeapAnalyzer {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(HeapSnapshotBuilder);
 public:
     enum SnapshotType { InspectorSnapshot, GCDebuggingSnapshot };
 

--- a/Source/JavaScriptCore/heap/IsoHeapCellType.cpp
+++ b/Source/JavaScriptCore/heap/IsoHeapCellType.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,8 +28,11 @@
 
 #include "JSCJSValueInlines.h"
 #include "MarkedBlockInlines.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(IsoHeapCellType);
 
 IsoHeapCellType::IsoHeapCellType(DestructionMode destructionMode, DestroyFunctionPtr destroyFunction)
     : HeapCellType(CellAttributes(destructionMode, HeapCell::JSCell))

--- a/Source/JavaScriptCore/heap/IsoHeapCellType.h
+++ b/Source/JavaScriptCore/heap/IsoHeapCellType.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,10 +27,12 @@
 
 #include "HeapCellType.h"
 #include <wtf/PtrTag.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
 class JS_EXPORT_PRIVATE IsoHeapCellType final : public HeapCellType {
+    WTF_MAKE_TZONE_ALLOCATED(IsoHeapCellType);
 public:
     using DestroyFunctionPtr = void (*)(JSCell*);
 

--- a/Source/JavaScriptCore/heap/IsoSubspace.cpp
+++ b/Source/JavaScriptCore/heap/IsoSubspace.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,8 +30,11 @@
 #include "IsoCellSetInlines.h"
 #include "JSCellInlines.h"
 #include "MarkedSpaceInlines.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(IsoSubspace);
 
 IsoSubspace::IsoSubspace(CString name, Heap& heap, const HeapCellType& heapCellType, size_t size, uint8_t numberOfLowerTierCells, std::unique_ptr<IsoMemoryAllocatorBase>&& allocator)
     : Subspace(name, heap)

--- a/Source/JavaScriptCore/heap/IsoSubspace.h
+++ b/Source/JavaScriptCore/heap/IsoSubspace.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,6 +30,7 @@
 #include "Subspace.h"
 #include "SubspaceAccess.h"
 #include <wtf/SinglyLinkedListWithTail.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -40,6 +41,7 @@ class IsoSubspace;
 }
 
 class IsoSubspace : public Subspace {
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(IsoSubspace, JS_EXPORT_PRIVATE);
 public:
     JS_EXPORT_PRIVATE IsoSubspace(CString name, Heap&, const HeapCellType&, size_t size, uint8_t numberOfLowerTierCells, std::unique_ptr<IsoMemoryAllocatorBase>&& = nullptr);
     JS_EXPORT_PRIVATE ~IsoSubspace() override;

--- a/Source/JavaScriptCore/heap/JITStubRoutineSet.cpp
+++ b/Source/JavaScriptCore/heap/JITStubRoutineSet.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,8 +30,11 @@
 
 #include "GCAwareJITStubRoutine.h"
 #include "HeapInlines.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(JITStubRoutineSet);
 
 JITStubRoutineSet::JITStubRoutineSet() { }
 JITStubRoutineSet::~JITStubRoutineSet()

--- a/Source/JavaScriptCore/heap/JITStubRoutineSet.h
+++ b/Source/JavaScriptCore/heap/JITStubRoutineSet.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,9 +26,9 @@
 #pragma once
 
 #include "JITStubRoutine.h"
-#include <wtf/FastMalloc.h>
 #include <wtf/HashMap.h>
 #include <wtf/Range.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 using WTF::Range;
@@ -41,8 +41,7 @@ class GCAwareJITStubRoutine;
 
 class JITStubRoutineSet {
     WTF_MAKE_NONCOPYABLE(JITStubRoutineSet);
-    WTF_MAKE_FAST_ALLOCATED;
-    
+    WTF_MAKE_TZONE_ALLOCATED(JITStubRoutineSet);
 public:
     JITStubRoutineSet();
     ~JITStubRoutineSet();
@@ -80,8 +79,7 @@ private:
 
 class JITStubRoutineSet {
     WTF_MAKE_NONCOPYABLE(JITStubRoutineSet);
-    WTF_MAKE_FAST_ALLOCATED;
-    
+    WTF_MAKE_TZONE_ALLOCATED(JITStubRoutineSet);
 public:
     JITStubRoutineSet() { }
     ~JITStubRoutineSet() { }

--- a/Source/JavaScriptCore/heap/MachineStackMarker.cpp
+++ b/Source/JavaScriptCore/heap/MachineStackMarker.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2003-2017 Apple Inc. All rights reserved.
+ *  Copyright (C) 2003-2023 Apple Inc. All rights reserved.
  *  Copyright (C) 2007 Eric Seidel <eric@webkit.org>
  *  Copyright (C) 2009 Acision BV. All rights reserved.
  *
@@ -27,8 +27,11 @@
 #include <wtf/BitVector.h>
 #include <wtf/PageBlock.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(MachineThreads);
 
 MachineThreads::MachineThreads()
     : m_threadGroup(ThreadGroup::create())

--- a/Source/JavaScriptCore/heap/MachineStackMarker.h
+++ b/Source/JavaScriptCore/heap/MachineStackMarker.h
@@ -1,7 +1,7 @@
 /*
  *  Copyright (C) 1999-2000 Harri Porten (porten@kde.org)
  *  Copyright (C) 2001 Peter Kelly (pmk@post.com)
- *  Copyright (C) 2003-2017 Apple Inc. All rights reserved.
+ *  Copyright (C) 2003-2023 Apple Inc. All rights reserved.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
@@ -24,6 +24,7 @@
 #include "RegisterState.h"
 #include <wtf/Lock.h>
 #include <wtf/ScopedLambda.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadGroup.h>
 
 namespace JSC {
@@ -40,7 +41,7 @@ struct CurrentThreadState {
 };
     
 class MachineThreads {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(MachineThreads);
     WTF_MAKE_NONCOPYABLE(MachineThreads);
 public:
     MachineThreads();

--- a/Source/JavaScriptCore/heap/MarkStackMergingConstraint.cpp
+++ b/Source/JavaScriptCore/heap/MarkStackMergingConstraint.cpp
@@ -28,8 +28,11 @@
 
 #include "GCSegmentedArrayInlines.h"
 #include "JSCInlines.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(MarkStackMergingConstraint);
 
 MarkStackMergingConstraint::MarkStackMergingConstraint(Heap& heap)
     : MarkingConstraint("Msm", "Mark Stack Merging", ConstraintVolatility::GreyedByExecution)

--- a/Source/JavaScriptCore/heap/MarkStackMergingConstraint.h
+++ b/Source/JavaScriptCore/heap/MarkStackMergingConstraint.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "MarkingConstraint.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -34,6 +35,7 @@ class AbstractSlotVisitor;
 class SlotVisitor;
 
 class MarkStackMergingConstraint final : public MarkingConstraint {
+    WTF_MAKE_TZONE_ALLOCATED(MarkStackMergingConstraint);
 public:
     MarkStackMergingConstraint(Heap&);
     ~MarkStackMergingConstraint() final;

--- a/Source/JavaScriptCore/heap/MarkingConstraint.cpp
+++ b/Source/JavaScriptCore/heap/MarkingConstraint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,10 +28,13 @@
 
 #include "JSCInlines.h"
 #include "VisitCounter.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
 
 static constexpr bool verboseMarkingConstraint = false;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(MarkingConstraint);
 
 MarkingConstraint::MarkingConstraint(CString abbreviatedName, CString name, ConstraintVolatility volatility, ConstraintConcurrency concurrency, ConstraintParallelism parallelism)
     : m_abbreviatedName(abbreviatedName)

--- a/Source/JavaScriptCore/heap/MarkingConstraint.h
+++ b/Source/JavaScriptCore/heap/MarkingConstraint.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,10 +29,10 @@
 #include "ConstraintParallelism.h"
 #include "ConstraintVolatility.h"
 #include <limits.h>
-#include <wtf/FastMalloc.h>
 #include <wtf/Lock.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/SharedTask.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/CString.h>
 
 namespace JSC {
@@ -43,7 +43,7 @@ class SlotVisitor;
 
 class MarkingConstraint {
     WTF_MAKE_NONCOPYABLE(MarkingConstraint);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(MarkingConstraint);
 public:
     JS_EXPORT_PRIVATE MarkingConstraint(
         CString abbreviatedName, CString name, ConstraintVolatility,

--- a/Source/JavaScriptCore/heap/MarkingConstraintSet.cpp
+++ b/Source/JavaScriptCore/heap/MarkingConstraintSet.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,8 +31,11 @@
 #include "SimpleMarkingConstraint.h"
 #include "SuperSampler.h"
 #include <wtf/Function.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(MarkingConstraintSet);
 
 MarkingConstraintSet::MarkingConstraintSet(Heap& heap)
     : m_heap(heap)

--- a/Source/JavaScriptCore/heap/MarkingConstraintSet.h
+++ b/Source/JavaScriptCore/heap/MarkingConstraintSet.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,6 +28,7 @@
 #include "MarkingConstraint.h"
 #include "MarkingConstraintExecutorPair.h"
 #include <wtf/BitVector.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace JSC {
@@ -36,7 +37,7 @@ class Heap;
 class MarkingConstraintSolver;
 
 class MarkingConstraintSet {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(MarkingConstraintSet);
     WTF_MAKE_NONCOPYABLE(MarkingConstraintSet);
 public:
     MarkingConstraintSet(Heap&);

--- a/Source/JavaScriptCore/heap/MarkingConstraintSolver.h
+++ b/Source/JavaScriptCore/heap/MarkingConstraintSolver.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,10 +29,10 @@
 #include <wtf/BitVector.h>
 #include <wtf/Condition.h>
 #include <wtf/Deque.h>
-#include <wtf/FastMalloc.h>
 #include <wtf/Lock.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/ScopedLambda.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace JSC {
@@ -43,7 +43,7 @@ class MarkingConstraintSet;
 
 class MarkingConstraintSolver {
     WTF_MAKE_NONCOPYABLE(MarkingConstraintSolver);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(MarkingConstraintSolver);
     
 public:
     MarkingConstraintSolver(MarkingConstraintSet&);

--- a/Source/JavaScriptCore/heap/MutatorScheduler.cpp
+++ b/Source/JavaScriptCore/heap/MutatorScheduler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,9 +26,12 @@
 #include "config.h"
 #include "MutatorScheduler.h"
 
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/TimeWithDynamicClockType.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(MutatorScheduler);
 
 MutatorScheduler::MutatorScheduler()
 {

--- a/Source/JavaScriptCore/heap/MutatorScheduler.h
+++ b/Source/JavaScriptCore/heap/MutatorScheduler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,15 +25,15 @@
 
 #pragma once
 
-#include <wtf/FastMalloc.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
 class MutatorScheduler {
     WTF_MAKE_NONCOPYABLE(MutatorScheduler);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(MutatorScheduler);
 public:
     enum State {
         Normal, // Not collecting.

--- a/Source/JavaScriptCore/heap/SimpleMarkingConstraint.cpp
+++ b/Source/JavaScriptCore/heap/SimpleMarkingConstraint.cpp
@@ -25,8 +25,11 @@
 
 #include "config.h"
 #include "SimpleMarkingConstraint.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SimpleMarkingConstraint);
 
 SimpleMarkingConstraint::SimpleMarkingConstraint(
     CString abbreviatedName, CString name,

--- a/Source/JavaScriptCore/heap/SimpleMarkingConstraint.h
+++ b/Source/JavaScriptCore/heap/SimpleMarkingConstraint.h
@@ -27,6 +27,7 @@
 
 #include "MarkingConstraint.h"
 #include "MarkingConstraintExecutorPair.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -34,6 +35,7 @@ namespace JSC {
 // downside is that this makes it hard for constraints to override any functions in MarkingConstraint
 // other than executeImpl. In those cases, just subclass MarkingConstraint.
 class SimpleMarkingConstraint final : public MarkingConstraint {
+    WTF_MAKE_TZONE_ALLOCATED(SimpleMarkingConstraint);
 public:
     JS_EXPORT_PRIVATE SimpleMarkingConstraint(
         CString abbreviatedName, CString name,

--- a/Source/JavaScriptCore/heap/SlotVisitor.cpp
+++ b/Source/JavaScriptCore/heap/SlotVisitor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -42,8 +42,11 @@
 #include <wtf/ListDump.h>
 #include <wtf/Lock.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SlotVisitor);
 
 #if ENABLE(GC_VALIDATION)
 static void validate(JSCell* cell)

--- a/Source/JavaScriptCore/heap/SlotVisitor.h
+++ b/Source/JavaScriptCore/heap/SlotVisitor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,6 +30,7 @@
 #include <wtf/Forward.h>
 #include <wtf/IterationStatus.h>
 #include <wtf/MonotonicTime.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -43,7 +44,7 @@ typedef uint32_t HeapVersion;
 
 class SlotVisitor final : public AbstractSlotVisitor {
     WTF_MAKE_NONCOPYABLE(SlotVisitor);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SlotVisitor);
 
     using Base = AbstractSlotVisitor;
 

--- a/Source/JavaScriptCore/heap/SpaceTimeMutatorScheduler.cpp
+++ b/Source/JavaScriptCore/heap/SpaceTimeMutatorScheduler.cpp
@@ -27,8 +27,12 @@
 #include "SpaceTimeMutatorScheduler.h"
 
 #include "JSCInlines.h"
+#include <wtf/TZoneMallocInlines.h>
+
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SpaceTimeMutatorScheduler);
 
 // The scheduler will often make decisions based on state that is in flux. It will be fine so
 // long as multiple uses of the same value all see the same value. We wouldn't get this for free,

--- a/Source/JavaScriptCore/heap/SpaceTimeMutatorScheduler.h
+++ b/Source/JavaScriptCore/heap/SpaceTimeMutatorScheduler.h
@@ -27,6 +27,8 @@
 
 #include "MutatorScheduler.h"
 #include <wtf/Seconds.h>
+#include <wtf/TZoneMalloc.h>
+
 
 namespace JSC {
 
@@ -39,6 +41,7 @@ class Heap;
 // began.
 
 class SpaceTimeMutatorScheduler final : public MutatorScheduler {
+    WTF_MAKE_TZONE_ALLOCATED(SpaceTimeMutatorScheduler);
 public:
     SpaceTimeMutatorScheduler(Heap&);
     ~SpaceTimeMutatorScheduler() final;

--- a/Source/JavaScriptCore/heap/StochasticSpaceTimeMutatorScheduler.cpp
+++ b/Source/JavaScriptCore/heap/StochasticSpaceTimeMutatorScheduler.cpp
@@ -27,8 +27,11 @@
 #include "StochasticSpaceTimeMutatorScheduler.h"
 
 #include "JSCInlines.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(StochasticSpaceTimeMutatorScheduler);
 
 // The scheduler will often make decisions based on state that is in flux. It will be fine so
 // long as multiple uses of the same value all see the same value. We wouldn't get this for free,

--- a/Source/JavaScriptCore/heap/StochasticSpaceTimeMutatorScheduler.h
+++ b/Source/JavaScriptCore/heap/StochasticSpaceTimeMutatorScheduler.h
@@ -27,6 +27,7 @@
 
 #include "MutatorScheduler.h"
 #include <wtf/Seconds.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakRandom.h>
 
 namespace JSC {
@@ -40,6 +41,7 @@ class Heap;
 // began.
 
 class StochasticSpaceTimeMutatorScheduler final : public MutatorScheduler {
+    WTF_MAKE_TZONE_ALLOCATED(StochasticSpaceTimeMutatorScheduler);
 public:
     StochasticSpaceTimeMutatorScheduler(Heap&);
     ~StochasticSpaceTimeMutatorScheduler() final;

--- a/Source/JavaScriptCore/heap/Subspace.cpp
+++ b/Source/JavaScriptCore/heap/Subspace.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,8 +31,11 @@
 #include "MarkedSpaceInlines.h"
 #include "ParallelSourceAdapter.h"
 #include "SubspaceInlines.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Subspace);
 
 Subspace::Subspace(CString name, Heap& heap)
     : m_space(heap.objectSpace())

--- a/Source/JavaScriptCore/heap/Subspace.h
+++ b/Source/JavaScriptCore/heap/Subspace.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,6 +30,7 @@
 #include "Allocator.h"
 #include "MarkedBlock.h"
 #include "MarkedSpace.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/CString.h>
 
 namespace JSC {
@@ -42,7 +43,7 @@ class HeapCellType;
 // class is the baseclass of all subspaces e.g. CompleteSubspace, IsoSubspace.
 class Subspace {
     WTF_MAKE_NONCOPYABLE(Subspace);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Subspace);
 public:
     JS_EXPORT_PRIVATE virtual ~Subspace();
 

--- a/Source/JavaScriptCore/heap/SynchronousStopTheWorldMutatorScheduler.cpp
+++ b/Source/JavaScriptCore/heap/SynchronousStopTheWorldMutatorScheduler.cpp
@@ -26,7 +26,11 @@
 #include "config.h"
 #include "SynchronousStopTheWorldMutatorScheduler.h"
 
+#include <wtf/TZoneMallocInlines.h>
+
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SynchronousStopTheWorldMutatorScheduler);
 
 SynchronousStopTheWorldMutatorScheduler::SynchronousStopTheWorldMutatorScheduler()
 {

--- a/Source/JavaScriptCore/heap/SynchronousStopTheWorldMutatorScheduler.h
+++ b/Source/JavaScriptCore/heap/SynchronousStopTheWorldMutatorScheduler.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "MutatorScheduler.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -36,6 +37,7 @@ namespace JSC {
 // SpaceTimeMutatorScheduler. It tells the GC to never resume the world once the GC cycle begins.
 
 class SynchronousStopTheWorldMutatorScheduler final : public MutatorScheduler {
+    WTF_MAKE_TZONE_ALLOCATED(SynchronousStopTheWorldMutatorScheduler);
 public:
     SynchronousStopTheWorldMutatorScheduler();
     ~SynchronousStopTheWorldMutatorScheduler() final;

--- a/Source/JavaScriptCore/heap/VerifierSlotVisitor.cpp
+++ b/Source/JavaScriptCore/heap/VerifierSlotVisitor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,8 +34,14 @@
 #include "VM.h"
 #include "VerifierSlotVisitorInlines.h"
 #include <wtf/StackTrace.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(VerifierSlotVisitor);
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(VerifierSlotVisitorMarkedBlockData, VerifierSlotVisitor::MarkedBlockData);
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(VerifierSlotVisitorOpaqueRootData, VerifierSlotVisitor::OpaqueRootData);
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(VerifierSlotVisitorPreciseAllocationData, VerifierSlotVisitor::PreciseAllocationData);
 
 using MarkerData = VerifierSlotVisitor::MarkerData;
 

--- a/Source/JavaScriptCore/heap/VerifierSlotVisitor.h
+++ b/Source/JavaScriptCore/heap/VerifierSlotVisitor.h
@@ -33,10 +33,10 @@
 #include <memory>
 #include <wtf/BitSet.h>
 #include <wtf/Deque.h>
-#include <wtf/FastMalloc.h>
 #include <wtf/HashMap.h>
 #include <wtf/RefPtr.h>
 #include <wtf/SharedTask.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WTF {
 
@@ -55,7 +55,7 @@ using WTF::StackTrace;
 
 class VerifierSlotVisitor : public AbstractSlotVisitor {
     WTF_MAKE_NONCOPYABLE(VerifierSlotVisitor);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(VerifierSlotVisitor);
     using Base = AbstractSlotVisitor;
 public:
     using ReferrerToken = AbstractSlotVisitor::ReferrerToken;
@@ -117,7 +117,7 @@ public:
 
 private:
     class MarkedBlockData {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED(MarkedBlockData);
         WTF_MAKE_NONCOPYABLE(MarkedBlockData);
     public:
         using AtomsBitSet = WTF::BitSet<MarkedBlock::atomsPerBlock>;
@@ -140,7 +140,7 @@ private:
     };
 
     class PreciseAllocationData {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED(PreciseAllocationData);
         WTF_MAKE_NONCOPYABLE(PreciseAllocationData);
     public:
         PreciseAllocationData(PreciseAllocation*);
@@ -155,7 +155,7 @@ private:
     };
 
     class OpaqueRootData {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED(OpaqueRootData);
         WTF_MAKE_NONCOPYABLE(OpaqueRootData);
     public:
         OpaqueRootData() = default;

--- a/Source/JavaScriptCore/inspector/ConsoleMessage.cpp
+++ b/Source/JavaScriptCore/inspector/ConsoleMessage.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007, 2008, 2014, 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2007-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2008 Matt Lilek <webkit@mattlilek.com>
  * Copyright (C) 2009, 2010 Google Inc. All rights reserved.
  *
@@ -39,8 +39,11 @@
 #include "ScriptCallFrame.h"
 #include "ScriptCallStack.h"
 #include "ScriptCallStackFactory.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace Inspector {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ConsoleMessage);
 
 ConsoleMessage::ConsoleMessage(MessageSource source, MessageType type, MessageLevel level, const String& message, unsigned long requestIdentifier, WallTime timestamp)
     : m_source(source)

--- a/Source/JavaScriptCore/inspector/ConsoleMessage.h
+++ b/Source/JavaScriptCore/inspector/ConsoleMessage.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007, 2008, 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2007-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2008 Matt Lilek <webkit@mattlilek.com>
  * Copyright (C) 2009, 2010 Google Inc. All rights reserved.
  *
@@ -32,10 +32,10 @@
 
 #include "ConsoleTypes.h"
 #include "Strong.h"
-#include <wtf/FastMalloc.h>
 #include <wtf/Forward.h>
 #include <wtf/Logger.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace JSC {
@@ -54,7 +54,7 @@ class ScriptCallStack;
 
 class JS_EXPORT_PRIVATE ConsoleMessage {
     WTF_MAKE_NONCOPYABLE(ConsoleMessage);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ConsoleMessage);
 public:
     ConsoleMessage(MessageSource, MessageType, MessageLevel, const String& message, unsigned long requestIdentifier = 0, WallTime timestamp = { });
     ConsoleMessage(MessageSource, MessageType, MessageLevel, const String& message, const String& url, unsigned line, unsigned column, JSC::JSGlobalObject* = nullptr, unsigned long requestIdentifier = 0, WallTime timestamp = { });

--- a/Source/JavaScriptCore/inspector/InjectedScriptManager.cpp
+++ b/Source/JavaScriptCore/inspector/InjectedScriptManager.cpp
@@ -38,10 +38,13 @@
 #include "JSObjectInlines.h"
 #include "SourceCode.h"
 #include <wtf/JSONValues.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace Inspector {
 
 using namespace JSC;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InjectedScriptManager);
 
 InjectedScriptManager::InjectedScriptManager(InspectorEnvironment& environment, Ref<InjectedScriptHost>&& injectedScriptHost)
     : m_environment(environment)

--- a/Source/JavaScriptCore/inspector/InjectedScriptManager.h
+++ b/Source/JavaScriptCore/inspector/InjectedScriptManager.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007, 2013 Apple Inc. All rights reserved.
+ * Copyright (C) 2007-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2012 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -36,6 +36,7 @@
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
 #include <wtf/NakedPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace JSC {
@@ -48,7 +49,7 @@ class InjectedScriptHost;
 
 class JS_EXPORT_PRIVATE InjectedScriptManager {
     WTF_MAKE_NONCOPYABLE(InjectedScriptManager);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(InjectedScriptManager);
 public:
     InjectedScriptManager(InspectorEnvironment&, Ref<InjectedScriptHost>&&);
     virtual ~InjectedScriptManager();

--- a/Source/JavaScriptCore/inspector/InspectorAgentBase.h
+++ b/Source/JavaScriptCore/inspector/InspectorAgentBase.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013, 2015 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All Rights Reserved.
  * Copyright (C) 2011 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace JSC {
@@ -62,7 +63,7 @@ enum class DisconnectReason {
 };
 
 class InspectorAgentBase {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(InspectorAgentBase);
 public:
     virtual ~InspectorAgentBase() { }
 

--- a/Source/JavaScriptCore/inspector/JSGlobalObjectConsoleClient.cpp
+++ b/Source/JavaScriptCore/inspector/JSGlobalObjectConsoleClient.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,6 +31,7 @@
 #include "InspectorDebuggerAgent.h"
 #include "InspectorScriptProfilerAgent.h"
 #include "ScriptArguments.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace Inspector {
 
@@ -41,6 +42,8 @@ static bool sLogToSystemConsole = true;
 #else
 static bool sLogToSystemConsole = false;
 #endif
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(JSGlobalObjectConsoleClient);
 
 bool JSGlobalObjectConsoleClient::logToSystemConsole()
 {

--- a/Source/JavaScriptCore/inspector/JSGlobalObjectConsoleClient.h
+++ b/Source/JavaScriptCore/inspector/JSGlobalObjectConsoleClient.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "ConsoleClient.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
@@ -38,7 +39,7 @@ class InspectorDebuggerAgent;
 class InspectorScriptProfilerAgent;
 
 class JSGlobalObjectConsoleClient final : public JSC::ConsoleClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(JSGlobalObjectConsoleClient);
 public:
     explicit JSGlobalObjectConsoleClient(InspectorConsoleAgent*);
     ~JSGlobalObjectConsoleClient() final { }

--- a/Source/JavaScriptCore/inspector/JSGlobalObjectDebugger.cpp
+++ b/Source/JavaScriptCore/inspector/JSGlobalObjectDebugger.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,10 +29,13 @@
 #include "JSGlobalObject.h"
 #include "JSLock.h"
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace Inspector {
 
 using namespace JSC;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(JSGlobalObjectDebugger);
 
 JSGlobalObjectDebugger::JSGlobalObjectDebugger(JSGlobalObject& globalObject)
     : Debugger(globalObject.vm())

--- a/Source/JavaScriptCore/inspector/JSGlobalObjectDebugger.h
+++ b/Source/JavaScriptCore/inspector/JSGlobalObjectDebugger.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,12 +27,13 @@
 
 #include "Debugger.h"
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace Inspector {
 
 class JSGlobalObjectDebugger final : public JSC::Debugger {
     WTF_MAKE_NONCOPYABLE(JSGlobalObjectDebugger);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(JSGlobalObjectDebugger);
 public:
     JSGlobalObjectDebugger(JSC::JSGlobalObject&);
     ~JSGlobalObjectDebugger() final { }

--- a/Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.cpp
+++ b/Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -49,6 +49,7 @@
 #include "ScriptCallStackFactory.h"
 #include <wtf/StackTrace.h>
 #include <wtf/Stopwatch.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(REMOTE_INSPECTOR)
 #include "JSGlobalObjectDebuggable.h"
@@ -58,6 +59,8 @@
 namespace Inspector {
 
 using namespace JSC;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(JSGlobalObjectInspectorController);
 
 JSGlobalObjectInspectorController::JSGlobalObjectInspectorController(JSGlobalObject& globalObject)
     : m_globalObject(globalObject)

--- a/Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.h
+++ b/Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014, 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,6 +31,7 @@
 #include "Strong.h"
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 #if ENABLE(INSPECTOR_ALTERNATE_DISPATCHERS)
@@ -65,7 +66,7 @@ class JSGlobalObjectInspectorController final
 #endif
 {
     WTF_MAKE_NONCOPYABLE(JSGlobalObjectInspectorController);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(JSGlobalObjectInspectorController);
 public:
     JSGlobalObjectInspectorController(JSC::JSGlobalObject&);
     ~JSGlobalObjectInspectorController() final;

--- a/Source/JavaScriptCore/inspector/JSInjectedScriptHost.cpp
+++ b/Source/JavaScriptCore/inspector/JSInjectedScriptHost.cpp
@@ -69,6 +69,7 @@
 #include <wtf/HashSet.h>
 #include <wtf/Lock.h>
 #include <wtf/PrintStream.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/StringConcatenate.h>
 
 namespace Inspector {
@@ -771,7 +772,7 @@ JSValue JSInjectedScriptHost::queryInstances(JSGlobalObject* globalObject, CallF
 }
 
 class HeapHolderFinder final : public HeapAnalyzer {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(HeapHolderFinder);
 public:
     HeapHolderFinder(HeapProfiler& profiler, JSCell* target)
         : HeapAnalyzer()
@@ -903,6 +904,8 @@ private:
     HashSet<JSCell*> m_holders;
     const JSCell* m_target;
 };
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(HeapHolderFinder);
 
 JSValue JSInjectedScriptHost::queryHolders(JSGlobalObject* globalObject, CallFrame* callFrame)
 {

--- a/Source/JavaScriptCore/inspector/agents/InspectorAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorAgent.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2010, 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2007-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2008 Matt Lilek <webkit@mattlilek.com>
  * Copyright (C) 2011 Google Inc. All rights reserved.
  *
@@ -33,8 +33,11 @@
 
 #include "InspectorEnvironment.h"
 #include <wtf/JSONValues.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace Inspector {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InspectorAgent);
 
 InspectorAgent::InspectorAgent(AgentContext& context)
     : InspectorAgentBase("Inspector"_s)

--- a/Source/JavaScriptCore/inspector/agents/InspectorAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorAgent.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2010, 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2007-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2011 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -33,6 +33,7 @@
 #include "InspectorBackendDispatchers.h"
 #include "InspectorFrontendDispatchers.h"
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace Inspector {
@@ -42,7 +43,7 @@ class InspectorEnvironment;
 
 class JS_EXPORT_PRIVATE InspectorAgent final : public InspectorAgentBase, public InspectorBackendDispatcherHandler {
     WTF_MAKE_NONCOPYABLE(InspectorAgent);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(InspectorAgent);
 public:
     InspectorAgent(AgentContext&);
     ~InspectorAgent() final;

--- a/Source/JavaScriptCore/inspector/agents/InspectorAuditAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorAuditAgent.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,12 +31,15 @@
 #include "JSLock.h"
 #include "ObjectConstructor.h"
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
 namespace Inspector {
 
 using namespace JSC;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InspectorAuditAgent);
 
 InspectorAuditAgent::InspectorAuditAgent(AgentContext& context)
     : InspectorAgentBase("Audit"_s)

--- a/Source/JavaScriptCore/inspector/agents/InspectorAuditAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorAuditAgent.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,9 +28,9 @@
 #include "InspectorAgentBase.h"
 #include "InspectorBackendDispatchers.h"
 #include "JSCInlines.h"
-#include <wtf/FastMalloc.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 class Debugger;
@@ -43,7 +43,7 @@ class InjectedScriptManager;
 
 class JS_EXPORT_PRIVATE InspectorAuditAgent : public InspectorAgentBase, public AuditBackendDispatcherHandler {
     WTF_MAKE_NONCOPYABLE(InspectorAuditAgent);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(InspectorAuditAgent);
 public:
     ~InspectorAuditAgent() override;
 

--- a/Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2011 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -32,12 +32,15 @@
 #include "ScriptArguments.h"
 #include "ScriptCallStackFactory.h"
 #include <wtf/SetForScope.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/StringConcatenateNumbers.h>
 
 namespace Inspector {
 
 static constexpr unsigned maximumConsoleMessages = 100;
 static constexpr int expireConsoleMessagesStep = 10;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InspectorConsoleAgent);
 
 InspectorConsoleAgent::InspectorConsoleAgent(AgentContext& context)
     : InspectorAgentBase("Console"_s)

--- a/Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.h
@@ -1,5 +1,5 @@
 /*
-* Copyright (C) 2014, 2015 Apple Inc. All rights reserved.
+* Copyright (C) 2014-2023 Apple Inc. All rights reserved.
 * Copyright (C) 2011 Google Inc. All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without
@@ -32,6 +32,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/text/StringHash.h>
 
@@ -49,7 +50,7 @@ class ScriptCallStack;
 
 class JS_EXPORT_PRIVATE InspectorConsoleAgent : public InspectorAgentBase, public ConsoleBackendDispatcherHandler {
     WTF_MAKE_NONCOPYABLE(InspectorConsoleAgent);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(InspectorConsoleAgent);
 public:
     InspectorConsoleAgent(AgentContext&);
     ~InspectorConsoleAgent() override;

--- a/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2010, 2011 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -54,12 +54,16 @@
 #include <wtf/Function.h>
 #include <wtf/JSONValues.h>
 #include <wtf/Stopwatch.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/StringToIntegerConversion.h>
 #include <wtf/text/WTFString.h>
 
 namespace Inspector {
 
 const ASCIILiteral InspectorDebuggerAgent::backtraceObjectGroup = "backtrace"_s;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InspectorDebuggerAgent);
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(InspectorDebuggerAgentProtocolBreakpoint, InspectorDebuggerAgent::ProtocolBreakpoint);
 
 // Objects created and retained by evaluating breakpoint actions are put into object groups
 // according to the breakpoint action identifier assigned by the frontend. A breakpoint may

--- a/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010, 2013, 2015-2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2010, 2011 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -42,6 +42,7 @@
 #include <wtf/HashSet.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace Inspector {
@@ -56,7 +57,7 @@ class JS_EXPORT_PRIVATE InspectorDebuggerAgent
     , public JSC::Debugger::Client
     , public JSC::Debugger::Observer {
     WTF_MAKE_NONCOPYABLE(InspectorDebuggerAgent);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(InspectorDebuggerAgent);
 public:
     ~InspectorDebuggerAgent() override;
 
@@ -186,7 +187,7 @@ private:
     Ref<JSON::ArrayOf<Protocol::Debugger::CallFrame>> currentCallFrames(const InjectedScript&);
 
     class ProtocolBreakpoint {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED(ProtocolBreakpoint);
     public:
         static std::optional<ProtocolBreakpoint> fromPayload(Protocol::ErrorString&, JSC::SourceID, unsigned lineNumber, unsigned columnNumber, RefPtr<JSON::Object>&& options = nullptr);
         static std::optional<ProtocolBreakpoint> fromPayload(Protocol::ErrorString&, const String& url, bool isRegex, unsigned lineNumber, unsigned columnNumber, RefPtr<JSON::Object>&& options = nullptr);

--- a/Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,10 +34,13 @@
 #include "JSBigInt.h"
 #include "VM.h"
 #include <wtf/Stopwatch.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace Inspector {
 
 using namespace JSC;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InspectorHeapAgent);
 
 InspectorHeapAgent::InspectorHeapAgent(AgentContext& context)
     : InspectorAgentBase("Heap"_s)

--- a/Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,6 +32,7 @@
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/Seconds.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 struct HeapSnapshotNode;
@@ -43,7 +44,7 @@ class InjectedScriptManager;
 
 class JS_EXPORT_PRIVATE InspectorHeapAgent : public InspectorAgentBase, public HeapBackendDispatcherHandler, public JSC::HeapObserver {
     WTF_MAKE_NONCOPYABLE(InspectorHeapAgent);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(InspectorHeapAgent);
 public:
     InspectorHeapAgent(AgentContext&);
     ~InspectorHeapAgent() override;

--- a/Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2011 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -44,11 +44,14 @@
 #include "TypeProfiler.h"
 #include "TypeProfilerLog.h"
 #include <wtf/JSONValues.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/StringToIntegerConversion.h>
 
 namespace Inspector {
 
 using namespace JSC;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InspectorRuntimeAgent);
 
 InspectorRuntimeAgent::InspectorRuntimeAgent(AgentContext& context)
     : InspectorAgentBase("Runtime"_s)

--- a/Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013, 2015-2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2011 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -35,6 +35,7 @@
 #include "InspectorBackendDispatchers.h"
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 class Debugger;
@@ -48,7 +49,7 @@ class InjectedScriptManager;
 
 class JS_EXPORT_PRIVATE InspectorRuntimeAgent : public InspectorAgentBase, public RuntimeBackendDispatcherHandler {
     WTF_MAKE_NONCOPYABLE(InspectorRuntimeAgent);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(InspectorRuntimeAgent);
 public:
     ~InspectorRuntimeAgent() override;
 

--- a/Source/JavaScriptCore/inspector/agents/InspectorScriptProfilerAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorScriptProfilerAgent.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,10 +32,13 @@
 #include "InspectorEnvironment.h"
 #include "SamplingProfiler.h"
 #include <wtf/Stopwatch.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace Inspector {
 
 using namespace JSC;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InspectorScriptProfilerAgent);
 
 InspectorScriptProfilerAgent::InspectorScriptProfilerAgent(AgentContext& context)
     : InspectorAgentBase("ScriptProfiler"_s)

--- a/Source/JavaScriptCore/inspector/agents/InspectorScriptProfilerAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorScriptProfilerAgent.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,6 +30,7 @@
 #include "InspectorBackendDispatchers.h"
 #include "InspectorFrontendDispatchers.h"
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 class Profile;
@@ -39,7 +40,7 @@ namespace Inspector {
 
 class JS_EXPORT_PRIVATE InspectorScriptProfilerAgent final : public InspectorAgentBase, public ScriptProfilerBackendDispatcherHandler, public JSC::Debugger::ProfilingClient {
     WTF_MAKE_NONCOPYABLE(InspectorScriptProfilerAgent);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(InspectorScriptProfilerAgent);
 public:
     InspectorScriptProfilerAgent(AgentContext&);
     ~InspectorScriptProfilerAgent() final;

--- a/Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,8 +27,11 @@
 #include "InspectorTargetAgent.h"
 
 #include "InspectorTarget.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace Inspector {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InspectorTargetAgent);
 
 InspectorTargetAgent::InspectorTargetAgent(FrontendRouter& frontendRouter, BackendDispatcher& backendDispatcher)
     : InspectorAgentBase("Target"_s)

--- a/Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,6 +30,7 @@
 #include "InspectorFrontendChannel.h"
 #include "InspectorFrontendDispatchers.h"
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace Inspector {
 
@@ -37,7 +38,7 @@ class InspectorTarget;
 
 class JS_EXPORT_PRIVATE InspectorTargetAgent final : public InspectorAgentBase, public TargetBackendDispatcherHandler {
     WTF_MAKE_NONCOPYABLE(InspectorTargetAgent);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(InspectorTargetAgent);
 public:
     InspectorTargetAgent(FrontendRouter&, BackendDispatcher&);
     ~InspectorTargetAgent() final;

--- a/Source/JavaScriptCore/inspector/agents/JSGlobalObjectAuditAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/JSGlobalObjectAuditAgent.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,10 +28,13 @@
 
 #include "InjectedScript.h"
 #include "InjectedScriptManager.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace Inspector {
 
 using namespace JSC;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(JSGlobalObjectAuditAgent);
 
 JSGlobalObjectAuditAgent::JSGlobalObjectAuditAgent(JSAgentContext& context)
     : InspectorAuditAgent(context)

--- a/Source/JavaScriptCore/inspector/agents/JSGlobalObjectAuditAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/JSGlobalObjectAuditAgent.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "InspectorAuditAgent.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 class JSGlobalObject;
@@ -35,7 +36,7 @@ namespace Inspector {
 
 class JSGlobalObjectAuditAgent final : public InspectorAuditAgent {
     WTF_MAKE_NONCOPYABLE(JSGlobalObjectAuditAgent);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(JSGlobalObjectAuditAgent);
 public:
     JSGlobalObjectAuditAgent(JSAgentContext&);
     ~JSGlobalObjectAuditAgent() final;

--- a/Source/JavaScriptCore/inspector/agents/JSGlobalObjectDebuggerAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/JSGlobalObjectDebuggerAgent.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014, 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,10 +31,13 @@
 #include "InspectorConsoleAgent.h"
 #include "JSGlobalObjectDebugger.h"
 #include "ScriptCallStackFactory.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace Inspector {
 
 using namespace JSC;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(JSGlobalObjectDebuggerAgent);
 
 JSGlobalObjectDebuggerAgent::JSGlobalObjectDebuggerAgent(JSAgentContext& context, InspectorConsoleAgent* consoleAgent)
     : InspectorDebuggerAgent(context)

--- a/Source/JavaScriptCore/inspector/agents/JSGlobalObjectDebuggerAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/JSGlobalObjectDebuggerAgent.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014, 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "InspectorDebuggerAgent.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace Inspector {
 
@@ -33,7 +34,7 @@ class InspectorConsoleAgent;
 
 class JSGlobalObjectDebuggerAgent final : public InspectorDebuggerAgent {
     WTF_MAKE_NONCOPYABLE(JSGlobalObjectDebuggerAgent);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(JSGlobalObjectDebuggerAgent);
 public:
     JSGlobalObjectDebuggerAgent(JSAgentContext&, InspectorConsoleAgent*);
     ~JSGlobalObjectDebuggerAgent() final;

--- a/Source/JavaScriptCore/inspector/agents/JSGlobalObjectRuntimeAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/JSGlobalObjectRuntimeAgent.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014, 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,10 +28,13 @@
 
 #include "InjectedScript.h"
 #include "InjectedScriptManager.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace Inspector {
 
 using namespace JSC;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(JSGlobalObjectRuntimeAgent);
 
 JSGlobalObjectRuntimeAgent::JSGlobalObjectRuntimeAgent(JSAgentContext& context)
     : InspectorRuntimeAgent(context)

--- a/Source/JavaScriptCore/inspector/agents/JSGlobalObjectRuntimeAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/JSGlobalObjectRuntimeAgent.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014, 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,6 +27,7 @@
 
 #include "InspectorFrontendDispatchers.h"
 #include "InspectorRuntimeAgent.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 class JSGlobalObject;
@@ -36,7 +37,7 @@ namespace Inspector {
 
 class JSGlobalObjectRuntimeAgent final : public InspectorRuntimeAgent {
     WTF_MAKE_NONCOPYABLE(JSGlobalObjectRuntimeAgent);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(JSGlobalObjectRuntimeAgent);
 public:
     JSGlobalObjectRuntimeAgent(JSAgentContext&);
     ~JSGlobalObjectRuntimeAgent() final;

--- a/Source/JavaScriptCore/interpreter/CheckpointOSRExitSideState.h
+++ b/Source/JavaScriptCore/interpreter/CheckpointOSRExitSideState.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,11 +27,12 @@
 
 #include "BytecodeIndex.h"
 #include "Operands.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
 struct CheckpointOSRExitSideState {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(CheckpointOSRExitSideState);
 public:
     CheckpointOSRExitSideState(CallFrame* frame)
         : associatedCallFrame(frame)

--- a/Source/JavaScriptCore/interpreter/Interpreter.h
+++ b/Source/JavaScriptCore/interpreter/Interpreter.h
@@ -35,6 +35,7 @@
 #include "Opcode.h"
 #include <variant>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 
 #if ENABLE(C_LOOP)
 #include "CLoopStack.h"
@@ -120,7 +121,7 @@ using JSOrWasmInstruction = std::variant<const JSInstruction*, const WasmInstruc
     };
 
     class Interpreter {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED(Interpreter);
         friend class CachedCall;
         friend class LLIntOffsetsExtractor;
         friend class JIT;

--- a/Source/JavaScriptCore/interpreter/Register.h
+++ b/Source/JavaScriptCore/interpreter/Register.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,6 +30,7 @@
 
 #include "JSCJSValue.h"
 #include <wtf/Assertions.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/VectorTraits.h>
 
 namespace JSC {
@@ -41,7 +42,7 @@ namespace JSC {
     class JSScope;
 
     class Register {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED(Register);
     public:
         Register();
 

--- a/Source/JavaScriptCore/interpreter/ShadowChicken.cpp
+++ b/Source/JavaScriptCore/interpreter/ShadowChicken.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,12 +30,15 @@
 #include "ShadowChickenInlines.h"
 #include "VMTrapsInlines.h"
 #include <wtf/ListDump.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
 
 namespace ShadowChickenInternal {
 static constexpr bool verbose = false;
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ShadowChicken);
 
 void ShadowChicken::Packet::dump(PrintStream& out) const
 {

--- a/Source/JavaScriptCore/interpreter/ShadowChicken.h
+++ b/Source/JavaScriptCore/interpreter/ShadowChicken.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,10 +27,10 @@
 
 #include "CallFrame.h"
 #include "JSCJSValue.h"
-#include <wtf/FastMalloc.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/PrintStream.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace JSC {
@@ -68,7 +68,7 @@ class VM;
 
 class ShadowChicken {
     WTF_MAKE_NONCOPYABLE(ShadowChicken);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ShadowChicken);
 public:
     struct Packet {
         Packet()

--- a/Source/JavaScriptCore/jit/AssemblyHelpers.cpp
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.cpp
@@ -40,6 +40,7 @@
 #include "SuperSampler.h"
 #include "ThunkGenerators.h"
 #include "UnlinkedCodeBlock.h"
+#include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(WEBASSEMBLY)
 #include "WasmContext.h"
@@ -52,6 +53,8 @@ namespace JSC {
 namespace AssemblyHelpersInternal {
 constexpr bool dumpVerbose = false;
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AssemblyHelpers);
 
 AssemblyHelpers::Jump AssemblyHelpers::branchIfFastTypedArray(GPRReg baseGPR)
 {

--- a/Source/JavaScriptCore/jit/AssemblyHelpers.h
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.h
@@ -47,12 +47,14 @@
 #include "TypeofType.h"
 #include "VM.h"
 #include <variant>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
 typedef void (*V_DebugOperation_EPP)(CallFrame*, void*, void*);
 
 class AssemblyHelpers : public MacroAssembler {
+    WTF_MAKE_TZONE_ALLOCATED(AssemblyHelpers);
 public:
     AssemblyHelpers(CodeBlock* codeBlock)
         : m_codeBlock(codeBlock)

--- a/Source/JavaScriptCore/jit/CCallHelpers.cpp
+++ b/Source/JavaScriptCore/jit/CCallHelpers.cpp
@@ -31,8 +31,11 @@
 #include "LinkBuffer.h"
 #include "MaxFrameExtentForSlowPathCall.h"
 #include "ShadowChicken.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CCallHelpers);
 
 void CCallHelpers::logShadowChickenProloguePacket(GPRReg shadowPacket, GPRReg scratch1, GPRReg scope)
 {

--- a/Source/JavaScriptCore/jit/CCallHelpers.h
+++ b/Source/JavaScriptCore/jit/CCallHelpers.h
@@ -33,6 +33,7 @@
 #include "StackAlignment.h"
 #include <wtf/FunctionTraits.h>
 #include <wtf/ScopedLambda.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -49,6 +50,7 @@ class RegisteredStructure;
 };
 
 class CCallHelpers : public AssemblyHelpers {
+    WTF_MAKE_TZONE_ALLOCATED(CCallHelpers);
 public:
     CCallHelpers(CodeBlock* codeBlock = nullptr)
         : AssemblyHelpers(codeBlock)

--- a/Source/JavaScriptCore/jit/CallFrameShuffleData.cpp
+++ b/Source/JavaScriptCore/jit/CallFrameShuffleData.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,8 +32,11 @@
 #include "BytecodeStructs.h"
 #include "CodeBlock.h"
 #include "RegisterAtOffsetList.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CallFrameShuffleData);
 
 void CallFrameShuffleData::setupCalleeSaveRegisters(const RegisterAtOffsetList* registerSaveLocations)
 {

--- a/Source/JavaScriptCore/jit/CallFrameShuffleData.h
+++ b/Source/JavaScriptCore/jit/CallFrameShuffleData.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,13 +29,14 @@
 
 #include "RegisterMap.h"
 #include "ValueRecovery.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
 struct OpTailCall;
 
 struct CallFrameShuffleData {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(CallFrameShuffleData);
 public:
     void shrinkToFit()
     {

--- a/Source/JavaScriptCore/jit/CallFrameShuffler.h
+++ b/Source/JavaScriptCore/jit/CallFrameShuffler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,6 +31,7 @@
 #include "CallFrameShuffleData.h"
 #include "MacroAssembler.h"
 #include "RegisterSet.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace JSC {
@@ -38,7 +39,7 @@ namespace JSC {
 class CCallHelpers;
 
 class CallFrameShuffler {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(CallFrameShuffler);
 public:
     CallFrameShuffler(CCallHelpers&, const CallFrameShuffleData&);
 

--- a/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
@@ -41,6 +41,7 @@
 #include <wtf/RedBlackTree.h>
 #include <wtf/Scope.h>
 #include <wtf/SystemTracing.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/WorkQueue.h>
 
 #if ENABLE(LIBPAS_JIT_HEAP)
@@ -91,6 +92,8 @@ WTF_WEAK_LINK_FORCE_IMPORT(se_memory_inline_jit_restrict_with_witness_supported)
 namespace JSC {
 
 using namespace WTF;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ExecutableAllocator);
 
 #if OS(DARWIN) && CPU(ARM64)
 // We already rely on page size being CeilingOnPageSize elsewhere (e.g. MarkedBlock).
@@ -454,7 +457,7 @@ static ALWAYS_INLINE JITReservation initializeJITPageReservation()
 }
 
 class FixedVMPoolExecutableAllocator final {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(FixedVMPoolExecutableAllocator);
 
 #if ENABLE(JUMP_ISLANDS)
     class Islands;
@@ -1019,7 +1022,7 @@ private:
 
 #if ENABLE(JUMP_ISLANDS)
     class Islands : public RedBlackTree<Islands, void*>::Node {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED(Islands);
     public:
         void* key() { return jumpSourceLocation.dataLocation(); }
         CodeLocationLabel<ExecutableMemoryPtrTag> jumpSourceLocation;
@@ -1041,6 +1044,9 @@ private:
     std::atomic<size_t> m_bytesAllocated { 0 };
 #endif
 };
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FixedVMPoolExecutableAllocator);
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(FixedVMPoolExecutableAllocatorIslands, FixedVMPoolExecutableAllocator::Islands);
 
 // Keep this pointer in a mutable global variable to help Leaks find it.
 // But we do not use this pointer.

--- a/Source/JavaScriptCore/jit/ExecutableAllocator.h
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,8 +33,10 @@
 #include "Options.h"
 #include <limits>
 #include <wtf/Assertions.h>
+#include <wtf/ForbidHeapAllocation.h>
 #include <wtf/Gigacage.h>
 #include <wtf/Lock.h>
+#include <wtf/TZoneMalloc.h>
 
 #if !ENABLE(LIBPAS_JIT_HEAP)
 #include <wtf/MetaAllocator.h>
@@ -56,7 +58,7 @@ namespace JSC {
 static constexpr unsigned jitAllocationGranule = 32;
 
 class ExecutableAllocatorBase {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_FORBID_HEAP_ALLOCATION;
     WTF_MAKE_NONCOPYABLE(ExecutableAllocatorBase);
 public:
     bool isValid() const { return false; }
@@ -150,6 +152,7 @@ static ALWAYS_INLINE void* performJITMemcpy(void *dst, const void *src, size_t n
 }
 
 class ExecutableAllocator : private ExecutableAllocatorBase {
+    WTF_MAKE_TZONE_ALLOCATED(ExecutableAllocator);
 public:
     using Base = ExecutableAllocatorBase;
 
@@ -192,6 +195,7 @@ private:
 #else
 
 class ExecutableAllocator : public ExecutableAllocatorBase {
+    WTF_MAKE_TZONE_ALLOCATED(ExecutableAllocator);
 public:
     static ExecutableAllocator& singleton();
     static void initialize();

--- a/Source/JavaScriptCore/jit/ICStats.cpp
+++ b/Source/JavaScriptCore/jit/ICStats.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,11 @@
 #include "config.h"
 #include "ICStats.h"
 
+#include <wtf/TZoneMallocInlines.h>
+
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ICStats);
 
 bool ICEvent::operator<(const ICEvent& other) const
 {

--- a/Source/JavaScriptCore/jit/ICStats.h
+++ b/Source/JavaScriptCore/jit/ICStats.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,11 +28,11 @@
 #include "ClassInfo.h"
 #include "Identifier.h"
 #include <wtf/Condition.h>
-#include <wtf/FastMalloc.h>
 #include <wtf/Lock.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/PrintStream.h>
 #include <wtf/Spectrum.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -194,7 +194,7 @@ namespace JSC {
 
 class ICStats {
     WTF_MAKE_NONCOPYABLE(ICStats);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ICStats);
 public:
     ICStats();
     ~ICStats();

--- a/Source/JavaScriptCore/jit/JIT.cpp
+++ b/Source/JavaScriptCore/jit/JIT.cpp
@@ -50,11 +50,14 @@
 #include "TypeProfilerLog.h"
 #include <wtf/GraphNodeWorklist.h>
 #include <wtf/SimpleStats.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
 namespace JITInternal {
 static constexpr const bool verbose = false;
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(JIT);
 
 Seconds totalBaselineCompileTime;
 Seconds totalDFGCompileTime;

--- a/Source/JavaScriptCore/jit/JIT.h
+++ b/Source/JavaScriptCore/jit/JIT.h
@@ -39,6 +39,7 @@
 #include "JSInterfaceJIT.h"
 #include "LLIntData.h"
 #include "PCToCodeOriginMap.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 
 namespace JSC {
@@ -149,6 +150,8 @@ namespace JSC {
     };
 
     class JIT final : public JSInterfaceJIT {
+        WTF_MAKE_TZONE_ALLOCATED(JIT);
+
         friend class JITSlowPathCall;
         friend class JITStubCall;
         friend class JITThunks;

--- a/Source/JavaScriptCore/jit/JITCompilation.cpp
+++ b/Source/JavaScriptCore/jit/JITCompilation.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,8 +29,11 @@
 #if ENABLE(JIT)
 
 #include "JITOpaqueByproducts.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Compilation);
 
 Compilation::Compilation(MacroAssemblerCodeRef<JITCompilationPtrTag> codeRef, std::unique_ptr<OpaqueByproducts> byproducts)
     : m_codeRef(codeRef)

--- a/Source/JavaScriptCore/jit/JITCompilation.h
+++ b/Source/JavaScriptCore/jit/JITCompilation.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,8 +28,8 @@
 #if ENABLE(JIT)
 
 #include "MacroAssemblerCodeRef.h"
-#include <wtf/FastMalloc.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -41,7 +41,7 @@ class OpaqueByproducts;
 
 class Compilation {
     WTF_MAKE_NONCOPYABLE(Compilation);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(Compilation, JS_EXPORT_PRIVATE);
 
 public:
     JS_EXPORT_PRIVATE Compilation(MacroAssemblerCodeRef<JITCompilationPtrTag>, std::unique_ptr<OpaqueByproducts>);

--- a/Source/JavaScriptCore/jit/JITDisassembler.cpp
+++ b/Source/JavaScriptCore/jit/JITDisassembler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,8 +35,11 @@
 #include "LinkBuffer.h"
 #include "ProfilerCompilation.h"
 #include <wtf/StringPrintStream.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(JITDisassembler);
 
 JITDisassembler::JITDisassembler(CodeBlock *codeBlock)
     : m_codeBlock(codeBlock)

--- a/Source/JavaScriptCore/jit/JITDisassembler.h
+++ b/Source/JavaScriptCore/jit/JITDisassembler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,6 +29,7 @@
 
 #include "BytecodeIndex.h"
 #include "MacroAssembler.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/text/CString.h>
 
@@ -42,7 +43,7 @@ class Compilation;
 }
 
 class JITDisassembler {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(JITDisassembler);
 public:
     JITDisassembler(CodeBlock*);
     ~JITDisassembler();

--- a/Source/JavaScriptCore/jit/JITMathIC.h
+++ b/Source/JavaScriptCore/jit/JITMathIC.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,6 +36,7 @@
 #include "JITSubGenerator.h"
 #include "LinkBuffer.h"
 #include "Repatch.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -55,7 +56,7 @@ struct MathICGenerationState {
 
 template <typename GeneratorType, typename ArithProfileType>
 class JITMathIC {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(JITMathIC);
 public:
     JITMathIC(ArithProfileType* arithProfile)
         : m_arithProfile(arithProfile)

--- a/Source/JavaScriptCore/jit/JITOpaqueByproduct.h
+++ b/Source/JavaScriptCore/jit/JITOpaqueByproduct.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,15 +27,15 @@
 
 #if ENABLE(JIT)
 
-#include <wtf/FastMalloc.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/PrintStream.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
 class OpaqueByproduct {
     WTF_MAKE_NONCOPYABLE(OpaqueByproduct);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(OpaqueByproduct);
 public:
     OpaqueByproduct() { }
     virtual ~OpaqueByproduct() { }

--- a/Source/JavaScriptCore/jit/JITOpaqueByproducts.cpp
+++ b/Source/JavaScriptCore/jit/JITOpaqueByproducts.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,7 +28,12 @@
 
 #if ENABLE(JIT)
 
+#include <wtf/TZoneMallocInlines.h>
+
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(OpaqueByproduct);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(OpaqueByproducts);
 
 OpaqueByproducts::OpaqueByproducts()
 {

--- a/Source/JavaScriptCore/jit/JITOpaqueByproducts.h
+++ b/Source/JavaScriptCore/jit/JITOpaqueByproducts.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,13 +29,14 @@
 
 #include "JITOpaqueByproduct.h"
 #include <memory>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace JSC {
 
 class OpaqueByproducts {
     WTF_MAKE_NONCOPYABLE(OpaqueByproducts)
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(OpaqueByproducts);
 public:
     OpaqueByproducts();
     JS_EXPORT_PRIVATE ~OpaqueByproducts();

--- a/Source/JavaScriptCore/jit/JITSizeStatistics.cpp
+++ b/Source/JavaScriptCore/jit/JITSizeStatistics.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,8 +31,11 @@
 #include "CCallHelpers.h"
 #include "LinkBuffer.h"
 #include <wtf/BubbleSort.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(JITSizeStatistics);
 
 JITSizeStatistics::Marker JITSizeStatistics::markStart(String identifier, CCallHelpers& jit)
 {

--- a/Source/JavaScriptCore/jit/JITSizeStatistics.h
+++ b/Source/JavaScriptCore/jit/JITSizeStatistics.h
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,15 +29,15 @@
 #if ENABLE(JIT)
 
 #include "CCallHelpers.h"
-#include <wtf/FastMalloc.h>
 #include <wtf/HashMap.h>
 #include <wtf/PrintStream.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace JSC {
 
 class JITSizeStatistics {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(JITSizeStatistics);
 public:
     struct Marker {
         String identifier;

--- a/Source/JavaScriptCore/jit/JITTZoneImpls.cpp
+++ b/Source/JavaScriptCore/jit/JITTZoneImpls.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#if ENABLE(JIT)
+
+#include "JSInterfaceJIT.h"
+#include "SpecializedThunkJIT.h"
+#include <wtf/TZoneMallocInlines.h>
+
+namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(JSInterfaceJIT);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SpecializedThunkJIT);
+
+} // namespace JSC
+
+#endif // ENABLE(JIT)

--- a/Source/JavaScriptCore/jit/JITThunks.cpp
+++ b/Source/JavaScriptCore/jit/JITThunks.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,8 +35,11 @@
 #include "SlowPathCall.h"
 #include "ThunkGenerators.h"
 #include "VM.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(JITThunks);
 
 JITThunks::JITThunks()
 {

--- a/Source/JavaScriptCore/jit/JITThunks.h
+++ b/Source/JavaScriptCore/jit/JITThunks.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -38,9 +38,10 @@
 #include <tuple>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
+#include <wtf/Hasher.h>
 #include <wtf/PackedRefPtr.h>
 #include <wtf/RecursiveLockAdapter.h>
-#include <wtf/Hasher.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 namespace DOMJIT {
@@ -81,7 +82,7 @@ static constexpr unsigned numberOfCommonThunkIDs = 0 JSC_FOR_EACH_COMMON_THUNK(J
 #undef JSC_COUNT_COMMON_JIT_THUNK_ID
 
 class JITThunks final : private WeakHandleOwner {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(JITThunks);
 public:
     JITThunks();
     ~JITThunks() final;

--- a/Source/JavaScriptCore/jit/JITWorklist.cpp
+++ b/Source/JavaScriptCore/jit/JITWorklist.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,8 +35,11 @@
 #include "SlotVisitorInlines.h"
 #include "VMInlines.h"
 #include <wtf/CompilationThread.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(JITWorklist);
 
 JITWorklist::JITWorklist()
     : m_lock(Box<Lock>::create())

--- a/Source/JavaScriptCore/jit/JITWorklist.h
+++ b/Source/JavaScriptCore/jit/JITWorklist.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,10 +30,10 @@
 #include "JITPlan.h"
 #include "JITWorklistThread.h"
 #include <wtf/Deque.h>
-#include <wtf/FastMalloc.h>
 #include <wtf/Lock.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace JSC {
@@ -43,7 +43,7 @@ class VM;
 
 class JITWorklist {
     WTF_MAKE_NONCOPYABLE(JITWorklist);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(JITWorklist);
 
     friend class JITWorklistThread;
 

--- a/Source/JavaScriptCore/jit/JSInterfaceJIT.h
+++ b/Source/JavaScriptCore/jit/JSInterfaceJIT.h
@@ -32,11 +32,13 @@
 #include "JSCJSValue.h"
 #include "JSString.h"
 #include "MacroAssembler.h"
+#include <wtf/TZoneMalloc.h>
 
 #if ENABLE(JIT)
 
 namespace JSC {
     class JSInterfaceJIT : public CCallHelpers, public GPRInfo, public JSRInfo, public FPRInfo {
+        WTF_MAKE_TZONE_ALLOCATED(JSInterfaceJIT);
     public:
 
         JSInterfaceJIT(VM* vm = nullptr, CodeBlock* codeBlock = nullptr)

--- a/Source/JavaScriptCore/jit/PCToCodeOriginMap.cpp
+++ b/Source/JavaScriptCore/jit/PCToCodeOriginMap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,6 +32,7 @@
 #include "DFGNode.h"
 #include "LinkBuffer.h"
 #include "WasmOpcodeOrigin.h"
+#include <wtf/TZoneMallocInlines.h>
 
 #if COMPILER(MSVC)
 // See https://msdn.microsoft.com/en-us/library/4wz07268.aspx
@@ -247,6 +248,8 @@ PCToCodeOriginMap::PCToCodeOriginMap(PCToCodeOriginMapBuilder&& builder, LinkBuf
     m_compressedCodeOriginsSize = codeOriginCompressor.m_offset;
     m_compressedCodeOrigins = static_cast<uint8_t*>(fastRealloc(codeOriginCompressor.m_buffer, m_compressedCodeOriginsSize));
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PCToCodeOriginMap);
 
 PCToCodeOriginMap::~PCToCodeOriginMap()
 {

--- a/Source/JavaScriptCore/jit/PCToCodeOriginMap.h
+++ b/Source/JavaScriptCore/jit/PCToCodeOriginMap.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -44,7 +44,7 @@ class LinkBuffer;
 class PCToCodeOriginMapBuilder;
 
 class PCToCodeOriginMapBuilder {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PCToCodeOriginMapBuilder);
     WTF_MAKE_NONCOPYABLE(PCToCodeOriginMapBuilder);
     friend class PCToCodeOriginMap;
 
@@ -90,7 +90,7 @@ private:
 
 // FIXME: <rdar://problem/39436658>
 class PCToCodeOriginMap {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PCToCodeOriginMap);
     WTF_MAKE_NONCOPYABLE(PCToCodeOriginMap);
 public:
     PCToCodeOriginMap(PCToCodeOriginMapBuilder&&, LinkBuffer&);

--- a/Source/JavaScriptCore/jit/SpecializedThunkJIT.h
+++ b/Source/JavaScriptCore/jit/SpecializedThunkJIT.h
@@ -31,10 +31,12 @@
 #include "JITInlines.h"
 #include "JSInterfaceJIT.h"
 #include "LinkBuffer.h"
+#include "MacroAssembler.h"
 
 namespace JSC {
 
     class SpecializedThunkJIT : public JSInterfaceJIT {
+        WTF_MAKE_TZONE_ALLOCATED(SpecializedThunkJIT);
     public:
         static constexpr int ThisArgument = -1;
         SpecializedThunkJIT(VM& vm, int expectedArgCount)

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -100,6 +100,7 @@
 #include <wtf/SafeStrerror.h>
 #include <wtf/Scope.h>
 #include <wtf/StringPrintStream.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/URL.h>
 #include <wtf/WTFProcess.h>
 #include <wtf/WallTime.h>
@@ -261,7 +262,7 @@ private:
 };
 
 class Workers {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Workers);
     WTF_MAKE_NONCOPYABLE(Workers);
 public:
     Workers();
@@ -284,6 +285,8 @@ private:
     SentinelLinkedList<Worker, BasicRawSentinelNode<Worker>> m_workers;
     Deque<String> m_reports;
 };
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Workers);
 
 
 static JSC_DECLARE_HOST_FUNCTION(functionAtob);

--- a/Source/JavaScriptCore/llint/LLIntOffsetsExtractor.cpp
+++ b/Source/JavaScriptCore/llint/LLIntOffsetsExtractor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -78,6 +78,7 @@
 #include "WebAssemblyFunction.h"
 #include <stdio.h>
 #include <wtf/FastTLS.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/StringImpl.h>
 
 namespace JSC {

--- a/Source/JavaScriptCore/parser/Lexer.cpp
+++ b/Source/JavaScriptCore/parser/Lexer.cpp
@@ -1,6 +1,6 @@
 /*
  *  Copyright (C) 1999-2000 Harri Porten (porten@kde.org)
- *  Copyright (C) 2006-2019 Apple Inc. All Rights Reserved.
+ *  Copyright (C) 2006-2023 Apple Inc. All Rights Reserved.
  *  Copyright (C) 2007 Cameron Zwarich (cwzwarich@uwaterloo.ca)
  *  Copyright (C) 2010 Zoltan Herczeg (zherczeg@inf.u-szeged.hu)
  *  Copyright (C) 2012 Mathias Bynens (mathias@qiwi.be)
@@ -35,6 +35,7 @@
 #include <variant>
 #include <wtf/Assertions.h>
 #include <wtf/HexNumber.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/dtoa.h>
 
 namespace JSC {
@@ -2739,5 +2740,11 @@ void Lexer<T>::clear()
 // Instantiate the two flavors of Lexer we need instead of putting most of this file in Lexer.h
 template class Lexer<LChar>;
 template class Lexer<UChar>;
+
+using LexerLChar = Lexer<LChar>;
+using LexerUChar = Lexer<UChar>;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL_TEMPLATE(LexerLChar);
+WTF_MAKE_TZONE_ALLOCATED_IMPL_TEMPLATE(LexerUChar);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/parser/Lexer.h
+++ b/Source/JavaScriptCore/parser/Lexer.h
@@ -1,6 +1,6 @@
 /*
  *  Copyright (C) 1999-2000 Harri Porten (porten@kde.org)
- *  Copyright (C) 2002-2019 Apple Inc. All rights reserved.
+ *  Copyright (C) 2002-2023 Apple Inc. All rights reserved.
  *  Copyright (C) 2010 Zoltan Herczeg (zherczeg@inf.u-szeged.hu)
  *
  *  This library is free software; you can redistribute it and/or
@@ -28,6 +28,7 @@
 #include "ParserTokens.h"
 #include "SourceCode.h"
 #include <wtf/ASCIICType.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/unicode/CharacterNames.h>
 
@@ -46,7 +47,7 @@ bool isLexerKeyword(const Identifier&);
 template <typename T>
 class Lexer {
     WTF_MAKE_NONCOPYABLE(Lexer);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Lexer);
 
 public:
     Lexer(VM&, JSParserBuiltinMode, JSParserScriptMode);

--- a/Source/JavaScriptCore/parser/ModuleScopeData.h
+++ b/Source/JavaScriptCore/parser/ModuleScopeData.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2016 Yusuke Suzuki <utatane.tea@gmail.com>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,12 +28,13 @@
 
 #include "Identifier.h"
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
 class ModuleScopeData : public RefCounted<ModuleScopeData> {
-WTF_MAKE_NONCOPYABLE(ModuleScopeData);
-WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_NONCOPYABLE(ModuleScopeData);
+    WTF_MAKE_TZONE_ALLOCATED(ModuleScopeData);
 public:
     typedef HashMap<RefPtr<UniquedStringImpl>, Vector<RefPtr<UniquedStringImpl>>, IdentifierRepHash, HashTraits<RefPtr<UniquedStringImpl>>> IdentifierAliasMap;
 

--- a/Source/JavaScriptCore/parser/Parser.cpp
+++ b/Source/JavaScriptCore/parser/Parser.cpp
@@ -32,6 +32,7 @@
 #include <wtf/Scope.h>
 #include <wtf/SetForScope.h>
 #include <wtf/StringPrintStream.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #define updateErrorMessage(shouldPrintToken, ...) do {\
     propagateError(); \
@@ -90,6 +91,8 @@
 namespace JSC {
 
 std::atomic<unsigned> globalParseCount { 0 };
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ModuleScopeData);
 
 ALWAYS_INLINE static SourceParseMode getAsyncFunctionBodyParseMode(SourceParseMode parseMode)
 {

--- a/Source/JavaScriptCore/parser/Parser.h
+++ b/Source/JavaScriptCore/parser/Parser.h
@@ -1,7 +1,7 @@
 /*
  *  Copyright (C) 1999-2001 Harri Porten (porten@kde.org)
  *  Copyright (C) 2001 Peter Kelly (pmk@post.com)
- *  Copyright (C) 2003-2019 Apple Inc. All rights reserved.
+ *  Copyright (C) 2003-2023 Apple Inc. All rights reserved.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Library General Public
@@ -40,6 +40,7 @@
 #include <wtf/IterationStatus.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -1032,7 +1033,7 @@ enum class ParsingContext { Program, FunctionConstructor, Eval };
 template <typename LexerType>
 class Parser {
     WTF_MAKE_NONCOPYABLE(Parser);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Parser);
 
 public:
     Parser(VM&, const SourceCode&, ImplementationVisibility, JSParserBuiltinMode, JSParserStrictMode, JSParserScriptMode, SourceParseMode, FunctionMode, SuperBinding, ConstructorKind defaultConstructorKindForTopLevelFunction = ConstructorKind::None, DerivedContextType = DerivedContextType::None, bool isEvalContext = false, EvalContextType = EvalContextType::None, DebuggerParseData* = nullptr, bool isInsideOrdinaryFunction = false);

--- a/Source/JavaScriptCore/parser/VariableEnvironment.cpp
+++ b/Source/JavaScriptCore/parser/VariableEnvironment.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,9 +27,13 @@
 #include "VariableEnvironment.h"
 #include <wtf/CommaPrinter.h>
 #include <wtf/HexNumber.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/UniquedStringImpl.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CompactTDZEnvironment);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(VariableEnvironment);
 
 void VariableEnvironmentEntry::dump(PrintStream& out) const
 {

--- a/Source/JavaScriptCore/parser/VariableEnvironment.h
+++ b/Source/JavaScriptCore/parser/VariableEnvironment.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2019 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,6 +30,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/IteratorRange.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -140,7 +141,7 @@ struct PrivateNameEntryHashTraits : HashTraits<PrivateNameEntry> {
 typedef HashMap<PackedRefPtr<UniquedStringImpl>, PrivateNameEntry, IdentifierRepHash, HashTraits<RefPtr<UniquedStringImpl>>, PrivateNameEntryHashTraits> PrivateNameEnvironment;
 
 class VariableEnvironment {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(VariableEnvironment);
 private:
     typedef HashMap<PackedRefPtr<UniquedStringImpl>, VariableEnvironmentEntry, IdentifierRepHash, HashTraits<RefPtr<UniquedStringImpl>>, VariableEnvironmentEntryHashTraits> Map;
 
@@ -333,7 +334,7 @@ private:
 using TDZEnvironment = HashSet<RefPtr<UniquedStringImpl>, IdentifierRepHash>;
 
 class CompactTDZEnvironment {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(CompactTDZEnvironment);
     WTF_MAKE_NONCOPYABLE(CompactTDZEnvironment);
 
     friend class CachedCompactTDZEnvironment;

--- a/Source/JavaScriptCore/profiler/ProfilerDatabase.cpp
+++ b/Source/JavaScriptCore/profiler/ProfilerDatabase.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2013, 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,8 +32,11 @@
 #include "ObjectConstructor.h"
 #include "ProfilerDumper.h"
 #include <wtf/FilePrintStream.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC { namespace Profiler {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Database);
 
 static std::atomic<int> databaseCounter;
 

--- a/Source/JavaScriptCore/profiler/ProfilerDatabase.h
+++ b/Source/JavaScriptCore/profiler/ProfilerDatabase.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2013, 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,18 +29,19 @@
 #include "ProfilerBytecodes.h"
 #include "ProfilerCompilation.h"
 #include "ProfilerEvent.h"
-#include <wtf/FastMalloc.h>
 #include <wtf/HashMap.h>
 #include <wtf/JSONValues.h>
 #include <wtf/Lock.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/SegmentedVector.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace JSC { namespace Profiler {
 
 class Database {
-    WTF_MAKE_FAST_ALLOCATED; WTF_MAKE_NONCOPYABLE(Database);
+    WTF_MAKE_TZONE_ALLOCATED(Database);
+    WTF_MAKE_NONCOPYABLE(Database);
 public:
     JS_EXPORT_PRIVATE Database(VM&);
     JS_EXPORT_PRIVATE ~Database();

--- a/Source/JavaScriptCore/profiler/ProfilerExecutionCounter.h
+++ b/Source/JavaScriptCore/profiler/ProfilerExecutionCounter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,13 +25,14 @@
 
 #pragma once
 
-#include <wtf/FastMalloc.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC { namespace Profiler {
 
 class ExecutionCounter {
-    WTF_MAKE_FAST_ALLOCATED; WTF_MAKE_NONCOPYABLE(ExecutionCounter);
+    WTF_MAKE_TZONE_ALLOCATED(ExecutionCounter);
+    WTF_MAKE_NONCOPYABLE(ExecutionCounter);
 public:
     ExecutionCounter() : m_counter(0) { }
     

--- a/Source/JavaScriptCore/profiler/ProfilerTZoneImpls.cpp
+++ b/Source/JavaScriptCore/profiler/ProfilerTZoneImpls.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ProfilerExecutionCounter.h"
+#include <wtf/TZoneMallocInlines.h>
+
+namespace JSC { namespace Profiler {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ExecutionCounter);
+
+} } // namespace JSC::Profiler

--- a/Source/JavaScriptCore/runtime/ArgList.cpp
+++ b/Source/JavaScriptCore/runtime/ArgList.cpp
@@ -22,10 +22,13 @@
 #include "ArgList.h"
 
 #include "JSCJSValueInlines.h"
+#include <wtf/TZoneMallocInlines.h>
 
 using std::min;
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ArgList);
 
 void MarkedVectorBase::addMarkSet(JSValue v)
 {

--- a/Source/JavaScriptCore/runtime/ArgList.h
+++ b/Source/JavaScriptCore/runtime/ArgList.h
@@ -1,6 +1,6 @@
 /*
  *  Copyright (C) 1999-2001 Harri Porten (porten@kde.org)
- *  Copyright (C) 2003-2021 Apple Inc. All rights reserved.
+ *  Copyright (C) 2003-2023 Apple Inc. All rights reserved.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Library General Public
@@ -26,6 +26,7 @@
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/ForbidHeapAllocation.h>
 #include <wtf/HashSet.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -236,7 +237,7 @@ class MarkedArgumentBufferWithSize : public MarkedVector<JSValue, passedInlineCa
 using MarkedArgumentBuffer = MarkedVector<JSValue, 8, RecordOverflow>;
 
 class ArgList {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ArgList);
     friend class Interpreter;
     friend class JIT;
 public:

--- a/Source/JavaScriptCore/runtime/ArrayBuffer.h
+++ b/Source/JavaScriptCore/runtime/ArrayBuffer.h
@@ -37,6 +37,7 @@
 #include <wtf/SharedTask.h>
 #include <wtf/StdIntExtras.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/text/WTFString.h>
 
@@ -430,7 +431,7 @@ JS_EXPORT_PRIVATE ASCIILiteral errorMessageForTransfer(ArrayBuffer*);
 // https://tc39.es/proposal-resizablearraybuffer/#sec-makeidempotentarraybufferbytelengthgetter
 template<std::memory_order order>
 class IdempotentArrayBufferByteLengthGetter {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(IdempotentArrayBufferByteLengthGetter);
 public:
     IdempotentArrayBufferByteLengthGetter() = default;
 

--- a/Source/JavaScriptCore/runtime/BasicBlockLocation.cpp
+++ b/Source/JavaScriptCore/runtime/BasicBlockLocation.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2014 Saam Barati. <saambarati1@gmail.com>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -30,8 +30,11 @@
 #include "CCallHelpers.h"
 #include <climits>
 #include <wtf/DataLog.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(BasicBlockLocation);
 
 BasicBlockLocation::BasicBlockLocation(int startOffset, int endOffset)
     : m_startOffset(startOffset)

--- a/Source/JavaScriptCore/runtime/BasicBlockLocation.h
+++ b/Source/JavaScriptCore/runtime/BasicBlockLocation.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2014 Saam Barati. <saambarati1@gmail.com>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,6 +28,7 @@
 
 #include "CPU.h"
 #include "MacroAssembler.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace JSC {
@@ -36,7 +37,7 @@ class CCallHelpers;
 class LLIntOffsetsExtractor;
 
 class BasicBlockLocation {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(BasicBlockLocation);
 public:
     typedef std::pair<int, int> Gap;
 

--- a/Source/JavaScriptCore/runtime/BufferMemoryHandle.cpp
+++ b/Source/JavaScriptCore/runtime/BufferMemoryHandle.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -40,6 +40,7 @@
 #include <wtf/Platform.h>
 #include <wtf/PrintStream.h>
 #include <wtf/SafeStrerror.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 
 namespace JSC {
@@ -47,6 +48,9 @@ namespace JSC {
 // FIXME: We could be smarter about memset / mmap / madvise. https://bugs.webkit.org/show_bug.cgi?id=170343
 // FIXME: Give up some of the cached fast memories if the GC determines it's easy to get them back, and they haven't been used in a while. https://bugs.webkit.org/show_bug.cgi?id=170773
 // FIXME: Limit slow memory size. https://bugs.webkit.org/show_bug.cgi?id=170825
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(BufferMemoryHandle);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(BufferMemoryManager);
 
 size_t BufferMemoryHandle::fastMappedRedzoneBytes()
 {

--- a/Source/JavaScriptCore/runtime/BufferMemoryHandle.h
+++ b/Source/JavaScriptCore/runtime/BufferMemoryHandle.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,6 +36,7 @@
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
 #include <wtf/StdSet.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
 
@@ -79,7 +80,7 @@ struct BufferMemoryResult {
 };
 
 class BufferMemoryManager {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(BufferMemoryManager);
     WTF_MAKE_NONCOPYABLE(BufferMemoryManager);
 public:
     friend class LazyNeverDestroyed<BufferMemoryManager>;
@@ -125,7 +126,7 @@ private:
 
 class BufferMemoryHandle final : public ThreadSafeRefCounted<BufferMemoryHandle> {
     WTF_MAKE_NONCOPYABLE(BufferMemoryHandle);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(BufferMemoryHandle, JS_EXPORT_PRIVATE);
     friend LLIntOffsetsExtractor;
 public:
     BufferMemoryHandle(void*, size_t size, size_t mappedCapacity, PageCount initial, PageCount maximum, MemorySharingMode, MemoryMode);

--- a/Source/JavaScriptCore/runtime/CodeCache.cpp
+++ b/Source/JavaScriptCore/runtime/CodeCache.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2019 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2012-2023 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,8 +28,11 @@
 
 #include "BytecodeGenerator.h"
 #include "IndirectEvalExecutable.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CodeCache);
 
 void CodeCacheMap::pruneSlowCase()
 {

--- a/Source/JavaScriptCore/runtime/CodeCache.h
+++ b/Source/JavaScriptCore/runtime/CodeCache.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2019 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2012-2023 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -40,6 +40,7 @@
 #include "UnlinkedProgramCodeBlock.h"
 #include <wtf/ApproximateTime.h>
 #include <wtf/MainThread.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -220,7 +221,7 @@ private:
 
 // Caches top-level code such as <script>, window.eval(), new Function, and JSEvaluateScript().
 class CodeCache {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(CodeCache);
 public:
     UnlinkedProgramCodeBlock* getUnlinkedProgramCodeBlock(VM&, ProgramExecutable*, const SourceCode&, JSParserStrictMode, OptionSet<CodeGenerationMode>, ParserError&);
     UnlinkedEvalCodeBlock* getUnlinkedEvalCodeBlock(VM&, IndirectEvalExecutable*, const SourceCode&, JSParserStrictMode, OptionSet<CodeGenerationMode>, ParserError&, EvalContextType);

--- a/Source/JavaScriptCore/runtime/CommonIdentifiers.cpp
+++ b/Source/JavaScriptCore/runtime/CommonIdentifiers.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2003-2019 Apple Inc. All rights reserved.
+ *  Copyright (C) 2003-2023 Apple Inc. All rights reserved.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Library General Public
@@ -23,8 +23,11 @@
 
 #include "BuiltinNames.h"
 #include "IdentifierInlines.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CommonIdentifiers);
 
 #define INITIALIZE_PROPERTY_NAME(name) , name(Identifier::fromString(vm, #name ""_s))
 #define INITIALIZE_KEYWORD(name) , name##Keyword(Identifier::fromString(vm, #name ""_s))

--- a/Source/JavaScriptCore/runtime/CommonIdentifiers.h
+++ b/Source/JavaScriptCore/runtime/CommonIdentifiers.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2003-2020 Apple Inc. All rights reserved.
+ *  Copyright (C) 2003-2023 Apple Inc. All rights reserved.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Library General Public
@@ -22,6 +22,7 @@
 
 #include "Identifier.h"
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 
 // MarkedArgumentBuffer of property names, passed to a macro so we can do set them up various
 // ways without repeating the list.
@@ -380,7 +381,8 @@ namespace JSC {
     class BuiltinNames;
     
     class CommonIdentifiers {
-        WTF_MAKE_NONCOPYABLE(CommonIdentifiers); WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_NONCOPYABLE(CommonIdentifiers);
+        WTF_MAKE_TZONE_ALLOCATED(CommonIdentifiers);
     private:
         CommonIdentifiers(VM&);
         ~CommonIdentifiers();

--- a/Source/JavaScriptCore/runtime/ControlFlowProfiler.cpp
+++ b/Source/JavaScriptCore/runtime/ControlFlowProfiler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2014 Saam Barati. <saambarati1@gmail.com>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,8 +28,11 @@
 #include "ControlFlowProfiler.h"
 
 #include "VM.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ControlFlowProfiler);
 
 ControlFlowProfiler::ControlFlowProfiler()
     : m_dummyBasicBlock(BasicBlockLocation(-1, -1))

--- a/Source/JavaScriptCore/runtime/ControlFlowProfiler.h
+++ b/Source/JavaScriptCore/runtime/ControlFlowProfiler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2014 Saam Barati. <saambarati1@gmail.com>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,6 +29,7 @@
 #include "BasicBlockLocation.h"
 #include "SourceID.h"
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -88,7 +89,7 @@ struct BasicBlockRange {
 };
 
 class ControlFlowProfiler {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ControlFlowProfiler);
 public:
     ControlFlowProfiler();
     ~ControlFlowProfiler();

--- a/Source/JavaScriptCore/runtime/DOMAnnotation.h
+++ b/Source/JavaScriptCore/runtime/DOMAnnotation.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Yusuke Suzuki <utatane.tea@gmail.com>.
+ * Copyright (C) 2017-2023 Yusuke Suzuki <utatane.tea@gmail.com>.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <wtf/FastMalloc.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -36,7 +36,7 @@ class GetterSetter;
 }
 
 struct DOMAttributeAnnotation {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(DOMAttributeAnnotation);
 public:
     const ClassInfo* classInfo;
     const DOMJIT::GetterSetter* domJIT;

--- a/Source/JavaScriptCore/runtime/DeferredWorkTimer.cpp
+++ b/Source/JavaScriptCore/runtime/DeferredWorkTimer.cpp
@@ -31,8 +31,11 @@
 #include "StrongInlines.h"
 #include "VM.h"
 #include <wtf/RunLoop.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(DeferredWorkTimerTicketData, DeferredWorkTimer::TicketData);
 
 namespace DeferredWorkTimerInternal {
 static constexpr bool verbose = false;

--- a/Source/JavaScriptCore/runtime/DeferredWorkTimer.h
+++ b/Source/JavaScriptCore/runtime/DeferredWorkTimer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,6 +33,7 @@
 #include <wtf/FixedVector.h>
 #include <wtf/HashSet.h>
 #include <wtf/Lock.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace JSC {
@@ -47,7 +48,7 @@ public:
 
     struct TicketData {
     private:
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_TZONE_ALLOCATED(TicketData);
     public:
         inline TicketData(VM&, JSObject* scriptExecutionOwner, Vector<Strong<JSCell>>&& dependencies);
 

--- a/Source/JavaScriptCore/runtime/DoublePredictionFuzzerAgent.cpp
+++ b/Source/JavaScriptCore/runtime/DoublePredictionFuzzerAgent.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,8 +25,11 @@
 
 #include "config.h"
 #include "DoublePredictionFuzzerAgent.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(DoublePredictionFuzzerAgent);
 
 DoublePredictionFuzzerAgent::DoublePredictionFuzzerAgent(VM&)
 {

--- a/Source/JavaScriptCore/runtime/DoublePredictionFuzzerAgent.h
+++ b/Source/JavaScriptCore/runtime/DoublePredictionFuzzerAgent.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,13 +26,14 @@
 #pragma once
 
 #include "FuzzerAgent.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
 class VM;
 
 class DoublePredictionFuzzerAgent final : public FuzzerAgent {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(DoublePredictionFuzzerAgent);
 public:
     DoublePredictionFuzzerAgent(VM&);
 

--- a/Source/JavaScriptCore/runtime/FileBasedFuzzerAgent.cpp
+++ b/Source/JavaScriptCore/runtime/FileBasedFuzzerAgent.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,8 +30,11 @@
 #include "FuzzerPredictions.h"
 #include "JSCellInlines.h"
 #include <wtf/AnsiColors.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FileBasedFuzzerAgent);
 
 FileBasedFuzzerAgent::FileBasedFuzzerAgent(VM& vm)
     : FileBasedFuzzerAgentBase(vm)

--- a/Source/JavaScriptCore/runtime/FileBasedFuzzerAgent.h
+++ b/Source/JavaScriptCore/runtime/FileBasedFuzzerAgent.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,13 +26,14 @@
 #pragma once
 
 #include "FileBasedFuzzerAgentBase.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
 class VM;
 
 class FileBasedFuzzerAgent final : public FileBasedFuzzerAgentBase {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(FileBasedFuzzerAgent);
 
 public:
     FileBasedFuzzerAgent(VM&);

--- a/Source/JavaScriptCore/runtime/FileBasedFuzzerAgentBase.h
+++ b/Source/JavaScriptCore/runtime/FileBasedFuzzerAgentBase.h
@@ -28,6 +28,7 @@
 #include "FuzzerAgent.h"
 #include "Opcode.h"
 #include <wtf/Lock.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -46,7 +47,7 @@ struct PredictionTarget {
 };
 
 class FileBasedFuzzerAgentBase : public FuzzerAgent {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(FileBasedFuzzerAgentBase);
 
 public:
     FileBasedFuzzerAgentBase(VM&);

--- a/Source/JavaScriptCore/runtime/GenericOffset.h
+++ b/Source/JavaScriptCore/runtime/GenericOffset.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,13 +27,14 @@
 
 #include <limits.h>
 #include <wtf/Assertions.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
 // A mixin for creating the various kinds of variable offsets that our engine supports.
 template<typename T>
 class GenericOffset {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(GenericOffset);
 public:
     static constexpr unsigned invalidOffset = UINT_MAX;
     

--- a/Source/JavaScriptCore/runtime/ISO8601.h
+++ b/Source/JavaScriptCore/runtime/ISO8601.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2021 Sony Interactive Entertainment Inc.
- * Copyright (C) 2021 Apple Inc.
+ * Copyright (C) 2021-2023 Apple Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,12 +29,13 @@
 #include "IntlObject.h"
 #include "TemporalObject.h"
 #include <wtf/Int128.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 namespace ISO8601 {
 
 class Duration {
-    WTF_MAKE_FAST_ALLOCATED(Duration);
+    WTF_MAKE_TZONE_ALLOCATED(Duration);
 public:
     using const_iterator = std::array<double, numberOfTemporalUnits>::const_iterator;
 
@@ -83,7 +84,7 @@ private:
 };
 
 class ExactTime {
-    WTF_MAKE_FAST_ALLOCATED(ExactTime);
+    WTF_MAKE_TZONE_ALLOCATED(ExactTime);
 public:
     static constexpr Int128 dayRangeSeconds { 86400'00000000 }; // 1e8 days
     static constexpr Int128 nsPerMicrosecond { 1000 };
@@ -191,7 +192,7 @@ private:
 };
 
 class PlainTime {
-    WTF_MAKE_FAST_ALLOCATED(PlainTime);
+    WTF_MAKE_TZONE_ALLOCATED(PlainTime);
 public:
     constexpr PlainTime()
         : m_millisecond(0)
@@ -229,7 +230,7 @@ static_assert(sizeof(PlainTime) <= sizeof(uint64_t));
 // Note that PlainDate does not include week unit.
 // year can be negative. And month and day starts with 1.
 class PlainDate {
-    WTF_MAKE_FAST_ALLOCATED(PlainDate);
+    WTF_MAKE_TZONE_ALLOCATED(PlainDate);
 public:
     constexpr PlainDate()
         : m_year(0)

--- a/Source/JavaScriptCore/runtime/IntlCache.cpp
+++ b/Source/JavaScriptCore/runtime/IntlCache.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,9 +26,12 @@
 #include "config.h"
 #include "IntlCache.h"
 
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(IntlCache);
 
 UDateTimePatternGenerator* IntlCache::cacheSharedPatternGenerator(const CString& locale, UErrorCode& status)
 {

--- a/Source/JavaScriptCore/runtime/IntlCache.h
+++ b/Source/JavaScriptCore/runtime/IntlCache.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,6 +27,7 @@
 
 #include <unicode/udatpg.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/CString.h>
 #include <wtf/unicode/icu/ICUHelpers.h>
 
@@ -34,7 +35,7 @@ namespace JSC {
 
 class IntlCache {
     WTF_MAKE_NONCOPYABLE(IntlCache);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(IntlCache);
 public:
     IntlCache() = default;
 

--- a/Source/JavaScriptCore/runtime/IntlNumberFormat.h
+++ b/Source/JavaScriptCore/runtime/IntlNumberFormat.h
@@ -31,6 +31,7 @@
 #include "MathCommon.h"
 #include "TemporalObject.h"
 #include <unicode/unum.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/unicode/icu/ICUHelpers.h>
 
 #if !defined(HAVE_ICU_U_NUMBER_FORMATTER)
@@ -82,7 +83,7 @@ struct UNumberRangeFormatterDeleter {
 #endif
 
 class IntlMathematicalValue {
-    WTF_MAKE_FAST_ALLOCATED(IntlMathematicalValue);
+    WTF_MAKE_TZONE_ALLOCATED(IntlMathematicalValue);
 public:
     enum class NumberType { Integer, Infinity, NaN, };
     using Value = std::variant<double, CString>;

--- a/Source/JavaScriptCore/runtime/JSDateMath.cpp
+++ b/Source/JavaScriptCore/runtime/JSDateMath.cpp
@@ -77,6 +77,7 @@
 #include <limits>
 #include <wtf/DateMath.h>
 #include <wtf/Language.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/unicode/CharacterNames.h>
 #include <wtf/unicode/icu/ICUHelpers.h>
 
@@ -110,11 +111,14 @@ std::atomic<uint64_t> lastTimeZoneID { 1 };
 
 #if HAVE(ICU_C_TIMEZONE_API)
 class OpaqueICUTimeZone {
-    WTF_MAKE_FAST_ALLOCATED(OpaqueICUTimeZone);
+    WTF_MAKE_TZONE_ALLOCATED(OpaqueICUTimeZone);
 public:
     std::unique_ptr<UCalendar, ICUDeleter<ucal_close>> m_calendar;
     String m_canonicalTimeZoneID;
 };
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(OpaqueICUTimeZone);
+
 #else
 static icu::TimeZone* toICUTimeZone(OpaqueICUTimeZone* timeZone)
 {

--- a/Source/JavaScriptCore/runtime/JSDateMath.h
+++ b/Source/JavaScriptCore/runtime/JSDateMath.h
@@ -47,6 +47,7 @@
 #include <wtf/DateMath.h>
 #include <wtf/GregorianDateTime.h>
 #include <wtf/SaturatedArithmetic.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -78,7 +79,7 @@ struct LocalTimeOffsetCache {
 };
 
 class DateCache {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(DateCache);
     WTF_MAKE_NONCOPYABLE(DateCache);
 public:
     DateCache();

--- a/Source/JavaScriptCore/runtime/JSDestructibleObjectHeapCellType.cpp
+++ b/Source/JavaScriptCore/runtime/JSDestructibleObjectHeapCellType.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,10 +29,15 @@
 #include "JSCJSValueInlines.h"
 #include "JSDestructibleObject.h"
 #include "MarkedBlockInlines.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
 
+WTF_MAKE_TZONE_ALLOCATED_IMPL(JSDestructibleObjectHeapCellType);
+
 struct JSDestructibleObjectDestroyFunc {
+    WTF_FORBID_HEAP_ALLOCATION;
+public:
     ALWAYS_INLINE void operator()(VM&, JSCell* cell) const
     {
         static_cast<JSDestructibleObject*>(cell)->classInfo()->methodTable.destroy(cell);

--- a/Source/JavaScriptCore/runtime/JSDestructibleObjectHeapCellType.h
+++ b/Source/JavaScriptCore/runtime/JSDestructibleObjectHeapCellType.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,10 +26,12 @@
 #pragma once
 
 #include "HeapCellType.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
 class JSDestructibleObjectHeapCellType final : public HeapCellType {
+    WTF_MAKE_TZONE_ALLOCATED(JSDestructibleObjectHeapCellType);
 public:
     JS_EXPORT_PRIVATE JSDestructibleObjectHeapCellType();
     JS_EXPORT_PRIVATE ~JSDestructibleObjectHeapCellType() final;

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -1,6 +1,6 @@
 /*
  *  Copyright (C) 2007 Eric Seidel <eric@webkit.org>
- *  Copyright (C) 2007-2022 Apple Inc. All rights reserved.
+ *  Copyright (C) 2007-2023 Apple Inc. All rights reserved.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Library General Public
@@ -555,11 +555,14 @@ public:
         static constexpr bool safeToCompareToEmptyOrDeleted = false;
     };
 
-    WeakGCSet<JSCustomGetterFunction, WeakCustomGetterOrSetterHash<JSCustomGetterFunction>> m_customGetterFunctionSet;
-    WeakGCSet<JSCustomSetterFunction, WeakCustomGetterOrSetterHash<JSCustomSetterFunction>> m_customSetterFunctionSet;
+    using WeakGCSetJSCustomGetterFunction = WeakGCSet<JSCustomGetterFunction, WeakCustomGetterOrSetterHash<JSCustomGetterFunction>>;
+    using WeakGCSetJSCustomSetterFunction = WeakGCSet<JSCustomSetterFunction, WeakCustomGetterOrSetterHash<JSCustomSetterFunction>>;
 
-    WeakGCSet<JSCustomGetterFunction, WeakCustomGetterOrSetterHash<JSCustomGetterFunction>>& customGetterFunctionSet() { return m_customGetterFunctionSet; }
-    WeakGCSet<JSCustomSetterFunction, WeakCustomGetterOrSetterHash<JSCustomSetterFunction>>& customSetterFunctionSet() { return m_customSetterFunctionSet; }
+    WeakGCSetJSCustomGetterFunction m_customGetterFunctionSet;
+    WeakGCSetJSCustomSetterFunction m_customSetterFunctionSet;
+
+    WeakGCSetJSCustomGetterFunction& customGetterFunctionSet() { return m_customGetterFunctionSet; }
+    WeakGCSetJSCustomSetterFunction& customSetterFunctionSet() { return m_customSetterFunctionSet; }
 
     Ref<ImportMap> m_importMap;
 

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectDebuggable.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectDebuggable.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,10 +34,13 @@
 #include "JSGlobalObjectInspectorController.h"
 #include "JSLock.h"
 #include "RemoteInspector.h"
+#include <wtf/TZoneMallocInlines.h>
 
 using namespace Inspector;
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(JSGlobalObjectDebuggable);
 
 JSGlobalObjectDebuggable::JSGlobalObjectDebuggable(JSGlobalObject& globalObject)
     : m_globalObject(globalObject)

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectDebuggable.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectDebuggable.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013, 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,6 +29,7 @@
 
 #include "RemoteInspectionTarget.h"
 #include <wtf/Noncopyable.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace Inspector {
 class FrontendChannel;
@@ -40,7 +41,7 @@ namespace JSC {
 class JSGlobalObject;
 
 class JSGlobalObjectDebuggable final : public Inspector::RemoteInspectionTarget {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(JSGlobalObjectDebuggable);
     WTF_MAKE_NONCOPYABLE(JSGlobalObjectDebuggable);
 public:
     JSGlobalObjectDebuggable(JSGlobalObject&);

--- a/Source/JavaScriptCore/runtime/JSRunLoopTimer.cpp
+++ b/Source/JavaScriptCore/runtime/JSRunLoopTimer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,6 +30,7 @@
 #include "VM.h"
 #include <mutex>
 #include <wtf/NoTailCalls.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if USE(GLIB_EVENT_LOOP)
 #include <glib.h>
@@ -37,6 +38,8 @@
 #endif
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(JSRunLoopTimerManager, JSRunLoopTimer::Manager);
 
 JSRunLoopTimer::Manager::PerVMData::PerVMData(Manager& manager, RunLoop& runLoop)
     : runLoop(runLoop)

--- a/Source/JavaScriptCore/runtime/JSRunLoopTimer.h
+++ b/Source/JavaScriptCore/runtime/JSRunLoopTimer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,6 +31,7 @@
 #include <wtf/RetainPtr.h>
 #include <wtf/RunLoop.h>
 #include <wtf/SharedTask.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
 
 namespace JSC {
@@ -44,8 +45,8 @@ public:
     using TimerNotificationCallback = RefPtr<WTF::SharedTask<TimerNotificationType>>;
 
     class Manager {
-        WTF_MAKE_FAST_ALLOCATED;
         WTF_MAKE_NONCOPYABLE(Manager);
+        WTF_MAKE_TZONE_ALLOCATED(Manager);
         void timerDidFireCallback();
 
         Manager() = default;

--- a/Source/JavaScriptCore/runtime/MegamorphicCache.cpp
+++ b/Source/JavaScriptCore/runtime/MegamorphicCache.cpp
@@ -26,9 +26,12 @@
 #include "config.h"
 #include "MegamorphicCache.h"
 
+#include <wtf/TZoneMallocInlines.h>
+
 namespace JSC {
 
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(MegamorphicCache);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(MegamorphicCache);
 
 void MegamorphicCache::age(CollectionScope collectionScope)
 {

--- a/Source/JavaScriptCore/runtime/MegamorphicCache.h
+++ b/Source/JavaScriptCore/runtime/MegamorphicCache.h
@@ -26,13 +26,14 @@
 #pragma once
 
 #include "Structure.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(MegamorphicCache);
 
 class MegamorphicCache {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(MegamorphicCache);
     WTF_MAKE_NONCOPYABLE(MegamorphicCache);
 public:
     static constexpr uint32_t primarySize = 2048;

--- a/Source/JavaScriptCore/runtime/NarrowingNumberPredictionFuzzerAgent.cpp
+++ b/Source/JavaScriptCore/runtime/NarrowingNumberPredictionFuzzerAgent.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,8 +27,11 @@
 #include "NarrowingNumberPredictionFuzzerAgent.h"
 
 #include "CodeBlock.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(NarrowingNumberPredictionFuzzerAgent);
 
 NarrowingNumberPredictionFuzzerAgent::NarrowingNumberPredictionFuzzerAgent(VM& vm)
     : NumberPredictionFuzzerAgent(vm)

--- a/Source/JavaScriptCore/runtime/NarrowingNumberPredictionFuzzerAgent.h
+++ b/Source/JavaScriptCore/runtime/NarrowingNumberPredictionFuzzerAgent.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,13 +26,14 @@
 #pragma once
 
 #include "NumberPredictionFuzzerAgent.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
 class VM;
 
 class NarrowingNumberPredictionFuzzerAgent final : public NumberPredictionFuzzerAgent {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(NarrowingNumberPredictionFuzzerAgent);
 
 public:
     NarrowingNumberPredictionFuzzerAgent(VM&);

--- a/Source/JavaScriptCore/runtime/NativeCallee.h
+++ b/Source/JavaScriptCore/runtime/NativeCallee.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "ImplementationVisibility.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
 
 namespace JSC {
@@ -33,7 +34,7 @@ namespace JSC {
 class LLIntOffsetsExtractor;
 
 class NativeCallee : public ThreadSafeRefCounted<NativeCallee> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(NativeCallee);
 public:
     enum class Category : uint8_t {
         InlineCache,

--- a/Source/JavaScriptCore/runtime/NativeCalleeRegistry.h
+++ b/Source/JavaScriptCore/runtime/NativeCalleeRegistry.h
@@ -29,13 +29,14 @@
 #include <wtf/Box.h>
 #include <wtf/HashSet.h>
 #include <wtf/Lock.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
 class NativeCallee;
 
 class NativeCalleeRegistry {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(NativeCalleeRegistry);
     WTF_MAKE_NONCOPYABLE(NativeCalleeRegistry);
 public:
     static void initialize();

--- a/Source/JavaScriptCore/runtime/ObjectPropertyChangeAdaptiveWatchpoint.h
+++ b/Source/JavaScriptCore/runtime/ObjectPropertyChangeAdaptiveWatchpoint.h
@@ -26,11 +26,13 @@
 #pragma once
 
 #include "AdaptiveInferredPropertyValueWatchpointBase.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
 template<typename WatchpointSet>
 class ObjectPropertyChangeAdaptiveWatchpoint final : public AdaptiveInferredPropertyValueWatchpointBase {
+    WTF_MAKE_TZONE_ALLOCATED(ObjectPropertyChangeAdaptiveWatchpoint);
 public:
     using Base = AdaptiveInferredPropertyValueWatchpointBase;
     ObjectPropertyChangeAdaptiveWatchpoint(JSCell* owner, const ObjectPropertyCondition& condition, WatchpointSet& watchpointSet)

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -44,6 +44,7 @@
 #include <wtf/NeverDestroyed.h>
 #include <wtf/NumberOfCores.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/TranslatedProcess.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/threads/Signals.h>
@@ -72,10 +73,12 @@ namespace OptionsHelper {
 // VM run time. For now, the only field it contains is a copy of Options defaults
 // which are only used to provide more info for Options dumps.
 struct Metadata {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Metadata);
 public:
     OptionsStorage defaults;
 };
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Metadata);
 
 static LazyNeverDestroyed<std::unique_ptr<Metadata>> g_metadata;
 static LazyNeverDestroyed<WTF::BitSet<NumberOfOptions>> g_optionWasOverridden;

--- a/Source/JavaScriptCore/runtime/PredictionFileCreatingFuzzerAgent.cpp
+++ b/Source/JavaScriptCore/runtime/PredictionFileCreatingFuzzerAgent.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,8 +26,11 @@
 #include "config.h"
 #include "PredictionFileCreatingFuzzerAgent.h"
 #include <wtf/DataLog.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PredictionFileCreatingFuzzerAgent);
 
 PredictionFileCreatingFuzzerAgent::PredictionFileCreatingFuzzerAgent(VM& vm)
     : FileBasedFuzzerAgentBase(vm)

--- a/Source/JavaScriptCore/runtime/PredictionFileCreatingFuzzerAgent.h
+++ b/Source/JavaScriptCore/runtime/PredictionFileCreatingFuzzerAgent.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,13 +26,14 @@
 #pragma once
 
 #include "FileBasedFuzzerAgentBase.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
 class VM;
 
 class PredictionFileCreatingFuzzerAgent final : public FileBasedFuzzerAgentBase {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PredictionFileCreatingFuzzerAgent);
 
 public:
     PredictionFileCreatingFuzzerAgent(VM&);

--- a/Source/JavaScriptCore/runtime/PropertyDescriptor.cpp
+++ b/Source/JavaScriptCore/runtime/PropertyDescriptor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2009-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,8 +29,11 @@
 
 #include "GetterSetter.h"
 #include "JSCJSValueInlines.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(DOMAttributeAnnotation);
 
 template<typename T>
 struct WeakCustomGetterOrSetterHashTranslator {

--- a/Source/JavaScriptCore/runtime/RandomizingFuzzerAgent.cpp
+++ b/Source/JavaScriptCore/runtime/RandomizingFuzzerAgent.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,8 +28,11 @@
 
 #include "CodeBlock.h"
 #include <wtf/Locker.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RandomizingFuzzerAgent);
 
 RandomizingFuzzerAgent::RandomizingFuzzerAgent(VM&)
     : m_random(Options::seedOfRandomizingFuzzerAgent())

--- a/Source/JavaScriptCore/runtime/RandomizingFuzzerAgent.h
+++ b/Source/JavaScriptCore/runtime/RandomizingFuzzerAgent.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,6 +27,7 @@
 
 #include "FuzzerAgent.h"
 #include <wtf/Lock.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/WeakRandom.h>
 
 namespace JSC {
@@ -34,7 +35,7 @@ namespace JSC {
 class VM;
 
 class RandomizingFuzzerAgent final : public FuzzerAgent {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RandomizingFuzzerAgent);
 public:
     RandomizingFuzzerAgent(VM&);
 

--- a/Source/JavaScriptCore/runtime/RegExpCache.cpp
+++ b/Source/JavaScriptCore/runtime/RegExpCache.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2010 University of Szeged
  * Copyright (C) 2010 Renata Hodovan (hodovan@inf.u-szeged.hu)
- * Copyright (C) 2012 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2023 Apple Inc. All rights reserved.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -30,8 +30,11 @@
 #include "RegExpCache.h"
 
 #include "StrongInlines.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RegExpCache);
 
 RegExp* RegExpCache::lookupOrCreate(const String& patternString, OptionSet<Yarr::Flags> flags)
 {

--- a/Source/JavaScriptCore/runtime/RegExpCache.h
+++ b/Source/JavaScriptCore/runtime/RegExpCache.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2010 University of Szeged
  * Copyright (C) 2010 Renata Hodovan (hodovan@inf.u-szeged.hu)
  * All rights reserved.
- * Copyright (C) 2019-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,6 +34,7 @@
 #include "Weak.h"
 #include <array>
 #include <wtf/RobinHoodHashMap.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -42,7 +43,7 @@ enum class Flags : uint16_t;
 }
 
 class RegExpCache final : private WeakHandleOwner {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RegExpCache);
 
     friend class RegExp;
     typedef MemoryCompactRobinHoodHashMap<RegExpKey, Weak<RegExp>> RegExpCacheMap;

--- a/Source/JavaScriptCore/runtime/RuntimeTZoneImpls.cpp
+++ b/Source/JavaScriptCore/runtime/RuntimeTZoneImpls.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CheckpointOSRExitSideState.h"
+#include "JSGlobalObject.h"
+#include "ObjectPropertyChangeAdaptiveWatchpoint.h"
+#include "StructureTransitionTable.h"
+#include "WeakGCMap.h"
+#include <wtf/TZoneMallocInlines.h>
+#include <wtf/text/SymbolImpl.h>
+
+namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CheckpointOSRExitSideState);
+
+using ObjectPropertyChangeAdaptiveWatchpointInlineWatchpointSet = ObjectPropertyChangeAdaptiveWatchpoint<InlineWatchpointSet>;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL_TEMPLATE(ObjectPropertyChangeAdaptiveWatchpointInlineWatchpointSet);
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED_TEMPLATE(JSGlobalObjectWeakGCSetJSCustomGetterFunction, JSGlobalObject::WeakGCSetJSCustomGetterFunction);
+WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED_TEMPLATE(JSGlobalObjectWeakGCSetJSCustomSetterFunction, JSGlobalObject::WeakGCSetJSCustomSetterFunction);
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
+++ b/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
@@ -51,6 +51,7 @@
 #include <wtf/JSONValues.h>
 #include <wtf/RefPtr.h>
 #include <wtf/StackTrace.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/StringBuilder.h>
 
 namespace JSC {
@@ -65,6 +66,8 @@ static constexpr bool sReportStats = false;
 
 using FrameType = SamplingProfiler::FrameType;
 using UnprocessedStackFrame = SamplingProfiler::UnprocessedStackFrame;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SamplingProfiler);
 
 ALWAYS_INLINE static void reportStats()
 {

--- a/Source/JavaScriptCore/runtime/SamplingProfiler.h
+++ b/Source/JavaScriptCore/runtime/SamplingProfiler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -39,6 +39,7 @@
 #include <wtf/HashSet.h>
 #include <wtf/Lock.h>
 #include <wtf/Stopwatch.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakRandom.h>
 
@@ -48,7 +49,7 @@ class VM;
 class ExecutableBase;
 
 class SamplingProfiler : public ThreadSafeRefCounted<SamplingProfiler> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SamplingProfiler);
 public:
 
     struct UnprocessedStackFrame {

--- a/Source/JavaScriptCore/runtime/SparseArrayValueMap.h
+++ b/Source/JavaScriptCore/runtime/SparseArrayValueMap.h
@@ -32,6 +32,7 @@
 #include "VM.h"
 #include "WriteBarrier.h"
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -135,7 +136,7 @@ private:
 };
 
 class SparseArrayEntry : private WriteBarrier<Unknown> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(SparseArrayEntry);
 public:
     using Base = WriteBarrier<Unknown>;
 

--- a/Source/JavaScriptCore/runtime/StringReplaceCache.h
+++ b/Source/JavaScriptCore/runtime/StringReplaceCache.h
@@ -28,6 +28,7 @@
 
 #include "MatchResult.h"
 #include <array>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -37,7 +38,7 @@ class JSImmutableButterfly;
 class RegExp;
 
 class StringReplaceCache {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(StringReplaceCache);
     WTF_MAKE_NONCOPYABLE(StringReplaceCache);
 
 public:

--- a/Source/JavaScriptCore/runtime/StringSplitCache.h
+++ b/Source/JavaScriptCore/runtime/StringSplitCache.h
@@ -28,6 +28,7 @@
 
 #include <array>
 #include <wtf/DebugHeap.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -36,7 +37,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER_AND_EXPORT(StringSplitCache, WTF_INTERNAL
 class JSImmutableButterfly;
 
 class StringSplitCache {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(StringSplitCache);
     WTF_MAKE_NONCOPYABLE(StringSplitCache);
 public:
     static constexpr unsigned cacheSize = 64;

--- a/Source/JavaScriptCore/runtime/StructureRareData.cpp
+++ b/Source/JavaScriptCore/runtime/StructureRareData.cpp
@@ -37,6 +37,8 @@
 #include "StructureChain.h"
 #include "StructureInlines.h"
 #include "StructureRareDataInlines.h"
+#include <wtf/TZoneMalloc.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
 
@@ -92,6 +94,7 @@ DEFINE_VISIT_CHILDREN(StructureRareData);
 // ----------- Cached special properties helper watchpoint classes -----------
 
 class CachedSpecialPropertyAdaptiveInferredPropertyValueWatchpoint final : public AdaptiveInferredPropertyValueWatchpointBase {
+    WTF_MAKE_TZONE_ALLOCATED(CachedSpecialPropertyAdaptiveInferredPropertyValueWatchpoint);
 public:
     typedef AdaptiveInferredPropertyValueWatchpointBase Base;
     CachedSpecialPropertyAdaptiveInferredPropertyValueWatchpoint(const ObjectPropertyCondition&, StructureRareData*);
@@ -250,6 +253,8 @@ void StructureRareData::finalizeUnconditionally(VM& vm, CollectionScope)
 }
 
 // ------------- Methods for Object.prototype.toString() helper watchpoint classes --------------
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CachedSpecialPropertyAdaptiveInferredPropertyValueWatchpoint);
 
 CachedSpecialPropertyAdaptiveInferredPropertyValueWatchpoint::CachedSpecialPropertyAdaptiveInferredPropertyValueWatchpoint(const ObjectPropertyCondition& key, StructureRareData* structureRareData)
     : Base(key)

--- a/Source/JavaScriptCore/runtime/TypeProfiler.cpp
+++ b/Source/JavaScriptCore/runtime/TypeProfiler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2019 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2014-2023 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,6 +27,7 @@
 #include "TypeProfiler.h"
 
 #include "TypeLocation.h"
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/StringBuilder.h>
 
 namespace JSC {
@@ -34,6 +35,8 @@ namespace JSC {
 namespace TypeProfilerInternal {
 static constexpr bool verbose = false;
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(TypeProfiler);
 
 TypeProfiler::TypeProfiler()
     : m_nextUniqueVariableID(1)

--- a/Source/JavaScriptCore/runtime/TypeProfiler.h
+++ b/Source/JavaScriptCore/runtime/TypeProfiler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2019 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2014-2023 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,6 +30,7 @@
 #include "TypeLocationCache.h"
 #include <wtf/Bag.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
@@ -108,7 +109,7 @@ namespace JSC {
 class VM;
 
 class TypeProfiler {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(TypeProfiler);
 public:
     TypeProfiler();
     void logTypesForTypeLocation(TypeLocation*, VM&);

--- a/Source/JavaScriptCore/runtime/TypeProfilerLog.cpp
+++ b/Source/JavaScriptCore/runtime/TypeProfilerLog.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,12 +32,15 @@
 #include "FrameTracers.h"
 #include "JSCJSValueInlines.h"
 #include "TypeLocation.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
 
 namespace TypeProfilerLogInternal {
 static constexpr bool verbose = false;
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(TypeProfilerLog);
 
 TypeProfilerLog::TypeProfilerLog(VM& vm)
     : m_vm(vm)

--- a/Source/JavaScriptCore/runtime/TypeProfilerLog.h
+++ b/Source/JavaScriptCore/runtime/TypeProfilerLog.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,6 +30,7 @@
 
 #include "JSCJSValue.h"
 #include "Structure.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -37,7 +38,7 @@ class AbstractSlotVisitor;
 class TypeLocation;
 
 class TypeProfilerLog {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(TypeProfilerLog);
 public:
     struct LogEntry {
         WTF_MAKE_STRUCT_FAST_ALLOCATED;

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -71,6 +71,7 @@
 #include <wtf/SetForScope.h>
 #include <wtf/StackPointer.h>
 #include <wtf/Stopwatch.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/ThreadSafeWeakHashSet.h>
 #include <wtf/UniqueArray.h>
@@ -174,7 +175,7 @@ struct EntryFrame;
 
 class MicrotaskQueue;
 class QueuedTask {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(QueuedTask);
     friend class MicrotaskQueue;
 public:
     static constexpr unsigned maxArguments = 4;
@@ -197,7 +198,7 @@ private:
 };
 
 class MicrotaskQueue {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(MicrotaskQueue);
     WTF_MAKE_NONCOPYABLE(MicrotaskQueue);
 public:
     MicrotaskQueue() = default;

--- a/Source/JavaScriptCore/runtime/WaiterListManager.cpp
+++ b/Source/JavaScriptCore/runtime/WaiterListManager.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,12 +33,16 @@
 #include <wtf/DataLog.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/RawPointer.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
 
 namespace WaiterListsManagerInternal {
 static constexpr bool verbose = false;
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Waiter);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WaiterList);
 
 WaiterListManager& WaiterListManager::singleton()
 {

--- a/Source/JavaScriptCore/runtime/WaiterListManager.h
+++ b/Source/JavaScriptCore/runtime/WaiterListManager.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,6 +30,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/Lock.h>
 #include <wtf/SentinelLinkedList.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -37,7 +38,7 @@ enum class AtomicsWaitType : uint8_t { Sync, Async };
 enum class AtomicsWaitValidation : uint8_t { Pass, Fail };
 
 class Waiter final : public WTF::BasicRawSentinelNode<Waiter>, public ThreadSafeRefCounted<Waiter> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Waiter);
 
 public:
     Waiter(VM* vm)
@@ -121,7 +122,7 @@ private:
 };
 
 class WaiterList : public ThreadSafeRefCounted<WaiterList> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WaiterList);
 
 public:
     ~WaiterList()
@@ -203,7 +204,7 @@ private:
 };
 
 class WaiterListManager {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WaiterListManager);
 public:
     static WaiterListManager& singleton();
 

--- a/Source/JavaScriptCore/runtime/Watchdog.cpp
+++ b/Source/JavaScriptCore/runtime/Watchdog.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,8 +28,11 @@
 
 #include "VM.h"
 #include <wtf/CPUTime.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Watchdog);
 
 Watchdog::Watchdog(VM* vm)
     : m_vm(vm)

--- a/Source/JavaScriptCore/runtime/Watchdog.h
+++ b/Source/JavaScriptCore/runtime/Watchdog.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,6 +28,7 @@
 #include <wtf/Lock.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/Ref.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/WorkQueue.h>
 
@@ -38,7 +39,7 @@ class JSGlobalObject;
 class VM;
 
 class Watchdog : public WTF::ThreadSafeRefCounted<Watchdog> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Watchdog);
 public:
     class Scope;
 

--- a/Source/JavaScriptCore/runtime/WeakGCSet.h
+++ b/Source/JavaScriptCore/runtime/WeakGCSet.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,6 +28,7 @@
 #include "Weak.h"
 #include "WeakGCHashTable.h"
 #include <wtf/HashSet.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -44,7 +45,7 @@ struct WeakGCSetHashTraits : HashTraits<Weak<T>> {
 
 template<typename ValueArg, typename HashArg = DefaultHash<Weak<ValueArg>>, typename TraitsArg = WeakGCSetHashTraits<ValueArg>>
 class WeakGCSet final : public WeakGCHashTable {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WeakGCSet);
     using ValueType = Weak<ValueArg>;
     using HashSetType = HashSet<ValueType, HashArg, TraitsArg>;
 

--- a/Source/JavaScriptCore/runtime/WideningNumberPredictionFuzzerAgent.cpp
+++ b/Source/JavaScriptCore/runtime/WideningNumberPredictionFuzzerAgent.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,8 +27,11 @@
 #include "WideningNumberPredictionFuzzerAgent.h"
 
 #include "CodeBlock.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WideningNumberPredictionFuzzerAgent);
 
 WideningNumberPredictionFuzzerAgent::WideningNumberPredictionFuzzerAgent(VM& vm)
     : NumberPredictionFuzzerAgent(vm)

--- a/Source/JavaScriptCore/runtime/WideningNumberPredictionFuzzerAgent.h
+++ b/Source/JavaScriptCore/runtime/WideningNumberPredictionFuzzerAgent.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,13 +26,14 @@
 #pragma once
 
 #include "NumberPredictionFuzzerAgent.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
 class VM;
 
 class WideningNumberPredictionFuzzerAgent final : public NumberPredictionFuzzerAgent {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WideningNumberPredictionFuzzerAgent);
 
 public:
     WideningNumberPredictionFuzzerAgent(VM&);

--- a/Source/JavaScriptCore/runtime/WriteBarrier.h
+++ b/Source/JavaScriptCore/runtime/WriteBarrier.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,6 +31,7 @@
 #include <type_traits>
 #include <wtf/RawPtrTraits.h>
 #include <wtf/RawValueTraits.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -196,7 +197,7 @@ private:
 
 template <typename T, typename Traits = WriteBarrierTraitsSelect<T>>
 class WriteBarrier : public WriteBarrierBase<T, Traits> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WriteBarrier);
 public:
     WriteBarrier()
     {
@@ -230,7 +231,7 @@ enum UndefinedWriteBarrierTagType { UndefinedWriteBarrierTag };
 enum NullWriteBarrierTagType { NullWriteBarrierTag };
 template <>
 class WriteBarrier<Unknown, RawValueTraits<Unknown>> : public WriteBarrierBase<Unknown, RawValueTraits<Unknown>> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(WriteBarrier);
 public:
     WriteBarrier()
     {

--- a/Source/JavaScriptCore/tools/CellList.h
+++ b/Source/JavaScriptCore/tools/CellList.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,11 +28,12 @@
 #include "CellProfile.h"
 #include <wtf/HashMap.h>
 #include <wtf/SegmentedVector.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
 class CellList {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(CellList);
 public:
     CellList(const char* name)
         : m_name(name)

--- a/Source/JavaScriptCore/tools/CompilerTimingScope.cpp
+++ b/Source/JavaScriptCore/tools/CompilerTimingScope.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,6 +29,7 @@
 #include "Options.h"
 #include <wtf/DataLog.h>
 #include <wtf/Lock.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
@@ -38,7 +39,7 @@ namespace {
 
 class CompilerTimingScopeState {
     WTF_MAKE_NONCOPYABLE(CompilerTimingScopeState);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(CompilerTimingScopeState);
 public:
     CompilerTimingScopeState() { }
     
@@ -70,6 +71,8 @@ private:
     Vector<std::tuple<const char*, const char*, Seconds, Seconds>> totals;
     Lock lock;
 };
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CompilerTimingScopeState);
 
 CompilerTimingScopeState& compilerTimingScopeState()
 {

--- a/Source/JavaScriptCore/tools/HeapVerifier.cpp
+++ b/Source/JavaScriptCore/tools/HeapVerifier.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,8 +33,11 @@
 #include "VMInspector.h"
 #include "ValueProfile.h"
 #include <wtf/ProcessID.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(HeapVerifier);
 
 HeapVerifier::HeapVerifier(Heap* heap, unsigned numberOfGCCyclesToRecord)
     : m_heap(heap)

--- a/Source/JavaScriptCore/tools/HeapVerifier.h
+++ b/Source/JavaScriptCore/tools/HeapVerifier.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,6 +29,7 @@
 #include "Heap.h"
 #include <wtf/MonotonicTime.h>
 #include <wtf/ScopedLambda.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueArray.h>
 
 namespace JSC {
@@ -37,7 +38,7 @@ class JSCell;
 class MarkedBlock;
 
 class HeapVerifier {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(HeapVerifier);
 public:
     enum class Phase {
         BeforeGC,

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -68,6 +68,7 @@
 #include <wtf/Language.h>
 #include <wtf/ProcessID.h>
 #include <wtf/StringPrintStream.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/WTFProcess.h>
 #include <wtf/unicode/icu/ICUHelpers.h>
 
@@ -278,7 +279,7 @@ void Element::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 DEFINE_VISIT_CHILDREN(Element);
 
 class ElementHandleOwner final : public WeakHandleOwner {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ElementHandleOwner);
 public:
     bool isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handle, void*, AbstractSlotVisitor& visitor, const char** reason) final
     {
@@ -289,6 +290,8 @@ public:
         return visitor.containsOpaqueRoot(element->root());
     }
 };
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ElementHandleOwner);
 
 class Root final : public JSDestructibleObject {
 public:
@@ -3521,7 +3524,7 @@ JSC_DEFINE_HOST_FUNCTION(functionBasicBlockExecutionCount, (JSGlobalObject* glob
 
 class DoNothingDebugger final : public Debugger {
     WTF_MAKE_NONCOPYABLE(DoNothingDebugger);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(DoNothingDebugger);
 public:
     DoNothingDebugger(VM& vm)
         : Debugger(vm)
@@ -3536,6 +3539,8 @@ private:
         DollarVMAssertScope assertScope;
     }
 };
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(DoNothingDebugger);
 
 static EncodedJSValue changeDebuggerModeWhenIdle(JSGlobalObject* globalObject, OptionSet<CodeGenerationMode> codeGenerationMode)
 {

--- a/Source/JavaScriptCore/tools/VMInspector.cpp
+++ b/Source/JavaScriptCore/tools/VMInspector.cpp
@@ -37,8 +37,11 @@
 #include "VMEntryRecord.h"
 #include <mutex>
 #include <wtf/Expected.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(VMInspector);
 
 VM* VMInspector::m_recentVM { nullptr };
 

--- a/Source/JavaScriptCore/tools/VMInspector.h
+++ b/Source/JavaScriptCore/tools/VMInspector.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,11 +31,12 @@
 #include <wtf/Expected.h>
 #include <wtf/IterationStatus.h>
 #include <wtf/Lock.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
 class VMInspector {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(VMInspector);
     WTF_MAKE_NONCOPYABLE(VMInspector);
     VMInspector() = default;
 public:

--- a/Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -74,6 +74,7 @@
 #include <limits>
 #include <wtf/FastMalloc.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if !ENABLE(WEBASSEMBLY)
 #error ENABLE(WEBASSEMBLY_OMGJIT) is enabled, but ENABLE(WEBASSEMBLY) is not.
@@ -108,7 +109,7 @@ static constexpr bool traceExecutionIncludesConstructionSite = false;
 #define TRACE_CF(...) do { if constexpr (WasmB3IRGeneratorInternal::traceExecution) { traceCF(__VA_ARGS__); } } while (0)
 
 class B3IRGenerator {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(B3IRGenerator);
 public:
     using ExpressionType = Variable*;
     using ResultList = Vector<ExpressionType, 8>;
@@ -968,6 +969,12 @@ private:
     Vector<std::unique_ptr<B3IRGenerator>> m_protectedInlineeGenerators;
     Vector<std::unique_ptr<FunctionParser<B3IRGenerator>>> m_protectedInlineeParsers;
 };
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(B3IRGenerator);
+
+using FunctionParserB3IRGenerator = FunctionParser<B3IRGenerator>;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL_TEMPLATE(FunctionParserB3IRGenerator);
 
 // Memory accesses in WebAssembly have unsigned 32-bit offsets, whereas they have signed 32-bit offsets in B3.
 int32_t B3IRGenerator::fixupPointerPlusOffset(Value*& ptr, uint32_t offset)

--- a/Source/JavaScriptCore/wasm/WasmBBQDisassembler.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQDisassembler.cpp
@@ -32,9 +32,12 @@
 #include "LinkBuffer.h"
 #include <wtf/HexNumber.h>
 #include <wtf/StringPrintStream.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
 namespace Wasm {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(BBQDisassembler);
 
 BBQDisassembler::BBQDisassembler() = default;
 

--- a/Source/JavaScriptCore/wasm/WasmBBQDisassembler.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQDisassembler.h
@@ -30,6 +30,7 @@
 #include "BytecodeIndex.h"
 #include "MacroAssembler.h"
 #include "WasmOpcodeOrigin.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/text/CString.h>
 
@@ -42,7 +43,7 @@ namespace Wasm {
 class BBQCallee;
 
 class BBQDisassembler {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(BBQDisassembler);
 public:
     BBQDisassembler();
     ~BBQDisassembler();

--- a/Source/JavaScriptCore/wasm/WasmCallee.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCallee.cpp
@@ -33,8 +33,21 @@
 #include "NativeCalleeRegistry.h"
 #include "WasmCallingConvention.h"
 #include "WasmModuleInformation.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC { namespace Wasm {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Callee);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(JITCallee);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(JSEntrypointCallee);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WasmToJSCallee);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(JSToWasmICCallee);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(OptimizingJITCallee);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(OMGCallee);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(OSREntryCallee);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(BBQCallee);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(IPIntCallee);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(LLIntCallee);
 
 Callee::Callee(Wasm::CompilationMode compilationMode)
     : NativeCallee(NativeCallee::Category::Wasm, ImplementationVisibility::Private)

--- a/Source/JavaScriptCore/wasm/WasmCallee.h
+++ b/Source/JavaScriptCore/wasm/WasmCallee.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -43,6 +43,7 @@
 #include <wtf/EmbeddedFixedVector.h>
 #include <wtf/FixedVector.h>
 #include <wtf/RefCountedFixedVector.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
 
 namespace JSC {
@@ -52,7 +53,7 @@ class LLIntOffsetsExtractor;
 namespace Wasm {
 
 class Callee : public NativeCallee {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Callee);
 public:
     IndexOrName indexOrName() const { return m_indexOrName; }
     CompilationMode compilationMode() const { return m_compilationMode; }
@@ -88,6 +89,7 @@ protected:
 
 #if ENABLE(JIT)
 class JITCallee : public Callee {
+    WTF_MAKE_TZONE_ALLOCATED(JITCallee);
 public:
     friend class Callee;
     FixedVector<UnlinkedWasmToWasmCall>& wasmToWasmCallsites() { return m_wasmToWasmCallsites; }
@@ -114,6 +116,7 @@ protected:
 };
 
 class JSEntrypointCallee final : public JITCallee {
+    WTF_MAKE_TZONE_ALLOCATED(JSEntrypointCallee);
 public:
     static Ref<JSEntrypointCallee> create()
     {
@@ -132,6 +135,7 @@ private:
 #else
 
 class JSEntrypointCallee final : public Callee {
+    WTF_MAKE_TZONE_ALLOCATED(JSEntrypointCallee);
 public:
     friend class Callee;
 
@@ -158,6 +162,7 @@ private:
 #endif // ENABLE(JIT)
 
 class WasmToJSCallee final : public Callee {
+    WTF_MAKE_TZONE_ALLOCATED(WasmToJSCallee);
 public:
     friend class Callee;
 
@@ -181,6 +186,7 @@ private:
 
 #if ENABLE(JIT)
 class JSToWasmICCallee final : public JITCallee {
+    WTF_MAKE_TZONE_ALLOCATED(JSToWasmICCallee);
 public:
     static Ref<JSToWasmICCallee> create()
     {
@@ -207,6 +213,7 @@ struct WasmCodeOrigin {
 };
 
 class OptimizingJITCallee : public JITCallee {
+    WTF_MAKE_TZONE_ALLOCATED(OptimizingJITCallee);
 public:
     const StackMap& stackmap(CallSiteIndex) const;
 
@@ -237,6 +244,7 @@ private:
 };
 
 class OMGCallee final : public OptimizingJITCallee {
+    WTF_MAKE_TZONE_ALLOCATED(OMGCallee);
 public:
     static Ref<OMGCallee> create(size_t index, std::pair<const Name*, RefPtr<NameSection>>&& name)
     {
@@ -253,6 +261,7 @@ private:
 };
 
 class OSREntryCallee final : public OptimizingJITCallee {
+    WTF_MAKE_TZONE_ALLOCATED(OSREntryCallee);
 public:
     static Ref<OSREntryCallee> create(CompilationMode compilationMode, size_t index, std::pair<const Name*, RefPtr<NameSection>>&& name, uint32_t loopIndex)
     {
@@ -281,6 +290,7 @@ private:
 };
 
 class BBQCallee final : public OptimizingJITCallee {
+    WTF_MAKE_TZONE_ALLOCATED(BBQCallee);
 public:
     static constexpr unsigned extraOSRValuesForLoopIndex = 1;
 
@@ -350,6 +360,7 @@ private:
 
 
 class IPIntCallee final : public Callee {
+    WTF_MAKE_TZONE_ALLOCATED(IPIntCallee);
     friend class JSC::LLIntOffsetsExtractor;
     friend class Callee;
 public:
@@ -420,6 +431,7 @@ public:
 };
 
 class LLIntCallee final : public Callee {
+    WTF_MAKE_TZONE_ALLOCATED(LLIntCallee);
     friend JSC::LLIntOffsetsExtractor;
     friend class Callee;
 public:

--- a/Source/JavaScriptCore/wasm/WasmFormat.h
+++ b/Source/JavaScriptCore/wasm/WasmFormat.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -44,6 +44,7 @@
 #include <cstdint>
 #include <limits>
 #include <memory>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace JSC {
@@ -529,7 +530,7 @@ struct FunctionData {
 };
 
 class I32InitExpr {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(I32InitExpr);
     enum Type : uint8_t {
         Global,
         Const,
@@ -638,7 +639,7 @@ struct Element {
 };
 
 class TableInformation {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(TableInformation);
 public:
     enum InitializationType : uint8_t {
         Default,

--- a/Source/JavaScriptCore/wasm/WasmFunctionCodeBlockGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmFunctionCodeBlockGenerator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,8 +32,11 @@
 #include "InstructionStream.h"
 #include "VirtualRegister.h"
 #include <wtf/FixedVector.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC { namespace Wasm {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FunctionCodeBlockGenerator);
 
 void FunctionCodeBlockGenerator::setInstructions(std::unique_ptr<WasmInstructionStream> instructions)
 {

--- a/Source/JavaScriptCore/wasm/WasmFunctionCodeBlockGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionCodeBlockGenerator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,6 +35,7 @@
 #include "WasmLLIntTierUpCounter.h"
 #include "WasmOps.h"
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace JSC {
@@ -61,7 +62,7 @@ struct JumpTableEntry {
 using JumpTable = FixedVector<JumpTableEntry>;
 
 class FunctionCodeBlockGenerator {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(FunctionCodeBlockGenerator);
     WTF_MAKE_NONCOPYABLE(FunctionCodeBlockGenerator);
 
     friend BytecodeGeneratorBase<GeneratorTraits>;

--- a/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.cpp
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (C) 2019-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,12 +28,15 @@
 #include "WasmFunctionIPIntMetadataGenerator.h"
 
 #include <numeric>
+#include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(WEBASSEMBLY)
 
 namespace JSC {
 
 namespace Wasm {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FunctionIPIntMetadataGenerator);
 
 unsigned FunctionIPIntMetadataGenerator::addSignature(const TypeDefinition& signature)
 {

--- a/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h
@@ -38,6 +38,7 @@
 #include "WasmOps.h"
 #include <wtf/BitVector.h>
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace JSC {
@@ -61,7 +62,7 @@ struct JumpTableEntry;
     } while (false)
 
 class FunctionIPIntMetadataGenerator {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(FunctionIPIntMetadataGenerator);
     WTF_MAKE_NONCOPYABLE(FunctionIPIntMetadataGenerator);
 
     friend class IPIntGenerator;

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,8 +32,8 @@
 #include "WasmParser.h"
 #include "WasmTypeDefinitionInlines.h"
 #include <wtf/DataLog.h>
-#include <wtf/FastMalloc.h>
 #include <wtf/ListDump.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC { namespace Wasm {
 
@@ -114,7 +114,7 @@ struct FunctionParserTypes {
 
 template<typename Context>
 class FunctionParser : public Parser<void>, public FunctionParserTypes<typename Context::ControlType, typename Context::ExpressionType, typename Context::CallType> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(FunctionParser);
 public:
     using CallType = typename FunctionParser::CallType;
     using ControlType = typename FunctionParser::ControlType;

--- a/Source/JavaScriptCore/wasm/WasmGlobal.cpp
+++ b/Source/JavaScriptCore/wasm/WasmGlobal.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,8 +34,11 @@
 #include "JSWebAssemblyRuntimeError.h"
 #include "WasmTypeDefinitionInlines.h"
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC { namespace Wasm {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Global);
 
 JSValue Global::get(JSGlobalObject* globalObject) const
 {

--- a/Source/JavaScriptCore/wasm/WasmGlobal.h
+++ b/Source/JavaScriptCore/wasm/WasmGlobal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,6 +32,7 @@
 #include "WasmLimits.h"
 #include "WriteBarrier.h"
 #include <wtf/Ref.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
 
 namespace JSC {
@@ -44,7 +45,7 @@ class Instance;
 
 class Global final : public ThreadSafeRefCounted<Global> {
     WTF_MAKE_NONCOPYABLE(Global);
-    WTF_MAKE_FAST_ALLOCATED(Global);
+    WTF_MAKE_TZONE_ALLOCATED(Global);
 public:
     union Value {
         v128_t m_vector { };

--- a/Source/JavaScriptCore/wasm/WasmMemory.cpp
+++ b/Source/JavaScriptCore/wasm/WasmMemory.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -40,6 +40,7 @@
 #include <wtf/RAMSize.h>
 #include <wtf/SafeStrerror.h>
 #include <wtf/StdSet.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 
 #include <cstring>
@@ -47,6 +48,8 @@
 #include <mutex>
 
 namespace JSC { namespace Wasm {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Memory);
 
 // FIXME: We could be smarter about memset / mmap / madvise. https://bugs.webkit.org/show_bug.cgi?id=170343
 // FIXME: Give up some of the cached fast memories if the GC determines it's easy to get them back, and they haven't been used in a while. https://bugs.webkit.org/show_bug.cgi?id=170773

--- a/Source/JavaScriptCore/wasm/WasmMemory.h
+++ b/Source/JavaScriptCore/wasm/WasmMemory.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,6 +36,7 @@
 #include <wtf/Function.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/Vector.h>
 
@@ -53,7 +54,7 @@ class Instance;
 
 class Memory final : public RefCounted<Memory> {
     WTF_MAKE_NONCOPYABLE(Memory);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(Memory, JS_EXPORT_PRIVATE);
     friend LLIntOffsetsExtractor;
 public:
     void dump(WTF::PrintStream&) const;

--- a/Source/JavaScriptCore/wasm/WasmOSREntryData.h
+++ b/Source/JavaScriptCore/wasm/WasmOSREntryData.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,6 +30,7 @@
 #include "B3Type.h"
 #include "B3ValueRep.h"
 #include <wtf/FixedVector.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC { namespace Wasm {
 
@@ -53,7 +54,7 @@ using StackMaps = HashMap<CallSiteIndex, StackMap>;
 
 class OSREntryData {
     WTF_MAKE_NONCOPYABLE(OSREntryData);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(OSREntryData);
 public:
     OSREntryData(uint32_t functionIndex, uint32_t loopIndex, StackMap&& stackMap)
         : m_functionIndex(functionIndex)

--- a/Source/JavaScriptCore/wasm/WasmStreamingParser.h
+++ b/Source/JavaScriptCore/wasm/WasmStreamingParser.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2018 Yusuke Suzuki <yusukesuzuki@slowstart.org>.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,6 +31,7 @@
 #include "WasmSections.h"
 #include <wtf/CrossThreadCopier.h>
 #include <wtf/SHA1.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
@@ -49,7 +51,7 @@ public:
 };
 
 class StreamingParser {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(StreamingParser);
 public:
     // The layout of the Wasm module is the following.
     //

--- a/Source/JavaScriptCore/wasm/WasmTZoneImpls.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTZoneImpls.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WasmOSREntryData.h"
+#include <wtf/TZoneMallocInlines.h>
+
+namespace JSC { namespace Wasm {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(OSREntryData);
+
+} } // namespace JSC::Wasm

--- a/Source/JavaScriptCore/wasm/WasmTable.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTable.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,10 +31,15 @@
 #include "JSCJSValueInlines.h"
 #include "JSWebAssemblyTable.h"
 #include "WasmTypeDefinitionInlines.h"
-#include <wtf/CheckedArithmetic.h>
 #include <type_traits>
+#include <wtf/CheckedArithmetic.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC { namespace Wasm {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Table);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ExternRefTable);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FuncRefTable);
 
 template<typename Visitor> constexpr decltype(auto) Table::visitDerived(Visitor&& visitor)
 {

--- a/Source/JavaScriptCore/wasm/WasmTable.h
+++ b/Source/JavaScriptCore/wasm/WasmTable.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,6 +33,7 @@
 #include "WriteBarrier.h"
 #include <wtf/MallocPtr.h>
 #include <wtf/Ref.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
 
 namespace JSC {
@@ -46,7 +47,7 @@ class FuncRefTable;
 
 class Table : public ThreadSafeRefCounted<Table> {
     WTF_MAKE_NONCOPYABLE(Table);
-    WTF_MAKE_FAST_ALLOCATED(Table);
+    WTF_MAKE_TZONE_ALLOCATED(Table);
 public:
     static RefPtr<Table> tryCreate(uint32_t initial, std::optional<uint32_t> maximum, TableElementType, Type);
 
@@ -105,6 +106,7 @@ protected:
 };
 
 class ExternRefTable final : public Table {
+    WTF_MAKE_TZONE_ALLOCATED(ExternRefTable);
 public:
     friend class Table;
 
@@ -119,6 +121,7 @@ private:
 };
 
 class FuncRefTable final : public Table {
+    WTF_MAKE_TZONE_ALLOCATED(FuncRefTable);
 public:
     friend class Table;
 

--- a/Source/JavaScriptCore/wasm/WasmTag.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTag.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,10 +26,14 @@
 #include "config.h"
 #include "WasmTag.h"
 
+#include <wtf/TZoneMallocInlines.h>
+
 #if ENABLE(WEBASSEMBLY)
 
 namespace JSC {
 namespace Wasm {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Tag);
 
 } } // namespace JSC::Wasm
 

--- a/Source/JavaScriptCore/wasm/WasmTag.h
+++ b/Source/JavaScriptCore/wasm/WasmTag.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,11 +28,12 @@
 #if ENABLE(WEBASSEMBLY)
 
 #include "WasmTypeDefinition.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC { namespace Wasm {
 
 class Tag final : public ThreadSafeRefCounted<Tag> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Tag);
     WTF_MAKE_NONCOPYABLE(Tag);
 public:
     static Ref<Tag> create(const TypeDefinition& type) { return adoptRef(*new Tag(type)); }

--- a/Source/JavaScriptCore/wasm/WasmThunks.cpp
+++ b/Source/JavaScriptCore/wasm/WasmThunks.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -37,8 +37,11 @@
 #include "WasmExceptionType.h"
 #include "WasmInstance.h"
 #include "WasmOperations.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC { namespace Wasm {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Thunks);
 
 MacroAssemblerCodeRef<JITThunkPtrTag> throwExceptionFromWasmThunkGenerator(const AbstractLocker&)
 {

--- a/Source/JavaScriptCore/wasm/WasmThunks.h
+++ b/Source/JavaScriptCore/wasm/WasmThunks.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,6 +29,7 @@
 
 #include "MacroAssemblerCodeRef.h"
 #include "WasmJS.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC { namespace Wasm {
 
@@ -52,7 +53,7 @@ constexpr ThunkGenerator triggerOMGEntryTierUpThunkGenerator(bool isSIMDContext)
 #endif
 
 class Thunks {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Thunks);
     WTF_MAKE_NONCOPYABLE(Thunks);
 public:
     static void initialize();

--- a/Source/JavaScriptCore/wasm/WasmTierUpCount.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTierUpCount.cpp
@@ -29,8 +29,11 @@
 #if ENABLE(WEBASSEMBLY_OMGJIT)
 
 #include "WasmOSREntryData.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC { namespace Wasm {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(TierUpCount);
 
 TierUpCount::TierUpCount()
 {

--- a/Source/JavaScriptCore/wasm/WasmTierUpCount.h
+++ b/Source/JavaScriptCore/wasm/WasmTierUpCount.h
@@ -34,6 +34,7 @@
 #include <wtf/Atomics.h>
 #include <wtf/SegmentedVector.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC { namespace Wasm {
 
@@ -45,6 +46,7 @@ class OSREntryData;
 // don't care too much if the countdown is slightly off. The tier up trigger is atomic, however,
 // so tier up will be triggered exactly once.
 class TierUpCount : public UpperTierExecutionCounter {
+    WTF_MAKE_TZONE_ALLOCATED(TierUpCount);
     WTF_MAKE_NONCOPYABLE(TierUpCount);
 public:
     enum class TriggerReason : uint8_t {

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -37,8 +37,12 @@
 #include <wtf/CommaPrinter.h>
 #include <wtf/FastMalloc.h>
 #include <wtf/StringPrintStream.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC { namespace Wasm {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(TypeDefinition);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(TypeInformation);
 
 String TypeDefinition::toString() const
 {
@@ -327,7 +331,7 @@ unsigned TypeDefinition::hash() const
 
 RefPtr<TypeDefinition> TypeDefinition::tryCreateFunctionSignature(FunctionArgCount returnCount, FunctionArgCount argumentCount)
 {
-    // We use WTF_MAKE_FAST_ALLOCATED for this class.
+    // We use WTF_MAKE_TZONE_ALLOCATED for this class.
     auto result = tryFastMalloc(allocatedFunctionSize(returnCount, argumentCount));
     void* memory = nullptr;
     if (!result.getValue(memory))
@@ -338,7 +342,7 @@ RefPtr<TypeDefinition> TypeDefinition::tryCreateFunctionSignature(FunctionArgCou
 
 RefPtr<TypeDefinition> TypeDefinition::tryCreateStructType(StructFieldCount fieldCount, const FieldType* fields)
 {
-    // We use WTF_MAKE_FAST_ALLOCATED for this class.
+    // We use WTF_MAKE_TZONE_ALLOCATED for this class.
     auto result = tryFastMalloc(allocatedStructSize(fieldCount));
     void* memory = nullptr;
     if (!result.getValue(memory))
@@ -349,7 +353,7 @@ RefPtr<TypeDefinition> TypeDefinition::tryCreateStructType(StructFieldCount fiel
 
 RefPtr<TypeDefinition> TypeDefinition::tryCreateArrayType()
 {
-    // We use WTF_MAKE_FAST_ALLOCATED for this class.
+    // We use WTF_MAKE_TZONE_ALLOCATED for this class.
     auto result = tryFastMalloc(allocatedArraySize());
     void* memory = nullptr;
     if (!result.getValue(memory))
@@ -360,7 +364,7 @@ RefPtr<TypeDefinition> TypeDefinition::tryCreateArrayType()
 
 RefPtr<TypeDefinition> TypeDefinition::tryCreateRecursionGroup(RecursionGroupCount typeCount)
 {
-    // We use WTF_MAKE_FAST_ALLOCATED for this class.
+    // We use WTF_MAKE_TZONE_ALLOCATED for this class.
     auto result = tryFastMalloc(allocatedRecursionGroupSize(typeCount));
     void* memory = nullptr;
     if (!result.getValue(memory))
@@ -371,7 +375,7 @@ RefPtr<TypeDefinition> TypeDefinition::tryCreateRecursionGroup(RecursionGroupCou
 
 RefPtr<TypeDefinition> TypeDefinition::tryCreateProjection()
 {
-    // We use WTF_MAKE_FAST_ALLOCATED for this class.
+    // We use WTF_MAKE_TZONE_ALLOCATED for this class.
     auto result = tryFastMalloc(allocatedProjectionSize());
     void* memory = nullptr;
     if (!result.getValue(memory))
@@ -382,7 +386,7 @@ RefPtr<TypeDefinition> TypeDefinition::tryCreateProjection()
 
 RefPtr<TypeDefinition> TypeDefinition::tryCreateSubtype(SupertypeCount count, bool isFinal)
 {
-    // We use WTF_MAKE_FAST_ALLOCATED for this class.
+    // We use WTF_MAKE_TZONE_ALLOCATED for this class.
     auto result = tryFastMalloc(allocatedSubtypeSize());
     void* memory = nullptr;
     if (!result.getValue(memory))

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -42,6 +42,7 @@
 #include <wtf/HashTraits.h>
 #include <wtf/Lock.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/Vector.h>
 
@@ -711,7 +712,7 @@ enum class TypeDefinitionKind : uint8_t {
 };
 
 class TypeDefinition : public ThreadSafeRefCounted<TypeDefinition> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(TypeDefinition);
 
     TypeDefinition() = delete;
     TypeDefinition(const TypeDefinition&) = delete;
@@ -873,7 +874,7 @@ namespace JSC { namespace Wasm {
 // Type information is held globally and shared by the entire process to allow all type definitions to be unique. This is required when wasm calls another wasm instance, and must work when modules are shared between multiple VMs.
 class TypeInformation {
     WTF_MAKE_NONCOPYABLE(TypeInformation);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(TypeInformation);
 
     TypeInformation();
 

--- a/Source/JavaScriptCore/wasm/WasmValueLocation.h
+++ b/Source/JavaScriptCore/wasm/WasmValueLocation.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2021 Igalia S.L. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -32,13 +32,14 @@
 #include "GPRInfo.h"
 #include "Reg.h"
 #include <wtf/PrintStream.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
 namespace Wasm {
 
 class ValueLocation {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ValueLocation);
 public:
     enum Kind : uint8_t {
         GPRRegister,

--- a/Source/JavaScriptCore/wasm/WasmWorklist.cpp
+++ b/Source/JavaScriptCore/wasm/WasmWorklist.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,8 +31,11 @@
 
 #include "CPU.h"
 #include "WasmPlan.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC { namespace Wasm {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Worklist);
 
 namespace WasmWorklistInternal {
 static constexpr bool verbose = false;

--- a/Source/JavaScriptCore/wasm/WasmWorklist.h
+++ b/Source/JavaScriptCore/wasm/WasmWorklist.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,6 +32,7 @@
 #include <wtf/AutomaticThread.h>
 #include <wtf/PrintStream.h>
 #include <wtf/PriorityQueue.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace JSC {
@@ -43,7 +44,7 @@ namespace Wasm {
 class Plan;
 
 class Worklist {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(Worklist);
 public:
     Worklist();
     ~Worklist();

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(WEBASSEMBLY)
 
+#include "JITOpaqueByproducts.h"
 #include "JSCJSValueInlines.h"
 #include "JSObject.h"
 #include "JSObjectInlines.h"

--- a/Source/JavaScriptCore/yarr/RegularExpression.cpp
+++ b/Source/JavaScriptCore/yarr/RegularExpression.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004, 2008, 2009 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2008 Collabora Ltd.
  * Copyright (C) 2011 Peter Varga (pvarga@webkit.org), University of Szeged
  *
@@ -32,8 +32,11 @@
 #include "YarrInterpreter.h"
 #include <wtf/Assertions.h>
 #include <wtf/BumpPointerAllocator.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC { namespace Yarr {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RegularExpression);
 
 class RegularExpression::Private : public RefCounted<RegularExpression::Private> {
 public:

--- a/Source/JavaScriptCore/yarr/RegularExpression.h
+++ b/Source/JavaScriptCore/yarr/RegularExpression.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2003, 2008, 2009 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,12 +27,13 @@
 
 #include "YarrFlags.h"
 #include <wtf/OptionSet.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace JSC { namespace Yarr {
 
 class JS_EXPORT_PRIVATE RegularExpression {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(RegularExpression);
 public:
     explicit RegularExpression(StringView, OptionSet<Flags> = { });
     ~RegularExpression();

--- a/Source/JavaScriptCore/yarr/YarrDisassembler.cpp
+++ b/Source/JavaScriptCore/yarr/YarrDisassembler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,8 +31,11 @@
 #include "Disassembler.h"
 #include "LinkBuffer.h"
 #include <wtf/StringPrintStream.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC { namespace Yarr {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(YarrDisassembler);
 
 static constexpr char s_spaces[] = "                        ";
 static constexpr unsigned s_maxIndent = sizeof(s_spaces) - 1;

--- a/Source/JavaScriptCore/yarr/YarrDisassembler.h
+++ b/Source/JavaScriptCore/yarr/YarrDisassembler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,6 +28,7 @@
 #if ENABLE(JIT)
 
 #include "MacroAssembler.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/text/CString.h>
 
@@ -50,7 +51,7 @@ public:
 };
 
 class YarrDisassembler {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(YarrDisassembler);
 public:
     YarrDisassembler(YarrJITInfo*);
     ~YarrDisassembler();

--- a/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
+++ b/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009, 2013-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2009-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2010 Peter Varga (pvarga@inf.u-szeged.hu), University of Szeged
  *
  * Redistribution and use in source and binary forms, with or without
@@ -36,9 +36,13 @@
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/DataLog.h>
 #include <wtf/StackCheck.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/WTFString.h>
 
 namespace JSC { namespace Yarr {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(BytecodePattern);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ByteDisjunction);
 
 class ByteTermDumper {
 public:

--- a/Source/JavaScriptCore/yarr/YarrInterpreter.h
+++ b/Source/JavaScriptCore/yarr/YarrInterpreter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009, 2010-2012, 2014, 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2009-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,6 +29,7 @@
 #include "YarrErrorCode.h"
 #include "YarrFlags.h"
 #include "YarrPattern.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace WTF {
 class BumpPointerAllocator;
@@ -439,7 +440,7 @@ struct ByteTerm {
 };
 
 class ByteDisjunction {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ByteDisjunction);
 public:
     ByteDisjunction(unsigned numSubpatterns, unsigned frameSize)
         : m_numSubpatterns(numSubpatterns)
@@ -455,7 +456,7 @@ public:
 };
 
 struct BytecodePattern {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(BytecodePattern);
 public:
     BytecodePattern(std::unique_ptr<ByteDisjunction> body, Vector<std::unique_ptr<ByteDisjunction>>& parenthesesInfoToAdopt, YarrPattern& pattern, BumpPointerAllocator* allocator, ConcurrentJSLock* lock, unsigned offsetVectorBaseForNamedCaptures, unsigned offsetsSize)
         : m_body(WTFMove(body))

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2009-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2019 the V8 project authors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -40,8 +40,8 @@
 #include <wtf/BitVector.h>
 #include <wtf/HexNumber.h>
 #include <wtf/ListDump.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Threading.h>
-
 
 #if ENABLE(YARR_JIT)
 
@@ -49,6 +49,11 @@ namespace JSC { namespace Yarr {
 namespace YarrJITInternal {
 static constexpr bool verbose = false;
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(BoyerMooreBitmap);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(BoyerMooreFastCandidates);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(YarrBoyerMooreData);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(YarrCodeBlock);
 
 #if CPU(ARM64E)
 JSC_ANNOTATE_JIT_OPERATION_RETURN(vmEntryToYarrJITAfter);
@@ -119,7 +124,7 @@ void BoyerMooreFastCandidates::dump(PrintStream& out) const
 
 class BoyerMooreInfo {
     WTF_MAKE_NONCOPYABLE(BoyerMooreInfo);
-    WTF_MAKE_FAST_ALLOCATED(BoyerMooreInfo);
+    WTF_MAKE_TZONE_ALLOCATED(BoyerMooreInfo);
 public:
     static constexpr unsigned maxLength = 32;
 
@@ -173,6 +178,8 @@ private:
     Vector<BoyerMooreBitmap> m_characters;
     CharSize m_charSize;
 };
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(BoyerMooreInfo);
 
 std::tuple<int32_t, unsigned, unsigned> BoyerMooreInfo::findBestCharacterSequence(const SubjectSampler& sampler, unsigned numberOfCandidatesLimit) const
 {

--- a/Source/JavaScriptCore/yarr/YarrJIT.h
+++ b/Source/JavaScriptCore/yarr/YarrJIT.h
@@ -37,6 +37,7 @@
 #include <wtf/BitSet.h>
 #include <wtf/FixedVector.h>
 #include <wtf/StackCheck.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 
 #define YARR_CALL
@@ -67,7 +68,7 @@ enum class JITFailureReason : uint8_t {
 };
 
 class BoyerMooreFastCandidates {
-    WTF_MAKE_FAST_ALLOCATED(BoyerMooreFastCandidates);
+    WTF_MAKE_TZONE_ALLOCATED(BoyerMooreFastCandidates);
 public:
     static constexpr unsigned maxSize = 2;
     using CharacterVector = Vector<char32_t, maxSize>;
@@ -118,7 +119,7 @@ private:
 
 class BoyerMooreBitmap {
     WTF_MAKE_NONCOPYABLE(BoyerMooreBitmap);
-    WTF_MAKE_FAST_ALLOCATED(BoyerMooreBitmap);
+    WTF_MAKE_TZONE_ALLOCATED(BoyerMooreBitmap);
 public:
     static constexpr unsigned mapSize = 128;
     static constexpr unsigned mapMask = 128 - 1;
@@ -208,7 +209,7 @@ extern "C" void vmEntryToYarrJITAfter(void);
 #endif
 
 class YarrBoyerMooreData {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(YarrBoyerMooreData);
     WTF_MAKE_NONCOPYABLE(YarrBoyerMooreData);
 
 public:
@@ -271,7 +272,7 @@ class YarrCodeBlock : public YarrBoyerMooreData {
         bool m_canInline : 1;
     };
 
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(YarrCodeBlock);
     WTF_MAKE_NONCOPYABLE(YarrCodeBlock);
 
 public:

--- a/Source/JavaScriptCore/yarr/YarrPattern.h
+++ b/Source/JavaScriptCore/yarr/YarrPattern.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009, 2013-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2009-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2010 Peter Varga (pvarga@inf.u-szeged.hu), University of Szeged
  *
  * Redistribution and use in source and binary forms, with or without
@@ -33,6 +33,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/OptionSet.h>
 #include <wtf/PrintStream.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/text/StringHash.h>
 
@@ -82,7 +83,7 @@ inline CharacterClassWidths& operator|=(CharacterClassWidths& lhs, CharacterClas
 }
 
 struct CharacterClass {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(CharacterClass);
 public:
     // All CharacterClass instances have to have the full set of matches and ranges,
     // they may have an optional m_table for faster lookups (which must match the
@@ -149,7 +150,7 @@ public:
 };
 
 struct ClassSet : public CharacterClass {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(ClassSet);
 public:
     ClassSet()
         : CharacterClass()
@@ -388,7 +389,7 @@ struct PatternTerm {
 };
 
 struct PatternAlternative {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PatternAlternative);
 public:
     PatternAlternative(PatternDisjunction* disjunction, unsigned firstSubpatternId, MatchDirection matchDirection = Forward)
         : m_parent(disjunction)
@@ -467,7 +468,7 @@ public:
 };
 
 struct PatternDisjunction {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_TZONE_ALLOCATED(PatternDisjunction);
 public:
     PatternDisjunction(PatternAlternative* parent = nullptr)
         : m_parent(parent)

--- a/Source/JavaScriptCore/yarr/YarrTZoneImpls.cpp
+++ b/Source/JavaScriptCore/yarr/YarrTZoneImpls.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "YarrPattern.h"
+#include <wtf/TZoneMallocInlines.h>
+
+namespace JSC { namespace Yarr {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CharacterClass);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ClassSet);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PatternAlternative);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PatternDisjunction);
+
+} } // namespace JSC::Yarr

--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -843,6 +843,8 @@
 		EB2C86D9267B275D0052CB9A /* CPUTimePOSIX.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EB2C86D8267B275C0052CB9A /* CPUTimePOSIX.cpp */; };
 		EB61EDC72409CCC1001EFE36 /* SystemTracingCocoa.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EB61EDC62409CCC0001EFE36 /* SystemTracingCocoa.cpp */; };
 		FE032AD22463E43B0012D7C7 /* WTFConfig.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE032AD02463E43B0012D7C7 /* WTFConfig.cpp */; };
+		FE03831C2ABC04F700A576A2 /* TZoneMallocInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = FE03831A2ABC04F700A576A2 /* TZoneMallocInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FE03831D2ABC04F700A576A2 /* TZoneMalloc.h in Headers */ = {isa = PBXBuildFile; fileRef = FE03831B2ABC04F700A576A2 /* TZoneMalloc.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FE05FAFF1FE5007500093230 /* WTFAssertions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE05FAFE1FE5007500093230 /* WTFAssertions.cpp */; };
 		FE1E2C3B2240C06600F6B729 /* PtrTag.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE1E2C392240C05400F6B729 /* PtrTag.cpp */; };
 		FE1E2C42224187C600F6B729 /* PlatformRegisters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE1E2C41224187C600F6B729 /* PlatformRegisters.cpp */; };
@@ -1796,6 +1798,8 @@
 		F72BBDB107FA424886178B9E /* SymbolImpl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SymbolImpl.cpp; sourceTree = "<group>"; };
 		FE032AD02463E43B0012D7C7 /* WTFConfig.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WTFConfig.cpp; sourceTree = "<group>"; };
 		FE032AD12463E43B0012D7C7 /* WTFConfig.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WTFConfig.h; sourceTree = "<group>"; };
+		FE03831A2ABC04F700A576A2 /* TZoneMallocInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TZoneMallocInlines.h; sourceTree = "<group>"; };
+		FE03831B2ABC04F700A576A2 /* TZoneMalloc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TZoneMalloc.h; sourceTree = "<group>"; };
 		FE05FAE61FDB214300093230 /* RawPtrTraits.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RawPtrTraits.h; sourceTree = "<group>"; };
 		FE05FAFE1FE5007500093230 /* WTFAssertions.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WTFAssertions.cpp; sourceTree = "<group>"; };
 		FE1D6D87237401CD007A5C26 /* StackCheck.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StackCheck.h; sourceTree = "<group>"; };
@@ -2418,6 +2422,8 @@
 				149EF16216BBFE0D000A4331 /* TriState.h */,
 				83FBA93119DF459700F30ADB /* TypeCasts.h */,
 				5164042E2AB1D4DD0042B1C3 /* TypeTraits.h */,
+				FE03831B2ABC04F700A576A2 /* TZoneMalloc.h */,
+				FE03831A2ABC04F700A576A2 /* TZoneMallocInlines.h */,
 				E360C7642127B85B00C90F0E /* UnalignedAccess.h */,
 				E360C7652127B85C00C90F0E /* Unexpected.h */,
 				A8A4735C151A825B004123FF /* UnionFind.h */,
@@ -3448,6 +3454,8 @@
 				DDF3070C27C086CC006A526F /* TypeCastsCF.h in Headers */,
 				DDF306FD27C086CC006A526F /* TypeCastsCocoa.h in Headers */,
 				5164042F2AB1D4DD0042B1C3 /* TypeTraits.h in Headers */,
+				FE03831D2ABC04F700A576A2 /* TZoneMalloc.h in Headers */,
+				FE03831C2ABC04F700A576A2 /* TZoneMallocInlines.h in Headers */,
 				DD3DC8C927A4BF8E007E5B61 /* UnalignedAccess.h in Headers */,
 				DD3DC86A27A4BF8E007E5B61 /* Unexpected.h in Headers */,
 				DD28468829248DDA0009A61D /* UnifiedWebPreferences.yaml in Headers */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -291,6 +291,8 @@ set(WTF_PUBLIC_HEADERS
     SystemFree.h
     SystemMalloc.h
     SystemTracing.h
+    TZoneMalloc.h
+    TZoneMallocInlines.h
     TaggedArrayStoragePtr.h
     ThreadAssertions.h
     ThreadGroup.h

--- a/Source/WTF/wtf/PlatformUse.h
+++ b/Source/WTF/wtf/PlatformUse.h
@@ -326,6 +326,16 @@
 #define USE_ISO_MALLOC 1
 #endif
 
+#if !defined(USE_TZONE_MALLOC)
+#if CPU(ARM64)
+// Only MacroAssemblerARM64 is known to build.
+// Building with TZONE_MALLOC currently disabled for all platforms.
+#define USE_TZONE_MALLOC 0
+#else
+#define USE_TZONE_MALLOC 0
+#endif
+#endif
+
 #if !PLATFORM(WATCHOS)
 #define USE_GLYPH_DISPLAY_LIST_CACHE 1
 #endif

--- a/Source/WTF/wtf/TZoneMalloc.h
+++ b/Source/WTF/wtf/TZoneMalloc.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/ForbidHeapAllocation.h>
+#include <wtf/Platform.h>
+
+#if USE(SYSTEM_MALLOC) || !USE(TZONE_MALLOC)
+
+#include <wtf/FastMalloc.h>
+
+#define WTF_MAKE_TZONE_ALLOCATED(name) WTF_MAKE_FAST_ALLOCATED
+#define WTF_MAKE_TZONE_ALLOCATED_EXPORT(name, exportMacro) WTF_MAKE_FAST_ALLOCATED
+#define WTF_MAKE_TZONE_NONALLOCATABLE(name) WTF_FORBID_HEAP_ALLOCATION
+
+#else
+
+#include <bmalloc/TZoneHeap.h>
+
+#define WTF_NOEXPORT
+
+#define WTF_MAKE_TZONE_ALLOCATED(name) MAKE_BTZONE_MALLOCED(name, WTF_NOEXPORT)
+#define WTF_MAKE_TZONE_ALLOCATED_EXPORT(name, exportMacro) MAKE_BTZONE_MALLOCED(name, exportMacro)
+#define WTF_MAKE_TZONE_NONALLOCATABLE(name) WTF_FORBID_HEAP_ALLOCATION
+
+#endif
+

--- a/Source/WTF/wtf/TZoneMallocInlines.h
+++ b/Source/WTF/wtf/TZoneMallocInlines.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Platform.h>
+
+#if USE(SYSTEM_MALLOC) || !USE(TZONE_MALLOC)
+
+#include <wtf/FastMalloc.h>
+
+#define WTF_MAKE_TZONE_ALLOCATED_INLINE(name) WTF_MAKE_FAST_ALLOCATED
+#define WTF_MAKE_TZONE_ALLOCATED_IMPL(name) struct WTFIsoMallocSemicolonifier##name { }
+#define WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(name, type) struct WTFIsoMallocSemicolonifier##name { }
+#define WTF_MAKE_TZONE_ALLOCATED_IMPL_TEMPLATE(name) struct WTFIsoMallocSemicolonifier##name { }
+#define WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED_TEMPLATE(name, type) struct WTFIsoMallocSemicolonifier##name { }
+
+#else
+
+#include <bmalloc/TZoneHeapInlines.h>
+
+#define WTF_MAKE_TZONE_ALLOCATED_INLINE(name) MAKE_BTZONE_MALLOCED_INLINE(name)
+#define WTF_MAKE_TZONE_ALLOCATED_IMPL(name) MAKE_BTZONE_MALLOCED_IMPL(name)
+#define WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(name, type) MAKE_BTZONE_MALLOCED_IMPL_NESTED(name, type)
+#define WTF_MAKE_TZONE_ALLOCATED_IMPL_TEMPLATE(name) MAKE_BTZONE_MALLOCED_IMPL_TEMPLATE(name)
+#define WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED_TEMPLATE(name, type) MAKE_BTZONE_MALLOCED_IMPL_NESTED_TEMPLATE(name, type)
+
+#endif
+
+

--- a/Source/bmalloc/bmalloc.xcodeproj/project.pbxproj
+++ b/Source/bmalloc/bmalloc.xcodeproj/project.pbxproj
@@ -679,6 +679,9 @@
 		E3FBB5A4225ECAD200DB6FBD /* IsoSharedHeapInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = E3FBB5A3225ECAD200DB6FBD /* IsoSharedHeapInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EB17D11123BFCD42002093A7 /* HeapConstants.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EB17D11023BFC8C4002093A7 /* HeapConstants.cpp */; };
 		EB17D11223BFCD7A002093A7 /* HeapConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = EB17D10E23BE691D002093A7 /* HeapConstants.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FE0383202ABC0E9F00A576A2 /* TZoneHeap.h in Headers */ = {isa = PBXBuildFile; fileRef = FE03831E2ABC0E9F00A576A2 /* TZoneHeap.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FE0383212ABC0E9F00A576A2 /* TZoneHeap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE03831F2ABC0E9F00A576A2 /* TZoneHeap.cpp */; };
+		FE0383232ABC988C00A576A2 /* TZoneHeapInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = FE0383222ABC988C00A576A2 /* TZoneHeapInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FE48BD3B2321E8D700F136D0 /* FailureAction.h in Headers */ = {isa = PBXBuildFile; fileRef = FE48BD3A2321E8CC00F136D0 /* FailureAction.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FEC3A39324846A8100395B54 /* GigacageConfig.h in Headers */ = {isa = PBXBuildFile; fileRef = FEC3A39224846A6D00395B54 /* GigacageConfig.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FEC3A395248471FE00395B54 /* GigacageKind.h in Headers */ = {isa = PBXBuildFile; fileRef = FEC3A394248471FE00395B54 /* GigacageKind.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1381,6 +1384,9 @@
 		E3FBB5A3225ECAD200DB6FBD /* IsoSharedHeapInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = IsoSharedHeapInlines.h; path = bmalloc/IsoSharedHeapInlines.h; sourceTree = "<group>"; };
 		EB17D10E23BE691D002093A7 /* HeapConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = HeapConstants.h; path = bmalloc/HeapConstants.h; sourceTree = "<group>"; };
 		EB17D11023BFC8C4002093A7 /* HeapConstants.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = HeapConstants.cpp; path = bmalloc/HeapConstants.cpp; sourceTree = "<group>"; };
+		FE03831E2ABC0E9F00A576A2 /* TZoneHeap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TZoneHeap.h; path = bmalloc/TZoneHeap.h; sourceTree = "<group>"; };
+		FE03831F2ABC0E9F00A576A2 /* TZoneHeap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TZoneHeap.cpp; path = bmalloc/TZoneHeap.cpp; sourceTree = "<group>"; };
+		FE0383222ABC988C00A576A2 /* TZoneHeapInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TZoneHeapInlines.h; path = bmalloc/TZoneHeapInlines.h; sourceTree = "<group>"; };
 		FE48BD3A2321E8CC00F136D0 /* FailureAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FailureAction.h; path = bmalloc/FailureAction.h; sourceTree = "<group>"; };
 		FEC3A39224846A6D00395B54 /* GigacageConfig.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GigacageConfig.h; path = bmalloc/GigacageConfig.h; sourceTree = "<group>"; };
 		FEC3A394248471FE00395B54 /* GigacageKind.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GigacageKind.h; path = bmalloc/GigacageKind.h; sourceTree = "<group>"; };
@@ -1477,6 +1483,9 @@
 				0F7EB81F1F9541B000F1ABCB /* IsoTLSInlines.h */,
 				0F7EB8181F9541AF00F1ABCB /* IsoTLSLayout.cpp */,
 				0F7EB8191F9541AF00F1ABCB /* IsoTLSLayout.h */,
+				FE03831F2ABC0E9F00A576A2 /* TZoneHeap.cpp */,
+				FE03831E2ABC0E9F00A576A2 /* TZoneHeap.h */,
+				FE0383222ABC988C00A576A2 /* TZoneHeapInlines.h */,
 			);
 			name = iso;
 			sourceTree = "<group>";
@@ -2287,6 +2296,8 @@
 				14DD78BD18F48D6B00950702 /* SmallPage.h in Headers */,
 				E31E74802238CA5C005D084A /* StaticPerProcess.h in Headers */,
 				7C571F0122388B840077A3C7 /* StdLibExtras.h in Headers */,
+				FE0383202ABC0E9F00A576A2 /* TZoneHeap.h in Headers */,
+				FE0383232ABC988C00A576A2 /* TZoneHeapInlines.h in Headers */,
 				14DD78CE18F48D7500950799 /* valgrind.h in Headers */,
 				14DD78CF18F48D7500950702 /* Vector.h in Headers */,
 				14DD78D018F48D7500950702 /* VMAllocate.h in Headers */,
@@ -2843,6 +2854,7 @@
 				0F26A7A5205483130090A141 /* PerProcess.cpp in Sources */,
 				AD14AD2A202529C700890E3B /* ProcessCheck.mm in Sources */,
 				0F5BF1521F22E1570029D91D /* Scavenger.cpp in Sources */,
+				FE0383212ABC0E9F00A576A2 /* TZoneHeap.cpp in Sources */,
 				1440AFCD1A9527AF00837FAA /* Zone.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Source/bmalloc/bmalloc/TZoneHeap.cpp
+++ b/Source/bmalloc/bmalloc/TZoneHeap.cpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#include "TZoneHeap.h"
+
+#if BUSE(LIBPAS)
+
+#include "IsoMallocFallback.h"
+#include "bmalloc_heap_inlines.h"
+
+namespace bmalloc { namespace api {
+
+void* tzoneAllocate(pas_heap_ref& heapRef)
+{
+    // FIXME: libpas should know how to do the fallback thing.
+    // https://bugs.webkit.org/show_bug.cgi?id=227177
+
+    if (IsoMallocFallback::shouldTryToFallBack()) {
+        IsoMallocFallback::MallocResult result = IsoMallocFallback::tryMalloc(
+            pas_simple_type_size(reinterpret_cast<pas_simple_type>(heapRef.type)));
+        if (result.didFallBack) {
+            RELEASE_BASSERT(result.ptr);
+            return result.ptr;
+        }
+    }
+
+    return bmalloc_iso_allocate_inline(&heapRef);
+}
+
+void* tzoneTryAllocate(pas_heap_ref& heapRef)
+{
+    if (IsoMallocFallback::shouldTryToFallBack()) {
+        IsoMallocFallback::MallocResult result = IsoMallocFallback::tryMalloc(
+            pas_simple_type_size(reinterpret_cast<pas_simple_type>(heapRef.type)));
+        if (result.didFallBack)
+            return result.ptr;
+    }
+
+    return bmalloc_try_iso_allocate_inline(&heapRef);
+}
+
+void tzoneDeallocate(void* ptr)
+{
+    if (IsoMallocFallback::shouldTryToFallBack()
+        && IsoMallocFallback::tryFree(ptr))
+        return;
+
+    bmalloc_deallocate_inline(ptr);
+}
+
+} } // namespace bmalloc::api
+
+#endif // BUSE(LIBPAS)
+

--- a/Source/bmalloc/bmalloc/TZoneHeap.h
+++ b/Source/bmalloc/bmalloc/TZoneHeap.h
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#pragma once
+
+#include "IsoConfig.h"
+#include "Mutex.h"
+
+#if BUSE(LIBPAS)
+#include "bmalloc_heap_ref.h"
+#endif
+
+#if BENABLE_MALLOC_HEAP_BREAKDOWN
+#include <malloc/malloc.h>
+#endif
+
+namespace bmalloc {
+
+template<typename Config> class IsoHeapImpl;
+
+namespace api {
+
+// You have to declare TZoneHeaps this way:
+//
+// static TZoneHeap<type> myTypeHeap;
+//
+// It's not valid to create an TZoneHeap except in static storage.
+
+#if BUSE(LIBPAS)
+BEXPORT void* tzoneAllocate(pas_heap_ref&);
+BEXPORT void* tzoneTryAllocate(pas_heap_ref&);
+BEXPORT void tzoneDeallocate(void* ptr);
+
+// The name "LibPasBmallocHeapType" is important for the pas_status_reporter to work right.
+template<typename LibPasBmallocHeapType>
+struct TZoneHeap {
+    constexpr TZoneHeap(const char* = nullptr) { }
+
+    void* allocate()
+    {
+        return tzoneAllocate(provideHeap());
+    }
+
+    void* tryAllocate()
+    {
+        return tzoneTryAllocate(provideHeap());
+    }
+
+    void deallocate(void* p)
+    {
+        tzoneDeallocate(p);
+    }
+
+    void scavenge()
+    {
+    }
+
+    void initialize()
+    {
+    }
+
+    bool isInitialized()
+    {
+        return true;
+    }
+
+    static pas_heap_ref& provideHeap()
+    {
+        static const bmalloc_type type = BMALLOC_TYPE_INITIALIZER(sizeof(LibPasBmallocHeapType), alignof(LibPasBmallocHeapType), __PRETTY_FUNCTION__);
+        static pas_heap_ref heap = BMALLOC_HEAP_REF_INITIALIZER(&type);
+        return heap;
+    }
+};
+#else // BUSE(LIBPAS) -> so !BUSE(LIBPAS)
+template<typename Type>
+struct TZoneHeap {
+    typedef IsoConfig<sizeof(Type)> Config;
+
+#if BENABLE_MALLOC_HEAP_BREAKDOWN
+    TZoneHeap(const char* = nullptr);
+#else
+    constexpr TZoneHeap(const char* = nullptr) { }
+#endif
+
+    void* allocate();
+    void* tryAllocate();
+    void deallocate(void* p);
+
+    void scavenge();
+
+    void initialize();
+    bool isInitialized();
+
+    unsigned allocatorOffset() { return m_allocatorOffsetPlusOne - 1; }
+    void setAllocatorOffset(unsigned value) { m_allocatorOffsetPlusOne = value + 1; }
+
+    unsigned deallocatorOffset() { return m_deallocatorOffsetPlusOne - 1; }
+    void setDeallocatorOffset(unsigned value) { m_deallocatorOffsetPlusOne = value + 1; }
+
+    IsoHeapImpl<Config>& impl();
+
+    Mutex m_initializationLock;
+    unsigned m_allocatorOffsetPlusOne { 0 };
+    unsigned m_deallocatorOffsetPlusOne { 0 };
+    IsoHeapImpl<Config>* m_impl { nullptr };
+
+#if BENABLE_MALLOC_HEAP_BREAKDOWN
+    malloc_zone_t* m_zone;
+#endif
+};
+#endif // BUSE(LIBPAS) -> so end of !BUSE(LIBPAS)
+
+// Use this together with MAKE_BISO_MALLOCED_IMPL.
+#define MAKE_BTZONE_MALLOCED(isoType, exportMacro) \
+public: \
+    static exportMacro ::bmalloc::api::TZoneHeap<isoType>& btzoneHeap(); \
+    \
+    void* operator new(size_t, void* p) { return p; } \
+    void* operator new[](size_t, void* p) { return p; } \
+    \
+    exportMacro void* operator new(size_t size);\
+    exportMacro void operator delete(void* p);\
+    \
+    void* operator new[](size_t size) = delete; \
+    void operator delete[](void* p) = delete; \
+    \
+    void* operator new(size_t, NotNullTag, void* location) \
+    { \
+        ASSERT(location); \
+        return location; \
+    } \
+    exportMacro static void freeAfterDestruction(void*); \
+    \
+    using webkitFastMalloced = int; \
+private: \
+    using __makeTZoneMallocedMacroSemicolonifier BunusedTypeAlias = int
+
+} } // namespace bmalloc::api

--- a/Source/bmalloc/bmalloc/TZoneHeapInlines.h
+++ b/Source/bmalloc/bmalloc/TZoneHeapInlines.h
@@ -1,0 +1,267 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#pragma once
+
+#include "BPlatform.h"
+#include "DeferredDecommitInlines.h"
+#include "DeferredTriggerInlines.h"
+#include "EligibilityResultInlines.h"
+#include "FreeListInlines.h"
+#include "IsoAllocatorInlines.h"
+#include "IsoDeallocatorInlines.h"
+#include "IsoDirectoryInlines.h"
+#include "IsoDirectoryPageInlines.h"
+#include "IsoHeapImplInlines.h"
+#include "IsoPageInlines.h"
+#include "IsoTLSAllocatorEntryInlines.h"
+#include "IsoTLSDeallocatorEntryInlines.h"
+#include "IsoTLSEntryInlines.h"
+#include "IsoTLSInlines.h"
+#include "TZoneHeap.h"
+
+namespace bmalloc { namespace api {
+
+#if !BUSE(LIBPAS)
+
+#if BENABLE_MALLOC_HEAP_BREAKDOWN
+template<typename Type>
+IsoHeap<Type>::TZoneHeap(const char* heapClass)
+    : m_zone(malloc_create_zone(0, 0))
+{
+    if (heapClass)
+        malloc_set_zone_name(m_zone, heapClass);
+}
+#endif
+
+template<typename Type>
+void* TZoneHeap<Type>::allocate()
+{
+    bool abortOnFailure = true;
+    return IsoTLS::allocate(*this, abortOnFailure);
+}
+
+template<typename Type>
+void* TZoneHeap<Type>::tryAllocate()
+{
+    bool abortOnFailure = false;
+    return IsoTLS::allocate(*this, abortOnFailure);
+}
+
+template<typename Type>
+void TZoneHeap<Type>::deallocate(void* p)
+{
+    IsoTLS::deallocate(*this, p);
+}
+
+template<typename Type>
+void TZoneHeap<Type>::scavenge()
+{
+    IsoTLS::scavenge(*this);
+}
+
+template<typename Type>
+bool TZoneHeap<Type>::isInitialized()
+{
+    auto* atomic = reinterpret_cast<std::atomic<IsoHeapImpl<Config>*>*>(&m_impl);
+    return atomic->load(std::memory_order_acquire);
+}
+
+template<typename Type>
+void TZoneHeap<Type>::initialize()
+{
+    // We are using m_impl field as a guard variable of the initialization of TZoneHeap.
+    // TZoneHeap::isInitialized gets m_impl with "acquire", and TZoneHeap::initialize stores
+    // the value to m_impl with "release". To make TZoneHeap changes visible to any threads
+    // when TZoneHeap::isInitialized returns true, we need to store the value to m_impl *after*
+    // all the initialization finishes.
+    auto* heap = new IsoHeapImpl<Config>();
+    heap->addToAllIsoHeaps();
+    setAllocatorOffset(heap->allocatorOffset());
+    setDeallocatorOffset(heap->deallocatorOffset());
+    auto* atomic = reinterpret_cast<std::atomic<IsoHeapImpl<Config>*>*>(&m_impl);
+    atomic->store(heap, std::memory_order_release);
+}
+
+template<typename Type>
+auto TZoneHeap<Type>::impl() -> IsoHeapImpl<Config>&
+{
+    IsoTLS::ensureHeap(*this);
+    return *m_impl;
+}
+
+#endif // !BUSE(LIBPAS)
+
+// This is most appropraite for template classes.
+
+#define MAKE_BTZONE_MALLOCED_INLINE(isoType) \
+public: \
+    static ::bmalloc::api::TZoneHeap<isoType>& btzoneHeap() \
+    { \
+        static ::bmalloc::api::TZoneHeap<isoType> heap("WebKit_"#isoType); \
+        return heap; \
+    } \
+    \
+    void* operator new(size_t, void* p) { return p; } \
+    void* operator new[](size_t, void* p) { return p; } \
+    \
+    void* operator new(size_t size) \
+    { \
+        RELEASE_BASSERT(size == sizeof(isoType)); \
+        return btzoneHeap().allocate(); \
+    } \
+    \
+    void operator delete(void* p) \
+    { \
+        btzoneHeap().deallocate(p); \
+    } \
+    \
+    void* operator new[](size_t size) = delete; \
+    void operator delete[](void* p) = delete; \
+    \
+    void* operator new(size_t, NotNullTag, void* location) \
+    { \
+        ASSERT(location); \
+        return location; \
+    } \
+    static void freeAfterDestruction(void* p) \
+    { \
+        btzoneHeap().deallocate(p); \
+    } \
+    \
+    using webkitFastMalloced = int; \
+private: \
+    using __makeBtzoneMallocedInlineMacroSemicolonifier BunusedTypeAlias = int
+
+#define MAKE_BTZONE_MALLOCED_IMPL(isoType) \
+::bmalloc::api::TZoneHeap<isoType>& isoType::btzoneHeap() \
+{ \
+    static ::bmalloc::api::TZoneHeap<isoType> heap("WebKit "#isoType); \
+    return heap; \
+} \
+\
+void* isoType::operator new(size_t size) \
+{ \
+    RELEASE_BASSERT(size == sizeof(isoType)); \
+    return btzoneHeap().allocate(); \
+} \
+\
+void isoType::operator delete(void* p) \
+{ \
+    btzoneHeap().deallocate(p); \
+} \
+\
+void isoType::freeAfterDestruction(void* p) \
+{ \
+    btzoneHeap().deallocate(p); \
+} \
+\
+struct MakeBtzoneMallocedImplMacroSemicolonifier##isoType { }
+
+#define MAKE_BTZONE_MALLOCED_IMPL_NESTED(isoTypeName, isoType) \
+::bmalloc::api::TZoneHeap<isoType>& isoType::btzoneHeap() \
+{ \
+    static ::bmalloc::api::TZoneHeap<isoType> heap("WebKit "#isoType); \
+    return heap; \
+} \
+\
+void* isoType::operator new(size_t size) \
+{ \
+    RELEASE_BASSERT(size == sizeof(isoType)); \
+    return btzoneHeap().allocate(); \
+} \
+\
+void isoType::operator delete(void* p) \
+{ \
+    btzoneHeap().deallocate(p); \
+} \
+\
+void isoType::freeAfterDestruction(void* p) \
+{ \
+    btzoneHeap().deallocate(p); \
+} \
+\
+struct MakeBtzoneMallocedImplMacroSemicolonifier##isoTypeName { }
+
+#define MAKE_BTZONE_MALLOCED_IMPL_TEMPLATE(isoType) \
+template<> \
+::bmalloc::api::TZoneHeap<isoType>& isoType::btzoneHeap() \
+{ \
+    static ::bmalloc::api::TZoneHeap<isoType> heap("WebKit_"#isoType); \
+    return heap; \
+} \
+\
+template<> \
+void* isoType::operator new(size_t size) \
+{ \
+    RELEASE_BASSERT(size == sizeof(isoType)); \
+    return btzoneHeap().allocate(); \
+} \
+\
+template<> \
+void isoType::operator delete(void* p) \
+{ \
+    btzoneHeap().deallocate(p); \
+} \
+\
+template<> \
+void isoType::freeAfterDestruction(void* p) \
+{ \
+    btzoneHeap().deallocate(p); \
+} \
+\
+struct MakeBtzoneMallocedImplMacroSemicolonifier##isoType { }
+
+#define MAKE_BTZONE_MALLOCED_IMPL_NESTED_TEMPLATE(isoTypeName, isoType) \
+template<> \
+::bmalloc::api::TZoneHeap<isoType>& isoType::btzoneHeap() \
+{ \
+    static ::bmalloc::api::TZoneHeap<isoType> heap("WebKit "#isoType); \
+    return heap; \
+} \
+\
+template<> \
+void* isoType::operator new(size_t size) \
+{ \
+    RELEASE_BASSERT(size == sizeof(isoType)); \
+    return btzoneHeap().allocate(); \
+} \
+\
+template<> \
+void isoType::operator delete(void* p) \
+{ \
+    btzoneHeap().deallocate(p); \
+} \
+\
+template<> \
+void isoType::freeAfterDestruction(void* p) \
+{ \
+    btzoneHeap().deallocate(p); \
+} \
+\
+struct MakeBtzoneMallocedImplMacroSemicolonifier##isoTypeName { }
+
+} } // namespace bmalloc::api
+


### PR DESCRIPTION
#### a9681223364eec9a18680e158395ed3bbdd7952e
<pre>
Implement and Apply TZone Allocation Macros
<a href="https://rdar.apple.com/114836775">rdar://114836775</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=266095">https://bugs.webkit.org/show_bug.cgi?id=266095</a>

Reviewed by Mark Lam.

Added initial implementation of sized typed allocators, aka TZone.
This change adds a basic sized type allocation system and the macros used so a class will use a TZone allocation.
It also changes fixed sized JavaScript classes to use those macros.

For Classes that don&apos;t have a corresponding .cpp file, a per-functional group XXXTZoneImpls.cpp file is created in
the function directory for the implementations of such TZone allocated classes.

The new Platform USE directive USE_TZONE_MALLOC enables building with TZone allocation or FastMalloc allocation.
This change defaults to using FastMalloc allocaiton.  Non-ARM64 builds have TZone allocations disabled as they
haven&apos;t been changed and built yet.

* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/assembler/AbstractMacroAssembler.h:
* Source/JavaScriptCore/assembler/AssemblyComments.cpp:
* Source/JavaScriptCore/assembler/AssemblyComments.h:
* Source/JavaScriptCore/assembler/LinkBuffer.cpp:
* Source/JavaScriptCore/assembler/LinkBuffer.h:
* Source/JavaScriptCore/assembler/MacroAssemblerARM64.cpp:
* Source/JavaScriptCore/assembler/MacroAssemblerARM64.h:
* Source/JavaScriptCore/assembler/PerfLog.cpp:
* Source/JavaScriptCore/assembler/PerfLog.h:
* Source/JavaScriptCore/assembler/ProbeContext.cpp:
* Source/JavaScriptCore/assembler/ProbeContext.h:
* Source/JavaScriptCore/assembler/ProbeStack.cpp:
* Source/JavaScriptCore/assembler/ProbeStack.h:
* Source/JavaScriptCore/b3/B3BackwardsCFG.h:
* Source/JavaScriptCore/b3/B3BackwardsDominators.h:
* Source/JavaScriptCore/b3/B3BasicBlock.cpp:
* Source/JavaScriptCore/b3/B3BasicBlock.h:
* Source/JavaScriptCore/b3/B3CFG.h:
* Source/JavaScriptCore/b3/B3CheckSpecial.cpp:
* Source/JavaScriptCore/b3/B3CheckSpecial.h:
* Source/JavaScriptCore/b3/B3DataSection.cpp:
* Source/JavaScriptCore/b3/B3DataSection.h:
* Source/JavaScriptCore/b3/B3Dominators.h:
* Source/JavaScriptCore/b3/B3NaturalLoops.h:
* Source/JavaScriptCore/b3/B3PhiChildren.cpp:
* Source/JavaScriptCore/b3/B3PhiChildren.h:
* Source/JavaScriptCore/b3/B3Procedure.cpp:
* Source/JavaScriptCore/b3/B3Procedure.h:
* Source/JavaScriptCore/b3/B3StackmapSpecial.cpp:
* Source/JavaScriptCore/b3/B3StackmapSpecial.h:
* Source/JavaScriptCore/b3/B3TZoneImpls.cpp: Copied from Source/JavaScriptCore/b3/B3BackwardsDominators.h.
* Source/JavaScriptCore/b3/B3Value.cpp:
* Source/JavaScriptCore/b3/B3Value.h:
* Source/JavaScriptCore/b3/B3ValueRep.cpp:
* Source/JavaScriptCore/b3/B3ValueRep.h:
* Source/JavaScriptCore/b3/B3Variable.cpp:
* Source/JavaScriptCore/b3/B3Variable.h:
* Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackAndGenerateCode.cpp:
* Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackAndGenerateCode.h:
* Source/JavaScriptCore/b3/air/AirBasicBlock.cpp:
* Source/JavaScriptCore/b3/air/AirBasicBlock.h:
* Source/JavaScriptCore/b3/air/AirCCallSpecial.cpp:
* Source/JavaScriptCore/b3/air/AirCCallSpecial.h:
* Source/JavaScriptCore/b3/air/AirCFG.h:
* Source/JavaScriptCore/b3/air/AirCode.cpp:
* Source/JavaScriptCore/b3/air/AirCode.h:
* Source/JavaScriptCore/b3/air/AirDisassembler.cpp:
* Source/JavaScriptCore/b3/air/AirDisassembler.h:
* Source/JavaScriptCore/b3/air/AirLiveness.h:
* Source/JavaScriptCore/b3/air/AirLivenessAdapter.h:
* Source/JavaScriptCore/b3/air/AirPrintSpecial.cpp:
* Source/JavaScriptCore/b3/air/AirPrintSpecial.h:
* Source/JavaScriptCore/b3/air/AirSpecial.cpp:
* Source/JavaScriptCore/b3/air/AirSpecial.h:
* Source/JavaScriptCore/b3/air/AirStackSlot.cpp:
* Source/JavaScriptCore/b3/air/AirStackSlot.h:
* Source/JavaScriptCore/b3/air/AirTZoneImpls.cpp: Copied from Source/JavaScriptCore/wasm/WasmTag.cpp.
* Source/JavaScriptCore/builtins/BuiltinExecutables.cpp:
* Source/JavaScriptCore/builtins/BuiltinExecutables.h:
* Source/JavaScriptCore/builtins/BuiltinNames.cpp:
* Source/JavaScriptCore/builtins/BuiltinNames.h:
* Source/JavaScriptCore/bytecode/AccessCaseSnippetParams.cpp:
* Source/JavaScriptCore/bytecode/AccessCaseSnippetParams.h:
* Source/JavaScriptCore/bytecode/AdaptiveInferredPropertyValueWatchpointBase.cpp:
* Source/JavaScriptCore/bytecode/AdaptiveInferredPropertyValueWatchpointBase.h:
* Source/JavaScriptCore/bytecode/BytecodeBasicBlock.h:
* Source/JavaScriptCore/bytecode/BytecodeGraph.h:
* Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.cpp:
* Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.h:
* Source/JavaScriptCore/bytecode/BytecodeLivenessAnalysis.cpp:
* Source/JavaScriptCore/bytecode/BytecodeLivenessAnalysis.h:
* Source/JavaScriptCore/bytecode/CallLinkStatus.cpp:
* Source/JavaScriptCore/bytecode/CallLinkStatus.h:
* Source/JavaScriptCore/bytecode/CallVariant.h:
* Source/JavaScriptCore/bytecode/CheckPrivateBrandStatus.cpp:
* Source/JavaScriptCore/bytecode/CheckPrivateBrandStatus.h:
* Source/JavaScriptCore/bytecode/CheckPrivateBrandVariant.h:
* Source/JavaScriptCore/bytecode/CodeOrigin.cpp:
* Source/JavaScriptCore/bytecode/CodeOrigin.h:
* Source/JavaScriptCore/bytecode/DeferredSourceDump.h:
* Source/JavaScriptCore/bytecode/DeleteByStatus.cpp:
* Source/JavaScriptCore/bytecode/DeleteByStatus.h:
* Source/JavaScriptCore/bytecode/DeleteByVariant.h:
* Source/JavaScriptCore/bytecode/ExecutionCounter.cpp:
* Source/JavaScriptCore/bytecode/ExecutionCounter.h:
* Source/JavaScriptCore/bytecode/FullBytecodeLiveness.h:
* Source/JavaScriptCore/bytecode/GetByVariant.h:
* Source/JavaScriptCore/bytecode/InByStatus.cpp:
* Source/JavaScriptCore/bytecode/InByStatus.h:
* Source/JavaScriptCore/bytecode/InByVariant.h:
* Source/JavaScriptCore/bytecode/InstanceOfStatus.h:
* Source/JavaScriptCore/bytecode/InstanceOfVariant.h:
* Source/JavaScriptCore/bytecode/MetadataTable.h:
* Source/JavaScriptCore/bytecode/PutByVariant.h:
* Source/JavaScriptCore/bytecode/SetPrivateBrandStatus.cpp:
* Source/JavaScriptCore/bytecode/SetPrivateBrandStatus.h:
* Source/JavaScriptCore/bytecode/SetPrivateBrandVariant.h:
* Source/JavaScriptCore/bytecode/StructureStubClearingWatchpoint.cpp:
* Source/JavaScriptCore/bytecode/StructureStubClearingWatchpoint.h:
* Source/JavaScriptCore/bytecode/StructureStubInfo.h:
* Source/JavaScriptCore/bytecode/UnlinkedCodeBlockGenerator.cpp:
* Source/JavaScriptCore/bytecode/UnlinkedCodeBlockGenerator.h:
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h:
* Source/JavaScriptCore/config.h:
* Source/JavaScriptCore/debugger/Breakpoint.h:
* Source/JavaScriptCore/debugger/Debugger.cpp:
* Source/JavaScriptCore/debugger/Debugger.h:
* Source/JavaScriptCore/dfg/DFGAbstractInterpreter.h:
* Source/JavaScriptCore/dfg/DFGAdaptiveInferredPropertyValueWatchpoint.cpp:
* Source/JavaScriptCore/dfg/DFGAdaptiveInferredPropertyValueWatchpoint.h:
* Source/JavaScriptCore/dfg/DFGArrayifySlowPathGenerator.h:
* Source/JavaScriptCore/dfg/DFGBackwardsCFG.h:
* Source/JavaScriptCore/dfg/DFGBackwardsDominators.h:
* Source/JavaScriptCore/dfg/DFGBasicBlock.cpp:
* Source/JavaScriptCore/dfg/DFGBasicBlock.h:
* Source/JavaScriptCore/dfg/DFGBlockMap.h:
* Source/JavaScriptCore/dfg/DFGCFG.h:
* Source/JavaScriptCore/dfg/DFGCSEPhase.cpp:
* Source/JavaScriptCore/dfg/DFGCallArrayAllocatorSlowPathGenerator.h:
* Source/JavaScriptCore/dfg/DFGCallCreateDirectArgumentsSlowPathGenerator.h:
* Source/JavaScriptCore/dfg/DFGCombinedLiveness.cpp:
* Source/JavaScriptCore/dfg/DFGCombinedLiveness.h:
* Source/JavaScriptCore/dfg/DFGControlEquivalenceAnalysis.h:
* Source/JavaScriptCore/dfg/DFGDisassembler.cpp:
* Source/JavaScriptCore/dfg/DFGDisassembler.h:
* Source/JavaScriptCore/dfg/DFGDominators.h:
* Source/JavaScriptCore/dfg/DFGFailedFinalizer.cpp:
* Source/JavaScriptCore/dfg/DFGFailedFinalizer.h:
* Source/JavaScriptCore/dfg/DFGFinalizer.cpp:
* Source/JavaScriptCore/dfg/DFGFinalizer.h:
* Source/JavaScriptCore/dfg/DFGFlowIndexing.cpp:
* Source/JavaScriptCore/dfg/DFGFlowIndexing.h:
* Source/JavaScriptCore/dfg/DFGFlowMap.h:
* Source/JavaScriptCore/dfg/DFGInPlaceAbstractState.cpp:
* Source/JavaScriptCore/dfg/DFGInPlaceAbstractState.h:
* Source/JavaScriptCore/dfg/DFGJITCompiler.cpp:
* Source/JavaScriptCore/dfg/DFGJITCompiler.h:
* Source/JavaScriptCore/dfg/DFGJITFinalizer.cpp:
* Source/JavaScriptCore/dfg/DFGJITFinalizer.h:
* Source/JavaScriptCore/dfg/DFGNaturalLoops.h:
* Source/JavaScriptCore/dfg/DFGNullAbstractState.h:
* Source/JavaScriptCore/dfg/DFGPhiChildren.cpp:
* Source/JavaScriptCore/dfg/DFGPhiChildren.h:
* Source/JavaScriptCore/dfg/DFGSaneStringGetByValSlowPathGenerator.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/dfg/DFGTZoneImpls.cpp: Copied from Source/JavaScriptCore/dfg/DFGFlowIndexing.cpp.
* Source/JavaScriptCore/dfg/DFGVariableAccessData.h:
* Source/JavaScriptCore/disassembler/ARM64/A64DOpcode.cpp:
* Source/JavaScriptCore/disassembler/ARM64/A64DOpcode.h:
* Source/JavaScriptCore/disassembler/Disassembler.cpp:
* Source/JavaScriptCore/ftl/FTLAbstractHeap.cpp:
* Source/JavaScriptCore/ftl/FTLAbstractHeap.h:
* Source/JavaScriptCore/ftl/FTLJITFinalizer.cpp:
* Source/JavaScriptCore/ftl/FTLJITFinalizer.h:
* Source/JavaScriptCore/ftl/FTLLazySlowPath.cpp:
* Source/JavaScriptCore/ftl/FTLLazySlowPath.h:
* Source/JavaScriptCore/ftl/FTLThunks.cpp:
* Source/JavaScriptCore/ftl/FTLThunks.h:
* Source/JavaScriptCore/heap/AbstractSlotVisitor.h:
* Source/JavaScriptCore/heap/AlignedMemoryAllocator.cpp:
* Source/JavaScriptCore/heap/BlockDirectoryBits.h:
* Source/JavaScriptCore/heap/CodeBlockSet.cpp:
* Source/JavaScriptCore/heap/CodeBlockSet.h:
* Source/JavaScriptCore/heap/GCSegmentedArray.cpp:
* Source/JavaScriptCore/heap/GCSegmentedArray.h:
* Source/JavaScriptCore/heap/HeapCellType.h:
* Source/JavaScriptCore/heap/HeapProfiler.cpp:
* Source/JavaScriptCore/heap/HeapProfiler.h:
* Source/JavaScriptCore/heap/HeapSnapshot.cpp:
* Source/JavaScriptCore/heap/HeapSnapshot.h:
* Source/JavaScriptCore/heap/HeapSnapshotBuilder.cpp:
* Source/JavaScriptCore/heap/HeapSnapshotBuilder.h:
* Source/JavaScriptCore/heap/IsoHeapCellType.cpp:
* Source/JavaScriptCore/heap/IsoHeapCellType.h:
* Source/JavaScriptCore/heap/IsoSubspace.cpp:
* Source/JavaScriptCore/heap/IsoSubspace.h:
* Source/JavaScriptCore/heap/JITStubRoutineSet.cpp:
* Source/JavaScriptCore/heap/JITStubRoutineSet.h:
* Source/JavaScriptCore/heap/MachineStackMarker.cpp:
* Source/JavaScriptCore/heap/MachineStackMarker.h:
* Source/JavaScriptCore/heap/MarkStackMergingConstraint.cpp:
* Source/JavaScriptCore/heap/MarkStackMergingConstraint.h:
* Source/JavaScriptCore/heap/MarkingConstraint.cpp:
* Source/JavaScriptCore/heap/MarkingConstraint.h:
* Source/JavaScriptCore/heap/MarkingConstraintSet.cpp:
* Source/JavaScriptCore/heap/MarkingConstraintSet.h:
* Source/JavaScriptCore/heap/MarkingConstraintSolver.h:
* Source/JavaScriptCore/heap/MutatorScheduler.cpp:
* Source/JavaScriptCore/heap/MutatorScheduler.h:
* Source/JavaScriptCore/heap/SimpleMarkingConstraint.cpp:
* Source/JavaScriptCore/heap/SimpleMarkingConstraint.h:
* Source/JavaScriptCore/heap/SlotVisitor.cpp:
* Source/JavaScriptCore/heap/SlotVisitor.h:
* Source/JavaScriptCore/heap/SpaceTimeMutatorScheduler.cpp:
* Source/JavaScriptCore/heap/SpaceTimeMutatorScheduler.h:
* Source/JavaScriptCore/heap/StochasticSpaceTimeMutatorScheduler.cpp:
* Source/JavaScriptCore/heap/StochasticSpaceTimeMutatorScheduler.h:
* Source/JavaScriptCore/heap/Subspace.cpp:
* Source/JavaScriptCore/heap/Subspace.h:
* Source/JavaScriptCore/heap/SynchronousStopTheWorldMutatorScheduler.cpp:
* Source/JavaScriptCore/heap/SynchronousStopTheWorldMutatorScheduler.h:
* Source/JavaScriptCore/heap/VerifierSlotVisitor.cpp:
* Source/JavaScriptCore/heap/VerifierSlotVisitor.h:
* Source/JavaScriptCore/inspector/ConsoleMessage.cpp:
* Source/JavaScriptCore/inspector/ConsoleMessage.h:
* Source/JavaScriptCore/inspector/InjectedScriptManager.cpp:
* Source/JavaScriptCore/inspector/InjectedScriptManager.h:
* Source/JavaScriptCore/inspector/InspectorAgentBase.h:
* Source/JavaScriptCore/inspector/JSGlobalObjectConsoleClient.cpp:
* Source/JavaScriptCore/inspector/JSGlobalObjectConsoleClient.h:
* Source/JavaScriptCore/inspector/JSGlobalObjectDebugger.cpp:
* Source/JavaScriptCore/inspector/JSGlobalObjectDebugger.h:
* Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.cpp:
* Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.h:
* Source/JavaScriptCore/inspector/JSInjectedScriptHost.cpp:
* Source/JavaScriptCore/inspector/agents/InspectorAgent.cpp:
* Source/JavaScriptCore/inspector/agents/InspectorAgent.h:
* Source/JavaScriptCore/inspector/agents/InspectorAuditAgent.cpp:
* Source/JavaScriptCore/inspector/agents/InspectorAuditAgent.h:
* Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.cpp:
* Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.h:
* Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp:
* Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.h:
* Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.cpp:
* Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.h:
* Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.cpp:
* Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.h:
* Source/JavaScriptCore/inspector/agents/InspectorScriptProfilerAgent.cpp:
* Source/JavaScriptCore/inspector/agents/InspectorScriptProfilerAgent.h:
* Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.cpp:
* Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.h:
* Source/JavaScriptCore/inspector/agents/JSGlobalObjectAuditAgent.cpp:
* Source/JavaScriptCore/inspector/agents/JSGlobalObjectAuditAgent.h:
* Source/JavaScriptCore/inspector/agents/JSGlobalObjectDebuggerAgent.cpp:
* Source/JavaScriptCore/inspector/agents/JSGlobalObjectDebuggerAgent.h:
* Source/JavaScriptCore/inspector/agents/JSGlobalObjectRuntimeAgent.cpp:
* Source/JavaScriptCore/inspector/agents/JSGlobalObjectRuntimeAgent.h:
* Source/JavaScriptCore/interpreter/CheckpointOSRExitSideState.h:
* Source/JavaScriptCore/interpreter/Interpreter.h:
* Source/JavaScriptCore/interpreter/Register.h:
* Source/JavaScriptCore/interpreter/ShadowChicken.cpp:
* Source/JavaScriptCore/interpreter/ShadowChicken.h:
* Source/JavaScriptCore/jit/AssemblyHelpers.cpp:
* Source/JavaScriptCore/jit/AssemblyHelpers.h:
* Source/JavaScriptCore/jit/CCallHelpers.cpp:
* Source/JavaScriptCore/jit/CCallHelpers.h:
* Source/JavaScriptCore/jit/CallFrameShuffleData.cpp:
* Source/JavaScriptCore/jit/CallFrameShuffleData.h:
* Source/JavaScriptCore/jit/CallFrameShuffler.h:
* Source/JavaScriptCore/jit/ExecutableAllocator.cpp:
* Source/JavaScriptCore/jit/ExecutableAllocator.h:
* Source/JavaScriptCore/jit/ICStats.cpp:
* Source/JavaScriptCore/jit/ICStats.h:
* Source/JavaScriptCore/jit/JIT.cpp:
* Source/JavaScriptCore/jit/JIT.h:
* Source/JavaScriptCore/jit/JITCompilation.cpp:
* Source/JavaScriptCore/jit/JITCompilation.h:
* Source/JavaScriptCore/jit/JITDisassembler.cpp:
* Source/JavaScriptCore/jit/JITDisassembler.h:
* Source/JavaScriptCore/jit/JITMathIC.h:
* Source/JavaScriptCore/jit/JITOpaqueByproduct.h:
* Source/JavaScriptCore/jit/JITOpaqueByproducts.cpp:
* Source/JavaScriptCore/jit/JITOpaqueByproducts.h:
* Source/JavaScriptCore/jit/JITSizeStatistics.cpp:
* Source/JavaScriptCore/jit/JITSizeStatistics.h:
* Source/JavaScriptCore/jit/JITTZoneImpls.cpp: Copied from Source/JavaScriptCore/wasm/WasmTag.cpp.
* Source/JavaScriptCore/jit/JITThunks.cpp:
* Source/JavaScriptCore/jit/JITThunks.h:
* Source/JavaScriptCore/jit/JITWorklist.cpp:
* Source/JavaScriptCore/jit/JITWorklist.h:
* Source/JavaScriptCore/jit/JSInterfaceJIT.h:
* Source/JavaScriptCore/jit/PCToCodeOriginMap.cpp:
* Source/JavaScriptCore/jit/PCToCodeOriginMap.h:
* Source/JavaScriptCore/jit/SpecializedThunkJIT.h:
* Source/JavaScriptCore/jsc.cpp:
* Source/JavaScriptCore/llint/LLIntOffsetsExtractor.cpp:
* Source/JavaScriptCore/parser/Lexer.cpp:
* Source/JavaScriptCore/parser/Lexer.h:
* Source/JavaScriptCore/parser/ModuleScopeData.h:
* Source/JavaScriptCore/parser/Parser.cpp:
* Source/JavaScriptCore/parser/Parser.h:
* Source/JavaScriptCore/parser/VariableEnvironment.cpp:
* Source/JavaScriptCore/parser/VariableEnvironment.h:
* Source/JavaScriptCore/profiler/ProfilerDatabase.cpp:
* Source/JavaScriptCore/profiler/ProfilerDatabase.h:
* Source/JavaScriptCore/profiler/ProfilerExecutionCounter.h:
* Source/JavaScriptCore/profiler/ProfilerTZoneImpls.cpp: Copied from Source/JavaScriptCore/wasm/WasmTag.cpp.
* Source/JavaScriptCore/runtime/ArgList.cpp:
* Source/JavaScriptCore/runtime/ArgList.h:
* Source/JavaScriptCore/runtime/ArrayBuffer.h:
* Source/JavaScriptCore/runtime/BasicBlockLocation.cpp:
* Source/JavaScriptCore/runtime/BasicBlockLocation.h:
* Source/JavaScriptCore/runtime/BufferMemoryHandle.cpp:
* Source/JavaScriptCore/runtime/BufferMemoryHandle.h:
* Source/JavaScriptCore/runtime/CodeCache.cpp:
* Source/JavaScriptCore/runtime/CodeCache.h:
* Source/JavaScriptCore/runtime/CommonIdentifiers.cpp:
* Source/JavaScriptCore/runtime/CommonIdentifiers.h:
* Source/JavaScriptCore/runtime/ControlFlowProfiler.cpp:
* Source/JavaScriptCore/runtime/ControlFlowProfiler.h:
* Source/JavaScriptCore/runtime/DOMAnnotation.h:
* Source/JavaScriptCore/runtime/DeferredWorkTimer.cpp:
* Source/JavaScriptCore/runtime/DeferredWorkTimer.h:
* Source/JavaScriptCore/runtime/DoublePredictionFuzzerAgent.cpp:
* Source/JavaScriptCore/runtime/DoublePredictionFuzzerAgent.h:
* Source/JavaScriptCore/runtime/FileBasedFuzzerAgent.cpp:
* Source/JavaScriptCore/runtime/FileBasedFuzzerAgent.h:
* Source/JavaScriptCore/runtime/FileBasedFuzzerAgentBase.h:
* Source/JavaScriptCore/runtime/GenericOffset.h:
* Source/JavaScriptCore/runtime/ISO8601.h:
* Source/JavaScriptCore/runtime/IntlCache.cpp:
* Source/JavaScriptCore/runtime/IntlCache.h:
* Source/JavaScriptCore/runtime/IntlNumberFormat.h:
* Source/JavaScriptCore/runtime/JSDateMath.cpp:
* Source/JavaScriptCore/runtime/JSDateMath.h:
* Source/JavaScriptCore/runtime/JSDestructibleObjectHeapCellType.cpp:
* Source/JavaScriptCore/runtime/JSDestructibleObjectHeapCellType.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
(JSC::JSGlobalObject::customGetterFunctionSet):
(JSC::JSGlobalObject::customSetterFunctionSet):
* Source/JavaScriptCore/runtime/JSGlobalObjectDebuggable.cpp:
* Source/JavaScriptCore/runtime/JSGlobalObjectDebuggable.h:
* Source/JavaScriptCore/runtime/JSRunLoopTimer.cpp:
* Source/JavaScriptCore/runtime/JSRunLoopTimer.h:
* Source/JavaScriptCore/runtime/MegamorphicCache.cpp:
* Source/JavaScriptCore/runtime/MegamorphicCache.h:
* Source/JavaScriptCore/runtime/NarrowingNumberPredictionFuzzerAgent.cpp:
* Source/JavaScriptCore/runtime/NarrowingNumberPredictionFuzzerAgent.h:
* Source/JavaScriptCore/runtime/NativeCallee.h:
* Source/JavaScriptCore/runtime/NativeCalleeRegistry.h:
* Source/JavaScriptCore/runtime/ObjectPropertyChangeAdaptiveWatchpoint.h:
* Source/JavaScriptCore/runtime/Options.cpp:
* Source/JavaScriptCore/runtime/PredictionFileCreatingFuzzerAgent.cpp:
* Source/JavaScriptCore/runtime/PredictionFileCreatingFuzzerAgent.h:
* Source/JavaScriptCore/runtime/PropertyDescriptor.cpp:
* Source/JavaScriptCore/runtime/RandomizingFuzzerAgent.cpp:
* Source/JavaScriptCore/runtime/RandomizingFuzzerAgent.h:
* Source/JavaScriptCore/runtime/RegExpCache.cpp:
* Source/JavaScriptCore/runtime/RegExpCache.h:
* Source/JavaScriptCore/runtime/RuntimeTZoneImpls.cpp: Copied from Source/JavaScriptCore/heap/IsoHeapCellType.cpp.
* Source/JavaScriptCore/runtime/SamplingProfiler.cpp:
* Source/JavaScriptCore/runtime/SamplingProfiler.h:
* Source/JavaScriptCore/runtime/SparseArrayValueMap.h:
* Source/JavaScriptCore/runtime/StringReplaceCache.h:
* Source/JavaScriptCore/runtime/StringSplitCache.h:
* Source/JavaScriptCore/runtime/StructureRareData.cpp:
* Source/JavaScriptCore/runtime/TypeProfiler.cpp:
* Source/JavaScriptCore/runtime/TypeProfiler.h:
* Source/JavaScriptCore/runtime/TypeProfilerLog.cpp:
* Source/JavaScriptCore/runtime/TypeProfilerLog.h:
* Source/JavaScriptCore/runtime/VM.h:
* Source/JavaScriptCore/runtime/WaiterListManager.cpp:
* Source/JavaScriptCore/runtime/WaiterListManager.h:
* Source/JavaScriptCore/runtime/Watchdog.cpp:
* Source/JavaScriptCore/runtime/Watchdog.h:
* Source/JavaScriptCore/runtime/WeakGCSet.h:
* Source/JavaScriptCore/runtime/WideningNumberPredictionFuzzerAgent.cpp:
* Source/JavaScriptCore/runtime/WideningNumberPredictionFuzzerAgent.h:
* Source/JavaScriptCore/runtime/WriteBarrier.h:
* Source/JavaScriptCore/tools/CellList.h:
* Source/JavaScriptCore/tools/CompilerTimingScope.cpp:
* Source/JavaScriptCore/tools/HeapVerifier.cpp:
* Source/JavaScriptCore/tools/HeapVerifier.h:
* Source/JavaScriptCore/tools/JSDollarVM.cpp:
* Source/JavaScriptCore/tools/VMInspector.cpp:
* Source/JavaScriptCore/tools/VMInspector.h:
* Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp:
* Source/JavaScriptCore/wasm/WasmBBQDisassembler.cpp:
* Source/JavaScriptCore/wasm/WasmBBQDisassembler.h:
* Source/JavaScriptCore/wasm/WasmCallee.cpp:
* Source/JavaScriptCore/wasm/WasmCallee.h:
* Source/JavaScriptCore/wasm/WasmFormat.h:
* Source/JavaScriptCore/wasm/WasmFunctionCodeBlockGenerator.cpp:
* Source/JavaScriptCore/wasm/WasmFunctionCodeBlockGenerator.h:
* Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.cpp:
* Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h:
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
* Source/JavaScriptCore/wasm/WasmGlobal.cpp:
* Source/JavaScriptCore/wasm/WasmGlobal.h:
* Source/JavaScriptCore/wasm/WasmMemory.cpp:
(): Deleted.
* Source/JavaScriptCore/wasm/WasmMemory.h:
* Source/JavaScriptCore/wasm/WasmOSREntryData.h:
* Source/JavaScriptCore/wasm/WasmStreamingParser.h:
* Source/JavaScriptCore/wasm/WasmTZoneImpls.cpp: Copied from Source/JavaScriptCore/wasm/WasmTag.cpp.
* Source/JavaScriptCore/wasm/WasmTable.cpp:
* Source/JavaScriptCore/wasm/WasmTable.h:
* Source/JavaScriptCore/wasm/WasmTag.cpp:
* Source/JavaScriptCore/wasm/WasmTag.h:
* Source/JavaScriptCore/wasm/WasmThunks.cpp:
* Source/JavaScriptCore/wasm/WasmThunks.h:
* Source/JavaScriptCore/wasm/WasmTierUpCount.cpp:
* Source/JavaScriptCore/wasm/WasmTierUpCount.h:
* Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp:
(JSC::Wasm::TypeDefinition::tryCreateFunctionSignature):
(JSC::Wasm::TypeDefinition::tryCreateStructType):
(JSC::Wasm::TypeDefinition::tryCreateArrayType):
(JSC::Wasm::TypeDefinition::tryCreateRecursionGroup):
(JSC::Wasm::TypeDefinition::tryCreateProjection):
(JSC::Wasm::TypeDefinition::tryCreateSubtype):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.h:
* Source/JavaScriptCore/wasm/WasmValueLocation.h:
* Source/JavaScriptCore/wasm/WasmWorklist.cpp:
* Source/JavaScriptCore/wasm/WasmWorklist.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp:
* Source/JavaScriptCore/yarr/RegularExpression.cpp:
* Source/JavaScriptCore/yarr/RegularExpression.h:
* Source/JavaScriptCore/yarr/YarrDisassembler.cpp:
* Source/JavaScriptCore/yarr/YarrDisassembler.h:
* Source/JavaScriptCore/yarr/YarrInterpreter.cpp:
* Source/JavaScriptCore/yarr/YarrInterpreter.h:
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
* Source/JavaScriptCore/yarr/YarrJIT.h:
* Source/JavaScriptCore/yarr/YarrPattern.h:
* Source/JavaScriptCore/yarr/YarrTZoneImpls.cpp: Copied from Source/JavaScriptCore/wasm/WasmTag.cpp.
* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/PlatformUse.h:
* Source/WTF/wtf/TZoneMalloc.h: Copied from Source/JavaScriptCore/jit/JITSizeStatistics.h.
* Source/WTF/wtf/TZoneMallocInlines.h: Copied from Source/JavaScriptCore/runtime/StringSplitCache.h.
* Source/bmalloc/bmalloc.xcodeproj/project.pbxproj:
* Source/bmalloc/bmalloc/TZoneHeap.cpp: Copied from Source/JavaScriptCore/runtime/StringReplaceCache.h.
(bmalloc::api::tzoneAllocate):
(bmalloc::api::tzoneTryAllocate):
(bmalloc::api::tzoneDeallocate):
* Source/bmalloc/bmalloc/TZoneHeap.h: Added.
(bmalloc::api::TZoneHeap::TZoneHeap):
(bmalloc::api::TZoneHeap::allocate):
(bmalloc::api::TZoneHeap::tryAllocate):
(bmalloc::api::TZoneHeap::deallocate):
(bmalloc::api::TZoneHeap::scavenge):
(bmalloc::api::TZoneHeap::initialize):
(bmalloc::api::TZoneHeap::isInitialized):
(bmalloc::api::TZoneHeap::provideHeap):
(bmalloc::api::TZoneHeap::allocatorOffset):
(bmalloc::api::TZoneHeap::setAllocatorOffset):
(bmalloc::api::TZoneHeap::deallocatorOffset):
(bmalloc::api::TZoneHeap::setDeallocatorOffset):
* Source/bmalloc/bmalloc/TZoneHeapInlines.h: Added.
(bmalloc::api::IsoHeap&lt;Type&gt;::TZoneHeap):
(bmalloc::api::TZoneHeap&lt;Type&gt;::allocate):
(bmalloc::api::TZoneHeap&lt;Type&gt;::tryAllocate):
(bmalloc::api::TZoneHeap&lt;Type&gt;::deallocate):
(bmalloc::api::TZoneHeap&lt;Type&gt;::scavenge):
(bmalloc::api::TZoneHeap&lt;Type&gt;::isInitialized):
(bmalloc::api::TZoneHeap&lt;Type&gt;::initialize):
(bmalloc::api::TZoneHeap&lt;Type&gt;::impl):

Canonical link: <a href="https://commits.webkit.org/271904@main">https://commits.webkit.org/271904@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca36dbd05d14b60b94aa02948dea9c6d54401965

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29973 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8639 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31291 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32483 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27102 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30633 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10828 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5893 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27148 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30267 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7246 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25576 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6182 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6345 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26665 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33819 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/25748 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27341 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27097 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32525 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/30142 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6286 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4457 "Found 1 new test failure: imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback-webrtc.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30321 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8024 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/36539 "Built successfully") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/7109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7029 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7883 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3874 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6813 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->