### PR TITLE
[MSE] Fix code spell in internal API

### DIFF
--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
@@ -599,11 +599,11 @@ void SourceBufferPrivate::didReceiveInitializationSegment(InitializationSegment&
             return MediaPromise::createAndReject(PlatformMediaError::BufferRemoved);
 
         if (abortCount != m_abortCount) {
-            processInitialisationSegment({ });
+            processInitializationSegment({ });
             return MediaPromise::createAndResolve();
         }
-        if (!result || ((m_receivedFirstInitializationSegment && !validateInitializationSegment(segment)) || !precheckInitialisationSegment(segment))) {
-            processInitialisationSegment({ });
+        if (!result || ((m_receivedFirstInitializationSegment && !validateInitializationSegment(segment)) || !precheckInitializationSegment(segment))) {
+            processInitializationSegment({ });
             return MediaPromise::createAndReject(!result ? result.error() : PlatformMediaError::ParsingError);
         }
 
@@ -617,7 +617,7 @@ void SourceBufferPrivate::didReceiveInitializationSegment(InitializationSegment&
         m_receivedFirstInitializationSegment = true;
         m_pendingInitializationSegmentForChangeType = false;
 
-        processInitialisationSegment(!result ? std::nullopt : std::make_optional(WTFMove(segment)));
+        processInitializationSegment(!result ? std::nullopt : std::make_optional(WTFMove(segment)));
 
         return MediaPromise::createAndSettle(WTFMove(result));
     });

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.h
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.h
@@ -193,8 +193,8 @@ protected:
 
     void reenqueSamples(TrackID);
 
-    virtual bool precheckInitialisationSegment(const InitializationSegment&) { return true; }
-    virtual void processInitialisationSegment(std::optional<InitializationSegment>&&) { }
+    virtual bool precheckInitializationSegment(const InitializationSegment&) { return true; }
+    virtual void processInitializationSegment(std::optional<InitializationSegment>&&) { }
     virtual void processFormatDescriptionForTrackId(Ref<TrackInfo>&&, uint64_t) { }
 
     void provideMediaData(TrackID);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
@@ -171,8 +171,8 @@ private:
     bool canSwitchToType(const ContentType&) final;
     bool isSeeking() const final;
 
-    bool precheckInitialisationSegment(const InitializationSegment&) final;
-    void processInitialisationSegment(std::optional<InitializationSegment>&&) final;
+    bool precheckInitializationSegment(const InitializationSegment&) final;
+    void processInitializationSegment(std::optional<InitializationSegment>&&) final;
     void processFormatDescriptionForTrackId(Ref<TrackInfo>&&, TrackID) final;
 
     void processPendingTrackChangeTasks();

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
@@ -411,7 +411,7 @@ void SourceBufferPrivateAVFObjC::setTrackChangeCallbacks(const InitializationSeg
     }
 }
 
-bool SourceBufferPrivateAVFObjC::precheckInitialisationSegment(const InitializationSegment& segment)
+bool SourceBufferPrivateAVFObjC::precheckInitializationSegment(const InitializationSegment& segment)
 {
     ALWAYS_LOG(LOGIDENTIFIER);
 
@@ -438,7 +438,7 @@ bool SourceBufferPrivateAVFObjC::precheckInitialisationSegment(const Initializat
     return true;
 }
 
-void SourceBufferPrivateAVFObjC::processInitialisationSegment(std::optional<InitializationSegment>&& segment)
+void SourceBufferPrivateAVFObjC::processInitializationSegment(std::optional<InitializationSegment>&& segment)
 {
     ALWAYS_LOG(LOGIDENTIFIER);
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
@@ -202,7 +202,7 @@ void SourceBufferPrivateGStreamer::allSamplesInTrackEnqueued(TrackID trackId)
     track->enqueueObject(adoptGRef(GST_MINI_OBJECT(gst_event_new_eos())));
 }
 
-bool SourceBufferPrivateGStreamer::precheckInitialisationSegment(const InitializationSegment& segment)
+bool SourceBufferPrivateGStreamer::precheckInitializationSegment(const InitializationSegment& segment)
 {
     for (auto& trackInfo : segment.videoTracks) {
         auto* videoTrackInfo = static_cast<VideoTrackPrivateGStreamer*>(trackInfo.track.get());
@@ -229,7 +229,7 @@ bool SourceBufferPrivateGStreamer::precheckInitialisationSegment(const Initializ
     return true;
 }
 
-void SourceBufferPrivateGStreamer::processInitialisationSegment(std::optional<InitializationSegment>&& segment)
+void SourceBufferPrivateGStreamer::processInitializationSegment(std::optional<InitializationSegment>&& segment)
 {
     if (RefPtr mediaSource = m_mediaSource.get(); mediaSource && segment)
         static_cast<MediaSourcePrivateGStreamer*>(mediaSource.get())->startPlaybackIfHasAllTracks();

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h
@@ -69,8 +69,8 @@ public:
     void allSamplesInTrackEnqueued(TrackID) final;
     bool isReadyForMoreSamples(TrackID) final;
 
-    bool precheckInitialisationSegment(const InitializationSegment&) final;
-    void processInitialisationSegment(std::optional<InitializationSegment>&&) final;
+    bool precheckInitializationSegment(const InitializationSegment&) final;
+    void processInitializationSegment(std::optional<InitializationSegment>&&) final;
 
     void didReceiveAllPendingSamples();
     void appendParsingFailed();


### PR DESCRIPTION
#### 121e1be5d68ec3497a60e451b313a92e65202b76
<pre>
[MSE] Fix code spell in internal API
<a href="https://bugs.webkit.org/show_bug.cgi?id=266175">https://bugs.webkit.org/show_bug.cgi?id=266175</a>

Reviewed by Xabier Rodriguez-Calvar.

Initialization goes with z, not s.

* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::didReceiveInitializationSegment):
* Source/WebCore/platform/graphics/SourceBufferPrivate.h:
(WebCore::SourceBufferPrivate::precheckInitializationSegment):
(WebCore::SourceBufferPrivate::processInitializationSegment):
(WebCore::SourceBufferPrivate::precheckInitialisationSegment): Deleted.
(WebCore::SourceBufferPrivate::processInitialisationSegment): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(WebCore::SourceBufferPrivateAVFObjC::precheckInitializationSegment):
(WebCore::SourceBufferPrivateAVFObjC::processInitializationSegment):
(WebCore::SourceBufferPrivateAVFObjC::precheckInitialisationSegment): Deleted.
(WebCore::SourceBufferPrivateAVFObjC::processInitialisationSegment): Deleted.
* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp:
(WebCore::SourceBufferPrivateGStreamer::precheckInitializationSegment):
(WebCore::SourceBufferPrivateGStreamer::processInitializationSegment):
(WebCore::SourceBufferPrivateGStreamer::precheckInitialisationSegment): Deleted.
(WebCore::SourceBufferPrivateGStreamer::processInitialisationSegment): Deleted.
* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/271862@main">https://commits.webkit.org/271862@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee7f9e50d63e4bb6b3ddadc271cb7a8aede11fd3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29802 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8464 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31108 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32306 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26947 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30428 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10637 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5729 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26988 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30085 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7081 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25413 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6039 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6202 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26499 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33643 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27177 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26923 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32383 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6125 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4321 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30165 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7870 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7084 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6877 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6655 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->