### PR TITLE
Add <input type=checkbox switch> macOS focus ring support

### DIFF
--- a/Source/WebCore/platform/graphics/mac/controls/SwitchTrackMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SwitchTrackMac.mm
@@ -27,6 +27,7 @@
 
 #if PLATFORM(MAC)
 
+#import "ColorCocoa.h"
 #import "SwitchMacUtilities.h"
 
 namespace WebCore {
@@ -140,6 +141,7 @@ void SwitchTrackMac::draw(GraphicsContext& context, const FloatRoundedRect& bord
     auto isEnabled = style.states.contains(ControlStyle::State::Enabled);
     auto isPressed = style.states.contains(ControlStyle::State::Pressed);
     auto isInActiveWindow = style.states.contains(ControlStyle::State::WindowActive);
+    auto isFocused = style.states.contains(ControlStyle::State::Focused);
     auto needsOnOffLabels = userPrefersWithoutColorDifferentiation();
     auto progress = SwitchMacUtilities::easeInOut(owningPart().progress());
 
@@ -190,6 +192,11 @@ void SwitchTrackMac::draw(GraphicsContext& context, const FloatRoundedRect& bord
         trackImage->context().drawConsumingImageBuffer(WTFMove(toImage), IntPoint(), ImagePaintingOptions { CompositeOperator::PlusLighter });
     }
     context.drawConsumingImageBuffer(WTFMove(trackImage), inflatedTrackRect.location());
+
+    if (isFocused) {
+        auto color = colorFromCocoaColor([NSColor keyboardFocusIndicatorColor]).opaqueColor();
+        context.drawFocusRing(Vector { trackRect }, 0, 1.0f, color);
+    }
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -809,7 +809,9 @@ ControlStyle RenderTheme::extractControlStyleForRenderer(const RenderBox& box) c
     const RenderObject* renderer = &box;
     auto type = box.style().effectiveAppearance();
 
-    if (type == StyleAppearance::SearchFieldCancelButton) {
+    if (type == StyleAppearance::SearchFieldCancelButton
+        || type == StyleAppearance::SwitchTrack
+        || type == StyleAppearance::SwitchThumb) {
         auto* input = box.element()->shadowHost();
         if (!input)
             input = box.element();
@@ -1314,11 +1316,8 @@ bool RenderTheme::isIndeterminate(const RenderObject& renderer) const
 
 bool RenderTheme::isEnabled(const RenderObject& renderer) const
 {
-    if (RefPtr element = dynamicDowncast<Element>(renderer.node())) {
-        return !(element->isDisabledFormControl()
-            || (element->shadowHost() && element->shadowHost()->isDisabledFormControl()));
-    }
-    return true;
+    RefPtr element = dynamicDowncast<Element>(renderer.node());
+    return element && !element->isDisabledFormControl();
 }
 
 bool RenderTheme::isFocused(const RenderObject& renderer) const
@@ -1327,6 +1326,7 @@ bool RenderTheme::isFocused(const RenderObject& renderer) const
     if (!element)
         return false;
 
+    // FIXME: This should be part of RenderTheme::extractControlStyleForRenderer().
     RefPtr delegate = element;
     if (RefPtr sliderThumb = dynamicDowncast<SliderThumbElement>(element))
         delegate = sliderThumb->hostInput();
@@ -1338,10 +1338,8 @@ bool RenderTheme::isFocused(const RenderObject& renderer) const
 
 bool RenderTheme::isPressed(const RenderObject& renderer) const
 {
-    if (auto* element = dynamicDowncast<Element>(renderer.node()))
-        return element->active()
-            || (element->shadowHost() && element->shadowHost()->active());
-    return false;
+    RefPtr element = dynamicDowncast<Element>(renderer.node());
+    return element && element->active();
 }
 
 bool RenderTheme::isSpinUpButtonPartPressed(const RenderObject& renderer) const

--- a/Source/WebCore/rendering/RenderThemeMac.h
+++ b/Source/WebCore/rendering/RenderThemeMac.h
@@ -162,7 +162,6 @@ private:
 
     void updateCheckedState(NSCell*, const RenderObject&);
     void updateEnabledState(NSCell*, const RenderObject&);
-    void updateFocusedState(NSCell *, const RenderObject*);
     void updatePressedState(NSCell*, const RenderObject&);
 
     // Helpers for adjusting appearance and for painting

--- a/Source/WebCore/rendering/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/RenderThemeMac.mm
@@ -792,14 +792,6 @@ void RenderThemeMac::updateEnabledState(NSCell* cell, const RenderObject& o)
         [cell setEnabled:enabled];
 }
 
-void RenderThemeMac::updateFocusedState(NSCell *cell, const RenderObject* o)
-{
-    bool oldFocused = [cell showsFirstResponder];
-    bool focused = o && isFocused(*o) && o->style().outlineStyleIsAuto() == OutlineIsAuto::On;
-    if (focused != oldFocused)
-        [cell setShowsFirstResponder:focused];
-}
-
 void RenderThemeMac::updatePressedState(NSCell* cell, const RenderObject& o)
 {
     bool oldPressed = [cell isHighlighted];


### PR DESCRIPTION
#### 8cbb6b66a695b63eb9a16a9f955d37c9c391e176
<pre>
Add &lt;input type=checkbox switch&gt; macOS focus ring support
<a href="https://bugs.webkit.org/show_bug.cgi?id=266139">https://bugs.webkit.org/show_bug.cgi?id=266139</a>

Reviewed by Aditya Keerthi.

I discovered that the approach taken in 269869@main to teach
RenderTheme is[State]() checks about switches was wrong. Rather than
changing individual state checks, it should have modified
extractControlStyleForRenderer() instead. By correcting that here the
correct thing will happen in RenderTheme for isFocused().

As a drive-by fix this removes RenderThemeMac::updateFocusedState()
which does not appear to be used and was confusing me.

* Source/WebCore/platform/graphics/mac/controls/SwitchTrackMac.mm:
(WebCore::SwitchTrackMac::draw):
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::extractControlStyleForRenderer const):
(WebCore::RenderTheme::isEnabled const):
(WebCore::RenderTheme::isFocused const):
(WebCore::RenderTheme::isPressed const):
* Source/WebCore/rendering/RenderThemeMac.h:
* Source/WebCore/rendering/RenderThemeMac.mm:
(WebCore::RenderThemeMac::updateFocusedState): Deleted.

Canonical link: <a href="https://commits.webkit.org/271884@main">https://commits.webkit.org/271884@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6cf43288943659b1c5b01b9b3ebccb8cc03c370

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29936 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8602 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31254 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32448 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27071 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30596 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10788 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5857 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27121 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30230 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7210 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25543 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6152 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6319 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26632 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33784 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27305 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27066 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32494 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6253 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/4430 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30284 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7989 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7091 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6995 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6779 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->