### PR TITLE
Remove HAVE(OS_DARK_MODE_SUPPORT) inside PLATFORM(MAC)

### DIFF
--- a/Source/WebCore/platform/graphics/mac/controls/WebControlView.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/WebControlView.mm
@@ -149,13 +149,11 @@ static NSRect _clipBounds;
 
 - (CFDictionaryRef)_adjustedCoreUIDrawOptionsForDrawingBordersOnly:(CFDictionaryRef)defaultOptions
 {
-#if HAVE(OS_DARK_MODE_SUPPORT)
     // Dark mode controls don't have borders, just a semi-transparent background of shadows.
     // In the dark mode case we can't disable borders, or we will not paint anything for the control.
     NSAppearanceName appearance = [self.controlView.effectiveAppearance bestMatchFromAppearancesWithNames:@[ NSAppearanceNameAqua, NSAppearanceNameDarkAqua ]];
     if ([appearance isEqualToString:NSAppearanceNameDarkAqua])
         return defaultOptions;
-#endif
 
     // FIXME: This is a workaround for <rdar://problem/11385461>. When that bug is resolved, we should remove this code,
     // as well as the internal method overrides below.

--- a/Source/WebCore/platform/mac/LocalDefaultSystemAppearance.h
+++ b/Source/WebCore/platform/mac/LocalDefaultSystemAppearance.h
@@ -46,23 +46,13 @@ public:
     WEBCORE_EXPORT LocalDefaultSystemAppearance(bool useDarkAppearance, const Color& tintColor = { });
     WEBCORE_EXPORT ~LocalDefaultSystemAppearance();
 
-    bool usingDarkAppearance() const
-    {
-#if HAVE(OS_DARK_MODE_SUPPORT)
-        return m_usingDarkAppearance;
-#else
-        return false;
-#endif
-    }
+    bool usingDarkAppearance() const { return m_usingDarkAppearance; }
 
 private:
-#if HAVE(OS_DARK_MODE_SUPPORT)
     RetainPtr<NSAppearance> m_savedSystemAppearance;
     bool m_usingDarkAppearance { false };
-#endif
 };
     
 }
 
 #endif // USE(APPKIT)
-

--- a/Source/WebCore/platform/mac/LocalDefaultSystemAppearance.mm
+++ b/Source/WebCore/platform/mac/LocalDefaultSystemAppearance.mm
@@ -36,7 +36,6 @@ namespace WebCore {
 
 LocalDefaultSystemAppearance::LocalDefaultSystemAppearance(bool useDarkAppearance, const Color& tintColor)
 {
-#if HAVE(OS_DARK_MODE_SUPPORT)
     m_savedSystemAppearance = [NSAppearance currentDrawingAppearance];
     m_usingDarkAppearance = useDarkAppearance;
 
@@ -48,19 +47,13 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 
     [NSAppearance setCurrentAppearance:appearance];
 ALLOW_DEPRECATED_DECLARATIONS_END
-#else
-    UNUSED_PARAM(useDarkAppearance);
-    UNUSED_PARAM(tintColor);
-#endif
 }
 
 LocalDefaultSystemAppearance::~LocalDefaultSystemAppearance()
 {
-#if HAVE(OS_DARK_MODE_SUPPORT)
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     [NSAppearance setCurrentAppearance:m_savedSystemAppearance.get()];
 ALLOW_DEPRECATED_DECLARATIONS_END
-#endif
 }
 
 }

--- a/Source/WebCore/rendering/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/RenderThemeMac.mm
@@ -256,13 +256,8 @@ Color RenderThemeMac::platformActiveSelectionBackgroundColor(OptionSet<StyleColo
 
 Color RenderThemeMac::platformInactiveSelectionBackgroundColor(OptionSet<StyleColorOptions> options) const
 {
-#if HAVE(OS_DARK_MODE_SUPPORT)
     LocalDefaultSystemAppearance localAppearance(options.contains(StyleColorOptions::UseDarkAppearance));
     return colorFromCocoaColor([NSColor unemphasizedSelectedTextBackgroundColor]);
-#else
-    UNUSED_PARAM(options);
-    return colorFromCocoaColor([NSColor unemphasizedSelectedContentBackgroundColor]);
-#endif
 }
 
 Color RenderThemeMac::transformSelectionBackgroundColor(const Color& color, OptionSet<StyleColorOptions> options) const
@@ -293,37 +288,21 @@ Color RenderThemeMac::platformActiveSelectionForegroundColor(OptionSet<StyleColo
 
 Color RenderThemeMac::platformInactiveSelectionForegroundColor(OptionSet<StyleColorOptions> options) const
 {
-#if HAVE(OS_DARK_MODE_SUPPORT)
     LocalDefaultSystemAppearance localAppearance(options.contains(StyleColorOptions::UseDarkAppearance));
     if (localAppearance.usingDarkAppearance())
         return colorFromCocoaColor([NSColor unemphasizedSelectedTextColor]);
     return { };
-#else
-    UNUSED_PARAM(options);
-    return { };
-#endif
 }
 
 Color RenderThemeMac::platformActiveListBoxSelectionBackgroundColor(OptionSet<StyleColorOptions> options) const
 {
-#if HAVE(OS_DARK_MODE_SUPPORT)
     LocalDefaultSystemAppearance localAppearance(options.contains(StyleColorOptions::UseDarkAppearance));
     return colorFromCocoaColor([NSColor selectedContentBackgroundColor]);
-#else
-    UNUSED_PARAM(options);
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    return colorFromCocoaColor([NSColor alternateSelectedControlColor]);
-ALLOW_DEPRECATED_DECLARATIONS_END
-#endif
 }
 
 Color RenderThemeMac::platformInactiveListBoxSelectionBackgroundColor(OptionSet<StyleColorOptions> options) const
 {
-#if HAVE(OS_DARK_MODE_SUPPORT)
     LocalDefaultSystemAppearance localAppearance(options.contains(StyleColorOptions::UseDarkAppearance));
-#else
-    UNUSED_PARAM(options);
-#endif
     return colorFromCocoaColor([NSColor unemphasizedSelectedContentBackgroundColor]);
 
 }
@@ -336,13 +315,8 @@ Color RenderThemeMac::platformActiveListBoxSelectionForegroundColor(OptionSet<St
 
 Color RenderThemeMac::platformInactiveListBoxSelectionForegroundColor(OptionSet<StyleColorOptions> options) const
 {
-#if HAVE(OS_DARK_MODE_SUPPORT)
     LocalDefaultSystemAppearance localAppearance(options.contains(StyleColorOptions::UseDarkAppearance));
     return colorFromCocoaColor([NSColor unemphasizedSelectedTextColor]);
-#else
-    UNUSED_PARAM(options);
-    return colorFromCocoaColor([NSColor selectedControlTextColor]);
-#endif
 }
 
 inline static Color defaultFocusRingColor(OptionSet<StyleColorOptions> options)
@@ -476,13 +450,7 @@ Color RenderThemeMac::systemColor(CSSValueID cssValueID, OptionSet<StyleColorOpt
             return focusRingColor(options);
 
         case CSSValueAppleSystemControlAccent:
-#if HAVE(OS_DARK_MODE_SUPPORT)
             return systemAppearanceColor(cache.systemControlAccentColor, @selector(controlAccentColor));
-#else
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-            return systemAppearanceColor(cache.systemControlAccentColor, @selector(alternateSelectedControlColor));
-ALLOW_DEPRECATED_DECLARATIONS_END
-#endif
 
         case CSSValueAppleSystemSelectedContentBackground:
             return activeListBoxSelectionBackgroundColor(options);
@@ -575,9 +543,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
             case CSSValueAppleSystemTextBackground:
                 return @selector(textBackgroundColor);
             case CSSValueAppleSystemControlBackground:
-#if HAVE(OS_DARK_MODE_SUPPORT)
             case CSSValueWebkitControlBackground:
-#endif
                 return @selector(controlBackgroundColor);
             case CSSValueAppleSystemAlternateSelectedText:
                 return @selector(alternateSelectedControlTextColor);
@@ -586,28 +552,15 @@ ALLOW_DEPRECATED_DECLARATIONS_END
             case CSSValueAppleSystemSelectedText:
                 return @selector(selectedTextColor);
             case CSSValueAppleSystemUnemphasizedSelectedText:
-#if HAVE(OS_DARK_MODE_SUPPORT)
                 return @selector(unemphasizedSelectedTextColor);
-#else
-                return @selector(textColor);
-#endif
             case CSSValueAppleSystemUnemphasizedSelectedTextBackground:
-#if HAVE(OS_DARK_MODE_SUPPORT)
                 return @selector(unemphasizedSelectedTextBackgroundColor);
-#else
-                return @selector(unemphasizedSelectedContentBackgroundColor);
-#endif
             case CSSValueAppleSystemPlaceholderText:
                 return @selector(placeholderTextColor);
             case CSSValueAppleSystemFindHighlightBackground:
                 return @selector(findHighlightColor);
             case CSSValueAppleSystemContainerBorder:
-#if HAVE(OS_DARK_MODE_SUPPORT)
                 return @selector(containerBorderColor);
-#else
-                // Handled below.
-                return nullptr;
-#endif
             case CSSValueAppleSystemLabel:
                 return @selector(labelColor);
             case CSSValueAppleSystemSecondaryLabel:
@@ -627,11 +580,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
             case CSSValueAppleSystemGrid:
                 return @selector(gridColor);
             case CSSValueAppleSystemSeparator:
-#if HAVE(OS_DARK_MODE_SUPPORT)
                 return @selector(separatorColor);
-#else
-                return @selector(gridColor);
-#endif
             case CSSValueAppleWirelessPlaybackTargetActive:
             case CSSValueAppleSystemBlue:
                 return @selector(systemBlueColor);
@@ -700,27 +649,14 @@ ALLOW_DEPRECATED_DECLARATIONS_END
                 return { SRGBA<uint8_t> { 63, 99, 139, 204 }, Color::Flags::Semantic };
             return { SRGBA<uint8_t> { 128, 188, 254, 153 }, Color::Flags::Semantic };
 
-#if !HAVE(OS_DARK_MODE_SUPPORT)
-        case CSSValueAppleSystemContainerBorder:
-            return SRGBA<uint8_t> { 197, 197, 197 };
-#endif
-
         case CSSValueAppleSystemEvenAlternatingContentBackground: {
-#if HAVE(OS_DARK_MODE_SUPPORT)
             NSArray<NSColor *> *alternateColors = [NSColor alternatingContentBackgroundColors];
-#else
-            NSArray<NSColor *> *alternateColors = [NSColor controlAlternatingRowBackgroundColors];
-#endif
             ASSERT(alternateColors.count >= 2);
             return semanticColorFromNSColor(alternateColors[0]);
         }
 
         case CSSValueAppleSystemOddAlternatingContentBackground: {
-#if HAVE(OS_DARK_MODE_SUPPORT)
             NSArray<NSColor *> *alternateColors = [NSColor alternatingContentBackgroundColors];
-#else
-            NSArray<NSColor *> *alternateColors = [NSColor controlAlternatingRowBackgroundColors];
-#endif
             ASSERT(alternateColors.count >= 2);
             return semanticColorFromNSColor(alternateColors[1]);
         }

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -5703,12 +5703,8 @@ void WebViewImpl::effectiveAppearanceDidChange()
 
 bool WebViewImpl::effectiveAppearanceIsDark()
 {
-#if HAVE(OS_DARK_MODE_SUPPORT)
     NSAppearanceName appearance = [[m_view effectiveAppearance] bestMatchFromAppearancesWithNames:@[ NSAppearanceNameAqua, NSAppearanceNameDarkAqua ]];
     return [appearance isEqualToString:NSAppearanceNameDarkAqua];
-#else
-    return false;
-#endif
 }
 
 bool WebViewImpl::effectiveUserInterfaceLevelIsElevated()


### PR DESCRIPTION
#### 1dc7738d93bb6d5326a0c2bd47e932eec216fc14
<pre>
Remove HAVE(OS_DARK_MODE_SUPPORT) inside PLATFORM(MAC)
<a href="https://bugs.webkit.org/show_bug.cgi?id=266146">https://bugs.webkit.org/show_bug.cgi?id=266146</a>

Reviewed by Tim Horton and Alex Christensen.

New functionality added in, e.g., RenderThemeMac, already did not use
this directive and it also makes things harder to read.

* Source/WebCore/platform/graphics/mac/controls/WebControlView.mm:
(-[WebControlTextFieldCell _adjustedCoreUIDrawOptionsForDrawingBordersOnly:]):
* Source/WebCore/platform/mac/LocalDefaultSystemAppearance.h:
(WebCore::LocalDefaultSystemAppearance::usingDarkAppearance const):
* Source/WebCore/platform/mac/LocalDefaultSystemAppearance.mm:
(WebCore::LocalDefaultSystemAppearance::LocalDefaultSystemAppearance):
(WebCore::LocalDefaultSystemAppearance::~LocalDefaultSystemAppearance):
* Source/WebCore/rendering/RenderThemeMac.mm:
(WebCore::RenderThemeMac::platformInactiveSelectionBackgroundColor const):
(WebCore::RenderThemeMac::platformInactiveSelectionForegroundColor const):
(WebCore::RenderThemeMac::platformActiveListBoxSelectionBackgroundColor const):
(WebCore::RenderThemeMac::platformInactiveListBoxSelectionBackgroundColor const):
(WebCore::RenderThemeMac::platformInactiveListBoxSelectionForegroundColor const):
(WebCore::RenderThemeMac::systemColor const):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::effectiveAppearanceIsDark):

Canonical link: <a href="https://commits.webkit.org/271830@main">https://commits.webkit.org/271830@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08725e4a4c2a991834571f114b8e49f16f538c9e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29721 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8378 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31019 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32221 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26876 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30339 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10531 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5650 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26887 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29996 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6991 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25339 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5963 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6114 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26427 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33559 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27087 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26851 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32310 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6052 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4252 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30092 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7797 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7067 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6805 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6586 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->