### PR TITLE
Make WeakPtr / WeakRef more convenient to use

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -77,6 +77,7 @@
 		4448265228D18CA600D916E8 /* VectorCF.h in Headers */ = {isa = PBXBuildFile; fileRef = 4448265128D18CA600D916E8 /* VectorCF.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		4606FEE72B1E901800D704F1 /* WeakRef.h in Headers */ = {isa = PBXBuildFile; fileRef = 4606FEE62B1E901800D704F1 /* WeakRef.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		461229722ACF6B3100BB1CCC /* FastCharacterComparison.h in Headers */ = {isa = PBXBuildFile; fileRef = 461229712ACF6B3100BB1CCC /* FastCharacterComparison.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		463CCFBC2B251D77009AB04E /* SingleThreadIntegralWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 463CCFBB2B251D77009AB04E /* SingleThreadIntegralWrapper.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		46449E8B2822E5680005A8BC /* WeakHashCountedSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 46449E8A2822E5670005A8BC /* WeakHashCountedSet.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		4655743627F5FC4A002D5522 /* ASCIILiteralCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4655743527F5FC4A002D5522 /* ASCIILiteralCocoa.mm */; };
 		46BEB6EB22FFE24900269867 /* RefCounted.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 46BEB6E922FFDDD500269867 /* RefCounted.cpp */; };
@@ -1155,6 +1156,7 @@
 		4606FEE62B1E901800D704F1 /* WeakRef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WeakRef.h; sourceTree = "<group>"; };
 		461229712ACF6B3100BB1CCC /* FastCharacterComparison.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FastCharacterComparison.h; sourceTree = "<group>"; };
 		46209A27266D543A007F8F4A /* CancellableTask.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CancellableTask.h; sourceTree = "<group>"; };
+		463CCFBB2B251D77009AB04E /* SingleThreadIntegralWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SingleThreadIntegralWrapper.h; sourceTree = "<group>"; };
 		46449E8A2822E5670005A8BC /* WeakHashCountedSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WeakHashCountedSet.h; sourceTree = "<group>"; };
 		4655743527F5FC4A002D5522 /* ASCIILiteralCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASCIILiteralCocoa.mm; sourceTree = "<group>"; };
 		46BA9EAB1F4CD61E009A2BBC /* CompletionHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CompletionHandler.h; sourceTree = "<group>"; };
@@ -2345,6 +2347,7 @@
 				862A8D32278DE74A0014120C /* SignedPtr.h */,
 				A8A4730A151A825B004123FF /* SimpleStats.h */,
 				795212021F42588800BD6421 /* SingleRootGraph.h */,
+				463CCFBB2B251D77009AB04E /* SingleThreadIntegralWrapper.h */,
 				A8A4730B151A825B004123FF /* SinglyLinkedList.h */,
 				0F4D8C711FC1E7CE001D32AC /* SinglyLinkedListWithTail.h */,
 				A748744F17A0BDAE00FA04CB /* SixCharacterHash.cpp */,
@@ -3357,6 +3360,7 @@
 				E361DB63289115D000B2A2B8 /* simple_decimal_conversion.h in Headers */,
 				DD3DC8F727A4BF8E007E5B61 /* SimpleStats.h in Headers */,
 				DD3DC97627A4BF8E007E5B61 /* SingleRootGraph.h in Headers */,
+				463CCFBC2B251D77009AB04E /* SingleThreadIntegralWrapper.h in Headers */,
 				DD3DC89627A4BF8E007E5B61 /* SinglyLinkedList.h in Headers */,
 				DD3DC99427A4BF8E007E5B61 /* SinglyLinkedListWithTail.h in Headers */,
 				DD3DC92F27A4BF8E007E5B61 /* SixCharacterHash.h in Headers */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -257,6 +257,7 @@ set(WTF_PUBLIC_HEADERS
     SignedPtr.h
     SimpleStats.h
     SingleRootGraph.h
+    SingleThreadIntegralWrapper.h
     SinglyLinkedList.h
     SinglyLinkedListWithTail.h
     SixCharacterHash.h

--- a/Source/WTF/wtf/SingleThreadIntegralWrapper.h
+++ b/Source/WTF/wtf/SingleThreadIntegralWrapper.h
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Threading.h>
+
+namespace WTF {
+
+template <typename IntegralType>
+class SingleThreadIntegralWrapper {
+public:
+    SingleThreadIntegralWrapper(IntegralType);
+
+    operator IntegralType() const;
+    explicit operator bool() const;
+    SingleThreadIntegralWrapper& operator=(IntegralType);
+    SingleThreadIntegralWrapper& operator++();
+    SingleThreadIntegralWrapper& operator--();
+
+private:
+#if ASSERT_ENABLED && !USE(WEB_THREAD)
+    void assertThread() const { ASSERT(m_thread.ptr() == &Thread::current()); }
+#else
+    constexpr void assertThread() const { }
+#endif
+
+    IntegralType m_value;
+#if ASSERT_ENABLED && !USE(WEB_THREAD)
+    Ref<Thread> m_thread;
+#endif
+};
+
+template <typename IntegralType>
+inline SingleThreadIntegralWrapper<IntegralType>::SingleThreadIntegralWrapper(IntegralType value)
+    : m_value { value }
+#if ASSERT_ENABLED && !USE(WEB_THREAD)
+    , m_thread { Thread::current() }
+#endif
+{ }
+
+template <typename IntegralType>
+inline SingleThreadIntegralWrapper<IntegralType>::operator IntegralType() const
+{
+    assertThread();
+    return m_value;
+}
+
+template <typename IntegralType>
+inline SingleThreadIntegralWrapper<IntegralType>::operator bool() const
+{
+    assertThread();
+    return m_value;
+}
+
+template <typename IntegralType>
+inline SingleThreadIntegralWrapper<IntegralType>& SingleThreadIntegralWrapper<IntegralType>::operator=(IntegralType value)
+{
+    assertThread();
+    m_value = value;
+    return *this;
+}
+
+template <typename IntegralType>
+inline SingleThreadIntegralWrapper<IntegralType>& SingleThreadIntegralWrapper<IntegralType>::operator++()
+{
+    assertThread();
+    m_value++;
+    return *this;
+}
+
+template <typename IntegralType>
+inline SingleThreadIntegralWrapper<IntegralType>& SingleThreadIntegralWrapper<IntegralType>::operator--()
+{
+    assertThread();
+    m_value--;
+    return *this;
+}
+
+} // namespace WTF
+
+using WTF::SingleThreadIntegralWrapper;

--- a/Source/WTF/wtf/WeakPtr.h
+++ b/Source/WTF/wtf/WeakPtr.h
@@ -26,118 +26,16 @@
 
 #pragma once
 
-#include <wtf/CheckedRef.h>
 #include <wtf/CompactRefPtrTuple.h>
-#include <wtf/GetPtr.h>
-#include <wtf/HashTraits.h>
-#include <wtf/Threading.h>
-#include <wtf/TypeCasts.h>
+#include <wtf/WeakRef.h>
 
 namespace WTF {
 
-enum class EnableWeakPtrThreadingAssertions : bool { No, Yes };
 template<typename, typename> class WeakPtrFactory;
 
 template<typename, typename, typename = DefaultWeakPtrImpl> class WeakHashMap;
 template<typename, typename = DefaultWeakPtrImpl, EnableWeakPtrThreadingAssertions = EnableWeakPtrThreadingAssertions::Yes> class WeakHashSet;
 template <typename, typename = DefaultWeakPtrImpl, EnableWeakPtrThreadingAssertions = EnableWeakPtrThreadingAssertions::Yes> class WeakListHashSet;
-
-DECLARE_COMPACT_ALLOCATOR_WITH_HEAP_IDENTIFIER(WeakPtrImplBase);
-
-template<typename Derived>
-class WeakPtrImplBase : public ThreadSafeRefCounted<Derived> {
-    WTF_MAKE_NONCOPYABLE(WeakPtrImplBase);
-    WTF_MAKE_FAST_COMPACT_ALLOCATED_WITH_HEAP_IDENTIFIER(WeakPtrImplBase);
-public:
-    ~WeakPtrImplBase() = default;
-
-    template<typename T> typename T::WeakValueType* get()
-    {
-        return static_cast<typename T::WeakValueType*>(m_ptr);
-    }
-
-    explicit operator bool() const { return m_ptr; }
-    void clear() { m_ptr = nullptr; }
-
-#if ASSERT_ENABLED
-    bool wasConstructedOnMainThread() const { return m_wasConstructedOnMainThread; }
-#endif
-
-    template<typename T>
-    explicit WeakPtrImplBase(T* ptr)
-        : m_ptr(static_cast<typename T::WeakValueType*>(ptr))
-#if ASSERT_ENABLED
-        , m_wasConstructedOnMainThread(isMainThread())
-#endif
-    {
-    }
-
-private:
-    void* m_ptr;
-#if ASSERT_ENABLED
-    bool m_wasConstructedOnMainThread;
-#endif
-};
-
-template<typename Derived>
-class WeakPtrImplBaseSingleThread {
-    WTF_MAKE_NONCOPYABLE(WeakPtrImplBaseSingleThread);
-    WTF_MAKE_FAST_COMPACT_ALLOCATED_WITH_HEAP_IDENTIFIER(WeakPtrImplBaseSingleThread);
-public:
-    ~WeakPtrImplBaseSingleThread() = default;
-
-    template<typename T> typename T::WeakValueType* get()
-    {
-        return static_cast<typename T::WeakValueType*>(m_ptr);
-    }
-
-    explicit operator bool() const { return m_ptr; }
-    void clear() { m_ptr = nullptr; }
-
-#if ASSERT_ENABLED
-    bool wasConstructedOnMainThread() const { return m_wasConstructedOnMainThread; }
-#endif
-
-    template<typename T>
-    explicit WeakPtrImplBaseSingleThread(T* ptr)
-        : m_ptr(static_cast<typename T::WeakValueType*>(ptr))
-#if ASSERT_ENABLED
-        , m_wasConstructedOnMainThread(isMainThread())
-#endif
-    {
-    }
-
-    uint32_t refCount() const { return m_refCount; }
-    void ref() const { ++m_refCount; }
-    void deref() const
-    {
-        uint32_t tempRefCount = m_refCount - 1;
-        if (!tempRefCount) {
-            delete this;
-            return;
-        }
-        m_refCount = tempRefCount;
-    }
-
-private:
-    mutable SingleThreadIntegralWrapper<uint32_t> m_refCount { 1 };
-    void* m_ptr;
-#if ASSERT_ENABLED
-    bool m_wasConstructedOnMainThread;
-#endif
-};
-
-class SingleThreadWeakPtrImpl final : public WeakPtrImplBaseSingleThread<SingleThreadWeakPtrImpl> {
-public:
-    template<typename T>
-    explicit SingleThreadWeakPtrImpl(T* ptr) : WeakPtrImplBaseSingleThread<SingleThreadWeakPtrImpl>(ptr) { }
-};
-
-class DefaultWeakPtrImpl final : public WeakPtrImplBase<DefaultWeakPtrImpl> {
-public:
-    template<typename T>
-    explicit DefaultWeakPtrImpl(T* ptr) : WeakPtrImplBase<DefaultWeakPtrImpl>(ptr) { }
-};
 
 template<typename T, typename WeakPtrImpl> class WeakPtr {
     WTF_MAKE_FAST_ALLOCATED;
@@ -146,6 +44,9 @@ public:
     WeakPtr(std::nullptr_t) { }
     template<typename U> WeakPtr(const WeakPtr<U, WeakPtrImpl>&);
     template<typename U> WeakPtr(WeakPtr<U, WeakPtrImpl>&&);
+
+    template<typename U> WeakPtr(const WeakRef<U, WeakPtrImpl>&);
+    template<typename U> WeakPtr(WeakRef<U, WeakPtrImpl>&&);
 
     template<typename = std::enable_if_t<!IsSmartPtr<T>::value>> WeakPtr(const T* object, EnableWeakPtrThreadingAssertions shouldEnableAssertions = EnableWeakPtrThreadingAssertions::Yes)
         : m_impl(object ? implForObject(*object) : nullptr)
@@ -175,10 +76,22 @@ public:
         : WeakPtr(object.get(), shouldEnableAssertions)
     { }
 
+    explicit WeakPtr(RefPtr<WeakPtrImpl> impl)
+        : m_impl(WTFMove(impl))
+    {
+    }
+
+    RefPtr<WeakPtrImpl> releaseImpl() { return WTFMove(m_impl); }
+
     T* get() const
     {
         ASSERT(canSafelyBeUsed());
         return m_impl ? static_cast<T*>(m_impl->template get<T>()) : nullptr;
+    }
+
+    WeakRef<T> releaseNonNull()
+    {
+        return WeakRef<T> { m_impl.releaseNonNull(), enableWeakPtrThreadingAssertions() };
     }
 
     bool operator!() const { return !m_impl || !*m_impl; }
@@ -187,6 +100,8 @@ public:
     WeakPtr& operator=(std::nullptr_t) { m_impl = nullptr; return *this; }
     template<typename U> WeakPtr& operator=(const WeakPtr<U, WeakPtrImpl>&);
     template<typename U> WeakPtr& operator=(WeakPtr<U, WeakPtrImpl>&&);
+    template<typename U> WeakPtr& operator=(const WeakRef<U, WeakPtrImpl>&);
+    template<typename U> WeakPtr& operator=(WeakRef<U, WeakPtrImpl>&&);
 
     T* operator->() const
     {
@@ -201,6 +116,15 @@ public:
     }
 
     void clear() { m_impl = nullptr; }
+
+    EnableWeakPtrThreadingAssertions enableWeakPtrThreadingAssertions() const
+    {
+#if ASSERT_ENABLED
+        return m_shouldEnableAssertions ? EnableWeakPtrThreadingAssertions::Yes : EnableWeakPtrThreadingAssertions::No;
+#else
+        return EnableWeakPtrThreadingAssertions::No;
+#endif
+    }
 
 private:
     template<typename, typename, typename> friend class WeakHashMap;
@@ -446,25 +370,77 @@ template<typename T, typename U, typename WeakPtrImpl> inline WeakPtrImpl* weak_
     return impl;
 }
 
+template<typename T, typename U, typename WeakPtrImpl> inline WeakPtrImpl& weak_ptr_impl_cast(WeakPtrImpl& impl)
+{
+    static_assert(std::is_same_v<typename T::WeakValueType, typename U::WeakValueType>, "Invalid weak pointer cast");
+    return impl;
+}
+
 template<typename T, typename WeakPtrImpl> template<typename U> inline WeakPtr<T, WeakPtrImpl>::WeakPtr(const WeakPtr<U, WeakPtrImpl>& o)
     : m_impl(weak_ptr_impl_cast<T, U>(o.m_impl.get()))
+#if ASSERT_ENABLED
+    , m_shouldEnableAssertions(o.m_shouldEnableAssertions)
+#endif
 {
 }
 
 template<typename T, typename WeakPtrImpl> template<typename U> inline WeakPtr<T, WeakPtrImpl>::WeakPtr(WeakPtr<U, WeakPtrImpl>&& o)
     : m_impl(adoptRef(weak_ptr_impl_cast<T, U>(o.m_impl.leakRef())))
+#if ASSERT_ENABLED
+    , m_shouldEnableAssertions(o.m_shouldEnableAssertions)
+#endif
+{
+}
+
+template<typename T, typename WeakPtrImpl> template<typename U> inline WeakPtr<T, WeakPtrImpl>::WeakPtr(const WeakRef<U, WeakPtrImpl>& o)
+    : m_impl(&weak_ptr_impl_cast<T, U>(o.m_impl.get()))
+#if ASSERT_ENABLED
+    , m_shouldEnableAssertions(o.enableWeakPtrThreadingAssertions() == EnableWeakPtrThreadingAssertions::Yes)
+#endif
+{
+}
+
+template<typename T, typename WeakPtrImpl> template<typename U> inline WeakPtr<T, WeakPtrImpl>::WeakPtr(WeakRef<U, WeakPtrImpl>&& o)
+    : m_impl(adoptRef(weak_ptr_impl_cast<T, U>(o.m_impl.leakRef())))
+#if ASSERT_ENABLED
+    , m_shouldEnableAssertions(o.enableWeakPtrThreadingAssertions() == EnableWeakPtrThreadingAssertions::Yes)
+#endif
 {
 }
 
 template<typename T, typename WeakPtrImpl> template<typename U> inline WeakPtr<T, WeakPtrImpl>& WeakPtr<T, WeakPtrImpl>::operator=(const WeakPtr<U, WeakPtrImpl>& o)
 {
     m_impl = weak_ptr_impl_cast<T, U>(o.m_impl.get());
+#if ASSERT_ENABLED
+    m_shouldEnableAssertions = o.m_shouldEnableAssertions;
+#endif
     return *this;
 }
 
 template<typename T, typename WeakPtrImpl> template<typename U> inline WeakPtr<T, WeakPtrImpl>& WeakPtr<T, WeakPtrImpl>::operator=(WeakPtr<U, WeakPtrImpl>&& o)
 {
     m_impl = adoptRef(weak_ptr_impl_cast<T, U>(o.m_impl.leakRef()));
+#if ASSERT_ENABLED
+    m_shouldEnableAssertions = o.m_shouldEnableAssertions;
+#endif
+    return *this;
+}
+
+template<typename T, typename WeakPtrImpl> template<typename U> inline WeakPtr<T, WeakPtrImpl>& WeakPtr<T, WeakPtrImpl>::operator=(const WeakRef<U, WeakPtrImpl>& o)
+{
+    m_impl = &weak_ptr_impl_cast<T, U>(o.m_impl.get());
+#if ASSERT_ENABLED
+    m_shouldEnableAssertions = o.enableWeakPtrThreadingAssertions() == EnableWeakPtrThreadingAssertions::Yes;
+#endif
+    return *this;
+}
+
+template<typename T, typename WeakPtrImpl> template<typename U> inline WeakPtr<T, WeakPtrImpl>& WeakPtr<T, WeakPtrImpl>::operator=(WeakRef<U, WeakPtrImpl>&& o)
+{
+    m_impl = adoptRef(weak_ptr_impl_cast<T, U>(o.m_impl.leakRef()));
+#if ASSERT_ENABLED
+    m_shouldEnableAssertions = o.enableWeakPtrThreadingAssertions() == EnableWeakPtrThreadingAssertions::Yes;
+#endif
     return *this;
 }
 
@@ -492,15 +468,22 @@ inline bool is(const WeakPtr<ArgType, WeakPtrImpl>& source)
 }
 
 template<typename Target, typename Source, typename WeakPtrImpl>
-inline Target* downcast(WeakPtr<Source, WeakPtrImpl>& source)
+inline WeakPtr<match_constness_t<Source, Target>, WeakPtrImpl> downcast(WeakPtr<Source, WeakPtrImpl> source)
 {
-    return downcast<Target>(source.get());
+    static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
+    static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
+    ASSERT_WITH_SECURITY_IMPLICATION(!source || is<Target>(*source));
+    return WeakPtr<match_constness_t<Source, Target>, WeakPtrImpl> { static_pointer_cast<match_constness_t<Source, Target>>(source.releaseImpl()), source.enableWeakPtrThreadingAssertions() };
 }
 
 template<typename Target, typename Source, typename WeakPtrImpl>
-inline Target* downcast(const WeakPtr<Source, WeakPtrImpl>& source)
+inline WeakPtr<match_constness_t<Source, Target>, WeakPtrImpl> dynamicDowncast(WeakPtr<Source, WeakPtrImpl> source)
 {
-    return downcast<Target>(source.get());
+    static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
+    static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
+    if (!is<Target>(source))
+        return nullptr;
+    return WeakPtr<match_constness_t<Source, Target>, WeakPtrImpl> { static_pointer_cast<match_constness_t<Source, Target>, WeakPtrImpl>(source.releaseImpl()), source.enableWeakPtrThreadingAssertions() };
 }
 
 template<typename T, typename U, typename WeakPtrImpl> inline bool operator==(const WeakPtr<T, WeakPtrImpl>& a, const WeakPtr<U, WeakPtrImpl>& b)
@@ -548,9 +531,7 @@ using SingleThreadWeakListHashSet = WeakListHashSet<T, SingleThreadWeakPtrImpl, 
 using WTF::CanMakeWeakPtr;
 using WTF::CanMakeWeakPtrWithBitField;
 using WTF::CanMakeSingleThreadWeakPtr;
-using WTF::EnableWeakPtrThreadingAssertions;
 using WTF::SingleThreadWeakPtr;
-using WTF::SingleThreadWeakPtrImpl;
 using WTF::SingleThreadWeakHashSet;
 using WTF::SingleThreadWeakListHashSet;
 using WTF::WeakHashMap;


### PR DESCRIPTION
#### e9948836bf97a6dc9d33ff80eb083b1a17c37e73
<pre>
Make WeakPtr / WeakRef more convenient to use
<a href="https://bugs.webkit.org/show_bug.cgi?id=266158">https://bugs.webkit.org/show_bug.cgi?id=266158</a>

Reviewed by Darin Adler.

Make WeakPtr / WeakRef more convenient to use and more consistent with RefPtr / Ref:
- Add WeakPtr::releaseNonNull() that returns a WeakRef
- Add WeakPtr constructors that that in a `const WeakRef&amp;` / `WeakRef&amp;&amp;`
- Add assignment operators to WeakPtr that in a `const WeakRef&amp;` / `WeakRef&amp;&amp;`
- Have downcast&lt;&gt;() return a WeakPtr / WeakRef when passing in a WeakPtr / WeakRef
- Introduce a dynamicDowncast&lt;&gt;() which works with WeakPtr / WeakRef

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/CheckedRef.h:
(WTF::SingleThreadIntegralWrapper::assertThread const): Deleted.
(WTF::SingleThreadIntegralWrapper&lt;IntegralType&gt;::SingleThreadIntegralWrapper): Deleted.
(WTF::IntegralType const): Deleted.
(WTF::bool const): Deleted.
(WTF::=): Deleted.
(WTF::SingleThreadIntegralWrapper&lt;IntegralType&gt;::operator): Deleted.
* Source/WTF/wtf/SingleThreadIntegralWrapper.h: Added.
(WTF::SingleThreadIntegralWrapper::assertThread const):
(WTF::SingleThreadIntegralWrapper&lt;IntegralType&gt;::SingleThreadIntegralWrapper):
(WTF::IntegralType const):
(WTF::bool const):
(WTF::=):
(WTF::SingleThreadIntegralWrapper&lt;IntegralType&gt;::operator):
* Source/WTF/wtf/WeakPtr.h:
(WTF::WeakPtr::WeakPtr):
(WTF::WeakPtr::releaseImpl):
(WTF::WeakPtr::releaseNonNull):
(WTF::weak_ptr_impl_cast):
(WTF::WeakPtrImpl&gt;::WeakPtr):
(WTF::=):
(WTF::downcast):
(WTF::dynamicDowncast):
(WTF::WeakPtrImplBase::get): Deleted.
(WTF::WeakPtrImplBase::operator bool const): Deleted.
(WTF::WeakPtrImplBase::clear): Deleted.
(WTF::WeakPtrImplBase::wasConstructedOnMainThread const): Deleted.
(WTF::WeakPtrImplBase::WeakPtrImplBase): Deleted.
(WTF::WeakPtrImplBaseSingleThread::get): Deleted.
(WTF::WeakPtrImplBaseSingleThread::operator bool const): Deleted.
(WTF::WeakPtrImplBaseSingleThread::clear): Deleted.
(WTF::WeakPtrImplBaseSingleThread::wasConstructedOnMainThread const): Deleted.
(WTF::WeakPtrImplBaseSingleThread::WeakPtrImplBaseSingleThread): Deleted.
(WTF::WeakPtrImplBaseSingleThread::refCount const): Deleted.
(WTF::WeakPtrImplBaseSingleThread::ref const): Deleted.
(WTF::WeakPtrImplBaseSingleThread::deref const): Deleted.
* Source/WTF/wtf/WeakRef.h:
(WTF::WeakRef::WeakRef):
(WTF::WeakRef::releaseImpl):
(WTF::WeakPtrImplBase::get):
(WTF::WeakPtrImplBase::operator bool const):
(WTF::WeakPtrImplBase::clear):
(WTF::WeakPtrImplBase::wasConstructedOnMainThread const):
(WTF::WeakPtrImplBase::WeakPtrImplBase):
(WTF::WeakPtrImplBaseSingleThread::get):
(WTF::WeakPtrImplBaseSingleThread::operator bool const):
(WTF::WeakPtrImplBaseSingleThread::clear):
(WTF::WeakPtrImplBaseSingleThread::wasConstructedOnMainThread const):
(WTF::WeakPtrImplBaseSingleThread::WeakPtrImplBaseSingleThread):
(WTF::WeakPtrImplBaseSingleThread::refCount const):
(WTF::WeakPtrImplBaseSingleThread::ref const):
(WTF::WeakPtrImplBaseSingleThread::deref const):
(WTF::is):
(WTF::downcast):
(WTF::dynamicDowncast):

Canonical link: <a href="https://commits.webkit.org/271841@main">https://commits.webkit.org/271841@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a9610b6a5c7d0e06b04ee2fe30956fc6dd7a9b8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29787 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8448 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31091 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32289 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26931 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10620 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5714 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26964 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30068 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7065 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25398 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6022 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6185 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26484 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33626 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/25575 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27161 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26908 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32368 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/29973 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6110 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4306 "Found 1 new test failure: fullscreen/full-screen-layer-dump.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30149 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7856 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/36354 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6862 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7845 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3842 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6640 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->