### PR TITLE
[iFC][Ruby] Add a mechanism to partially enable style based ruby

### DIFF
--- a/Source/WebCore/html/RubyElement.cpp
+++ b/Source/WebCore/html/RubyElement.cpp
@@ -53,12 +53,11 @@ Ref<RubyElement> RubyElement::create(Document& document)
 
 RenderPtr<RenderElement> RubyElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition& insertionPosition)
 {
-    if (!document().settings().cssBasedRubyEnabled()) {
-        if (style.display() == DisplayType::Inline)
-            return createRenderer<RenderRubyAsInline>(*this, WTFMove(style));
-        if (style.display() == DisplayType::Block || style.display() == DisplayType::InlineBlock)
-            return createRenderer<RenderRubyAsBlock>(*this, WTFMove(style));
-    }
+    if (style.display() == DisplayType::Inline)
+        return createRenderer<RenderRubyAsInline>(*this, WTFMove(style));
+    if (style.display() == DisplayType::Block || style.display() == DisplayType::InlineBlock)
+        return createRenderer<RenderRubyAsBlock>(*this, WTFMove(style));
+
     return HTMLElement::createElementRenderer(WTFMove(style), insertionPosition);
 }
 


### PR DESCRIPTION
#### 658e8c04ba57845361f43f6310a64b1e0f39e357
<pre>
[iFC][Ruby] Add a mechanism to partially enable style based ruby
<a href="https://bugs.webkit.org/show_bug.cgi?id=266214">https://bugs.webkit.org/show_bug.cgi?id=266214</a>
<a href="https://rdar.apple.com/119489155">rdar://119489155</a>

Reviewed by Alan Baradlay.

Allow incremental enabling.

* Source/WebCore/html/RubyElement.cpp:
(WebCore::RubyElement::createElementRenderer):
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::disableStyleBasedRubyIfNeeded):

For now disable style based ruby for &apos;text-align:justify&apos; and nested case.

(WebCore::Style::Adjuster::adjust const):

Canonical link: <a href="https://commits.webkit.org/271873@main">https://commits.webkit.org/271873@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f88dc4eec24da9ed2b43a8934d94d5ec48e094a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29906 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8572 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31224 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32418 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27044 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30566 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10757 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5828 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27102 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30200 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7182 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25516 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6124 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6301 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26604 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33754 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27278 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27029 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32471 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6224 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4409 "Found 2 new test failures: fullscreen/full-screen-layer-dump.html, imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback-webrtc.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30259 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7962 "Built successfully") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/7089 "The change is no longer eligible for processing.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6968 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3858 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6752 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->