### PR TITLE
60 second hang loading WebGPU samples page.

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp
@@ -96,12 +96,11 @@ void RemoteImageBufferSet::setFlushSignal(IPC::Signal&& signal)
 
 void RemoteImageBufferSet::flush()
 {
-    if (m_frontBuffer) {
-        m_backend->releaseDisplayListRecorder(m_displayListIdentifier);
-        ASSERT(m_flushSignal);
+    m_backend->releaseDisplayListRecorder(m_displayListIdentifier);
+    ASSERT(m_flushSignal);
+    if (m_frontBuffer)
         m_frontBuffer->flushDrawingContext();
-        m_flushSignal->signal();
-    }
+    m_flushSignal->signal();
 }
 
 // This is the GPU Process version of RemoteLayerBackingStore::prepareBuffers().


### PR DESCRIPTION
#### cd96716c74c6706c65e9792fa94d26ab170ab673
<pre>
60 second hang loading WebGPU samples page.
<a href="https://bugs.webkit.org/show_bug.cgi?id=266113">https://bugs.webkit.org/show_bug.cgi?id=266113</a>
&lt;<a href="https://rdar.apple.com/119406028">rdar://119406028</a>&gt;

Reviewed by Mike Wyrzykowski.

Front buffer allocation can fail, if the surface dimensions are too big. This test
was trying to allocate a surface 19k high.

We should still notify the signal in this case, since there&apos;s no point leaving the
web process waiting arbitrarily. We still don&apos;t render any content for that layer,
but that&apos;s the existing behaviour.

* Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp:
(WebKit::RemoteImageBufferSet::flush):

Canonical link: <a href="https://commits.webkit.org/271854@main">https://commits.webkit.org/271854@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30b9f715ebb2135dfd7b38ba7e528db5c8b668e0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29851 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8514 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31165 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32362 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26992 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10696 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5778 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27044 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30142 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7133 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25463 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6081 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6254 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33697 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27229 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26975 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32423 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6170 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4364 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30207 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7914 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7075 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6920 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6699 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->