### PR TITLE
Reduce necessary bits in some compact pointer encodings

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_enumerate_segregated_heaps.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_enumerate_segregated_heaps.c
@@ -674,7 +674,7 @@ bool pas_enumerate_segregated_heaps(pas_enumerator* enumerator)
 
         for (index = PAS_DEALLOCATION_LOG_SIZE; index--;) {
             uintptr_t object =
-                tlc->deallocation_log[index] >> PAS_SEGREGATED_PAGE_CONFIG_KIND_AND_ROLE_NUM_BITS;
+                tlc->deallocation_log[index] & ~PAS_SEGREGATED_PAGE_CONFIG_KIND_AND_ROLE_MASK;
             if (object) {
                 pas_ptr_hash_set_set(
                     &context.objects_in_deallocation_log, (void*)object,

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_page_config_kind_and_role.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_page_config_kind_and_role.h
@@ -41,17 +41,18 @@ enum pas_segregated_page_config_kind_and_role {
 
 typedef enum pas_segregated_page_config_kind_and_role pas_segregated_page_config_kind_and_role;
 
-#define PAS_SEGREGATED_PAGE_CONFIG_KIND_AND_ROLE_NUM_BITS 6u
+#define PAS_SEGREGATED_PAGE_CONFIG_KIND_AND_ROLE_NUM_BITS 6ull
+#define PAS_SEGREGATED_PAGE_CONFIG_KIND_AND_ROLE_SHIFT 48ull
 #define PAS_SEGREGATED_PAGE_CONFIG_KIND_AND_ROLE_MASK \
-    ((1u << PAS_SEGREGATED_PAGE_CONFIG_KIND_AND_ROLE_NUM_BITS) - 1u)
+    (((1u << PAS_SEGREGATED_PAGE_CONFIG_KIND_AND_ROLE_NUM_BITS) - 1ull) << PAS_SEGREGATED_PAGE_CONFIG_KIND_AND_ROLE_SHIFT)
 
 #if PAS_COMPILER(CLANG)
 #define PAS_DEFINE_SEGREGATED_PAGE_CONFIG_KIND(name, value) \
     _Static_assert(pas_segregated_page_config_kind_ ## name ## _and_shared_role \
-                   <= PAS_SEGREGATED_PAGE_CONFIG_KIND_AND_ROLE_MASK, \
+                   < (1u << PAS_SEGREGATED_PAGE_CONFIG_KIND_AND_ROLE_NUM_BITS), \
                    "Kind-and-role doesn't fit in kind-and-role bits"); \
     _Static_assert(pas_segregated_page_config_kind_ ## name ## _and_exclusive_role \
-                   <= PAS_SEGREGATED_PAGE_CONFIG_KIND_AND_ROLE_MASK, \
+                   < (1u << PAS_SEGREGATED_PAGE_CONFIG_KIND_AND_ROLE_NUM_BITS), \
                    "Kind-and-role doesn't fit in kind-and-role bits");
 #include "pas_segregated_page_config_kind.def"
 #undef PAS_DEFINE_SEGREGATED_PAGE_CONFIG_KIND

--- a/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.c
@@ -667,7 +667,7 @@ process_deallocation_log_with_config(pas_thread_local_cache* cache,
 
     for (;;) {
         uintptr_t begin;
-        begin = encoded_begin >> PAS_SEGREGATED_PAGE_CONFIG_KIND_AND_ROLE_NUM_BITS;
+        begin = encoded_begin & ~PAS_SEGREGATED_PAGE_CONFIG_KIND_AND_ROLE_MASK;
 
         switch (page_config.kind) {
         case pas_segregated_page_config_kind_null:
@@ -693,7 +693,7 @@ process_deallocation_log_with_config(pas_thread_local_cache* cache,
             return;
 
         encoded_begin = cache->deallocation_log[--*index];
-        if (PAS_UNLIKELY((encoded_begin & PAS_SEGREGATED_PAGE_CONFIG_KIND_AND_ROLE_MASK)
+        if (PAS_UNLIKELY((encoded_begin & PAS_SEGREGATED_PAGE_CONFIG_KIND_AND_ROLE_MASK) >> PAS_SEGREGATED_PAGE_CONFIG_KIND_AND_ROLE_SHIFT
             != pas_segregated_page_config_kind_and_role_create(page_config.kind, role))) {
             ++*index;
             return;
@@ -719,7 +719,7 @@ static PAS_ALWAYS_INLINE void flush_deallocation_log_without_resetting(
         encoded_begin = thread_local_cache->deallocation_log[--index];
 
         switch ((pas_segregated_page_config_kind_and_role)
-                (encoded_begin & PAS_SEGREGATED_PAGE_CONFIG_KIND_AND_ROLE_MASK)) {
+                ((encoded_begin & PAS_SEGREGATED_PAGE_CONFIG_KIND_AND_ROLE_MASK) >> PAS_SEGREGATED_PAGE_CONFIG_KIND_AND_ROLE_SHIFT)) {
 #define PAS_DEFINE_SEGREGATED_PAGE_CONFIG_KIND(name, value) \
         case pas_segregated_page_config_kind_ ## name ## _and_shared_role: \
             process_deallocation_log_with_config( \

--- a/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.h
@@ -383,7 +383,7 @@ static PAS_ALWAYS_INLINE uintptr_t pas_thread_local_cache_encode_object(
     uintptr_t begin,
     pas_segregated_page_config_kind_and_role kind_and_role)
 {
-    return (begin << PAS_SEGREGATED_PAGE_CONFIG_KIND_AND_ROLE_NUM_BITS) | (uintptr_t)kind_and_role;
+    return begin | (uintptr_t)kind_and_role << PAS_SEGREGATED_PAGE_CONFIG_KIND_AND_ROLE_SHIFT;
 }
 
 static PAS_ALWAYS_INLINE void pas_thread_local_cache_append_deallocation(


### PR DESCRIPTION
#### 8b1288d0a44b3d28f7266449d1c123618bcd0fac
<pre>
Reduce necessary bits in some compact pointer encodings
<a href="https://bugs.webkit.org/show_bug.cgi?id=266098">https://bugs.webkit.org/show_bug.cgi?id=266098</a>
<a href="https://rdar.apple.com/119397319">rdar://119397319</a>

Reviewed by Mark Lam.

Reduces the reserved non-pointer space for some ad-hoc compact pointer tuples.

* Source/JavaScriptCore/dfg/DFGEdge.h:
(JSC::DFG::Edge::shift):
(JSC::DFG::Edge::addressMask):
(JSC::DFG::Edge::node const):
(JSC::DFG::Edge::useKindUnchecked const):
(JSC::DFG::Edge::proofStatusUnchecked const):
(JSC::DFG::Edge::killStatusUnchecked const):
(JSC::DFG::Edge::makeWord):
* Source/bmalloc/libpas/src/libpas/pas_enumerate_segregated_heaps.c:
(pas_enumerate_segregated_heaps):
* Source/bmalloc/libpas/src/libpas/pas_segregated_page_config_kind_and_role.h:
* Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.c:
(process_deallocation_log_with_config):
(flush_deallocation_log_without_resetting):
* Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.h:
(pas_thread_local_cache_encode_object):

Canonical link: <a href="https://commits.webkit.org/271789@main">https://commits.webkit.org/271789@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/140923f4627369a3da087818fe2c1a55a24314ec

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29605 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8264 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30909 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32114 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26800 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10411 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5549 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26812 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29878 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6898 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25272 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5893 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6033 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26358 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33456 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/25432 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27003 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26776 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32251 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/29851 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5979 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4181 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/30035 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7714 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/36175 "Built successfully") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/7043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6523 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7798 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3820 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6502 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->