### PR TITLE
Switch to libwebrtc new DNS resolver interface

### DIFF
--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.cpp
@@ -388,9 +388,7 @@ void LibWebRTCProvider::setUseDTLS10(bool useDTLS10)
     m_factory->SetOptions(options);
 }
 
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-// FIXME: https://bugs.webkit.org/show_bug.cgi?id=265791
-rtc::scoped_refptr<webrtc::PeerConnectionInterface> LibWebRTCProvider::createPeerConnection(webrtc::PeerConnectionObserver& observer, rtc::NetworkManager& networkManager, rtc::PacketSocketFactory& packetSocketFactory, webrtc::PeerConnectionInterface::RTCConfiguration&& configuration, std::unique_ptr<webrtc::AsyncResolverFactory>&& asyncResolveFactory)
+rtc::scoped_refptr<webrtc::PeerConnectionInterface> LibWebRTCProvider::createPeerConnection(webrtc::PeerConnectionObserver& observer, rtc::NetworkManager& networkManager, rtc::PacketSocketFactory& packetSocketFactory, webrtc::PeerConnectionInterface::RTCConfiguration&& configuration, std::unique_ptr<webrtc::AsyncDnsResolverFactoryInterface>&& asyncDnsResolverFactory)
 {
     auto& factoryAndThreads = getStaticFactoryAndThreads(m_useNetworkThreadWithSocketServer);
 
@@ -408,7 +406,7 @@ rtc::scoped_refptr<webrtc::PeerConnectionInterface> LibWebRTCProvider::createPee
 
     webrtc::PeerConnectionDependencies dependencies { &observer };
     dependencies.allocator = WTFMove(portAllocator);
-    dependencies.async_resolver_factory = WTFMove(asyncResolveFactory);
+    dependencies.async_dns_resolver_factory = WTFMove(asyncDnsResolverFactory);
 
     auto peerConnectionOrError = m_factory->CreatePeerConnectionOrError(configuration, WTFMove(dependencies));
     if (!peerConnectionOrError.ok())
@@ -416,7 +414,6 @@ rtc::scoped_refptr<webrtc::PeerConnectionInterface> LibWebRTCProvider::createPee
 
     return peerConnectionOrError.MoveValue();
 }
-ALLOW_DEPRECATED_DECLARATIONS_END
 
 void LibWebRTCProvider::prepareCertificateGenerator(Function<void(rtc::RTCCertificateGenerator&)>&& callback)
 {

--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.h
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.h
@@ -52,7 +52,7 @@ class RTCCertificateGenerator;
 }
 
 namespace webrtc {
-class AsyncResolverFactory;
+class AsyncDnsResolverFactory;
 class PeerConnectionFactoryInterface;
 }
 
@@ -122,10 +122,7 @@ public:
 protected:
     LibWebRTCProvider();
 
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=265791
-    rtc::scoped_refptr<webrtc::PeerConnectionInterface> createPeerConnection(webrtc::PeerConnectionObserver&, rtc::NetworkManager&, rtc::PacketSocketFactory&, webrtc::PeerConnectionInterface::RTCConfiguration&&, std::unique_ptr<webrtc::AsyncResolverFactory>&&);
-ALLOW_DEPRECATED_DECLARATIONS_END
+    rtc::scoped_refptr<webrtc::PeerConnectionInterface> createPeerConnection(webrtc::PeerConnectionObserver&, rtc::NetworkManager&, rtc::PacketSocketFactory&, webrtc::PeerConnectionInterface::RTCConfiguration&&, std::unique_ptr<webrtc::AsyncDnsResolverFactoryInterface>&&);
 
     rtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> createPeerConnectionFactory(rtc::Thread* networkThread, rtc::Thread* signalingThread);
     virtual std::unique_ptr<webrtc::VideoDecoderFactory> createDecoderFactory();

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 55;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -1020,6 +1020,7 @@
 		417915B92257046F00D6F97E /* NetworkSocketChannel.h in Headers */ = {isa = PBXBuildFile; fileRef = 417915B62257046E00D6F97E /* NetworkSocketChannel.h */; };
 		41897ED11F415D680016FA42 /* WebCacheStorageConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 41897ECD1F415D5C0016FA42 /* WebCacheStorageConnection.h */; };
 		4193927828BE41C000162139 /* LSApplicationWorkspaceSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 4193927728BE41C000162139 /* LSApplicationWorkspaceSPI.h */; };
+		419E200F2B286E8900BB13A6 /* LibWebRTCDnsResolverFactory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 419E200D2B286CF700BB13A6 /* LibWebRTCDnsResolverFactory.cpp */; };
 		41A0EB142641714900794471 /* LibWebRTCCodecsProxy.mm in Sources */ = {isa = PBXBuildFile; fileRef = 41E0A7C823B6397900561060 /* LibWebRTCCodecsProxy.mm */; };
 		41C5379021F15B55008B1FAD /* _WKWebsiteDataStoreDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 41C5378F21F1362D008B1FAD /* _WKWebsiteDataStoreDelegate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		41D129DA1F3D101800D15E47 /* WebCacheStorageProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 41D129D91F3D101400D15E47 /* WebCacheStorageProvider.h */; };
@@ -4937,6 +4938,8 @@
 		4193927728BE41C000162139 /* LSApplicationWorkspaceSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LSApplicationWorkspaceSPI.h; sourceTree = "<group>"; };
 		419ACF9B1F981D26009F1A83 /* WebServiceWorkerFetchTaskClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebServiceWorkerFetchTaskClient.h; sourceTree = "<group>"; };
 		419BD18F28E1A86C0089D7B7 /* VideoCodecType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VideoCodecType.h; sourceTree = "<group>"; };
+		419E200D2B286CF700BB13A6 /* LibWebRTCDnsResolverFactory.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LibWebRTCDnsResolverFactory.cpp; path = Network/webrtc/LibWebRTCDnsResolverFactory.cpp; sourceTree = "<group>"; };
+		419E200E2B286CF700BB13A6 /* LibWebRTCDnsResolverFactory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = LibWebRTCDnsResolverFactory.h; path = Network/webrtc/LibWebRTCDnsResolverFactory.h; sourceTree = "<group>"; };
 		41A5F7B9226ECF7C00671764 /* AuthenticationChallengeDispositionCocoa.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AuthenticationChallengeDispositionCocoa.h; sourceTree = "<group>"; };
 		41A5F7BA226ECF7C00671764 /* AuthenticationChallengeDispositionCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = AuthenticationChallengeDispositionCocoa.mm; sourceTree = "<group>"; };
 		41AC86811E042E5300303074 /* WebRTCResolver.messages.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; lineEnding = 0; name = WebRTCResolver.messages.in; path = Network/webrtc/WebRTCResolver.messages.in; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = "<none>"; };
@@ -11216,6 +11219,8 @@
 		4130759E1DE85E650039EC69 /* webrtc */ = {
 			isa = PBXGroup;
 			children = (
+				419E200D2B286CF700BB13A6 /* LibWebRTCDnsResolverFactory.cpp */,
+				419E200E2B286CF700BB13A6 /* LibWebRTCDnsResolverFactory.h */,
 				416F8089245C7FF500B68F02 /* LibWebRTCNetwork.cpp */,
 				411B22621E371244004F7363 /* LibWebRTCNetwork.h */,
 				416F8086245B397400B68F02 /* LibWebRTCNetwork.messages.in */,
@@ -18306,6 +18311,7 @@
 				2984F588164BA095004BC0C6 /* LegacyCustomProtocolManagerMessageReceiver.cpp in Sources */,
 				2984F57C164B915F004BC0C6 /* LegacyCustomProtocolManagerProxyMessageReceiver.cpp in Sources */,
 				41A0EB142641714900794471 /* LibWebRTCCodecsProxy.mm in Sources */,
+				419E200F2B286E8900BB13A6 /* LibWebRTCDnsResolverFactory.cpp in Sources */,
 				51F060E11654318500F3281C /* LibWebRTCNetworkMessageReceiver.cpp in Sources */,
 				449D90DA21FDC30B00F677C0 /* LocalAuthenticationSoftLink.mm in Sources */,
 				A141DF502B06ED0F00E80B2D /* MediaCapability.mm in Sources */,
@@ -18853,9 +18859,7 @@
 		};
 		5C400E6A29DB8AB500446F6F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			platformFilters = (
-				ios,
-			);
+			platformFilter = ios;
 			target = 5C139DA129DB82E500D5117B /* WebContentCaptivePortalExtension */;
 			targetProxy = 5C400E6929DB8AB500446F6F /* PBXContainerItemProxy */;
 		};
@@ -18871,25 +18875,19 @@
 		};
 		5CE4B60729CEBB760038F565 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			platformFilters = (
-				ios,
-			);
+			platformFilter = ios;
 			target = 5CA5A2C929CBBA1A000F1046 /* WebContentExtension */;
 			targetProxy = 5CE4B60629CEBB760038F565 /* PBXContainerItemProxy */;
 		};
 		5CE4B62329CF880B0038F565 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			platformFilters = (
-				ios,
-			);
+			platformFilter = ios;
 			target = 5CE4B61529CF877F0038F565 /* GPUExtension */;
 			targetProxy = 5CE4B62229CF880B0038F565 /* PBXContainerItemProxy */;
 		};
 		5CE4B62529CF880B0038F565 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			platformFilters = (
-				ios,
-			);
+			platformFilter = ios;
 			target = 5CE4B60829CF87680038F565 /* NetworkingExtension */;
 			targetProxy = 5CE4B62429CF880B0038F565 /* PBXContainerItemProxy */;
 		};

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCDnsResolverFactory.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCDnsResolverFactory.cpp
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "LibWebRTCDnsResolverFactory.h"
+
+#if USE(LIBWEBRTC)
+
+#include "LibWebRTCNetwork.h"
+#include "WebProcess.h"
+
+namespace WebKit {
+
+std::unique_ptr<webrtc::AsyncDnsResolverInterface> LibWebRTCDnsResolverFactory::CreateAndResolve(const rtc::SocketAddress& address, absl::AnyInvocable<void()> callback)
+{
+    auto resolver = WebProcess::singleton().libWebRTCNetwork().socketFactory().createAsyncDnsResolver();
+    resolver->start(address, [callback = absl::move(callback)] () mutable {
+        callback();
+    });
+    return resolver;
+}
+
+std::unique_ptr<webrtc::AsyncDnsResolverInterface> LibWebRTCDnsResolverFactory::CreateAndResolve(const rtc::SocketAddress& address, int /* family */, absl::AnyInvocable<void()> callback)
+{
+    auto resolver = WebProcess::singleton().libWebRTCNetwork().socketFactory().createAsyncDnsResolver();
+    // FIXME: Make use of family.
+    resolver->start(address, [callback = absl::move(callback)] () mutable {
+        callback();
+    });
+    return resolver;
+}
+
+std::unique_ptr<webrtc::AsyncDnsResolverInterface> LibWebRTCDnsResolverFactory::Create()
+{
+    return WebProcess::singleton().libWebRTCNetwork().socketFactory().createAsyncDnsResolver();
+}
+
+void LibWebRTCDnsResolverFactory::Resolver::Start(const rtc::SocketAddress& address, absl::AnyInvocable<void()> callback)
+{
+    start(address, [callback = absl::move(callback)] () mutable {
+        callback();
+    });
+}
+
+void LibWebRTCDnsResolverFactory::Resolver::Start(const rtc::SocketAddress& address, int /* family */, absl::AnyInvocable<void()> callback)
+{
+    // FIXME: Make use of family.
+    start(address, [callback = absl::move(callback)] () mutable {
+        callback();
+    });
+}
+
+} // namespace WebKit
+
+#endif // USE(LIBWEBRTC)

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.cpp
@@ -32,6 +32,7 @@
 #include "LibWebRTCCodecs.h"
 #endif
 
+#include "LibWebRTCDnsResolverFactory.h"
 #include "LibWebRTCNetwork.h"
 #include "LibWebRTCNetworkManager.h"
 #include "RTCDataChannelRemoteManager.h"
@@ -43,25 +44,12 @@
 
 ALLOW_COMMA_BEGIN
 
-#include <webrtc/api/async_resolver_factory.h>
 #include <webrtc/pc/peer_connection_factory.h>
 
 ALLOW_COMMA_END
 
 namespace WebKit {
 using namespace WebCore;
-
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-// FIXME: https://bugs.webkit.org/show_bug.cgi?id=265791
-class AsyncResolverFactory : public webrtc::AsyncResolverFactory {
-    WTF_MAKE_FAST_ALLOCATED;
-private:
-    rtc::AsyncResolverInterface* Create() final
-    {
-        return WebProcess::singleton().libWebRTCNetwork().socketFactory().createAsyncResolver();
-    }
-};
-ALLOW_DEPRECATED_DECLARATIONS_END
 
 LibWebRTCProvider::LibWebRTCProvider(WebPage& webPage)
     : m_webPage(webPage)
@@ -85,7 +73,7 @@ rtc::scoped_refptr<webrtc::PeerConnectionInterface> LibWebRTCProvider::createPee
     networkManager->setEnumeratingAllNetworkInterfacesEnabled(isEnumeratingAllNetworkInterfacesEnabled());
     networkManager->setEnumeratingVisibleNetworkInterfacesEnabled(isEnumeratingVisibleNetworkInterfacesEnabled());
 
-    return WebCore::LibWebRTCProvider::createPeerConnection(observer, *networkManager, *socketFactory, WTFMove(configuration), makeUnique<AsyncResolverFactory>());
+    return WebCore::LibWebRTCProvider::createPeerConnection(observer, *networkManager, *socketFactory, WTFMove(configuration), makeUnique<LibWebRTCDnsResolverFactory>());
 }
 
 void LibWebRTCProvider::disableNonLocalhostConnections()
@@ -105,10 +93,7 @@ private:
     rtc::AsyncPacketSocket* CreateUdpSocket(const rtc::SocketAddress&, uint16_t minPort, uint16_t maxPort) final;
     rtc::AsyncListenSocket* CreateServerTcpSocket(const rtc::SocketAddress&, uint16_t minPort, uint16_t maxPort, int options) final { return nullptr; }
     rtc::AsyncPacketSocket* CreateClientTcpSocket(const rtc::SocketAddress& localAddress, const rtc::SocketAddress& remoteAddress, const rtc::ProxyInfo&, const std::string&, const rtc::PacketSocketTcpOptions&) final;
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=265791
-    rtc::AsyncResolverInterface* CreateAsyncResolver() final;
-ALLOW_DEPRECATED_DECLARATIONS_END
+    std::unique_ptr<webrtc::AsyncDnsResolverInterface> CreateAsyncDnsResolver() final;
     void suspend() final;
     void resume() final;
 
@@ -140,13 +125,10 @@ rtc::AsyncPacketSocket* RTCSocketFactory::CreateClientTcpSocket(const rtc::Socke
     return WebProcess::singleton().libWebRTCNetwork().socketFactory().createClientTcpSocket(m_contextIdentifier, localAddress, remoteAddress, String { m_userAgent }, options, m_pageIdentifier, m_isFirstParty, m_isRelayDisabled, m_domain);
 }
 
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-// FIXME: https://bugs.webkit.org/show_bug.cgi?id=265791
-rtc::AsyncResolverInterface* RTCSocketFactory::CreateAsyncResolver()
+std::unique_ptr<webrtc::AsyncDnsResolverInterface> RTCSocketFactory::CreateAsyncDnsResolver()
 {
-    return WebProcess::singleton().libWebRTCNetwork().socketFactory().createAsyncResolver();
+    return WebProcess::singleton().libWebRTCNetwork().socketFactory().createAsyncDnsResolver();
 }
-ALLOW_DEPRECATED_DECLARATIONS_END
 
 void RTCSocketFactory::suspend()
 {

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCResolver.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCResolver.cpp
@@ -45,10 +45,19 @@ void LibWebRTCResolver::sendOnMainThread(Function<void(IPC::Connection&)>&& call
     });
 }
 
-void LibWebRTCResolver::Start(const rtc::SocketAddress& address, int /* family */)
+LibWebRTCResolver::~LibWebRTCResolver()
 {
-    // FIXME: Make use of family parameter.
-    m_isResolving = true;
+    WebProcess::singleton().libWebRTCNetwork().socketFactory().removeResolver(m_identifier);
+    sendOnMainThread([identifier = m_identifier](IPC::Connection& connection) {
+        connection.send(Messages::NetworkRTCProvider::StopResolver(identifier), 0);
+    });
+}
+
+void LibWebRTCResolver::start(const rtc::SocketAddress& address, Function<void()>&& callback)
+{
+    ASSERT(!m_callback);
+
+    m_callback = WTFMove(callback);
     m_addressToResolve = address;
     m_port = address.port();
 
@@ -64,6 +73,11 @@ void LibWebRTCResolver::Start(const rtc::SocketAddress& address, int /* family *
     sendOnMainThread([identifier = m_identifier, name = WTFMove(name).isolatedCopy()](IPC::Connection& connection) {
         connection.send(Messages::NetworkRTCProvider::CreateResolver(identifier, name), 0);
     });
+}
+
+const webrtc::AsyncDnsResolverResult& LibWebRTCResolver::result() const
+{
+    return *this;
 }
 
 bool LibWebRTCResolver::GetResolvedAddress(int family, rtc::SocketAddress* address) const
@@ -83,48 +97,16 @@ bool LibWebRTCResolver::GetResolvedAddress(int family, rtc::SocketAddress* addre
     return false;
 }
 
-void LibWebRTCResolver::Destroy(bool)
+void LibWebRTCResolver::setResolvedAddress(Vector<rtc::IPAddress>&& addresses)
 {
-    if (!isResolving())
-        return;
-
-    if (m_isProvidingResults) {
-        m_shouldDestroy = true;
-        return;
-    }
-
-    sendOnMainThread([identifier = m_identifier](IPC::Connection& connection) {
-        connection.send(Messages::NetworkRTCProvider::StopResolver(identifier), 0);
-    });
-
-    doDestroy();
-}
-
-void LibWebRTCResolver::doDestroy()
-{
-    // Let's take the resolver so that it gets destroyed at the end of this function.
-    auto resolver = WebProcess::singleton().libWebRTCNetwork().socketFactory().takeResolver(m_identifier);
-    ASSERT(resolver);
-}
-
-void LibWebRTCResolver::setResolvedAddress(const Vector<rtc::IPAddress>& addresses)
-{
-    m_addresses = addresses;
-    m_isProvidingResults = true;
-    SignalDone(this);
-    m_isProvidingResults = false;
-    if (m_shouldDestroy)
-        doDestroy();
+    m_addresses = WTFMove(addresses);
+    m_callback();
 }
 
 void LibWebRTCResolver::setError(int error)
 {
     m_error = error;
-    m_isProvidingResults = true;
-    SignalDone(this);
-    m_isProvidingResults = false;
-    if (m_shouldDestroy)
-        doDestroy();
+    m_callback();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCResolver.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCResolver.h
@@ -27,16 +27,11 @@
 
 #if USE(LIBWEBRTC)
 
+#include "LibWebRTCDnsResolverFactory.h"
 #include "LibWebRTCResolverIdentifier.h"
 #include <WebCore/LibWebRTCMacros.h>
 #include <wtf/Vector.h>
-
-ALLOW_COMMA_BEGIN
-
-#include <webrtc/api/packet_socket_factory.h>
-#include <webrtc/rtc_base/async_resolver_interface.h>
-
-ALLOW_COMMA_END
+#include <wtf/WeakPtr.h>
 
 namespace IPC {
 class Connection;
@@ -45,41 +40,37 @@ class Connection;
 namespace WebKit {
 class LibWebRTCSocketFactory;
 
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-// FIXME: https://bugs.webkit.org/show_bug.cgi?id=265791
-class LibWebRTCResolver final : public rtc::AsyncResolverInterface {
-ALLOW_DEPRECATED_DECLARATIONS_END
+class LibWebRTCResolver final : public LibWebRTCDnsResolverFactory::Resolver, private webrtc::AsyncDnsResolverResult, public CanMakeWeakPtr<LibWebRTCResolver> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     LibWebRTCResolver() : m_identifier(LibWebRTCResolverIdentifier::generate()) { }
+    ~LibWebRTCResolver();
 
-    bool isResolving() const { return m_isResolving; }
     LibWebRTCResolverIdentifier identifier() const { return m_identifier; }
+
+    void start(const rtc::SocketAddress&, Function<void()>&&) final;
 
 private:
     friend class WebRTCResolver;
 
-    // AsyncResolverInterface API.
-    void Start(const rtc::SocketAddress& address) final { Start(address, address.family()); }
-    void Start(const rtc::SocketAddress&, int) final;
-    bool GetResolvedAddress(int, rtc::SocketAddress*) const final;
-    int GetError() const final { return m_error; }
-    void Destroy(bool) final;
+    // webrtc::AsyncDnsResolverInterface
+    const webrtc::AsyncDnsResolverResult& result() const final;
 
-    void doDestroy();
+    // webrtc::AsyncDnsResolverResult
+    bool GetResolvedAddress(int family, rtc::SocketAddress*) const final;
+    int GetError() const { return m_error; }
+
     void setError(int);
-    void setResolvedAddress(const Vector<rtc::IPAddress>&);
+    void setResolvedAddress(Vector<rtc::IPAddress>&&);
 
     static void sendOnMainThread(Function<void(IPC::Connection&)>&&);
 
     LibWebRTCResolverIdentifier m_identifier;
     Vector<rtc::IPAddress> m_addresses;
     rtc::SocketAddress m_addressToResolve;
+    Function<void()> m_callback;
     int m_error { 0 };
     uint16_t m_port { 0 };
-    bool m_isResolving { false };
-    bool m_isProvidingResults { false };
-    bool m_shouldDestroy { false };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocketFactory.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocketFactory.cpp
@@ -148,16 +148,15 @@ void LibWebRTCSocketFactory::forSocketInGroup(ScriptExecutionContextIdentifier c
     }
 }
 
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-// FIXME: https://bugs.webkit.org/show_bug.cgi?id=265791
-rtc::AsyncResolverInterface* LibWebRTCSocketFactory::createAsyncResolver()
+std::unique_ptr<LibWebRTCResolver> LibWebRTCSocketFactory::createAsyncDnsResolver()
 {
     auto resolver = makeUnique<LibWebRTCResolver>();
-    auto* resolverPointer = resolver.get();
-    m_resolvers.set(resolverPointer->identifier(), WTFMove(resolver));
-    return resolverPointer;
+
+    ASSERT(!m_resolvers.contains(resolver->identifier()));
+    m_resolvers.add(resolver->identifier(), resolver.get());
+
+    return resolver;
 }
-ALLOW_DEPRECATED_DECLARATIONS_END
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocketFactory.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocketFactory.h
@@ -62,13 +62,10 @@ public:
     rtc::AsyncPacketSocket* createClientTcpSocket(WebCore::ScriptExecutionContextIdentifier, const rtc::SocketAddress& localAddress, const rtc::SocketAddress& remoteAddress, String&& userAgent, const rtc::PacketSocketTcpOptions&, WebPageProxyIdentifier, bool isFirstParty, bool isRelayDisabled, const WebCore::RegistrableDomain&);
     rtc::AsyncPacketSocket* createNewConnectionSocket(LibWebRTCSocket&, WebCore::LibWebRTCSocketIdentifier newConnectionSocketIdentifier, const rtc::SocketAddress&);
 
-    LibWebRTCResolver* resolver(LibWebRTCResolverIdentifier identifier) { return m_resolvers.get(identifier); }
-    std::unique_ptr<LibWebRTCResolver> takeResolver(LibWebRTCResolverIdentifier identifier) { return m_resolvers.take(identifier); }
+    WeakPtr<LibWebRTCResolver> resolver(LibWebRTCResolverIdentifier identifier) { return m_resolvers.get(identifier); }
+    void removeResolver(LibWebRTCResolverIdentifier identifier) { m_resolvers.remove(identifier); }
 
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=265791
-    rtc::AsyncResolverInterface* createAsyncResolver();
-ALLOW_DEPRECATED_DECLARATIONS_END
+    std::unique_ptr<LibWebRTCResolver> createAsyncDnsResolver();
 
     void disableNonLocalhostConnections() { m_disableNonLocalhostConnections = true; }
 
@@ -78,9 +75,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 private:
     // We cannot own sockets, clients of the factory are responsible to free them.
     HashMap<WebCore::LibWebRTCSocketIdentifier, CheckedPtr<LibWebRTCSocket>> m_sockets;
-    
-    // We can own resolvers as we control their Destroy method.
-    HashMap<LibWebRTCResolverIdentifier, std::unique_ptr<LibWebRTCResolver>> m_resolvers;
+
+    HashMap<LibWebRTCResolverIdentifier, WeakPtr<LibWebRTCResolver>> m_resolvers;
     bool m_disableNonLocalhostConnections { false };
 
     RefPtr<IPC::Connection> m_connection;


### PR DESCRIPTION
#### fb5c6b1cd67e74114df904d35df8bfcfba6c144c
<pre>
Switch to libwebrtc new DNS resolver interface
<a href="https://bugs.webkit.org/show_bug.cgi?id=265791">https://bugs.webkit.org/show_bug.cgi?id=265791</a>
<a href="https://rdar.apple.com/119133276">rdar://119133276</a>

Reviewed by Eric Carlson.

Migrate code from deprecated webrtc::AsyncResolverFactory to webrtc::AsyncDnsResolverFactory.
This in particular simplifies how we do memory management, since the peer connection factory is now owned by the peer connection.

We keep using a map of WeakPtr to allow to handle IPC responses from network process.

We work around a header conflict between SDK and libwebrtc by isolating absl::InvokeCall in LibWebRTCDnsResolverFactory.cpp.

* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.cpp:
(WebCore::LibWebRTCProvider::createPeerConnection):
* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.h:
* Source/WebKit/Sources.txt:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCDnsResolverFactory.cpp: Added.
(WebKit::LibWebRTCDnsResolverFactory::CreateAndResolve):
(WebKit::LibWebRTCDnsResolverFactory::Create):
(WebKit::LibWebRTCDnsResolverFactory::Resolver::Start):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCDnsResolverFactory.h: Added.
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.cpp:
(WebKit::LibWebRTCProvider::createPeerConnection):
(WebKit::RTCSocketFactory::CreateAsyncDnsResolver):
(WebKit::RTCSocketFactory::CreateAsyncResolver): Deleted.
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCResolver.cpp:
(WebKit::LibWebRTCResolver::~LibWebRTCResolver):
(WebKit::LibWebRTCResolver::start):
(WebKit::LibWebRTCResolver::result const):
(WebKit::LibWebRTCResolver::setResolvedAddress):
(WebKit::LibWebRTCResolver::setError):
(WebKit::LibWebRTCResolver::Start): Deleted.
(WebKit::LibWebRTCResolver::Destroy): Deleted.
(WebKit::LibWebRTCResolver::doDestroy): Deleted.
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCResolver.h:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocketFactory.cpp:
(WebKit::LibWebRTCSocketFactory::createAsyncDnsResolver):
(WebKit::LibWebRTCSocketFactory::createAsyncResolver): Deleted.
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocketFactory.h:
(WebKit::LibWebRTCSocketFactory::resolver):
(WebKit::LibWebRTCSocketFactory::removeResolver):
(WebKit::LibWebRTCSocketFactory::takeResolver): Deleted.
* Source/WebKit/WebProcess/Network/webrtc/WebRTCResolver.cpp:
(WebKit::WebRTCResolver::setResolvedAddress):
(WebKit::WebRTCResolver::resolvedAddressError):

Canonical link: <a href="https://commits.webkit.org/272029@main">https://commits.webkit.org/272029@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d5e6084a30cbb55af39ec67f19bb5a68ae3204d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30413 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9087 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32023 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32924 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27509 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31115 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11318 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6324 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27469 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30721 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7639 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/27269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6545 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6689 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27105 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34261 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27712 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27602 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32873 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6670 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4815 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30696 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8421 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7204 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7412 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7212 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->