### PR TITLE
Profile misc. pointer usage in libPAS

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -520,7 +520,6 @@
 		DDA35E4A29CA9B68006C1018 /* PlatformEnablePlayStation.h in Headers */ = {isa = PBXBuildFile; fileRef = DD4901E127B4748A00D7E50D /* PlatformEnablePlayStation.h */; };
 		DDA35E4B29CA9B68006C1018 /* PlatformEnableWinCairo.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C98CDC923E7AFC80012F232 /* PlatformEnableWinCairo.h */; };
 		DDCAF31D27B1E7C500C45308 /* GenericHashKey.h in Headers */ = {isa = PBXBuildFile; fileRef = E3FD6D6627A1F6AD00935000 /* GenericHashKey.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		DDE99319278D08DC00F60D26 /* libWebKitAdditions.a in Product Dependencies */ = {isa = PBXBuildFile; fileRef = DDE99317278D08C900F60D26 /* libWebKitAdditions.a */; };
 		DDF306D827C08654006A526F /* CFStringSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = DDF306C127C08654006A526F /* CFStringSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DDF306D927C08654006A526F /* CFRunLoopSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = DDF306C227C08654006A526F /* CFRunLoopSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DDF306DA27C08654006A526F /* CFBundleSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = DDF306C327C08654006A526F /* CFBundleSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -952,7 +951,6 @@
 			dstSubfolderSpec = 16;
 			files = (
 				DD403D5628EB93BE009B4684 /* libbmalloc.a in Product Dependencies */,
-				DDE99319278D08DC00F60D26 /* libWebKitAdditions.a in Product Dependencies */,
 			);
 			name = "Product Dependencies";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1698,7 +1696,6 @@
 		DDD8BB7A27B347C500C109E0 /* ulistformatter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ulistformatter.h; sourceTree = "<group>"; };
 		DDD8BB7B27B347C500C109E0 /* measfmt.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = measfmt.h; sourceTree = "<group>"; };
 		DDD8BB7C27B347C500C109E0 /* unifilt.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = unifilt.h; sourceTree = "<group>"; };
-		DDE99317278D08C900F60D26 /* libWebKitAdditions.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libWebKitAdditions.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		DDF306C127C08654006A526F /* CFStringSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CFStringSPI.h; sourceTree = "<group>"; };
 		DDF306C227C08654006A526F /* CFRunLoopSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CFRunLoopSPI.h; sourceTree = "<group>"; };
 		DDF306C327C08654006A526F /* CFBundleSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CFBundleSPI.h; sourceTree = "<group>"; };
@@ -2845,7 +2842,6 @@
 			isa = PBXGroup;
 			children = (
 				DD403D5528EB93BE009B4684 /* libbmalloc.a */,
-				DDE99317278D08C900F60D26 /* libWebKitAdditions.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";

--- a/Source/bmalloc/Configurations/Base.xcconfig
+++ b/Source/bmalloc/Configurations/Base.xcconfig
@@ -91,6 +91,9 @@ GCC_WARN_UNUSED_FUNCTION = YES;
 GCC_WARN_UNUSED_VARIABLE = YES;
 PREBINDING = NO;
 WARNING_CFLAGS = $(inherited) -Wcast-qual -Wchar-subscripts -Wextra-tokens -Winit-self -Wmissing-noreturn -Wpacked -Wpointer-arith -Wredundant-decls -Wwrite-strings -Wexit-time-destructors -Wglobal-constructors -Wtautological-compare -Wimplicit-fallthrough -Wvla -Wliteral-conversion -Wthread-safety -Wno-typedef-redefinition;
+HEADER_SEARCH_PATHS = $(BUILT_PRODUCTS_DIR)$(BMALLOC_INSTALL_PATH_PREFIX)$(WK_LIBRARY_HEADERS_FOLDER_PATH) $(DSTROOT)$(BMALLOC_INSTALL_PATH_PREFIX)$(WK_LIBRARY_HEADERS_FOLDER_PATH) $(inherited);
+SYSTEM_HEADER_SEARCH_PATHS = $(WK_PRIVATE_SDK_DIR)$(BMALLOC_INSTALL_PATH_PREFIX)$(WK_LIBRARY_HEADERS_FOLDER_PATH) $(inherited);
+LIBRARY_SEARCH_PATHS = $(SDK_DIR)$(BMALLOC_INSTALL_PATH_PREFIX)$(WK_LIBRARY_INSTALL_PATH) $(inherited);
 
 SUPPORTED_PLATFORMS = iphoneos iphonesimulator macosx appletvos appletvsimulator watchos watchsimulator xros xrsimulator;
 SUPPORTS_MACCATALYST = YES;
@@ -114,6 +117,8 @@ BMALLOC_INSTALL_PATH_PREFIX_DEPLOYMENT_YES = $(BMALLOC_INSTALL_PATH_PREFIX_DEPLO
 BMALLOC_INSTALL_PATH_PREFIX_DEPLOYMENT_YES_USE_ALTERNATE_YES = $(WK_ALTERNATE_FRAMEWORKS_DIR)/;
 
 LLVM_LTO = $(WK_USER_LTO_MODE_$(WK_LTO_MODE));
+
+EXCLUDED_SOURCE_FILE_NAMES = libWebKitAdditions.a
 
 WK_USER_LTO_MODE_full = YES;
 WK_USER_LTO_MODE_thin = YES_THIN;

--- a/Source/bmalloc/bmalloc.xcodeproj/project.pbxproj
+++ b/Source/bmalloc/bmalloc.xcodeproj/project.pbxproj
@@ -131,8 +131,8 @@
 		2B6EB7A029EE102E00F10400 /* pas_report_crash_pgm_report.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B6EB79F29EE102E00F10400 /* pas_report_crash_pgm_report.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2BDF4F4C29E8B8BA0056BF50 /* pas_report_crash.c in Sources */ = {isa = PBXBuildFile; fileRef = 2BDF4F4A29E8B8BA0056BF50 /* pas_report_crash.c */; };
 		2BDF4F4D29E8B8BA0056BF50 /* pas_report_crash.h in Headers */ = {isa = PBXBuildFile; fileRef = 2BDF4F4B29E8B8BA0056BF50 /* pas_report_crash.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		306D490A2ACCA05900CCFEE5 /* AllocationCounts.h in Headers */ = {isa = PBXBuildFile; fileRef = 306D49052ACCA01400CCFEE5 /* AllocationCounts.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		306D490B2ACCA05A00CCFEE5 /* AllocationCounts.h in Headers */ = {isa = PBXBuildFile; fileRef = 306D49052ACCA01400CCFEE5 /* AllocationCounts.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		304B034B2B18FBE00063B1B5 /* AllocationCounts.h in Headers */ = {isa = PBXBuildFile; fileRef = 306D49052ACCA01400CCFEE5 /* AllocationCounts.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		304B03532B1901730063B1B5 /* libWebKitAdditions.a in Product Dependencies */ = {isa = PBXBuildFile; fileRef = 304B03502B19014B0063B1B5 /* libWebKitAdditions.a */; };
 		4426E2801C838EE0008EB042 /* Logging.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4426E27E1C838EE0008EB042 /* Logging.cpp */; };
 		4426E2811C838EE0008EB042 /* Logging.h in Headers */ = {isa = PBXBuildFile; fileRef = 4426E27F1C838EE0008EB042 /* Logging.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		52F47249210BA30200B730BB /* MemoryStatusSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 52F47248210BA2F500B730BB /* MemoryStatusSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -707,6 +707,20 @@
 			remoteInfo = libpas;
 		};
 /* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		304B03472B181ED00063B1B5 /* Product Dependencies */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 16;
+			files = (
+				304B03532B1901730063B1B5 /* libWebKitAdditions.a in Product Dependencies */,
+			);
+			name = "Product Dependencies";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		0F18F83C25C3467700721C2A /* pas_segregated_exclusive_view_inlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_segregated_exclusive_view_inlines.h; path = libpas/src/libpas/pas_segregated_exclusive_view_inlines.h; sourceTree = "<group>"; };
@@ -1331,6 +1345,7 @@
 		2CE2AE512769928200D02BBC /* pas_compact_tagged_void_ptr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_compact_tagged_void_ptr.h; path = libpas/src/libpas/pas_compact_tagged_void_ptr.h; sourceTree = "<group>"; };
 		2CE2AE572769928300D02BBC /* pas_probabilistic_guard_malloc_allocator.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pas_probabilistic_guard_malloc_allocator.c; path = libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c; sourceTree = "<group>"; };
 		2CE2AE582769928300D02BBC /* pas_probabilistic_guard_malloc_allocator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_probabilistic_guard_malloc_allocator.h; path = libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.h; sourceTree = "<group>"; };
+		304B03502B19014B0063B1B5 /* libWebKitAdditions.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libWebKitAdditions.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		306D49052ACCA01400CCFEE5 /* AllocationCounts.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AllocationCounts.h; path = bmalloc/AllocationCounts.h; sourceTree = "<group>"; };
 		4426E27E1C838EE0008EB042 /* Logging.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Logging.cpp; path = bmalloc/Logging.cpp; sourceTree = "<group>"; };
 		4426E27F1C838EE0008EB042 /* Logging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Logging.h; path = bmalloc/Logging.h; sourceTree = "<group>"; };
@@ -1388,7 +1403,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		DD4BEC1529CBA36000398E35 /* Frameworks */ = {
+		304B03522B1901670063B1B5 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1402,6 +1417,7 @@
 			isa = PBXGroup;
 			children = (
 				142FC6212096409E00A99362 /* Foundation.framework */,
+				304B03502B19014B0063B1B5 /* libWebKitAdditions.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -2167,7 +2183,6 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				306D490A2ACCA05900CCFEE5 /* AllocationCounts.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2179,7 +2194,7 @@
 				14DD78C518F48D7500950702 /* Algorithm.h in Headers */,
 				0F7EB8341F9541B000F1ABCB /* AllIsoHeaps.h in Headers */,
 				0F7EB84F1F954D4E00F1ABCB /* AllIsoHeapsInlines.h in Headers */,
-				306D490B2ACCA05A00CCFEE5 /* AllocationCounts.h in Headers */,
+				304B034B2B18FBE00063B1B5 /* AllocationCounts.h in Headers */,
 				14DD789818F48D4A00950702 /* Allocator.h in Headers */,
 				6599C5CD1EC3F15900A2F7BB /* AvailableMemory.h in Headers */,
 				14DD78C718F48D7500950702 /* BAssert.h in Headers */,
@@ -2706,9 +2721,10 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = DD4BEC1E29CBA36000398E35 /* Build configuration list for PBXNativeTarget "libpas" */;
 			buildPhases = (
+				304B03472B181ED00063B1B5 /* Product Dependencies */,
 				DD4BEC2529CBA48800398E35 /* Headers */,
 				DD4BEC1429CBA36000398E35 /* Sources */,
-				DD4BEC1529CBA36000398E35 /* Frameworks */,
+				304B03522B1901670063B1B5 /* Frameworks */,
 			);
 			buildRules = (
 			);

--- a/Source/bmalloc/libpas/src/libpas/pas_deallocate.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_deallocate.h
@@ -189,6 +189,7 @@ static PAS_ALWAYS_INLINE bool pas_try_deallocate(void* ptr,
 {
     static const bool verbose = false;
     
+    PAS_PROFILE(ptr, TRY_DEALLOCATE);
     pas_thread_local_cache* thread_local_cache;
 
     if (verbose)

--- a/Source/bmalloc/libpas/src/libpas/pas_page_base_config_utils.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_base_config_utils.h
@@ -67,6 +67,7 @@ typedef struct {
         \
         switch (arguments.header_placement_mode) { \
         case pas_page_header_at_head_of_page: { \
+            PAS_PROFILE(boundary, PAGE_HEADER); \
             return (pas_page_base*)boundary; \
         } \
         \

--- a/Source/bmalloc/libpas/src/libpas/pas_page_base_config_utils_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_base_config_utils_inlines.h
@@ -49,6 +49,7 @@ typedef struct {
         \
         switch (name ## _header_placement_mode) { \
         case pas_page_header_at_head_of_page: { \
+            PAS_PROFILE(boundary, PAGE_HEADER); \
             return (pas_page_base*)boundary; \
         } \
         \

--- a/Source/bmalloc/libpas/src/libpas/pas_try_reallocate.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_try_reallocate.h
@@ -199,7 +199,7 @@ pas_try_reallocate(void* old_ptr,
                    void* allocate_callback_arg)
 {
     uintptr_t begin;
-    
+    PAS_PROFILE(old_ptr, REALLOCATE);
     begin = (uintptr_t)old_ptr;
 
     switch (config.fast_megapage_kind_func(begin)) {

--- a/Source/bmalloc/libpas/src/libpas/pas_utils.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_utils.h
@@ -53,6 +53,12 @@
 
 PAS_BEGIN_EXTERN_C;
 
+#if defined(__has_include)
+#if __has_include(<WebKitAdditions/pas_utils_additions.h>)
+#include <WebKitAdditions/pas_utils_additions.h>
+#endif
+#endif
+
 #define PAS_ALWAYS_INLINE_BUT_NOT_INLINE __PAS_ALWAYS_INLINE_BUT_NOT_INLINE
 #define PAS_ALWAYS_INLINE __PAS_ALWAYS_INLINE
 #define PAS_NEVER_INLINE __PAS_NEVER_INLINE
@@ -171,8 +177,13 @@ PAS_BEGIN_EXTERN_C;
 #define PAS_TYPEOF(a) typeof (a)
 #endif
 
+#ifndef PAS_PROFILE
+#define PAS_PROFILE(...)
+#endif
+
 static PAS_ALWAYS_INLINE void pas_zero_memory(void* memory, size_t size)
 {
+    PAS_PROFILE(memory, ZERO_MEMORY);
     memset(memory, 0, size);
 }
 


### PR DESCRIPTION
#### 517a1dca062e8ea6dbb6e18d9718e51e622a6762
<pre>
Profile misc. pointer usage in libPAS
<a href="https://bugs.webkit.org/show_bug.cgi?id=266107">https://bugs.webkit.org/show_bug.cgi?id=266107</a>
<a href="https://rdar.apple.com/119401118">rdar://119401118</a>

Reviewed by Mark Lam.

Introduces an optionally-defined macro PAS_PROFILE to allow an
embedder to decorate libPAS functions with logging or profiling
code.

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/bmalloc/Configurations/Base.xcconfig:
* Source/bmalloc/bmalloc.xcodeproj/project.pbxproj:
* Source/bmalloc/libpas/src/libpas/pas_deallocate.h:
(pas_try_deallocate):
* Source/bmalloc/libpas/src/libpas/pas_page_base_config_utils.h:
* Source/bmalloc/libpas/src/libpas/pas_page_base_config_utils_inlines.h:
* Source/bmalloc/libpas/src/libpas/pas_try_reallocate.h:
(pas_try_reallocate):
* Source/bmalloc/libpas/src/libpas/pas_utils.h:
(pas_zero_memory):

Canonical link: <a href="https://commits.webkit.org/271797@main">https://commits.webkit.org/271797@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/089505ef158eb69895253baf9284bf0a552c2406

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29692 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8350 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30987 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32187 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26850 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10492 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5619 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26860 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29965 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6962 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25319 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5941 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/6084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26406 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33527 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/25484 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27058 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26829 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32291 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/29893 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6028 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4225 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/30068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7771 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/36257 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6571 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7816 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3823 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6558 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->