### PR TITLE
[WebCore] Optimize circular buffer handling

### DIFF
--- a/Source/WTF/wtf/text/StringHasherInlines.h
+++ b/Source/WTF/wtf/text/StringHasherInlines.h
@@ -99,7 +99,7 @@ inline unsigned StringHasher::hashWithTop8BitsMasked()
         uint64_t a = 0;
         uint64_t b = 0;
         if (m_bufferSize >= 8) {
-            a = wyr8(p + i - 8);
+            a = wyr8(p - (8 - i));
             b = wyr8(p + i - 4);
         } else {
             UChar tmp[8];

--- a/Source/WebCore/Modules/webaudio/ScriptProcessorNode.h
+++ b/Source/WebCore/Modules/webaudio/ScriptProcessorNode.h
@@ -85,7 +85,7 @@ private:
     // Double buffering.
     static constexpr unsigned bufferCount = 2;
     unsigned bufferIndex() const { return m_bufferIndex; }
-    void swapBuffers() { m_bufferIndex = (m_bufferIndex + 1) % bufferCount; }
+    void swapBuffers() { m_bufferIndex ^= 1; }
 
     unsigned m_bufferIndex { 0 };
     std::array<Lock, bufferCount> m_bufferLocks;

--- a/Source/WebCore/Modules/webdatabase/SQLTransactionStateMachine.h
+++ b/Source/WebCore/Modules/webdatabase/SQLTransactionStateMachine.h
@@ -51,8 +51,8 @@ protected:
     // s_sizeOfStateAuditTrail states that the state machine enters. The audit
     // trail is updated before entering each state. This is for debugging use
     // only.
-    static const int s_sizeOfStateAuditTrail = 20;
-    int m_nextStateAuditEntry;
+    static constexpr unsigned s_sizeOfStateAuditTrail = 20U;
+    unsigned m_nextStateAuditEntry;
     SQLTransactionState m_stateAuditTrail[s_sizeOfStateAuditTrail];
 #endif
 };
@@ -70,7 +70,7 @@ SQLTransactionStateMachine<T>::SQLTransactionStateMachine()
 #endif
 {
 #ifndef NDEBUG
-    for (int i = 0; i < s_sizeOfStateAuditTrail; i++)
+    for (unsigned i = 0; i < s_sizeOfStateAuditTrail; i++)
         m_stateAuditTrail[i] = SQLTransactionState::NumberOfStates;
 #endif
 }
@@ -98,8 +98,9 @@ void SQLTransactionStateMachine<T>::runStateMachine()
     ASSERT(stateFunction);
 
 #ifndef NDEBUG
-    m_stateAuditTrail[m_nextStateAuditEntry] = m_nextState;
-    m_nextStateAuditEntry = (m_nextStateAuditEntry + 1) % s_sizeOfStateAuditTrail;
+    m_stateAuditTrail[m_nextStateAuditEntry++] = m_nextState;
+    if (m_nextStateAuditEntry == s_sizeOfStateAuditTrail)
+        m_nextStateAuditEntry = 0;
 #endif
 
     (static_cast<T*>(this)->*stateFunction)();

--- a/Source/WebCore/html/TypeAhead.cpp
+++ b/Source/WebCore/html/TypeAhead.cpp
@@ -93,7 +93,7 @@ int TypeAhead::handleEvent(KeyboardEvent* event, MatchModeFlags matchMode)
         index %= optionCount;
 
         String prefixWithCaseFolded(prefix.foldCase());
-        for (int i = 0; i < optionCount; ++i, index = (index + 1) % optionCount) {
+        for (int i = 0; i < optionCount; ++i, index = ((index + 1) == optionCount) ? 0 : index + 1) {
             // Fold the option string and check if its prefix is equal to the folded prefix.
             String text = m_dataSource->optionAtIndex(index);
             if (stripLeadingWhiteSpace(text).foldCase().startsWith(prefixWithCaseFolded))

--- a/Source/WebCore/platform/audio/HRTFElevation.cpp
+++ b/Source/WebCore/platform/audio/HRTFElevation.cpp
@@ -305,7 +305,7 @@ void HRTFElevation::getKernelsFromAzimuth(double azimuthBlend, unsigned azimuthI
     frameDelayL = m_kernelListL->at(azimuthIndex)->frameDelay();
     frameDelayR = m_kernelListR->at(azimuthIndex)->frameDelay();
 
-    int azimuthIndex2 = (azimuthIndex + 1) % numKernels;
+    unsigned azimuthIndex2 = (azimuthIndex + 1) == numKernels ? 0 : azimuthIndex + 1;
     double frameDelay2L = m_kernelListL->at(azimuthIndex2)->frameDelay();
     double frameDelay2R = m_kernelListR->at(azimuthIndex2)->frameDelay();
 

--- a/Source/WebCore/platform/graphics/VelocityData.cpp
+++ b/Source/WebCore/platform/graphics/VelocityData.cpp
@@ -32,9 +32,8 @@ namespace WebCore {
 
 VelocityData HistoricalVelocityData::velocityForNewData(FloatPoint newPosition, double scale, MonotonicTime timestamp)
 {
-    auto append = [&](FloatPoint newPosition, double scale, MonotonicTime timestamp)
-    {
-        m_latestDataIndex = (m_latestDataIndex + 1) % maxHistoryDepth;
+    auto append = [&](FloatPoint newPosition, double scale, MonotonicTime timestamp) {
+        m_latestDataIndex = (m_latestDataIndex + 1) == maxHistoryDepth ? 0 : m_latestDataIndex + 1;
         m_positionHistory[m_latestDataIndex] = { timestamp, newPosition, scale };
         m_historySize = std::min(m_historySize + 1, maxHistoryDepth);
         m_lastAppendTimestamp = timestamp;

--- a/Source/WebCore/rendering/style/StyleGradientImage.cpp
+++ b/Source/WebCore/rendering/style/StyleGradientImage.cpp
@@ -614,9 +614,13 @@ GradientColorStops StyleGradientImage::computeStops(GradientAdapter& gradientAda
                     stops.append(newStop);
                     if (currOffset > maxExtent)
                         break;
-                    if (srcStopOrdinal < originalNumberOfStops - 1)
+
+                    if (++srcStopOrdinal < originalNumberOfStops) {
                         currOffset += *stops[srcStopIndex + 1].offset - *stops[srcStopIndex].offset;
-                    srcStopOrdinal = (srcStopOrdinal + 1) % originalNumberOfStops;
+                        continue;
+                    }
+
+                    srcStopOrdinal %= originalNumberOfStops;
                 }
             }
         }

--- a/Source/WebKit/UIProcess/gtk/WebPopupMenuProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/WebPopupMenuProxyGtk.cpp
@@ -473,7 +473,7 @@ std::optional<unsigned> WebPopupMenuProxyGtk::typeAheadFindIndex(unsigned keyval
         return std::nullopt;
 
     model = gtk_tree_view_get_model(GTK_TREE_VIEW(m_treeView));
-    for (unsigned i = 0; i < itemCount; i++, index = (index + 1) % itemCount) {
+    for (unsigned i = 0; i < itemCount; i++, index = ((index + 1) == itemCount) ? 0 : index + 1) {
         auto& path = m_paths[index];
         if (!path || !gtk_tree_model_get_iter(model, &iter, path.get()))
             continue;


### PR DESCRIPTION
<pre>
[WebCore] Optimize circular buffer handling
<a href="https://bugs.webkit.org/show_bug.cgi?id=266253">https://bugs.webkit.org/show_bug.cgi?id=266253</a>

Reviewed by NOBODY (OOPS!).

In cases where the divisor can be proven to always be below
the modulus, and said modulus is not a power of 2, we can
replace this with a check and manually reset as this is more
efficient than modulus every time.

* Source/WTF/wtf/text/StringHasherInlines.h:
(WTF::StringHasher::hashWithTop8BitsMasked): Fix bounds
* Source/WebCore/Modules/webaudio/ScriptProcessorNode.h: Switch between double buffer with ^= 1
* Source/WebCore/Modules/webdatabase/SQLTransactionStateMachine.h:
(WebCore::SQLTransactionStateMachine<T>::SQLTransactionStateMachine): Check for reaching buffer length and then reset to 0.
(WebCore::SQLTransactionStateMachine<T>::runStateMachine): Ditto.
* Source/WebCore/html/TypeAhead.cpp:
(WebCore::TypeAhead::handleEvent): Ditto.
* Source/WebCore/platform/audio/HRTFElevation.cpp;
(WebCore::HRTFElevation::getKernelsFromAzimuth): Ditto.
* Source/WebCore/platform/graphics/VelocityData.cpp:
(WebCore::HistoricalVelocityData::velocityForNewData): Ditto.
* Source/WebCore/rendering/style/StyleGradientImage.cpp:
(WebCore::StyleGradientImage::computeStops const): Ditto.
* Source/WebKit/UIProcess/gtk/WebPopupMenuProxyGtk.cpp:
(WebKit::WebPopupMenuProxyGtk::typeAheadFindIndex): Ditto.
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2f38dcad73b743e29f479fdd2f99925344a4e38

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31716 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10399 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33441 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34209 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28721 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32501 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12756 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7647 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28311 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32069 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8766 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28308 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7561 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7726 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28222 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35554 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/27220 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28830 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28669 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33842 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/31780 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7819 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5820 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31699 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9475 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/38229 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8497 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8110 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8336 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->