### PR TITLE
[iOS] Tapping 'Look Up' hangs when async UIKit interactions are disabled

### DIFF
--- a/LayoutTests/editing/selection/ios/look-up-selected-text-expected.txt
+++ b/LayoutTests/editing/selection/ios/look-up-selected-text-expected.txt
@@ -1,0 +1,10 @@
+Verifies that tapping 'Look Up' in the edit menu does not cause a crash or hang. To manually run the test, select 'Apple' below and select 'Look Up' in the edit menu.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Tapped 'Look Up'
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Apple

--- a/LayoutTests/editing/selection/ios/look-up-selected-text.html
+++ b/LayoutTests/editing/selection/ios/look-up-selected-text.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+body, html {
+    font-size: 16px;
+    font-family: system-ui;
+}
+
+#target {
+    font-size: 44px;
+    border: 1px solid tomato;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("Verifies that tapping 'Look Up' in the edit menu does not cause a crash or hang. To manually run the test, select 'Apple' below and select 'Look Up' in the edit menu.");
+    let target = document.getElementById("target");
+    await UIHelper.longPressElement(target);
+    await UIHelper.waitForMenuToShow();
+    while (true) {
+        if (await UIHelper.rectForMenuAction("Look Up"))
+            break;
+        await UIHelper.delayFor(100);
+    }
+    await UIHelper.chooseMenuAction("Look Up");
+    testPassed("Tapped 'Look Up'");
+    await UIHelper.activateAt(0, 0);
+    await UIHelper.delayFor(1000); // Wait for the Look Up view controller to finish dismissing.
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+<span id="target">Apple</span>
+</body>
+</html>

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -4730,7 +4730,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 {
     RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
-    [self _defineForWebView:sender];
+    [self defineForWebView:sender];
 }
 
 - (void)accessibilityRetrieveSpeakSelectionContent


### PR DESCRIPTION
#### f1f3c6392ba01727d527df042087dd28d03e95a3
<pre>
[iOS] Tapping &apos;Look Up&apos; hangs when async UIKit interactions are disabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=266151">https://bugs.webkit.org/show_bug.cgi?id=266151</a>
<a href="https://rdar.apple.com/119434158">rdar://119434158</a>

Reviewed by Megan Gardner.

Fix a hang under `-_defineForWebView:`; instead of calling back into itself, it should be calling
into the real implementation in `-defineForWebView:`.

* LayoutTests/editing/selection/ios/look-up-selected-text-expected.txt: Added.
* LayoutTests/editing/selection/ios/look-up-selected-text.html: Added.
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _defineForWebView:]):

Canonical link: <a href="https://commits.webkit.org/271813@main">https://commits.webkit.org/271813@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3056dfa474b7fe36a2ffd3e10ff0ea2aa316a1f2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29752 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8412 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31054 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32254 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26899 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10574 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5680 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26920 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30031 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7028 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/25367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5990 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6148 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/26454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33590 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/27124 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/26878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/32336 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6078 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4277 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/30118 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7825 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/26253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6830 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3832 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6609 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->