### PR TITLE
[WTF] Distinguish SerialFunctionDispatcher that are refcounted and guarantee that the function will be run.

### DIFF
--- a/Source/WTF/wtf/FunctionDispatcher.h
+++ b/Source/WTF/wtf/FunctionDispatcher.h
@@ -48,6 +48,13 @@ public:
     virtual bool isCurrent() const = 0;
 };
 
+// A RefCountedSerialFunctionDispatcher guarantees that a dispatched function will always be run.
+class RefCountedSerialFunctionDispatcher : public SerialFunctionDispatcher {
+public:
+    virtual void ref() const = 0;
+    virtual void deref() const = 0;
+};
+
 inline void assertIsCurrent(const SerialFunctionDispatcher& queue) WTF_ASSERTS_ACQUIRED_CAPABILITY(queue)
 {
     ASSERT(queue.isCurrent());
@@ -60,3 +67,4 @@ inline void assertIsCurrent(const SerialFunctionDispatcher& queue) WTF_ASSERTS_A
 
 using WTF::FunctionDispatcher;
 using WTF::SerialFunctionDispatcher;
+using WTF::RefCountedSerialFunctionDispatcher;

--- a/Source/WTF/wtf/RunLoop.h
+++ b/Source/WTF/wtf/RunLoop.h
@@ -72,7 +72,7 @@ using RunLoopMode = unsigned;
 #define DefaultRunLoopMode 0
 #endif
 
-class WTF_CAPABILITY("is current") RunLoop final : public SerialFunctionDispatcher, public ThreadSafeRefCounted<RunLoop> {
+class WTF_CAPABILITY("is current") RunLoop final : public RefCountedSerialFunctionDispatcher, public ThreadSafeRefCounted<RunLoop> {
     WTF_MAKE_NONCOPYABLE(RunLoop);
 public:
     // Must be called from the main thread.
@@ -90,7 +90,9 @@ public:
     WTF_EXPORT_PRIVATE static Ref<RunLoop> create(const char* threadName, ThreadType = ThreadType::Unknown, Thread::QOS = Thread::QOS::UserInitiated);
 
     static bool isMain() { return main().isCurrent(); }
-    WTF_EXPORT_PRIVATE bool isCurrent() const;
+    void ref() const final { ThreadSafeRefCounted::ref(); }
+    void deref() const final { ThreadSafeRefCounted::deref(); }
+    WTF_EXPORT_PRIVATE bool isCurrent() const final;
     WTF_EXPORT_PRIVATE ~RunLoop() final;
 
     WTF_EXPORT_PRIVATE void dispatch(Function<void()>&&) final;

--- a/Source/WTF/wtf/WorkQueue.cpp
+++ b/Source/WTF/wtf/WorkQueue.cpp
@@ -202,6 +202,16 @@ bool WorkQueue::isCurrent() const
     return currentSequence() == m_threadID;
 }
 
+void WorkQueue::ref() const
+{
+    ThreadSafeRefCounted::ref();
+}
+
+void WorkQueue::deref() const
+{
+    ThreadSafeRefCounted::deref();
+}
+
 ConcurrentWorkQueue::ConcurrentWorkQueue(const char* name, QOS qos)
     : WorkQueueBase(name, Type::Concurrent, qos)
 {

--- a/Source/WTF/wtf/WorkQueue.h
+++ b/Source/WTF/wtf/WorkQueue.h
@@ -86,12 +86,15 @@ private:
  * They may be executed on different threads but can safely be used by objects that aren't already threadsafe.
  * Use `assertIsCurrent(m_myQueue);` in a runnable to assert that the runnable runs in a specific queue.
  */
-class WTF_CAPABILITY("is current") WTF_EXPORT_PRIVATE WorkQueue : public WorkQueueBase, public SerialFunctionDispatcher {
+class WTF_CAPABILITY("is current") WTF_EXPORT_PRIVATE WorkQueue : public WorkQueueBase, public RefCountedSerialFunctionDispatcher {
 public:
     static WorkQueue& main();
     static Ref<WorkQueue> create(const char* name, QOS = QOS::Default);
     void dispatch(Function<void()>&&) override;
     bool isCurrent() const override;
+    void ref() const override;
+    void deref() const override;
+
 #if !USE(COCOA_EVENT_LOOP)
     RunLoop& runLoop() const { return *m_runLoop; }
 #endif


### PR DESCRIPTION
#### cfe5a3b9ba53fba674b45ad476a8a5c8bbfaea95
<pre>
[WTF] Distinguish SerialFunctionDispatcher that are refcounted and guarantee that the function will be run.
<a href="https://bugs.webkit.org/show_bug.cgi?id=266199">https://bugs.webkit.org/show_bug.cgi?id=266199</a>
<a href="https://rdar.apple.com/119476929">rdar://119476929</a>

Reviewed by Youenn Fablet.

A SerialFunctionDispatcher has an explicit lifetime, while most implementations
are ref-counted, their API contract do not guarantee that a dispatched function would
be run (such as a WorkerThread that can be stopped at any time).

To distinguish those, we create a RefCountedSerialFunctionDispatcher, that is both
refcounted and that has an API contract lifetime that matches its owner.

For now, only WorkQueue and RunLoop satisfy the requirement.

NativePromise is modified to take this type as the NativePromise API contract
requires that the settled method be called.

No change in observable behaviour.

* Source/WTF/wtf/FunctionDispatcher.h:
* Source/WTF/wtf/NativePromise.h:
* Source/WTF/wtf/RunLoop.h:
* Source/WTF/wtf/WorkQueue.cpp:
(WTF::WorkQueue::ref const):
(WTF::WorkQueue::deref const):
* Source/WTF/wtf/WorkQueue.h:

Canonical link: <a href="https://commits.webkit.org/271860@main">https://commits.webkit.org/271860@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c186e5740873220c2ed42d52b8ca3d24b5557ce8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29878 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8543 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31195 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32391 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27019 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10726 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5804 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27086 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30171 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7159 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25491 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6110 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6280 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26579 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33726 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/25663 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27255 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27004 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32452 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/30057 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6197 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4389 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30238 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7940 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/36448 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7080 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6945 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7867 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6725 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->