### PR TITLE
Share code for buffer swapping and copy-forward between RemoteLayerWithInProcessRendering and RemoteImageBufferSet.

### DIFF
--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -44,6 +44,7 @@ set(WebKit_PRIVATE_INCLUDE_DIRECTORIES
     "${WEBKIT_DIR}/Shared/Databases/IndexedDB"
     "${WEBKIT_DIR}/Shared/Extensions"
     "${WEBKIT_DIR}/Shared/FileAPI"
+    "${WEBKIT_DIR}/Shared/graphics"
     "${WEBKIT_DIR}/Shared/Gamepad"
     "${WEBKIT_DIR}/Shared/Notifications"
     "${WEBKIT_DIR}/Shared/RemoteLayerTree"

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.h
@@ -28,6 +28,7 @@
 #if ENABLE(GPU_PROCESS)
 
 #include "IPCEvent.h"
+#include "ImageBufferSet.h"
 #include "PrepareBackingStoreBuffersData.h"
 #include "RemoteImageBufferSetIdentifier.h"
 #include "RenderingUpdateID.h"
@@ -43,7 +44,7 @@ namespace WebKit {
 
 class RemoteRenderingBackend;
 
-class RemoteImageBufferSet : public IPC::StreamMessageReceiver {
+class RemoteImageBufferSet : public IPC::StreamMessageReceiver, public ImageBufferSet {
 public:
     static Ref<RemoteImageBufferSet> create(RemoteImageBufferSetIdentifier, WebCore::RenderingResourceIdentifier displayListIdentifier, RemoteRenderingBackend&);
     ~RemoteImageBufferSet();
@@ -51,7 +52,7 @@ public:
 
     // Ensures frontBuffer is valid, either by swapping an existing back
     // buffer, or allocating a new one.
-    void ensureBufferForDisplay(ImageBufferSetPrepareBufferForDisplayInputData&, SwapBuffersDisplayRequirement&);
+    void ensureBufferForDisplay(ImageBufferSetPrepareBufferForDisplayInputData&, SwapBuffersDisplayRequirement&, bool isSync);
 
     // Initializes the contents of the new front buffer using the previous
     // frames (if applicable), clips to the dirty region, and clears the pixels
@@ -86,19 +87,11 @@ private:
     const WebCore::RenderingResourceIdentifier m_displayListIdentifier;
     RefPtr<RemoteRenderingBackend> m_backend;
 
-    RefPtr<WebCore::ImageBuffer> m_frontBuffer;
-    RefPtr<WebCore::ImageBuffer> m_backBuffer;
-    RefPtr<WebCore::ImageBuffer> m_secondaryBackBuffer;
-
-    RefPtr<WebCore::ImageBuffer> m_previousFrontBuffer;
-
     WebCore::FloatSize m_logicalSize;
     WebCore::RenderingMode m_renderingMode;
-    WebCore::RenderingPurpose m_purpose;
     float m_resolutionScale { 1.0f };
     WebCore::DestinationColorSpace m_colorSpace { WebCore::DestinationColorSpace::SRGB() };
     WebCore::ImageBufferPixelFormat m_pixelFormat;
-    bool m_frontBufferIsCleared { false };
     bool m_displayListCreated { false };
 
     std::optional<WebCore::IntRect> m_previouslyPaintedRect;

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -447,8 +447,7 @@ void RemoteRenderingBackend::prepareImageBufferSetsForDisplay(Vector<ImageBuffer
         RefPtr<RemoteImageBufferSet> remoteImageBufferSet = m_remoteImageBufferSets.get(swapBuffersInput[i].remoteBufferSet);
         MESSAGE_CHECK(remoteImageBufferSet, "BufferSet is being updated before being created");
         SwapBuffersDisplayRequirement displayRequirement = SwapBuffersDisplayRequirement::NeedsNormalDisplay;
-        remoteImageBufferSet->ensureBufferForDisplay(swapBuffersInput[i], displayRequirement);
-        MESSAGE_CHECK(displayRequirement != SwapBuffersDisplayRequirement::NeedsFullDisplay, "Can't asynchronously require full display for a buffer set");
+        remoteImageBufferSet->ensureBufferForDisplay(swapBuffersInput[i], displayRequirement, false);
 
         if (displayRequirement != SwapBuffersDisplayRequirement::NeedsNoDisplay)
             remoteImageBufferSet->prepareBufferForDisplay(swapBuffersInput[i].dirtyRegion, swapBuffersInput[i].requiresClearedPixels);
@@ -465,7 +464,7 @@ void RemoteRenderingBackend::prepareImageBufferSetsForDisplaySync(Vector<ImageBu
     for (unsigned i = 0; i < swapBuffersInput.size(); ++i) {
         RefPtr<RemoteImageBufferSet> remoteImageBufferSet = m_remoteImageBufferSets.get(swapBuffersInput[i].remoteBufferSet);
         MESSAGE_CHECK(remoteImageBufferSet, "BufferSet is being updated before being created");
-        remoteImageBufferSet->ensureBufferForDisplay(swapBuffersInput[i], outputData[i]);
+        remoteImageBufferSet->ensureBufferForDisplay(swapBuffersInput[i], outputData[i], true);
     }
 
     completionHandler(WTFMove(outputData));

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "RemoteImageBufferSet.h"
 #include "RemoteLayerBackingStore.h"
 #include <WebCore/DynamicContentScalingResourceCache.h>
 #include <wtf/TZoneMalloc.h>
@@ -57,9 +58,6 @@ public:
 
 private:
     RefPtr<WebCore::ImageBuffer> allocateBuffer();
-    SwapBuffersDisplayRequirement prepareBuffers();
-    WebCore::SetNonVolatileResult swapToValidFrontBuffer();
-
     void ensureFrontBuffer();
     bool hasFrontBuffer() const final;
     bool frontBufferMayBeVolatile() const final;
@@ -81,14 +79,10 @@ private:
     };
 
     // Returns true if it was able to fulfill the request. This can fail when trying to mark an in-use surface as volatile.
-    bool setBufferVolatile(Buffer&, bool forcePurge = false);
-
+    bool setBufferVolatile(RefPtr<WebCore::ImageBuffer>&, bool forcePurge = false);
     WebCore::SetNonVolatileResult setBufferNonVolatile(Buffer&);
-    WebCore::SetNonVolatileResult setFrontBufferNonVolatile();
 
-    Buffer m_frontBuffer;
-    Buffer m_backBuffer;
-    Buffer m_secondaryBackBuffer;
+    ImageBufferSet m_bufferSet;
 
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
     WebCore::DynamicContentScalingResourceCache m_dynamicContentScalingResourceCache;

--- a/Source/WebKit/Shared/graphics/ImageBufferSet.cpp
+++ b/Source/WebKit/Shared/graphics/ImageBufferSet.cpp
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ImageBufferSet.h"
+
+#include <WebCore/GraphicsContext.h>
+#include <WebCore/ImageBufferBackend.h>
+
+#if PLATFORM(COCOA)
+#include <WebCore/PlatformCALayer.h>
+#endif
+
+#if ENABLE(GPU_PROCESS)
+
+namespace WebKit {
+
+using namespace WebCore;
+
+SwapBuffersDisplayRequirement ImageBufferSet::swapBuffersForDisplay(bool hasEmptyDirtyRegion, bool supportsPartialRepaint)
+{
+    auto displayRequirement = SwapBuffersDisplayRequirement::NeedsNoDisplay;
+
+    // Make the previous front buffer non-volatile early, so that we can dirty the whole layer if it comes back empty.
+    if (!m_frontBuffer || m_frontBuffer->setNonVolatile() == WebCore::SetNonVolatileResult::Empty)
+        displayRequirement = SwapBuffersDisplayRequirement::NeedsFullDisplay;
+    else if (!hasEmptyDirtyRegion)
+        displayRequirement = SwapBuffersDisplayRequirement::NeedsNormalDisplay;
+
+    if (displayRequirement == SwapBuffersDisplayRequirement::NeedsNoDisplay)
+        return displayRequirement;
+
+    if (!supportsPartialRepaint)
+        displayRequirement = SwapBuffersDisplayRequirement::NeedsFullDisplay;
+
+    if (!m_backBuffer || m_backBuffer->isInUse()) {
+        m_previouslyPaintedRect = std::nullopt;
+        std::swap(m_backBuffer, m_secondaryBackBuffer);
+
+        // When pulling the secondary back buffer out of hibernation (to become
+        // the new front buffer), if it is somehow still in use (e.g. we got
+        // three swaps ahead of the render server), just give up and discard it.
+        if (m_backBuffer && m_backBuffer->isInUse())
+            m_backBuffer = nullptr;
+    }
+
+    std::swap(m_frontBuffer, m_backBuffer);
+
+    if (m_frontBuffer && m_frontBuffer->setNonVolatile() == WebCore::SetNonVolatileResult::Empty)
+        m_previouslyPaintedRect = std::nullopt;
+
+    return displayRequirement;
+}
+
+ImageBufferSet::PaintRectList ImageBufferSet::computePaintingRects(const Region& dirtyRegion, float resolutionScale)
+{
+    // If we have less than webLayerMaxRectsToPaint rects to paint and they cover less
+    // than webLayerWastedSpaceThreshold of the total dirty area, we'll repaint each rect separately.
+    // Otherwise, repaint the entire bounding box of the dirty region.
+    auto dirtyRects = dirtyRegion.rects();
+#if PLATFORM(COCOA)
+    IntRect dirtyBounds = dirtyRegion.bounds();
+    if (dirtyRects.size() > PlatformCALayer::webLayerMaxRectsToPaint || dirtyRegion.totalArea() > PlatformCALayer::webLayerWastedSpaceThreshold * dirtyBounds.width() * dirtyBounds.height()) {
+        dirtyRects.clear();
+        dirtyRects.append(dirtyBounds);
+    }
+#endif
+
+    // FIXME: find a consistent way to scale and snap dirty and CG clip rects.
+    Vector<FloatRect, 5> paintingRects;
+    for (const auto& rect : dirtyRects) {
+        FloatRect scaledRect(rect);
+        scaledRect.scale(resolutionScale);
+        scaledRect = enclosingIntRect(scaledRect);
+        scaledRect.scale(1 / resolutionScale);
+        paintingRects.append(scaledRect);
+    }
+    return paintingRects;
+}
+
+void ImageBufferSet::prepareBufferForDisplay(const FloatRect& layerBounds, const Region& dirtyRegion, const PaintRectList& paintingRects, bool requiresClearedPixels)
+{
+    if (!m_frontBuffer) {
+        m_previouslyPaintedRect = std::nullopt;
+        return;
+    }
+
+    GraphicsContext& context = m_frontBuffer->context();
+    context.resetClip();
+
+    WebCore::FloatRect copyRect;
+    if (m_backBuffer) {
+        WebCore::IntRect enclosingCopyRect { m_previouslyPaintedRect ? *m_previouslyPaintedRect : enclosingIntRect(layerBounds) };
+        if (!dirtyRegion.contains(enclosingCopyRect)) {
+            WebCore::Region copyRegion(enclosingCopyRect);
+            copyRegion.subtract(dirtyRegion);
+            copyRect = intersection(copyRegion.bounds(), layerBounds);
+            if (!copyRect.isEmpty())
+                m_frontBuffer->context().drawImageBuffer(*m_backBuffer, copyRect, copyRect, { WebCore::CompositeOperator::Copy });
+        }
+    }
+
+    if (paintingRects.size() == 1) {
+        context.clip(paintingRects[0]);
+        if (copyRect.intersects(paintingRects[0]))
+            m_frontBufferIsCleared = false;
+    } else {
+        Path clipPath;
+        for (auto rect : paintingRects) {
+            clipPath.addRect(rect);
+
+            // If the copy-forward touched pixels that are about to be painted, then they
+            // won't be 'clear' any more.
+            if (copyRect.intersects(rect))
+                m_frontBufferIsCleared = false;
+        }
+        context.clipPath(clipPath);
+    }
+
+    if (requiresClearedPixels && !m_frontBufferIsCleared)
+        context.clearRect(layerBounds);
+
+    m_previouslyPaintedRect = dirtyRegion.bounds();
+    m_frontBufferIsCleared = false;
+}
+
+void ImageBufferSet::clearBuffers()
+{
+    m_frontBuffer = m_backBuffer = m_secondaryBackBuffer = nullptr;
+}
+
+}
+
+#endif

--- a/Source/WebKit/Shared/graphics/ImageBufferSet.h
+++ b/Source/WebKit/Shared/graphics/ImageBufferSet.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(GPU_PROCESS)
+
+#include "SwapBuffersDisplayRequirement.h"
+#include <WebCore/FloatRect.h>
+#include <WebCore/ImageBuffer.h>
+#include <WebCore/Region.h>
+#include <wtf/Vector.h>
+
+namespace WebKit {
+
+// An ImageBufferSet is a set of three ImageBuffers (front, back, secondary back),
+// for the purpose of drawing successive (layer) frames.
+// It handles picking an existing buffer to be the new front buffer, and then copying
+// forward the previous pixels, clipping to the dirty area and clearing that subset.
+// FIXME: This class should also have common code for buffer allocation, setting volatility,
+// and accessing the GraphicsContext.
+// Splitting out a virtual base class so that RemoteImageBufferProxy can implement the interface
+// would also be nice.
+class ImageBufferSet {
+public:
+    using PaintRectList = Vector<WebCore::FloatRect, 5>;
+
+    // Tries to swap one of the existing back buffers to the new front buffer, if any are
+    // not currently in-use.
+    SwapBuffersDisplayRequirement swapBuffersForDisplay(bool hasEmptyDirtyRegion, bool supportsPartialRepaint);
+
+    // Initializes the contents of the new front buffer using the previous
+    // frames pixels(if applicable), clips to the dirty region, and clears the pixels
+    // to be drawn (unless drawing will be opaque).
+    void prepareBufferForDisplay(const WebCore::FloatRect& layerBounds, const WebCore::Region& dirtyRegion, const PaintRectList& paintingRects, bool requiresClearedPixels);
+
+
+    static PaintRectList computePaintingRects(const WebCore::Region& dirtyRegion, float resolutionScale);
+
+    void clearBuffers();
+
+    RefPtr<WebCore::ImageBuffer> m_frontBuffer;
+    RefPtr<WebCore::ImageBuffer> m_backBuffer;
+    RefPtr<WebCore::ImageBuffer> m_secondaryBackBuffer;
+
+    std::optional<WebCore::IntRect> m_previouslyPaintedRect;
+    bool m_frontBufferIsCleared { false };
+};
+
+} // namespace WebKit
+
+#endif

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -307,6 +307,8 @@ Shared/Databases/IndexedDB/IDBUtilities.cpp
 
 Shared/Gamepad/GamepadData.cpp
 
+Shared/graphics/ImageBufferSet.cpp
+
 Shared/WebGPU/WebGPUBindGroupDescriptor.cpp
 Shared/WebGPU/WebGPUBindGroupEntry.cpp
 Shared/WebGPU/WebGPUBindGroupLayoutDescriptor.cpp

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2020,6 +2020,7 @@
 		A73E66BD2AB107C3005FC327 /* IPCEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = A73E66BC2AB107BB005FC327 /* IPCEvent.h */; };
 		A78A5FE42B0EB39E005036D3 /* RemoteImageBufferSetIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = A78A5FE32B0EB39E005036D3 /* RemoteImageBufferSetIdentifier.h */; };
 		A7A3D555289395E2008D683D /* WebWorkerClient.h in Headers */ = {isa = PBXBuildFile; fileRef = A7A3D553289395E2008D683D /* WebWorkerClient.h */; };
+		A7D5005D2B266E0D00D3497E /* ImageBufferSet.h in Headers */ = {isa = PBXBuildFile; fileRef = A7D5005C2B266E0600D3497E /* ImageBufferSet.h */; };
 		A7D792D81767CCA300881CBE /* ActivityAssertion.h in Headers */ = {isa = PBXBuildFile; fileRef = A7D792D41767CB0900881CBE /* ActivityAssertion.h */; };
 		A7E69BCC2B2117A100D43D3F /* BufferAndBackendInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = A7E69BCB2B21179600D43D3F /* BufferAndBackendInfo.h */; };
 		A7F35F5C2B194C0800E43D98 /* RemoteLayerWithRemoteRenderingBackingStore.h in Headers */ = {isa = PBXBuildFile; fileRef = A7F35F5B2B194C0800E43D98 /* RemoteLayerWithRemoteRenderingBackingStore.h */; };
@@ -7210,6 +7211,8 @@
 		A7A3D552289395E2008D683D /* WebWorkerClient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebWorkerClient.cpp; sourceTree = "<group>"; };
 		A7A3D553289395E2008D683D /* WebWorkerClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebWorkerClient.h; sourceTree = "<group>"; };
 		A7B94DE32B5D9DBB0058780B /* RemoteImageBufferSetProxy.messages.in */ = {isa = PBXFileReference; explicitFileType = text; path = RemoteImageBufferSetProxy.messages.in; sourceTree = "<group>"; };
+		A7D5005A2B266DF200D3497E /* ImageBufferSet.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ImageBufferSet.cpp; sourceTree = "<group>"; };
+		A7D5005C2B266E0600D3497E /* ImageBufferSet.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ImageBufferSet.h; sourceTree = "<group>"; };
 		A7D792D41767CB0900881CBE /* ActivityAssertion.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ActivityAssertion.h; sourceTree = "<group>"; };
 		A7D792D51767CB6E00881CBE /* ActivityAssertion.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ActivityAssertion.cpp; sourceTree = "<group>"; };
 		A7E1503A2B1D6F030000E921 /* RemoteImageBuffer.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = RemoteImageBuffer.messages.in; sourceTree = "<group>"; };
@@ -9088,6 +9091,7 @@
 				B6114A8A293AE03600380B1B /* Extensions */,
 				E170877216D6CFEC00F99226 /* FileAPI */,
 				515BE1AE1D59003400DD7C68 /* Gamepad */,
+				A71DC05D2B266DA3001C3075 /* graphics */,
 				2DA944961884E4DA00ED86DB /* ios */,
 				BC111B5A112F628200337BAB /* mac */,
 				51AF1B3D271F46A6001538E6 /* Notifications */,
@@ -13656,6 +13660,15 @@
 			path = mac;
 			sourceTree = "<group>";
 		};
+		A71DC05D2B266DA3001C3075 /* graphics */ = {
+			isa = PBXGroup;
+			children = (
+				A7D5005A2B266DF200D3497E /* ImageBufferSet.cpp */,
+				A7D5005C2B266E0600D3497E /* ImageBufferSet.h */,
+			);
+			path = graphics;
+			sourceTree = "<group>";
+		};
 		A78CCDD5193AC9E3005ECC25 /* SandboxProfiles */ = {
 			isa = PBXGroup;
 			children = (
@@ -16480,6 +16493,7 @@
 				93B631ED27ABA6B400443A44 /* IDBStorageRegistry.h in Headers */,
 				51E351CB180F2CCC00E53BE9 /* IDBUtilities.h in Headers */,
 				F4351B9E25EEC84C00D63892 /* ImageAnalysisUtilities.h in Headers */,
+				A7D5005D2B266E0D00D3497E /* ImageBufferSet.h in Headers */,
 				BCCF6B2512C93E7A008F9C35 /* ImageOptions.h in Headers */,
 				1A1EC69E1872092100B951F0 /* ImportanceAssertion.h in Headers */,
 				BC204EE311C83E98008F3375 /* InjectedBundle.h in Headers */,

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.h
@@ -67,9 +67,7 @@ public:
     virtual bool flushAndCollectHandles(HashMap<RemoteImageBufferSetIdentifier, std::unique_ptr<BufferSetBackendHandle>>&) = 0;
 };
 
-// A RemoteImageBufferSet is a set of three ImageBuffers (front, back,
-// secondary back) owned by the GPU process, for the purpose of drawing
-// successive (layer) frames.
+// A RemoteImageBufferSet is an ImageBufferSet, where the actual ImageBuffers are owned by the GPU process.
 // To draw a frame, the consumer allocates a new RemoteDisplayListRecorderProxy and
 // asks the RemoteImageBufferSet set to map it to an appropriate new front
 // buffer (either by picking one of the back buffers, or by allocating a new
@@ -78,6 +76,8 @@ public:
 // Usage is done through RemoteRenderingBackendProxy::prepareImageBufferSetsForDisplay,
 // so that a Vector of RemoteImageBufferSets can be used with a single
 // IPC call.
+// FIXME: It would be nice if this could actually be a subclass of ImageBufferSet, but
+// probably can't while it uses batching for prepare and volatility.
 class RemoteImageBufferSetProxy : public IPC::WorkQueueMessageReceiver, public Identified<RemoteImageBufferSetIdentifier> {
 public:
     RemoteImageBufferSetProxy(RemoteRenderingBackendProxy&);


### PR DESCRIPTION
#### 27846c09e4fee72c441c3d78c0c93ed53bae2b2e
<pre>
Share code for buffer swapping and copy-forward between RemoteLayerWithInProcessRendering and RemoteImageBufferSet.
<a href="https://bugs.webkit.org/show_bug.cgi?id=266201">https://bugs.webkit.org/show_bug.cgi?id=266201</a>
&lt;<a href="https://rdar.apple.com/119474592">rdar://119474592</a>&gt;

Reviewed by Dan Glastonbury.

This moves a bunch of code into a base class &apos;ImageBufferSet&apos;, where the in-process and remote versions can both use it.
I think we can go further here, including volatility, and ideally RemoteImageBufferSetProxy would be a subclass to.

* Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp:
(WebKit::RemoteImageBufferSet::ensureBufferForDisplay):
(WebKit::RemoteImageBufferSet::prepareBufferForDisplay):
* Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm:
(WebKit::RemoteLayerBackingStore::paintContents):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm:
(WebKit::RemoteLayerWithInProcessRenderingBackingStore::hasFrontBuffer const):
(WebKit::RemoteLayerWithInProcessRenderingBackingStore::frontBufferMayBeVolatile const):
(WebKit::RemoteLayerWithInProcessRenderingBackingStore::clearBackingStore):
(WebKit::RemoteLayerWithInProcessRenderingBackingStore::frontBufferHandle const):
(WebKit::RemoteLayerWithInProcessRenderingBackingStore::createContextAndPaintContents):
(WebKit::RemoteLayerWithInProcessRenderingBackingStore::createFlushers):
(WebKit::RemoteLayerWithInProcessRenderingBackingStore::setBufferVolatile):
(WebKit::RemoteLayerWithInProcessRenderingBackingStore::ensureFrontBuffer):
(WebKit::RemoteLayerWithInProcessRenderingBackingStore::prepareToDisplay):
(WebKit::RemoteLayerWithInProcessRenderingBackingStore::encodeBufferAndBackendInfos const):
(WebKit::RemoteLayerWithInProcessRenderingBackingStore::dump const):
(WebKit::RemoteLayerWithInProcessRenderingBackingStore::prepareBuffers): Deleted.
(WebKit::RemoteLayerWithInProcessRenderingBackingStore::setFrontBufferNonVolatile): Deleted.
(WebKit::RemoteLayerWithInProcessRenderingBackingStore::swapToValidFrontBuffer): Deleted.
* Source/WebKit/Shared/graphics/ImageBufferSet.cpp: Added.
(WebKit::ImageBufferSet::swapBuffersForDisplay):
(WebKit::ImageBufferSet::computePaintingRects):
(WebKit::ImageBufferSet::prepareBufferForDisplay):
* Source/WebKit/Shared/graphics/ImageBufferSet.h: Added.
* Source/WebKit/Sources.txt:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.h:

Canonical link: <a href="https://commits.webkit.org/283678@main">https://commits.webkit.org/283678@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3c322aa1600c9469659c52bf71af3c562d967d3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/67017 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46392 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19639 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/71052 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/18150 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/54191 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17933 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53751 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12215 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/70084 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42670 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57985 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34270 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39341 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16504 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/61269 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15720 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72753 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10974 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/15056 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/61220 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11006 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/58044 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61296 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14810 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/9014 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2620 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42199 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/43276 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44459 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/43019 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->