### PR TITLE
REGRESSION (270787@main): Leak of two instance variables in _WKArchiveConfiguration

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKArchiveConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKArchiveConfiguration.mm
@@ -32,6 +32,10 @@
 
 - (void)dealloc
 {
+    [_directory release];
+    _directory = nil;
+    [_suggestedFileName release];
+    _suggestedFileName = nil;
     [_exclusionRules release];
     _exclusionRules = nil;
 


### PR DESCRIPTION
#### 0d14fc33455658e0bea474f76ae373b62f2b4faf
<pre>
REGRESSION (270787@main): Leak of two instance variables in _WKArchiveConfiguration
<a href="https://bugs.webkit.org/show_bug.cgi?id=266186">https://bugs.webkit.org/show_bug.cgi?id=266186</a>
&lt;<a href="https://rdar.apple.com/119463815">rdar://119463815</a>&gt;

Reviewed by Darin Adler.

* Source/WebKit/UIProcess/API/Cocoa/_WKArchiveConfiguration.mm:
(-[_WKArchiveConfiguration dealloc]):
- Release the other two instance variables to fix the leaks.

Canonical link: <a href="https://commits.webkit.org/271883@main">https://commits.webkit.org/271883@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38667b4a80cd7a525982d90ceda64ce5586d5417

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29834 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8497 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31146 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32344 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26978 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10675 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5761 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27027 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30123 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7114 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25445 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6065 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6239 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33680 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27210 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26956 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32411 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6156 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4349 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30204 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7900 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7093 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6908 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6687 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->