### PR TITLE
[IFC][Ruby] Remove rt { line-height:1 } from ruby.css

### DIFF
--- a/LayoutTests/fast/ruby/ruby-line-height-expected.txt
+++ b/LayoutTests/fast/ruby/ruby-line-height-expected.txt
@@ -8,7 +8,7 @@ PASS getLineHeight('p') is "48px"
 PASS [object HTMLElement] is non-null.
 PASS getLineHeight('r') is "48px"
 PASS [object HTMLElement] is non-null.
-PASS getLineHeight('t') is "8px"
+PASS getLineHeight('t') is "normal"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/ruby/ruby-line-height.html
+++ b/LayoutTests/fast/ruby/ruby-line-height.html
@@ -1,4 +1,3 @@
-<!-- webkit-test-runner [ CSSBasedRubyEnabled=true ] -->
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
@@ -22,7 +21,7 @@ document.body.appendChild(div);
 
 shouldBeEqualToString("getLineHeight('p')", "48px");
 shouldBeEqualToString("getLineHeight('r')", "48px");
-shouldBeEqualToString("getLineHeight('t')", "8px");
+shouldBeEqualToString("getLineHeight('t')", "normal");
 </script>
 <script src="../../resources/js-test-post.js"></script>
 </body>

--- a/Source/WebCore/css/ruby.css
+++ b/Source/WebCore/css/ruby.css
@@ -6,5 +6,4 @@ ruby {
 ruby > rt {
     display: ruby-text;
     white-space: nowrap;
-    line-height: 1;
 }


### PR DESCRIPTION
#### 3909033f7ed2560462c6536c74ab5fa2cbecec90
<pre>
[IFC][Ruby] Remove rt { line-height:1 } from ruby.css
<a href="https://bugs.webkit.org/show_bug.cgi?id=266217">https://bugs.webkit.org/show_bug.cgi?id=266217</a>
<a href="https://rdar.apple.com/119489614">rdar://119489614</a>

Reviewed by Alan Baradlay.

* LayoutTests/fast/ruby/ruby-line-height-expected.txt:
* LayoutTests/fast/ruby/ruby-line-height.html:
* Source/WebCore/css/ruby.css:
(ruby &gt; rt):

This rule is from the ruby spec. For ease of feature enablement remove the rule for now
and use the same annotation line-height as the legacy.

Canonical link: <a href="https://commits.webkit.org/271874@main">https://commits.webkit.org/271874@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/109271965db4d74a92ba406d33e1fc1d3e383607

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29913 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8579 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31231 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32425 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27050 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30573 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10765 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5835 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27106 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30207 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7189 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25517 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6131 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/6306 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26605 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33761 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27285 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27030 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32475 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6230 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4414 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30263 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7968 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/26403 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7088 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6974 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6758 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->