### PR TITLE
[MSE] SourceBufferPrivate isn't destructed as early as it could.

### DIFF
--- a/Source/WebCore/Modules/mediasource/SourceBuffer.h
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.h
@@ -195,7 +195,6 @@ private:
     void scheduleEvent(const AtomString& eventName);
 
     ExceptionOr<void> appendBufferInternal(const unsigned char*, unsigned);
-    void sourceBufferPrivateAppendComplete(MediaPromise::Result&&);
     void resetParserState();
 
     void setActive(bool);
@@ -223,7 +222,7 @@ private:
 
     void updateBuffered();
 
-    Ref<SourceBufferPrivate> m_private;
+    RefPtr<SourceBufferPrivate> m_private;
     MediaSource* m_source;
     AppendMode m_mode { AppendMode::Segments };
 

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
@@ -191,7 +191,7 @@ void MediaSourcePrivateRemote::mediaSourcePrivateShuttingDown(CompletionHandler<
     m_readyState = MediaPlayer::ReadyState::HaveNothing;
 
     for (auto& sourceBuffer : m_sourceBuffers)
-        sourceBuffer->disconnect();
+        downcast<SourceBufferPrivateRemote>(sourceBuffer)->disconnect();
     completionHandler();
 }
 

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h
@@ -100,7 +100,6 @@ private:
     RemoteMediaSourceIdentifier m_identifier;
     RemoteMediaPlayerMIMETypeCache& m_mimeTypeCache;
     WeakPtr<MediaPlayerPrivateRemote> m_mediaPlayerPrivate;
-    Vector<RefPtr<SourceBufferPrivateRemote>> m_sourceBuffers;
     bool m_shutdown { false };
     WebCore::MediaPlayer::ReadyState m_readyState { WebCore::MediaPlayer::ReadyState::HaveNothing };
 

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
@@ -145,4 +145,8 @@ private:
 
 } // namespace WebKit
 
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::SourceBufferPrivateRemote)
+static bool isType(const WebCore::SourceBufferPrivate& sourceBuffer) { return sourceBuffer.platformType() == WebCore::MediaPlatformType::Remote; }
+SPECIALIZE_TYPE_TRAITS_END()
+
 #endif // ENABLE(GPU_PROCESS) && ENABLE(MEDIA_SOURCE)


### PR DESCRIPTION
#### d4faf4991bffe622ae0ba93c3f2c2511d7a9d1ba
<pre>
[MSE] SourceBufferPrivate isn&apos;t destructed as early as it could.
<a href="https://bugs.webkit.org/show_bug.cgi?id=266209">https://bugs.webkit.org/show_bug.cgi?id=266209</a>
<a href="https://rdar.apple.com/119485852">rdar://119485852</a>

Reviewed by NOBODY (OOPS!).

The SourceBufferPrivate becomes unusable as soon as the SourceBuffer is
removed from its MediaSource. And when the GPU process is in use, we tear-down
all the SourceBufferPrivate/MediaSourcePrivate as soon as removedFromMediaSource
is invoked.
At this stage the MediaPlayerPrivate has also been destructed.

The SourceBuffer however did keep a strong reference to the SourceBufferPrivate
until it was GCed.

So we clear the sourceBuffer&apos;s reference to the SourceBufferPrivate as soon
it&apos;s been removed from the MediaSource and the MediaPlayer has been torn down.

All strong references to itself in the SourceBuffer are removed, and add check
to ensure we haven&apos;t been removed whenever SourceBuffer::m_private is accessed.

Manually tested.

Fly-by fix: The MediaSourcePrivateRemote kept its own array of SourceBufferPrivate
when the MediaSourcePrivate base class is expected to do so.

* Source/WebCore/Modules/mediasource/SourceBuffer.cpp:
(WebCore::SourceBuffer::~SourceBuffer):
(WebCore::SourceBuffer::timestampOffset const):
(WebCore::SourceBuffer::resetParserState):
(WebCore::SourceBuffer::rangeRemoval):
(WebCore::SourceBuffer::abortIfUpdating):
(WebCore::SourceBuffer::removedFromMediaSource):
(WebCore::SourceBuffer::computeSeekTime):
(WebCore::SourceBuffer::seekToTime):
(WebCore::SourceBuffer::appendBufferInternal):
(WebCore::SourceBuffer::setActive):
(WebCore::SourceBuffer::bufferedSamplesForTrackId):
(WebCore::SourceBuffer::enqueuedSamplesForTrackID):
(WebCore::SourceBuffer::minimumUpcomingPresentationTimeForTrackID):
(WebCore::SourceBuffer::setMaximumQueueDepthForTrackID):
(WebCore::SourceBuffer::setShouldGenerateTimestamps):
(WebCore::SourceBuffer::setMediaSourceEnded):
(WebCore::SourceBuffer::memoryPressure):
(WebCore::SourceBuffer::sourceBufferPrivateAppendComplete): Deleted.
* Source/WebCore/Modules/mediasource/SourceBuffer.h:
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp:
(WebKit::MediaSourcePrivateRemote::mediaSourcePrivateShuttingDown):
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h:
(isType):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d4faf4991bffe622ae0ba93c3f2c2511d7a9d1ba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29916 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8582 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31826 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32428 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27051 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30576 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10794 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5837 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27108 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30210 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7212 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/26875 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6135 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6321 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27006 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33764 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27307 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27493 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32479 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6233 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4416 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30268 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7970 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6976 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6759 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->