### PR TITLE
Add NativeImageBackend to support GPUP NativeImage

### DIFF
--- a/Source/WebCore/platform/graphics/NativeImage.h
+++ b/Source/WebCore/platform/graphics/NativeImage.h
@@ -32,10 +32,13 @@
 #include "IntSize.h"
 #include "PlatformImage.h"
 #include "RenderingResource.h"
+#include <wtf/UniqueRef.h>
 
 namespace WebCore {
 
 class GraphicsContext;
+
+class NativeImageBackend;
 
 class NativeImage final : public RenderingResource {
     WTF_MAKE_FAST_ALLOCATED;
@@ -44,8 +47,7 @@ public:
     // Creates a NativeImage that is intended to be drawn once or only few times. Signals the platform to avoid generating any caches for the image.
     static WEBCORE_EXPORT RefPtr<NativeImage> createTransient(PlatformImagePtr&&, RenderingResourceIdentifier = RenderingResourceIdentifier::generate());
 
-    WEBCORE_EXPORT void setPlatformImage(PlatformImagePtr&&);
-    const PlatformImagePtr& platformImage() const { return m_platformImage; }
+    WEBCORE_EXPORT const PlatformImagePtr& platformImage() const;
 
     WEBCORE_EXPORT IntSize size() const;
     bool hasAlpha() const;
@@ -55,12 +57,35 @@ public:
     void draw(GraphicsContext&, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions);
     void clearSubimages();
 
-private:
-    NativeImage(PlatformImagePtr&&, RenderingResourceIdentifier);
+    WEBCORE_EXPORT void replaceContents(PlatformImagePtr);
+protected:
+    NativeImage(UniqueRef<NativeImageBackend>, RenderingResourceIdentifier);
 
     bool isNativeImage() const final { return true; }
 
+    UniqueRef<NativeImageBackend> m_backend;
+};
+
+class NativeImageBackend {
+public:
+    WEBCORE_EXPORT virtual ~NativeImageBackend();
+    virtual const PlatformImagePtr& platformImage() const = 0;
+    virtual IntSize size() const = 0;
+    virtual bool hasAlpha() const = 0;
+    virtual DestinationColorSpace colorSpace() const = 0;
+};
+
+class PlatformImageNativeImageBackend final : public NativeImageBackend {
+public:
+    WEBCORE_EXPORT ~PlatformImageNativeImageBackend() final;
+    WEBCORE_EXPORT const PlatformImagePtr& platformImage() const final;
+    WEBCORE_EXPORT IntSize size() const final;
+    WEBCORE_EXPORT bool hasAlpha() const final;
+    WEBCORE_EXPORT DestinationColorSpace colorSpace() const final;
+private:
+    PlatformImageNativeImageBackend(PlatformImagePtr);
     PlatformImagePtr m_platformImage;
+    friend class NativeImage;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/cairo/NativeImageCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/NativeImageCairo.cpp
@@ -35,14 +35,20 @@
 
 namespace WebCore {
 
-IntSize NativeImage::size() const
+IntSize PlatformImageNativeImageBackend::size() const
 {
     return cairoSurfaceSize(m_platformImage.get());
 }
 
-bool NativeImage::hasAlpha() const
+bool PlatformImageNativeImageBackend::hasAlpha() const
 {
     return cairo_surface_get_content(m_platformImage.get()) != CAIRO_CONTENT_COLOR;
+}
+
+DestinationColorSpace PlatformImageNativeImageBackend::colorSpace() const
+{
+    notImplemented();
+    return DestinationColorSpace::SRGB();
 }
 
 Color NativeImage::singlePixelSolidColor() const
@@ -50,17 +56,12 @@ Color NativeImage::singlePixelSolidColor() const
     if (size() != IntSize(1, 1))
         return Color();
 
-    if (cairo_surface_get_type(m_platformImage.get()) != CAIRO_SURFACE_TYPE_IMAGE)
+    auto platformImage = this->platformImage().get();
+    if (cairo_surface_get_type(platformImage) != CAIRO_SURFACE_TYPE_IMAGE)
         return Color();
 
-    unsigned* pixel = reinterpret_cast_ptr<unsigned*>(cairo_image_surface_get_data(m_platformImage.get()));
+    unsigned* pixel = reinterpret_cast_ptr<unsigned*>(cairo_image_surface_get_data(platformImage));
     return unpremultiplied(asSRGBA(PackedColor::ARGB { *pixel }));
-}
-
-DestinationColorSpace NativeImage::colorSpace() const
-{
-    notImplemented();
-    return DestinationColorSpace::SRGB();
 }
 
 void NativeImage::draw(GraphicsContext& context, const FloatRect& destinationRect, const FloatRect& sourceRect, ImagePaintingOptions options)

--- a/Source/WebCore/platform/graphics/cg/NativeImageCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/NativeImageCG.cpp
@@ -36,13 +36,30 @@
 
 namespace WebCore {
 
+IntSize PlatformImageNativeImageBackend::size() const
+{
+    return IntSize(CGImageGetWidth(m_platformImage.get()), CGImageGetHeight(m_platformImage.get()));
+}
+
+bool PlatformImageNativeImageBackend::hasAlpha() const
+{
+    CGImageAlphaInfo info = CGImageGetAlphaInfo(m_platformImage.get());
+    return (info >= kCGImageAlphaPremultipliedLast) && (info <= kCGImageAlphaFirst);
+}
+
+DestinationColorSpace PlatformImageNativeImageBackend::colorSpace() const
+{
+    return DestinationColorSpace(CGImageGetColorSpace(m_platformImage.get()));
+}
+
 RefPtr<NativeImage> NativeImage::create(PlatformImagePtr&& image, RenderingResourceIdentifier renderingResourceIdentifier)
 {
     if (!image)
         return nullptr;
     if (CGImageGetWidth(image.get()) > std::numeric_limits<int>::max() || CGImageGetHeight(image.get()) > std::numeric_limits<int>::max())
         return nullptr;
-    return adoptRef(*new NativeImage(WTFMove(image), renderingResourceIdentifier));
+    UniqueRef<PlatformImageNativeImageBackend> backend { *new PlatformImageNativeImageBackend(WTFMove(image)) };
+    return adoptRef(*new NativeImage(WTFMove(backend), renderingResourceIdentifier));
 }
 
 RefPtr<NativeImage> NativeImage::createTransient(PlatformImagePtr&& image, RenderingResourceIdentifier identifier)
@@ -60,17 +77,6 @@ RefPtr<NativeImage> NativeImage::createTransient(PlatformImagePtr&& image, Rende
     return create(WTFMove(transientImage), identifier);
 }
 
-IntSize NativeImage::size() const
-{
-    return IntSize(CGImageGetWidth(m_platformImage.get()), CGImageGetHeight(m_platformImage.get()));
-}
-
-bool NativeImage::hasAlpha() const
-{
-    CGImageAlphaInfo info = CGImageGetAlphaInfo(m_platformImage.get());
-    return (info >= kCGImageAlphaPremultipliedLast) && (info <= kCGImageAlphaFirst);
-}
-
 Color NativeImage::singlePixelSolidColor() const
 {
     if (size() != IntSize(1, 1))
@@ -83,17 +89,12 @@ Color NativeImage::singlePixelSolidColor() const
         return Color();
 
     CGContextSetBlendMode(bitmapContext.get(), kCGBlendModeCopy);
-    CGContextDrawImage(bitmapContext.get(), CGRectMake(0, 0, 1, 1), m_platformImage.get());
+    CGContextDrawImage(bitmapContext.get(), CGRectMake(0, 0, 1, 1), platformImage().get());
 
     if (!pixel[3])
         return Color::transparentBlack;
 
     return makeFromComponentsClampingExceptAlpha<SRGBA<uint8_t>>(pixel[0] * 255 / pixel[3], pixel[1] * 255 / pixel[3], pixel[2] * 255 / pixel[3], pixel[3]);
-}
-
-DestinationColorSpace NativeImage::colorSpace() const
-{
-    return DestinationColorSpace(CGImageGetColorSpace(m_platformImage.get()));
 }
 
 void NativeImage::draw(GraphicsContext& context, const FloatRect& destinationRect, const FloatRect& sourceRect, ImagePaintingOptions options)
@@ -159,7 +160,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 void NativeImage::clearSubimages()
 {
 #if CACHE_SUBIMAGES
-    CGSubimageCacheWithTimer::clearImage(m_platformImage.get());
+    CGSubimageCacheWithTimer::clearImage(platformImage().get());
 #endif
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
@@ -108,11 +108,11 @@ inline static std::optional<ShareableBitmap::Handle> createShareableBitmapFromNa
 #endif
 
     // If we failed to create ShareableBitmap or PlatformImage, fall back to image-draw method.
-    if (!platformImage)
+    if (!platformImage) {
         bitmap = ShareableBitmap::createFromImageDraw(image);
-
-    if (!platformImage && bitmap)
-        platformImage = bitmap->createPlatformImage(DontCopyBackingStore, ShouldInterpolate::Yes);
+        if (bitmap)
+            platformImage = bitmap->createPlatformImage(DontCopyBackingStore, ShouldInterpolate::Yes);
+    }
 
     if (!platformImage)
         return std::nullopt;
@@ -124,7 +124,7 @@ inline static std::optional<ShareableBitmap::Handle> createShareableBitmapFromNa
     handle->takeOwnershipOfMemory(MemoryLedger::Graphics);
 
     // Replace the PlatformImage of the input NativeImage with the shared one.
-    image.setPlatformImage(WTFMove(platformImage));
+    image.replaceContents(WTFMove(platformImage));
     return handle;
 }
 


### PR DESCRIPTION
#### aaab202e6d11709b07b80ca0aa4e5421129f656d
<pre>
Add NativeImageBackend to support GPUP NativeImage
<a href="https://bugs.webkit.org/show_bug.cgi?id=266216">https://bugs.webkit.org/show_bug.cgi?id=266216</a>
<a href="https://rdar.apple.com/119489321">rdar://119489321</a>

Reviewed by Matt Woodrow.

Add NativeImageBackend interface that future work can use to implement
NativeImage that exists in GPUP.

NativeImage instances are held as members of objects. Thus the interface
cannot be based on NativeImage itself, because this would mean that
transitioning from local to remote would need the held objects replaced.
Instead, make the polymorphic extension point the &quot;backend&quot;, similar to
current ImageBuffer.

* Source/WebCore/platform/graphics/NativeImage.cpp:
(WebCore::PlatformImageNativeImageBackend::platformImage const):
(WebCore::PlatformImageNativeImageBackend::PlatformImageNativeImageBackend):
(WebCore::NativeImage::create):
(WebCore::NativeImage::NativeImage):
(WebCore::NativeImage::platformImage const):
(WebCore::NativeImage::replaceContents):
(WebCore::NativeImage::setPlatformImage): Deleted.
* Source/WebCore/platform/graphics/NativeImage.h:
* Source/WebCore/platform/graphics/cg/NativeImageCG.cpp:
(WebCore::NativeImage::create):
(WebCore::NativeImage::size const):
(WebCore::NativeImage::hasAlpha const):
(WebCore::NativeImage::singlePixelSolidColor const):
(WebCore::NativeImage::colorSpace const):
(WebCore::NativeImage::clearSubimages):
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp:
(WebKit::createShareableBitmapFromNativeImage):

Canonical link: <a href="https://commits.webkit.org/272103@main">https://commits.webkit.org/272103@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e76cf680e2a4527e6815a2173a53ed974822c96

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30440 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9114 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32059 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32952 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27537 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31143 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11348 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6352 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27490 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30749 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7661 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27295 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6569 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6713 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27134 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34289 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27732 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27635 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32897 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6697 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4841 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30721 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8447 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7245 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7437 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7239 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->