### PR TITLE
[git-webkit] Revert's bug filing should be less manual

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/revert.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/revert.py
@@ -31,7 +31,7 @@ from .branch import Branch
 from .pull_request import PullRequest
 from .commit import Commit as CommitProgram
 
-from webkitbugspy import Tracker
+from webkitbugspy import Tracker, bugzilla
 from webkitcorepy import arguments, run, Terminal, string_utils
 from webkitscmpy import local, log, remote
 from ..commit import Commit
@@ -59,10 +59,10 @@ class Revert(Command):
         )
 
         parser.add_argument(
-            '--revert-issue',
-            dest='revert_issue',
+            '--reason', '--why', '-w',
+            dest='reason',
             type=str,
-            help='Issue for the revert'
+            help='Reason for the revert'
         )
 
         parser.add_argument(
@@ -73,23 +73,60 @@ class Revert(Command):
         )
 
     @classmethod
-    def get_issue_info(cls, args, repository, **kwargs):
-        # Can give either a bug URL or a title of the new issue.
-        # Using --revert-issue to differentiate from PR arg --issue/-i
-        if not args.revert_issue:
-            prompt = 'Enter issue URL or title of new issue for the revert: '
+    def get_commit_info(cls, args, repository, **kwargs):
+        commit_objects = []
+        commits_to_revert = []
+        commit_bugs = set()
+        for c in args.commit:
+            try:
+                commit = repository.find(c, include_log=True)
+            except (local.Scm.Exception, ValueError) as exception:
+                sys.stderr.write('Could not find "{}"'.format(c) + '\n')
+                return None, None, None
+            commit_objects.append(commit)
+            commits_to_revert.append(commit.hash)
+            commit_bugs.update({Tracker.from_string(i.link) for i in commit.issues if isinstance(Tracker.from_string(i.link).tracker, bugzilla.Tracker)})
+        return commit_objects, commits_to_revert, commit_bugs
+
+    @classmethod
+    def get_issue_info(cls, args, repository, commit_objects, commit_bugs, **kwargs):
+        # Can give either a bug URL or a title of the new issue
+        if not args.issue and not args.reason:
+            prompt = 'Enter issue URL or reason for the revert: '
             args.issue = Terminal.input(prompt, alert_after=2 * Terminal.RING_INTERVAL)
-        else:
-            args.issue = args.revert_issue
+        elif args.reason:
+            args.issue = args.reason
 
         issue = Tracker.from_string(args.issue)
-
         if not issue and Tracker.instance() and getattr(args, 'update_issue', True):
             if getattr(Tracker.instance(), 'credentials', None):
                 Tracker.instance().credentials(required=True, validate=True)
+
+            # Automatically set project, component, and version of new bug
+            print('Setting bug properties...')
+            commit_bug = commit_bugs.pop()
+            project = commit_bug.project
+            component = commit_bug.component
+            version = commit_bug.version
+
+            # Check whether properties are the same if multiple commits are reverted
+            while len(commit_bugs):
+                commit_bug = commit_bugs.pop()
+                # Setting properties to None will prompt for user input
+                if commit_bug.project != project:
+                    project = None
+                if commit_bug.component != component:
+                    component = None
+                if commit_bug.version != version:
+                    version = None
+
+            commits = [repr(c) for c in commit_objects]
             issue = Tracker.instance().create(
                 title=args.issue,
-                description=Terminal.input('Issue description: '),
+                description='Revert {} because {}.'.format(string_utils.join(commits), args.issue),
+                project=project,
+                component=component,
+                version=version,
             )
             if not issue:
                 sys.stderr.write('Failed to create new issue\n')
@@ -106,20 +143,11 @@ class Revert(Command):
         return issue
 
     @classmethod
-    def create_revert_commit_msg(cls, args, repository, **kwargs):
-        commit_identifiers = []
-        commits_to_revert = []
+    def create_revert_commit_msg(cls, args, commit_objects, **kwargs):
         reverted_changeset = ''
-        # Retrieve information for commits to be reverted.
-        for c in args.commit:
-            try:
-                commit = repository.find(c, include_log=True)
-            except (local.Scm.Exception, ValueError) as exception:
-                # ValueErrors and Scm exceptions usually contain enough information to be displayed
-                # to the user as an error
-                sys.stderr.write('Could not find "{}"'.format(c) + '\n')
-                return None, None
-            commits_to_revert.append(commit.hash)
+        commit_identifiers = []
+        # Retrieve information for commits to be reverted
+        for commit in commit_objects:
             commit_title = None
             for line in commit.message.splitlines():
                 if not commit_title:
@@ -133,13 +161,13 @@ class Revert(Command):
                 reverted_changeset += '\nhttps://commits.webkit.org/{}@{}\n'.format(commit.identifier, commit.branch)
             else:
                 sys.stderr.write('Could not find "{}"'.format(', '.join(args.commit)) + '\n')
-                return None, None
+                return None
 
-        # Retrieve information for the issue tracking the revert.
+        # Retrieve information for the issue tracking the revert
         revert_issue = Tracker.from_string(args.issue)
         if not revert_issue:
             sys.stderr.write('Could not find issue {}'.format(revert_issue))
-            return None, None
+            return None
         revert_issue_radar = None
         for bug in CommitProgram.bug_urls(revert_issue):
             for regex in cls.RES:
@@ -153,10 +181,10 @@ class Revert(Command):
         env['COMMIT_MESSAGE_TITLE'] = cls.REVERT_TITLE_TEMPLATE.format(string_utils.join(commit_identifiers))
         env['COMMIT_MESSAGE_REVERT'] = '{}\n{}\n\n{}\n\n'.format(revert_issue.link, revert_issue_radar or 'Include a Radar link (OOPS!).', revert_issue.title)
         env['COMMIT_MESSAGE_REVERT'] += 'Reverted {}:\n{}'.format('changes' if len(commit_identifiers) > 1 else 'change', reverted_changeset)
-        return commit_identifiers, commits_to_revert
+        return commit_identifiers
 
     @classmethod
-    def revert_commit(cls, args, repository, issue, commit_identifiers, commits_to_revert, **kwargs):
+    def revert_commit(cls, args, repository, issue, commit_objects, commits_to_revert, **kwargs):
         result = run([repository.executable(), 'revert', '--no-commit'] + commits_to_revert, cwd=repository.root_path, capture_output=True)
         if result.returncode:
             # git revert will output nothing if this commit is already reverted
@@ -168,9 +196,10 @@ class Revert(Command):
             sys.stderr.write('If you have merge conflicts, after resolving them, please use git-webkit pfr to publish your pull request')
             return 1
 
+        commits = [repr(c) for c in commit_objects]
         cls.write_branch_variables(
             repository, repository.branch,
-            title=cls.REVERT_TITLE_TEMPLATE.format(', '.join(commit_identifiers)),
+            title=cls.REVERT_TITLE_TEMPLATE.format(', '.join(commits)),
             bug=[issue],
         )
 
@@ -179,7 +208,7 @@ class Revert(Command):
             run([repository.executable(), 'revert', '--abort'], cwd=repository.root_path)
             sys.stderr.write('Failed revert commit')
             return 1
-        log.info('Reverted {}'.format(', '.join(args.commit)))
+        log.info('Reverted {}'.format(', '.join(commits)))
         return 0
 
     @classmethod
@@ -188,7 +217,6 @@ class Revert(Command):
             sys.stderr.write("Can only '{}' on a native Git repository\n".format(cls.name))
             return 1
 
-        # Check if there are any outstanding changes:
         if repository.modified():
             sys.stderr.write('Please commit your changes or stash them before you revert commit: {}'.format(', '.join(args.commit)))
             return 1
@@ -196,19 +224,23 @@ class Revert(Command):
         if not PullRequest.check_pull_request_args(repository, args):
             return 1
 
-        issue = cls.get_issue_info(args, repository, **kwargs)
+        commit_objects, commits_to_revert, commit_bugs = cls.get_commit_info(args, repository, **kwargs)
+        if not commit_objects:
+            return 1
+
+        issue = cls.get_issue_info(args, repository, commit_objects, commit_bugs, **kwargs)
         if not issue:
             return 1
 
-        commit_identifiers, commits_to_revert = cls.create_revert_commit_msg(args, repository, **kwargs)
-        if not commit_identifiers or not commits_to_revert:
+        commit_identifiers = cls.create_revert_commit_msg(args, commit_objects, **kwargs)
+        if not commit_identifiers:
             return 1
 
         branch_point = PullRequest.pull_request_branch_point(repository, args, **kwargs)
         if not branch_point:
             return 1
 
-        result = cls.revert_commit(args, repository, issue, commit_identifiers, commits_to_revert, **kwargs)
+        result = cls.revert_commit(args, repository, issue, commit_objects, commits_to_revert, **kwargs)
         if result:
             return result
 

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/revert_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/revert_unittest.py
@@ -64,7 +64,7 @@ class TestRevert(testing.PathTestCase):
 
         self.assertEqual(
             captured.stdout.getvalue(),
-            "Enter issue URL or title of new issue for the revert: \n"
+            "Enter issue URL or reason for the revert: \n"
             "Created the local development branch 'eng/Example-feature-1'\n"
             "Created 'PR 1 | Unreviewed, reverting 5@main'!\n"
             "https://github.example.com/WebKit/WebKit/pull/1\n",
@@ -74,7 +74,7 @@ class TestRevert(testing.PathTestCase):
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
                 "Creating the local development branch 'eng/Example-feature-1'...",
-                'Reverted d8bce26fa65c6fc8f39c17927abb77f69fab82fc',
+                'Reverted 5@main',
                 "Rebasing 'eng/Example-feature-1' on 'main'...",
                 "Rebased 'eng/Example-feature-1' on 'main!'",
                 'Running pre-PR checks...',
@@ -113,7 +113,7 @@ class TestRevert(testing.PathTestCase):
 
         self.assertEqual(
             captured.stdout.getvalue(),
-            "Enter issue URL or title of new issue for the revert: \n"
+            "Enter issue URL or reason for the revert: \n"
             "Created the local development branch 'eng/Example-feature-1'\n"
             "Created 'PR 1 | Unreviewed, reverting 5@main'!\n"
             "https://github.example.com/WebKit/WebKit/pull/1\n",
@@ -123,7 +123,7 @@ class TestRevert(testing.PathTestCase):
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
                 "Creating the local development branch 'eng/Example-feature-1'...",
-                'Reverted d8bce26fa65c6fc8f39c17927abb77f69fab82fc',
+                'Reverted 5@main',
                 'Using committed changes...',
                 "Rebasing 'eng/Example-feature-1' on 'main'...",
                 "Rebased 'eng/Example-feature-1' on 'main!'",
@@ -150,7 +150,7 @@ class TestRevert(testing.PathTestCase):
             ),
         ), mocks.local.Svn(), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA)]):
             result = program.main(
-                args=('revert', 'd8bce26fa65c6fc8f39c17927abb77f69fab82fc', '--revert-issue', '{}/show_bug.cgi?id=2'.format(self.BUGZILLA), '-v'),
+                args=('revert', 'd8bce26fa65c6fc8f39c17927abb77f69fab82fc', '--issue', '{}/show_bug.cgi?id=2'.format(self.BUGZILLA), '-v'),
                 path=self.path,
             )
             self.assertEqual(0, result)
@@ -172,7 +172,7 @@ class TestRevert(testing.PathTestCase):
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
                 "Creating the local development branch 'eng/Example-feature-1'...",
-                'Reverted d8bce26fa65c6fc8f39c17927abb77f69fab82fc',
+                'Reverted 5@main',
                 'Using committed changes...',
                 "Rebasing 'eng/Example-feature-1' on 'main'...",
                 "Rebased 'eng/Example-feature-1' on 'main!'",
@@ -236,7 +236,7 @@ index 05e8751..0bf3c85 100644
 
         self.assertEqual(
             captured.stdout.getvalue(),
-            "Enter issue URL or title of new issue for the revert: \n"
+            "Enter issue URL or reason for the revert: \n"
             "Created the local development branch 'eng/Example-feature-1'\n"
             "Created 'PR 1 | Unreviewed, reverting 5@main'!\n"
             "https://github.example.com/WebKit/WebKit/pull/1\n"
@@ -248,7 +248,7 @@ index 05e8751..0bf3c85 100644
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
                 "Creating the local development branch 'eng/Example-feature-1'...",
-                'Reverted d8bce26fa65c6fc8f39c17927abb77f69fab82fc',
+                'Reverted 5@main',
                 "Rebasing 'eng/Example-feature-1' on 'main'...",
                 "Rebased 'eng/Example-feature-1' on 'main!'",
                 'Running pre-PR checks...',


### PR DESCRIPTION
#### 29338cd2b8a9aa9c7537b3c74944400f9b3ed19f
<pre>
[git-webkit] Revert&apos;s bug filing should be less manual
<a href="https://bugs.webkit.org/show_bug.cgi?id=265593">https://bugs.webkit.org/show_bug.cgi?id=265593</a>
<a href="https://rdar.apple.com/problem/118996008">rdar://problem/118996008</a>

Reviewed by Jonathan Bedard.

Prompts user for a reason for revert and creates revert bug using existing bug details.
If there are multiple commits being reverted and the categories differ, the user is prompted.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/revert.py:
(Revert.get_commit_info):
(Revert):
(Revert.get_issue_info):
(Revert.create_revert_commit_msg):
(Revert.revert_commit):
(Revert.main):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/revert_unittest.py:
(TestRevert.test_github):
(TestRevert.test_github_two_step):
(TestRevert.test_args):
(test_update):

Canonical link: <a href="https://commits.webkit.org/271939@main">https://commits.webkit.org/271939@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1bf90ca10daf1cb1c26afc7952db78e238054d88

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30126 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8791 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31440 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32630 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27241 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30801 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10991 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6036 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/27251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/30426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/7378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/25695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/6303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/6/builds/30281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/6460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/26788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33967 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/27471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/27221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/32636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/6404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/4573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/30438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/29912 "Failed to checkout and rebase branch from PR 21536") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/8154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7158 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3885 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/6933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->