### PR TITLE
Adopt new drag and context menu interaction classes from ServiceExtensions

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -43,6 +43,7 @@
 #import "TransactionID.h"
 #import "UIKitSPI.h"
 #import "WKMouseInteraction.h"
+#import "WKSEDefinitions.h"
 #import <WebKit/WKActionSheetAssistant.h>
 #import <WebKit/WKAirPlayRoutePicker.h>
 #import <WebKit/WKContactPicker.h>
@@ -606,7 +607,7 @@ struct ImageAnalysisContextMenuActionData {
     , WKMouseInteractionDelegate
 #endif
 #if HAVE(UI_ASYNC_DRAG_INTERACTION)
-    , _UIAsyncDragInteractionDelegate
+    , WKSEDragInteractionDelegate
 #elif ENABLE(DRAG_SUPPORT)
     , UIDragInteractionDelegate
 #endif


### PR DESCRIPTION
#### 423bb847e3d8c73a62ee314f81a9d30fa6a20da9
<pre>
Adopt new drag and context menu interaction classes from ServiceExtensions
<a href="https://bugs.webkit.org/show_bug.cgi?id=266077">https://bugs.webkit.org/show_bug.cgi?id=266077</a>
<a href="https://rdar.apple.com/119380896">rdar://119380896</a>

Reviewed by Megan Gardner.

Replace the following with classes from ServiceExtensions, if available, and use WKSE-prefixed type
defines to stage adoption:

```
_UIContextMenuAsyncConfiguration    →   WKSEContextMenuConfiguration
_UIAsyncDragInteraction             →   WKSEDragInteraction
_UIAsyncDragInteractionDelegate     →   WKSEDragInteractionDelegate
```

Additionally, remove several soft-linked symbols from UIKit, which were only necessary for staging.
These symbols have existed in their targeted SDKs for a while now, so we can now explicitly link
against them.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _shouldUseUIContextMenuAsyncConfiguration]):
(-[WKContentView _deferKeyEventToInputMethodEditing:]):
(-[WKContentView _interpretKeyEvent:isCharEvent:]):
(-[WKContentView _dragInteractionClass]):
(-[WKContentView setUpDragAndDropInteractions]):
(-[WKContentView dragInteraction:prepareDragSession:completion:]):
(-[WKContentView dragInteraction:itemsForAddingToSession:forTouchAtPoint:completion:]):
(-[WKContentView _asyncDragInteraction:prepareDragSession:completion:]):
(-[WKContentView _asyncDragInteraction:itemsForAddingToSession:withTouchAtPoint:completion:]):
(-[WKContentView contextMenuInteraction:configurationForMenuAtLocation:]):

Canonical link: <a href="https://commits.webkit.org/271809@main">https://commits.webkit.org/271809@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c68923ad4adcd61547e846cc67936bff3a163352

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29706 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8359 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31001 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32201 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26860 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10526 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5633 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26869 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29978 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6988 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25328 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5952 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6111 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33541 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27084 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26840 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32300 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6038 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4235 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30085 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7782 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7053 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6795 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6571 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->