### PR TITLE
[scroll-anchoring] Add extra checks to viablePriorityCandidateForElement to ensure a sensible priority candidate

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/focused-element-outside-scroller-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/focused-element-outside-scroller-expected.txt
@@ -1,0 +1,4 @@
+abc
+
+PASS Ensure there is no scroll anchoring adjustment in subscroller.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/focused-element-outside-scroller.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/focused-element-outside-scroller.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+
+body { height: 4000px; }
+div { height: 100px; }
+
+.scroller {
+  overflow: scroll;
+  position: fixed;
+  width: 300px;
+  height: 300px;
+  background-color: green;
+}
+
+#content {
+  background-color: #D3D3D3;
+  height: 50px;
+  width: 50px;
+  position: relative;
+  top: 500px;
+}
+
+</style>
+<div id="scroller" class="scroller">
+  <div id="content"></div>
+</div>
+<div id="block1" tabindex="-1">abc</div>
+
+<script>
+
+// Tests that a focused element doesn't become the 
+// priority candidate of the subscroller
+
+promise_test(async function() {
+  var scroller = document.querySelector("#scroller");
+  var focusElement = document.querySelector("#block1");
+  focusElement.focus();
+  scroller.scrollBy(0,150);
+  document.scrollingElement.scrollBy(0,100);
+  await new Promise(resolve => {
+     document.addEventListener("scroll", () => step_timeout(resolve, 0));
+   });
+
+  assert_equals(scroller.scrollTop, 150);
+}, "Ensure there is no scroll anchoring adjustment in subscroller.");
+
+</script>

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.h
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.h
@@ -57,7 +57,7 @@ public:
 
 private:
     Element* findAnchorElementRecursive(Element*);
-    CandidateExaminationResult examineCandidate(Element&);
+    CandidateExaminationResult examineAnchorCandidate(Element&);
     bool didFindPriorityCandidate(Document&);
     FloatPoint computeOffsetFromOwningScroller(RenderObject& candidate);
     LocalFrameView& frameView();


### PR DESCRIPTION
#### 1c6a14248561e2b8b643d85f75968d761940008f
<pre>
[scroll-anchoring] Add extra checks to viablePriorityCandidateForElement to ensure a sensible priority candidate
<a href="https://bugs.webkit.org/show_bug.cgi?id=266096">https://bugs.webkit.org/show_bug.cgi?id=266096</a>
<a href="https://rdar.apple.com/119203528">rdar://119203528</a>

Reviewed by Simon Fraser.

Add checks to ensure that the priority candidate is a descendant of the current scroller and that it
is not an excluded subtree.

* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/focused-element-outside-scroller-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/focused-element-outside-scroller.html: Added.
* Source/WebCore/page/scrolling/ScrollAnchoringController.cpp:
(WebCore::ScrollAnchoringController::didFindPriorityCandidate):

Canonical link: <a href="https://commits.webkit.org/271783@main">https://commits.webkit.org/271783@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f034557d2f104de16043e99db7960614ef1c2a7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29618 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8275 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30938 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32125 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26807 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30232 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10437 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5556 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26820 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29891 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6911 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25285 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5902 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6037 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26369 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33466 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27009 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26791 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32256 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/5985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4186 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/30029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7723 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/26168 "Passed tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/6529 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3819 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6509 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->