### PR TITLE
-[TestWebsiteDataStoreDelegate init] should call [super init] and initialize _shouldAllowAnySSLCertificate

### DIFF
--- a/Tools/WebKitTestRunner/cocoa/TestWebsiteDataStoreDelegate.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestWebsiteDataStoreDelegate.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,8 +35,13 @@
 @implementation TestWebsiteDataStoreDelegate { }
 - (instancetype)init
 {
-    _shouldAllowRaisingQuota = false;
-    _shouldAllowBackgroundFetchPermission = false;
+    if (!(self = [super init]))
+        return nil;
+
+    _shouldAllowRaisingQuota = NO;
+    _shouldAllowAnySSLCertificate = NO;
+    _shouldAllowBackgroundFetchPermission = NO;
+
     _quota = 40 * KB;
     _windowProxyAccessDomains = adoptNS([[NSMutableArray alloc] init]);
     return self;


### PR DESCRIPTION
#### 5e10b6dd520c6aaf70dec791daf2402cbea77136
<pre>
-[TestWebsiteDataStoreDelegate init] should call [super init] and initialize _shouldAllowAnySSLCertificate
<a href="https://bugs.webkit.org/show_bug.cgi?id=266189">https://bugs.webkit.org/show_bug.cgi?id=266189</a>
&lt;<a href="https://rdar.apple.com/119463963">rdar://119463963</a>&gt;

Reviewed by Youenn Fablet.

* Tools/WebKitTestRunner/cocoa/TestWebsiteDataStoreDelegate.mm:
(-[TestWebsiteDataStoreDelegate init]):
- Call `[super init]` as required for Objective-C classes.
- Initialize _shouldAllowAnySSLCertificate to `NO`.
- Use `NO` instead of `false` for other BOOL instance variables.

Canonical link: <a href="https://commits.webkit.org/271877@main">https://commits.webkit.org/271877@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9fe2d575eb4a0c7312b90a1e71635059fcd4bdb0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29835 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8498 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31147 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32345 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26979 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30473 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10676 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5762 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27031 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30124 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7116 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25446 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6067 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6241 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26532 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33681 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27212 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26958 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32412 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6157 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4350 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30195 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7901 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6909 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3859 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6688 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->