### PR TITLE
Toggling the spellcheck attribute on input elements doesn't toggle spelling markers

### DIFF
--- a/LayoutTests/editing/spelling/spellcheck-attribute-toggle-expected.html
+++ b/LayoutTests/editing/spelling/spellcheck-attribute-toggle-expected.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+
+.spelling-error {
+    color: red;
+    text-decoration-line: underline;
+    text-decoration-style: solid;
+    text-decoration-color: blue;
+}
+
+</style>
+</head>
+
+<body>
+
+<div>
+    <input class="spelling-error" value="mitake">
+</div>
+
+<div>
+    <input value="mitake">
+</div>
+
+<div>
+    <input class="spelling-error" value="mitake">
+</div>
+
+<div>
+    <input value="mitake">
+</div>
+
+<div>
+    <div>
+        <input value="mitake">
+    </div>
+</div>
+
+<div>
+    <div>
+        <input class="spelling-error" value="mitake">
+    </div>
+</div>
+
+<div>
+    <input class="spelling-error" value="mitake">
+    <input class="spelling-error" value="mitake">
+    <input value="mitake">
+</div>
+
+<div>
+    <input class="spelling-error" value="mitake">
+</div>
+
+<div>
+    <input value="mitake">
+</div>
+
+<div>
+    <input value="mitake">
+</div>
+
+<div>
+    <input class="spelling-error" value="mitake">
+</div>
+
+<div>
+    <div>
+        <input class="spelling-error" value="mitake">
+    </div>
+</div>
+
+<div>
+    <input value="mitake">
+    <input value="mitake">
+    <input class="spelling-error" value="mitake">
+</div>
+
+</body>
+</html>

--- a/LayoutTests/editing/spelling/spellcheck-attribute-toggle.html
+++ b/LayoutTests/editing/spelling/spellcheck-attribute-toggle.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html><!-- webkit-test-runner [ spellCheckingDots=true ] -->
+<html>
+<head>
+<script src="../../resources/ui-helper.js"></script>
+<style>
+
+::spelling-error {
+    color: red;
+    text-decoration-line: underline;
+    text-decoration-style: solid;
+    text-decoration-color: blue;
+}
+
+</style>
+</head>
+
+<body>
+
+<div>
+    <input spellcheck="false" class="insert-text toggle-spellcheck">
+</div>
+
+<div>
+    <input spellcheck="false" class="toggle-spellcheck" value="mitake">
+</div>
+
+<div spellcheck="false" class="toggle-spellcheck">
+    <input class="insert-text">
+</div>
+
+<div spellcheck="false" class="toggle-spellcheck">
+    <input spellcheck="false" class="insert-text">
+</div>
+
+<div spellcheck="false" class="toggle-spellcheck">
+    <div spellcheck="false">
+        <input class="insert-text">
+    </div>
+</div>
+
+<div spellcheck="false">
+    <div spellcheck="false" class="toggle-spellcheck">
+        <input class="insert-text">
+    </div>
+</div>
+
+<div spellcheck="false" class="toggle-spellcheck">
+    <input class="insert-text">
+    <input class="insert-text">
+    <input value="mitake">
+</div>
+
+<div>
+    <input spellcheck="true" class="insert-text">
+</div>
+
+<div>
+    <input spellcheck="true" class="insert-text toggle-spellcheck">
+</div>
+
+<div spellcheck="true" class="toggle-spellcheck">
+    <input class="insert-text">
+</div>
+
+<div spellcheck="true" class="toggle-spellcheck">
+    <input spellcheck="true" class="insert-text">
+</div>
+
+<div spellcheck="true" class="toggle-spellcheck">
+    <div spellcheck="true">
+        <input class="insert-text">
+    </div>
+</div>
+
+<div spellcheck="true" class="toggle-spellcheck">
+    <input class="insert-text">
+    <input class="insert-text">
+    <input spellcheck="true" class="insert-text">
+</div>
+
+<script>
+
+const incorrectPhrase = "mitake";
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+if (window.internals)
+    internals.setContinuousSpellCheckingEnabled(true);
+
+async function runTest()
+{
+    const inputs = document.querySelectorAll(".insert-text");
+    for (const input of inputs) {
+        input.focus();
+        document.execCommand("InsertText", false, incorrectPhrase);
+        input.blur();
+    }
+
+    const elementsToToggle = document.querySelectorAll(".toggle-spellcheck");
+    for (const element of elementsToToggle)
+        element.spellcheck = !element.spellcheck;
+
+    await UIHelper.ensurePresentationUpdate();
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+UIHelper.setSpellCheckerResults({
+    "mitake" : [
+        { type : "spelling", from : 0, to : 6 },
+    ]
+}).then(runTest);
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1568,6 +1568,9 @@ public:
     WEBCORE_EXPORT void updateIsPlayingMedia();
     void pageMutedStateDidChange();
 
+    bool hasEverHadSelectionInsideTextFormControl() const { return m_hasEverHadSelectionInsideTextFormControl; }
+    void setHasEverHadSelectionInsideTextFormControl() { m_hasEverHadSelectionInsideTextFormControl = true; }
+
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
     void addPlaybackTargetPickerClient(MediaPlaybackTargetClient&);
     void removePlaybackTargetPickerClient(MediaPlaybackTargetClient&);
@@ -2457,6 +2460,8 @@ private:
     bool m_mayHaveRenderedSVGRootElements { false };
 
     bool m_userHasInteractedWithMediaElement { false };
+
+    bool m_hasEverHadSelectionInsideTextFormControl { false };
 
     bool m_updateTitleTaskScheduled { false };
 

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -38,6 +38,7 @@
 #include "CustomElementReactionQueue.h"
 #include "DOMTokenList.h"
 #include "DocumentFragment.h"
+#include "Editor.h"
 #include "ElementAncestorIteratorInlines.h"
 #include "ElementChildIteratorInlines.h"
 #include "ElementInternals.h"
@@ -422,6 +423,19 @@ void HTMLElement::attributeChanged(const QualifiedName& name, const AtomString& 
         if (document().settings().popoverAttributeEnabled() && !document().quirks().shouldDisablePopoverAttributeQuirk())
             popoverAttributeChanged(newValue);
         return;
+    case AttributeNames::spellcheckAttr: {
+        if (!document().hasEverHadSelectionInsideTextFormControl())
+            return;
+
+        bool oldEffectiveAttributeValue = !equalLettersIgnoringASCIICase(oldValue, "false"_s);
+        bool newEffectiveAttributeValue = !equalLettersIgnoringASCIICase(newValue, "false"_s);
+
+        if (oldEffectiveAttributeValue == newEffectiveAttributeValue)
+            return;
+
+        effectiveSpellcheckAttributeChanged(newEffectiveAttributeValue);
+        return;
+    }
     default:
         break;
     }
@@ -712,6 +726,27 @@ bool HTMLElement::spellcheck() const
 void HTMLElement::setSpellcheck(bool enable)
 {
     setAttributeWithoutSynchronization(spellcheckAttr, enable ? trueAtom() : falseAtom());
+}
+
+void HTMLElement::effectiveSpellcheckAttributeChanged(bool newValue)
+{
+    for (auto it = descendantsOfType<HTMLElement>(*this).begin(); it;) {
+        Ref element = *it;
+
+        auto& value = element->attributeWithoutSynchronization(HTMLNames::spellcheckAttr);
+        if (!value.isNull()) {
+            it.traverseNextSkippingChildren();
+            continue;
+        }
+
+        if (element->isTextFormControlElement()) {
+            element->effectiveSpellcheckAttributeChanged(newValue);
+            it.traverseNextSkippingChildren();
+            continue;
+        }
+
+        it.traverseNext();
+    }
 }
 
 void HTMLElement::click()

--- a/Source/WebCore/html/HTMLElement.h
+++ b/Source/WebCore/html/HTMLElement.h
@@ -196,6 +196,8 @@ protected:
     void updateTextDirectionalityAfterInputTypeChange();
     void updateEffectiveDirectionalityOfDirAuto();
 
+    virtual void effectiveSpellcheckAttributeChanged(bool);
+
     using EventHandlerNameMap = HashMap<AtomString, AtomString>;
     static const AtomString& eventNameForEventHandlerAttribute(const QualifiedName& attributeName, const EventHandlerNameMap&);
 

--- a/Source/WebCore/html/HTMLTextFormControlElement.h
+++ b/Source/WebCore/html/HTMLTextFormControlElement.h
@@ -156,6 +156,8 @@ private:
     
     void setHovered(bool, Style::InvalidationScope, HitTestRequest) final;
 
+    void effectiveSpellcheckAttributeChanged(bool) final;
+
     unsigned indexForPosition(const Position&) const;
 
     // Returns true if user-editable value is empty. Used to check placeholder visibility.


### PR DESCRIPTION
#### 971fabe99b16ea2ee306f940b85753ed7c83fe74
<pre>
Toggling the spellcheck attribute on input elements doesn&apos;t toggle spelling markers
<a href="https://bugs.webkit.org/show_bug.cgi?id=265958">https://bugs.webkit.org/show_bug.cgi?id=265958</a>
<a href="https://rdar.apple.com/119269616">rdar://119269616</a>

Reviewed by Wenson Hsieh.

Add or remove spelling and grammar markers from &lt;input&gt; and &lt;textarea&gt; if the
control has been focused at some point, and the spellcheck attribute is toggled.

General `contenteditable` are currently excluded from this behavior, since
storing additional information about whether an element has ever been focused
would be expensive. Additionally, the behavior this patch implements matches
Firefox exactly.

* LayoutTests/editing/spelling/spellcheck-attribute-toggle-expected.html: Added.
* LayoutTests/editing/spelling/spellcheck-attribute-toggle.html: Added.
* Source/WebCore/dom/Document.h:
(WebCore::Document::hasEverHadSelectionInsideTextFormControl const):
(WebCore::Document::setHasEverHadSelectionInsideTextFormControl):

Store a bit to indicate if a selection has ever been inside a text form control.
Since spellchecking can only occur if a selection has been made, this serves to
provide an optimization where changes to the spellcheck attribute do not perform
unnecessary tree walks when the page is first loaded, before any editing commands
have occured, and before a selection is made.

* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::attributeChanged):
(WebCore::HTMLElement::effectiveSpellcheckAttributeChanged):

The effective value of the spellcheck attribute is determined by the nearest
ancestor if the element itself does not have the attribute specified. Perform
a descendant tree walk to find affected elements for a given attribute change.
Note the optimization described earlier to avoid unnecessary tree walks.

* Source/WebCore/html/HTMLElement.h:
* Source/WebCore/html/HTMLTextFormControlElement.cpp:
(WebCore::HTMLTextFormControlElement::selectionChanged):
(WebCore::HTMLTextFormControlElement::effectiveSpellcheckAttributeChanged):

Toggle markers only if the control has had a selection at some point.

* Source/WebCore/html/HTMLTextFormControlElement.h:

Canonical link: <a href="https://commits.webkit.org/271927@main">https://commits.webkit.org/271927@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1f0b02566d55512352b11f196c2a449bf0636d5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30043 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8705 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31353 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32541 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27155 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30705 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10918 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5954 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27195 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30337 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7312 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25620 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6238 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6399 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26713 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33876 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27407 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27144 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32568 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6330 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4501 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30367 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8078 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/26513 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7124 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7082 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6857 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->