### PR TITLE
More dynamicDowncast and RefPtr in WebCore/style

### DIFF
--- a/Source/WebCore/style/UserAgentStyle.cpp
+++ b/Source/WebCore/style/UserAgentStyle.cpp
@@ -215,12 +215,12 @@ void UserAgentStyle::ensureDefaultStyleSheetsForElement(const Element& element)
         }
 #endif // ENABLE(DATALIST_ELEMENT)
 #if ENABLE(INPUT_TYPE_COLOR)
-        else if (!colorInputStyleSheet && is<HTMLInputElement>(element) && downcast<HTMLInputElement>(element).isColorControl()) {
+        else if (RefPtr input = dynamicDowncast<HTMLInputElement>(element); !colorInputStyleSheet && input && input->isColorControl()) {
             colorInputStyleSheet = parseUASheet(RenderTheme::singleton().colorInputStyleSheet());
             addToDefaultStyle(*colorInputStyleSheet);
         }
 #endif // ENABLE(INPUT_TYPE_COLOR)
-        else if (!htmlSwitchControlStyleSheet && is<HTMLInputElement>(element) && downcast<HTMLInputElement>(element).isSwitch()) {
+        else if (RefPtr input = dynamicDowncast<HTMLInputElement>(element); !htmlSwitchControlStyleSheet && input && input->isSwitch()) {
             htmlSwitchControlStyleSheet = parseUASheet(StringImpl::createWithoutCopying(htmlSwitchControlUserAgentStyleSheet, sizeof(htmlSwitchControlUserAgentStyleSheet)));
             addToDefaultStyle(*htmlSwitchControlStyleSheet);
         }

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebFormManager.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebFormManager.cpp
@@ -193,11 +193,11 @@ gboolean webkit_web_form_manager_input_element_is_user_edited(JSCValue* element)
     g_return_val_if_fail(jsc_value_is_object(element), FALSE);
 
     auto* node = nodeForJSCValue(element);
-    if (is<HTMLInputElement>(node))
-        return downcast<HTMLInputElement>(*node).lastChangeWasUserEdit();
+    if (RefPtr input = dynamicDowncast<HTMLInputElement>(node))
+        return input->lastChangeWasUserEdit();
 
-    if (is<HTMLTextAreaElement>(node))
-        return downcast<HTMLTextAreaElement>(*node).lastChangeWasUserEdit();
+    if (RefPtr textarea = dynamicDowncast<HTMLTextAreaElement>(node))
+        return textarea->lastChangeWasUserEdit();
 
     return FALSE;
 }
@@ -219,12 +219,12 @@ void webkit_web_form_manager_input_element_auto_fill(JSCValue* element, const ch
     g_return_if_fail(jsc_value_is_object(element));
 
     auto* node = nodeForJSCValue(element);
-    if (!is<WebCore::HTMLInputElement>(node))
+    RefPtr input = dynamicDowncast<HTMLInputElement>(node);
+    if (!input)
         return;
 
-    auto& inputElement = downcast<WebCore::HTMLInputElement>(*node);
-    inputElement.setAutoFilled(true);
-    inputElement.setValueForUser(String::fromUTF8(value));
+    input->setAutoFilled(true);
+    input->setValueForUser(String::fromUTF8(value));
 }
 
 /**
@@ -244,5 +244,6 @@ gboolean webkit_web_form_manager_input_element_is_auto_filled(JSCValue* element)
     g_return_val_if_fail(jsc_value_is_object(element), FALSE);
 
     auto* node = nodeForJSCValue(element);
-    return is<WebCore::HTMLInputElement>(node) ? downcast<WebCore::HTMLInputElement>(*node).isAutoFilled() : FALSE;
+    RefPtr input = dynamicDowncast<HTMLInputElement>(node);
+    return input && input->isAutoFilled();
 }


### PR DESCRIPTION
#### bfcf7fa3af7e2a898dffe289be9549f3dc7853eb
<pre>
More dynamicDowncast and RefPtr in WebCore/style
<a href="https://bugs.webkit.org/show_bug.cgi?id=266208">https://bugs.webkit.org/show_bug.cgi?id=266208</a>

Reviewed by Chris Dumez.

This leaves one downcast in StyleAdjuster alone that is guarded by
ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION).

* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::shouldInheritTextDecorationsInEffect):
(WebCore::Style::Adjuster::adjust const):
(WebCore::Style::Adjuster::adjustForSiteSpecificQuirks const):
(WebCore::Style::isOutermostSVGElement): Deleted.
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::resolveElement):
(WebCore::Style::TreeResolver::pushParent):
(WebCore::Style::TreeResolver::resolveComposedTree):
* Source/WebCore/style/UserAgentStyle.cpp:
(WebCore::Style::UserAgentStyle::ensureDefaultStyleSheetsForElement):
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebFormManager.cpp:
(webkit_web_form_manager_input_element_is_user_edited):
(webkit_web_form_manager_input_element_auto_fill):
(webkit_web_form_manager_input_element_is_auto_filled):

Canonical link: <a href="https://commits.webkit.org/271885@main">https://commits.webkit.org/271885@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5f61b0b6e9f3298bee09f1b303931517842e3c8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29933 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8599 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31251 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32445 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27068 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30593 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10785 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5854 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27118 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30227 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7206 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25538 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6148 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6317 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26627 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33781 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27302 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27052 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32491 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6250 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4429 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30281 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7986 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7094 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6992 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6776 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->