### PR TITLE
[UnifiedPDF] Make PDFPluginAnnotations agnostic of plugin implementation.

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
@@ -84,10 +84,9 @@ public:
     static Ref<PDFPlugin> create(WebCore::HTMLPlugInElement&);
     virtual ~PDFPlugin() = default;
 
-    void didMutatePDFDocument() { m_pdfDocumentWasMutated = true; }
 
     void paintControlForLayerInContext(CALayer *, CGContextRef);
-    void setActiveAnnotation(PDFAnnotation *);
+    void setActiveAnnotation(RetainPtr<PDFAnnotation>&&) final;
 
     void notifyContentScaleFactorChanged(CGFloat scaleFactor);
     void notifyDisplayModeChanged(int);
@@ -109,10 +108,11 @@ public:
     void performWebSearch(NSString *);
     void performSpotlightSearch(NSString *);
 
-    void focusNextAnnotation();
-    void focusPreviousAnnotation();
+    CGRect boundsForAnnotation(RetainPtr<PDFAnnotation>&) const final;
+    void focusNextAnnotation() final;
+    void focusPreviousAnnotation() final;
 
-    void attemptToUnlockPDF(const String& password);
+    void attemptToUnlockPDF(const String& password) final;
 
     bool showContextMenuAtPoint(const WebCore::IntPoint&);
 
@@ -138,6 +138,9 @@ public:
     WebCore::IntPoint convertFromRootViewToPDFView(const WebCore::IntPoint&) const;
     WebCore::FloatRect convertFromPDFViewToScreen(const WebCore::FloatRect&) const;
 
+    CGFloat scaleFactor() const override;
+    CGSize contentSizeRespectingZoom() const final;
+
 private:
     explicit PDFPlugin(WebCore::HTMLPlugInElement&);
     bool isLegacyPDFPlugin() const override { return true; }
@@ -162,7 +165,6 @@ private:
 
     void installPDFDocument() override;
 
-    CGFloat scaleFactor() const override;
 
     RetainPtr<PDFDocument> pdfDocumentForPrinting() const override { return m_pdfDocument; }
     WebCore::FloatSize pdfDocumentSizeForPrinting() const override;
@@ -210,15 +212,11 @@ private:
 
     NSEvent *nsEventForWebMouseEvent(const WebMouseEvent&);
 
-    bool supportsForms();
-
     void updatePageAndDeviceScaleFactors();
 
     void createPasswordEntryForm();
 
     NSData *liveData() const;
-
-    bool m_pdfDocumentWasMutated { false };
 
     RetainPtr<CALayer> m_containerLayer;
     RetainPtr<CALayer> m_contentLayer;
@@ -228,9 +226,7 @@ private:
     RetainPtr<PDFLayerController> m_pdfLayerController;
     RetainPtr<WKPDFPluginAccessibilityObject> m_accessibilityObject;
     
-    RefPtr<PDFPluginAnnotation> m_activeAnnotation;
     RefPtr<PDFPluginPasswordField> m_passwordField;
-    RefPtr<WebCore::Element> m_annotationContainer;
 
     std::optional<WebMouseEvent> m_lastMouseEvent;
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.h
@@ -47,12 +47,12 @@ class PDFPlugin;
 
 class PDFPluginAnnotation : public RefCounted<PDFPluginAnnotation> {
 public:
-    static RefPtr<PDFPluginAnnotation> create(PDFAnnotation *, PDFLayerController *, PDFPlugin*);
+    static RefPtr<PDFPluginAnnotation> create(PDFAnnotation *, PDFPluginBase*);
     virtual ~PDFPluginAnnotation();
 
     WebCore::Element* element() const { return m_element.get(); }
     PDFAnnotation *annotation() const { return m_annotation.get(); }
-    PDFPlugin* plugin() const { return m_plugin; }
+    PDFPluginBase* plugin() const { return m_plugin.get(); }
 
     virtual void updateGeometry();
     virtual void commit();
@@ -60,16 +60,14 @@ public:
     void attach(WebCore::Element*);
 
 protected:
-    PDFPluginAnnotation(PDFAnnotation *annotation, PDFLayerController *pdfLayerController, PDFPlugin* plugin)
+    PDFPluginAnnotation(PDFAnnotation *annotation, PDFPluginBase* plugin)
         : m_annotation(annotation)
         , m_eventListener(PDFPluginAnnotationEventListener::create(this))
-        , m_pdfLayerController(pdfLayerController)
         , m_plugin(plugin)
     {
     }
 
     WebCore::Element* parent() const { return m_parent.get(); }
-    PDFLayerController *pdfLayerController() const { return m_pdfLayerController; }
     WebCore::EventListener* eventListener() const { return m_eventListener.get(); }
 
     virtual bool handleEvent(WebCore::Event&);
@@ -106,8 +104,7 @@ private:
 
     RefPtr<PDFPluginAnnotationEventListener> m_eventListener;
 
-    PDFLayerController *m_pdfLayerController;
-    PDFPlugin* m_plugin;
+    RefPtr<PDFPluginBase> m_plugin;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.mm
@@ -28,9 +28,8 @@
 
 #if ENABLE(LEGACY_PDFKIT_PLUGIN)
 
-#import "PDFKitSoftLink.h"
 #import "PDFLayerControllerSPI.h"
-#import "PDFPlugin.h"
+#import "PDFPluginBase.h"
 #import "PDFPluginChoiceAnnotation.h"
 #import "PDFPluginTextAnnotation.h"
 #import <Quartz/Quartz.h>
@@ -48,16 +47,18 @@
 #import <WebCore/HTMLTextAreaElement.h>
 #import <WebCore/Page.h>
 
+#import "PDFKitSoftLink.h"
+
 namespace WebKit {
 using namespace WebCore;
 using namespace HTMLNames;
 
-RefPtr<PDFPluginAnnotation> PDFPluginAnnotation::create(PDFAnnotation *annotation, PDFLayerController *pdfLayerController, PDFPlugin* plugin)
+RefPtr<PDFPluginAnnotation> PDFPluginAnnotation::create(PDFAnnotation *annotation, PDFPluginBase* plugin)
 {
     if ([annotation isKindOfClass:getPDFAnnotationTextWidgetClass()])
-        return PDFPluginTextAnnotation::create(annotation, pdfLayerController, plugin);
+        return PDFPluginTextAnnotation::create(annotation, plugin);
     if ([annotation isKindOfClass:getPDFAnnotationChoiceWidgetClass()])
-        return PDFPluginChoiceAnnotation::create(annotation, pdfLayerController, plugin);
+        return PDFPluginChoiceAnnotation::create(annotation, plugin);
 
     return nullptr;
 }
@@ -103,13 +104,13 @@ PDFPluginAnnotation::~PDFPluginAnnotation()
 
 void PDFPluginAnnotation::updateGeometry()
 {
-    IntSize documentSize(m_pdfLayerController.contentSizeRespectingZoom);
-    NSRect annotationRect = NSRectFromCGRect([m_pdfLayerController boundsForAnnotation:m_annotation.get()]);
+    IntSize documentSize(m_plugin->contentSizeRespectingZoom());
+    NSRect annotationRect = NSRectFromCGRect(m_plugin->boundsForAnnotation(m_annotation));
 
     StyledElement* styledElement = static_cast<StyledElement*>(element());
     styledElement->setInlineStyleProperty(CSSPropertyWidth, annotationRect.size.width, CSSUnitType::CSS_PX);
     styledElement->setInlineStyleProperty(CSSPropertyHeight, annotationRect.size.height, CSSUnitType::CSS_PX);
-    IntPoint scrollPosition(m_pdfLayerController.scrollPosition);
+    IntPoint scrollPosition(m_plugin->scrollPosition());
     styledElement->setInlineStyleProperty(CSSPropertyLeft, annotationRect.origin.x - scrollPosition.x(), CSSUnitType::CSS_PX);
     styledElement->setInlineStyleProperty(CSSPropertyTop, documentSize.height() - annotationRect.origin.y - annotationRect.size.height - scrollPosition.y(), CSSUnitType::CSS_PX);
 }

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -608,6 +608,12 @@ void PDFPluginBase::notifyCursorChanged(WebCore::PlatformCursorType cursorType)
     m_frame->protectedPage()->send(Messages::WebPageProxy::SetCursor(WebCore::Cursor::fromType(cursorType)));
 }
 
+bool PDFPluginBase::supportsForms()
+{
+    // FIXME: We support forms for full-main-frame and <iframe> PDFs, but not <embed> or <object>, because those cases do not have their own Document into which to inject form elements.
+    return isFullFramePlugin();
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(PDF_PLUGIN)

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginChoiceAnnotation.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginChoiceAnnotation.h
@@ -39,14 +39,14 @@ namespace WebKit {
 
 class PDFPluginChoiceAnnotation : public PDFPluginAnnotation {
 public:
-    static Ref<PDFPluginChoiceAnnotation> create(PDFAnnotation *, PDFLayerController *, PDFPlugin*);
+    static Ref<PDFPluginChoiceAnnotation> create(PDFAnnotation *, PDFPluginBase*);
 
     void updateGeometry() override;
     void commit() override;
 
 private:
-    PDFPluginChoiceAnnotation(PDFAnnotation *annotation, PDFLayerController *pdfLayerController, PDFPlugin* plugin)
-        : PDFPluginAnnotation(annotation, pdfLayerController, plugin)
+    PDFPluginChoiceAnnotation(PDFAnnotation *annotation, PDFPluginBase* plugin)
+        : PDFPluginAnnotation(annotation, plugin)
     {
     }
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginChoiceAnnotation.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginChoiceAnnotation.mm
@@ -28,7 +28,6 @@
 #import "config.h"
 #import "PDFPluginChoiceAnnotation.h"
 
-#import "PDFLayerControllerSPI.h"
 #import <WebCore/CSSPrimitiveValue.h>
 #import <WebCore/CSSPropertyNames.h>
 #import <WebCore/ColorMac.h>
@@ -43,9 +42,9 @@ namespace WebKit {
 using namespace WebCore;
 using namespace HTMLNames;
 
-Ref<PDFPluginChoiceAnnotation> PDFPluginChoiceAnnotation::create(PDFAnnotation *annotation, PDFLayerController *pdfLayerController, PDFPlugin* plugin)
+Ref<PDFPluginChoiceAnnotation> PDFPluginChoiceAnnotation::create(PDFAnnotation *annotation, PDFPluginBase* plugin)
 {
-    return adoptRef(*new PDFPluginChoiceAnnotation(annotation, pdfLayerController, plugin));
+    return adoptRef(*new PDFPluginChoiceAnnotation(annotation, plugin));
 }
 
 void PDFPluginChoiceAnnotation::updateGeometry()
@@ -53,7 +52,7 @@ void PDFPluginChoiceAnnotation::updateGeometry()
     PDFPluginAnnotation::updateGeometry();
 
     RefPtr styledElement = downcast<StyledElement>(element());
-    styledElement->setInlineStyleProperty(CSSPropertyFontSize, choiceAnnotation().font.pointSize * pdfLayerController().contentScaleFactor, CSSUnitType::CSS_PX);
+    styledElement->setInlineStyleProperty(CSSPropertyFontSize, choiceAnnotation().font.pointSize * plugin()->scaleFactor(), CSSUnitType::CSS_PX);
 }
 
 void PDFPluginChoiceAnnotation::commit()

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginPasswordField.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginPasswordField.h
@@ -34,14 +34,14 @@ namespace WebKit {
 
 class PDFPluginPasswordField : public PDFPluginTextAnnotation {
 public:
-    static Ref<PDFPluginPasswordField> create(PDFLayerController *, PDFPlugin*);
+    static Ref<PDFPluginPasswordField> create(PDFPluginBase*);
     virtual ~PDFPluginPasswordField();
 
     void updateGeometry() override;
 
 private:
-    PDFPluginPasswordField(PDFLayerController *pdfLayerController, PDFPlugin* plugin)
-        : PDFPluginTextAnnotation(0, pdfLayerController, plugin)
+    PDFPluginPasswordField(PDFPluginBase* plugin)
+        : PDFPluginTextAnnotation(0, plugin)
     {
     }
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginPasswordField.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginPasswordField.mm
@@ -41,9 +41,9 @@ namespace WebKit {
 using namespace WebCore;
 using namespace HTMLNames;
 
-Ref<PDFPluginPasswordField> PDFPluginPasswordField::create(PDFLayerController *pdfLayerController, PDFPlugin* plugin)
+Ref<PDFPluginPasswordField> PDFPluginPasswordField::create(PDFPluginBase* plugin)
 {
-    return adoptRef(*new PDFPluginPasswordField(pdfLayerController, plugin));
+    return adoptRef(*new PDFPluginPasswordField(plugin));
 }
 
 PDFPluginPasswordField::~PDFPluginPasswordField()

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginTextAnnotation.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginTextAnnotation.h
@@ -42,15 +42,15 @@ namespace WebKit {
 
 class PDFPluginTextAnnotation : public PDFPluginAnnotation {
 public:
-    static Ref<PDFPluginTextAnnotation> create(PDFAnnotation *, PDFLayerController *, PDFPlugin*);
+    static Ref<PDFPluginTextAnnotation> create(PDFAnnotation *, PDFPluginBase*);
     virtual ~PDFPluginTextAnnotation();
 
     void updateGeometry() override;
     void commit() override;
 
 protected:
-    PDFPluginTextAnnotation(PDFAnnotation *annotation, PDFLayerController *pdfLayerController, PDFPlugin* plugin)
-        : PDFPluginAnnotation(annotation, pdfLayerController, plugin)
+    PDFPluginTextAnnotation(PDFAnnotation *annotation, PDFPluginBase* plugin)
+        : PDFPluginAnnotation(annotation, plugin)
     {
     }
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginTextAnnotation.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginTextAnnotation.mm
@@ -68,9 +68,9 @@ static const String cssAlignmentValueForNSTextAlignment(NSTextAlignment alignmen
     return String();
 }
 
-Ref<PDFPluginTextAnnotation> PDFPluginTextAnnotation::create(PDFAnnotation *annotation, PDFLayerController *pdfLayerController, PDFPlugin* plugin)
+Ref<PDFPluginTextAnnotation> PDFPluginTextAnnotation::create(PDFAnnotation *annotation, PDFPluginBase* plugin)
 {
-    return adoptRef(*new PDFPluginTextAnnotation(annotation, pdfLayerController, plugin));
+    return adoptRef(*new PDFPluginTextAnnotation(annotation, plugin));
 }
 
 PDFPluginTextAnnotation::~PDFPluginTextAnnotation()
@@ -112,7 +112,7 @@ void PDFPluginTextAnnotation::updateGeometry()
     PDFPluginAnnotation::updateGeometry();
 
     StyledElement* styledElement = static_cast<StyledElement*>(element());
-    styledElement->setInlineStyleProperty(CSSPropertyFontSize, textAnnotation().font.pointSize * pdfLayerController().contentScaleFactor, CSSUnitType::CSS_PX);
+    styledElement->setInlineStyleProperty(CSSPropertyFontSize, textAnnotation().font.pointSize * plugin()->scaleFactor(), CSSUnitType::CSS_PX);
 }
 
 void PDFPluginTextAnnotation::commit()

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -59,6 +59,12 @@ public:
     };
     using PDFElementTypes = OptionSet<PDFElementType>;
 
+    CGRect boundsForAnnotation(RetainPtr<PDFAnnotation>&) const final;
+    void setActiveAnnotation(RetainPtr<PDFAnnotation>&&) final;
+    void focusNextAnnotation() final;
+    void focusPreviousAnnotation() final;
+
+    void attemptToUnlockPDF(const String& password) final;
 private:
     explicit UnifiedPDFPlugin(WebCore::HTMLPlugInElement&);
     bool isUnifiedPDFPlugin() const override { return true; }
@@ -71,6 +77,7 @@ private:
     void installPDFDocument() override;
 
     CGFloat scaleFactor() const override;
+    CGSize contentSizeRespectingZoom() const final;
 
     void didBeginMagnificationGesture() override;
     void didEndMagnificationGesture() override;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -364,6 +364,11 @@ CGFloat UnifiedPDFPlugin::scaleFactor() const
     return m_scaleFactor;
 }
 
+CGSize UnifiedPDFPlugin::contentSizeRespectingZoom() const
+{
+    return { };
+}
+
 float UnifiedPDFPlugin::deviceScaleFactor() const
 {
     return PDFPluginBase::deviceScaleFactor();
@@ -1063,6 +1068,27 @@ void UnifiedPDFPlugin::openWithPreview(CompletionHandler<void(const String&, Fra
 }
 
 #endif // ENABLE(PDF_HUD)
+
+CGRect UnifiedPDFPlugin::boundsForAnnotation(RetainPtr<PDFAnnotation>& annotation) const
+{
+    return { };
+}
+
+void UnifiedPDFPlugin::focusNextAnnotation()
+{
+}
+
+void UnifiedPDFPlugin::focusPreviousAnnotation()
+{
+}
+
+void UnifiedPDFPlugin::setActiveAnnotation(RetainPtr<PDFAnnotation>&& annotation)
+{
+}
+
+void UnifiedPDFPlugin::attemptToUnlockPDF(const String& password)
+{
+}
 
 bool UnifiedPDFPlugin::isTaggedPDF() const
 {


### PR DESCRIPTION
#### a41c12c7f45ac004a807697b084279562ac41f6f
<pre>
[UnifiedPDF] Make PDFPluginAnnotations agnostic of plugin implementation.
<a href="https://bugs.webkit.org/show_bug.cgi?id=266097">https://bugs.webkit.org/show_bug.cgi?id=266097</a>
<a href="https://rdar.apple.com/problem/119397505">rdar://problem/119397505</a>

Reviewed by Simon Fraser.

Currently PDFPluginAnnotations depends on the PDFLayerController to
interact with the PDF. In order to get the UnifiedPDFPlugin working
with annotations, the plugin annotations need to move away from this
dependence and instead use an API that is agnostic of the underlying
plugin implementation.

This requires two main things:
1.) PDFPluginAnnotations should no longer hold onto a PDFLayerController
2.) They should hold onto a PDFPluginBase instead of a PDFPlugin

Any PDFPlugin API that was used by the plugin annotations needs to be
moved over to PDFPluginBase as virtual functions. Similarly, any
functionality from the PDFLayerController that was used should be
exposed in the same way.

* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(WebKit::PDFPlugin::createPasswordEntryForm):
(WebKit::PDFPlugin::setActiveAnnotation):
(WebKit::PDFPlugin::boundsForAnnotation const):
(WebKit::PDFPlugin::contentSizeRespectingZoom const):
(WebKit::PDFPlugin::supportsForms): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.h:
(WebKit::PDFPluginAnnotation::plugin const):
(WebKit::PDFPluginAnnotation::PDFPluginAnnotation):
(WebKit::PDFPluginAnnotation::parent const):
(WebKit::PDFPluginAnnotation::pdfLayerController const): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.mm:
(WebKit::PDFPluginAnnotation::create):
(WebKit::PDFPluginAnnotation::updateGeometry):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
(WebKit::PDFPluginBase::didMutatePDFDocument):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::supportsForms):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginChoiceAnnotation.h:
(WebKit::PDFPluginChoiceAnnotation::PDFPluginChoiceAnnotation):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginChoiceAnnotation.mm:
(WebKit::PDFPluginChoiceAnnotation::create):
(WebKit::PDFPluginChoiceAnnotation::updateGeometry):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginPasswordField.h:
(WebKit::PDFPluginPasswordField::PDFPluginPasswordField):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginPasswordField.mm:
(WebKit::PDFPluginPasswordField::create):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginTextAnnotation.h:
(WebKit::PDFPluginTextAnnotation::PDFPluginTextAnnotation):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginTextAnnotation.mm:
(WebKit::PDFPluginTextAnnotation::create):
(WebKit::PDFPluginTextAnnotation::updateGeometry):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::contentSizeRespectingZoom const):
(WebKit::UnifiedPDFPlugin::boundsForAnnotation const):
(WebKit::UnifiedPDFPlugin::focusNextAnnotation):
(WebKit::UnifiedPDFPlugin::focusPreviousAnnotation):
(WebKit::UnifiedPDFPlugin::setActiveAnnotation):
(WebKit::UnifiedPDFPlugin::attemptToUnlockPDF):

Canonical link: <a href="https://commits.webkit.org/273241@main">https://commits.webkit.org/273241@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d0400feb0e66c55ce6e8126eb8fffe4238806365

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34256 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13067 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36250 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36944 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31031 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15453 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10193 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30053 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34768 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11064 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9662 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9763 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38235 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31129 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30925 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35843 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9887 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7753 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33767 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11679 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7990 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10446 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10712 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->