### PR TITLE
Add a preference to enable ::thumb / ::track pseudo-elements

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -6565,6 +6565,20 @@ ThreadedScrollingEnabled:
     WebKit:
       default: true
 
+ThumbAndTrackPseudoElementsEnabled:
+  type: bool
+  status: testable
+  category: css
+  humanReadableName: "::thumb and ::track pseudo-elements"
+  humanReadableDescription: "Enable support for CSS ::thumb and ::track pseudo-elements"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 # FIXME: This is not relevent for WebKitLegacy, so should be excluded from WebKitLegacy entirely.
 TiledScrollingIndicatorVisible:
   type: bool

--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -325,7 +325,7 @@ CSSSelector::PseudoElementType CSSSelector::parsePseudoElementType(StringView na
     auto type = parsePseudoElementString(name);
     switch (type) {
     case PseudoElementWebKitCustom:
-        if (context.mode != UASheetMode && (equalLettersIgnoringASCIICase(name, "thumb"_s) || equalLettersIgnoringASCIICase(name, "track"_s)))
+        if (!context.thumbAndTrackPseudoElementsEnabled && (equalLettersIgnoringASCIICase(name, "thumb"_s) || equalLettersIgnoringASCIICase(name, "track"_s)))
             return PseudoElementUnknown;
         break;
     case PseudoElementUnknown:

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -62,6 +62,7 @@ CSSParserContext::CSSParserContext(CSSParserMode mode, const URL& baseURL)
         propertySettings.cssInputSecurityEnabled = true;
         propertySettings.cssCounterStyleAtRulesEnabled = true;
         propertySettings.viewTransitionsEnabled = true;
+        thumbAndTrackPseudoElementsEnabled = true;
 #if ENABLE(CSS_TRANSFORM_STYLE_OPTIMIZED_3D)
         transformStyleOptimized3DEnabled = true;
 #endif
@@ -107,6 +108,7 @@ CSSParserContext::CSSParserContext(const Document& document, const URL& sheetBas
     , highlightAPIEnabled { document.settings().highlightAPIEnabled() }
     , grammarAndSpellingPseudoElementsEnabled { document.settings().grammarAndSpellingPseudoElementsEnabled() }
     , customStateSetEnabled { document.settings().customStateSetEnabled() }
+    , thumbAndTrackPseudoElementsEnabled { document.settings().thumbAndTrackPseudoElementsEnabled() }
     , propertySettings { CSSPropertySettings { document.settings() } }
 {
 }
@@ -144,7 +146,8 @@ void add(Hasher& hasher, const CSSParserContext& context)
         | context.highlightAPIEnabled                       << 26
         | context.grammarAndSpellingPseudoElementsEnabled   << 27
         | context.customStateSetEnabled                     << 28
-        | (uint64_t)context.mode                            << 29; // This is multiple bits, so keep it last.
+        | context.thumbAndTrackPseudoElementsEnabled        << 29
+        | (uint64_t)context.mode                            << 30; // This is multiple bits, so keep it last.
     add(hasher, context.baseURL, context.charset, context.propertySettings, bits);
 }
 

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -100,6 +100,7 @@ struct CSSParserContext {
     bool highlightAPIEnabled : 1 { false };
     bool grammarAndSpellingPseudoElementsEnabled : 1 { false };
     bool customStateSetEnabled : 1 { false };
+    bool thumbAndTrackPseudoElementsEnabled : 1 { false };
 
     // Settings, those affecting properties.
     CSSPropertySettings propertySettings;

--- a/Source/WebCore/css/parser/CSSSelectorParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParserContext.cpp
@@ -41,6 +41,7 @@ CSSSelectorParserContext::CSSSelectorParserContext(const CSSParserContext& conte
     , hasPseudoClassEnabled(context.hasPseudoClassEnabled)
     , highlightAPIEnabled(context.highlightAPIEnabled)
     , popoverAttributeEnabled(context.popoverAttributeEnabled)
+    , thumbAndTrackPseudoElementsEnabled(context.thumbAndTrackPseudoElementsEnabled)
     , viewTransitionsEnabled(context.propertySettings.viewTransitionsEnabled)
 {
 }
@@ -54,6 +55,7 @@ CSSSelectorParserContext::CSSSelectorParserContext(const Document& document)
     , hasPseudoClassEnabled(document.settings().hasPseudoClassEnabled())
     , highlightAPIEnabled(document.settings().highlightAPIEnabled())
     , popoverAttributeEnabled(document.settings().popoverAttributeEnabled())
+    , thumbAndTrackPseudoElementsEnabled(document.settings().thumbAndTrackPseudoElementsEnabled())
     , viewTransitionsEnabled(document.settings().viewTransitionsEnabled())
 {
 }
@@ -69,6 +71,7 @@ void add(Hasher& hasher, const CSSSelectorParserContext& context)
         context.hasPseudoClassEnabled,
         context.highlightAPIEnabled,
         context.popoverAttributeEnabled,
+        context.thumbAndTrackPseudoElementsEnabled,
         context.viewTransitionsEnabled
     );
 }

--- a/Source/WebCore/css/parser/CSSSelectorParserContext.h
+++ b/Source/WebCore/css/parser/CSSSelectorParserContext.h
@@ -43,6 +43,7 @@ struct CSSSelectorParserContext {
     bool hasPseudoClassEnabled { false };
     bool highlightAPIEnabled { false };
     bool popoverAttributeEnabled { false };
+    bool thumbAndTrackPseudoElementsEnabled { false };
     bool viewTransitionsEnabled { false };
 
     bool isHashTableDeletedValue { false };


### PR DESCRIPTION
#### ec21acd844553ba47b79865445047472b9db225b
<pre>
Add a preference to enable ::thumb / ::track pseudo-elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=266136">https://bugs.webkit.org/show_bug.cgi?id=266136</a>
<a href="https://rdar.apple.com/119422878">rdar://119422878</a>

Reviewed by Aditya Keerthi.

These can be tested out currently for &lt;input type=checkbox switch&gt;, but eventually the preference should extend to &lt;input type=range&gt; and other form controls.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/css/CSSSelector.cpp:
(WebCore::CSSSelector::parsePseudoElementType):
* Source/WebCore/css/parser/CSSParserContext.cpp:
(WebCore::CSSParserContext::CSSParserContext):
(WebCore::add):
* Source/WebCore/css/parser/CSSParserContext.h:
* Source/WebCore/css/parser/CSSSelectorParserContext.cpp:
(WebCore::CSSSelectorParserContext::CSSSelectorParserContext):
(WebCore::add):
* Source/WebCore/css/parser/CSSSelectorParserContext.h:

Canonical link: <a href="https://commits.webkit.org/271806@main">https://commits.webkit.org/271806@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/86140b7de44271a29d31d06a884e16ce22d3e97d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29707 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8376 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31002 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32202 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26861 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30323 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10509 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5634 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26870 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29979 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6975 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25329 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5953 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6101 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26417 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33542 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/25495 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27071 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26841 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32301 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/29904 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6039 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4238 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30079 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7783 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/36271 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7050 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6793 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7824 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6572 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->