### PR TITLE
Add EnumeratedArrayKey, remove EnumTraits fallback for EnumeratedArray's last-value logic

### DIFF
--- a/Source/WTF/wtf/EnumeratedArray.h
+++ b/Source/WTF/wtf/EnumeratedArray.h
@@ -26,25 +26,28 @@
 #pragma once
 
 #include <array>
-#include <wtf/EnumTraits.h>
+#include <type_traits>
 
 namespace WTF {
+
+template<typename KeyType, KeyType lastValue>
+using EnumeratedArrayKey = std::integral_constant<KeyType, lastValue>;
 
 // This is an std::array where the indices of the array are values of an enum (rather than a size_t).
 // This assumes the values of the enum start at 0 and monotonically increase by 1
 // (so the conversion function between size_t and the enum is just a simple static_cast).
 // LastValue is the maximum value of the enum, which determines the size of the array.
-template <typename Key, typename T, Key LastValue = EnumTraits<Key>::values::max>
+template <typename Key, typename T>
 class EnumeratedArray {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     using value_type = T;
-    using size_type = Key;
+    using size_type = typename Key::value_type;
     using reference = value_type&;
     using const_reference = const value_type&;
     using pointer = value_type*;
     using const_pointer = const value_type*;
-    using UnderlyingType = std::array<T, static_cast<std::size_t>(LastValue) + 1>;
+    using UnderlyingType = std::array<T, static_cast<std::size_t>(Key::value) + 1>;
     using iterator = typename UnderlyingType::iterator;
     using const_iterator = typename UnderlyingType::const_iterator;
     using reverse_iterator = std::reverse_iterator<iterator>;
@@ -219,32 +222,32 @@ public:
         return m_storage.swap(other.m_storage);
     }
 
-    template <typename Key2, typename T2, Key2 LastValue2>
-    constexpr bool operator==(const EnumeratedArray<Key2, T2, LastValue2>& rhs) const
+    template <typename Key2, typename T2>
+    constexpr bool operator==(const EnumeratedArray<Key2, T2>& rhs) const
     {
         return m_storage == rhs.m_storage;
     }
 
-    template <typename Key2, typename T2, Key2 LastValue2>
-    bool operator<(const EnumeratedArray<Key2, T2, LastValue2>& rhs) const
+    template <typename Key2, typename T2>
+    bool operator<(const EnumeratedArray<Key2, T2>& rhs) const
     {
         return m_storage < rhs.m_storage;
     }
 
-    template <typename Key2, typename T2, Key2 LastValue2>
-    bool operator<=(const EnumeratedArray<Key2, T2, LastValue2>& rhs) const
+    template <typename Key2, typename T2>
+    bool operator<=(const EnumeratedArray<Key2, T2>& rhs) const
     {
         return m_storage <= rhs.m_storage;
     }
 
-    template <typename Key2, typename T2, Key2 LastValue2>
-    bool operator>(const EnumeratedArray<Key2, T2, LastValue2>& rhs) const
+    template <typename Key2, typename T2>
+    bool operator>(const EnumeratedArray<Key2, T2>& rhs) const
     {
         return m_storage > rhs.m_storage;
     }
 
-    template <typename Key2, typename T2, Key2 LastValue2>
-    bool operator>=(const EnumeratedArray<Key2, T2, LastValue2>& rhs) const
+    template <typename Key2, typename T2>
+    bool operator>=(const EnumeratedArray<Key2, T2>& rhs) const
     {
         return m_storage >= rhs.m_storage;
     }
@@ -260,4 +263,5 @@ private:
 
 } // namespace WTF
 
+using WTF::EnumeratedArrayKey;
 using WTF::EnumeratedArray;

--- a/Source/WTF/wtf/Forward.h
+++ b/Source/WTF/wtf/Forward.h
@@ -72,7 +72,7 @@ template<typename> struct DefaultRefDerefTraits;
 template<typename> class CompactPtr;
 template<typename> class CompletionHandler;
 template<typename, size_t = 0> class Deque;
-template<typename Key, typename, Key> class EnumeratedArray;
+template<typename, typename> class EnumeratedArray;
 template<typename> class FixedVector;
 template<typename> class Function;
 template<typename, typename = AnyThreadsAccessTraits> class LazyNeverDestroyed;

--- a/Source/WebCore/dom/make_names.pl
+++ b/Source/WebCore/dom/make_names.pl
@@ -937,8 +937,7 @@ sub printTagNameHeaderFile
         $lastTagEnumValue = $unadjustedTagEnumValue if $unadjustedTagEnumValue ne "";
     }
 
-    print F "inline constexpr auto lastTagNameEnumValue = TagName::$lastTagEnumValue;\n";
-    print F "inline LazyNeverDestroyed<EnumeratedArray<TagName, AtomString, lastTagNameEnumValue>> tagNameStrings;\n";
+    print F "inline LazyNeverDestroyed<EnumeratedArray<EnumeratedArrayKey<TagName, TagName::$lastTagEnumValue>, AtomString>> tagNameStrings;\n";
     print F "\n";
     print F "WEBCORE_EXPORT void initializeTagNameStrings();\n";
     print F "TagName findTagName(std::span<const UChar>);\n";

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.h
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.h
@@ -111,7 +111,7 @@ private:
         std::unique_ptr<MixedFontGlyphPage> m_mixedFont;
     };
 
-    EnumeratedArray<ResolvedEmojiPolicy, HashMap<unsigned, GlyphPageCacheEntry, IntHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>>> m_cachedPages;
+    EnumeratedArray<EnumeratedArrayKey<ResolvedEmojiPolicy, ResolvedEmojiPolicy::RequireEmoji>, HashMap<unsigned, GlyphPageCacheEntry, IntHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>>> m_cachedPages;
 
     HashSet<RefPtr<Font>> m_systemFallbackFontSet;
 

--- a/Source/WebCore/platform/graphics/SystemFontDatabase.h
+++ b/Source/WebCore/platform/graphics/SystemFontDatabase.h
@@ -91,7 +91,7 @@ private:
     const SystemFontShorthandInfo& systemFontShorthandInfo(FontShorthand);
     static SystemFontShorthandInfo platformSystemFontShorthandInfo(FontShorthand);
 
-    using SystemFontShorthandCache = EnumeratedArray<FontShorthand, std::optional<SystemFontShorthandInfo>, FontShorthand::StatusBar>;
+    using SystemFontShorthandCache = EnumeratedArray<EnumeratedArrayKey<FontShorthand, FontShorthand::StatusBar>, std::optional<SystemFontShorthandInfo>>;
     SystemFontShorthandCache m_systemFontShorthandCache;
 };
 

--- a/Source/WebCore/platform/graphics/filters/FEComponentTransfer.h
+++ b/Source/WebCore/platform/graphics/filters/FEComponentTransfer.h
@@ -67,7 +67,7 @@ template<> struct EnumTraits<WebCore::ComponentTransferChannel> {
 
 namespace WebCore {
 
-using ComponentTransferFunctions = EnumeratedArray<ComponentTransferChannel, ComponentTransferFunction>;
+using ComponentTransferFunctions = EnumeratedArray<EnumeratedArrayKey<ComponentTransferChannel, ComponentTransferChannel::Alpha>, ComponentTransferFunction>;
 
 class FEComponentTransfer : public FilterEffect {
 public:

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.h
@@ -95,7 +95,7 @@ private:
     bool drawContentIntoMaskImage(ImageBuffer&, const FloatRect& objectBoundingBox, float effectiveZoom);
     void calculateClipContentRepaintRect(RepaintRectCalculation);
 
-    EnumeratedArray<RepaintRectCalculation, FloatRect, RepaintRectCalculation::Accurate> m_clipBoundaries;
+    EnumeratedArray<EnumeratedArrayKey<RepaintRectCalculation, RepaintRectCalculation::Accurate>, FloatRect> m_clipBoundaries;
     HashMap<const RenderObject*, std::unique_ptr<ClipperData>> m_clipperMap;
 };
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.h
@@ -65,7 +65,7 @@ private:
     bool drawContentIntoMaskImage(MaskerData*, const DestinationColorSpace&, RenderObject*);
     void calculateMaskContentRepaintRect(RepaintRectCalculation);
 
-    EnumeratedArray<RepaintRectCalculation, FloatRect, RepaintRectCalculation::Accurate> m_maskContentBoundaries;
+    EnumeratedArray<EnumeratedArrayKey<RepaintRectCalculation, RepaintRectCalculation::Accurate>, FloatRect> m_maskContentBoundaries;
     HashMap<RenderObject*, std::unique_ptr<MaskerData>> m_masker;
 };
 

--- a/Source/WebGPU/WebGPU/BindGroup.mm
+++ b/Source/WebGPU/WebGPU/BindGroup.mm
@@ -76,7 +76,7 @@ static MTLRenderStages metalRenderStage(ShaderStage shaderStage)
 }
 
 template <typename T>
-using ShaderStageArray = EnumeratedArray<ShaderStage, T, ShaderStage::Compute>;
+using ShaderStageArray = EnumeratedArray<EnumeratedArrayKey<ShaderStage, ShaderStage::Compute>, T>;
 
 #if HAVE(COREVIDEO_METAL_SUPPORT)
 

--- a/Source/WebGPU/WebGPU/BindGroupLayout.h
+++ b/Source/WebGPU/WebGPU/BindGroupLayout.h
@@ -51,7 +51,7 @@ class BindGroupLayout : public WGPUBindGroupLayoutImpl, public RefCounted<BindGr
     WTF_MAKE_FAST_ALLOCATED;
 public:
     template <typename T>
-    using ShaderStageArray = EnumeratedArray<ShaderStage, T, ShaderStage::Compute>;
+    using ShaderStageArray = EnumeratedArray<EnumeratedArrayKey<ShaderStage, ShaderStage::Compute>, T>;
     using ArgumentBufferIndices = ShaderStageArray<std::optional<uint32_t>>;
     struct Entry {
         uint32_t binding;

--- a/Source/WebKit/Platform/IPC/ArgumentCoders.h
+++ b/Source/WebKit/Platform/IPC/ArgumentCoders.h
@@ -446,22 +446,22 @@ template<typename T, size_t size> struct ArgumentCoder<std::array<T, size>> {
     }
 };
 
-template<typename Key, typename T, Key lastValue> struct ArgumentCoder<EnumeratedArray<Key, T, lastValue>> {
+template<typename Key, typename T> struct ArgumentCoder<EnumeratedArray<Key, T>> {
     template<typename Encoder>
-    static void encode(Encoder& encoder, const EnumeratedArray<Key, T, lastValue>& array)
+    static void encode(Encoder& encoder, const EnumeratedArray<Key, T>& array)
     {
         for (auto& item : array)
             encoder << item;
     }
 
     template<typename Decoder>
-    static std::optional<EnumeratedArray<Key, T, lastValue>> decode(Decoder& decoder)
+    static std::optional<EnumeratedArray<Key, T>> decode(Decoder& decoder)
     {
-        auto array = decoder.template decode<typename EnumeratedArray<Key, T, lastValue>::UnderlyingType>();
+        auto array = decoder.template decode<typename EnumeratedArray<Key, T>::UnderlyingType>();
         if (!array)
             return std::nullopt;
 
-        return std::make_optional<EnumeratedArray<Key, T, lastValue>>(WTFMove(*array));
+        return std::make_optional<EnumeratedArray<Key, T>>(WTFMove(*array));
     }
 };
 

--- a/Tools/TestWebKitAPI/Tests/WTF/EnumeratedArray.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/EnumeratedArray.cpp
@@ -55,7 +55,7 @@ namespace TestWebKitAPI {
 
 TEST(WTF_EnumeratedArray, Basic)
 {
-    EnumeratedArray<Foo, int, Foo::Three> array;
+    EnumeratedArray<EnumeratedArrayKey<Foo, Foo::Three>, int> array;
     array[Foo::Three] = 17;
     EXPECT_EQ(array[Foo::Three], 17);
     EXPECT_EQ(array.at(Foo::Three), 17);
@@ -67,7 +67,7 @@ TEST(WTF_EnumeratedArray, Basic)
     EXPECT_EQ(data[static_cast<size_t>(Foo::Three)], 17);
     array[Foo::Two] = 10;
     EXPECT_FALSE(array.empty());
-    EnumeratedArray<Foo, int, Foo::Three> array2;
+    EnumeratedArray<EnumeratedArrayKey<Foo, Foo::Three>, int> array2;
     array2.fill(4);
     EXPECT_EQ(array2.at(Foo::One), 4);
     EXPECT_EQ(array2.at(Foo::Two), 4);
@@ -85,7 +85,7 @@ TEST(WTF_EnumeratedArray, Basic)
 
 TEST(WTF_EnumeratedArray, Comparison)
 {
-    EnumeratedArray<Foo, int, Foo::Three> array { { 3, 10, 17 } };
+    EnumeratedArray<EnumeratedArrayKey<Foo, Foo::Three>, int> array { { 3, 10, 17 } };
     auto array2 = array;
     EXPECT_EQ(array, array2);
     EXPECT_LE(array, array2);
@@ -104,20 +104,20 @@ TEST(WTF_EnumeratedArray, Comparison)
 
 TEST(WTF_EnumeratedArray, Construction)
 {
-    EnumeratedArray<Foo, int, Foo::Three> array1 { { 3, 10, 17 } };
+    EnumeratedArray<EnumeratedArrayKey<Foo, Foo::Three>, int> array1 { { 3, 10, 17 } };
     EXPECT_EQ(array1.front(), 3);
     EXPECT_EQ(array1.back(), 17);
-    EnumeratedArray<Foo, int, Foo::Three> array2(array1);
+    EnumeratedArray<EnumeratedArrayKey<Foo, Foo::Three>, int> array2(array1);
     EXPECT_EQ(array2.front(), 3);
     EXPECT_EQ(array2.back(), 17);
-    EnumeratedArray<Foo, int, Foo::Three> array3(WTFMove(array1));
+    EnumeratedArray<EnumeratedArrayKey<Foo, Foo::Three>, int> array3(WTFMove(array1));
     EXPECT_EQ(array3.front(), 3);
     EXPECT_EQ(array3.back(), 17);
-    EnumeratedArray<Foo, int, Foo::Three> array4;
+    EnumeratedArray<EnumeratedArrayKey<Foo, Foo::Three>, int> array4;
     array4 = array2;
     EXPECT_EQ(array4.front(), 3);
     EXPECT_EQ(array4.back(), 17);
-    EnumeratedArray<Foo, int, Foo::Three> array5;
+    EnumeratedArray<EnumeratedArrayKey<Foo, Foo::Three>, int> array5;
     array5 = WTFMove(array2);
     EXPECT_EQ(array5.front(), 3);
     EXPECT_EQ(array5.back(), 17);
@@ -125,7 +125,7 @@ TEST(WTF_EnumeratedArray, Construction)
 
 TEST(WTF_EnumeratedArray, Iteration)
 {
-    EnumeratedArray<Foo, int, Foo::Three> array { { 3, 10, 17 } };
+    EnumeratedArray<EnumeratedArrayKey<Foo, Foo::Three>, int> array { { 3, 10, 17 } };
     int index = 0;
     for (int value : array) {
         switch (index) {
@@ -167,7 +167,7 @@ TEST(WTF_EnumeratedArray, Iteration)
 
 TEST(WTF_EnumeratedArray, InferMax)
 {
-    EnumeratedArray<Foo, int> array1 { { 3, 10, 17 } };
+    EnumeratedArray<EnumeratedArrayKey<Foo, Foo::Three>, int> array1 { { 3, 10, 17 } };
     EXPECT_EQ(array1.front(), 3);
     EXPECT_EQ(array1.back(), 17);
 }


### PR DESCRIPTION
#### 6ed583e59663d5ea3d84bbc5aecfc41f5c5aba86
<pre>
Add EnumeratedArrayKey, remove EnumTraits fallback for EnumeratedArray&apos;s last-value logic
<a href="https://bugs.webkit.org/show_bug.cgi?id=266147">https://bugs.webkit.org/show_bug.cgi?id=266147</a>

Reviewed by NOBODY (OOPS!).

Provide EnumeratedArrayKey template that enables combining the desired enumeration
and its last valid value as the key for EnumeratedArray specializations. This
removes the need for the EnumTraits-based fallback of determining that last valid
value.

All EnumeratedArray specializations are shrunk to needing two template parameters,
the EnumeratedArrayKey and the value type. All points of usage are updated
accordingly.

* Source/WTF/wtf/EnumeratedArray.h:
(WTF::EnumeratedArray::operator== const):
(WTF::EnumeratedArray::operator&lt; const):
(WTF::EnumeratedArray::operator&lt;= const):
(WTF::EnumeratedArray::operator&gt; const):
(WTF::EnumeratedArray::operator&gt;= const):
* Source/WTF/wtf/Forward.h:
* Source/WebCore/dom/make_names.pl:
(printTagNameHeaderFile):
* Source/WebCore/platform/graphics/FontCascadeFonts.h:
* Source/WebCore/platform/graphics/SystemFontDatabase.h:
* Source/WebCore/platform/graphics/filters/FEComponentTransfer.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.h:
* Source/WebGPU/WebGPU/BindGroup.mm:
* Source/WebGPU/WebGPU/BindGroupLayout.h:
* Source/WebKit/Platform/IPC/ArgumentCoders.h:
* Tools/TestWebKitAPI/Tests/WTF/EnumeratedArray.cpp:
(TestWebKitAPI::TEST):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ed583e59663d5ea3d84bbc5aecfc41f5c5aba86

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30956 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9627 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32641 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33470 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27967 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31717 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11972 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6892 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27826 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31286 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8108 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27694 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6962 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7135 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27573 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34808 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/26611 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28183 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28044 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33277 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/31057 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7167 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5236 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31109 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8871 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/37477 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7874 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8034 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7714 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->