### PR TITLE
Add ShadowRoot clonable attribute

### DIFF
--- a/LayoutTests/fast/shadow-dom/cloneable-shadow-root.html
+++ b/LayoutTests/fast/shadow-dom/cloneable-shadow-root.html
@@ -12,6 +12,7 @@ function testShadowRootIsNotCloneableByDefault(mode) {
     test(() => {
         const host = document.createElement('div');
         const shadowRoot = host.attachShadow({mode});
+        assert_false(shadowRoot.cloneable);
 
         const clonedHost = host.cloneNode(true);
         assert_true(!!clonedHost.attachShadow({mode}));
@@ -28,6 +29,7 @@ function testShadowRootIsCloneable(mode) {
     test(() => {
         const host = document.createElement('div');
         const shadowRoot = host.attachShadow({mode, cloneable: true});
+        assert_true(shadowRoot.cloneable);
 
         const clonedHost = host.cloneNode(true);
         assert_throws_dom('NotSupportedError', () => {
@@ -44,6 +46,7 @@ function testShadowRootClonesShadowRootMode(mode) {
     test(() => {
         const host = document.createElement('div');
         const shadowRoot = host.attachShadow({mode, cloneable: true});
+        assert_true(shadowRoot.cloneable);
         const clonedHost = host.cloneNode(true);
         assert_equals(!!clonedHost.shadowRoot, mode == 'open');
     }, `Cloning ShadowRoot in "${mode}" mode clones shadow root mode`);
@@ -56,6 +59,7 @@ function testShadowRootClonesDelegatesFocus(mode, delegatesFocus) {
     test(() => {
         const host = document.createElement('div');
         const shadowRoot = host.attachShadow({mode, cloneable: true, delegatesFocus});
+        assert_true(shadowRoot.cloneable);
         shadowRoot.innerHTML = '<input onfocus="window.didFocusInputElement = true">';
 
         const clonedHost = host.cloneNode(true);
@@ -79,6 +83,7 @@ function testShadowRootClonesSlotAssignment(mode) {
         const host = document.createElement('span');
         host.innerHTML = '<div style="width: 100px; height: 100px; display: inline-block;"></div>';
         const shadowRoot = host.attachShadow({mode, cloneable: true, slotAssignment: 'manual'});
+        assert_true(shadowRoot.cloneable);
         shadowRoot.innerHTML = '<slot></slot>';
         const clonedHost = host.cloneNode(true);
         if (mode == 'open')
@@ -92,6 +97,7 @@ function testShadowRootClonesSlotAssignment(mode) {
         const host = document.createElement('span');
         host.innerHTML = '<div style="width: 100px; height: 100px; display: inline-block;"></div>';
         const shadowRoot = host.attachShadow({mode, cloneable: true, slotAssignment: 'named'});
+        assert_true(shadowRoot.cloneable);
         shadowRoot.innerHTML = '<slot></slot>';
         const clonedHost = host.cloneNode(true);
         if (mode == 'open')
@@ -109,6 +115,7 @@ function testShadowRootClonesShadowDescendants(mode) {
     test(() => {
         const host = document.createElement('span');
         const shadowRoot = host.attachShadow({mode, cloneable: true});
+        assert_true(shadowRoot.cloneable);
         shadowRoot.innerHTML = '<div style="width: 100px; height: 100px; display: inline-block;"><div></div></div>';
         const clonedHost = host.cloneNode(true);
         if (mode == 'open')

--- a/Source/WebCore/dom/ShadowRoot.idl
+++ b/Source/WebCore/dom/ShadowRoot.idl
@@ -31,6 +31,7 @@
     readonly attribute ShadowRootMode mode;
     readonly attribute boolean delegatesFocus;
     [ImplementedAs=slotAssignmentMode, EnabledBySetting=ImperativeSlotAPIEnabled] readonly attribute SlotAssignmentMode slotAssignment;
+    [ImplementedAs=isCloneable, EnabledBySetting=DeclarativeShadowRootsEnabled] readonly attribute boolean cloneable;
     readonly attribute Element host;
     attribute EventHandler onslotchange;
 };


### PR DESCRIPTION
#### 9bb617ff68ef4a758e79ee85f5bea77e220f015f
<pre>
Add ShadowRoot clonable attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=266227">https://bugs.webkit.org/show_bug.cgi?id=266227</a>

Reviewed by Chris Dumez.

Added the attribute proposed in <a href="https://github.com/whatwg/dom/pull/1237.">https://github.com/whatwg/dom/pull/1237.</a>

* LayoutTests/fast/shadow-dom/cloneable-shadow-root.html:
* Source/WebCore/dom/ShadowRoot.idl:

Canonical link: <a href="https://commits.webkit.org/272096@main">https://commits.webkit.org/272096@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd50e33a5d3b8758cecb9477d2e918528e57517e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30026 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8689 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31834 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32526 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27140 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30686 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10880 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5941 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27178 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30320 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7282 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/26919 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6222 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6375 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27013 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33863 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27377 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27504 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32555 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6320 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4489 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30353 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8064 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/26767 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7241 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7069 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6847 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->