### PR TITLE
Optimize looking up keys by raw reference in hash containers whose key is a non-nullable smart pointer type

### DIFF
--- a/Source/JavaScriptCore/bytecode/StructureStubInfo.h
+++ b/Source/JavaScriptCore/bytecode/StructureStubInfo.h
@@ -663,12 +663,12 @@ public:
     };
 
     struct PointerTranslator {
-        static unsigned hash(PolymorphicAccessJITStubRoutine* stub)
+        static unsigned hash(const PolymorphicAccessJITStubRoutine* stub)
         {
             return stub->hash();
         }
 
-        static bool equal(const Hash::Key& key, PolymorphicAccessJITStubRoutine* stub)
+        static bool equal(const Hash::Key& key, const PolymorphicAccessJITStubRoutine* stub)
         {
             return key.m_wrapped == stub;
         }

--- a/Source/JavaScriptCore/jit/JITThunks.cpp
+++ b/Source/JavaScriptCore/jit/JITThunks.cpp
@@ -69,7 +69,7 @@ static inline NativeExecutable& getMayBeDyingNativeExecutable(const Weak<NativeE
     return *executable;
 }
 
-inline unsigned JITThunks::WeakNativeExecutableHash::hash(NativeExecutable* executable)
+inline unsigned JITThunks::WeakNativeExecutableHash::hash(const NativeExecutable* executable)
 {
     return hash(executable->function(), executable->constructor(), executable->implementationVisibility(), executable->name());
 }
@@ -79,7 +79,7 @@ inline unsigned JITThunks::WeakNativeExecutableHash::hash(const Weak<NativeExecu
     return hash(&getMayBeDyingNativeExecutable(key));
 }
 
-inline bool JITThunks::WeakNativeExecutableHash::equal(NativeExecutable& a, NativeExecutable& b)
+inline bool JITThunks::WeakNativeExecutableHash::equal(const NativeExecutable& a, const NativeExecutable& b)
 {
     if (&a == &b)
         return true;
@@ -91,7 +91,7 @@ inline bool JITThunks::WeakNativeExecutableHash::equal(const Weak<NativeExecutab
     return equal(getMayBeDyingNativeExecutable(a), getMayBeDyingNativeExecutable(b));
 }
 
-inline bool JITThunks::WeakNativeExecutableHash::equal(const Weak<NativeExecutable>& a, NativeExecutable* bExecutable)
+inline bool JITThunks::WeakNativeExecutableHash::equal(const Weak<NativeExecutable>& a, const NativeExecutable* bExecutable)
 {
     return equal(getMayBeDyingNativeExecutable(a), *bExecutable);
 }
@@ -213,8 +213,8 @@ struct JITThunks::HostKeySearcher {
 };
 
 struct JITThunks::NativeExecutableTranslator {
-    static unsigned hash(NativeExecutable* key) { return WeakNativeExecutableHash::hash(key); }
-    static bool equal(const Weak<NativeExecutable>& a, NativeExecutable* b) { return WeakNativeExecutableHash::equal(a, b); }
+    static unsigned hash(const NativeExecutable* key) { return WeakNativeExecutableHash::hash(key); }
+    static bool equal(const Weak<NativeExecutable>& a, const NativeExecutable* b) { return WeakNativeExecutableHash::equal(a, b); }
     static void translate(Weak<NativeExecutable>& location, NativeExecutable* executable, unsigned)
     {
         location = Weak<NativeExecutable>(executable, executable->vm().jitStubs.get());

--- a/Source/JavaScriptCore/jit/JITThunks.h
+++ b/Source/JavaScriptCore/jit/JITThunks.h
@@ -121,7 +121,7 @@ private:
 
     struct WeakNativeExecutableHash {
         static inline unsigned hash(const Weak<NativeExecutable>&);
-        static inline unsigned hash(NativeExecutable*);
+        static inline unsigned hash(const NativeExecutable*);
         static unsigned hash(const HostFunctionKey& key)
         {
             return hash(std::get<0>(key), std::get<1>(key), std::get<2>(key), std::get<3>(key));
@@ -129,8 +129,8 @@ private:
 
         static inline bool equal(const Weak<NativeExecutable>&, const Weak<NativeExecutable>&);
         static inline bool equal(const Weak<NativeExecutable>&, const HostFunctionKey&);
-        static inline bool equal(const Weak<NativeExecutable>&, NativeExecutable*);
-        static inline bool equal(NativeExecutable&, NativeExecutable&);
+        static inline bool equal(const Weak<NativeExecutable>&, const NativeExecutable*);
+        static inline bool equal(const NativeExecutable&, const NativeExecutable&);
         static constexpr bool safeToCompareToEmptyOrDeleted = false;
 
     private:

--- a/Source/JavaScriptCore/runtime/Identifier.h
+++ b/Source/JavaScriptCore/runtime/Identifier.h
@@ -277,7 +277,7 @@ JSValue identifierToSafePublicJSValue(VM&, const Identifier&);
 // https://bugs.webkit.org/show_bug.cgi?id=150137
 struct IdentifierRepHash : PtrHash<RefPtr<UniquedStringImpl>> {
     static unsigned hash(const RefPtr<UniquedStringImpl>& key) { return key->existingSymbolAwareHash(); }
-    static unsigned hash(UniquedStringImpl* key) { return key->existingSymbolAwareHash(); }
+    static unsigned hash(const UniquedStringImpl* key) { return key->existingSymbolAwareHash(); }
     static constexpr bool hasHashInValue = true;
 };
 

--- a/Source/WTF/wtf/CheckedPtr.h
+++ b/Source/WTF/wtf/CheckedPtr.h
@@ -263,7 +263,8 @@ private:
 
 template <typename T, typename PtrTraits>
 struct GetPtrHelper<CheckedPtr<T, PtrTraits>> {
-    typedef T* PtrType;
+    using PtrType = T*;
+    using UnderlyingType = T;
     static T* getPtr(const CheckedPtr<T, PtrTraits>& p) { return const_cast<T*>(p.get()); }
 };
 

--- a/Source/WTF/wtf/CheckedRef.h
+++ b/Source/WTF/wtf/CheckedRef.h
@@ -237,13 +237,15 @@ private:
 
 template <typename T, typename PtrTraits>
 struct GetPtrHelper<CheckedRef<T, PtrTraits>> {
-    typedef T* PtrType;
+    using PtrType = T*;
+    using UnderlyingType = T;
     static T* getPtr(const CheckedRef<T, PtrTraits>& p) { return const_cast<T*>(p.ptr()); }
 };
 
 template <typename T, typename U>
 struct IsSmartPtr<CheckedRef<T, U>> {
     static constexpr bool value = true;
+    static constexpr bool isNullable = true;
 };
 
 template<typename ExpectedType, typename ArgType, typename ArgPtrTraits>

--- a/Source/WTF/wtf/CompactPtr.h
+++ b/Source/WTF/wtf/CompactPtr.h
@@ -237,12 +237,14 @@ inline bool operator==(T* a, const CompactPtr<U>& b)
 template <typename T>
 struct GetPtrHelper<CompactPtr<T>> {
     using PtrType = T*;
+    using UnderlyingType = T;
     static T* getPtr(const CompactPtr<T>& p) { return const_cast<T*>(p.get()); }
 };
 
 template <typename T>
 struct IsSmartPtr<CompactPtr<T>> {
     static constexpr bool value = true;
+    static constexpr bool isNullable = true;
 };
 
 template <typename T>

--- a/Source/WTF/wtf/ConcurrentPtrHashSet.h
+++ b/Source/WTF/wtf/ConcurrentPtrHashSet.h
@@ -108,9 +108,9 @@ private:
         Atomic<void*> array[1];
     };
     
-    static unsigned hash(void* ptr)
+    static unsigned hash(const void* ptr)
     {
-        return PtrHash<void*>::hash(ptr);
+        return PtrHash<const void*>::hash(ptr);
     }
     
     void initialize();

--- a/Source/WTF/wtf/GetPtr.h
+++ b/Source/WTF/wtf/GetPtr.h
@@ -31,6 +31,7 @@ template <typename T> inline T* getPtr(T* p) { return p; }
 
 template <typename T> struct IsSmartPtr {
     static constexpr bool value = false;
+    static constexpr bool isNullable = true;
 };
 
 template <typename T, bool isSmartPtr>
@@ -38,13 +39,15 @@ struct GetPtrHelperBase;
 
 template <typename T>
 struct GetPtrHelperBase<T, false /* isSmartPtr */> {
-    typedef T* PtrType;
+    using PtrType = T*;
+    using UnderlyingType = T;
     static T* getPtr(T& p) { return std::addressof(p); }
 };
 
 template <typename T>
 struct GetPtrHelperBase<T, true /* isSmartPtr */> {
-    typedef typename T::PtrType PtrType;
+    using PtrType = typename T::PtrType;
+    using UnderlyingType = typename T::ValueType;
     static PtrType getPtr(const T& p) { return p.get(); }
 };
 
@@ -68,11 +71,13 @@ inline typename GetPtrHelper<T>::PtrType getPtr(const T& p)
 
 template <typename T, typename Deleter> struct IsSmartPtr<std::unique_ptr<T, Deleter>> {
     static constexpr bool value = true;
+    static constexpr bool isNullable = true;
 };
 
 template <typename T, typename Deleter>
 struct GetPtrHelper<std::unique_ptr<T, Deleter>> {
-    typedef T* PtrType;
+    using PtrType = T*;
+    using UnderlyingType = T;
     static T* getPtr(const std::unique_ptr<T, Deleter>& p) { return p.get(); }
 };
 

--- a/Source/WTF/wtf/HashCountedSet.h
+++ b/Source/WTF/wtf/HashCountedSet.h
@@ -104,11 +104,18 @@ public:
     void clear();
 
     // Overloads for smart pointer keys that take the raw pointer type as the parameter.
-    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value, iterator>::type find(typename GetPtrHelper<V>::PtrType);
-    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value, const_iterator>::type find(typename GetPtrHelper<V>::PtrType) const;
-    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value, bool>::type contains(typename GetPtrHelper<V>::PtrType) const;
-    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value, unsigned>::type count(typename GetPtrHelper<V>::PtrType) const;
-    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value, bool>::type remove(typename GetPtrHelper<V>::PtrType);
+    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value, iterator>::type find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*);
+    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value, const_iterator>::type find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*) const;
+    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value, bool>::type contains(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*) const;
+    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value, unsigned>::type count(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*) const;
+    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value, bool>::type remove(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*);
+
+    // Overloads for non-nullable smart pointer values that take the raw reference type as the parameter.
+    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, iterator>::type find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&);
+    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, const_iterator>::type find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&) const;
+    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, bool>::type contains(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&) const;
+    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, unsigned>::type count(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&) const;
+    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, bool>::type remove(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&);
 
     static bool isValidValue(const ValueType& value) { return ImplType::isValidValue(value); }
 
@@ -281,37 +288,72 @@ inline void HashCountedSet<Value, HashFunctions, Traits>::clear()
 
 template<typename Value, typename HashFunctions, typename Traits>
 template<typename V>
-inline auto HashCountedSet<Value, HashFunctions, Traits>::find(typename GetPtrHelper<V>::PtrType value) -> typename std::enable_if<IsSmartPtr<V>::value, iterator>::type
+inline auto HashCountedSet<Value, HashFunctions, Traits>::find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* value) -> typename std::enable_if<IsSmartPtr<V>::value, iterator>::type
 {
     return m_impl.find(value);
 }
 
 template<typename Value, typename HashFunctions, typename Traits>
 template<typename V>
-inline auto HashCountedSet<Value, HashFunctions, Traits>::find(typename GetPtrHelper<V>::PtrType value) const -> typename std::enable_if<IsSmartPtr<V>::value, const_iterator>::type
+inline auto HashCountedSet<Value, HashFunctions, Traits>::find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* value) const -> typename std::enable_if<IsSmartPtr<V>::value, const_iterator>::type
 {
     return m_impl.find(value);
 }
 
 template<typename Value, typename HashFunctions, typename Traits>
 template<typename V>
-inline auto HashCountedSet<Value, HashFunctions, Traits>::contains(typename GetPtrHelper<V>::PtrType value) const -> typename std::enable_if<IsSmartPtr<V>::value, bool>::type
+inline auto HashCountedSet<Value, HashFunctions, Traits>::contains(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* value) const -> typename std::enable_if<IsSmartPtr<V>::value, bool>::type
 {
     return m_impl.contains(value);
 }
 
 template<typename Value, typename HashFunctions, typename Traits>
 template<typename V>
-inline auto HashCountedSet<Value, HashFunctions, Traits>::count(typename GetPtrHelper<V>::PtrType value) const -> typename std::enable_if<IsSmartPtr<V>::value, unsigned>::type
+inline auto HashCountedSet<Value, HashFunctions, Traits>::count(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* value) const -> typename std::enable_if<IsSmartPtr<V>::value, unsigned>::type
 {
     return m_impl.get(value);
 }
 
 template<typename Value, typename HashFunctions, typename Traits>
 template<typename V>
-inline auto HashCountedSet<Value, HashFunctions, Traits>::remove(typename GetPtrHelper<V>::PtrType value) -> typename std::enable_if<IsSmartPtr<V>::value, bool>::type
+inline auto HashCountedSet<Value, HashFunctions, Traits>::remove(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* value) -> typename std::enable_if<IsSmartPtr<V>::value, bool>::type
 {
     return remove(find(value));
+}
+
+template<typename Value, typename HashFunctions, typename Traits>
+template<typename V>
+inline auto HashCountedSet<Value, HashFunctions, Traits>::find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>& value) -> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, iterator>::type
+{
+    return find(&value);
+}
+
+template<typename Value, typename HashFunctions, typename Traits>
+template<typename V>
+inline auto HashCountedSet<Value, HashFunctions, Traits>::find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>& value) const -> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, const_iterator>::type
+{
+    return find(&value);
+}
+
+template<typename Value, typename HashFunctions, typename Traits>
+template<typename V>
+inline auto HashCountedSet<Value, HashFunctions, Traits>::contains(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>& value) const -> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, bool>::type
+{
+    return contains(&value);
+}
+
+template<typename Value, typename HashFunctions, typename Traits>
+template<typename V>
+inline auto HashCountedSet<Value, HashFunctions, Traits>::count(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>& value) const -> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, unsigned>::type
+{
+    return count(&value);
+}
+
+template<typename Value, typename HashFunctions, typename Traits>
+template<typename V>
+inline auto HashCountedSet<Value, HashFunctions, Traits>::remove(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>& value) -> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, bool>::type
+{
+    return remove(&value);
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/HashFunctions.h
+++ b/Source/WTF/wtf/HashFunctions.h
@@ -134,16 +134,17 @@ namespace WTF {
 
     template <typename T>
     struct PtrHashBase<T, true /* isSmartPtr */> {
-        typedef typename GetPtrHelper<T>::PtrType PtrType; 
+        typedef typename GetPtrHelper<T>::PtrType PtrType;
+        typedef typename GetPtrHelper<T>::UnderlyingType UnderlyingType;
 
-        static unsigned hash(PtrType key) { return IntHash<uintptr_t>::hash(reinterpret_cast<uintptr_t>(key)); }
-        static bool equal(PtrType a, PtrType b) { return a == b; }
+        static unsigned hash(std::add_const_t<UnderlyingType>* key) { return IntHash<uintptr_t>::hash(reinterpret_cast<uintptr_t>(key)); }
+        static bool equal(std::add_const_t<UnderlyingType>* a, std::add_const_t<UnderlyingType>* b) { return a == b; }
         static constexpr bool safeToCompareToEmptyOrDeleted = true;
 
         static unsigned hash(const T& key) { return hash(getPtr(key)); }
         static bool equal(const T& a, const T& b) { return getPtr(a) == getPtr(b); }
-        static bool equal(PtrType a, const T& b) { return a == getPtr(b); }
-        static bool equal(const T& a, PtrType b) { return getPtr(a) == b; }
+        static bool equal(std::add_const_t<UnderlyingType>* a, const T& b) { return a == getPtr(b); }
+        static bool equal(const T& a, std::add_const_t<UnderlyingType>* b) { return getPtr(a) == b; }
     };
 
     template<typename T> struct PtrHash : PtrHashBase<T, IsSmartPtr<T>::value> {

--- a/Source/WTF/wtf/HashMap.h
+++ b/Source/WTF/wtf/HashMap.h
@@ -188,13 +188,22 @@ public:
     template<typename HashTranslator, typename K, typename V> AddResult add(K&&, V&&);
 
     // Overloads for smart pointer keys that take the raw pointer type as the parameter.
-    template<typename K = KeyType> typename std::enable_if<IsSmartPtr<K>::value, iterator>::type find(typename GetPtrHelper<K>::PtrType);
-    template<typename K = KeyType> typename std::enable_if<IsSmartPtr<K>::value, const_iterator>::type find(typename GetPtrHelper<K>::PtrType) const;
-    template<typename K = KeyType> typename std::enable_if<IsSmartPtr<K>::value, bool>::type contains(typename GetPtrHelper<K>::PtrType) const;
-    template<typename K = KeyType> typename std::enable_if<IsSmartPtr<K>::value, MappedPeekType>::type inlineGet(typename GetPtrHelper<K>::PtrType) const;
-    template<typename K = KeyType> typename std::enable_if<IsSmartPtr<K>::value, MappedPeekType>::type get(typename GetPtrHelper<K>::PtrType) const;
-    template<typename K = KeyType> typename std::enable_if<IsSmartPtr<K>::value, bool>::type remove(typename GetPtrHelper<K>::PtrType);
-    template<typename K = KeyType> typename std::enable_if<IsSmartPtr<K>::value, MappedTakeType>::type take(typename GetPtrHelper<K>::PtrType);
+    template<typename K = KeyType> typename std::enable_if<IsSmartPtr<K>::value, iterator>::type find(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>*);
+    template<typename K = KeyType> typename std::enable_if<IsSmartPtr<K>::value, const_iterator>::type find(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>*) const;
+    template<typename K = KeyType> typename std::enable_if<IsSmartPtr<K>::value, bool>::type contains(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>*) const;
+    template<typename K = KeyType> typename std::enable_if<IsSmartPtr<K>::value, MappedPeekType>::type inlineGet(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>*) const;
+    template<typename K = KeyType> typename std::enable_if<IsSmartPtr<K>::value, MappedPeekType>::type get(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>*) const;
+    template<typename K = KeyType> typename std::enable_if<IsSmartPtr<K>::value, bool>::type remove(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>*);
+    template<typename K = KeyType> typename std::enable_if<IsSmartPtr<K>::value, MappedTakeType>::type take(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>*);
+
+    // Overloads for non-nullable smart pointer values that take the raw reference type as the parameter.
+    template<typename K = KeyType> typename std::enable_if<IsSmartPtr<K>::value && !IsSmartPtr<K>::isNullable, iterator>::type find(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>&);
+    template<typename K = KeyType> typename std::enable_if<IsSmartPtr<K>::value && !IsSmartPtr<K>::isNullable, const_iterator>::type find(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>&) const;
+    template<typename K = KeyType> typename std::enable_if<IsSmartPtr<K>::value && !IsSmartPtr<K>::isNullable, bool>::type contains(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>&) const;
+    template<typename K = KeyType> typename std::enable_if<IsSmartPtr<K>::value && !IsSmartPtr<K>::isNullable, MappedPeekType>::type inlineGet(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>&) const;
+    template<typename K = KeyType> typename std::enable_if<IsSmartPtr<K>::value && !IsSmartPtr<K>::isNullable, MappedPeekType>::type get(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>&) const;
+    template<typename K = KeyType> typename std::enable_if<IsSmartPtr<K>::value && !IsSmartPtr<K>::isNullable, bool>::type remove(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>&);
+    template<typename K = KeyType> typename std::enable_if<IsSmartPtr<K>::value && !IsSmartPtr<K>::isNullable, MappedTakeType>::type take(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>&);
 
     void checkConsistency() const;
 
@@ -531,28 +540,28 @@ auto HashMap<T, U, V, W, MappedTraits, Y>::take(const KeyType& key) -> MappedTak
 
 template<typename T, typename U, typename V, typename W, typename X, typename Y>
 template<typename K>
-inline auto HashMap<T, U, V, W, X, Y>::find(typename GetPtrHelper<K>::PtrType key) -> typename std::enable_if<IsSmartPtr<K>::value, iterator>::type
+inline auto HashMap<T, U, V, W, X, Y>::find(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>* key) -> typename std::enable_if<IsSmartPtr<K>::value, iterator>::type
 {
     return m_impl.template find<HashMapTranslator<KeyValuePairTraits, HashFunctions>>(key);
 }
 
 template<typename T, typename U, typename V, typename W, typename X, typename Y>
 template<typename K>
-inline auto HashMap<T, U, V, W, X, Y>::find(typename GetPtrHelper<K>::PtrType key) const -> typename std::enable_if<IsSmartPtr<K>::value, const_iterator>::type
+inline auto HashMap<T, U, V, W, X, Y>::find(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>* key) const -> typename std::enable_if<IsSmartPtr<K>::value, const_iterator>::type
 {
     return m_impl.template find<HashMapTranslator<KeyValuePairTraits, HashFunctions>>(key);
 }
 
 template<typename T, typename U, typename V, typename W, typename X, typename Y>
 template<typename K>
-inline auto HashMap<T, U, V, W, X, Y>::contains(typename GetPtrHelper<K>::PtrType key) const -> typename std::enable_if<IsSmartPtr<K>::value, bool>::type
+inline auto HashMap<T, U, V, W, X, Y>::contains(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>* key) const -> typename std::enable_if<IsSmartPtr<K>::value, bool>::type
 {
     return m_impl.template contains<HashMapTranslator<KeyValuePairTraits, HashFunctions>>(key);
 }
 
 template<typename T, typename U, typename V, typename W, typename X, typename Y>
 template<typename K>
-inline auto HashMap<T, U, V, W, X, Y>::inlineGet(typename GetPtrHelper<K>::PtrType key) const -> typename std::enable_if<IsSmartPtr<K>::value, MappedPeekType>::type
+inline auto HashMap<T, U, V, W, X, Y>::inlineGet(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>* key) const -> typename std::enable_if<IsSmartPtr<K>::value, MappedPeekType>::type
 {
     KeyValuePairType* entry = const_cast<HashTableType&>(m_impl).template inlineLookup<HashMapTranslator<KeyValuePairTraits, HashFunctions>>(key);
     if (!entry)
@@ -562,21 +571,21 @@ inline auto HashMap<T, U, V, W, X, Y>::inlineGet(typename GetPtrHelper<K>::PtrTy
 
 template<typename T, typename U, typename V, typename W, typename X, typename Y>
 template<typename K>
-auto HashMap<T, U, V, W, X, Y>::get(typename GetPtrHelper<K>::PtrType key) const -> typename std::enable_if<IsSmartPtr<K>::value, MappedPeekType>::type
+auto HashMap<T, U, V, W, X, Y>::get(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>* key) const -> typename std::enable_if<IsSmartPtr<K>::value, MappedPeekType>::type
 {
     return inlineGet(key);
 }
 
 template<typename T, typename U, typename V, typename W, typename X, typename Y>
 template<typename K>
-inline auto HashMap<T, U, V, W, X, Y>::remove(typename GetPtrHelper<K>::PtrType key) -> typename std::enable_if<IsSmartPtr<K>::value, bool>::type
+inline auto HashMap<T, U, V, W, X, Y>::remove(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>* key) -> typename std::enable_if<IsSmartPtr<K>::value, bool>::type
 {
     return remove(find(key));
 }
 
 template<typename T, typename U, typename V, typename W, typename X, typename Y>
 template<typename K>
-inline auto HashMap<T, U, V, W, X, Y>::take(typename GetPtrHelper<K>::PtrType key) -> typename std::enable_if<IsSmartPtr<K>::value, MappedTakeType>::type
+inline auto HashMap<T, U, V, W, X, Y>::take(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>* key) -> typename std::enable_if<IsSmartPtr<K>::value, MappedTakeType>::type
 {
     iterator it = find(key);
     if (it == end())
@@ -584,6 +593,55 @@ inline auto HashMap<T, U, V, W, X, Y>::take(typename GetPtrHelper<K>::PtrType ke
     auto value = MappedTraits::take(WTFMove(it->value));
     remove(it);
     return value;
+}
+
+template<typename T, typename U, typename V, typename W, typename X, typename Y>
+template<typename K>
+inline auto HashMap<T, U, V, W, X, Y>::find(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>& key) -> typename std::enable_if<IsSmartPtr<K>::value && !IsSmartPtr<K>::isNullable, iterator>::type
+{
+    return find(&key);
+}
+
+template<typename T, typename U, typename V, typename W, typename X, typename Y>
+template<typename K>
+inline auto HashMap<T, U, V, W, X, Y>::find(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>& key) const -> typename std::enable_if<IsSmartPtr<K>::value && !IsSmartPtr<K>::isNullable, const_iterator>::type
+{
+    return find(&key);
+}
+
+template<typename T, typename U, typename V, typename W, typename X, typename Y>
+template<typename K>
+inline auto HashMap<T, U, V, W, X, Y>::contains(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>& key) const -> typename std::enable_if<IsSmartPtr<K>::value && !IsSmartPtr<K>::isNullable, bool>::type
+{
+    return contains(&key);
+}
+
+template<typename T, typename U, typename V, typename W, typename X, typename Y>
+template<typename K>
+inline auto HashMap<T, U, V, W, X, Y>::inlineGet(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>& key) const -> typename std::enable_if<IsSmartPtr<K>::value && !IsSmartPtr<K>::isNullable, MappedPeekType>::type
+{
+    return inlineGet(&key);
+}
+
+template<typename T, typename U, typename V, typename W, typename X, typename Y>
+template<typename K>
+auto HashMap<T, U, V, W, X, Y>::get(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>& key) const -> typename std::enable_if<IsSmartPtr<K>::value && !IsSmartPtr<K>::isNullable, MappedPeekType>::type
+{
+    return inlineGet(&key);
+}
+
+template<typename T, typename U, typename V, typename W, typename X, typename Y>
+template<typename K>
+inline auto HashMap<T, U, V, W, X, Y>::remove(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>& key) -> typename std::enable_if<IsSmartPtr<K>::value && !IsSmartPtr<K>::isNullable, bool>::type
+{
+    return remove(&key);
+}
+
+template<typename T, typename U, typename V, typename W, typename X, typename Y>
+template<typename K>
+inline auto HashMap<T, U, V, W, X, Y>::take(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>& key) -> typename std::enable_if<IsSmartPtr<K>::value && !IsSmartPtr<K>::isNullable, MappedTakeType>::type
+{
+    return take(&key);
 }
 
 template<typename T, typename U, typename V, typename W, typename X, typename Y>

--- a/Source/WTF/wtf/HashSet.h
+++ b/Source/WTF/wtf/HashSet.h
@@ -171,10 +171,16 @@ public:
     bool isSubset(const OtherCollection&);
 
     // Overloads for smart pointer values that take the raw pointer type as the parameter.
-    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value, iterator>::type find(typename GetPtrHelper<V>::PtrType) const;
-    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value, bool>::type contains(typename GetPtrHelper<V>::PtrType) const;
-    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value, bool>::type remove(typename GetPtrHelper<V>::PtrType);
-    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value, TakeType>::type take(typename GetPtrHelper<V>::PtrType);
+    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value, iterator>::type find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*) const;
+    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value, bool>::type contains(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*) const;
+    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value, bool>::type remove(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*);
+    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value, TakeType>::type take(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*);
+
+    // Overloads for non-nullable smart pointer values that take the raw reference type as the parameter.
+    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, iterator>::type find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&) const;
+    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, bool>::type contains(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&) const;
+    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, bool>::type remove(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&);
+    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, TakeType>::type take(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&);
 
     static bool isValidValue(const ValueType&);
 
@@ -462,30 +468,58 @@ inline bool HashSet<T, U, V, W>::isSubset(const OtherCollection& other)
 
 template<typename Value, typename HashFunctions, typename Traits, typename TableTraits>
 template<typename V>
-inline auto HashSet<Value, HashFunctions, Traits, TableTraits>::find(typename GetPtrHelper<V>::PtrType value) const -> typename std::enable_if<IsSmartPtr<V>::value, iterator>::type
+inline auto HashSet<Value, HashFunctions, Traits, TableTraits>::find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* value) const -> typename std::enable_if<IsSmartPtr<V>::value, iterator>::type
 {
     return m_impl.template find<HashSetTranslator<Traits, HashFunctions>>(value);
 }
 
 template<typename Value, typename HashFunctions, typename Traits, typename TableTraits>
 template<typename V>
-inline auto HashSet<Value, HashFunctions, Traits, TableTraits>::contains(typename GetPtrHelper<V>::PtrType value) const -> typename std::enable_if<IsSmartPtr<V>::value, bool>::type
+inline auto HashSet<Value, HashFunctions, Traits, TableTraits>::contains(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* value) const -> typename std::enable_if<IsSmartPtr<V>::value, bool>::type
 {
     return m_impl.template contains<HashSetTranslator<Traits, HashFunctions>>(value);
 }
 
 template<typename Value, typename HashFunctions, typename Traits, typename TableTraits>
 template<typename V>
-inline auto HashSet<Value, HashFunctions, Traits, TableTraits>::remove(typename GetPtrHelper<V>::PtrType value) -> typename std::enable_if<IsSmartPtr<V>::value, bool>::type
+inline auto HashSet<Value, HashFunctions, Traits, TableTraits>::remove(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* value) -> typename std::enable_if<IsSmartPtr<V>::value, bool>::type
 {
     return remove(find(value));
 }
 
 template<typename Value, typename HashFunctions, typename Traits, typename TableTraits>
 template<typename V>
-inline auto HashSet<Value, HashFunctions, Traits, TableTraits>::take(typename GetPtrHelper<V>::PtrType value) -> typename std::enable_if<IsSmartPtr<V>::value, TakeType>::type
+inline auto HashSet<Value, HashFunctions, Traits, TableTraits>::take(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* value) -> typename std::enable_if<IsSmartPtr<V>::value, TakeType>::type
 {
     return take(find(value));
+}
+
+template<typename Value, typename HashFunctions, typename Traits, typename TableTraits>
+template<typename V>
+inline auto HashSet<Value, HashFunctions, Traits, TableTraits>::find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>& value) const -> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, iterator>::type
+{
+    return find(&value);
+}
+
+template<typename Value, typename HashFunctions, typename Traits, typename TableTraits>
+template<typename V>
+inline auto HashSet<Value, HashFunctions, Traits, TableTraits>::contains(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>& value) const -> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, bool>::type
+{
+    return contains(&value);
+}
+
+template<typename Value, typename HashFunctions, typename Traits, typename TableTraits>
+template<typename V>
+inline auto HashSet<Value, HashFunctions, Traits, TableTraits>::remove(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>& value) -> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, bool>::type
+{
+    return remove(&value);
+}
+
+template<typename Value, typename HashFunctions, typename Traits, typename TableTraits>
+template<typename V>
+inline auto HashSet<Value, HashFunctions, Traits, TableTraits>::take(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>& value) -> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, TakeType>::type
+{
+    return take(&value);
 }
 
 template<typename T, typename U, typename V, typename W>

--- a/Source/WTF/wtf/ListHashSet.h
+++ b/Source/WTF/wtf/ListHashSet.h
@@ -150,12 +150,20 @@ public:
     void clear();
 
     // Overloads for smart pointer values that take the raw pointer type as the parameter.
-    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value, iterator>::type find(typename GetPtrHelper<V>::PtrType);
-    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value, const_iterator>::type find(typename GetPtrHelper<V>::PtrType) const;
-    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value, bool>::type contains(typename GetPtrHelper<V>::PtrType) const;
-    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value, AddResult>::type insertBefore(typename GetPtrHelper<V>::PtrType, const ValueType&);
-    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value, AddResult>::type insertBefore(typename GetPtrHelper<V>::PtrType, ValueType&&);
-    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value, bool>::type remove(typename GetPtrHelper<V>::PtrType);
+    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value, iterator>::type find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*);
+    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value, const_iterator>::type find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*) const;
+    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value, bool>::type contains(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*) const;
+    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value, AddResult>::type insertBefore(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*, const ValueType&);
+    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value, AddResult>::type insertBefore(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*, ValueType&&);
+    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value, bool>::type remove(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>*);
+
+    // Overloads for non-nullable smart pointer values that take the raw reference type as the parameter.
+    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, iterator>::type find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&);
+    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, const_iterator>::type find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&) const;
+    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, bool>::type contains(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&) const;
+    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, AddResult>::type insertBefore(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&, const ValueType&);
+    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, AddResult>::type insertBefore(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&, ValueType&&);
+    template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, bool>::type remove(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&);
 
 private:
     void unlink(Node*);
@@ -678,7 +686,7 @@ inline void ListHashSet<T, U>::clear()
 
 template<typename T, typename U>
 template<typename V>
-inline auto ListHashSet<T, U>::find(typename GetPtrHelper<V>::PtrType value) -> typename std::enable_if<IsSmartPtr<V>::value, iterator>::type
+inline auto ListHashSet<T, U>::find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* value) -> typename std::enable_if<IsSmartPtr<V>::value, iterator>::type
 {
     auto it = m_impl.template find<BaseTranslator>(value);
     if (it == m_impl.end())
@@ -688,7 +696,7 @@ inline auto ListHashSet<T, U>::find(typename GetPtrHelper<V>::PtrType value) -> 
 
 template<typename T, typename U>
 template<typename V>
-inline auto ListHashSet<T, U>::find(typename GetPtrHelper<V>::PtrType value) const -> typename std::enable_if<IsSmartPtr<V>::value, const_iterator>::type
+inline auto ListHashSet<T, U>::find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* value) const -> typename std::enable_if<IsSmartPtr<V>::value, const_iterator>::type
 {
     auto it = m_impl.template find<BaseTranslator>(value);
     if (it == m_impl.end())
@@ -698,30 +706,72 @@ inline auto ListHashSet<T, U>::find(typename GetPtrHelper<V>::PtrType value) con
 
 template<typename T, typename U>
 template<typename V>
-inline auto ListHashSet<T, U>::contains(typename GetPtrHelper<V>::PtrType value) const -> typename std::enable_if<IsSmartPtr<V>::value, bool>::type
+inline auto ListHashSet<T, U>::contains(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* value) const -> typename std::enable_if<IsSmartPtr<V>::value, bool>::type
 {
     return m_impl.template contains<BaseTranslator>(value);
 }
 
 template<typename T, typename U>
 template<typename V>
-inline auto ListHashSet<T, U>::insertBefore(typename GetPtrHelper<V>::PtrType beforeValue, const ValueType& newValue) -> typename std::enable_if<IsSmartPtr<V>::value, AddResult>::type
+inline auto ListHashSet<T, U>::insertBefore(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* beforeValue, const ValueType& newValue) -> typename std::enable_if<IsSmartPtr<V>::value, AddResult>::type
 {
     return insertBefore(find(beforeValue), newValue);
 }
 
 template<typename T, typename U>
 template<typename V>
-inline auto ListHashSet<T, U>::insertBefore(typename GetPtrHelper<V>::PtrType beforeValue, ValueType&& newValue) -> typename std::enable_if<IsSmartPtr<V>::value, AddResult>::type
+inline auto ListHashSet<T, U>::insertBefore(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* beforeValue, ValueType&& newValue) -> typename std::enable_if<IsSmartPtr<V>::value, AddResult>::type
 {
     return insertBefore(find(beforeValue), WTFMove(newValue));
 }
 
 template<typename T, typename U>
 template<typename V>
-inline auto ListHashSet<T, U>::remove(typename GetPtrHelper<V>::PtrType value) -> typename std::enable_if<IsSmartPtr<V>::value, bool>::type
+inline auto ListHashSet<T, U>::remove(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* value) -> typename std::enable_if<IsSmartPtr<V>::value, bool>::type
 {
     return remove(find(value));
+}
+
+template<typename T, typename U>
+template<typename V>
+inline auto ListHashSet<T, U>::find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>& value) -> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, iterator>::type
+{
+    return find(&value);
+}
+
+template<typename T, typename U>
+template<typename V>
+inline auto ListHashSet<T, U>::find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>& value) const -> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, const_iterator>::type
+{
+    return find(&value);
+}
+
+template<typename T, typename U>
+template<typename V>
+inline auto ListHashSet<T, U>::contains(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>& value) const -> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, bool>::type
+{
+    return contains(&value);
+}
+
+template<typename T, typename U>
+template<typename V>
+inline auto ListHashSet<T, U>::insertBefore(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>& beforeValue, const ValueType& newValue) -> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, AddResult>::type
+{
+    return insertBefore(&beforeValue, newValue);
+}
+
+template<typename T, typename U>
+template<typename V>
+inline auto ListHashSet<T, U>::insertBefore(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>& beforeValue, ValueType&& newValue) -> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, AddResult>::type
+{
+    return insertBefore(&beforeValue, WTFMove(newValue));
+}
+
+template<typename T, typename U>
+template<typename V>
+inline auto ListHashSet<T, U>::remove(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>& value) -> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, bool>::type
+{
+    return remove(&value);
 }
 
 template<typename T, typename U>

--- a/Source/WTF/wtf/Packed.h
+++ b/Source/WTF/wtf/Packed.h
@@ -257,12 +257,14 @@ using PackedPtr = Packed<T*>;
 template <typename T>
 struct GetPtrHelper<PackedPtr<T>> {
     using PtrType = T*;
+    using UnderlyingType = T;
     static T* getPtr(const PackedPtr<T>& p) { return const_cast<T*>(p.get()); }
 };
 
 template <typename T>
 struct IsSmartPtr<PackedPtr<T>> {
     static constexpr bool value = true;
+    static constexpr bool isNullable = true;
 };
 
 template<typename T, typename U>

--- a/Source/WTF/wtf/Ref.h
+++ b/Source/WTF/wtf/Ref.h
@@ -269,13 +269,15 @@ ALWAYS_INLINE Ref<T, U> static_reference_cast(const Ref<X, Y>& reference)
 
 template <typename T, typename U>
 struct GetPtrHelper<Ref<T, U>> {
-    typedef T* PtrType;
+    using PtrType = T*;
+    using UnderlyingType = T;
     static T* getPtr(const Ref<T, U>& p) { return const_cast<T*>(p.ptr()); }
 };
 
 template <typename T, typename U>
 struct IsSmartPtr<Ref<T, U>> {
     static constexpr bool value = true;
+    static constexpr bool isNullable = false;
 };
 
 template<typename T, typename U>

--- a/Source/WTF/wtf/RefPtr.h
+++ b/Source/WTF/wtf/RefPtr.h
@@ -250,6 +250,7 @@ inline RefPtr<T, U, V> static_pointer_cast(RefPtr<X, Y, Z>&& p)
 template <typename T, typename U, typename V>
 struct IsSmartPtr<RefPtr<T, U, V>> {
     static constexpr bool value = true;
+    static constexpr bool isNullable = true;
 };
 
 template<typename ExpectedType, typename ArgType, typename PtrTraits, typename RefDerefTraits>

--- a/Source/WTF/wtf/RetainPtr.h
+++ b/Source/WTF/wtf/RetainPtr.h
@@ -344,6 +344,7 @@ template<typename T> inline RetainPtr<typename RetainPtr<T>::HelperPtrType> reta
 
 template<typename T> struct IsSmartPtr<RetainPtr<T>> {
     static constexpr bool value = true;
+    static constexpr bool isNullable = true;
 };
 
 template<typename P> struct HashTraits<RetainPtr<P>> : SimpleClassHashTraits<RetainPtr<P>> {

--- a/Source/WTF/wtf/SchedulePair.h
+++ b/Source/WTF/wtf/SchedulePair.h
@@ -78,12 +78,19 @@ inline void add(Hasher& hasher, const SchedulePair& pair)
 }
 
 struct SchedulePairHash {
+    static unsigned hash(const SchedulePair* pair)
+    {
+        return computeHash(*pair);
+    }
+
     static unsigned hash(const RefPtr<SchedulePair>& pair)
     {
         return computeHash(*pair);
     }
 
+    static bool equal(const SchedulePair* a, const RefPtr<SchedulePair>& b) { return a == b; }
     static bool equal(const RefPtr<SchedulePair>& a, const RefPtr<SchedulePair>& b) { return a == b; }
+    static bool equal(const RefPtr<SchedulePair>& a, const SchedulePair* b) { return a == b; }
 
     static constexpr bool safeToCompareToEmptyOrDeleted = true;
 };

--- a/Source/WTF/wtf/SignedPtr.h
+++ b/Source/WTF/wtf/SignedPtr.h
@@ -122,6 +122,7 @@ private:
 template <typename T, uintptr_t Tag>
 struct IsSmartPtr<SignedPtr<T, Tag>> {
     static constexpr bool value = true;
+    static constexpr bool isNullable = true;
 };
 
 template<typename T, uintptr_t Tag>

--- a/Source/WTF/wtf/UniqueRef.h
+++ b/Source/WTF/wtf/UniqueRef.h
@@ -108,12 +108,14 @@ private:
 template <typename T>
 struct GetPtrHelper<UniqueRef<T>> {
     using PtrType = T*;
+    using UnderlyingType = T;
     static T* getPtr(const UniqueRef<T>& p) { return const_cast<T*>(p.ptr()); }
 };
 
 template <typename T>
 struct IsSmartPtr<UniqueRef<T>> {
     static constexpr bool value = true;
+    static constexpr bool isNullable = false;
 };
 
 template<typename ExpectedType, typename ArgType>

--- a/Source/WTF/wtf/WeakPtr.h
+++ b/Source/WTF/wtf/WeakPtr.h
@@ -393,7 +393,7 @@ template<typename T, typename WeakPtrImpl> template<typename U> inline WeakPtr<T
 }
 
 template<typename T, typename WeakPtrImpl> template<typename U> inline WeakPtr<T, WeakPtrImpl>::WeakPtr(const WeakRef<U, WeakPtrImpl>& o)
-    : m_impl(&weak_ptr_impl_cast<T, U>(o.m_impl.get()))
+    : m_impl(&weak_ptr_impl_cast<T, U>(o.impl()))
 #if ASSERT_ENABLED
     , m_shouldEnableAssertions(o.enableWeakPtrThreadingAssertions() == EnableWeakPtrThreadingAssertions::Yes)
 #endif
@@ -401,7 +401,7 @@ template<typename T, typename WeakPtrImpl> template<typename U> inline WeakPtr<T
 }
 
 template<typename T, typename WeakPtrImpl> template<typename U> inline WeakPtr<T, WeakPtrImpl>::WeakPtr(WeakRef<U, WeakPtrImpl>&& o)
-    : m_impl(adoptRef(weak_ptr_impl_cast<T, U>(o.m_impl.leakRef())))
+    : m_impl(adoptRef(weak_ptr_impl_cast<T, U>(o.releaseImpl().leakRef())))
 #if ASSERT_ENABLED
     , m_shouldEnableAssertions(o.enableWeakPtrThreadingAssertions() == EnableWeakPtrThreadingAssertions::Yes)
 #endif
@@ -447,12 +447,14 @@ template<typename T, typename WeakPtrImpl> template<typename U> inline WeakPtr<T
 template <typename T, typename WeakPtrImpl>
 struct GetPtrHelper<WeakPtr<T, WeakPtrImpl>> {
     using PtrType = T*;
+    using UnderlyingType = T;
     static T* getPtr(const WeakPtr<T, WeakPtrImpl>& p) { return const_cast<T*>(p.get()); }
 };
 
 template <typename T, typename WeakPtrImpl>
 struct IsSmartPtr<WeakPtr<T, WeakPtrImpl>> {
     static constexpr bool value = true;
+    static constexpr bool isNullable = true;
 };
 
 template<typename ExpectedType, typename ArgType, typename WeakPtrImpl>

--- a/Source/WTF/wtf/WeakRef.h
+++ b/Source/WTF/wtf/WeakRef.h
@@ -66,6 +66,7 @@ public:
     bool isHashTableDeletedValue() const { return m_impl.isHashTableDeletedValue(); }
     bool isHashTableEmptyValue() const { return m_impl.isHashTableEmptyValue(); }
 
+    WeakPtrImpl& impl() const { return m_impl; }
     Ref<WeakPtrImpl> releaseImpl() { return WTFMove(m_impl); }
 
     T* ptr() const
@@ -127,13 +128,15 @@ WeakRef(const T& value, EnableWeakPtrThreadingAssertions = EnableWeakPtrThreadin
 
 template <typename T, typename WeakPtrImpl>
 struct GetPtrHelper<WeakRef<T, WeakPtrImpl>> {
-    typedef T* PtrType;
+    using PtrType = T*;
+    using UnderlyingType = T;
     static T* getPtr(const WeakRef<T, WeakPtrImpl>& p) { return const_cast<T*>(p.ptr()); }
 };
 
 template <typename T, typename WeakPtrImpl>
 struct IsSmartPtr<WeakRef<T, WeakPtrImpl>> {
     static constexpr bool value = true;
+    static constexpr bool isNullable = false;
 };
 
 template<typename P, typename WeakPtrImpl> struct WeakRefHashTraits : SimpleClassHashTraits<WeakRef<P, WeakPtrImpl>> {

--- a/Source/WTF/wtf/glib/GRefPtr.h
+++ b/Source/WTF/wtf/glib/GRefPtr.h
@@ -215,6 +215,7 @@ template <typename T, typename U> inline GRefPtr<T> const_pointer_cast(const GRe
 
 template <typename T> struct IsSmartPtr<GRefPtr<T>> {
     static const bool value = true;
+    static constexpr bool isNullable = true;
 };
 
 template <typename T> GRefPtr<T> adoptGRef(T* p)

--- a/Source/WTF/wtf/text/AtomStringImpl.cpp
+++ b/Source/WTF/wtf/text/AtomStringImpl.cpp
@@ -466,8 +466,8 @@ Ref<AtomStringImpl> AtomStringImpl::addSlowCase(AtomStringTable& stringTable, St
 
 // When removing a string from the table, we know it's already the one in the table, so no need for a string equality check.
 struct AtomStringTableRemovalHashTranslator {
-    static unsigned hash(AtomStringImpl* string) { return string->hash(); }
-    static bool equal(const AtomStringTable::StringEntry& a, AtomStringImpl* b) { return a == b; }
+    static unsigned hash(const AtomStringImpl* string) { return string->hash(); }
+    static bool equal(const AtomStringTable::StringEntry& a, const AtomStringImpl* b) { return a == b; }
 };
 
 void AtomStringImpl::remove(AtomStringImpl* string)

--- a/Source/WTF/wtf/text/StringHash.h
+++ b/Source/WTF/wtf/text/StringHash.h
@@ -50,7 +50,7 @@ namespace WTF {
     // closer to having all the nearly-identical hash functions in one place.
 
     struct StringHash {
-        static unsigned hash(StringImpl* key) { return key->hash(); }
+        static unsigned hash(const StringImpl* key) { return key->hash(); }
         static inline bool equal(const StringImpl* a, const StringImpl* b)
         {
             return WTF::equal(*a, *b);
@@ -122,13 +122,13 @@ namespace WTF {
             return StringHasher::computeHashAndMaskTop8Bits<UChar, FoldCase>(data, length);
         }
 
-        static unsigned hash(StringImpl& string)
+        static unsigned hash(const StringImpl& string)
         {
             if (string.is8Bit())
                 return hash(string.characters8(), string.length());
             return hash(string.characters16(), string.length());
         }
-        static unsigned hash(StringImpl* string)
+        static unsigned hash(const StringImpl* string)
         {
             ASSERT(string);
             return hash(*string);

--- a/Source/WTF/wtf/text/SymbolRegistry.cpp
+++ b/Source/WTF/wtf/text/SymbolRegistry.cpp
@@ -64,7 +64,7 @@ Ref<RegisteredSymbolImpl> SymbolRegistry::symbolForKey(const String& rep)
 
 // When removing a registered symbol from the table, we know it's already the one in the table, so no need for a string equality check.
 struct SymbolRegistryTableRemovalHashTranslator {
-    static unsigned hash(RegisteredSymbolImpl* key) { return key->hash(); }
+    static unsigned hash(const RegisteredSymbolImpl* key) { return key->hash(); }
     static bool equal(const RefPtr<StringImpl>& a, const RegisteredSymbolImpl* b) { return a.get() == b; }
 };
 

--- a/Source/WebCore/dom/GCReachableRef.h
+++ b/Source/WebCore/dom/GCReachableRef.h
@@ -138,13 +138,15 @@ template<typename P> struct HashTraits<WebCore::GCReachableRef<P>> : SimpleClass
 
 template <typename T, typename U>
 struct GetPtrHelper<WebCore::GCReachableRef<T, U>> {
-    typedef T* PtrType;
+    using PtrType = T*;
+    using UnderlyingType = T;
     static T* getPtr(const WebCore::GCReachableRef<T, U>& reference) { return const_cast<T*>(reference.ptr()); }
 };
 
 template <typename T, typename U>
 struct IsSmartPtr<WebCore::GCReachableRef<T, U>> {
     static const bool value = true;
+    static constexpr bool isNullable = true;
 };
 
 template<typename P> struct PtrHash<WebCore::GCReachableRef<P>> : PtrHashBase<WebCore::GCReachableRef<P>, IsSmartPtr<WebCore::GCReachableRef<P>>::value> {

--- a/Source/WebCore/page/SecurityOriginHash.h
+++ b/Source/WebCore/page/SecurityOriginHash.h
@@ -36,7 +36,7 @@
 namespace WebCore {
 
 struct SecurityOriginHash {
-    static unsigned hash(SecurityOrigin* origin)
+    static unsigned hash(const SecurityOrigin* origin)
     {
         return computeHash(*origin);
     }
@@ -45,17 +45,17 @@ struct SecurityOriginHash {
         return hash(origin.get());
     }
 
-    static bool equal(SecurityOrigin* a, SecurityOrigin* b)
+    static bool equal(const SecurityOrigin* a, const SecurityOrigin* b)
     {
         if (!a || !b)
             return a == b;
         return a->isSameSchemeHostPort(*b);
     }
-    static bool equal(SecurityOrigin* a, const RefPtr<SecurityOrigin>& b)
+    static bool equal(const SecurityOrigin* a, const RefPtr<SecurityOrigin>& b)
     {
         return equal(a, b.get());
     }
-    static bool equal(const RefPtr<SecurityOrigin>& a, SecurityOrigin* b)
+    static bool equal(const RefPtr<SecurityOrigin>& a, const SecurityOrigin* b)
     {
         return equal(a.get(), b);
     }

--- a/Source/WebCore/platform/win/COMPtr.h
+++ b/Source/WebCore/platform/win/COMPtr.h
@@ -45,7 +45,7 @@ enum CreateTag { Create };
 
 template<typename T> class COMPtr {
 public:
-    typedef T* PtrType;
+    using PtrType = T*;
     COMPtr() : m_ptr(nullptr) { }
     COMPtr(T* ptr) : m_ptr(ptr) { if (m_ptr) m_ptr->AddRef(); }
     COMPtr(AdoptCOMTag, T* ptr) : m_ptr(ptr) { }
@@ -245,6 +245,7 @@ namespace WTF {
 
 template<typename P> struct IsSmartPtr<COMPtr<P>> {
     static const bool value = true;
+    static constexpr bool isNullable = true;
 };
 
 template<typename P> struct HashTraits<COMPtr<P> > : SimpleClassHashTraits<COMPtr<P>> {

--- a/Source/WebCore/rendering/FloatingObjects.h
+++ b/Source/WebCore/rendering/FloatingObjects.h
@@ -125,17 +125,17 @@ private:
 // changed PtrHashBase to have all of its hash and equal functions bottleneck through single functions (as
 // is done here). That would allow us to only override those master hash and equal functions.
 struct FloatingObjectHashFunctions {
-    typedef std::unique_ptr<FloatingObject> T;
-    typedef typename WTF::GetPtrHelper<T>::PtrType PtrType;
+    using T = std::unique_ptr<FloatingObject>;
+    using PtrType = FloatingObject*;
 
-    static unsigned hash(PtrType key) { return PtrHash<RenderBox*>::hash(&key->renderer()); }
-    static bool equal(PtrType a, PtrType b) { return &a->renderer() == &b->renderer(); }
+    static unsigned hash(const FloatingObject* key) { return PtrHash<RenderBox*>::hash(&key->renderer()); }
+    static bool equal(const FloatingObject* a, const FloatingObject* b) { return &a->renderer() == &b->renderer(); }
     static const bool safeToCompareToEmptyOrDeleted = true;
 
     static unsigned hash(const T& key) { return hash(WTF::getPtr(key)); }
     static bool equal(const T& a, const T& b) { return equal(WTF::getPtr(a), WTF::getPtr(b)); }
-    static bool equal(PtrType a, const T& b) { return equal(a, WTF::getPtr(b)); }
-    static bool equal(const T& a, PtrType b) { return equal(WTF::getPtr(a), b); }
+    static bool equal(const FloatingObject* a, const T& b) { return equal(a, WTF::getPtr(b)); }
+    static bool equal(const T& a, const FloatingObject* b) { return equal(WTF::getPtr(a), b); }
 };
 struct FloatingObjectHashTranslator {
     static unsigned hash(const RenderBox& key) { return PtrHash<const RenderBox*>::hash(&key); }

--- a/Source/WebCore/rendering/GlyphDisplayListCache.h
+++ b/Source/WebCore/rendering/GlyphDisplayListCache.h
@@ -91,8 +91,11 @@ inline void add(Hasher& hasher, const GlyphDisplayListCacheEntry& entry)
 }
 
 struct GlyphDisplayListCacheEntryHash {
+    static unsigned hash(const GlyphDisplayListCacheEntry* entry) { return computeHash(*entry); }
     static unsigned hash(const CheckedPtr<GlyphDisplayListCacheEntry>& entry) { return computeHash(*entry); }
-    static bool equal(const CheckedPtr<GlyphDisplayListCacheEntry>& a, const CheckedPtr<GlyphDisplayListCacheEntry>& b) { return a.get() == b.get(); }
+    static bool equal(const CheckedPtr<GlyphDisplayListCacheEntry>& a, const CheckedPtr<GlyphDisplayListCacheEntry>& b) { return a == b; }
+    static bool equal(const CheckedPtr<GlyphDisplayListCacheEntry>& a, const GlyphDisplayListCacheEntry* b) { return a == b; }
+    static bool equal(const GlyphDisplayListCacheEntry* a, const CheckedPtr<GlyphDisplayListCacheEntry>& b) { return a == b; }
     static constexpr bool safeToCompareToEmptyOrDeleted = false;
 };
 

--- a/Source/WebKit/UIProcess/API/cpp/WKRetainPtr.h
+++ b/Source/WebKit/UIProcess/API/cpp/WKRetainPtr.h
@@ -35,7 +35,8 @@ namespace WebKit {
 
 template<typename T> class WKRetainPtr {
 public:
-    typedef T PtrType;
+    using PtrType = T;
+    using ValueType = std::remove_pointer_t<PtrType>;
 
     WKRetainPtr()
         : m_ptr(0)
@@ -251,6 +252,7 @@ template<typename> struct DefaultHash;
 
 template<typename T> struct IsSmartPtr<WKRetainPtr<T>> {
     WTF_INTERNAL static const bool value = true;
+    WTF_INTERNAL static constexpr bool isNullable = true;
 };
 
 template<typename P> struct DefaultHash<WKRetainPtr<P>> : PtrHash<WKRetainPtr<P>> { };


### PR DESCRIPTION
#### 38bcd3245042be3cb678e0242a6ab95d4b1a9688
<pre>
Optimize looking up keys by raw reference in hash containers whose key is a non-nullable smart pointer type
<a href="https://bugs.webkit.org/show_bug.cgi?id=266166">https://bugs.webkit.org/show_bug.cgi?id=266166</a>

Reviewed by Darin Adler.

Optimize looking up keys by raw reference in hash containers whose key is a
non-nullable smart pointer type (such as Ref&lt;&gt; / WeakRef&lt;&gt; / CheckedRef&lt;&gt;).

I noticed while adopting WeakRef&lt;&gt; more in our containers that hash container
functions can be passed a raw C++ reference. This is convenient but actually
generates unnecessary refcounting churn for many of these functions because
it creates a WeakRef. Creating a WeakRef is unnecessary for lookup functions
such as contains() / find() and removal functions such as remove() / take().

We already had overloads in place for these functions when passing in
a raw C++ pointer and the key is a smart pointer type to avoid refcounting
churn. However, we didn&apos;t have such optimization when passing a raw C++
reference, which is useful when the key type is a non-nullable smart pointer.

This patch adds to our hash containers function overloads that take in a
raw C++ reference, similar to the ones that take in a raw C++ pointer. These
overloads are only available when the key is a non-nullable smart pointer
type.

I also make an improvement to our existing overloads taking in a raw C++
pointer so that they no longer require a non-const pointer. There is no
reason to require a non-const pointer just for pointer hashing and pointer
comparison. I also noticed this issue when adopting more smart pointers in
containers.

* Source/JavaScriptCore/runtime/Identifier.h:
(JSC::IdentifierRepHash::hash):
* Source/WTF/wtf/CheckedPtr.h:
* Source/WTF/wtf/CheckedRef.h:
* Source/WTF/wtf/CompactPtr.h:
* Source/WTF/wtf/ConcurrentPtrHashSet.h:
* Source/WTF/wtf/GetPtr.h:
* Source/WTF/wtf/HashCountedSet.h:
(WTF::Traits&gt;::find):
(WTF::Traits&gt;::find const):
(WTF::Traits&gt;::contains const):
(WTF::Traits&gt;::count const):
(WTF::Traits&gt;::remove):
* Source/WTF/wtf/HashFunctions.h:
* Source/WTF/wtf/HashMap.h:
(WTF::Y&gt;::find):
(WTF::Y&gt;::find const):
(WTF::Y&gt;::contains const):
(WTF::Y&gt;::inlineGet const):
(WTF::Y&gt;::get const):
(WTF::Y&gt;::remove):
(WTF::Y&gt;::take):
* Source/WTF/wtf/HashSet.h:
(WTF::TableTraits&gt;::find const):
(WTF::TableTraits&gt;::contains const):
(WTF::TableTraits&gt;::remove):
(WTF::TableTraits&gt;::take):
* Source/WTF/wtf/ListHashSet.h:
(WTF::U&gt;::find):
(WTF::U&gt;::find const):
(WTF::U&gt;::contains const):
(WTF::U&gt;::insertBefore):
(WTF::U&gt;::remove):
* Source/WTF/wtf/Packed.h:
* Source/WTF/wtf/Ref.h:
* Source/WTF/wtf/RefPtr.h:
* Source/WTF/wtf/RetainPtr.h:
* Source/WTF/wtf/SchedulePair.h:
(WTF::SchedulePairHash::hash):
(WTF::SchedulePairHash::equal):
* Source/WTF/wtf/SignedPtr.h:
* Source/WTF/wtf/UniqueRef.h:
* Source/WTF/wtf/WeakPtr.h:
(WTF::WeakPtr::WeakPtr):
* Source/WTF/wtf/WeakRef.h:
(WTF::WeakRef::releaseImpl):
(WTF::WeakRefHashTraits::take):
* Source/WTF/wtf/glib/GRefPtr.h:
* Source/WTF/wtf/text/StringHash.h:
(WTF::StringHash::hash):
(WTF::ASCIICaseInsensitiveHash::hash):
* Source/WebCore/dom/GCReachableRef.h:
* Source/WebCore/page/SecurityOriginHash.h:
(WebCore::SecurityOriginHash::hash):
(WebCore::SecurityOriginHash::equal):
* Source/WebCore/platform/win/COMPtr.h:
* Source/WebCore/rendering/FloatingObjects.h:
(WebCore::FloatingObjectHashFunctions::hash):
(WebCore::FloatingObjectHashFunctions::equal):
* Source/WebCore/rendering/GlyphDisplayListCache.h:
(WebCore::GlyphDisplayListCacheEntryHash::hash):
(WebCore::GlyphDisplayListCacheEntryHash::equal):
* Source/WebKit/UIProcess/API/cpp/WKRetainPtr.h:
* Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp:
(TestWebKitAPI::TestType::resetDidUpdateImplRefCount):
(TestWebKitAPI::TestType::didUpdateImplRefCount const):
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/271853@main">https://commits.webkit.org/271853@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8fafd691f67a6a3bc7f8385251370dc3b4f2fa8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29849 "22 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8512 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31163 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32360 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26990 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30504 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10694 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5776 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/27045 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30140 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7131 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25465 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6083 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6252 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26552 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33695 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/25637 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27227 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/26982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/32426 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/30032 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6168 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4362 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30210 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7912 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/36418 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6918 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7856 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3851 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6697 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->