### PR TITLE
Unreviewed libwebrtc build fix after 271863@main

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/webrtc/pc/jsep_transport_controller.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/pc/jsep_transport_controller.cc
@@ -80,7 +80,7 @@ RTCError JsepTransportController::SetLocalDescription(
   TRACE_EVENT0("webrtc", "JsepTransportController::SetLocalDescription");
   if (!network_thread_->IsCurrent()) {
     return network_thread_->BlockingCall(
-        [=] { return SetLocalDescription(type, description); });
+        [=, this] { return SetLocalDescription(type, description); });
   }
 
   RTC_DCHECK_RUN_ON(network_thread_);
@@ -101,7 +101,7 @@ RTCError JsepTransportController::SetRemoteDescription(
   TRACE_EVENT0("webrtc", "JsepTransportController::SetRemoteDescription");
   if (!network_thread_->IsCurrent()) {
     return network_thread_->BlockingCall(
-        [=] { return SetRemoteDescription(type, description); });
+        [=, this] { return SetRemoteDescription(type, description); });
   }
 
   RTC_DCHECK_RUN_ON(network_thread_);
@@ -372,7 +372,7 @@ void JsepTransportController::SetActiveResetSrtpParams(
 
 RTCError JsepTransportController::RollbackTransports() {
   if (!network_thread_->IsCurrent()) {
-    return network_thread_->BlockingCall([=] { return RollbackTransports(); });
+    return network_thread_->BlockingCall([=, this] { return RollbackTransports(); });
   }
   RTC_DCHECK_RUN_ON(network_thread_);
   bundles_.Rollback();


### PR DESCRIPTION
#### fa8e2cc27f45d0aa8ca3f7f42475c63f183f9c72
<pre>
Unreviewed libwebrtc build fix after 271863@main

Unreviewed, fix the following build error in libwebrtc:

```
error: implicit capture of &apos;this&apos; with a capture default of &apos;=&apos; is deprecated [-Werror,-Wdeprecated-this-capture]
   83 |         [=] { return SetLocalDescription(type, description); });
/Source/ThirdParty/libwebrtc/Source/webrtc/pc/jsep_transport_controller.cc:83:10: note: add an explicit capture of &apos;this&apos; to capture &apos;*this&apos; by reference
   83 |         [=] { return SetLocalDescription(type, description); });
/Source/ThirdParty/libwebrtc/Source/webrtc/pc/jsep_transport_controller.cc:104:22: error: implicit capture of &apos;this&apos; with a capture default of &apos;=&apos; is deprecated [-Werror,-Wdeprecated-this-capture]
  104 |         [=] { return SetRemoteDescription(type, description); });
/Source/ThirdParty/libwebrtc/Source/webrtc/pc/jsep_transport_controller.cc:104:10: note: add an explicit capture of &apos;this&apos; to capture &apos;*this&apos; by reference
  104 |         [=] { return SetRemoteDescription(type, description); });
/Source/ThirdParty/libwebrtc/Source/webrtc/pc/jsep_transport_controller.cc:375:55: error: implicit capture of &apos;this&apos; with a capture default of &apos;=&apos; is deprecated [-Werror,-Wdeprecated-this-capture]
  375 |     return network_thread_-&gt;BlockingCall([=] { return RollbackTransports(); });
/Source/ThirdParty/libwebrtc/Source/webrtc/pc/jsep_transport_controller.cc:375:43: note: add an explicit capture of &apos;this&apos; to capture &apos;*this&apos; by reference
  375 |     return network_thread_-&gt;BlockingCall([=] { return RollbackTransports(); });
```

* Source/ThirdParty/libwebrtc/Source/webrtc/pc/jsep_transport_controller.cc:

Canonical link: <a href="https://commits.webkit.org/271866@main">https://commits.webkit.org/271866@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a7a181facb096e0bf035922006121224ecd1bff

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29893 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8559 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31211 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32406 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27033 "Built successfully") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10743 "Hash 1a7a181f for PR 21622 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5816 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/27092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30187 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/10743 "Hash 1a7a181f for PR 21622 does not build (failure)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/25501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/6114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/10743 "Hash 1a7a181f for PR 21622 does not build (failure)") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/26589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33742 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/10743 "Hash 1a7a181f for PR 21622 does not build (failure)") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/27014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/32461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6212 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/4398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/30248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7952 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6957 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3853 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6740 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->