### PR TITLE
[:has() pseudo-class] Support invalidation for :any-link, :link and :-webkit-any-link

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/link-pseudo-class-in-has-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/link-pseudo-class-in-has-expected.txt
@@ -1,0 +1,6 @@
+This is some text. This is an anchor element
+This is an SVG anchor element
+
+PASS :any-link & :link pseudo-class invalidation with an HTML link
+PASS :any-link & :link pseudo-class invalidation with an SVG link
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/link-pseudo-class-in-has.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/link-pseudo-class-in-has.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>CSS Selectors Invalidation: :any-link and :link pseudo class in :has()</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/selectors/#relational">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<style>
+    /* :any-link and :link should match similarly */
+    #subject:has(#target:link:any-link) { color: green; }
+    #subject:has(#svgTarget:link:any-link) { color: blue; }
+</style>
+
+<div id="subject">
+    This is some text.
+    <a id="target">This is an anchor element</a>
+    <svg xmlns="http://www.w3.org/2000/svg">
+        <a id="svgTarget"><text>This is an SVG anchor element</text></a>
+    </svg>
+</div>
+
+<script>
+test(function() {
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 0)",
+                  "ancestor should be black");
+    target.setAttribute("href", "/");
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 128, 0)",
+                  "ancestor should be green since target is a link");
+    target.removeAttribute("href");
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 0)",
+                  "ancestor should be black since target is no longer a link");
+}, ":any-link & :link pseudo-class invalidation with an HTML link");
+
+test(function() {
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 0)",
+                  "ancestor should be black");
+    svgTarget.setAttribute("href", "/")
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 255)",
+                  "ancestor should be blue since target is a link");
+    svgTarget.removeAttribute("href");
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 0)",
+                  "ancestor should be black since target is no longer a link");
+}, ":any-link & :link pseudo-class invalidation with an SVG link");
+</script>

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -348,7 +348,7 @@ AccessibilityRole AccessibilityNodeObject::determineAccessibilityRoleFromNode(Tr
     if (!node())
         return AccessibilityRole::Unknown;
 
-    if (node()->isLink())
+    if (RefPtr element = dynamicDowncast<Element>(*node()); element && element->isLink())
         return AccessibilityRole::WebCoreLink;
     if (node()->isTextNode())
         return AccessibilityRole::StaticText;

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2342,6 +2342,18 @@ URL Element::absoluteLinkURL() const
     return document().completeURL(linkAttribute);
 }
 
+void Element::setIsLink(bool flag)
+{
+    if (isLink() == flag)
+        return;
+    Style::PseudoClassChangeInvalidation styleInvalidation(*this, {
+        { CSSSelector::PseudoClassType::AnyLink, flag },
+        { CSSSelector::PseudoClassType::AnyLinkDeprecated, flag },
+        { CSSSelector::PseudoClassType::Link, flag }
+    });
+    setNodeFlag(NodeFlag::IsLink, flag);
+}
+
 #if ENABLE(TOUCH_EVENTS)
 
 bool Element::allowsDoubleTapGesture() const

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -593,6 +593,9 @@ public:
     bool hasPendingKeyframesUpdate(PseudoId) const;
     // FIXME: do we need a counter style didChange here? (rdar://103018993).
 
+    bool isLink() const { return hasNodeFlag(NodeFlag::IsLink); }
+    void setIsLink(bool flag);
+
     bool isInTopLayer() const { return hasNodeFlag(NodeFlag::IsInTopLayer); }
     void addToTopLayer();
     void removeFromTopLayer();

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -2095,8 +2095,8 @@ Element* Node::enclosingLinkEventParentOrSelf()
         // For imagemaps, the enclosing link element is the associated area element not the image itself.
         // So we don't let images be the enclosing link element, even though isLink sometimes returns
         // true for them.
-        if (node->isLink() && !is<HTMLImageElement>(*node))
-            return downcast<Element>(node);
+        if (auto* element = dynamicDowncast<Element>(*node); element && element->isLink() && !is<HTMLImageElement>(*element))
+            return element;
     }
 
     return nullptr;

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -360,9 +360,6 @@ public:
 
     void setHasValidStyle();
 
-    bool isLink() const { return hasNodeFlag(NodeFlag::IsLink); }
-    void setIsLink(bool flag) { setNodeFlag(NodeFlag::IsLink, flag); }
-
     bool isInGCReacheableRefMap() const { return hasNodeFlag(NodeFlag::IsInGCReachableRefMap); }
     void setIsInGCReacheableRefMap(bool flag) { setNodeFlag(NodeFlag::IsInGCReachableRefMap, flag); }
 

--- a/Source/WebCore/editing/Editing.cpp
+++ b/Source/WebCore/editing/Editing.cpp
@@ -576,8 +576,8 @@ RefPtr<Element> enclosingTableCell(const Position& position)
 RefPtr<Element> enclosingAnchorElement(const Position& p)
 {
     for (auto node = p.protectedDeprecatedNode(); node; node = node->parentNode()) {
-        if (is<Element>(*node) && node->isLink())
-            return downcast<Element>(node.releaseNonNull());
+        if (auto* element = dynamicDowncast<Element>(*node); element && element->isLink())
+            return element;
     }
     return nullptr;
 }

--- a/Source/WebCore/html/HTMLAnchorElement.cpp
+++ b/Source/WebCore/html/HTMLAnchorElement.cpp
@@ -241,10 +241,7 @@ void HTMLAnchorElement::attributeChanged(const QualifiedName& name, const AtomSt
     HTMLElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 
     if (name == hrefAttr) {
-        bool wasLink = isLink();
         setIsLink(!newValue.isNull() && !shouldProhibitLinks(this));
-        if (wasLink != isLink())
-            invalidateStyleForSubtree();
         if (isLink()) {
             auto parsedURL = newValue.string().trim(isASCIIWhitespace);
             if (document().isDNSPrefetchEnabled() && document().frame()) {

--- a/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
+++ b/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
@@ -2491,12 +2491,15 @@ void HTMLTreeBuilder::linkifyPhoneNumbers(const String& string)
 // Looks at the ancestors of the element to determine whether we're inside an element which disallows parsing phone numbers.
 static inline bool disallowTelephoneNumberParsing(const ContainerNode& node)
 {
-    if (node.isLink() || is<HTMLFormControlElement>(node))
+    if (is<HTMLFormControlElement>(node))
         return true;
 
     auto* element = dynamicDowncast<Element>(node);
     if (!element)
         return false;
+
+    if (element->isLink())
+        return true;
 
     switch (element->elementName()) {
     case HTML::a:

--- a/Source/WebCore/mathml/MathMLElement.cpp
+++ b/Source/WebCore/mathml/MathMLElement.cpp
@@ -82,13 +82,9 @@ unsigned MathMLElement::rowSpan() const
 void MathMLElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     switch (name.nodeName()) {
-    case AttributeNames::hrefAttr: {
-        bool wasLink = isLink();
+    case AttributeNames::hrefAttr:
         setIsLink(!newValue.isNull() && !shouldProhibitLinks(this));
-        if (wasLink != isLink())
-            invalidateStyleForSubtree();
         break;
-    }
     case AttributeNames::columnspanAttr:
     case AttributeNames::rowspanAttr:
         if (is<RenderTableCell>(renderer()) && hasTagName(mtdTag))

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -217,11 +217,14 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject
 
     bool isLabelable = is<HTMLElement>(matchedElement) && downcast<HTMLElement>(matchedElement)->isLabelable();
     for (Node* node = matchedElement; node; node = node->parentInComposedTree()) {
-        bool matchedButton = is<HTMLButtonElement>(node);
-        bool matchedLabel = isLabelable && is<HTMLLabelElement>(node);
-        bool matchedLink = node->isLink();
+        auto* element = dynamicDowncast<Element>(node);
+        if (!element)
+            continue;
+        bool matchedButton = is<HTMLButtonElement>(*element);
+        bool matchedLabel = isLabelable && is<HTMLLabelElement>(*element);
+        bool matchedLink = element->isLink();
         if (matchedButton || matchedLabel || matchedLink) {
-            matchedElement = downcast<Element>(node);
+            matchedElement = element;
             break;
         }
     }

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -755,14 +755,11 @@ void RenderObject::addPDFURLRect(const PaintInfo& paintInfo, const LayoutPoint& 
 
     if (urlRect.isEmpty())
         return;
-    RefPtr element = [this]() -> RefPtr<Element> {
-        RefPtr node = this->node();
-        if (!is<Element>(node) || !node->isLink())
-            return nullptr;
-        return downcast<Element>(WTFMove(node));
-    }();
-    if (!element)
+
+    RefPtr element = dynamicDowncast<Element>(node());
+    if (!element || !element->isLink())
         return;
+
     const AtomString& href = element->getAttribute(hrefAttr);
     if (href.isNull())
         return;

--- a/Source/WebCore/svg/SVGAElement.cpp
+++ b/Source/WebCore/svg/SVGAElement.cpp
@@ -95,12 +95,8 @@ void SVGAElement::attributeChanged(const QualifiedName& name, const AtomString& 
 void SVGAElement::svgAttributeChanged(const QualifiedName& attrName)
 {
     if (SVGURIReference::isKnownAttribute(attrName)) {
-        bool wasLink = isLink();
+        InstanceInvalidationGuard guard(*this);
         setIsLink(!href().isNull() && !shouldProhibitLinks(this));
-        if (wasLink != isLink()) {
-            InstanceInvalidationGuard guard(*this);
-            invalidateStyleForSubtree();
-        }
         return;
     }
 

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -1142,7 +1142,7 @@ void WebPage::sendTapHighlightForNodeIfNecessary(WebKit::TapIdentifier requestID
         if (is<RenderBox>(*renderer))
             borderRadii = downcast<RenderBox>(*renderer).borderRadii();
 
-        bool nodeHasBuiltInClickHandling = is<HTMLFormControlElement>(*node) || is<HTMLAnchorElement>(*node) || is<HTMLLabelElement>(*node) || is<HTMLSummaryElement>(*node) || node->isLink();
+        bool nodeHasBuiltInClickHandling = is<HTMLFormControlElement>(*node) || is<HTMLAnchorElement>(*node) || is<HTMLLabelElement>(*node) || is<HTMLSummaryElement>(*node) || (is<Element>(*node) && downcast<Element>(*node).isLink());
         send(Messages::WebPageProxy::DidGetTapHighlightGeometries(requestID, highlightColor, quads, roundedIntSize(borderRadii.topLeft()), roundedIntSize(borderRadii.topRight()), roundedIntSize(borderRadii.bottomLeft()), roundedIntSize(borderRadii.bottomRight()), nodeHasBuiltInClickHandling));
     }
 #else

--- a/Source/WebKitLegacy/mac/DOM/DOM.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOM.mm
@@ -375,8 +375,8 @@ id <DOMEventTarget> kit(EventTarget* target)
 - (Element*)_linkElement
 {
     for (auto* node = core(self); node; node = node->parentNode()) {
-        if (node->isLink())
-            return &downcast<Element>(*node);
+        if (auto* element = dynamicDowncast<Element>(*node); element && element->isLink())
+            return element;
     }
     return nullptr;
 }


### PR DESCRIPTION
#### 1d40c072bffe76581c75de0c192d379951ca4daa
<pre>
[:has() pseudo-class] Support invalidation for :any-link, :link and :-webkit-any-link
<a href="https://bugs.webkit.org/show_bug.cgi?id=262836">https://bugs.webkit.org/show_bug.cgi?id=262836</a>
<a href="https://rdar.apple.com/116616425">rdar://116616425</a>

Reviewed by Darin Adler.

Move Node::isLink/setIsLink to Element, and make use of Style::PseudoClassChangeInvalidation in the setter.

Add a web platform test as well.

* LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/link-pseudo-class-in-has-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/link-pseudo-class-in-has.html: Added.
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::determineAccessibilityRoleFromNode const):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::setIsLink):
* Source/WebCore/dom/Element.h:
(WebCore::Element::isLink const):
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::enclosingLinkEventParentOrSelf):
* Source/WebCore/dom/Node.h:
(WebCore::Node::isLink const): Deleted.
(WebCore::Node::setIsLink): Deleted.
* Source/WebCore/editing/Editing.cpp:
(WebCore::enclosingAnchorElement):
* Source/WebCore/html/HTMLAnchorElement.cpp:
(WebCore::HTMLAnchorElement::attributeChanged):
* Source/WebCore/html/parser/HTMLTreeBuilder.cpp:
(WebCore::disallowTelephoneNumberParsing):
* Source/WebCore/mathml/MathMLElement.cpp:
(WebCore::MathMLElement::attributeChanged):
* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::interactionRegionForRenderedRegion):
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::addPDFURLRect const):
* Source/WebCore/svg/SVGAElement.cpp:
(WebCore::SVGAElement::svgAttributeChanged):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::sendTapHighlightForNodeIfNecessary):
* Source/WebKitLegacy/mac/DOM/DOM.mm:
(-[DOMNode _linkElement]):

Canonical link: <a href="https://commits.webkit.org/271919@main">https://commits.webkit.org/271919@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/384cf40f9d29e0a9e9a975b07b3260f889a74206

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30064 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8728 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31378 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32565 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27180 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30733 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10924 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5975 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/27205 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30362 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7318 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25639 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6247 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6405 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/26732 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33901 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27413 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27163 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32585 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6348 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4517 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30384 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8097 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/26532 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/7119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7101 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3876 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6876 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->