### PR TITLE
[WebGPU] Overrides with duplicate @id(values) are not rejected

### DIFF
--- a/LayoutTests/http/tests/webgpu/webgpu/api/validation/shader_module/overrides-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/validation/shader_module/overrides-expected.txt
@@ -1,1 +1,4 @@
-(Populate me when we're ready to investigate this test)
+
+PASS :id_conflict:
+PASS :name_conflict:
+

--- a/Source/WebGPU/WGSL/AttributeValidator.cpp
+++ b/Source/WebGPU/WGSL/AttributeValidator.cpp
@@ -215,8 +215,15 @@ void AttributeValidator::visit(AST::Variable& variable)
             auto idValue = idExpression.constantValue()->integerValue();
             if (idValue < 0)
                 error(attribute.span(), "@id value must be non-negative");
-            else
-                update(attribute.span(), variable.m_id, static_cast<unsigned>(idValue));
+            else {
+                auto uintIdValue = static_cast<unsigned>(idValue);
+                if (m_shaderModule.containsOverride(uintIdValue))
+                    error(attribute.span(), "@id value must be unique");
+                else {
+                    update(attribute.span(), variable.m_id, uintIdValue);
+                    m_shaderModule.addOverride(uintIdValue);
+                }
+            }
             continue;
         }
 

--- a/Source/WebGPU/WGSL/WGSLShaderModule.h
+++ b/Source/WebGPU/WGSL/WGSLShaderModule.h
@@ -33,6 +33,7 @@
 #include "WGSL.h"
 #include "WGSLEnums.h"
 
+#include <wtf/HashSet.h>
 #include <wtf/OptionSet.h>
 #include <wtf/text/StringHash.h>
 #include <wtf/text/WTFString.h>
@@ -220,6 +221,14 @@ public:
 
     OptionSet<Extension>& enabledExtensions() { return m_enabledExtensions; }
     OptionSet<LanguageFeature> requiredFeatures() { return m_requiredFeatures; }
+    bool containsOverride(uint32_t idValue) const
+    {
+        return m_pipelineOverrideIds.contains(idValue);
+    }
+    void addOverride(uint32_t idValue)
+    {
+        m_pipelineOverrideIds.add(idValue);
+    }
 
 private:
     String m_source;
@@ -239,6 +248,7 @@ private:
     TypeStore m_types;
     AST::Builder m_astBuilder;
     Vector<std::function<void()>> m_replacements;
+    HashSet<uint32_t, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_pipelineOverrideIds;
 };
 
 } // namespace WGSL


### PR DESCRIPTION
#### 8db4245f77a3baa881e5aeae9d80bd900e2af657
<pre>
[WebGPU] Overrides with duplicate @id(values) are not rejected
<a href="https://bugs.webkit.org/show_bug.cgi?id=266259">https://bugs.webkit.org/show_bug.cgi?id=266259</a>
radar://119520604

Reviewed by Dan Glastonbury.

The integer value inside of @id(...) must be unique.

* LayoutTests/http/tests/webgpu/webgpu/api/validation/shader_module/overrides-expected.txt:
* Source/WebGPU/WGSL/AttributeValidator.cpp:
(WGSL::AttributeValidator::visit):
* Source/WebGPU/WGSL/WGSLShaderModule.h:
(WGSL::ShaderModule::containsOverride const):
(WGSL::ShaderModule::addOverride):

Canonical link: <a href="https://commits.webkit.org/271956@main">https://commits.webkit.org/271956@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5c7cea48e74f2877ecd0b0f5228c3b574e2e49e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30034 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8697 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31345 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32533 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27146 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10889 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5948 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27186 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30328 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7292 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25615 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6229 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6381 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26708 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33869 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27387 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27139 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32561 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6323 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4498 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30359 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8071 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7145 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7075 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6850 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->