### PR TITLE
WKWebExtensionAPIDeclarativeNetRequest.DynamicRules is flaky due to SQLite errors.

### DIFF
--- a/Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteDatabase.mm
+++ b/Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteDatabase.mm
@@ -129,7 +129,9 @@ using namespace WebKit;
 
 - (BOOL)enableWAL:(NSError **)error
 {
-    return SQLiteDatabaseEnumerate(self, error, @"PRAGMA journal_mode = WAL", std::tie(std::ignore));
+    // SQLite docs: The synchronous NORMAL setting is a good choice for most applications running in WAL mode.
+    if (!SQLiteDatabaseExecuteAndReturnError(self, error, @"PRAGMA synchronous = NORMAL"))
+        return NO;
     return SQLiteDatabaseEnumerate(self, error, @"PRAGMA journal_mode = WAL", std::tie(std::ignore));
 }
 
@@ -207,7 +209,7 @@ using namespace WebKit;
     // SQLite may return a valid database handle even if an error occurred. sqlite3_close silently
     // ignores calls with a null handle so we can call it here unconditionally.
     sqlite3_close_v2(_handle);
-    _handle = 0;
+    _handle = nullptr;
 
     if (error)
         *error = [[self class] _errorWith_WKSQLiteErrorCode:result userInfo:nil];

--- a/Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteStore.h
+++ b/Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteStore.h
@@ -45,7 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly) BOOL useInMemoryDatabase;
 
-- (void)deleteStorageWithCompletionHandler:(void (^)(NSError * _Nullable error))completionHandler;
+- (void)close;
 
 - (void)deleteDatabaseWithCompletionHandler:(void (^)(NSString * _Nullable errorMessage))completionHandler;
 


### PR DESCRIPTION
#### 79ae2d98bffebe586578a7ffedf1cc8215252716
<pre>
WKWebExtensionAPIDeclarativeNetRequest.DynamicRules is flaky due to SQLite errors.
<a href="https://webkit.org/b/266197">https://webkit.org/b/266197</a>
<a href="https://rdar.apple.com/problem/119469498">rdar://problem/119469498</a>

Reviewed by Brian Weinstein.

Fix a number of SQL database errors seen when stress-testing the DynamicRules test.

* Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteDatabase.mm:
(-[_WKWebExtensionSQLiteDatabase enableWAL:]): Also set synchronous to NORMAL per SQLite docs.
(-[_WKWebExtensionSQLiteDatabase _openWithFlags:vfs:error:]): Use nullptr instead of 0.
* Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteStore.h:
* Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteStore.mm:
(-[_WKWebExtensionSQLiteStore dealloc]): Moved to `close` method, and call it.
(-[_WKWebExtensionSQLiteStore close]): Added. Return early if already closed. Synchronously close
to prevent SQLite errors when trying to load the file immediately after, which would happen from
another database background queue and fail, which then tries to delete the locked DB file.
(-[_WKWebExtensionSQLiteStore _openDatabase:deleteDatabaseFileOnError:]): Return the result of
`_deleteDatabaseFileAtURL:` instead, since the retry error (if any) should be reported back.
Also moved `close` to after the early return since `_deleteDatabaseFileAtURL:` already does a close.
(-[_WKWebExtensionSQLiteStore _deleteDatabaseFileAtURL:reopenDatabase:]): Changed databaseFileSuffixes
to use ASCIILiteral and moved inside since this is the only client. Always check if the DB file exists
before trying to delete it, since thats what the original Safari code did and that was lost in the move.
(-[_WKWebExtensionSQLiteStore _handleSchemaVersioningWithDeleteDatabaseFileOnError:]):
(-[_WKWebExtensionSQLiteStore initWithUniqueIdentifier:directory:usesInMemoryDatabase:]): Deleted. Unused
and it was the only code using NSFileManager.
(-[_WKWebExtensionSQLiteStore deleteStorageWithCompletionHandler:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/271891@main">https://commits.webkit.org/271891@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a703e0dc307192ca294d7e70a0661996b59754f6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29857 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8521 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31172 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32369 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26999 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10704 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5784 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27060 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30149 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7139 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25471 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6092 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6260 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33704 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27235 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26984 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32433 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6177 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4369 "Found 1 new test failure: fullscreen/full-screen-layer-dump.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30217 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7920 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6926 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3864 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6705 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->