### PR TITLE
Make wpe match gtk expected values for failing align-content table cell test.

### DIFF
--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-align/blocks/align-content-table-cell-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-align/blocks/align-content-table-cell-expected.txt
@@ -1,0 +1,24 @@
+first
+second
+first
+second
+first
+second
+third
+first
+second
+first
+second
+first
+second
+third
+
+FAIL vertical-align:top and align-content:start are equivalent assert_equals: The first cell content top expected 0 but got 15
+PASS vertical-align:middle and `align-content:unsafe center` are equivalent
+FAIL vertical-align:bottom and `align-content:unsafe end` are equivalent assert_equals: The first cell content top expected 30 but got 15
+FAIL vertical-align:baseline and align-content:baseline are equivalent assert_equals: The first cell content top expected 9 but got 15
+PASS vertical-align:middle and `align-content:safe center` are equivalent if the container is tall
+FAIL vertical-align:bottom and `align-content:safe end` are equivalent if the container is tall assert_equals: The first cell content top expected 30 but got 15
+PASS `align-content:safe center` is equivalent to `unsafe center` even if the specified `height` is short
+PASS `align-content:safe end` is equivalent to `unsafe end` even if the specified `height` is short
+


### PR DESCRIPTION
#### 4bc774ae6e17fd0180a4f366bac42eee09739d64
<pre>
Make wpe match gtk expected values for failing align-content table cell test.
<a href="https://bugs.webkit.org/show_bug.cgi?id=266085">https://bugs.webkit.org/show_bug.cgi?id=266085</a>
<a href="https://rdar.apple.com/114740670">https://rdar.apple.com/114740670</a>

Reviewed by Alan Baradlay.

Test expectation has a 1px difference between Mac/iOS and Linux, but I only
committed the file for gtk. :/

* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-align/blocks/align-content-table-cell-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/271826@main">https://commits.webkit.org/271826@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0884b20aedf24fbe90c2d33a72d61e8c73cfbd37

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29778 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8438 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31081 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32279 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26922 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10607 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5706 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26947 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30057 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7054 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25386 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6010 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6175 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26473 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33616 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27150 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26897 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32357 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6101 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4298 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30138 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7848 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7065 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6854 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6632 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->