### PR TITLE
[css-transitions] account for `transition-behavior` when considering whether to start transitions for non-animated properties

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-custom-ident-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-custom-ident-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL A custom property of type <custom-ident> can yield a discrete CSS Transition assert_equals: A single animation is running expected 1 but got 0
+PASS A custom property of type <custom-ident> can yield a discrete CSS Transition
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-image-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-image-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL A custom property of type <image> can yield a CSS Transition assert_equals: A single animation is running expected 1 but got 0
+PASS A custom property of type <image> can yield a CSS Transition
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-mismatched-list-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-mismatched-list-expected.txt
@@ -1,26 +1,26 @@
 
-FAIL A custom property of type <angle># yields a discrete CSS Transition if the lists do not contain the same number of values assert_equals: A single animation is running expected 1 but got 0
-FAIL A custom property of type <angle>+ yields a discrete CSS Transition if the lists do not contain the same number of values assert_equals: A single animation is running expected 1 but got 0
-FAIL A custom property of type <color># yields a discrete CSS Transition if the lists do not contain the same number of values assert_equals: A single animation is running expected 1 but got 0
-FAIL A custom property of type <color>+ yields a discrete CSS Transition if the lists do not contain the same number of values assert_equals: A single animation is running expected 1 but got 0
-FAIL A custom property of type <custom-ident># yields a discrete CSS Transition if the lists do not contain the same number of values assert_equals: A single animation is running expected 1 but got 0
-FAIL A custom property of type <custom-ident>+ yields a discrete CSS Transition if the lists do not contain the same number of values assert_equals: A single animation is running expected 1 but got 0
-FAIL A custom property of type <image># yields a discrete CSS Transition if the lists do not contain the same number of values assert_equals: A single animation is running expected 1 but got 0
-FAIL A custom property of type <image>+ yields a discrete CSS Transition if the lists do not contain the same number of values assert_equals: A single animation is running expected 1 but got 0
-FAIL A custom property of type <integer># yields a discrete CSS Transition if the lists do not contain the same number of values assert_equals: A single animation is running expected 1 but got 0
-FAIL A custom property of type <integer>+ yields a discrete CSS Transition if the lists do not contain the same number of values assert_equals: A single animation is running expected 1 but got 0
-FAIL A custom property of type <length-percentage># yields a discrete CSS Transition if the lists do not contain the same number of values assert_equals: A single animation is running expected 1 but got 0
-FAIL A custom property of type <length-percentage>+ yields a discrete CSS Transition if the lists do not contain the same number of values assert_equals: A single animation is running expected 1 but got 0
-FAIL A custom property of type <length># yields a discrete CSS Transition if the lists do not contain the same number of values assert_equals: A single animation is running expected 1 but got 0
-FAIL A custom property of type <length>+ yields a discrete CSS Transition if the lists do not contain the same number of values assert_equals: A single animation is running expected 1 but got 0
-FAIL A custom property of type <number># yields a discrete CSS Transition if the lists do not contain the same number of values assert_equals: A single animation is running expected 1 but got 0
-FAIL A custom property of type <number>+ yields a discrete CSS Transition if the lists do not contain the same number of values assert_equals: A single animation is running expected 1 but got 0
-FAIL A custom property of type <percentage># yields a discrete CSS Transition if the lists do not contain the same number of values assert_equals: A single animation is running expected 1 but got 0
-FAIL A custom property of type <percentage>+ yields a discrete CSS Transition if the lists do not contain the same number of values assert_equals: A single animation is running expected 1 but got 0
-FAIL A custom property of type <resolution># yields a discrete CSS Transition if the lists do not contain the same number of values assert_equals: A single animation is running expected 1 but got 0
-FAIL A custom property of type <resolution>+ yields a discrete CSS Transition if the lists do not contain the same number of values assert_equals: A single animation is running expected 1 but got 0
-FAIL A custom property of type <time># yields a discrete CSS Transition if the lists do not contain the same number of values assert_equals: A single animation is running expected 1 but got 0
-FAIL A custom property of type <time>+ yields a discrete CSS Transition if the lists do not contain the same number of values assert_equals: A single animation is running expected 1 but got 0
-FAIL A custom property of type <url># yields a discrete CSS Transition if the lists do not contain the same number of values assert_equals: A single animation is running expected 1 but got 0
-FAIL A custom property of type <url>+ yields a discrete CSS Transition if the lists do not contain the same number of values assert_equals: A single animation is running expected 1 but got 0
+PASS A custom property of type <angle># yields a discrete CSS Transition if the lists do not contain the same number of values
+PASS A custom property of type <angle>+ yields a discrete CSS Transition if the lists do not contain the same number of values
+PASS A custom property of type <color># yields a discrete CSS Transition if the lists do not contain the same number of values
+PASS A custom property of type <color>+ yields a discrete CSS Transition if the lists do not contain the same number of values
+PASS A custom property of type <custom-ident># yields a discrete CSS Transition if the lists do not contain the same number of values
+PASS A custom property of type <custom-ident>+ yields a discrete CSS Transition if the lists do not contain the same number of values
+PASS A custom property of type <image># yields a discrete CSS Transition if the lists do not contain the same number of values
+PASS A custom property of type <image>+ yields a discrete CSS Transition if the lists do not contain the same number of values
+PASS A custom property of type <integer># yields a discrete CSS Transition if the lists do not contain the same number of values
+PASS A custom property of type <integer>+ yields a discrete CSS Transition if the lists do not contain the same number of values
+PASS A custom property of type <length-percentage># yields a discrete CSS Transition if the lists do not contain the same number of values
+PASS A custom property of type <length-percentage>+ yields a discrete CSS Transition if the lists do not contain the same number of values
+PASS A custom property of type <length># yields a discrete CSS Transition if the lists do not contain the same number of values
+PASS A custom property of type <length>+ yields a discrete CSS Transition if the lists do not contain the same number of values
+PASS A custom property of type <number># yields a discrete CSS Transition if the lists do not contain the same number of values
+PASS A custom property of type <number>+ yields a discrete CSS Transition if the lists do not contain the same number of values
+PASS A custom property of type <percentage># yields a discrete CSS Transition if the lists do not contain the same number of values
+PASS A custom property of type <percentage>+ yields a discrete CSS Transition if the lists do not contain the same number of values
+PASS A custom property of type <resolution># yields a discrete CSS Transition if the lists do not contain the same number of values
+PASS A custom property of type <resolution>+ yields a discrete CSS Transition if the lists do not contain the same number of values
+PASS A custom property of type <time># yields a discrete CSS Transition if the lists do not contain the same number of values
+PASS A custom property of type <time>+ yields a discrete CSS Transition if the lists do not contain the same number of values
+PASS A custom property of type <url># yields a discrete CSS Transition if the lists do not contain the same number of values
+PASS A custom property of type <url>+ yields a discrete CSS Transition if the lists do not contain the same number of values
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-transform-function-none.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-transform-function-none.tentative-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL A custom property keyword none is not a <transform-function> value and is not interpolable with <transform-function> values assert_equals: A single animation is running expected 1 but got 0
+PASS A custom property keyword none is not a <transform-function> value and is not interpolable with <transform-function> values
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-transform-function-to-list-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-transform-function-to-list-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL A custom property cannot yield a CSS Transition from <transform-function> to <transform-list> assert_equals: A single animation is running expected 1 but got 0
+PASS A custom property cannot yield a CSS Transition from <transform-function> to <transform-list>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-url-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-url-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL A custom property of type <url> can yield a discrete CSS Transition assert_equals: A single animation is running expected 1 but got 0
+PASS A custom property of type <url> can yield a discrete CSS Transition
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/all-with-discrete.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/all-with-discrete.tentative-expected.txt
@@ -1,4 +1,4 @@
 hello
 
-FAIL transition:all with transition-behavior:allow-discrete should animate discrete properties. assert_equals: Did not start a discrete-property transition expected 1 but got 0
+PASS transition:all with transition-behavior:allow-discrete should animate discrete properties.
 


### PR DESCRIPTION
#### 336b9f90b63d33c8b54eb526fd7cd0f67a892aba
<pre>
[css-transitions] account for `transition-behavior` when considering whether to start transitions for non-animated properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=266072">https://bugs.webkit.org/show_bug.cgi?id=266072</a>
<a href="https://rdar.apple.com/119379014">rdar://119379014</a>

Reviewed by Dean Jackson.

Consult whether `transition-behavior` was set to allow discrete transitions to occur when
considering whether to start a transition.

* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-custom-ident-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-image-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-mismatched-list-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-transform-function-none.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-transform-function-to-list-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-url-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/all-with-discrete.tentative-expected.txt:
* Source/WebCore/style/Styleable.cpp:
(WebCore::updateCSSTransitionsForStyleableAndProperty):

Canonical link: <a href="https://commits.webkit.org/271763@main">https://commits.webkit.org/271763@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47a057d519dc3846ce139c65abf31cdb9b9e0b99

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29614 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8271 "Failed to checkout and rebase branch from PR 21535") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/30913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/32121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/26803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30227 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/10415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/5552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/32121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29887 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/10415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/30913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/32121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/10415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/30913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/33462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/10415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/30913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/33462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/5982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/5552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/33462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/7719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/30913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/6526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3809 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/6505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->