### PR TITLE
Fix visionOS build after 271747@main

### DIFF
--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm
@@ -36,6 +36,11 @@
 #import <WebCore/PlatformCALayerClient.h>
 #import <wtf/Scope.h>
 
+#if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
+#import "DynamicContentScalingImageBufferBackend.h"
+#import <WebCore/BifurcatedGraphicsContext.h>
+#endif
+
 namespace WebKit {
 
 using namespace WebCore;


### PR DESCRIPTION
#### 13a137b334fadd72224d2eafdbf2a82831f0d4e6
<pre>
Fix visionOS build after 271747@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=266109">https://bugs.webkit.org/show_bug.cgi?id=266109</a>
<a href="https://rdar.apple.com/119403888">rdar://119403888</a>

Reviewed by NOBODY (OOPS!).

Import missing headers.

* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm:
</pre>