### PR TITLE
Page and DrawingArea's root frame collections should be updated with LocalFrame lifetime

### DIFF
--- a/Source/WebCore/bindings/js/WindowProxy.cpp
+++ b/Source/WebCore/bindings/js/WindowProxy.cpp
@@ -88,6 +88,8 @@ void WindowProxy::detachFromFrame()
 
 void WindowProxy::replaceFrame(Frame& frame)
 {
+    ASSERT(m_frame);
+    ASSERT(is<LocalFrame>(m_frame) != is<LocalFrame>(frame));
     m_frame = frame;
     setDOMWindow(frame.window());
 }

--- a/Source/WebCore/loader/EmptyClients.h
+++ b/Source/WebCore/loader/EmptyClients.h
@@ -90,6 +90,9 @@ class EmptyChromeClient : public ChromeClient {
 
     void closeWindow() final { }
 
+    void rootFrameAdded(const LocalFrame&) final { }
+    void rootFrameRemoved(const LocalFrame&) final { }
+
     void runJavaScriptAlert(LocalFrame&, const String&) final { }
     bool runJavaScriptConfirm(LocalFrame&, const String&) final { return false; }
     bool runJavaScriptPrompt(LocalFrame&, const String&, const String&, String&) final { return false; }

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -208,6 +208,9 @@ public:
 
     virtual void closeWindow() = 0;
 
+    virtual void rootFrameAdded(const LocalFrame&) = 0;
+    virtual void rootFrameRemoved(const LocalFrame&) = 0;
+
     virtual void runJavaScriptAlert(LocalFrame&, const String&) = 0;
     virtual bool runJavaScriptConfirm(LocalFrame&, const String&) = 0;
     virtual bool runJavaScriptPrompt(LocalFrame&, const String& message, const String& defaultValue, String& result) = 0;

--- a/Source/WebCore/page/FocusController.h
+++ b/Source/WebCore/page/FocusController.h
@@ -122,7 +122,7 @@ private:
     void focusRepaintTimerFired();
 
     Page& m_page;
-    RefPtr<Frame> m_focusedFrame;
+    WeakPtr<Frame> m_focusedFrame;
     bool m_isChangingFocusedFrame;
     OptionSet<ActivityState> m_activityState;
 

--- a/Source/WebCore/page/Frame.cpp
+++ b/Source/WebCore/page/Frame.cpp
@@ -66,27 +66,8 @@ std::optional<PageIdentifier> Frame::pageID() const
     return std::nullopt;
 }
 
-bool Frame::isRootFrame() const
-{
-    // A root frame is a local frame with a remote frame parent or no parent.
-    // It is the root of its local frame tree in this process but might have
-    // a parent in another process.
-    switch (m_frameType) {
-    case FrameType::Local:
-        if (auto* parent = tree().parent())
-            return is<RemoteFrame>(parent);
-        ASSERT(m_mainFrame.ptr() == this);
-        return true;
-    case FrameType::Remote:
-        break;
-    }
-    return false;
-}
-
 void Frame::resetWindowProxy()
 {
-    ASSERT(m_windowProxy->frame() == this);
-    m_windowProxy->detachFromFrame();
     m_windowProxy = WindowProxy::create(*this);
 }
 
@@ -110,6 +91,7 @@ void Frame::takeWindowProxyFrom(Frame& frame)
     ASSERT(m_windowProxy->frame() == this);
     m_windowProxy->detachFromFrame();
     m_windowProxy = frame.windowProxy();
+    frame.resetWindowProxy();
     m_windowProxy->replaceFrame(*this);
 }
 

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -67,7 +67,7 @@ public:
     Settings& settings() const { return m_settings.get(); }
     Frame& mainFrame() const { return m_mainFrame.get(); }
     bool isMainFrame() const { return this == m_mainFrame.ptr(); }
-    WEBCORE_EXPORT bool isRootFrame() const;
+    virtual bool isRootFrame() const = 0;
 
     WEBCORE_EXPORT void detachFromPage();
 

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -168,7 +168,7 @@ public:
     CheckedRef<const ScriptController> checkedScript() const;
     void resetScript();
 
-    WEBCORE_EXPORT bool isRootFrame() const;
+    WEBCORE_EXPORT bool isRootFrame() const final;
 
     WEBCORE_EXPORT RenderView* contentRenderer() const; // Root of the render tree for the document contained in this frame.
 
@@ -367,6 +367,7 @@ private:
     unsigned m_navigationDisableCount { 0 };
     unsigned m_selfOnlyRefCount { 0 };
     bool m_hasHadUserInteraction { false };
+    const bool m_isRootFrame { false };
 
 #if ENABLE(WINDOW_PROXY_PROPERTY_ACCESS_NOTIFICATION)
     OptionSet<WindowProxyProperty> m_accessedWindowProxyPropertiesViaOpener;

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -271,9 +271,7 @@ static Ref<Frame> createMainFrame(Page& page, std::variant<UniqueRef<LocalFrameL
 {
     page.relaxAdoptionRequirement();
     return switchOn(WTFMove(client), [&] (UniqueRef<LocalFrameLoaderClient>&& localFrameClient) -> Ref<Frame> {
-        auto localFrame = LocalFrame::createMainFrame(page, WTFMove(localFrameClient), identifier);
-        page.addRootFrame(localFrame.get());
-        return localFrame;
+        return LocalFrame::createMainFrame(page, WTFMove(localFrameClient), identifier);
     }, [&] (UniqueRef<RemoteFrameClient>&& remoteFrameClient) -> Ref<Frame> {
         return RemoteFrame::createMainFrame(page, WTFMove(remoteFrameClient), identifier);
     });
@@ -4526,12 +4524,15 @@ void Page::addRootFrame(LocalFrame& frame)
     ASSERT(frame.isRootFrame());
     ASSERT(!m_rootFrames.contains(frame));
     m_rootFrames.add(frame);
+    chrome().client().rootFrameAdded(frame);
 }
 
 void Page::removeRootFrame(LocalFrame& frame)
 {
     ASSERT(frame.isRootFrame());
+    ASSERT(m_rootFrames.contains(frame));
     m_rootFrames.remove(frame);
+    chrome().client().rootFrameRemoved(frame);
 }
 
 String Page::ensureMediaKeysStorageDirectoryForOrigin(const SecurityOriginData& origin)

--- a/Source/WebCore/page/RemoteFrame.h
+++ b/Source/WebCore/page/RemoteFrame.h
@@ -71,6 +71,7 @@ private:
     void changeLocation(FrameLoadRequest&&) final;
     void broadcastFrameRemovalToOtherProcesses() final;
     void didFinishLoadInAnotherProcess() final;
+    bool isRootFrame() const final { return false; }
 
     FrameView* virtualView() const final;
     void disconnectView() final;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -509,6 +509,18 @@ void WebChromeClient::closeWindow()
     page->sendClose();
 }
 
+void WebChromeClient::rootFrameAdded(const WebCore::LocalFrame& frame)
+{
+    if (auto* drawingArea = page().drawingArea())
+        drawingArea->addRootFrame(frame.frameID());
+}
+
+void WebChromeClient::rootFrameRemoved(const WebCore::LocalFrame& frame)
+{
+    if (auto* drawingArea = page().drawingArea())
+        drawingArea->removeRootFrame(frame.frameID());
+}
+
 static bool shouldSuppressJavaScriptDialogs(LocalFrame& frame)
 {
     if (frame.loader().opener() && frame.loader().stateMachine().isDisplayingInitialEmptyDocument() && frame.loader().provisionalDocumentLoader())

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -107,7 +107,10 @@ private:
     bool runBeforeUnloadConfirmPanel(const String& message, WebCore::LocalFrame&) final;
     
     void closeWindow() final;
-    
+
+    void rootFrameAdded(const WebCore::LocalFrame&) final;
+    void rootFrameRemoved(const WebCore::LocalFrame&) final;
+
     void runJavaScriptAlert(WebCore::LocalFrame&, const String&) final;
     bool runJavaScriptConfirm(WebCore::LocalFrame&, const String&) final;
     bool runJavaScriptPrompt(WebCore::LocalFrame&, const String& message, const String& defaultValue, String& result) final;

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
@@ -64,8 +64,6 @@ DrawingAreaCoordinatedGraphics::DrawingAreaCoordinatedGraphics(WebPage& webPage,
 #if USE(GLIB_EVENT_LOOP) && !PLATFORM(WPE)
     m_displayTimer.setPriority(RunLoopSourcePriority::NonAcceleratedDrawingTimer);
 #endif
-
-    updatePreferences(parameters.store);
 }
 
 DrawingAreaCoordinatedGraphics::~DrawingAreaCoordinatedGraphics() = default;

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.h
@@ -124,7 +124,7 @@ public:
     virtual WebCore::GraphicsLayerFactory* graphicsLayerFactory() { return nullptr; }
     virtual void setRootCompositingLayer(WebCore::Frame&, WebCore::GraphicsLayer*) = 0;
     virtual void addRootFrame(WebCore::FrameIdentifier) { }
-    // FIXME: Add a corresponding removeRootFrame. <rdar://116202445>
+    virtual void removeRootFrame(WebCore::FrameIdentifier) { }
 
     // Cause a rendering update to happen as soon as possible.
     virtual void triggerRenderingUpdate() = 0;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h
@@ -72,6 +72,7 @@ private:
     WebCore::GraphicsLayerFactory* graphicsLayerFactory() final;
     void setRootCompositingLayer(WebCore::Frame&, WebCore::GraphicsLayer*) final;
     void addRootFrame(WebCore::FrameIdentifier) final;
+    void removeRootFrame(WebCore::FrameIdentifier) final;
     void triggerRenderingUpdate() final;
     bool scheduleRenderingUpdate() final;
     void renderingUpdateFramesPerSecondChanged() final;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
@@ -71,8 +71,6 @@ RemoteLayerTreeDrawingArea::RemoteLayerTreeDrawingArea(WebPage& webPage, const W
     , m_scheduleRenderingTimer(*this, &RemoteLayerTreeDrawingArea::scheduleRenderingUpdateTimerFired)
     , m_preferredFramesPerSecond(DefaultPreferredFramesPerSecond)
 {
-    webPage.corePage()->settings().setForceCompositingMode(true);
-
     if (auto viewExposedRect = parameters.viewExposedRect)
         setViewExposedRect(viewExposedRect);
 }
@@ -143,6 +141,14 @@ void RemoteLayerTreeDrawingArea::addRootFrame(WebCore::FrameIdentifier frameID)
         nullptr,
         frameID
     });
+}
+
+void RemoteLayerTreeDrawingArea::removeRootFrame(WebCore::FrameIdentifier frameID)
+{
+    auto count = m_rootLayers.removeAllMatching([frameID] (const auto& layer) {
+        return layer.frameID == frameID;
+    });
+    ASSERT_UNUSED(count, count == 1);
 }
 
 void RemoteLayerTreeDrawingArea::setRootCompositingLayer(WebCore::Frame& frame, GraphicsLayer* rootGraphicsLayer)

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -339,7 +339,7 @@ void WebFrame::didCommitLoadInAnotherProcess(std::optional<WebCore::LayerHosting
 
     RefPtr parent = coreFrame->tree().parent();
 
-    auto* localFrame = dynamicDowncast<WebCore::LocalFrame>(coreFrame.get());
+    RefPtr localFrame = dynamicDowncast<WebCore::LocalFrame>(coreFrame.get());
     if (!localFrame) {
         ASSERT_NOT_REACHED();
         return;
@@ -357,8 +357,6 @@ void WebFrame::didCommitLoadInAnotherProcess(std::optional<WebCore::LayerHosting
     auto* ownerRenderer = localFrame->ownerRenderer();
     localFrame->setView(nullptr);
 
-    if (localFrame->isRootFrame())
-        corePage->removeRootFrame(*localFrame);
     if (parent)
         parent->tree().removeChild(*coreFrame);
     if (ownerElement)
@@ -367,15 +365,17 @@ void WebFrame::didCommitLoadInAnotherProcess(std::optional<WebCore::LayerHosting
     auto newFrame = ownerElement
         ? WebCore::RemoteFrame::createSubframeWithContentsInAnotherProcess(*corePage, WTFMove(client), m_frameID, *ownerElement, layerHostingContextIdentifier)
         : parent ? WebCore::RemoteFrame::createSubframe(*corePage, WTFMove(client), m_frameID, *parent) : WebCore::RemoteFrame::createMainFrame(*corePage, WTFMove(client), m_frameID, localFrame->loader().opener());
-    if (!parent) {
+    if (!parent)
         corePage->setMainFrame(newFrame.copyRef());
-        newFrame->takeWindowProxyFrom(*localFrame);
-    }
+    newFrame->takeWindowProxyFrom(*localFrame);
     newFrame->tree().setSpecifiedName(localFrame->tree().specifiedName());
     if (ownerRenderer)
         ownerRenderer->setWidget(newFrame->view());
 
     m_coreFrame = newFrame.get();
+
+    if (corePage->focusController().focusedFrame() == localFrame.get())
+        corePage->focusController().setFocusedFrame(newFrame.ptr(), FocusController::BroadcastFocusedFrame::No);
 
     if (ownerElement)
         ownerElement->scheduleInvalidateStyleAndLayerComposition();
@@ -401,8 +401,6 @@ void WebFrame::removeFromTree()
         return;
     }
 
-    if (RefPtr localFrame = dynamicDowncast<LocalFrame>(*coreFrame); localFrame && localFrame->isRootFrame())
-        corePage->removeRootFrame(*localFrame);
     if (RefPtr parent = coreFrame->tree().parent())
         parent->tree().removeChild(*coreFrame);
     coreFrame->disconnectView();
@@ -435,20 +433,14 @@ void WebFrame::transitionToLocal(std::optional<WebCore::LayerHostingContextIdent
     remoteFrame->setView(nullptr);
     localFrame->init();
     localFrame->tree().setSpecifiedName(remoteFrame->tree().specifiedName());
-    if (localFrame->isMainFrame()) {
+    if (localFrame->isMainFrame())
         corePage->setMainFrame(localFrame);
-        localFrame->takeWindowProxyFrom(*remoteFrame);
-    }
+    localFrame->takeWindowProxyFrom(*remoteFrame);
 
+    if (corePage->focusController().focusedFrame() == remoteFrame.get())
+        corePage->focusController().setFocusedFrame(localFrame.ptr(), FocusController::BroadcastFocusedFrame::No);
     if (layerHostingContextIdentifier)
         setLayerHostingContextIdentifier(*layerHostingContextIdentifier);
-    if (localFrame->isRootFrame())
-        corePage->addRootFrame(localFrame.get());
-
-    if (auto* webPage = page(); webPage && m_coreFrame->isRootFrame()) {
-        if (auto* drawingArea = webPage->drawingArea())
-            drawingArea->addRootFrame(m_coreFrame->frameID());
-    }
 }
 
 void WebFrame::didFinishLoadInAnotherProcess()

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1770,6 +1770,7 @@ private:
     void testProcessIncomingSyncMessagesWhenWaitingForSyncReply(CompletionHandler<void(bool)>&&);
 
     void updateDrawingAreaLayerTreeFreezeState();
+    void updateAfterDrawingAreaCreation(const WebPageCreationParameters&);
 
     enum class MarkLayersVolatileDontRetryReason : uint8_t { None, SuspendedUnderLock, TimedOut };
     void markLayersVolatileOrRetry(MarkLayersVolatileDontRetryReason);
@@ -2168,14 +2169,17 @@ private:
     WebCore::PageIdentifier m_identifier;
 
     RefPtr<WebCore::Page> m_page;
+
+    WebCore::IntSize m_viewSize;
+    LayerHostingMode m_layerHostingMode;
+    std::unique_ptr<DrawingArea> m_drawingArea;
+
     Ref<WebFrame> m_mainFrame;
 
     RefPtr<WebPageGroupProxy> m_pageGroup;
 
     String m_userAgent;
 
-    WebCore::IntSize m_viewSize;
-    std::unique_ptr<DrawingArea> m_drawingArea;
     DrawingAreaType m_drawingAreaType;
 
     HashMap<TextCheckerRequestID, RefPtr<WebCore::TextCheckingRequest>> m_pendingTextCheckingRequestMap;
@@ -2214,9 +2218,6 @@ private:
 #if ENABLE(APP_BOUND_DOMAINS)
     bool m_needsInAppBrowserPrivacyQuirks { false };
 #endif
-
-    // The layer hosting mode.
-    LayerHostingMode m_layerHostingMode;
 
 #if ENABLE(APP_HIGHLIGHTS)
     WebCore::CreateNewGroupForHighlight m_highlightIsNewGroup { WebCore::CreateNewGroupForHighlight::No };

--- a/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
@@ -78,8 +78,6 @@ TiledCoreAnimationDrawingArea::TiledCoreAnimationDrawingArea(WebPage& webPage, c
     : DrawingArea(DrawingAreaType::TiledCoreAnimation, parameters.drawingAreaIdentifier, webPage)
     , m_isPaintingSuspended(!(parameters.activityState & ActivityState::IsVisible))
 {
-    webPage.corePage()->settings().setForceCompositingMode(true);
-
     m_hostingLayer = [CALayer layer];
     [m_hostingLayer setDelegate:[WebActionDisablingCALayerDelegate shared]];
     [m_hostingLayer setFrame:webPage.bounds()];
@@ -97,9 +95,6 @@ TiledCoreAnimationDrawingArea::TiledCoreAnimationDrawingArea(WebPage& webPage, c
     updateLayerHostingContext();
     
     setColorSpace(parameters.colorSpace);
-
-    if (auto viewExposedRect = parameters.viewExposedRect)
-        setViewExposedRect(viewExposedRect);
 
     if (!parameters.isProcessSwap)
         sendEnterAcceleratedCompositingModeIfNeeded();

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h
@@ -91,6 +91,9 @@ private:
 
     void closeWindow() final;
 
+    void rootFrameAdded(const WebCore::LocalFrame&) final { }
+    void rootFrameRemoved(const WebCore::LocalFrame&) final { }
+
     void runJavaScriptAlert(WebCore::LocalFrame&, const String&) override;
     bool runJavaScriptConfirm(WebCore::LocalFrame&, const String&) override;
     bool runJavaScriptPrompt(WebCore::LocalFrame&, const String& message, const String& defaultValue, String& result) override;


### PR DESCRIPTION
#### 764b4263af17c189ca7ed6f197f3a216f4d9d96b
<pre>
Page and DrawingArea&apos;s root frame collections should be updated with LocalFrame lifetime
<a href="https://bugs.webkit.org/show_bug.cgi?id=266105">https://bugs.webkit.org/show_bug.cgi?id=266105</a>
<a href="https://rdar.apple.com/116202445">rdar://116202445</a>

Reviewed by Pascoe.

Before this PR we were calling addRootFrame in an ad-hoc manner, and we weren&apos;t calling
remoteRootFrame at all except confusingly in the LocalFrame constructor, which was quite
incorrect.  This caused memory leaks and crashes when site isolation was enabled.

To fix this, I call addRootFrame in the LocalFrame constructor and removeRootFrame in the
LocalFrame destructor.  During the destructor call, we can&apos;t reliably check the parent
frame because it may have also been destroyed, so I cache the value of whether the
LocalFrame is a root frame using a const bool member function.  I use the ChromeClient
to tell the WebPage&apos;s DrawingArea about the creation and destruction of root frames.

In order to successfully draw after this root frame lifetime management change, I needed
the WebPage to already have a DrawingArea when the main frame is constructed, which
required moving it up in the list of constructed members of the WebPage.  When I did this,
though, the calls to WebPage::corePage in the DrawingArea constructors returned null because
the DrawingArea was being constructed before the WebCore::Page.  To fix this, I just moved
the settings update code from the DrawingArea constructors to the WebPage constructor
after creating the WebCore::Page.  Additionally, a few members needed to be initialized
before the DrawingArea constructor might use them, so I moved them around, and the call to
TiledCoreAnimationDrawingArea::setViewExposedRect needs the main frame to have been initialized,
so I moved that to after the main frame was initialized.

I need the Frame to be destroyed when it transitions between LocalFrame and RemoteFrame,
and FocusController was keeping it alive sometimes, which caused crashes.  I changed
FocusController to have a WeakPtr instead of a RefPtr keeping the Frame alive.

When the Frame is destroyed after having called Frame::takeWindowProxyFrom on it, it does some
teardown on its WindowProxy.  To make that teardown not happen on a WindowProxy that is still
being used by another Frame, I added a call to frame.resetWindowProxy() but without the
detachFromFrame() call.  This is needed to keep the WindowProxy pointing to the right Frame
and DOMWindow after the transition when the Frame lifetime is managed better.

* Source/WebCore/loader/EmptyClients.h:
* Source/WebCore/page/ChromeClient.h:
* Source/WebCore/page/FrameTree.h:
(WebCore::FrameTree::thisFrame const):
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::isRootFrame):
(WebCore::LocalFrame::LocalFrame):
(WebCore::LocalFrame::~LocalFrame):
(WebCore::LocalFrame::isRootFrame const):
* Source/WebCore/page/LocalFrame.h:
* Source/WebCore/page/Page.cpp:
(WebCore::createMainFrame):
(WebCore::Page::addRootFrame):
(WebCore::Page::removeRootFrame):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::rootFrameAdded):
(WebKit::WebChromeClient::rootFrameRemoved):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp:
(WebKit::DrawingAreaCoordinatedGraphics::DrawingAreaCoordinatedGraphics):
* Source/WebKit/WebProcess/WebPage/DrawingArea.h:
(WebKit::DrawingArea::removeRootFrame):
(WebKit::DrawingArea::shouldForceCompositingMode const):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::RemoteLayerTreeDrawingArea):
(WebKit::RemoteLayerTreeDrawingArea::removeRootFrame):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::transitionToLocal):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::WebPage):
(WebKit::m_historyItemClient):
(WebKit::addRootFramesToNewDrawingArea):
(WebKit::WebPage::reinitializeWebPage):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm:
(WebKit::TiledCoreAnimationDrawingArea::TiledCoreAnimationDrawingArea):
* Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h:

Canonical link: <a href="https://commits.webkit.org/272224@main">https://commits.webkit.org/272224@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a88bd05040ff60d14cce27405c2d9c742cf0aba2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30862 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9541 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32535 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33364 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27879 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31614 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11861 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6790 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27750 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31181 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8015 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27603 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6878 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7030 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27481 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34702 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28088 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27961 "Found 1 new test failure: tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-mainframe-vertical-then-horizontal.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33183 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7077 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5153 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31016 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8789 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7790 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4019 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7632 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->