### PR TITLE
Replace a few `PackedCheckedPtr<RenderObject>` data members with weak pointers

### DIFF
--- a/Source/WTF/wtf/Forward.h
+++ b/Source/WTF/wtf/Forward.h
@@ -97,7 +97,7 @@ template<typename, typename = void> class StringTypeAdapter;
 template<typename> class UniqueRef;
 template<typename T, class... Args> UniqueRef<T> makeUniqueRef(Args&&...);
 template<typename, size_t = 0, typename = CrashOnOverflow, size_t = 16, typename = VectorBufferMalloc> class Vector;
-template<typename, typename = DefaultWeakPtrImpl> class WeakPtr;
+template<typename, typename WeakPtrImpl = DefaultWeakPtrImpl, typename = RawPtrTraits<WeakPtrImpl>> class WeakPtr;
 template<typename, typename = DefaultWeakPtrImpl> class WeakRef;
 
 template<typename> struct DefaultHash;

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -107,9 +107,9 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderElement);
 
 struct SameSizeAsRenderElement : public RenderObject {
-    PackedPtr<RenderObject> firstChild;
+    SingleThreadPackedWeakPtr<RenderObject> firstChild;
     unsigned bitfields1 : 12;
-    PackedPtr<RenderObject> lastChild;
+    SingleThreadPackedWeakPtr<RenderObject> lastChild;
     unsigned bitfields2 : 13;
     RenderStyle style;
 };

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -407,7 +407,7 @@ private:
 
     const RenderStyle* textSegmentPseudoStyle(PseudoId) const;
 
-    PackedCheckedPtr<RenderObject> m_firstChild;
+    SingleThreadPackedWeakPtr<RenderObject> m_firstChild;
     unsigned m_baseTypeFlags : 8;
     unsigned m_ancestorLineBoxDirty : 1;
     unsigned m_hasInitializedStyle : 1;
@@ -417,7 +417,7 @@ private:
     unsigned m_hasCounterNodeMap : 1;
     unsigned m_hasContinuationChainNode : 1;
 
-    PackedCheckedPtr<RenderObject> m_lastChild;
+    SingleThreadPackedWeakPtr<RenderObject> m_lastChild;
 
     unsigned m_isContinuation : 1;
     unsigned m_isFirstLetter : 1;

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -119,7 +119,7 @@ struct SameSizeAsRenderObject : public CachedImageClient, public CanMakeCheckedP
     unsigned m_bitfields;
     CheckedRef<Node> node;
     SingleThreadWeakPtr<RenderObject> pointers[2];
-    PackedPtr<RenderObject> m_next;
+    SingleThreadPackedWeakPtr<RenderObject> m_next;
     uint8_t m_type;
     CheckedPtr<Layout::Box> layoutBox;
 };

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -1207,7 +1207,7 @@ private:
 
     SingleThreadWeakPtr<RenderElement> m_parent;
     SingleThreadWeakPtr<RenderObject> m_previous;
-    PackedCheckedPtr<RenderObject> m_next;
+    SingleThreadPackedWeakPtr<RenderObject> m_next;
     Type m_type;
 
     CheckedPtr<Layout::Box> m_layoutBox;


### PR DESCRIPTION
#### 34c74ccc0e3371ff3bbb65dcad4c15b22d36154c
<pre>
Replace a few `PackedCheckedPtr&lt;RenderObject&gt;` data members with weak pointers
<a href="https://bugs.webkit.org/show_bug.cgi?id=266222">https://bugs.webkit.org/show_bug.cgi?id=266222</a>

Reviewed by Darin Adler.

Replace a few `PackedCheckedPtr&lt;RenderObject&gt;` data members with weak pointers.
The crashes generated by WeakPtr are more actionable and this tested as
performance-neutral on the benchmarks we track.

This is a follow-up to 271749@main.

* Source/WTF/wtf/Forward.h:
* Source/WTF/wtf/WeakPtr.h:
(WTF::WeakPtr::WeakPtr):
(WTF::WeakPtr::releaseImpl):
(WTF::PtrTraits&gt;::WeakPtr):
(WTF::=):
(WTF::is):
(WTF::downcast):
(WTF::dynamicDowncast):
(WTF::operator==):
(WTF::WeakPtrImpl&gt;::WeakPtr): Deleted.
* Source/WebCore/rendering/RenderElement.cpp:
* Source/WebCore/rendering/RenderElement.h:
* Source/WebCore/rendering/RenderObject.cpp:
* Source/WebCore/rendering/RenderObject.h:

Canonical link: <a href="https://commits.webkit.org/271881@main">https://commits.webkit.org/271881@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a4077f11bda8717a20c06a08fc60962320db1ca

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29927 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8593 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31245 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32439 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27062 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30587 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10779 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5848 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/27140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30221 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7200 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25534 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/6174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6313 "Found 5 new test failures: imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-below-viewport-partially-onscreen-new.html, imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-below-viewport-partially-onscreen-old.html, imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch.tentative.html, imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative.html, imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/readwrite-readonly.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26623 "Found 1 new test failure: svg/compositing/transform-change-repainting-viewBox.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33775 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/25708 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/simple-inline-stacktrace-with-catch.js.wasm-agressive-inline (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27296 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27048 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/32515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/30100 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6244 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4423 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/30309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7981 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/36495 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6987 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7875 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3862 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6770 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->