### PR TITLE
[TextureMapper] Remove unnecessary EnumTraits specialization for TextureMapperShaderProgram::Option enum

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.h
@@ -143,40 +143,4 @@ private:
 
 } // namespace WebCore
 
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::TextureMapperShaderProgram::Option> {
-    using values = EnumValues<
-        WebCore::TextureMapperShaderProgram::Option,
-        WebCore::TextureMapperShaderProgram::TextureRGB,
-        WebCore::TextureMapperShaderProgram::SolidColor,
-        WebCore::TextureMapperShaderProgram::Opacity,
-        WebCore::TextureMapperShaderProgram::Antialiasing,
-        WebCore::TextureMapperShaderProgram::GrayscaleFilter,
-        WebCore::TextureMapperShaderProgram::SepiaFilter,
-        WebCore::TextureMapperShaderProgram::SaturateFilter,
-        WebCore::TextureMapperShaderProgram::HueRotateFilter,
-        WebCore::TextureMapperShaderProgram::BrightnessFilter,
-        WebCore::TextureMapperShaderProgram::ContrastFilter,
-        WebCore::TextureMapperShaderProgram::InvertFilter,
-        WebCore::TextureMapperShaderProgram::OpacityFilter,
-        WebCore::TextureMapperShaderProgram::BlurFilter,
-        WebCore::TextureMapperShaderProgram::AlphaBlur,
-        WebCore::TextureMapperShaderProgram::ContentTexture,
-        WebCore::TextureMapperShaderProgram::ManualRepeat,
-        WebCore::TextureMapperShaderProgram::TextureYUV,
-        WebCore::TextureMapperShaderProgram::TextureNV12,
-        WebCore::TextureMapperShaderProgram::TextureNV21,
-        WebCore::TextureMapperShaderProgram::TexturePackedYUV,
-        WebCore::TextureMapperShaderProgram::TextureExternalOES,
-        WebCore::TextureMapperShaderProgram::RoundedRectClip,
-        WebCore::TextureMapperShaderProgram::Premultiply,
-        WebCore::TextureMapperShaderProgram::TextureYUVA,
-        WebCore::TextureMapperShaderProgram::TextureCopy,
-        WebCore::TextureMapperShaderProgram::AlphaToShadow
-    >;
-};
-
-} // namespace WTF
-
 #endif // USE(TEXTURE_MAPPER)


### PR DESCRIPTION
#### 70abbebb063b2e771cd54e8a4214a6966e7a853f
<pre>
[TextureMapper] Remove unnecessary EnumTraits specialization for TextureMapperShaderProgram::Option enum
<a href="https://bugs.webkit.org/show_bug.cgi?id=266210">https://bugs.webkit.org/show_bug.cgi?id=266210</a>

Reviewed by Adrian Perez de Castro and Carlos Garcia Campos.

The EnumTraits specialization for TextureMapperShaderProgram::Option is redundant and removable.

* Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.h:

Canonical link: <a href="https://commits.webkit.org/271871@main">https://commits.webkit.org/271871@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b4582c857315084d682d93f908a5a46b57b2d49

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29896 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8562 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31214 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32408 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27036 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30556 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10746 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5818 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27095 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30190 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7170 "Found 1 new test failure: webrtc/audio-samplerate-change.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25505 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6117 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6292 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26593 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33744 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27266 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27018 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32464 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6215 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4399 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30251 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7954 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7086 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6959 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6742 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->