### PR TITLE
Remove lazy repaints from RenderView and more

### DIFF
--- a/Source/WebCore/platform/ControlStates.h
+++ b/Source/WebCore/platform/ControlStates.h
@@ -27,20 +27,8 @@
 #define ControlStates_h
 
 #include <wtf/OptionSet.h>
-#include <wtf/RetainPtr.h>
-#include <wtf/Seconds.h>
-
-#if PLATFORM(COCOA)
-#ifndef __OBJC__
-typedef struct objc_object *id;
-#endif
-#endif
 
 namespace WebCore {
-
-#if PLATFORM(COCOA)
-typedef id PlatformControlInstance;
-#endif
 
 class ControlStates {
     WTF_MAKE_FAST_ALLOCATED;
@@ -71,35 +59,12 @@ public:
         if (newStates == m_states)
             return;
         m_states = newStates;
-        m_isDirty = m_initialized;
-        m_initialized = true;
     }
-
-    bool needsRepaint() const { return m_needsRepaint; }
-    void setNeedsRepaint(bool r) { m_needsRepaint = r; }
-
-    bool isDirty() const { return m_isDirty; }
-    void setDirty(bool d) { m_isDirty = d; }
-
-    Seconds timeSinceControlWasFocused() const { return m_timeSinceControlWasFocused; }
-    void setTimeSinceControlWasFocused(Seconds time) { m_timeSinceControlWasFocused = time; }
-
-#if PLATFORM(COCOA)
-    PlatformControlInstance platformControl() const { return m_controlInstance.get(); }
-    void setPlatformControl(PlatformControlInstance instance) { m_controlInstance = instance; }
-#endif
 
 private:
     OptionSet<States> m_states;
-    bool m_initialized { false };
-    bool m_needsRepaint { false };
-    bool m_isDirty { false };
-    Seconds m_timeSinceControlWasFocused { 0_s };
-#if PLATFORM(COCOA)
-    RetainPtr<PlatformControlInstance> m_controlInstance;
-#endif
 };
 
-}
+} // namespace WebCore
 
 #endif

--- a/Source/WebCore/rendering/RenderAttachment.cpp
+++ b/Source/WebCore/rendering/RenderAttachment.cpp
@@ -127,8 +127,7 @@ void RenderAttachment::paintReplaced(PaintInfo& paintInfo, const LayoutPoint& of
     auto paintRect = borderBoxRect();
     paintRect.moveBy(offset);
 
-    ControlStates controlStates;
-    theme().paint(*this, controlStates, paintInfo, paintRect);
+    theme().paint(*this, paintInfo, paintRect);
 }
 
 void RenderAttachment::layoutShadowContent(const LayoutSize& size)

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -29,7 +29,6 @@
 #include "BackgroundPainter.h"
 #include "BorderPainter.h"
 #include "CSSFontSelector.h"
-#include "ControlStates.h"
 #include "Document.h"
 #include "Editing.h"
 #include "EventHandler.h"
@@ -131,25 +130,6 @@ static OverrideOptionalSizeMap* gOverridingContainingBlockContentLogicalWidthMap
 static const int autoscrollBeltSize = 20;
 static const unsigned backgroundObscurationTestMaxDepth = 4;
 
-using ControlStatesRendererMap = HashMap<const RenderObject*, std::unique_ptr<ControlStates>>;
-static ControlStatesRendererMap& controlStatesRendererMap()
-{
-    static NeverDestroyed<ControlStatesRendererMap> map;
-    return map;
-}
-
-static ControlStates* controlStatesForRenderer(const RenderBox& renderer)
-{
-    return controlStatesRendererMap().ensure(&renderer, [] {
-        return makeUnique<ControlStates>();
-    }).iterator->value.get();
-}
-
-static void removeControlStatesForRenderer(const RenderBox& renderer)
-{
-    controlStatesRendererMap().remove(&renderer);
-}
-
 bool RenderBox::s_hadNonVisibleOverflow = false;
 
 RenderBox::RenderBox(Type type, Element& element, RenderStyle&& style, BaseTypeFlags baseTypeFlags)
@@ -182,9 +162,6 @@ void RenderBox::willBeDestroyed()
     RenderBlock::removePercentHeightDescendantIfNeeded(*this);
 
     ShapeOutsideInfo::removeInfo(*this);
-
-    view().unscheduleLazyRepaint(*this);
-    removeControlStatesForRenderer(*this);
 
     if (hasInitializedStyle()) {
         if (style().hasSnapPosition())
@@ -1730,12 +1707,8 @@ void RenderBox::paintBoxDecorations(PaintInfo& paintInfo, const LayoutPoint& pai
     if (style().hasEffectiveAppearance()) {
         if (auto* control = ensureControlPartForRenderer())
             borderOrBackgroundPaintingIsNeeded = theme().paint(*this, *control, paintInfo, paintRect);
-        else {
-            ControlStates* controlStates = controlStatesForRenderer(*this);
-            borderOrBackgroundPaintingIsNeeded = theme().paint(*this, *controlStates, paintInfo, paintRect);
-            if (controlStates->needsRepaint())
-                view().scheduleLazyRepaint(*this);
-        }
+        else
+            borderOrBackgroundPaintingIsNeeded = theme().paint(*this, paintInfo, paintRect);
     }
 
     BorderPainter borderPainter { *this, paintInfo };

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -122,7 +122,6 @@ inline RenderElement::RenderElement(Type type, ContainerNode& elementOrDocument,
     , m_baseTypeFlags(baseTypeFlags)
     , m_ancestorLineBoxDirty(false)
     , m_hasInitializedStyle(false)
-    , m_renderBoxNeedsLazyRepaint(false)
     , m_hasPausedImageAnimations(false)
     , m_hasCounterNodeMap(false)
     , m_hasContinuationChainNode(false)

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -237,9 +237,6 @@ public:
     bool hasPausedImageAnimations() const { return m_hasPausedImageAnimations; }
     void setHasPausedImageAnimations(bool b) { m_hasPausedImageAnimations = b; }
 
-    void setRenderBoxNeedsLazyRepaint(bool b) { m_renderBoxNeedsLazyRepaint = b; }
-    bool renderBoxNeedsLazyRepaint() const { return m_renderBoxNeedsLazyRepaint; }
-
     bool hasCounterNodeMap() const { return m_hasCounterNodeMap; }
     void setHasCounterNodeMap(bool f) { m_hasCounterNodeMap = f; }
 
@@ -412,7 +409,6 @@ private:
     unsigned m_ancestorLineBoxDirty : 1;
     unsigned m_hasInitializedStyle : 1;
 
-    unsigned m_renderBoxNeedsLazyRepaint : 1;
     unsigned m_hasPausedImageAnimations : 1;
     unsigned m_hasCounterNodeMap : 1;
     unsigned m_hasContinuationChainNode : 1;

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -754,7 +754,7 @@ bool RenderTheme::paint(const RenderBox& box, ControlPart& part, const PaintInfo
     return false;
 }
 
-bool RenderTheme::paint(const RenderBox& box, ControlStates& controlStates, const PaintInfo& paintInfo, const LayoutRect& rect)
+bool RenderTheme::paint(const RenderBox& box, const PaintInfo& paintInfo, const LayoutRect& rect)
 {
     // If painting is disabled, but we aren't updating control tints, then just bail.
     // If we are updating control tints, just schedule a repaint if the theme supports tinting
@@ -776,11 +776,6 @@ bool RenderTheme::paint(const RenderBox& box, ControlStates& controlStates, cons
     float deviceScaleFactor = box.document().deviceScaleFactor();
     FloatRect devicePixelSnappedRect = snapRectToDevicePixels(rect, deviceScaleFactor);
 
-
-#if !USE(THEME_ADWAITA)
-    UNUSED_PARAM(controlStates);
-#endif
-
     switch (appearance) {
 #if USE(THEME_ADWAITA)
     case StyleAppearance::Checkbox:
@@ -792,10 +787,11 @@ bool RenderTheme::paint(const RenderBox& box, ControlStates& controlStates, cons
 #endif
     case StyleAppearance::DefaultButton:
     case StyleAppearance::Button:
-    case StyleAppearance::InnerSpinButton:
-        updateControlStatesForRenderer(box, controlStates);
-        Theme::singleton().paint(appearance, controlStates, paintInfo.context(), devicePixelSnappedRect, box.useDarkAppearance(), box.style().effectiveAccentColor());
+    case StyleAppearance::InnerSpinButton: {
+        ControlStates states(extractControlStatesForRenderer(box));
+        Theme::singleton().paint(appearance, states, paintInfo.context(), devicePixelSnappedRect, box.useDarkAppearance(), box.style().effectiveAccentColor());
         return false;
+    }
 #else // !USE(THEME_ADWAITA)
     case StyleAppearance::Checkbox:
         return paintCheckbox(box, paintInfo, devicePixelSnappedRect);
@@ -1146,14 +1142,6 @@ bool RenderTheme::stateChanged(const RenderObject& o, ControlStates::States stat
     // Repaint the control.
     o.repaint();
     return true;
-}
-
-void RenderTheme::updateControlStatesForRenderer(const RenderBox& box, ControlStates& controlStates) const
-{
-    ControlStates newStates = extractControlStatesForRenderer(box);
-    controlStates.setStates(newStates.states());
-    if (isFocused(box))
-        controlStates.setTimeSinceControlWasFocused(box.page().focusController().timeSinceFocusWasSet());
 }
 
 OptionSet<ControlStates::States> RenderTheme::extractControlStatesForRenderer(const RenderObject& o) const

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -85,7 +85,7 @@ public:
     // text of a button, is always rendered by the engine itself. The boolean return value indicates
     // whether the CSS border/background should also be painted.
     bool paint(const RenderBox&, ControlPart&, const PaintInfo&, const LayoutRect&);
-    bool paint(const RenderBox&, ControlStates&, const PaintInfo&, const LayoutRect&);
+    bool paint(const RenderBox&, const PaintInfo&, const LayoutRect&);
     
     bool paintBorderOnly(const RenderBox&, const PaintInfo&, const LayoutRect&);
     void paintDecorations(const RenderBox&, const PaintInfo&, const LayoutRect&);
@@ -389,7 +389,6 @@ private:
     void adjustButtonOrCheckboxOrColorWellOrInnerSpinButtonOrRadioOrSwitchStyle(RenderStyle&, const Element*) const;
 
 public:
-    void updateControlStatesForRenderer(const RenderBox&, ControlStates&) const;
     OptionSet<ControlStates::States> extractControlStatesForRenderer(const RenderObject&) const;
     bool isWindowActive(const RenderObject&) const;
     bool isChecked(const RenderObject&) const;

--- a/Source/WebCore/rendering/RenderView.h
+++ b/Source/WebCore/rendering/RenderView.h
@@ -199,9 +199,6 @@ public:
         bool m_wasAccumulatingRepaintRegion { false };
     };
 
-    void scheduleLazyRepaint(RenderBox&);
-    void unscheduleLazyRepaint(RenderBox&);
-    
     void layerChildrenChangedDuringStyleChange(RenderLayer&);
     RenderLayer* takeStyleChangeLayerTreeMutationRoot();
 
@@ -260,11 +257,6 @@ private:
     // End deprecated members.
 
     bool shouldUsePrintingLayout() const;
-
-    void lazyRepaintTimerFired();
-
-    Timer m_lazyRepaintTimer;
-    SingleThreadWeakHashSet<RenderBox> m_renderersNeedingLazyRepaint;
 
     std::unique_ptr<ImageQualityController> m_imageQualityController;
     std::optional<LayoutSize> m_pageLogicalSize;


### PR DESCRIPTION
#### da12017bead8aa1b692483acae18be32813f8940
<pre>
Remove lazy repaints from RenderView and more
<a href="https://bugs.webkit.org/show_bug.cgi?id=266272">https://bugs.webkit.org/show_bug.cgi?id=266272</a>

Reviewed by Aditya Keerthi.

I looked into whether the controlStates argument of
RenderTheme::paint() could be removed as it&apos;s only used by a single
theme.

I then discovered that ControlStates&apos;s needsRepaint() always returned
false. I then checked other state in ControlStates and that was
similarly not manipulated anywhere and thus could be removed.

Since needsRepaint() was false, scheduleLazyRepaint() was never called.
This allowed for removal of lazy repaints and their Timer
infrastructure.

I suspect that we want to get rid of ControlStates in its entirety in
favor of ControlStyle, but baby steps.

* Source/WebCore/platform/ControlStates.h:
(WebCore::ControlStates::setStates):
(WebCore::ControlStates::needsRepaint const): Deleted.
(WebCore::ControlStates::setNeedsRepaint): Deleted.
(WebCore::ControlStates::isDirty const): Deleted.
(WebCore::ControlStates::setDirty): Deleted.
(WebCore::ControlStates::timeSinceControlWasFocused const): Deleted.
(WebCore::ControlStates::setTimeSinceControlWasFocused): Deleted.
(WebCore::ControlStates::platformControl const): Deleted.
(WebCore::ControlStates::setPlatformControl): Deleted.
(): Deleted.
* Source/WebCore/rendering/RenderAttachment.cpp:
(WebCore::RenderAttachment::paintReplaced):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::willBeDestroyed):
(WebCore::RenderBox::paintBoxDecorations):
(WebCore::controlStatesRendererMap): Deleted.
(WebCore::controlStatesForRenderer): Deleted.
(WebCore::removeControlStatesForRenderer): Deleted.
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::RenderElement):
* Source/WebCore/rendering/RenderElement.h:
(WebCore::RenderElement::setRenderBoxNeedsLazyRepaint): Deleted.
(WebCore::RenderElement::renderBoxNeedsLazyRepaint const): Deleted.
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::paint):
(WebCore::RenderTheme::updateControlStatesForRenderer const): Deleted.
* Source/WebCore/rendering/RenderTheme.h:
* Source/WebCore/rendering/RenderView.cpp:
(WebCore::RenderView::RenderView):
(WebCore::RenderView::scheduleLazyRepaint): Deleted.
(WebCore::RenderView::unscheduleLazyRepaint): Deleted.
(WebCore::RenderView::lazyRepaintTimerFired): Deleted.
* Source/WebCore/rendering/RenderView.h:

Canonical link: <a href="https://commits.webkit.org/271938@main">https://commits.webkit.org/271938@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37169676266c6f44b02bd0df07cf23cd5a49649a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30090 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8754 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31403 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32592 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27204 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30762 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10953 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6001 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27226 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30389 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7342 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25658 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6270 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6427 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26752 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33929 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27436 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27184 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32606 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6369 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4541 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30407 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8119 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7131 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7123 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6897 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->