### PR TITLE
[Wasm-GC] Avoid spurious assertion in JSWebAssemblyArray::set

### DIFF
--- a/JSTests/wasm/gc/bug266249.js
+++ b/JSTests/wasm/gc/bug266249.js
@@ -1,0 +1,15 @@
+//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true", "--useWebAssemblyExtendedConstantExpressions=true")
+
+import { compile, instantiate } from "./wast-wrapper.js";
+
+instantiate(`
+ (module
+   (type (sub (array (mut i16))))
+   (global (mut (ref null 0)) (ref.null 0))
+   (func (export "init")
+     (global.set 0 (array.new 0 (i32.const 42) (i32.const 5)))
+     (array.set 0 (global.get 0) (i32.const 3) (i32.and (i32.const 84) (i32.const 0xFFFF))))
+   (func (export "get") (param i32) (result i32)
+     (array.get_u 0 (global.get 0) (local.get 0)))
+   )
+`).exports.init();

--- a/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
@@ -474,7 +474,7 @@ WASM_SLOW_PATH_DECL(array_set)
     if (JSValue::decode(arrayref).isNull())
         WASM_THROW(Wasm::ExceptionType::NullArraySet);
     uint32_t index = READ(instruction.m_index).unboxedUInt32();
-    EncodedJSValue value = READ(instruction.m_value).encodedJSValue();
+    uint64_t value = static_cast<uint64_t>(READ(instruction.m_value).unboxedInt64());
 
     JSValue arrayValue = JSValue::decode(arrayref);
     ASSERT(arrayValue.isObject());
@@ -545,7 +545,7 @@ WASM_SLOW_PATH_DECL(struct_set)
     auto structReference = READ(instruction.m_structReference).encodedJSValue();
     if (JSValue::decode(structReference).isNull())
         WASM_THROW(Wasm::ExceptionType::NullStructSet);
-    auto value = READ(instruction.m_value).encodedJSValue();
+    auto value = static_cast<uint64_t>(READ(instruction.m_value).unboxedInt64());
     Wasm::structSet(structReference, instruction.m_fieldIndex, value);
     WASM_END();
 }

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h
@@ -96,14 +96,14 @@ public:
         return m_payload64.data();
     }
 
-    EncodedJSValue get(uint32_t index)
+    uint64_t get(uint32_t index)
     {
         if (m_elementType.type.is<Wasm::PackedType>()) {
             switch (m_elementType.type.as<Wasm::PackedType>()) {
             case Wasm::PackedType::I8:
-                return static_cast<EncodedJSValue>(m_payload8[index]);
+                return static_cast<uint64_t>(m_payload8[index]);
             case Wasm::PackedType::I16:
-                return static_cast<EncodedJSValue>(m_payload16[index]);
+                return static_cast<uint64_t>(m_payload16[index]);
             }
         }
         // m_element_type must be a type, so we can get its kind
@@ -111,17 +111,15 @@ public:
         switch (m_elementType.type.as<Wasm::Type>().kind) {
         case Wasm::TypeKind::I32:
         case Wasm::TypeKind::F32:
-            return static_cast<EncodedJSValue>(m_payload32[index]);
+            return static_cast<uint64_t>(m_payload32[index]);
         default:
-            return static_cast<EncodedJSValue>(m_payload64[index]);
+            return static_cast<uint64_t>(m_payload64[index]);
         }
     }
 
-    void set(uint32_t index, EncodedJSValue value)
+    void set(uint32_t index, uint64_t value)
     {
         if (m_elementType.type.is<Wasm::PackedType>()) {
-            // `value` is assumed to be an unboxed int32; truncate it to either 8 or 16 bits
-            ASSERT(value <= UINT32_MAX);
             switch (m_elementType.type.as<Wasm::PackedType>()) {
             case Wasm::PackedType::I8:
                 m_payload8[index] = static_cast<uint8_t>(value);
@@ -150,7 +148,7 @@ public:
         case Wasm::TypeKind::RefNull: {
             WriteBarrier<Unknown>* pointer = bitwise_cast<WriteBarrier<Unknown>*>(m_payload64.data());
             pointer += index;
-            pointer->set(vm(), this, JSValue::decode(value));
+            pointer->set(vm(), this, JSValue::decode(static_cast<EncodedJSValue>(value)));
             break;
         }
         case Wasm::TypeKind::V128:

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp
@@ -105,7 +105,7 @@ uint64_t JSWebAssemblyStruct::get(uint32_t fieldIndex) const
     }
 }
 
-void JSWebAssemblyStruct::set(uint32_t fieldIndex, EncodedJSValue argument)
+void JSWebAssemblyStruct::set(uint32_t fieldIndex, uint64_t argument)
 {
     using Wasm::TypeKind;
 
@@ -140,7 +140,7 @@ void JSWebAssemblyStruct::set(uint32_t fieldIndex, EncodedJSValue argument)
     case TypeKind::Funcref:
     case TypeKind::Ref:
     case TypeKind::RefNull: {
-        bitwise_cast<WriteBarrierBase<Unknown>*>(targetPointer)->set(vm(), this, JSValue::decode(argument));
+        bitwise_cast<WriteBarrierBase<Unknown>*>(targetPointer)->set(vm(), this, JSValue::decode(static_cast<EncodedJSValue>(argument)));
         return;
     }
     case TypeKind::V128:

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.h
@@ -58,7 +58,7 @@ public:
     DECLARE_VISIT_CHILDREN;
 
     uint64_t get(uint32_t) const;
-    void set(uint32_t, EncodedJSValue);
+    void set(uint32_t, uint64_t);
     const Wasm::StructType* structType() const { return m_type->as<Wasm::StructType>(); }
     Wasm::FieldType fieldType(uint32_t fieldIndex) const { return structType()->field(fieldIndex); }
 


### PR DESCRIPTION
#### 1e4c23e67107054c015e3e846d8ee804ad934953
<pre>
[Wasm-GC] Avoid spurious assertion in JSWebAssemblyArray::set
<a href="https://bugs.webkit.org/show_bug.cgi?id=266249">https://bugs.webkit.org/show_bug.cgi?id=266249</a>

Reviewed by Justin Michaud.

Avoid an assertion that isn&apos;t necessary. The reason is sometimes triggers is
due to the LLInt slow path code reading a uint64_t value from the
VirtualRegister instead of a uint32_t. While we could dispatch on the type
in the slow path code, this would require more overhead to extract the type
from the object or more space in the bytecode to pass the type through.

Also change some uses of EncodedJSValue to uint64_t for better clarity.

* JSTests/wasm/gc/bug266249.js: Added.
* Source/JavaScriptCore/wasm/WasmSlowPaths.cpp:
(JSC::LLInt::WASM_SLOW_PATH_DECL):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp:
(JSC::JSWebAssemblyStruct::set):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.h:

Canonical link: <a href="https://commits.webkit.org/272719@main">https://commits.webkit.org/272719@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df64c7967f9369d9500d75504d1a75d05cfcdc15

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32748 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11503 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34608 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35322 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29587 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13851 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8714 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29066 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33191 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9706 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29257 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8455 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8595 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29210 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36659 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/28038 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29763 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29618 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34713 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/32767 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8711 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6693 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32580 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10395 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/39231 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7618 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9322 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8275 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9320 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->