### PR TITLE
REGRESSION(271747@main): [Win][GPUP] Rendering artifact of repainting a window

### DIFF
--- a/LayoutTests/platform/wincairo/TestExpectations
+++ b/LayoutTests/platform/wincairo/TestExpectations
@@ -2725,5 +2725,3 @@ imported/w3c/web-platform-tests/scroll-animations/view-timelines/animation-event
 webkit.org/b/48997 animations/animation-iteration-event-destroy-renderer.html [ Pass Timeout ]
 
 webkit.org/b/229584 animations/fill-mode-forwards.html [ Pass Failure Timeout ]
-
-webkit.org/b/266163 fast/transforms/interleaved-2d-transforms-with-gpu-process.html [ Pass ImageOnlyFailure ]

--- a/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.cpp
+++ b/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.cpp
@@ -210,22 +210,6 @@ void DrawingAreaWC::triggerRenderingUpdate()
     m_updateRenderingTimer.startOneShot(0_s);
 }
 
-static Vector<std::unique_ptr<WebCore::ThreadSafeImageBufferFlusher>> createLayerImageBufferFlushers(WCUpdateInfo& info)
-{
-    Vector<std::unique_ptr<WebCore::ThreadSafeImageBufferFlusher>> flushers;
-    for (auto& layerInfo : info.changedLayers) {
-        if (layerInfo.changes & WCLayerChange::Background) {
-            for (auto& tileUpdate : layerInfo.tileUpdate) {
-                if (auto image = tileUpdate.backingStore.imageBuffer()) {
-                    if (auto flusher = image->createFlusher())
-                        flushers.append(WTFMove(flusher));
-                }
-            }
-        }
-    }
-    return flushers;
-}
-
 bool DrawingAreaWC::isCompositingMode()
 {
     auto& mainWebFrame = m_webPage->mainWebFrame();
@@ -292,25 +276,16 @@ void DrawingAreaWC::sendUpdateAC()
         if (rootLayer.viewOverlayRootLayer)
             rootLayer.viewOverlayRootLayer->flushCompositingState(visibleRect);
 
-        auto flushers = createLayerImageBufferFlushers(m_updateInfo);
-
-        m_commitQueue->dispatch([this, weakThis = WeakPtr(*this), stateID = m_backingStoreStateID, updateInfo = std::exchange(m_updateInfo, { }), flushers = WTFMove(flushers), willCallDisplayDidRefresh]() mutable {
-            WTF::forEach(flushers, [](auto& flusher) { flusher->flush(); });
-            RunLoop::main().dispatch([this, weakThis = WTFMove(weakThis), stateID, updateInfo = WTFMove(updateInfo), willCallDisplayDidRefresh]() mutable {
-                if (!weakThis)
-                    return;
-                m_remoteWCLayerTreeHostProxy->update(WTFMove(updateInfo), [this, weakThis = WTFMove(weakThis), stateID, willCallDisplayDidRefresh](std::optional<UpdateInfo> updateInfo) {
-                    if (!weakThis)
-                        return;
-                    if (updateInfo && stateID == m_backingStoreStateID) {
-                        ASSERT(willCallDisplayDidRefresh);
-                        send(Messages::DrawingAreaProxy::Update(m_backingStoreStateID, WTFMove(*updateInfo)));
-                        return;
-                    }
-                    if (willCallDisplayDidRefresh)
-                        displayDidRefresh();
-                });
-            });
+        m_remoteWCLayerTreeHostProxy->update(std::exchange(m_updateInfo, { }), [this, weakThis = WeakPtr(*this), stateID = m_backingStoreStateID, willCallDisplayDidRefresh](std::optional<UpdateInfo> updateInfo) {
+            if (!weakThis)
+                return;
+            if (updateInfo && stateID == m_backingStoreStateID) {
+                ASSERT(willCallDisplayDidRefresh);
+                send(Messages::DrawingAreaProxy::Update(m_backingStoreStateID, WTFMove(*updateInfo)));
+                return;
+            }
+            if (willCallDisplayDidRefresh)
+                displayDidRefresh();
         });
     }
 }
@@ -370,29 +345,15 @@ void DrawingAreaWC::sendUpdateNonAC()
     graphicsContext.translate(-bounds.x(), -bounds.y());
     for (const auto& rect : rects)
         webPage->drawRect(image->context(), rect);
-    image->flushDrawingContextAsync();
-    auto flusher = image->createFlusher();
+    image->flushDrawingContext();
 
-    m_commitQueue->dispatch([this, weakThis = WeakPtr(*this), stateID = m_backingStoreStateID, updateInfo = WTFMove(updateInfo), image = WTFMove(image), flusher = WTFMove(flusher)]() mutable {
-        if (flusher)
-            flusher->flush();
-        RunLoop::main().dispatch([this, weakThis = WTFMove(weakThis), stateID, updateInfo = WTFMove(updateInfo), image = WTFMove(image)]() mutable {
-            if (!weakThis)
-                return;
-            if (stateID != m_backingStoreStateID) {
-                displayDidRefresh();
-                return;
-            }
+    auto* sharing = image->toBackendSharing();
+    if (is<ImageBufferBackendHandleSharing>(sharing)) {
+        if (auto handle = downcast<ImageBufferBackendHandleSharing>(*sharing).createBackendHandle())
+            updateInfo.bitmapHandle = std::get<ShareableBitmap::Handle>(WTFMove(*handle));
+    }
 
-            auto* sharing = image->toBackendSharing();
-            if (is<ImageBufferBackendHandleSharing>(sharing)) {
-                if (auto handle = downcast<ImageBufferBackendHandleSharing>(*sharing).createBackendHandle())
-                    updateInfo.bitmapHandle = std::get<ShareableBitmap::Handle>(WTFMove(*handle));
-            }
-
-            send(Messages::DrawingAreaProxy::Update(stateID, WTFMove(updateInfo)));
-        });
-    });
+    send(Messages::DrawingAreaProxy::Update(m_backingStoreStateID, WTFMove(updateInfo)));
 }
 
 void DrawingAreaWC::graphicsLayerAdded(GraphicsLayerWC& layer)


### PR DESCRIPTION
#### b1bfde1c5473b914bde5413fd0fe63c33e71f4d8
<pre>
REGRESSION(271747@main): [Win][GPUP] Rendering artifact of repainting a window
<a href="https://bugs.webkit.org/show_bug.cgi?id=266165">https://bugs.webkit.org/show_bug.cgi?id=266165</a>

Reviewed by Kimmo Kinnunen.

After 271747@main removed RemoteImageBufferProxy::createFlusher
implementation, repainting a window caused a rendering artifact for
non-AC mode of Windows port.

Use syncronous ImageBuffer::flushDrawingContext intead of asyncronous
flushDrawingContextAsync for non-AC mode.

In AC mode, the compositor is running in GPU process on Windows port.
They don&apos;t need to wait for RemoteImageBuffer flush because the flush
finishes when a message to the compositor arrives at GPU process.

* LayoutTests/platform/wincairo/TestExpectations:
* Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.cpp:

Canonical link: <a href="https://commits.webkit.org/271892@main">https://commits.webkit.org/271892@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a699092967860e06b597ddcbe0d0fbbcbe4e74d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29879 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8544 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31196 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32392 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27020 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10727 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5805 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27084 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30172 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7158 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25490 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6109 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6279 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26578 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33727 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27254 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27003 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32450 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6198 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4388 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30235 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7941 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6946 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3865 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6726 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->