### PR TITLE
Implement MouseEvent's x and y in terms of clientX and clientY

### DIFF
--- a/Source/WebCore/dom/MouseEvent.idl
+++ b/Source/WebCore/dom/MouseEvent.idl
@@ -54,8 +54,8 @@
 
     readonly attribute long offsetX;
     readonly attribute long offsetY;
-    readonly attribute long x;
-    readonly attribute long y;
+    [ImplementedAs=clientX] readonly attribute long x;
+    [ImplementedAs=clientY] readonly attribute long y;
     readonly attribute Node? fromElement;
     readonly attribute Node? toElement;
 };

--- a/Source/WebCore/dom/MouseRelatedEvent.cpp
+++ b/Source/WebCore/dom/MouseRelatedEvent.cpp
@@ -263,18 +263,4 @@ const LayoutPoint& MouseRelatedEvent::pageLocation() const
     return m_pageLocation;
 }
 
-int MouseRelatedEvent::x() const
-{
-    // FIXME: This is not correct.
-    // See Microsoft documentation and <http://www.quirksmode.org/dom/w3c_events.html>.
-    return m_clientLocation.x();
-}
-
-int MouseRelatedEvent::y() const
-{
-    // FIXME: This is not correct.
-    // See Microsoft documentation and <http://www.quirksmode.org/dom/w3c_events.html>.
-    return m_clientLocation.y();
-}
-
 } // namespace WebCore

--- a/Source/WebCore/dom/MouseRelatedEvent.h
+++ b/Source/WebCore/dom/MouseRelatedEvent.h
@@ -64,8 +64,6 @@ public:
     int pageY() const final;
     WEBCORE_EXPORT FloatPoint locationInRootViewCoordinates() const;
     virtual const LayoutPoint& pageLocation() const;
-    WEBCORE_EXPORT int x() const;
-    WEBCORE_EXPORT int y() const;
 
     // Page point in "absolute" coordinates (i.e. post-zoomed, page-relative coords,
     // usable with RenderObject::absoluteToLocal).

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMMouseEvent.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMMouseEvent.cpp
@@ -436,7 +436,7 @@ glong webkit_dom_mouse_event_get_x(WebKitDOMMouseEvent* self)
     WebCore::JSMainThreadNullState state;
     g_return_val_if_fail(WEBKIT_DOM_IS_MOUSE_EVENT(self), 0);
     WebCore::MouseEvent* item = WebKit::core(self);
-    glong result = item->x();
+    glong result = item->clientX();
     return result;
 }
 
@@ -445,7 +445,7 @@ glong webkit_dom_mouse_event_get_y(WebKitDOMMouseEvent* self)
     WebCore::JSMainThreadNullState state;
     g_return_val_if_fail(WEBKIT_DOM_IS_MOUSE_EVENT(self), 0);
     WebCore::MouseEvent* item = WebKit::core(self);
-    glong result = item->y();
+    glong result = item->clientY();
     return result;
 }
 

--- a/Source/WebKitLegacy/mac/DOM/DOMMouseEvent.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMMouseEvent.mm
@@ -119,13 +119,13 @@
 - (int)x
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->x();
+    return IMPL->clientX();
 }
 
 - (int)y
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->y();
+    return IMPL->clientY();
 }
 
 - (DOMNode *)fromElement


### PR DESCRIPTION
#### e0208f9d20753e8efdd34f160b2c49478b99eb13
<pre>
Implement MouseEvent&apos;s x and y in terms of clientX and clientY
<a href="https://bugs.webkit.org/show_bug.cgi?id=10809">https://bugs.webkit.org/show_bug.cgi?id=10809</a>
<a href="https://rdar.apple.com/6970140">rdar://6970140</a>

Reviewed by Darin Adler.

This is a change for clarity with no impact on behavior. See
<a href="https://drafts.csswg.org/cssom-view/#dom-mouseevent-x">https://drafts.csswg.org/cssom-view/#dom-mouseevent-x</a> for the relevant
specification requirements.

* Source/WebCore/dom/MouseEvent.idl:
* Source/WebCore/dom/MouseRelatedEvent.cpp:
(WebCore::MouseRelatedEvent::x const): Deleted.
(WebCore::MouseRelatedEvent::y const): Deleted.
* Source/WebCore/dom/MouseRelatedEvent.h:
* Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMMouseEvent.cpp:
(webkit_dom_mouse_event_get_x):
(webkit_dom_mouse_event_get_y):
* Source/WebKitLegacy/mac/DOM/DOMMouseEvent.mm:
(-[DOMMouseEvent x]):
(-[DOMMouseEvent y]):

Canonical link: <a href="https://commits.webkit.org/271890@main">https://commits.webkit.org/271890@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/170e820fa0c47b7d5710f37409aa4cf5810078f1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29931 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8597 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31249 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32443 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27066 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30591 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10783 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5852 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27117 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30225 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7202 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25535 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6146 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6315 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26624 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33779 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27298 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27060 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32489 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6248 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4427 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30279 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7984 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7098 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6990 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6774 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->