### PR TITLE
More minor Theme and RenderTheme cleanup

### DIFF
--- a/Source/WebCore/platform/Theme.cpp
+++ b/Source/WebCore/platform/Theme.cpp
@@ -33,11 +33,6 @@
 
 namespace WebCore {
 
-int Theme::baselinePositionAdjustment(StyleAppearance, bool) const
-{
-    return 0;
-}
-
 std::optional<FontCascadeDescription> Theme::controlFont(StyleAppearance, const FontCascade&, float) const
 {
     return std::nullopt;
@@ -66,16 +61,7 @@ LengthSize Theme::minimumControlSize(StyleAppearance, const FontCascade&, const 
     return { { 0, LengthType::Fixed }, { 0, LengthType::Fixed } };
 }
 
-bool Theme::controlRequiresPreWhiteSpace(StyleAppearance) const
-{
-    return false;
-}
-
 void Theme::paint(StyleAppearance, ControlStates&, GraphicsContext&, const FloatRect&, float, ScrollView*, float, float, bool, bool, const Color&)
-{
-}
-
-void Theme::inflateControlPaintRect(StyleAppearance, const ControlStates&, FloatRect&, float) const
 {
 }
 

--- a/Source/WebCore/platform/Theme.h
+++ b/Source/WebCore/platform/Theme.h
@@ -47,17 +47,11 @@ class Theme {
 public:
     static Theme& singleton();
 
-    // A function to obtain the baseline position adjustment for a "leaf" control. This will be used if a baseline
-    // position cannot be determined by examining child content. Checkboxes and radio buttons are examples of
-    // controls that need to do this. The adjustment is an offset that adds to the baseline, e.g., marginTop() + height() + |offset|.
-    // The offset is not zoomed.
-    virtual int baselinePositionAdjustment(StyleAppearance, bool isHorizontalWritingMode) const;
-
     // The font description result should have a zoomed font size.
-    virtual std::optional<FontCascadeDescription> controlFont(StyleAppearance, const FontCascade&, float zoomFactor) const;
+    virtual std::optional<FontCascadeDescription> controlFont(StyleAppearance, const FontCascade&, float) const;
 
     // The size here is in zoomed coordinates already. If a new size is returned, it also needs to be in zoomed coordinates.
-    virtual LengthSize controlSize(StyleAppearance, const FontCascade&, const LengthSize& zoomedSize, float zoomFactor) const;
+    virtual LengthSize controlSize(StyleAppearance, const FontCascade&, const LengthSize&, float) const;
 
     // Returns the minimum size for a control in zoomed coordinates.
     LengthSize minimumControlSize(StyleAppearance, const FontCascade&, const LengthSize& zoomedSize, const LengthSize& nonShrinkableZoomedSize, float zoomFactor) const;
@@ -67,7 +61,7 @@ public:
     virtual LengthBox controlBorder(StyleAppearance, const FontCascade&, const LengthBox& zoomedBox, float zoomFactor) const;
 
     // Whether or not whitespace: pre should be forced on always.
-    virtual bool controlRequiresPreWhiteSpace(StyleAppearance) const;
+    virtual bool controlRequiresPreWhiteSpace(StyleAppearance) const { return false; }
 
     // Method for painting a control. The rect is in zoomed coordinates.
     // FIXME: <https://webkit.org/b/231637> Move parameters to a struct.
@@ -77,7 +71,7 @@ public:
     // the theme needs to communicate this inflated rect to the engine so that it can invalidate the whole control.
     // The rect passed in is in zoomed coordinates, so the inflation should take that into account and make sure the inflation
     // amount is also scaled by the zoomFactor.
-    virtual void inflateControlPaintRect(StyleAppearance, const ControlStates&, FloatRect& zoomedRect, float zoomFactor) const;
+    virtual void inflateControlPaintRect(StyleAppearance, const ControlStates&, FloatRect&, float) const { }
 
     virtual void drawNamedImage(const String&, GraphicsContext&, const FloatSize&) const;
 

--- a/Source/WebCore/platform/mac/ThemeMac.h
+++ b/Source/WebCore/platform/mac/ThemeMac.h
@@ -44,8 +44,6 @@ private:
     friend NeverDestroyed<ThemeMac>;
     ThemeMac() = default;
 
-    int baselinePositionAdjustment(StyleAppearance, bool isHorizontalWritingMode) const final;
-
     std::optional<FontCascadeDescription> controlFont(StyleAppearance, const FontCascade&, float zoomFactor) const final;
 
     LengthSize controlSize(StyleAppearance, const FontCascade&, const LengthSize&, float zoomFactor) const final;

--- a/Source/WebCore/platform/mac/ThemeMac.mm
+++ b/Source/WebCore/platform/mac/ThemeMac.mm
@@ -548,13 +548,6 @@ static LengthSize switchSize(const LengthSize& zoomedSize, float zoomFactor)
 
 // Theme overrides
 
-int ThemeMac::baselinePositionAdjustment(StyleAppearance appearance, bool isHorizontalWritingMode) const
-{
-    if ((appearance == StyleAppearance::Checkbox || appearance == StyleAppearance::Radio) && isHorizontalWritingMode)
-        return -2;
-    return Theme::baselinePositionAdjustment(appearance, isHorizontalWritingMode);
-}
-
 std::optional<FontCascadeDescription> ThemeMac::controlFont(StyleAppearance appearance, const FontCascade& font, float zoomFactor) const
 {
     switch (appearance) {

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -1195,18 +1195,9 @@ Color RenderTheme::platformInactiveListBoxSelectionForegroundColor(OptionSet<Sty
 
 int RenderTheme::baselinePosition(const RenderBox& box) const
 {
-    auto baseline = [&]() -> int {
-        if (box.isHorizontalWritingMode())
-            return box.height() + box.marginTop();
-
-        return (box.width() / 2.0f) + box.marginBefore();
-    }();
-
-#if !PLATFORM(IOS_FAMILY)
-    return baseline + Theme::singleton().baselinePositionAdjustment(box.style().effectiveAppearance(), box.isHorizontalWritingMode()) * box.style().effectiveZoom();
-#else
-    return baseline;
-#endif
+    if (box.isHorizontalWritingMode())
+        return box.height() + box.marginTop();
+    return (box.width() / 2.0f) + box.marginBefore();
 }
 
 bool RenderTheme::isControlContainer(StyleAppearance appearance) const
@@ -1238,17 +1229,6 @@ bool RenderTheme::isControlStyled(const RenderStyle& style, const RenderStyle& u
     default:
         return false;
     }
-}
-
-void RenderTheme::adjustRepaintRect(const RenderObject& renderer, FloatRect& rect)
-{
-#if !PLATFORM(IOS_FAMILY)
-    ControlStates states(extractControlStatesForRenderer(renderer));
-    Theme::singleton().inflateControlPaintRect(renderer.style().effectiveAppearance(), states, rect, renderer.style().effectiveZoom());
-#else
-    UNUSED_PARAM(renderer);
-    UNUSED_PARAM(rect);
-#endif
 }
 
 bool RenderTheme::supportsFocusRing(const RenderStyle& style) const

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -139,7 +139,7 @@ public:
 
     // Some controls may spill out of their containers (e.g., the check on an OS X checkbox).  When these controls repaint,
     // the theme needs to communicate this inflated rect to the engine so that it can invalidate the whole control.
-    virtual void adjustRepaintRect(const RenderObject&, FloatRect&);
+    virtual void adjustRepaintRect(const RenderObject&, FloatRect&) { }
 
     // This method is called whenever a relevant state changes on a particular themed object, e.g., the mouse becomes pressed
     // or a control becomes disabled.

--- a/Source/WebCore/rendering/RenderThemeMac.h
+++ b/Source/WebCore/rendering/RenderThemeMac.h
@@ -99,6 +99,8 @@ private:
     bool canCreateControlPartForBorderOnly(const RenderObject&) const final;
     bool canCreateControlPartForDecorations(const RenderObject&) const final;
 
+    int baselinePosition(const RenderBox&) const final;
+
     bool useFormSemanticContext() const final;
     bool supportsLargeFormControls() const final;
 

--- a/Source/WebCore/rendering/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/RenderThemeMac.mm
@@ -231,6 +231,15 @@ bool RenderThemeMac::canCreateControlPartForDecorations(const RenderObject& rend
     return renderer.style().effectiveAppearance() == StyleAppearance::MenulistButton;
 }
 
+int RenderThemeMac::baselinePosition(const RenderBox& renderer) const
+{
+    auto appearance = renderer.style().effectiveAppearance();
+    auto baseline = RenderTheme::baselinePosition(renderer);
+    if ((appearance == StyleAppearance::Checkbox || appearance == StyleAppearance::Radio) && renderer.isHorizontalWritingMode())
+        return baseline - (2 * renderer.style().effectiveZoom());
+    return baseline;
+}
+
 bool RenderThemeMac::useFormSemanticContext() const
 {
     return ThemeMac::useFormSemanticContext();
@@ -740,9 +749,11 @@ void RenderThemeMac::adjustRepaintRect(const RenderObject& renderer, FloatRect& 
     case StyleAppearance::PushButton:
     case StyleAppearance::Radio:
     case StyleAppearance::SquareButton:
-    case StyleAppearance::Switch:
-        RenderTheme::adjustRepaintRect(renderer, rect);
+    case StyleAppearance::Switch: {
+        ControlStates states(extractControlStatesForRenderer(renderer));
+        Theme::singleton().inflateControlPaintRect(renderer.style().effectiveAppearance(), states, rect, renderer.style().effectiveZoom());
         break;
+    }
     case StyleAppearance::Menulist: {
         auto zoomLevel = renderer.style().effectiveZoom();
         setPopupButtonCellState(renderer, IntSize(rect.size()));


### PR DESCRIPTION
#### 5b14c827a3e38d548c4635dc387049eef09133e4
<pre>
More minor Theme and RenderTheme cleanup
<a href="https://bugs.webkit.org/show_bug.cgi?id=266148">https://bugs.webkit.org/show_bug.cgi?id=266148</a>

Reviewed by Tim Horton.

Only macOS uses Theme::singleton().baselinePositionAdjustment() so
instead fold that into RenderThemeMac.

Make RenderTheme::adjustRepaintRect() more clearly macOS specific.
Although Adwaita would also run the code,
Theme::singleton().inflateControlPaintRect() is a no-op in all themes
except for macOS. A future larger refactoring could maybe fold that
into RenderThemeMac too.

And then finally inline some Theme methods for nicer git grep results.

* Source/WebCore/platform/Theme.cpp:
(WebCore::Theme::baselinePositionAdjustment const): Deleted.
(WebCore::Theme::controlRequiresPreWhiteSpace const): Deleted.
(WebCore::Theme::inflateControlPaintRect const): Deleted.
* Source/WebCore/platform/Theme.h:
(WebCore::Theme::controlRequiresPreWhiteSpace const):
(WebCore::Theme::inflateControlPaintRect const):
* Source/WebCore/platform/mac/ThemeMac.h:
* Source/WebCore/platform/mac/ThemeMac.mm:
(WebCore::ThemeMac::baselinePositionAdjustment const): Deleted.
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::baselinePosition const):
(WebCore::RenderTheme::adjustRepaintRect): Deleted.
* Source/WebCore/rendering/RenderTheme.h:
(WebCore::RenderTheme::adjustRepaintRect):
* Source/WebCore/rendering/RenderThemeMac.h:
* Source/WebCore/rendering/RenderThemeMac.mm:
(WebCore::RenderThemeMac::baselinePosition const):
(WebCore::RenderThemeMac::adjustRepaintRect):

Canonical link: <a href="https://commits.webkit.org/271831@main">https://commits.webkit.org/271831@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80eb64e902d3af917de23428c732b51ba5ab3ff2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29743 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8403 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31045 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32245 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26891 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30365 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10575 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5671 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26908 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30022 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7026 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25357 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5981 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6146 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26445 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33581 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27122 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26869 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32326 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6070 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4295 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30108 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7816 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7068 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6821 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6601 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->