### PR TITLE
[UIAsyncTextInput] Release assertion after selecting "Translate" when async text input is enabled

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -4615,6 +4615,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (id)targetForActionForWebView:(SEL)action withSender:(id)sender
 {
+    BOOL hasFallbackAsyncTextInputAction = action == @selector(_define:) || action == @selector(_translate:) || action == @selector(_lookup:);
+    if (self.shouldUseAsyncInteractions && hasFallbackAsyncTextInputAction)
+        return nil;
     return [super targetForAction:action withSender:sender];
 }
 


### PR DESCRIPTION
#### 161dbc0f0eb5324c45e62eeee11d67c4cbd163c9
<pre>
[UIAsyncTextInput] Release assertion after selecting &quot;Translate&quot; when async text input is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=266157">https://bugs.webkit.org/show_bug.cgi?id=266157</a>
<a href="https://rdar.apple.com/119434259">rdar://119434259</a>

Reviewed by Megan Gardner.

After the UIKit changes in <a href="https://rdar.apple.com/119283621">rdar://119283621</a>, the default commands corresponding to these 3 actions:

```
_define:     define:
_translate:  translate:
_lookup:     lookup:
```

...now follow an inverted model for dispatching fallback actions, where the primary action selector
is the legacy private action, and the fallback selector is the new selector on `UIAsyncTextInput`.
This means that UIKit ends up calling into private selectors on the content view instead of their
non-underscore-prefixed counterparts even when `UIKit/async_text_input` is enabled, causing us to
hit release assertions under these three methods.

To avoid this, we adjust the default behavior of `-targetForActionForWebView:withSender:` to always
return `nil` for these three private selectors, in order to force UIKit to fall back to calling into
the new action selectors.

Changes covered by the layout test `editing/selection/ios/look-up-selected-text.html`, when async
text input is enabled.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView targetForActionForWebView:withSender:]):

Canonical link: <a href="https://commits.webkit.org/271817@main">https://commits.webkit.org/271817@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a85fbe33100bda7a868cf47bfe1aec9f7d8280f0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29767 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8427 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31069 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32269 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26913 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10593 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5694 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26935 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30046 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7042 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/25377 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6001 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/6162 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33605 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27138 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26888 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/32346 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6092 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/4287 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/30128 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7837 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6843 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3834 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6622 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->