### PR TITLE
Clean up ExtensionKitSPI.h in preparation for importing `ServiceExtensions` private headers

### DIFF
--- a/Source/WebKit/Platform/spi/Cocoa/ExtensionKitSPI.h
+++ b/Source/WebKit/Platform/spi/Cocoa/ExtensionKitSPI.h
@@ -23,73 +23,94 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#pragma once
+
 #if USE(EXTENSIONKIT)
 
+#import <Foundation/Foundation.h>
+
+#if __has_include(<ServiceExtensions/SEServiceManager_Private.h>)
+#import <ServiceExtensions/SEServiceManager_Private.h>
+#else
+
+@class _SEContentProcess;
+@class _SEGPUProcess;
+@class _SENetworkProcess;
 @protocol UIInteraction;
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface _SEServiceConfiguration: NSObject
+@interface _SEServiceConfiguration : NSObject
 typedef void(^_SEServiceInteruptionHandler)();
-@property (copy) NSString* serviceIdentifier;
+@property (copy) NSString *serviceIdentifier;
 @property (copy) _SEServiceInteruptionHandler interuptionHandler;
 
--(instancetype)initWithServiceIdentifier:(NSString*)serviceIdentifier;
+- (instancetype)initWithServiceIdentifier:(NSString *)serviceIdentifier;
 
 @end
 
+@interface _SEServiceManager: NSObject
+
++ (instancetype)sharedInstance;
+
+- (void)contentProcessWithConfiguration:(_SEServiceConfiguration *)configuration completion:(void(^)(_SEContentProcess * _Nullable process, NSError * _Nullable error))completion;
+
+- (void)networkProcessWithConfiguration:(_SEServiceConfiguration *)configuration completion:(void(^)(_SENetworkProcess * _Nullable process, NSError * _Nullable error))completion;
+
+- (void)gpuProcessWithConfiguration:(_SEServiceConfiguration *)configuration completion:(void(^)(_SEGPUProcess * _Nullable process, NSError * _Nullable error))completion;
+
+@end
+
+#endif
+
+#if __has_include(<ServiceExtensions/SEProcesses_Private.h>)
+#import <ServiceExtensions/SEProcesses_Private.h>
+#else
+
 @protocol _SEGrant <NSObject>
--(BOOL)invalidateWithError:(NSError* _Nullable*)error;
+- (BOOL)invalidateWithError:(NSError * _Nullable *)error;
 @property (readonly) BOOL isValid;
 @end
 
 @interface _SECapabilities : NSObject
-+(instancetype)assertionWithDomain:(NSString*)domain name:(NSString*)name;
-+(instancetype)assertionWithDomain:(NSString*)domain name:(NSString*)name environmentIdentifier:(NSString*)environmentIdentifier;
-+(instancetype)assertionWithDomain:(NSString*)domain name:(NSString*)name environmentIdentifier:(NSString*)environmentIdentifier willInvalidate:(void (^)())willInvalidateBlock didInvalidate:(void (^)())didInvalidateBlock;
-+(instancetype)mediaWithWebsite:(NSString*)website;
--(BOOL)setActive:(BOOL)active;
-@property (nonatomic, readonly) NSString *mediaEnvironment;
 @end
 
 NS_REFINED_FOR_SWIFT
-@interface _SEExtensionProcess: NSObject
+@interface _SEExtensionProcess : NSObject
 
--(nullable xpc_connection_t)makeLibXPCConnectionError:(NSError* _Nullable*)error;
+- (nullable xpc_connection_t)makeLibXPCConnectionError:(NSError * _Nullable *)error;
 
--(void)invalidate;
+- (void)invalidate;
 
--(nullable id<_SEGrant>)grantCapabilities:(_SECapabilities*)capabilities error:(NSError* _Nullable*)error;
+- (nullable id<_SEGrant>)grantCapabilities:(_SECapabilities *)capabilities error:(NSError * _Nullable *)error;
 
 @end
 
 NS_REFINED_FOR_SWIFT
-@interface _SEContentProcess: _SEExtensionProcess
--(id<UIInteraction>)createVisibilityPropagationInteraction;
+@interface _SEContentProcess : _SEExtensionProcess
+- (id<UIInteraction>)createVisibilityPropagationInteraction;
 @end
 
 NS_REFINED_FOR_SWIFT
-@interface _SEGPUProcess: _SEExtensionProcess
--(id<UIInteraction>)createVisibilityPropagationInteraction;
+@interface _SEGPUProcess : _SEExtensionProcess
+- (id<UIInteraction>)createVisibilityPropagationInteraction;
 @end
 
 NS_REFINED_FOR_SWIFT
-@interface _SENetworkProcess: _SEExtensionProcess
-@end
-
-
-@interface _SEServiceManager: NSObject
-
-+(instancetype)sharedInstance;
-
--(void)contentProcessWithConfiguration:(_SEServiceConfiguration*)configuration completion:(void(^)(_SEContentProcess* _Nullable process, NSError* _Nullable error))completion;
-
--(void)networkProcessWithConfiguration:(_SEServiceConfiguration*)configuration completion:(void(^)(_SENetworkProcess* _Nullable process, NSError* _Nullable error))completion;
-
--(void)gpuProcessWithConfiguration:(_SEServiceConfiguration*)configuration completion:(void(^)(_SEGPUProcess* _Nullable process, NSError* _Nullable error))completion;
-
+@interface _SENetworkProcess : _SEExtensionProcess
 @end
 
 NS_ASSUME_NONNULL_END
+
+#endif
+
+@interface _SECapabilities (IPI)
+- (BOOL)setActive:(BOOL)active;
++ (instancetype)mediaWithWebsite:(NSString*)website;
++ (instancetype)assertionWithDomain:(NSString *)domain name:(NSString *)name;
++ (instancetype)assertionWithDomain:(NSString *)domain name:(NSString *)name environmentIdentifier:(NSString *)environmentIdentifier;
++ (instancetype)assertionWithDomain:(NSString *)domain name:(NSString *)name environmentIdentifier:(NSString *)environmentIdentifier willInvalidate:(void (^)())willInvalidateBlock didInvalidate:(void (^)())didInvalidateBlock;
+@property (nonatomic, readonly) NSString *mediaEnvironment;
+@end
 
 #endif // USE(EXTENSIONKIT)


### PR DESCRIPTION
#### 26ce6ffaed99412d0b7d6f5296170da6e989ddcd
<pre>
Clean up ExtensionKitSPI.h in preparation for importing `ServiceExtensions` private headers
<a href="https://bugs.webkit.org/show_bug.cgi?id=266269">https://bugs.webkit.org/show_bug.cgi?id=266269</a>
<a href="https://rdar.apple.com/119534794">rdar://119534794</a>

Reviewed by Tim Horton.

Clean up this SPI header, in preparation for subsequent patches that rely on importing
`ServiceExtensions_Private.h`:
-   Import the declarations of these ObjC classes directly from framework headers when available.
    Only fall back to forward declarations when the headers are absent.
-   Define IPI functionality in a separate IPI category.
-   Miscellaneous style cleanup (spaces before `*` for ObjC objects, and spaces before return types
    when declaring methods).

* Source/WebKit/Platform/spi/Cocoa/ExtensionKitSPI.h:

Canonical link: <a href="https://commits.webkit.org/271916@main">https://commits.webkit.org/271916@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4866b51740da634ef99c6eec5f13e00740640996

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30051 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8714 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31363 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32550 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27165 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10908 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5962 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27193 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30347 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7306 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25627 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6236 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6394 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33886 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27401 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27151 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32573 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6338 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4507 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30373 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8085 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7118 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7090 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6866 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->