### PR TITLE
[GStreamer] Misc leak fixes

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -55,6 +55,7 @@
 #endif
 
 #if ENABLE(MEDIA_STREAM)
+#include "GStreamerCaptureDeviceManager.h"
 #include "GStreamerMediaStreamSource.h"
 #endif
 
@@ -438,6 +439,15 @@ void registerWebKitGStreamerVideoEncoder()
     // we need to reset the internal state of the registry scanner.
     if (registryWasUpdated && !GStreamerRegistryScanner::singletonNeedsInitialization())
         GStreamerRegistryScanner::singleton().refresh();
+}
+
+void deinitializeGStreamer()
+{
+#if ENABLE(MEDIA_STREAM)
+    teardownGStreamerCaptureDeviceManagers();
+#endif
+    teardownGStreamerRegistryScanner();
+    gst_deinit();
 }
 
 unsigned getGstPlayFlag(const char* nick)

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -74,6 +74,8 @@ void setGStreamerOptionsFromUIProcess(Vector<String>&&);
 bool ensureGStreamerInitialized();
 void registerWebKitGStreamerElements();
 void registerWebKitGStreamerVideoEncoder();
+void deinitializeGStreamer();
+
 unsigned getGstPlayFlag(const char* nick);
 uint64_t toGstUnsigned64Time(const MediaTime&);
 

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -120,6 +120,15 @@ GStreamerRegistryScanner& GStreamerRegistryScanner::singleton()
     return sharedInstance;
 }
 
+void teardownGStreamerRegistryScanner()
+{
+    if (GStreamerRegistryScanner::singletonNeedsInitialization())
+        return;
+
+    auto& scanner = GStreamerRegistryScanner::singleton();
+    scanner.teardown();
+}
+
 void GStreamerRegistryScanner::getSupportedDecodingTypes(HashSet<String>& types)
 {
     if (isInWebProcess())
@@ -306,10 +315,7 @@ GStreamerRegistryScanner::RegistryLookupResult GStreamerRegistryScanner::Element
     }
 
     gst_plugin_feature_list_free(candidates);
-    // Valid `selectedFactory` ends up stored in the scanner singleton.
-    if (isSupported)
-        GST_OBJECT_FLAG_SET(selectedFactory.get(), GST_OBJECT_FLAG_MAY_BE_LEAKED);
-    else
+    if (!isSupported)
         selectedFactory.clear();
 
     GST_LOG("Lookup result for %s matching caps %" GST_PTR_FORMAT " : isSupported=%s, isUsingHardware=%s", elementFactoryTypeToString(factoryType), caps.get(), boolForPrinting(isSupported), boolForPrinting(isUsingHardware));
@@ -354,6 +360,12 @@ void GStreamerRegistryScanner::refresh()
     for (auto& item : m_encoderCodecMap)
         GST_DEBUG("%s encoder codec pattern registered: %s", item.value ? "Hardware" : "Software", item.key.string().utf8().data());
 #endif
+}
+
+void GStreamerRegistryScanner::teardown()
+{
+    m_decoderCodecMap.clear();
+    m_encoderCodecMap.clear();
 }
 
 const HashSet<String>& GStreamerRegistryScanner::mimeTypeSet(Configuration configuration) const

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h
@@ -28,6 +28,7 @@
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
+#include <wtf/Noncopyable.h>
 #include <wtf/OptionSet.h>
 #include <wtf/text/AtomString.h>
 #include <wtf/text/AtomStringHash.h>
@@ -36,7 +37,10 @@
 namespace WebCore {
 class ContentType;
 
+void teardownGStreamerRegistryScanner();
+
 class GStreamerRegistryScanner {
+    WTF_MAKE_NONCOPYABLE(GStreamerRegistryScanner)
 public:
     static bool singletonNeedsInitialization();
     static GStreamerRegistryScanner& singleton();
@@ -46,6 +50,7 @@ public:
     ~GStreamerRegistryScanner() = default;
 
     void refresh();
+    void teardown();
 
     enum Configuration {
         Decoding = 0,

--- a/Source/WebCore/platform/graphics/gstreamer/GstAllocatorFastMalloc.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GstAllocatorFastMalloc.cpp
@@ -148,6 +148,8 @@ static void gst_allocator_fast_malloc_init(GstAllocatorFastMalloc* allocator)
 {
     auto* baseAllocator = GST_ALLOCATOR_CAST(allocator);
 
+    GST_OBJECT_FLAG_SET(allocator, GST_OBJECT_FLAG_MAY_BE_LEAKED);
+
     baseAllocator->mem_type = "FastMalloc";
     baseAllocator->mem_map = reinterpret_cast<GstMemoryMapFunction>(gstAllocatorFastMallocMemMap);
     baseAllocator->mem_unmap = reinterpret_cast<GstMemoryUnmapFunction>(gstAllocatorFastMallocMemUnmap);

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -2030,8 +2030,8 @@ void MediaPlayerPrivateGStreamer::handleMessage(GstMessage* message)
         GST_DEBUG_OBJECT(m_pipeline.get(), "Received STREAMS_SELECTED message selecting the following streams:");
         unsigned numStreams = gst_message_streams_selected_get_size(message);
         for (unsigned i = 0; i < numStreams; i++) {
-            GstStream* stream = gst_message_streams_selected_get_stream(message, i);
-            GST_DEBUG_OBJECT(pipeline(), "#%u %s %s", i, gst_stream_type_get_name(gst_stream_get_stream_type(stream)), gst_stream_get_stream_id(stream));
+            auto stream = adoptGRef(gst_message_streams_selected_get_stream(message, i));
+            GST_DEBUG_OBJECT(pipeline(), "#%u %s %s", i, gst_stream_type_get_name(gst_stream_get_stream_type(stream.get())), gst_stream_get_stream_id(stream.get()));
         }
 #endif
         GST_DEBUG_OBJECT(m_pipeline.get(), "Setting m_waitingForStreamsSelectedEvent to false.");

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.h
@@ -31,11 +31,16 @@
 #include "RealtimeMediaSourceCenter.h"
 #include "RealtimeMediaSourceFactory.h"
 
+#include <wtf/Noncopyable.h>
+
 namespace WebCore {
 
 using NodeAndFD = GStreamerVideoCapturer::NodeAndFD;
 
+void teardownGStreamerCaptureDeviceManagers();
+
 class GStreamerCaptureDeviceManager : public CaptureDeviceManager, public RealtimeMediaSourceCenter::Observer {
+    WTF_MAKE_NONCOPYABLE(GStreamerCaptureDeviceManager)
 public:
     GStreamerCaptureDeviceManager();
     ~GStreamerCaptureDeviceManager();
@@ -52,6 +57,8 @@ public:
     void unregisterCapturer(const GStreamerCapturer&);
     void stopCapturing(const String& persistentId);
 
+    void teardown();
+
 private:
     void addDevice(GRefPtr<GstDevice>&&);
     void removeDevice(GRefPtr<GstDevice>&&);
@@ -62,6 +69,7 @@ private:
     Vector<GStreamerCaptureDevice> m_gstreamerDevices;
     Vector<CaptureDevice> m_devices;
     Vector<RefPtr<GStreamerCapturer>> m_capturers;
+    bool m_isTearingDown { false };
 };
 
 class GStreamerAudioCaptureDeviceManager final : public GStreamerCaptureDeviceManager {

--- a/Source/WebKit/WebProcess/gtk/WebProcessMainGtk.cpp
+++ b/Source/WebKit/WebProcess/gtk/WebProcessMainGtk.cpp
@@ -33,7 +33,7 @@
 #include <libintl.h>
 
 #if USE(GSTREAMER)
-#include <gst/gst.h>
+#include <WebCore/GStreamerCommon.h>
 #endif
 
 #if USE(GCRYPT)
@@ -67,7 +67,7 @@ public:
     void platformFinalize() override
     {
 #if USE(GSTREAMER)
-        gst_deinit();
+        deinitializeGStreamer();
 #endif
     }
 };

--- a/Source/WebKit/WebProcess/wpe/WebProcessMainWPE.cpp
+++ b/Source/WebKit/WebProcess/wpe/WebProcessMainWPE.cpp
@@ -36,7 +36,7 @@
 #endif
 
 #if USE(GSTREAMER)
-#include <gst/gst.h>
+#include <WebCore/GStreamerCommon.h>
 #endif
 
 namespace WebKit {
@@ -65,7 +65,7 @@ public:
     void platformFinalize() override
     {
 #if USE(GSTREAMER)
-        gst_deinit();
+        deinitializeGStreamer();
 #endif
     }
 };


### PR DESCRIPTION
#### 0bb420a995f55481f114b16dd183ea9ed96decbd
<pre>
[GStreamer] Misc leak fixes
<a href="https://bugs.webkit.org/show_bug.cgi?id=266188">https://bugs.webkit.org/show_bug.cgi?id=266188</a>

Reviewed by Xabier Rodriguez-Calvar.

The GStreamer device-related objects were leaked, along with a couple GstStream objects in the
player. There are more issues, specially in the MSE code, but that&apos;s for another time...

We now explicitely clean-up the capture device managers and the registry scanner before
de-initializing GStreamer. The FastMalloc allocator is flagged as leaked as well, as it is static
and I didn&apos;t find how to properly clean it up.

* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::deinitializeGStreamer):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h:
* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp:
(WebCore::teardownGStreamerRegistryScanner):
(WebCore::GStreamerRegistryScanner::ElementFactories::hasElementForCaps const):
(WebCore::GStreamerRegistryScanner::teardown):
* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h:
* Source/WebCore/platform/graphics/gstreamer/GstAllocatorFastMalloc.cpp:
(gst_allocator_fast_malloc_init):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::handleMessage):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp:
(WebCore::teardownGStreamerCaptureDeviceManagers):
(WebCore::GStreamerCaptureDeviceManager::~GStreamerCaptureDeviceManager):
(WebCore::GStreamerCaptureDeviceManager::teardown):
(WebCore::GStreamerCaptureDeviceManager::captureDevices):
(WebCore::GStreamerCaptureDeviceManager::refreshCaptureDevices):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.h:
* Source/WebKit/WebProcess/gtk/WebProcessMainGtk.cpp:
* Source/WebKit/WebProcess/wpe/WebProcessMainWPE.cpp:

Canonical link: <a href="https://commits.webkit.org/271861@main">https://commits.webkit.org/271861@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb6dc92cef3e2e90f58db7ca38b06c16eaed0bb4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29836 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8499 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31148 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32346 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26980 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30467 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10677 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5763 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27034 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30125 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7115 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25449 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6069 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6240 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26535 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33682 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27211 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26960 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32414 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6158 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4351 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30197 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7902 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7083 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6910 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6689 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->