### PR TITLE
Build fix: Generate serialization for PKContact

### DIFF
--- a/Source/WebKit/Shared/Cocoa/CoreIPCPassKit.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPassKit.mm
@@ -37,7 +37,9 @@ CoreIPCPKContact::CoreIPCPKContact(PKContact *contact)
     , m_emailAddress(contact.emailAddress)
     , m_phoneNumber(contact.phoneNumber)
     , m_postalAddress(contact.postalAddress)
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     , m_supplementarySublocality(contact.supplementarySubLocality)
+ALLOW_DEPRECATED_DECLARATIONS_END
 {
 }
 
@@ -49,7 +51,9 @@ RetainPtr<id> CoreIPCPKContact::toID() const
     contact.get().emailAddress = (NSString *)m_emailAddress;
     contact.get().phoneNumber = (CNPhoneNumber *)m_phoneNumber.toID();
     contact.get().postalAddress = (CNPostalAddress *)m_postalAddress.toID();
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     contact.get().supplementarySubLocality = (NSString *)m_supplementarySublocality;
+ALLOW_DEPRECATED_DECLARATIONS_END
 
     return contact;
 }

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
@@ -616,7 +616,9 @@ TEST(IPCSerialization, Basic)
     contact.get().emailAddress = @"admin@webkit.org";
     contact.get().phoneNumber = phoneNumber.get();
     contact.get().postalAddress = address.get();
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     contact.get().supplementarySubLocality = @"City 17";
+ALLOW_DEPRECATED_DECLARATIONS_END
     runTestNS({ contact.get() });
 #endif // USE(PASSKIT) && !PLATFORM(WATCHOS)
 


### PR DESCRIPTION
#### 55045fd24d227511d1744361935fa6202ea35a66
<pre>
Build fix: Generate serialization for PKContact
<a href="https://bugs.webkit.org/show_bug.cgi?id=266115">https://bugs.webkit.org/show_bug.cgi?id=266115</a>
<a href="https://rdar.apple.com/119407339">rdar://119407339</a>

Unreviewed build fix.

Ignore deprecation warnings for PKContact.supplementarySubLocality
property.

* Source/WebKit/Shared/Cocoa/CoreIPCPassKit.mm:
(WebKit::CoreIPCPKContact::CoreIPCPKContact):
(WebKit::CoreIPCPKContact::toID const):
* Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/271820@main">https://commits.webkit.org/271820@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e371cee970c87cb9c853ae903ba86b407bc46a5c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29777 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8437 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31080 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32278 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26921 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30399 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10606 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5705 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/26948 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30056 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7053 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/25387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6011 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6174 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/26474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33615 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27149 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/26898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/32356 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6100 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/4297 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/30137 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7847 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6853 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3838 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6631 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->