### PR TITLE
Invalid layer contents when navigating and hovering on slack and Facebook.

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp
@@ -181,6 +181,9 @@ void RemoteImageBufferSet::prepareBufferForDisplay(const WebCore::Region& dirtyR
 
     IntRect layerBounds = IntRect { { }, expandedIntSize(m_logicalSize) };
 
+    GraphicsContext& context = m_frontBuffer->context();
+    context.resetClip();
+
     if (m_previousFrontBuffer && m_frontBuffer != m_previousFrontBuffer && !dirtyRegion.contains(layerBounds)) {
         Region copyRegion(m_previouslyPaintedRect ? *m_previouslyPaintedRect : layerBounds);
         copyRegion.subtract(dirtyRegion);
@@ -188,9 +191,6 @@ void RemoteImageBufferSet::prepareBufferForDisplay(const WebCore::Region& dirtyR
         if (!copyRect.isEmpty())
             m_frontBuffer->context().drawImageBuffer(*m_previousFrontBuffer, copyRect, copyRect, { CompositeOperator::Copy });
     }
-
-    GraphicsContext& context = m_frontBuffer->context();
-    context.resetClip();
 
     auto dirtyRects = dirtyRegion.rects();
 #if PLATFORM(COCOA)


### PR DESCRIPTION
#### 8c21d17d0a028e2002f8361b0b93c02785473dcb
<pre>
Invalid layer contents when navigating and hovering on slack and Facebook.
<a href="https://bugs.webkit.org/show_bug.cgi?id=266255">https://bugs.webkit.org/show_bug.cgi?id=266255</a>
&lt;<a href="https://rdar.apple.com/119505126">rdar://119505126</a>&gt;

Reviewed by Mike Wyrzykowski.

Sometimes when hovering text entries on slack, the previous highlight isn&apos;t fully removed.
Likewise, navigating between the profile page and home page on Facebook can leave remnants
of the rendering of the previous page.

The code is resetting the graphics context clip to remove any partial-update clips applied
from a previous draw into that context. Unfortunately this was happening after the copy
forward draw, not before. This moves it up, so that we&apos;re not clipped to the old draw region.

It would be nice to add a test here.

* Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp:
(WebKit::RemoteImageBufferSet::prepareBufferForDisplay):

Canonical link: <a href="https://commits.webkit.org/271908@main">https://commits.webkit.org/271908@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/190e0fa89bd997bd621fad6415fb077b62241703

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30009 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8672 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31323 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32511 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27127 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10863 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5924 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/27167 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30303 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7269 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25594 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6207 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6364 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33848 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27364 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27117 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32543 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6307 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4478 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30339 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8051 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7111 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7056 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6834 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->