### PR TITLE
[UIAsyncTextInput] Crash when pressing shift key with async text input enabled after 271417@main

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -7094,6 +7094,11 @@ inline static UIShiftKeyState shiftKeyState(UIKeyModifierFlags flags)
 {
     RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
+    [self _internalHandleKeyWebEvent:theEvent];
+}
+
+- (void)_internalHandleKeyWebEvent:(::WebEvent *)theEvent
+{
     _page->handleKeyboardEvent(WebKit::NativeWebKeyboardEvent(theEvent, WebKit::NativeWebKeyboardEvent::HandledByInputMethod::No));
 }
 
@@ -12770,7 +12775,7 @@ inline static NSString *extendSelectionCommand(UITextLayoutDirection direction)
             syntheticEvent = adoptNS([[WKSyntheticFlagsChangedWebEvent alloc] initWithCapsLockState:keyDown]);
             break;
         }
-        [self handleKeyWebEvent:syntheticEvent.get()];
+        [self _internalHandleKeyWebEvent:syntheticEvent.get()];
     };
 
     dispatchSyntheticFlagsChangedEvents(oldState, false);


### PR DESCRIPTION
#### 7a80a44bef3662e8d7e2de89f6c5ee978a597a4e
<pre>
[UIAsyncTextInput] Crash when pressing shift key with async text input enabled after 271417@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=266200">https://bugs.webkit.org/show_bug.cgi?id=266200</a>
<a href="https://rdar.apple.com/119472884">rdar://119472884</a>

Reviewed by Aditya Keerthi.

Move the logic in `-handleKeyWebEvent:` out into `-_internalHandleKeyWebEvent:`, and invoke the
latter underneath `-shiftKeyStateChangedFrom:to:` to avoid triggering the &quot;async text input
disabled&quot; assertion from within our own code.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView handleKeyWebEvent:]):
(-[WKContentView _internalHandleKeyWebEvent:]):
(-[WKContentView shiftKeyStateChangedFrom:to:]):

Canonical link: <a href="https://commits.webkit.org/271882@main">https://commits.webkit.org/271882@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bdb3c35e957c6ce0e77f0b26a25364351a1a4018

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29866 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8531 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31182 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32379 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27008 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10714 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5792 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27071 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30159 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7152 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25481 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6099 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6273 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33714 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27248 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26994 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32439 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6186 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4378 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30232 "Found 2 new API test failures: /WebKitGTK/TestWebKitUserContentFilterStore:/webkit/WebKitUserContentFilterStore/filter-persistence, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/close-quickly (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7928 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7092 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6934 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6714 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->