### PR TITLE
Rename ContextMenuItemTagCopyImageUrlToClipboard to please the style-checker

### DIFF
--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -332,7 +332,7 @@ void ContextMenuController::contextMenuItemSelected(ContextMenuAction action, co
         frame->editor().copyImage(m_context.hitTestResult());
         break;
 #if PLATFORM(GTK)
-    case ContextMenuItemTagCopyImageUrlToClipboard:
+    case ContextMenuItemTagCopyImageURLToClipboard:
         frame->editor().copyURL(m_context.hitTestResult().absoluteImageURL(), m_context.hitTestResult().textContent());
         break;
 #endif
@@ -902,8 +902,8 @@ void ContextMenuController::populate()
     ContextMenuItem CopyImageItem(ActionType, ContextMenuItemTagCopyImageToClipboard, 
         contextMenuItemTagCopyImageToClipboard());
 #if PLATFORM(GTK)
-    ContextMenuItem CopyImageUrlItem(ActionType, ContextMenuItemTagCopyImageUrlToClipboard, 
-        contextMenuItemTagCopyImageUrlToClipboard());
+    ContextMenuItem CopyImageURLItem(ActionType, ContextMenuItemTagCopyImageURLToClipboard,
+        contextMenuItemTagCopyImageURLToClipboard());
 #endif
     ContextMenuItem OpenMediaInNewWindowItem(ActionType, ContextMenuItemTagOpenMediaInNewWindow, String());
     ContextMenuItem DownloadMediaItem(ActionType, ContextMenuItemTagDownloadMediaToDisk, String());
@@ -1108,7 +1108,7 @@ void ContextMenuController::populate()
 #endif // ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
             }
 #if PLATFORM(GTK)
-            appendItem(CopyImageUrlItem, m_contextMenu.get());
+            appendItem(CopyImageURLItem, m_contextMenu.get());
 #endif
         }
 
@@ -1631,7 +1631,7 @@ void ContextMenuController::checkOrEnableIfNeeded(ContextMenuItem& item) const
         case ContextMenuItemTagCopyImageToClipboard:
         case ContextMenuItemTagCopySubject:
 #if PLATFORM(GTK)
-        case ContextMenuItemTagCopyImageUrlToClipboard:
+        case ContextMenuItemTagCopyImageURLToClipboard:
 #endif
             break;
         case ContextMenuItemTagDownloadImageToDisk:

--- a/Source/WebCore/platform/ContextMenuItem.cpp
+++ b/Source/WebCore/platform/ContextMenuItem.cpp
@@ -155,7 +155,7 @@ static bool isValidContextMenuAction(WebCore::ContextMenuAction action)
     case ContextMenuAction::ContextMenuItemTagCopyImageToClipboard:
     case ContextMenuAction::ContextMenuItemTagCopySubject:
 #if PLATFORM(GTK)
-    case ContextMenuAction::ContextMenuItemTagCopyImageUrlToClipboard:
+    case ContextMenuAction::ContextMenuItemTagCopyImageURLToClipboard:
 #endif
     case ContextMenuAction::ContextMenuItemTagOpenFrameInNewWindow:
     case ContextMenuAction::ContextMenuItemTagCopy:

--- a/Source/WebCore/platform/ContextMenuItem.h
+++ b/Source/WebCore/platform/ContextMenuItem.h
@@ -43,7 +43,7 @@ enum ContextMenuAction {
     ContextMenuItemTagDownloadImageToDisk,
     ContextMenuItemTagCopyImageToClipboard,
 #if PLATFORM(GTK)
-    ContextMenuItemTagCopyImageUrlToClipboard,
+    ContextMenuItemTagCopyImageURLToClipboard,
 #endif
     ContextMenuItemTagOpenFrameInNewWindow,
     ContextMenuItemTagCopy,

--- a/Source/WebCore/platform/LocalizedStrings.h
+++ b/Source/WebCore/platform/LocalizedStrings.h
@@ -71,7 +71,7 @@ namespace WebCore {
     String contextMenuItemTagDownloadImageToDisk();
     String contextMenuItemTagCopyImageToClipboard();
 #if PLATFORM(GTK)
-    String contextMenuItemTagCopyImageUrlToClipboard();
+    String contextMenuItemTagCopyImageURLToClipboard();
 #endif
     String contextMenuItemTagOpenFrameInNewWindow();
     String contextMenuItemTagCopy();

--- a/Source/WebCore/platform/gtk/LocalizedStringsGtk.cpp
+++ b/Source/WebCore/platform/gtk/LocalizedStringsGtk.cpp
@@ -48,7 +48,7 @@ String contextMenuItemTagDownloadImageToDisk()
     return String::fromUTF8(_("Sa_ve Image As"));
 }
 
-String contextMenuItemTagCopyImageUrlToClipboard()
+String contextMenuItemTagCopyImageURLToClipboard()
 {
     return String::fromUTF8(_("Copy Image _Address"));
 }

--- a/Source/WebKit/Shared/API/c/WKContextMenuItemTypes.h
+++ b/Source/WebKit/Shared/API/c/WKContextMenuItemTypes.h
@@ -121,7 +121,7 @@ enum {
     kWKContextMenuItemTagPauseAllAnimations,
     kWKContextMenuItemTagPlayAnimation,
     kWKContextMenuItemTagPauseAnimation,
-    kWKContextMenuItemTagCopyImageUrlToClipboard,
+    kWKContextMenuItemTagCopyImageURLToClipboard,
     kWKContextMenuItemTagSelectAll,
     kWKContextMenuItemTagOpenLinkInThisWindow,
     kWKContextMenuItemTagToggleVideoFullscreen,

--- a/Source/WebKit/Shared/API/c/WKSharedAPICast.h
+++ b/Source/WebKit/Shared/API/c/WKSharedAPICast.h
@@ -404,8 +404,8 @@ inline WKContextMenuItemTag toAPI(WebCore::ContextMenuAction action)
         return kWKContextMenuItemTagPauseAnimation;
 #endif // ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
 #if PLATFORM(GTK)
-    case WebCore::ContextMenuItemTagCopyImageUrlToClipboard:
-        return kWKContextMenuItemTagCopyImageUrlToClipboard;
+    case WebCore::ContextMenuItemTagCopyImageURLToClipboard:
+        return kWKContextMenuItemTagCopyImageURLToClipboard;
 #endif
     case WebCore::ContextMenuItemTagOpenFrameInNewWindow:
         return kWKContextMenuItemTagOpenFrameInNewWindow;
@@ -619,8 +619,8 @@ inline WebCore::ContextMenuAction toImpl(WKContextMenuItemTag tag)
 #endif // ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
     case kWKContextMenuItemTagOpenFrameInNewWindow:
 #if PLATFORM(GTK)
-    case kWKContextMenuItemTagCopyImageUrlToClipboard:
-        return WebCore::ContextMenuItemTagCopyImageUrlToClipboard;
+    case kWKContextMenuItemTagCopyImageURLToClipboard:
+        return WebCore::ContextMenuItemTagCopyImageURLToClipboard;
 #endif
         return WebCore::ContextMenuItemTagOpenFrameInNewWindow;
     case kWKContextMenuItemTagCopy:

--- a/Source/WebKit/Shared/API/glib/WebKitContextMenuActions.cpp
+++ b/Source/WebKit/Shared/API/glib/WebKitContextMenuActions.cpp
@@ -62,7 +62,7 @@ ContextMenuAction webkitContextMenuActionGetActionTag(WebKitContextMenuAction ac
         return ContextMenuItemTagCopyImageToClipboard;
 #if PLATFORM(GTK)
     case WEBKIT_CONTEXT_MENU_ACTION_COPY_IMAGE_URL_TO_CLIPBOARD:
-        return ContextMenuItemTagCopyImageUrlToClipboard;
+        return ContextMenuItemTagCopyImageURLToClipboard;
 #endif
     case WEBKIT_CONTEXT_MENU_ACTION_OPEN_FRAME_IN_NEW_WINDOW:
         return ContextMenuItemTagOpenFrameInNewWindow;
@@ -165,7 +165,7 @@ WebKitContextMenuAction webkitContextMenuActionGetForContextMenuItem(const WebKi
     case ContextMenuItemTagCopyImageToClipboard:
         return WEBKIT_CONTEXT_MENU_ACTION_COPY_IMAGE_TO_CLIPBOARD;
 #if PLATFORM(GTK)
-    case ContextMenuItemTagCopyImageUrlToClipboard:
+    case ContextMenuItemTagCopyImageURLToClipboard:
         return WEBKIT_CONTEXT_MENU_ACTION_COPY_IMAGE_URL_TO_CLIPBOARD;
 #endif
     case ContextMenuItemTagOpenFrameInNewWindow:
@@ -268,7 +268,7 @@ String webkitContextMenuActionGetLabel(WebKitContextMenuAction action)
         return contextMenuItemTagCopyImageToClipboard();
 #if PLATFORM(GTK)
     case WEBKIT_CONTEXT_MENU_ACTION_COPY_IMAGE_URL_TO_CLIPBOARD:
-        return contextMenuItemTagCopyImageUrlToClipboard();
+        return contextMenuItemTagCopyImageURLToClipboard();
 #endif
     case WEBKIT_CONTEXT_MENU_ACTION_OPEN_FRAME_IN_NEW_WINDOW:
         return contextMenuItemTagOpenFrameInNewWindow();

--- a/Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.mm
@@ -229,7 +229,7 @@ static NSString * const WKInspectorResourceScheme = @"inspector-resource";
         case kWKContextMenuItemTagOpenImageInNewWindow:
         case kWKContextMenuItemTagOpenFrameInNewWindow:
         case kWKContextMenuItemTagOpenMediaInNewWindow:
-        case kWKContextMenuItemTagCopyImageUrlToClipboard:
+        case kWKContextMenuItemTagCopyImageURLToClipboard:
         case kWKContextMenuItemTagCopyImageToClipboard:
         case kWKContextMenuItemTagDownloadLinkToDisk:
         case kWKContextMenuItemTagDownloadImageToDisk:


### PR DESCRIPTION
#### c38667754e0673f0662f01833aa07e5ae4973e8a
<pre>
Rename ContextMenuItemTagCopyImageUrlToClipboard to please the style-checker
<a href="https://bugs.webkit.org/show_bug.cgi?id=266137">https://bugs.webkit.org/show_bug.cgi?id=266137</a>

Reviewed by Chris Dumez.

The style checker has been bugging me in a different MR because
of ContextMenuItemTagCopyImageUrlToClipboard. Rename it to
capitalize URL properly and a fix the capitalization of a
few related methods as well.

* Source/WebCore/page/ContextMenuController.cpp:
(WebCore::ContextMenuController::contextMenuItemSelected):
(WebCore::ContextMenuController::populate):
(WebCore::ContextMenuController::checkOrEnableIfNeeded const):
* Source/WebCore/platform/ContextMenuItem.cpp:
(WebCore::isValidContextMenuAction):
* Source/WebCore/platform/ContextMenuItem.h:
* Source/WebCore/platform/LocalizedStrings.h:
* Source/WebCore/platform/gtk/LocalizedStringsGtk.cpp:
(WebCore::contextMenuItemTagCopyImageURLToClipboard):
(WebCore::contextMenuItemTagCopyImageUrlToClipboard): Deleted.
* Source/WebKit/Shared/API/c/WKContextMenuItemTypes.h:
* Source/WebKit/Shared/API/c/WKSharedAPICast.h:
(WebKit::toAPI):
(WebKit::toImpl):
* Source/WebKit/Shared/API/glib/WebKitContextMenuActions.cpp:
(webkitContextMenuActionGetActionTag):
(webkitContextMenuActionGetForContextMenuItem):
(webkitContextMenuActionGetLabel):
* Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.mm:
(-[WKInspectorViewController _webView:contextMenu:forElement:]):

Canonical link: <a href="https://commits.webkit.org/271808@main">https://commits.webkit.org/271808@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2dd7a79fe013c43ddf99c98a63e2d67408a2bc0b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29708 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8361 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31003 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32203 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26862 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30324 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10510 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5635 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26867 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29980 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6974 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25330 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5951 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6093 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26418 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33543 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27070 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26842 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32298 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6040 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4242 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30078 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7784 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7052 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6796 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6573 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->