### PR TITLE
glib-reviewers should not own libwebrtc directories

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -210,6 +210,19 @@ xdg/ @WebKit/glib-reviewers
 wpe/ @WebKit/glib-reviewers @zdobersek
 **/wpe/qt/ @philn
 
+# Don't want to own these
+/Source/ThirdParty/libwebrtc/Source/third_party/boringssl/src/util/ar/testdata/linux
+/Source/ThirdParty/libwebrtc/Source/third_party/libaom/source/config/linux
+/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/config/linux
+/Source/ThirdParty/libwebrtc/Source/webrtc/examples/peerconnection/client/linux
+/Source/ThirdParty/libwebrtc/Source/webrtc/modules/audio_device/linux
+/Source/ThirdParty/libwebrtc/Source/webrtc/modules/desktop_capture/linux
+/Source/ThirdParty/libwebrtc/Source/webrtc/modules/video_capture/linux
+/Source/ThirdParty/libwebrtc/Source/webrtc/test/linux
+/Source/ThirdParty/libwebrtc/Source/webrtc/tools_webrtc/audio_quality/linux
+/Source/ThirdParty/libwebrtc/Source/webrtc/tools_webrtc/video_quality_toolchain/linux
+/Source/ThirdParty/libwebrtc/Source/webrtc/rtc_tools/testing/golang/linux
+
 /LayoutTests/platform/glib/
 /LayoutTests/platform/gtk/
 /LayoutTests/platform/gtk4/


### PR DESCRIPTION
#### 3633f4ec40d4f89701c1ae27434402133500ae8b
<pre>
glib-reviewers should not own libwebrtc directories
<a href="https://bugs.webkit.org/show_bug.cgi?id=266219">https://bugs.webkit.org/show_bug.cgi?id=266219</a>

Reviewed by Jonathan Bedard.

Unfortunately there&apos;s no good way to do this without giving up ownership
of linux directories outside libwebrtc, but we can at least manually
denylist particular paths that we don&apos;t want to own, which will work
until more paths get added in the future.

* .github/CODEOWNERS:

Canonical link: <a href="https://commits.webkit.org/271931@main">https://commits.webkit.org/271931@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c8bab36b9ba49010cd411d109ce8ab6b7c6b01b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29965 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8631 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31283 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32477 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27096 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10820 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5886 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27149 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30259 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7236 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25567 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6183 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6337 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33813 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27331 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27088 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32518 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6280 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4452 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30312 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8018 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7127 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7023 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6807 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->