### PR TITLE
[web-animations] setting currentTime=0 when animation-play-state=paused, doesn't restart animation after unpausing it

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-restarted-after-changing-iteration-count-after-completion-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-restarted-after-changing-iteration-count-after-completion-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Setting 'animation-iteration-count: infinite' after a CSS Animation is completed restarts the animation.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-restarted-after-changing-iteration-count-after-completion.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-restarted-after-changing-iteration-count-after-completion.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Setting 'animation-iteration-count: infinite' after a CSS Animation is completed restarts the animation</title>
+<link rel="help" href="https://www.w3.org/TR/css-animations-1/#animation-iteration-count">
+<style>
+
+@keyframes anim {
+    to { margin-left: 100px }
+}
+
+</style>
+</head>
+<body>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<div id="target"></div>
+<script>
+
+promise_test(async test => {
+    const target = document.getElementById("target");
+    target.style.animation = "anim 0.1s linear";
+
+    const initialAnimations = target.getAnimations();
+    assert_equals(initialAnimations.length, 1, "An animation runs initially.");
+
+    await initialAnimations[0].finished;
+    assert_equals(target.getAnimations().length, 0, "An animation no longer runs after its completion.");
+
+    await new Promise(setTimeout);
+    target.style.animationIterationCount = "infinite";
+    assert_equals(target.getAnimations().length, 1, "An animation runs again once animation-iteration-count is set.");
+}, "Setting 'animation-iteration-count: infinite' after a CSS Animation is completed restarts the animation.");
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -174,7 +174,8 @@ public:
     bool preventsAcceleration() const;
     void effectStackNoLongerPreventsAcceleration();
     void effectStackNoLongerAllowsAcceleration();
-    void wasRemovedFromStack();
+    void wasAddedToEffectStack();
+    void wasRemovedFromEffectStack();
 
     void lastStyleChangeEventStyleDidChange(const RenderStyle* previousStyle, const RenderStyle* currentStyle);
     void acceleratedPropertiesOverriddenByCascadeDidChange();

--- a/Source/WebCore/animation/KeyframeEffectStack.cpp
+++ b/Source/WebCore/animation/KeyframeEffectStack.cpp
@@ -59,12 +59,13 @@ bool KeyframeEffectStack::addEffect(KeyframeEffect& effect)
     if (!effect.targetStyleable() || !effect.animation() || !effect.animation()->timeline() || !effect.animation()->isRelevant())
         return false;
 
-    effect.invalidate();
     m_effects.append(effect);
     m_isSorted = false;
 
     if (m_effects.size() > 1 && effect.preventsAcceleration())
         stopAcceleratedAnimations();
+
+    effect.wasAddedToEffectStack();
 
     return true;
 }
@@ -72,12 +73,14 @@ bool KeyframeEffectStack::addEffect(KeyframeEffect& effect)
 void KeyframeEffectStack::removeEffect(KeyframeEffect& effect)
 {
     auto removedEffect = m_effects.removeFirst(&effect);
+
+    if (removedEffect)
+        effect.wasRemovedFromEffectStack();
+
     if (!removedEffect || m_effects.isEmpty())
         return;
 
-    if (effect.canBeAccelerated())
-        effect.wasRemovedFromStack();
-    else
+    if (!effect.canBeAccelerated())
         startAcceleratedAnimationsIfPossible();
 }
 


### PR DESCRIPTION
#### 494bf388fd775f7a80dc95337a3ba8c58e29bf21
<pre>
[web-animations] setting currentTime=0 when animation-play-state=paused, doesn&apos;t restart animation after unpausing it
<a href="https://bugs.webkit.org/show_bug.cgi?id=265280">https://bugs.webkit.org/show_bug.cgi?id=265280</a>
<a href="https://rdar.apple.com/118826588">rdar://118826588</a>

Reviewed by Antti Koivisto.

The test attached to the bug report did the following:

- started a CSS Animation with the default single iteration
- when that animation ended would set `animation-iteration-count: infinite`
- called getAnimations() on the target element on which the CSS Animation was applied

We failed to return an animation in that case because, even though we did everything right to update
the timing properties of the CSS Animation and mark it as &quot;relevant&quot; (in Web Animations parlance) again,
we did not successfully add it back to the target&apos;s keyframe effect stack.

This was due to some shoddy engineering (on this patch author&apos;s part) which almost guaranteed a bug like
this would crop up. Indeed, KeyframeEffect keeps an instance variable `m_inTargetEffectStack` around to
cache whether it is in the associated target&apos;s keyframe effect stack. While we would correctly update
this instance variable when calling `addEffect()` and `removeEffect()` within KeyframeEffect on the
effect stack, we completely neglected to have this instance variable updated when other parts of the
code would manipulate the effect stack in which this effect was found, such as under
`AnimationTimeline::removeAnimation()`.

Arguably, we could have change the call in `AnimationTimeline::removeAnimation()` to go through
`KeyframeEffectStack`, but instead we chose to guarantee `m_inTargetEffectStack` is now reflective
of whether the effect is found in its associated target&apos;s effect stack by ensuring that, when
calls to `addEffect()` and `removeEffect()` successfully add or remove the provided effect to or
from the stack, the instance variable is updated.

To that end, we add a new `KeyframeEffect::wasAddedToEffectStack()` method and rename `wasRemovedFromStack()`
to be more specific that this is an effect stack we&apos;re dealing with.

* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-restarted-after-changing-iteration-count-after-completion-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-restarted-after-changing-iteration-count-after-completion.html: Added.
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::animationTimelineDidChange):
(WebCore::KeyframeEffect::updateEffectStackMembership):
(WebCore::KeyframeEffect::didChangeTargetStyleable):
(WebCore::KeyframeEffect::wasAddedToEffectStack):
(WebCore::KeyframeEffect::wasRemovedFromEffectStack):
(WebCore::KeyframeEffect::wasRemovedFromStack): Deleted.
* Source/WebCore/animation/KeyframeEffect.h:
* Source/WebCore/animation/KeyframeEffectStack.cpp:
(WebCore::KeyframeEffectStack::addEffect):
(WebCore::KeyframeEffectStack::removeEffect):

Canonical link: <a href="https://commits.webkit.org/271872@main">https://commits.webkit.org/271872@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41275c7f3388246ed9f00ede3b81ed335e1b6fc8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29901 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8567 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31219 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32413 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27041 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30561 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10751 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5823 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27100 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30195 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7181 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25515 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6122 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6300 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26603 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33749 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27277 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27028 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32470 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6219 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4405 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30257 "Found 2 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state-changed (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7958 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/26401 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6964 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3857 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6747 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->