### PR TITLE
[WebXR] Port PlatformXR::FrameData to new serialization format

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXRFrame.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRFrame.cpp
@@ -205,7 +205,7 @@ ExceptionOr<RefPtr<WebXRViewerPose>> WebXRFrame::getViewerPose(const Document& d
         auto transform = WebXRRigidTransform::create(pose->transform().rawTransform() * offset);
 
         // Set projection matrix for each view
-        std::array<float, 16> projection = WTF::switchOn(frameData.views[index].projection, [&](const PlatformXR::Device::FrameData::Fov& fov) {
+        std::array<float, 16> projection = WTF::switchOn(frameData.views[index].projection, [&](const PlatformXR::FrameData::Fov& fov) {
             double near = m_session->renderState().depthNear();
             double far = m_session->renderState().depthFar();
             return TransformationMatrix::fromProjection(fov.up, fov.down, fov.left, fov.right, near, far).toColumnMajorFloatArray();
@@ -255,7 +255,7 @@ ExceptionOr<RefPtr<WebXRPose>> WebXRFrame::getPose(const Document& document, con
     return RefPtr<WebXRPose>(WebXRPose::create(WebXRRigidTransform::create(populateValue->transform), populateValue->emulatedPosition));
 }
 
-TransformationMatrix WebXRFrame::matrixFromPose(const PlatformXR::Device::FrameData::Pose& pose)
+TransformationMatrix WebXRFrame::matrixFromPose(const PlatformXR::FrameData::Pose& pose)
 {
     TransformationMatrix matrix;
     matrix.translate3d(pose.position.x(), pose.position.y(), pose.position.z());

--- a/Source/WebCore/Modules/webxr/WebXRFrame.h
+++ b/Source/WebCore/Modules/webxr/WebXRFrame.h
@@ -71,7 +71,7 @@ public:
     bool isActive() const { return m_active; }
     bool isAnimationFrame() const { return m_isAnimationFrame; }
 
-    static TransformationMatrix matrixFromPose(const PlatformXR::Device::FrameData::Pose&);
+    static TransformationMatrix matrixFromPose(const PlatformXR::FrameData::Pose&);
 
 private:
     WebXRFrame(WebXRSession&, IsAnimationFrame);

--- a/Source/WebCore/Modules/webxr/WebXRGamepad.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRGamepad.cpp
@@ -39,7 +39,7 @@ namespace WebCore {
 constexpr int DefaultXRGamepadId = -1;
 
 // https://immersive-web.github.io/webxr-gamepads-module/#gamepad-differences
-WebXRGamepad::WebXRGamepad(double timestamp, double connectTime, const PlatformXR::Device::FrameData::InputSource& source)
+WebXRGamepad::WebXRGamepad(double timestamp, double connectTime, const PlatformXR::FrameData::InputSource& source)
     : PlatformGamepad(DefaultXRGamepadId)
 {
     m_lastUpdateTime = MonotonicTime::fromRawSeconds(Seconds::fromMilliseconds(timestamp).value());

--- a/Source/WebCore/Modules/webxr/WebXRGamepad.h
+++ b/Source/WebCore/Modules/webxr/WebXRGamepad.h
@@ -35,7 +35,7 @@ namespace WebCore {
 
 class WebXRGamepad: public PlatformGamepad {
 public:
-    WebXRGamepad(double timestamp, double connectTime, const PlatformXR::Device::FrameData::InputSource&);
+    WebXRGamepad(double timestamp, double connectTime, const PlatformXR::FrameData::InputSource&);
 
 private:
     const Vector<SharedGamepadValue>& axisValues() const final { return m_axes; }

--- a/Source/WebCore/Modules/webxr/WebXRHand.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRHand.cpp
@@ -87,7 +87,7 @@ WebXRSession* WebXRHand::session()
     return m_inputSource->session();
 }
 
-void WebXRHand::updateFromInputSource(const PlatformXR::Device::FrameData::InputSource& inputSource)
+void WebXRHand::updateFromInputSource(const PlatformXR::FrameData::InputSource& inputSource)
 {
     if (!inputSource.handJoints) {
         m_hasMissingPoses = true;

--- a/Source/WebCore/Modules/webxr/WebXRHand.h
+++ b/Source/WebCore/Modules/webxr/WebXRHand.h
@@ -66,7 +66,7 @@ public:
     WebXRSession* session();
 
     bool hasMissingPoses() const { return m_hasMissingPoses; }
-    void updateFromInputSource(const PlatformXR::Device::FrameData::InputSource&);
+    void updateFromInputSource(const PlatformXR::FrameData::InputSource&);
 
 private:
     WebXRHand(const WebXRInputSource&);

--- a/Source/WebCore/Modules/webxr/WebXRInputSource.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRInputSource.cpp
@@ -42,12 +42,12 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(WebXRInputSource);
 
-Ref<WebXRInputSource> WebXRInputSource::create(Document& document, WebXRSession& session, double timestamp, const PlatformXR::Device::FrameData::InputSource& source)
+Ref<WebXRInputSource> WebXRInputSource::create(Document& document, WebXRSession& session, double timestamp, const PlatformXR::FrameData::InputSource& source)
 {
     return adoptRef(*new WebXRInputSource(document, session, timestamp, source));
 }
 
-WebXRInputSource::WebXRInputSource(Document& document, WebXRSession& session, double timestamp, const PlatformXR::Device::FrameData::InputSource& source)
+WebXRInputSource::WebXRInputSource(Document& document, WebXRSession& session, double timestamp, const PlatformXR::FrameData::InputSource& source)
     : m_session(session)
     , m_targetRaySpace(WebXRInputSpace::create(document, session, source.pointerOrigin))
     , m_connectTime(timestamp)
@@ -65,7 +65,7 @@ WebXRSession* WebXRInputSource::session()
     return m_session.get();
 }
 
-void WebXRInputSource::update(double timestamp, const PlatformXR::Device::FrameData::InputSource& source)
+void WebXRInputSource::update(double timestamp, const PlatformXR::FrameData::InputSource& source)
 {
     RefPtr session = m_session.get();
     if (!session)

--- a/Source/WebCore/Modules/webxr/WebXRInputSource.h
+++ b/Source/WebCore/Modules/webxr/WebXRInputSource.h
@@ -56,8 +56,8 @@ class WebXRInputSpace;
 class WebXRInputSource : public RefCounted<WebXRInputSource>, public CanMakeWeakPtr<WebXRInputSource> {
     WTF_MAKE_ISO_ALLOCATED(WebXRInputSource);
 public:
-    using InputSource = PlatformXR::Device::FrameData::InputSource;
-    using InputSourceButton = PlatformXR::Device::FrameData::InputSourceButton;
+    using InputSource = PlatformXR::FrameData::InputSource;
+    using InputSourceButton = PlatformXR::FrameData::InputSourceButton;
 
     static Ref<WebXRInputSource> create(Document&, WebXRSession&, double timestamp, const InputSource&);
     ~WebXRInputSource();

--- a/Source/WebCore/Modules/webxr/WebXRInputSourceArray.h
+++ b/Source/WebCore/Modules/webxr/WebXRInputSourceArray.h
@@ -45,7 +45,7 @@ class WebXRInputSourceArray final : public ScriptWrappable {
     WTF_MAKE_ISO_ALLOCATED(WebXRInputSourceArray);
     friend UniqueRef<WebXRInputSourceArray> WTF::makeUniqueRefWithoutFastMallocCheck<WebXRInputSourceArray, WebCore::WebXRSession&>(WebCore::WebXRSession&);
 public:
-    using InputSourceList = Vector<PlatformXR::Device::FrameData::InputSource>;
+    using InputSourceList = Vector<PlatformXR::FrameData::InputSource>;
     static UniqueRef<WebXRInputSourceArray> create(WebXRSession&);
     ~WebXRInputSourceArray();
 

--- a/Source/WebCore/Modules/webxr/WebXRInputSpace.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRInputSpace.cpp
@@ -39,12 +39,12 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(WebXRInputSpace);
 
 // WebXRInputSpace
 
-Ref<WebXRInputSpace> WebXRInputSpace::create(Document& document, WebXRSession& session, const PlatformXR::Device::FrameData::InputSourcePose& pose)
+Ref<WebXRInputSpace> WebXRInputSpace::create(Document& document, WebXRSession& session, const PlatformXR::FrameData::InputSourcePose& pose)
 {
     return adoptRef(*new WebXRInputSpace(document, session, pose));
 }
 
-WebXRInputSpace::WebXRInputSpace(Document& document, WebXRSession& session, const PlatformXR::Device::FrameData::InputSourcePose& pose)
+WebXRInputSpace::WebXRInputSpace(Document& document, WebXRSession& session, const PlatformXR::FrameData::InputSourcePose& pose)
     : WebXRSpace(document, WebXRRigidTransform::create())
     , m_session(session)
     , m_pose(pose)

--- a/Source/WebCore/Modules/webxr/WebXRInputSpace.h
+++ b/Source/WebCore/Modules/webxr/WebXRInputSpace.h
@@ -38,17 +38,17 @@ namespace WebCore {
 class WebXRInputSpace : public RefCounted<WebXRInputSpace>, public WebXRSpace {
     WTF_MAKE_ISO_ALLOCATED(WebXRInputSpace);
 public:
-    static Ref<WebXRInputSpace> create(Document&, WebXRSession&, const PlatformXR::Device::FrameData::InputSourcePose&);
+    static Ref<WebXRInputSpace> create(Document&, WebXRSession&, const PlatformXR::FrameData::InputSourcePose&);
     virtual ~WebXRInputSpace();
 
     using RefCounted<WebXRInputSpace>::ref;
     using RefCounted<WebXRInputSpace>::deref;
 
     std::optional<bool> isPositionEmulated() const final { return m_pose.isPositionEmulated; }
-    void setPose(const PlatformXR::Device::FrameData::InputSourcePose& pose) { m_pose = pose; }
+    void setPose(const PlatformXR::FrameData::InputSourcePose& pose) { m_pose = pose; }
 
 private:
-    WebXRInputSpace(Document&, WebXRSession&, const PlatformXR::Device::FrameData::InputSourcePose&);
+    WebXRInputSpace(Document&, WebXRSession&, const PlatformXR::FrameData::InputSourcePose&);
     WebXRSession* session() const final { return m_session.get(); }
     std::optional<TransformationMatrix> nativeOrigin() const final;
 
@@ -56,7 +56,7 @@ private:
     void derefEventTarget() final { deref(); }
 
     WeakPtr<WebXRSession> m_session;
-    PlatformXR::Device::FrameData::InputSourcePose m_pose;
+    PlatformXR::FrameData::InputSourcePose m_pose;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webxr/WebXRJointSpace.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRJointSpace.cpp
@@ -37,12 +37,12 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(WebXRJointSpace);
 
-Ref<WebXRJointSpace> WebXRJointSpace::create(Document& document, WebXRHand& hand, XRHandJoint jointName, std::optional<PlatformXR::Device::FrameData::InputSourceHandJoint>&& joint)
+Ref<WebXRJointSpace> WebXRJointSpace::create(Document& document, WebXRHand& hand, XRHandJoint jointName, std::optional<PlatformXR::FrameData::InputSourceHandJoint>&& joint)
 {
     return adoptRef(*new WebXRJointSpace(document, hand, jointName, WTFMove(joint)));
 }
 
-WebXRJointSpace::WebXRJointSpace(Document& document, WebXRHand& hand, XRHandJoint jointName, std::optional<PlatformXR::Device::FrameData::InputSourceHandJoint>&& joint)
+WebXRJointSpace::WebXRJointSpace(Document& document, WebXRHand& hand, XRHandJoint jointName, std::optional<PlatformXR::FrameData::InputSourceHandJoint>&& joint)
     : WebXRSpace(document, WebXRRigidTransform::create())
     , m_hand(hand)
     , m_jointName(jointName)
@@ -52,7 +52,7 @@ WebXRJointSpace::WebXRJointSpace(Document& document, WebXRHand& hand, XRHandJoin
 
 WebXRJointSpace::~WebXRJointSpace() = default;
 
-void WebXRJointSpace::updateFromJoint(const std::optional<PlatformXR::Device::FrameData::InputSourceHandJoint>& joint)
+void WebXRJointSpace::updateFromJoint(const std::optional<PlatformXR::FrameData::InputSourceHandJoint>& joint)
 {
     m_joint = joint;
 }

--- a/Source/WebCore/Modules/webxr/WebXRJointSpace.h
+++ b/Source/WebCore/Modules/webxr/WebXRJointSpace.h
@@ -45,7 +45,7 @@ class WebXRSession;
 class WebXRJointSpace final: public RefCounted<WebXRJointSpace>, public WebXRSpace {
     WTF_MAKE_ISO_ALLOCATED(WebXRJointSpace);
 public:
-    static Ref<WebXRJointSpace> create(Document&, WebXRHand&, XRHandJoint, std::optional<PlatformXR::Device::FrameData::InputSourceHandJoint>&& = std::nullopt);
+    static Ref<WebXRJointSpace> create(Document&, WebXRHand&, XRHandJoint, std::optional<PlatformXR::FrameData::InputSourceHandJoint>&& = std::nullopt);
     virtual ~WebXRJointSpace();
 
     using RefCounted<WebXRJointSpace>::ref;
@@ -54,13 +54,13 @@ public:
     XRHandJoint jointName() const { return m_jointName; }
 
     float radius() const { return m_joint ? m_joint->radius : 0; }
-    void updateFromJoint(const std::optional<PlatformXR::Device::FrameData::InputSourceHandJoint>&);
+    void updateFromJoint(const std::optional<PlatformXR::FrameData::InputSourceHandJoint>&);
     bool handHasMissingPoses() const;
 
     WebXRSession* session() const final;
 
 private:
-    WebXRJointSpace(Document&, WebXRHand&, XRHandJoint, std::optional<PlatformXR::Device::FrameData::InputSourceHandJoint>&&);
+    WebXRJointSpace(Document&, WebXRHand&, XRHandJoint, std::optional<PlatformXR::FrameData::InputSourceHandJoint>&&);
 
     std::optional<TransformationMatrix> nativeOrigin() const final;
 
@@ -71,7 +71,7 @@ private:
 
     WeakPtr<WebXRHand> m_hand;
     XRHandJoint m_jointName { XRHandJoint::Wrist };
-    std::optional<PlatformXR::Device::FrameData::InputSourceHandJoint> m_joint;
+    std::optional<PlatformXR::FrameData::InputSourceHandJoint> m_joint;
 };
 
 }

--- a/Source/WebCore/Modules/webxr/WebXRLayer.h
+++ b/Source/WebCore/Modules/webxr/WebXRLayer.h
@@ -45,7 +45,7 @@ public:
     using RefCounted<WebXRLayer>::ref;
     using RefCounted<WebXRLayer>::deref;
 
-    virtual void startFrame(const PlatformXR::Device::FrameData&) = 0;
+    virtual void startFrame(const PlatformXR::FrameData&) = 0;
     virtual PlatformXR::Device::Layer endFrame() = 0;
 
 protected:

--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
@@ -126,7 +126,7 @@ WebXROpaqueFramebuffer::~WebXROpaqueFramebuffer()
     }
 }
 
-void WebXROpaqueFramebuffer::startFrame(const PlatformXR::Device::FrameData::LayerData& data)
+void WebXROpaqueFramebuffer::startFrame(const PlatformXR::FrameData::LayerData& data)
 {
     if (!m_context.graphicsContextGL())
         return;

--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h
@@ -59,7 +59,7 @@ public:
     GCGLint width() const { return m_framebufferSize.width(); }
     GCGLint height() const { return m_framebufferSize.height(); }
 
-    void startFrame(const PlatformXR::Device::FrameData::LayerData&);
+    void startFrame(const PlatformXR::FrameData::LayerData&);
     void endFrame();
 
 private:

--- a/Source/WebCore/Modules/webxr/WebXRSession.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSession.cpp
@@ -422,7 +422,7 @@ void WebXRSession::stop()
 {
 }
 
-void WebXRSession::sessionDidInitializeInputSources(Vector<PlatformXR::Device::FrameData::InputSource>&& inputSources)
+void WebXRSession::sessionDidInitializeInputSources(Vector<PlatformXR::FrameData::InputSource>&& inputSources)
 {
     // https://immersive-web.github.io/webxr/#dom-xrsystem-requestsession
     // 5.4.11 Queue a task to perform the following steps: NOTE: These steps ensure that initial inputsourceschange
@@ -546,7 +546,7 @@ void WebXRSession::requestFrameIfNeeded()
     });
 }
 
-void WebXRSession::onFrame(PlatformXR::Device::FrameData&& frameData)
+void WebXRSession::onFrame(PlatformXR::FrameData&& frameData)
 {
     ASSERT(isMainThread());
 

--- a/Source/WebCore/Modules/webxr/WebXRSession.h
+++ b/Source/WebCore/Modules/webxr/WebXRSession.h
@@ -98,7 +98,7 @@ public:
     XRSessionMode mode() const { return m_mode; }
 
     const Vector<PlatformXR::Device::ViewData>& views() const { return m_views; }
-    const PlatformXR::Device::FrameData& frameData() const { return m_frameData; }
+    const PlatformXR::FrameData& frameData() const { return m_frameData; }
     const WebXRViewerSpace& viewerReferenceSpace() const { return m_viewerReferenceSpace; }
     bool posesCanBeReported(const Document&) const;
     
@@ -119,7 +119,7 @@ private:
     void stop() override;
 
     // PlatformXR::TrackingAndRenderingClient
-    void sessionDidInitializeInputSources(Vector<PlatformXR::Device::FrameData::InputSource>&&) final;
+    void sessionDidInitializeInputSources(Vector<PlatformXR::FrameData::InputSource>&&) final;
     void sessionDidEnd() final;
     void updateSessionVisibilityState(PlatformXR::VisibilityState) final;
 
@@ -131,7 +131,7 @@ private:
 
     bool frameShouldBeRendered() const;
     void requestFrameIfNeeded();
-    void onFrame(PlatformXR::Device::FrameData&&);
+    void onFrame(PlatformXR::FrameData&&);
     void applyPendingRenderState();
 
     XREnvironmentBlendMode m_environmentBlendMode { XREnvironmentBlendMode::Opaque };
@@ -155,7 +155,7 @@ private:
     bool m_isDeviceFrameRequestPending { false };
 
     Vector<PlatformXR::Device::ViewData> m_views;
-    PlatformXR::Device::FrameData m_frameData;
+    PlatformXR::FrameData m_frameData;
 
     double m_minimumInlineFOV { 0.0 };
     double m_maximumInlineFOV { piFloat };

--- a/Source/WebCore/Modules/webxr/WebXRSystem.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSystem.cpp
@@ -627,7 +627,7 @@ void WebXRSystem::DummyInlineDevice::requestFrame(PlatformXR::Device::RequestFra
         return;
 
     auto raf = InlineRequestAnimationFrameCallback::create(*scriptExecutionContext(), [callback = WTFMove(callback)]() mutable {
-        PlatformXR::Device::FrameData data;
+        PlatformXR::FrameData data;
         data.isTrackingValid = true;
         data.isPositionValid = true;
         data.shouldRender = true;

--- a/Source/WebCore/Modules/webxr/WebXRWebGLLayer.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRWebGLLayer.cpp
@@ -273,7 +273,7 @@ HTMLCanvasElement* WebXRWebGLLayer::canvas() const
 }
 
 
-void WebXRWebGLLayer::startFrame(const PlatformXR::Device::FrameData& data)
+void WebXRWebGLLayer::startFrame(const PlatformXR::FrameData& data)
 {
     ASSERT(m_framebuffer);
 

--- a/Source/WebCore/Modules/webxr/WebXRWebGLLayer.h
+++ b/Source/WebCore/Modules/webxr/WebXRWebGLLayer.h
@@ -83,7 +83,7 @@ public:
     HTMLCanvasElement* canvas() const;
 
     // WebXRLayer
-    void startFrame(const PlatformXR::Device::FrameData&) final;
+    void startFrame(const PlatformXR::FrameData&) final;
     PlatformXR::Device::Layer endFrame() final;
 
 private:

--- a/Source/WebCore/platform/xr/cocoa/PlatformXRPose.cpp
+++ b/Source/WebCore/platform/xr/cocoa/PlatformXRPose.cpp
@@ -13,15 +13,15 @@ WebCore::FloatPoint3D PlatformXRPose::position() const
     return { static_cast<float>(simdPosition.x), static_cast<float>(simdPosition.y), static_cast<float>(simdPosition.z) };
 }
 
-PlatformXR::Device::FrameData::FloatQuaternion PlatformXRPose::orientation() const
+PlatformXR::FrameData::FloatQuaternion PlatformXRPose::orientation() const
 {
     simd_quatf simdOrientation = this->simdOrientation();
     return { simdOrientation.vector.x, simdOrientation.vector.y, simdOrientation.vector.z, simdOrientation.vector.w };
 }
 
-PlatformXR::Device::FrameData::Pose PlatformXRPose::pose() const
+PlatformXR::FrameData::Pose PlatformXRPose::pose() const
 {
-    PlatformXR::Device::FrameData::Pose pose;
+    PlatformXR::FrameData::Pose pose;
     pose.position = position();
     pose.orientation = orientation();
     return pose;

--- a/Source/WebCore/platform/xr/cocoa/PlatformXRPose.h
+++ b/Source/WebCore/platform/xr/cocoa/PlatformXRPose.h
@@ -17,8 +17,8 @@ public:
     simd_float3 simdPosition() const { return m_simdTransform.columns[3].xyz; }
     simd_quatf simdOrientation() const { return simd_quaternion(m_simdTransform); }
     WEBCORE_EXPORT WebCore::FloatPoint3D position() const;
-    WEBCORE_EXPORT PlatformXR::Device::FrameData::FloatQuaternion orientation() const;
-    WEBCORE_EXPORT PlatformXR::Device::FrameData::Pose pose() const;
+    WEBCORE_EXPORT PlatformXR::FrameData::FloatQuaternion orientation() const;
+    WEBCORE_EXPORT PlatformXR::FrameData::Pose pose() const;
 
     using FloatMatrix4 = std::array<float, 16>;
     WEBCORE_EXPORT FloatMatrix4 toColumnMajorFloatArray() const;

--- a/Source/WebCore/platform/xr/openxr/OpenXRInput.cpp
+++ b/Source/WebCore/platform/xr/openxr/OpenXRInput.cpp
@@ -77,7 +77,7 @@ XrResult OpenXRInput::initialize()
     return XR_SUCCESS;
 }
 
-Vector<Device::FrameData::InputSource> OpenXRInput::collectInputSources(const XrFrameState& frameState) const
+Vector<FrameData::InputSource> OpenXRInput::collectInputSources(const XrFrameState& frameState) const
 {
     Vector<XrActiveActionSet> actionSets;
     for (auto& input : m_inputSources)
@@ -88,7 +88,7 @@ Vector<Device::FrameData::InputSource> OpenXRInput::collectInputSources(const Xr
     syncInfo.activeActionSets = actionSets.data();
     RETURN_IF_FAILED(xrSyncActions(m_session, &syncInfo), "xrSyncActions", m_instance, { });
 
-    Vector<Device::FrameData::InputSource> result;
+    Vector<FrameData::InputSource> result;
     for (auto& input : m_inputSources) {
         if (auto data = input->getInputSource(m_localSpace, frameState))
             result.append(*data);

--- a/Source/WebCore/platform/xr/openxr/OpenXRInput.h
+++ b/Source/WebCore/platform/xr/openxr/OpenXRInput.h
@@ -37,7 +37,7 @@ class OpenXRInput {
 public:
     static std::unique_ptr<OpenXRInput> create(XrInstance, XrSession, XrSpace);
 
-    Vector<Device::FrameData::InputSource> collectInputSources(const XrFrameState&) const;
+    Vector<FrameData::InputSource> collectInputSources(const XrFrameState&) const;
     void updateInteractionProfile();
 
 private:

--- a/Source/WebCore/platform/xr/openxr/OpenXRInputSource.cpp
+++ b/Source/WebCore/platform/xr/openxr/OpenXRInputSource.cpp
@@ -142,9 +142,9 @@ XrResult OpenXRInputSource::suggestBindings(SuggestedBindings& bindings) const
     return XR_SUCCESS;
 }
 
-std::optional<Device::FrameData::InputSource> OpenXRInputSource::getInputSource(XrSpace localSpace, const XrFrameState& frameState) const
+std::optional<FrameData::InputSource> OpenXRInputSource::getInputSource(XrSpace localSpace, const XrFrameState& frameState) const
 {
-    Device::FrameData::InputSource data;
+    FrameData::InputSource data;
     data.handeness = m_handeness;
     data.handle = m_handle;
     data.targetRayMode = XRTargetRayMode::TrackedPointer;
@@ -152,12 +152,12 @@ std::optional<Device::FrameData::InputSource> OpenXRInputSource::getInputSource(
 
     // Pose transforms.
     getPose(m_pointerSpace, localSpace, frameState, data.pointerOrigin);
-    Device::FrameData::InputSourcePose gripPose;
+    FrameData::InputSourcePose gripPose;
     if (XR_SUCCEEDED(getPose(m_gripSpace, localSpace, frameState, gripPose)))
         data.gripOrigin = gripPose;
 
     // Buttons.
-    Vector<std::optional<Device::FrameData::InputSourceButton>> buttons;
+    Vector<std::optional<FrameData::InputSourceButton>> buttons;
     for (auto& type : openXRButtonTypes) 
         buttons.append(getButton(type));
 
@@ -277,7 +277,7 @@ XrResult OpenXRInputSource::createBinding(const char* profilePath, XrAction acti
     return XR_SUCCESS;
 }
 
-XrResult OpenXRInputSource::getPose(XrSpace space, XrSpace baseSpace, const XrFrameState& frameState, Device::FrameData::InputSourcePose& pose) const
+XrResult OpenXRInputSource::getPose(XrSpace space, XrSpace baseSpace, const XrFrameState& frameState, FrameData::InputSourcePose& pose) const
 {
     auto location = createStructure<XrSpaceLocation, XR_TYPE_SPACE_LOCATION>();
     RETURN_RESULT_IF_FAILED(xrLocateSpace(space, baseSpace, frameState.predictedDisplayTime, &location), m_instance);
@@ -289,13 +289,13 @@ XrResult OpenXRInputSource::getPose(XrSpace space, XrSpace baseSpace, const XrFr
     return XR_SUCCESS;
 }
 
-std::optional<Device::FrameData::InputSourceButton> OpenXRInputSource::getButton(OpenXRButtonType buttonType) const
+std::optional<FrameData::InputSourceButton> OpenXRInputSource::getButton(OpenXRButtonType buttonType) const
 {
     auto it = m_buttonActions.find(buttonType);
     if (it == m_buttonActions.end())
         return std::nullopt;
 
-    Device::FrameData::InputSourceButton result;
+    FrameData::InputSourceButton result;
     bool hasValue = false;
     auto& actions = it->value;
 

--- a/Source/WebCore/platform/xr/openxr/OpenXRInputSource.h
+++ b/Source/WebCore/platform/xr/openxr/OpenXRInputSource.h
@@ -38,7 +38,7 @@ public:
     ~OpenXRInputSource();
 
     XrResult suggestBindings(SuggestedBindings&) const;
-    std::optional<Device::FrameData::InputSource> getInputSource(XrSpace, const XrFrameState&) const;
+    std::optional<FrameData::InputSource> getInputSource(XrSpace, const XrFrameState&) const;
     XrActionSet actionSet() const { return m_actionSet; }
     XrResult updateInteractionProfile();
 
@@ -57,8 +57,8 @@ private:
     XrResult createButtonActions(OpenXRButtonType, const String& prefix, OpenXRButtonActions&) const;
     XrResult createBinding(const char* profilePath, XrAction, const String& bindingPath, SuggestedBindings&) const;
 
-    XrResult getPose(XrSpace, XrSpace, const XrFrameState&, Device::FrameData::InputSourcePose&) const;
-    std::optional<Device::FrameData::InputSourceButton> getButton(OpenXRButtonType) const;
+    XrResult getPose(XrSpace, XrSpace, const XrFrameState&, FrameData::InputSourcePose&) const;
+    std::optional<FrameData::InputSourceButton> getButton(OpenXRButtonType) const;
     std::optional<XrVector2f> getAxis(OpenXRAxisType) const;
     XrResult getActionState(XrAction, bool*) const;
     XrResult getActionState(XrAction, float*) const;

--- a/Source/WebCore/platform/xr/openxr/OpenXRLayer.cpp
+++ b/Source/WebCore/platform/xr/openxr/OpenXRLayer.cpp
@@ -57,13 +57,13 @@ OpenXRLayerProjection::OpenXRLayerProjection(UniqueRef<OpenXRSwapchain>&& swapch
 {
 }
 
-std::optional<Device::FrameData::LayerData> OpenXRLayerProjection::startFrame()
+std::optional<FrameData::LayerData> OpenXRLayerProjection::startFrame()
 {
     auto texture = m_swapchain->acquireImage();
     if (!texture)
         return std::nullopt;
 
-    return Device::FrameData::LayerData { *texture };
+    return FrameData::LayerData { *texture };
 }
 
 XrCompositionLayerBaseHeader* OpenXRLayerProjection::endFrame(const Device::Layer& layer, XrSpace space, const Vector<XrView>& frameViews)

--- a/Source/WebCore/platform/xr/openxr/OpenXRLayer.h
+++ b/Source/WebCore/platform/xr/openxr/OpenXRLayer.h
@@ -37,7 +37,7 @@ class OpenXRLayer {
 public:
     virtual ~OpenXRLayer() = default;
 
-    virtual std::optional<Device::FrameData::LayerData> startFrame() = 0;
+    virtual std::optional<FrameData::LayerData> startFrame() = 0;
     virtual XrCompositionLayerBaseHeader* endFrame(const Device::Layer&, XrSpace, const Vector<XrView>&) = 0;
 
 protected:
@@ -52,7 +52,7 @@ public:
 private:
     OpenXRLayerProjection(UniqueRef<OpenXRSwapchain>&&);
 
-    std::optional<Device::FrameData::LayerData> startFrame() final;
+    std::optional<FrameData::LayerData> startFrame() final;
     XrCompositionLayerBaseHeader* endFrame(const Device::Layer&, XrSpace, const Vector<XrView>&) final;
 
     UniqueRef<OpenXRSwapchain> m_swapchain;

--- a/Source/WebCore/platform/xr/openxr/OpenXRUtils.h
+++ b/Source/WebCore/platform/xr/openxr/OpenXRUtils.h
@@ -84,18 +84,18 @@ inline String resultToString(XrResult value, XrInstance instance)
         LOG(XR, "%s %s: %s\n", __func__, call, resultToString(result, instance).utf8().data());
 
 
-inline Device::FrameData::Pose XrPosefToPose(XrPosef pose)
+inline FrameData::Pose XrPosefToPose(XrPosef pose)
 {
-    Device::FrameData::Pose result;
+    FrameData::Pose result;
     result.orientation = { pose.orientation.x, pose.orientation.y, pose.orientation.z, pose.orientation.w };
     result.position = { pose.position.x, pose.position.y, pose.position.z };
     return result;
 }
 
-inline Device::FrameData::View xrViewToPose(XrView view)
+inline FrameData::View xrViewToPose(XrView view)
 {
-    Device::FrameData::View pose;
-    pose.projection = Device::FrameData::Fov { std::abs(view.fov.angleUp), std::abs(view.fov.angleDown), std::abs(view.fov.angleLeft), std::abs(view.fov.angleRight) };
+    FrameData::View pose;
+    pose.projection = FrameData::Fov { std::abs(view.fov.angleUp), std::abs(view.fov.angleDown), std::abs(view.fov.angleLeft), std::abs(view.fov.angleRight) };
     pose.offset = XrPosefToPose(view.pose);
     return pose;
 }

--- a/Source/WebCore/platform/xr/openxr/PlatformXROpenXR.cpp
+++ b/Source/WebCore/platform/xr/openxr/PlatformXROpenXR.cpp
@@ -189,7 +189,7 @@ void OpenXRDevice::requestFrame(RequestFrameCallback&& callback)
         result = xrBeginFrame(m_session, &frameBeginInfo);
         RETURN_IF_FAILED(result, "xrBeginFrame", m_instance);
 
-        Device::FrameData frameData;
+        FrameData frameData;
         frameData.predictedDisplayTime = m_frameState.predictedDisplayTime;
         frameData.shouldRender = m_frameState.shouldRender;
         frameData.stageParameters = m_stageParameters;

--- a/Source/WebCore/platform/xr/openxr/PlatformXROpenXR.h
+++ b/Source/WebCore/platform/xr/openxr/PlatformXROpenXR.h
@@ -110,7 +110,7 @@ private:
     XrSpace m_localSpace { XR_NULL_HANDLE };
     XrSpace m_viewSpace { XR_NULL_HANDLE };
     XrSpace m_stageSpace { XR_NULL_HANDLE };
-    Device::FrameData::StageParameters m_stageParameters;
+    FrameData::StageParameters m_stageParameters;
 };
 
 } // namespace PlatformXR

--- a/Source/WebCore/testing/WebFakeXRDevice.h
+++ b/Source/WebCore/testing/WebFakeXRDevice.h
@@ -46,8 +46,8 @@ class GraphicsContextGL;
 class FakeXRView final : public RefCounted<FakeXRView> {
 public:
     static Ref<FakeXRView> create(XREye eye) { return adoptRef(*new FakeXRView(eye)); }
-    using Pose = PlatformXR::Device::FrameData::Pose;
-    using Fov = PlatformXR::Device::FrameData::Fov;
+    using Pose = PlatformXR::FrameData::Pose;
+    using Fov = PlatformXR::FrameData::Fov;
 
     XREye eye() const { return m_eye; }
     const Pose& offset() const { return m_offset; }
@@ -75,10 +75,10 @@ class SimulatedXRDevice final : public PlatformXR::Device {
 public:
     SimulatedXRDevice();
     virtual ~SimulatedXRDevice();
-    void setViews(Vector<FrameData::View>&&);
+    void setViews(Vector<PlatformXR::FrameData::View>&&);
     void setNativeBoundsGeometry(const Vector<FakeXRBoundsPoint>&);
-    void setViewerOrigin(const std::optional<FrameData::Pose>&);
-    void setFloorOrigin(std::optional<FrameData::Pose>&& origin) { m_frameData.floorTransform = WTFMove(origin); }
+    void setViewerOrigin(const std::optional<PlatformXR::FrameData::Pose>&);
+    void setFloorOrigin(std::optional<PlatformXR::FrameData::Pose>&& origin) { m_frameData.floorTransform = WTFMove(origin); }
     void setEmulatedPosition(bool emulated) { m_frameData.isPositionEmulated = emulated; }
     void setSupportsShutdownNotification(bool supportsShutdownNotification) { m_supportsShutdownNotification = supportsShutdownNotification; }
     void setVisibilityState(XRVisibilityState);
@@ -99,7 +99,7 @@ private:
     void stopTimer();
     void frameTimerFired();
 
-    PlatformXR::Device::FrameData m_frameData;
+    PlatformXR::FrameData m_frameData;
     bool m_supportsShutdownNotification { false };
     Timer m_frameTimer;
     RequestFrameCallback m_FrameCallback;
@@ -128,7 +128,7 @@ public:
     void setSupportsShutdownNotification();
     void simulateShutdown();
 
-    static ExceptionOr<PlatformXR::Device::FrameData::Pose> parseRigidTransform(const FakeXRRigidTransformInit&);
+    static ExceptionOr<PlatformXR::FrameData::Pose> parseRigidTransform(const FakeXRRigidTransformInit&);
 
 private:
     WebFakeXRDevice();

--- a/Source/WebCore/testing/WebFakeXRInputController.cpp
+++ b/Source/WebCore/testing/WebFakeXRInputController.cpp
@@ -32,14 +32,14 @@
 
 namespace WebCore {
 
-using InputSource = PlatformXR::Device::FrameData::InputSource;
-using InputSourceButton = PlatformXR::Device::FrameData::InputSourceButton;
-using InputSourcePose = PlatformXR::Device::FrameData::InputSourcePose;
+using InputSource = PlatformXR::FrameData::InputSource;
+using InputSourceButton = PlatformXR::FrameData::InputSourceButton;
+using InputSourcePose = PlatformXR::FrameData::InputSourcePose;
 using ButtonType = FakeXRButtonStateInit::Type;
 
 #if ENABLE(WEBXR_HANDS)
-using HandJointsVector = PlatformXR::Device::FrameData::HandJointsVector;
-using InputSourceHandJoint = PlatformXR::Device::FrameData::InputSourceHandJoint;
+using HandJointsVector = PlatformXR::FrameData::HandJointsVector;
+using InputSourceHandJoint = PlatformXR::FrameData::InputSourceHandJoint;
 #endif
 
 // https://immersive-web.github.io/webxr-gamepads-module/#xr-standard-gamepad-mapping

--- a/Source/WebCore/testing/WebFakeXRInputController.h
+++ b/Source/WebCore/testing/WebFakeXRInputController.h
@@ -66,13 +66,13 @@ public:
     void updateHandJoints(const Vector<FakeXRJointStateInit>&);
 #endif
 
-    PlatformXR::Device::FrameData::InputSource getFrameData();
+    PlatformXR::FrameData::InputSource getFrameData();
 
 private:
     WebFakeXRInputController(PlatformXR::InputSourceHandle, const FakeXRInputSourceInit&);
 
     struct ButtonOrPlaceholder {
-        std::optional<PlatformXR::Device::FrameData::InputSourceButton> button;
+        std::optional<PlatformXR::FrameData::InputSourceButton> button;
         std::optional<Vector<float>> axes;
     };
     ButtonOrPlaceholder getButtonOrPlaceholder(FakeXRButtonStateInit::Type) const;
@@ -81,14 +81,14 @@ private:
     XRHandedness m_handeness { XRHandedness::None };
     XRTargetRayMode m_targetRayMode { XRTargetRayMode::Gaze };
     Vector<String> m_profiles;
-    PlatformXR::Device::FrameData::InputSourcePose m_pointerOrigin;
-    std::optional<PlatformXR::Device::FrameData::InputSourcePose> m_gripOrigin;
+    PlatformXR::FrameData::InputSourcePose m_pointerOrigin;
+    std::optional<PlatformXR::FrameData::InputSourcePose> m_gripOrigin;
     HashMap<FakeXRButtonStateInit::Type, FakeXRButtonStateInit, IntHash<FakeXRButtonStateInit::Type>, WTF::StrongEnumHashTraits<FakeXRButtonStateInit::Type>> m_buttons;
     bool m_connected { true };
     bool m_primarySelected { false };
     bool m_simulateSelect { false };
 #if ENABLE(WEBXR_HANDS)
-    std::optional<PlatformXR::Device::FrameData::HandJointsVector> m_handJoints;
+    std::optional<PlatformXR::FrameData::HandJointsVector> m_handJoints;
 #endif
 };
 

--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -546,6 +546,7 @@ set(WebKit_SERIALIZATION_IN_FILES
     Shared/WebsiteData/WebsiteDataFetchOption.serialization.in
     Shared/WebsiteData/WebsiteDataType.serialization.in
 
+    Shared/XR/PlatformXR.serialization.in
     Shared/XR/XRSystem.serialization.in
 
     WebProcess/GPU/GPUProcessConnectionInfo.serialization.in

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -408,6 +408,7 @@ $(PROJECT_DIR)/Shared/WebsiteData/WebsiteDataFetchOption.serialization.in
 $(PROJECT_DIR)/Shared/WebsiteData/WebsiteDataType.serialization.in
 $(PROJECT_DIR)/Shared/WebsiteDataStoreParameters.serialization.in
 $(PROJECT_DIR)/Shared/WebsitePoliciesData.serialization.in
+$(PROJECT_DIR)/Shared/XR/PlatformXR.serialization.in
 $(PROJECT_DIR)/Shared/XR/XRSystem.serialization.in
 $(PROJECT_DIR)/Shared/cf/CFTypes.serialization.in
 $(PROJECT_DIR)/Shared/cf/CoreIPCBoolean.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -725,6 +725,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/WebGPU/WebGPUBlendState.serialization.in \
 	Shared/WebGPU/WebGPUBlendComponent.serialization.in \
 	Shared/WebGPU/WebGPUBindGroupEntry.serialization.in \
+	Shared/XR/PlatformXR.serialization.in \
 	Shared/XR/XRSystem.serialization.in \
 	Shared/WebUserContentControllerDataTypes.serialization.in \
 	WebProcess/GPU/GPUProcessConnectionInfo.serialization.in \

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -746,7 +746,7 @@ def headers_for_type(type):
         'MonotonicTime': ['<wtf/MonotonicTime.h>'],
         'PAL::SessionID': ['<pal/SessionID.h>'],
         'PAL::UserInterfaceIdiom': ['<pal/system/ios/UserInterfaceIdiom.h>'],
-        'PlatformXR::Device::FrameData': ['<WebCore/PlatformXR.h>'],
+        'PlatformXR::FrameData': ['<WebCore/PlatformXR.h>'],
         'PlatformXR::ReferenceSpaceType': ['<WebCore/PlatformXR.h>'],
         'PlatformXR::SessionFeature': ['<WebCore/PlatformXR.h>'],
         'PlatformXR::SessionMode': ['<WebCore/PlatformXR.h>'],

--- a/Source/WebKit/Shared/XR/PlatformXR.serialization.in
+++ b/Source/WebKit/Shared/XR/PlatformXR.serialization.in
@@ -1,0 +1,161 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE(WEBXR)
+
+enum class PlatformXR::SessionFeature : uint8_t {
+    ReferenceSpaceTypeViewer,
+    ReferenceSpaceTypeLocal,
+    ReferenceSpaceTypeLocalFloor,
+    ReferenceSpaceTypeBoundedFloor,
+    ReferenceSpaceTypeUnbounded,
+#if ENABLE(WEBXR_HANDS)
+    HandTracking,
+#endif
+};
+
+enum class PlatformXR::SessionMode : uint8_t {
+    Inline,
+    ImmersiveVr,
+    ImmersiveAr,
+};
+
+enum class PlatformXR::ReferenceSpaceType : uint8_t {
+    Viewer,
+    Local,
+    LocalFloor,
+    BoundedFloor,
+    Unbounded
+};
+
+enum class PlatformXR::VisibilityState : uint8_t {
+    Visible,
+    VisibleBlurred,
+    Hidden
+};
+
+enum class PlatformXR::XRHandedness : uint8_t {
+    None,
+    Left,
+    Right,
+};
+
+enum class PlatformXR::XRTargetRayMode : uint8_t {
+    Gaze,
+    TrackedPointer,
+    Screen,
+    TransientPointer,
+};
+
+[Nested] struct PlatformXR::FrameData::FloatQuaternion {
+    float x;
+    float y;
+    float z;
+    float w;
+};
+
+[Nested] struct PlatformXR::FrameData::Pose {
+    WebCore::FloatPoint3D position;
+    PlatformXR::FrameData::FloatQuaternion orientation;
+};
+
+[Nested] struct PlatformXR::FrameData::Fov {
+    float up;
+    float down;
+    float left;
+    float right;
+};
+
+[Nested] struct PlatformXR::FrameData::View {
+    PlatformXR::FrameData::Pose offset;
+    PlatformXR::FrameData::Projection projection;
+};
+
+[Nested] struct PlatformXR::FrameData::StageParameters {
+    int id;
+    Vector<WebCore::FloatPoint> bounds;
+};
+
+[Nested, RValue] struct PlatformXR::FrameData::LayerData {
+#if PLATFORM(COCOA)
+    std::tuple<MachSendRight, bool> colorTexture;
+    std::tuple<MachSendRight, bool> depthStencilBuffer;
+    std::tuple<MachSendRight, uint64_t> completionSyncEvent;
+#else
+    PlatformGLObject opaqueTexture;
+#endif
+};
+
+[Nested] struct PlatformXR::FrameData::InputSourceButton {
+    bool touched;
+    bool pressed;
+    float pressedValue;
+};
+
+[Nested] struct PlatformXR::FrameData::InputSourcePose {
+    PlatformXR::FrameData::Pose pose;
+    bool isPositionEmulated;
+};
+
+#endif
+
+#if ENABLE(WEBXR_HANDS)
+
+[Nested] struct PlatformXR::FrameData::InputSourceHandJoint {
+    PlatformXR::FrameData::InputSourcePose pose;
+    float radius;
+};
+
+#endif
+
+#if ENABLE(WEBXR)
+
+[Nested] struct PlatformXR::FrameData::InputSource {
+    int handle;
+    PlatformXR::XRHandedness handeness;
+    PlatformXR::XRTargetRayMode targetRayMode;
+    Vector<String> profiles;
+    PlatformXR::FrameData::InputSourcePose pointerOrigin;
+    std::optional<PlatformXR::FrameData::InputSourcePose> gripOrigin;
+    Vector<PlatformXR::FrameData::InputSourceButton> buttons;
+    Vector<float> axes;
+#if ENABLE(WEBXR_HANDS)
+    std::optional<PlatformXR::FrameData::HandJointsVector> handJoints;
+#endif
+};
+
+header: <WebCore/PlatformXR.h>
+[CustomHeader, RValue] struct PlatformXR::FrameData {
+    bool isTrackingValid;
+    bool isPositionValid;
+    bool isPositionEmulated;
+    bool shouldRender;
+    long predictedDisplayTime;
+    PlatformXR::FrameData::Pose origin;
+    std::optional<PlatformXR::FrameData::Pose> floorTransform;
+    PlatformXR::FrameData::StageParameters stageParameters;
+    Vector<PlatformXR::FrameData::View> views;
+    HashMap<PlatformXR::LayerHandle, PlatformXR::FrameData::LayerData> layers;
+    Vector<PlatformXR::FrameData::InputSource> inputSources;
+};
+
+#endif

--- a/Source/WebKit/Shared/XR/XRSystem.serialization.in
+++ b/Source/WebKit/Shared/XR/XRSystem.serialization.in
@@ -21,49 +21,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #if ENABLE(WEBXR)
-enum class PlatformXR::SessionFeature : uint8_t {
-    ReferenceSpaceTypeViewer,
-    ReferenceSpaceTypeLocal,
-    ReferenceSpaceTypeLocalFloor,
-    ReferenceSpaceTypeBoundedFloor,
-    ReferenceSpaceTypeUnbounded,
-#if ENABLE(WEBXR_HANDS)
-    HandTracking,
-#endif
-};
-
-enum class PlatformXR::SessionMode : uint8_t {
-    Inline,
-    ImmersiveVr,
-    ImmersiveAr,
-};
-
-[Nested] enum class PlatformXR::ReferenceSpaceType : uint8_t {
-    Viewer,
-    Local,
-    LocalFloor,
-    BoundedFloor,
-    Unbounded
-};
-
-enum class PlatformXR::VisibilityState : uint8_t {
-    Visible,
-    VisibleBlurred,
-    Hidden
-};
-
-enum class PlatformXR::XRHandedness : uint8_t {
-    None,
-    Left,
-    Right,
-};
-
-enum class PlatformXR::XRTargetRayMode : uint8_t {
-    Gaze,
-    TrackedPointer,
-    Screen,
-    TransientPointer,
-};
 
 struct WebKit::XRDeviceInfo {
     WebKit::XRDeviceIdentifier identifier;
@@ -73,4 +30,5 @@ struct WebKit::XRDeviceInfo {
     PlatformXR::Device::FeatureList arFeatures;
     WebCore::IntSize recommendedResolution;
 };
+
 #endif

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp
@@ -111,7 +111,7 @@ void PlatformXRSystem::shutDownTrackingAndRendering()
         xrCoordinator->endSessionIfExists(m_page);
 }
 
-void PlatformXRSystem::requestFrame(CompletionHandler<void(PlatformXR::Device::FrameData&&)>&& completionHandler)
+void PlatformXRSystem::requestFrame(CompletionHandler<void(PlatformXR::FrameData&&)>&& completionHandler)
 {
     if (auto* xrCoordinator = PlatformXRSystem::xrCoordinator())
         xrCoordinator->scheduleAnimationFrame(m_page, WTFMove(completionHandler));

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.h
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.h
@@ -70,7 +70,7 @@ private:
     void requestPermissionOnSessionFeatures(const WebCore::SecurityOriginData&, PlatformXR::SessionMode, const PlatformXR::Device::FeatureList&, const PlatformXR::Device::FeatureList&, const PlatformXR::Device::FeatureList&, const PlatformXR::Device::FeatureList&, const PlatformXR::Device::FeatureList&, CompletionHandler<void(std::optional<PlatformXR::Device::FeatureList>&&)>&&);
     void initializeTrackingAndRendering(const WebCore::SecurityOriginData&, PlatformXR::SessionMode, const PlatformXR::Device::FeatureList&);
     void shutDownTrackingAndRendering();
-    void requestFrame(CompletionHandler<void(PlatformXR::Device::FrameData&&)>&&);
+    void requestFrame(CompletionHandler<void(PlatformXR::FrameData&&)>&&);
     void submitFrame();
 
     // PlatformXRCoordinator::SessionEventClient

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.messages.in
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.messages.in
@@ -30,7 +30,7 @@ messages -> PlatformXRSystem NotRefCounted {
     RequestPermissionOnSessionFeatures(WebCore::SecurityOriginData origin, PlatformXR::SessionMode mode, Vector<PlatformXR::SessionFeature> granted, Vector<PlatformXR::SessionFeature> consentRequired, Vector<PlatformXR::SessionFeature> consentOptional, Vector<PlatformXR::SessionFeature> requiredFeaturesRequested, Vector<PlatformXR::SessionFeature> optionalFeaturesRequested) -> (std::optional<Vector<PlatformXR::SessionFeature>> userGranted)
     InitializeTrackingAndRendering(WebCore::SecurityOriginData origin, PlatformXR::SessionMode mode, Vector<PlatformXR::SessionFeature> requestedFeatures)
     ShutDownTrackingAndRendering()
-    RequestFrame() -> (struct PlatformXR::Device::FrameData frameData)
+    RequestFrame() -> (struct PlatformXR::FrameData frameData)
     SubmitFrame()
 }
 

--- a/Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.mm
+++ b/Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.mm
@@ -266,7 +266,7 @@ void ARKitCoordinator::renderLoop(Box<RenderState> active)
             ARFrame* frame = presentationSession.currentFrame;
             ARCamera* camera = frame.camera;
 
-            PlatformXR::Device::FrameData frameData = { };
+            PlatformXR::FrameData frameData = { };
             // FIXME: Use ARSession state to calculate correct values.
             frameData.isTrackingValid = true;
             frameData.isPositionValid = true;
@@ -290,7 +290,7 @@ void ARKitCoordinator::renderLoop(Box<RenderState> active)
             auto completionPort = MachSendRight::create([completionHandle.get() eventPort]);
 
             // FIXME: rdar://77858090 (Need to transmit color space information)
-            frameData.layers.set(defaultLayerHandle(), PlatformXR::Device::FrameData::LayerData {
+            frameData.layers.set(defaultLayerHandle(), PlatformXR::FrameData::LayerData {
                 .colorTexture = WTFMove(colorTexture),
                 .completionSyncEvent = { MachSendRight(completionPort), renderingFrameIndex }
             });

--- a/Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.h
+++ b/Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.h
@@ -53,7 +53,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (atomic, readonly, getter=isSessionEndRequested) BOOL sessionEndRequested;
 
 - (NSUInteger)startFrame;
-- (Vector<PlatformXR::Device::FrameData::InputSource>)collectInputSources;
+- (Vector<PlatformXR::FrameData::InputSource>)collectInputSources;
 - (void)present;
 - (void)terminate;
 @end

--- a/Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.mm
+++ b/Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.mm
@@ -29,11 +29,11 @@
 #if ENABLE(WEBXR) && USE(ARKITXR_IOS)
 
 #import "Logging.h"
-#import "PlatformXRPose.h"
 #import "WKExtrinsicButton.h"
 
 #import <Metal/Metal.h>
 #import <WebCore/PlatformXR.h>
+#import <WebCore/PlatformXRPose.h>
 #import <wtf/OSObjectPtr.h>
 #import <wtf/RunLoop.h>
 #import <wtf/WeakObjCPtr.h>
@@ -114,7 +114,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface _WKTransientGestureRecognizer : UIGestureRecognizer
 - (nullable instancetype)initWithSession:(_WKARPresentationSession *)session;
-- (Vector<PlatformXR::Device::FrameData::InputSource>)collectInputSources;
+- (Vector<PlatformXR::FrameData::InputSource>)collectInputSources;
 @end
 
 #pragma mark - _WKARPresentationSession implementation
@@ -207,7 +207,7 @@ NS_ASSUME_NONNULL_BEGIN
     return 1;
 }
 
-- (Vector<PlatformXR::Device::FrameData::InputSource>)collectInputSources
+- (Vector<PlatformXR::FrameData::InputSource>)collectInputSources
 {
     return [_touchGestureRecognizer collectInputSources];
 }
@@ -494,7 +494,7 @@ id<WKARPresentationSession> createPresesentationSession(ARSession *session, WKAR
 
 #pragma mark - Input sources collection
 
-- (std::optional<PlatformXR::Device::FrameData::InputSource>)_platformXRInputSourceFromTransientAction:(_WKTransientAction *)transientAction actionIdentifier:(int)actionIdentifier
+- (std::optional<PlatformXR::FrameData::InputSource>)_platformXRInputSourceFromTransientAction:(_WKTransientAction *)transientAction actionIdentifier:(int)actionIdentifier
 {
     dispatch_assert_queue(_accessQueue.get());
 
@@ -502,7 +502,7 @@ id<WKARPresentationSession> createPresesentationSession(ARSession *session, WKAR
     PlatformXRPose targetRay(simd_mul(multiplier, transientAction.targetRay));
     PlatformXRPose pose(transientAction.pose);
 
-    PlatformXR::Device::FrameData::InputSource data;
+    PlatformXR::FrameData::InputSource data;
     data.handeness = PlatformXR::XRHandedness::None;
     data.handle = actionIdentifier;
     data.profiles = Vector<String> { "generic-button-invisible"_s, "generic-button"_s };
@@ -511,12 +511,12 @@ id<WKARPresentationSession> createPresesentationSession(ARSession *session, WKAR
     data.pointerOrigin.pose = targetRay.pose();
     data.pointerOrigin.isPositionEmulated = false;
 
-    PlatformXR::Device::FrameData::InputSourcePose gripPose;
+    PlatformXR::FrameData::InputSourcePose gripPose;
     gripPose.pose = pose.pose();
     gripPose.isPositionEmulated = false;
     data.gripOrigin = gripPose;
 
-    PlatformXR::Device::FrameData::InputSourceButton button;
+    PlatformXR::FrameData::InputSourceButton button;
     button.pressed = true;
     button.touched = true;
     button.pressedValue = 1.0;
@@ -525,9 +525,9 @@ id<WKARPresentationSession> createPresesentationSession(ARSession *session, WKAR
     return data;
 }
 
-- (Vector<PlatformXR::Device::FrameData::InputSource>)collectInputSources
+- (Vector<PlatformXR::FrameData::InputSource>)collectInputSources
 {
-    __block Vector<PlatformXR::Device::FrameData::InputSource> result;
+    __block Vector<PlatformXR::FrameData::InputSource> result;
 
     dispatch_sync(_accessQueue.get(), ^{
         [_transientActions enumerateKeysAndObjectsUsingBlock:^(NSNumber *id, _WKTransientAction *transientAction, BOOL*) {

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -4794,6 +4794,7 @@
 		3A18A2F02AFF006C00DB976C /* _WKArchiveConfiguration.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKArchiveConfiguration.mm; sourceTree = "<group>"; };
 		3A18A2F22B02969800DB976C /* _WKArchiveExclusionRule.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKArchiveExclusionRule.mm; sourceTree = "<group>"; };
 		3A18A2F32B02969800DB976C /* _WKArchiveExclusionRule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKArchiveExclusionRule.h; sourceTree = "<group>"; };
+		3A26F82D2B258CEF00FEB1B0 /* PlatformXR.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = PlatformXR.serialization.in; sourceTree = "<group>"; };
 		3A5B68962AC266D400B11868 /* WKARPresentationSession.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKARPresentationSession.h; sourceTree = "<group>"; };
 		3A5B68972AC266D400B11868 /* WKARPresentationSession.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKARPresentationSession.mm; sourceTree = "<group>"; };
 		3A7D62D229D35D9D00D57DAC /* WebSWRegistrationStore.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebSWRegistrationStore.cpp; sourceTree = "<group>"; };
@@ -8372,6 +8373,7 @@
 		118502602673B0DA00A6425E /* XR */ = {
 			isa = PBXGroup;
 			children = (
+				3A26F82D2B258CEF00FEB1B0 /* PlatformXR.serialization.in */,
 				118502632673B0DA00A6425E /* XRDeviceIdentifier.h */,
 				118502652673B0DA00A6425E /* XRDeviceInfo.h */,
 				118502622673B0DA00A6425E /* XRDeviceProxy.cpp */,


### PR DESCRIPTION
#### 9a4085b2914ed55f4dd95684333d61c8511faa14
<pre>
[WebXR] Port PlatformXR::FrameData to new serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=266202">https://bugs.webkit.org/show_bug.cgi?id=266202</a>
<a href="https://rdar.apple.com/119474838">rdar://119474838</a>

Reviewed by Brady Eidson.

Port PlatformXR::FrameData and it&apos;s related member structs to use automatically
generated IPC serialization and remove the explicit encode/decode functions.

Due to constraints imposed by generate-serializers.py,
PlatformXR::Device::FrameData has been moved to PlatformXR::FrameData.

* Source/WebCore/Modules/webxr/WebXRFrame.cpp:
(WebCore::WebXRFrame::getViewerPose):
(WebCore::WebXRFrame::matrixFromPose):
* Source/WebCore/Modules/webxr/WebXRFrame.h:
* Source/WebCore/Modules/webxr/WebXRGamepad.cpp:
(WebCore::WebXRGamepad::WebXRGamepad):
* Source/WebCore/Modules/webxr/WebXRGamepad.h:
* Source/WebCore/Modules/webxr/WebXRHand.cpp:
(WebCore::WebXRHand::updateFromInputSource):
* Source/WebCore/Modules/webxr/WebXRHand.h:
* Source/WebCore/Modules/webxr/WebXRInputSource.cpp:
(WebCore::WebXRInputSource::create):
(WebCore::WebXRInputSource::WebXRInputSource):
(WebCore::WebXRInputSource::update):
* Source/WebCore/Modules/webxr/WebXRInputSource.h:
* Source/WebCore/Modules/webxr/WebXRInputSourceArray.h:
* Source/WebCore/Modules/webxr/WebXRInputSpace.cpp:
(WebCore::WebXRInputSpace::create):
(WebCore::WebXRInputSpace::WebXRInputSpace):
* Source/WebCore/Modules/webxr/WebXRInputSpace.h:
(WebCore::WebXRInputSpace::setPose):
* Source/WebCore/Modules/webxr/WebXRJointSpace.cpp:
(WebCore::WebXRJointSpace::create):
(WebCore::WebXRJointSpace::WebXRJointSpace):
(WebCore::WebXRJointSpace::updateFromJoint):
* Source/WebCore/Modules/webxr/WebXRJointSpace.h:
* Source/WebCore/Modules/webxr/WebXRLayer.h:
* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp:
(WebCore::WebXROpaqueFramebuffer::startFrame):
* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h:
* Source/WebCore/Modules/webxr/WebXRSession.cpp:
(WebCore::WebXRSession::sessionDidInitializeInputSources):
(WebCore::WebXRSession::onFrame):
* Source/WebCore/Modules/webxr/WebXRSession.h:
* Source/WebCore/Modules/webxr/WebXRSystem.cpp:
(WebCore::WebXRSystem::DummyInlineDevice::requestFrame):
* Source/WebCore/Modules/webxr/WebXRWebGLLayer.cpp:
(WebCore::WebXRWebGLLayer::startFrame):
* Source/WebCore/Modules/webxr/WebXRWebGLLayer.h:
* Source/WebCore/platform/xr/PlatformXR.h:
(PlatformXR::FrameData::copy const):
(PlatformXR::Device::FrameData::FloatQuaternion::encode const): Deleted.
(PlatformXR::Device::FrameData::FloatQuaternion::decode): Deleted.
(PlatformXR::Device::FrameData::Pose::encode const): Deleted.
(PlatformXR::Device::FrameData::Pose::decode): Deleted.
(PlatformXR::Device::FrameData::Fov::encode const): Deleted.
(PlatformXR::Device::FrameData::Fov::decode): Deleted.
(PlatformXR::Device::FrameData::View::encode const): Deleted.
(PlatformXR::Device::FrameData::View::decode): Deleted.
(PlatformXR::Device::FrameData::StageParameters::encode const): Deleted.
(PlatformXR::Device::FrameData::StageParameters::decode): Deleted.
(PlatformXR::Device::FrameData::LayerData::encode const): Deleted.
(PlatformXR::Device::FrameData::LayerData::decode): Deleted.
(PlatformXR::Device::FrameData::InputSourceButton::encode const): Deleted.
(PlatformXR::Device::FrameData::InputSourceButton::decode): Deleted.
(PlatformXR::Device::FrameData::InputSourcePose::encode const): Deleted.
(PlatformXR::Device::FrameData::InputSourcePose::decode): Deleted.
(PlatformXR::Device::FrameData::InputSourceHandJoint::encode const): Deleted.
(PlatformXR::Device::FrameData::InputSourceHandJoint::decode): Deleted.
(PlatformXR::Device::FrameData::InputSource::encode const): Deleted.
(PlatformXR::Device::FrameData::InputSource::decode): Deleted.
(PlatformXR::Device::FrameData::encode const): Deleted.
(PlatformXR::Device::FrameData::decode): Deleted.
(PlatformXR::Device::FrameData::copy const): Deleted.
* Source/WebCore/platform/xr/cocoa/PlatformXRPose.cpp:
(PlatformXRPose::orientation const):
(PlatformXRPose::pose const):
* Source/WebCore/platform/xr/cocoa/PlatformXRPose.h:
* Source/WebCore/platform/xr/openxr/OpenXRInput.cpp:
(PlatformXR::OpenXRInput::collectInputSources const):
* Source/WebCore/platform/xr/openxr/OpenXRInput.h:
* Source/WebCore/platform/xr/openxr/OpenXRInputSource.cpp:
(PlatformXR::OpenXRInputSource::getInputSource const):
(PlatformXR::OpenXRInputSource::getPose const):
(PlatformXR::OpenXRInputSource::getButton const):
* Source/WebCore/platform/xr/openxr/OpenXRInputSource.h:
* Source/WebCore/platform/xr/openxr/OpenXRLayer.cpp:
(PlatformXR::OpenXRLayerProjection::startFrame):
* Source/WebCore/platform/xr/openxr/OpenXRLayer.h:
* Source/WebCore/platform/xr/openxr/OpenXRUtils.h:
(PlatformXR::XrPosefToPose):
(PlatformXR::xrViewToPose):
* Source/WebCore/platform/xr/openxr/PlatformXROpenXR.cpp:
(PlatformXR::OpenXRDevice::requestFrame):
* Source/WebCore/platform/xr/openxr/PlatformXROpenXR.h:
* Source/WebCore/testing/WebFakeXRDevice.cpp:
(WebCore::FakeXRView::setFieldOfView):
(WebCore::SimulatedXRDevice::setViews):
(WebCore::SimulatedXRDevice::setViewerOrigin):
(WebCore::SimulatedXRDevice::frameTimerFired):
(WebCore::WebFakeXRDevice::setViews):
(WebCore::WebFakeXRDevice::parseRigidTransform):
* Source/WebCore/testing/WebFakeXRDevice.h:
* Source/WebCore/testing/WebFakeXRInputController.cpp:
* Source/WebCore/testing/WebFakeXRInputController.h:
* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/Shared/XR/PlatformXR.serialization.in: Added.
* Source/WebKit/Shared/XR/XRSystem.serialization.in:
* Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp:
(WebKit::PlatformXRSystem::requestFrame):
* Source/WebKit/UIProcess/XR/PlatformXRSystem.h:
* Source/WebKit/UIProcess/XR/PlatformXRSystem.messages.in:
* Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.mm:
(WebKit::ARKitCoordinator::renderLoop):
* Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.h:
* Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.mm:
(-[_WKARPresentationSession collectInputSources]):
(-[_WKTransientGestureRecognizer _platformXRInputSourceFromTransientAction:actionIdentifier:]):
(-[_WKTransientGestureRecognizer collectInputSources]):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/271912@main">https://commits.webkit.org/271912@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/170f0e167b41a677e55770bdb5a64d24b87aa158

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30040 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8702 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31350 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32538 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27153 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30700 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10894 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5952 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27185 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30334 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7293 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25613 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6225 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/30192 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6382 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26705 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33873 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27388 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27138 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32563 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6327 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4496 "Found 2 new test failures: fullscreen/full-screen-layer-dump.html, imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/clip-path-content-use-007.svg (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30361 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8076 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7113 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7079 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6854 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->