### PR TITLE
visionOS: WKTR TestWTFAlwaysMissing fails to build

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WTF/darwin/libTestWTFAlwaysMissing-iOS.tbd
+++ b/Tools/TestWebKitAPI/Tests/WTF/darwin/libTestWTFAlwaysMissing-iOS.tbd
@@ -4,13 +4,15 @@ targets:         [ i386-ios-simulator, i386-tvos-simulator, i386-watchos-simulat
                    x86_64-ios-simulator, x86_64-tvos-simulator, x86_64-watchos-simulator,
                    armv7-ios, armv7-watchos, armv7s-ios, arm64-ios, arm64-tvos, arm64-watchos,
                    arm64_32-watchos, arm64e-ios, arm64e-tvos, arm64e-watchos, arm64-ios-simulator,
-                   arm64-watchos-simulator, arm64-tvos-simulator ]
+                   arm64-watchos-simulator, arm64-tvos-simulator, arm64-xros, arm64e-xros,
+                   x86_64-xros-simulator, arm64-xros-simulator ]
 install-name:    '/usr/local/lib/libTestWTFAlwaysMissing.dylib'
 exports:
   - targets:         [ i386-ios-simulator, i386-tvos-simulator, i386-watchos-simulator,
                        x86_64-ios-simulator, x86_64-tvos-simulator, x86_64-watchos-simulator,
                        armv7-ios, armv7-watchos, armv7s-ios, arm64-ios, arm64-tvos, arm64-watchos,
                        arm64_32-watchos, arm64e-ios, arm64e-tvos, arm64e-watchos, arm64-ios-simulator,
-                       arm64-watchos-simulator, arm64-tvos-simulator ]
+                       arm64-watchos-simulator, arm64-tvos-simulator, arm64-xros, arm64e-xros,
+                       x86_64-xros-simulator, arm64-xros-simulator ]
     symbols:         [ _TestWTFAlwaysMissing, _TestWTFAlwaysMissingWithoutAttributeWeakImport ]
 ...


### PR DESCRIPTION
#### 3fc47d1bb773e62913bea4498568be87010cf9d9
<pre>
visionOS: WKTR TestWTFAlwaysMissing fails to build
<a href="https://bugs.webkit.org/show_bug.cgi?id=266238">https://bugs.webkit.org/show_bug.cgi?id=266238</a>
<a href="https://rdar.apple.com/119502325">rdar://119502325</a>

Reviewed by Wenson Hsieh.

* Tools/TestWebKitAPI/Tests/WTF/darwin/libTestWTFAlwaysMissing-iOS.tbd:
Add visionOS to the TBD.

Canonical link: <a href="https://commits.webkit.org/271887@main">https://commits.webkit.org/271887@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/558b41080436d18e1ca452e9b6acf77d7880c283

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29960 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8626 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31278 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/32472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/27091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30620 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10815 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5881 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/32472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30254 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7233 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/25562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/32472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/6335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/26651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/33808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27328 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/27083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/33808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6275 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/4449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/33808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8013 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/7018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3863 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/6802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->