### PR TITLE
REGRESSION(268128@main): wpt /css/css-break/widows-orphans-019.html

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7224,7 +7224,6 @@ imported/w3c/web-platform-tests/css/css-break/widows-orphans-006.html [ ImageOnl
 imported/w3c/web-platform-tests/css/css-break/widows-orphans-007.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-break/widows-orphans-015.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-break/widows-orphans-017.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-break/widows-orphans-019.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-break/will-change-filter.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-break/flexbox/flex-container-fragmentation-003.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-break/flexbox/flex-container-fragmentation-004.html [ ImageOnlyFailure ]

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationPagination.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationPagination.cpp
@@ -114,11 +114,14 @@ Vector<LineAdjustment> computeAdjustmentsForPagination(const InlineContent& inli
                 auto previousPageLineCount = lineIndex - previousPageBreakIndex.value_or(0);
                 auto neededLines = widows - remainingLines;
                 auto availableLines = previousPageLineCount > orphans ? previousPageLineCount - orphans : 0;
-                auto breakIndex = lineIndex - std::min(neededLines, availableLines);
-                // Set the widow break and recompute the adjustments starting from that line.
-                flow.setBreakAtLineToAvoidWidow(breakIndex + 1);
-                lineIndex = breakIndex;
-                continue;
+                auto linesToMove = std::min(neededLines, availableLines);
+                if (linesToMove) {
+                    auto breakIndex = lineIndex - linesToMove;
+                    // Set the widow break and recompute the adjustments starting from that line.
+                    flow.setBreakAtLineToAvoidWidow(breakIndex + 1);
+                    lineIndex = breakIndex;
+                    continue;
+                }
             }
 
             previousPageBreakIndex = lineIndex;


### PR DESCRIPTION
#### 82e8aacca639924ab97b4f7541c103f46307ac1f
<pre>
REGRESSION(268128@main): wpt /css/css-break/widows-orphans-019.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=266276">https://bugs.webkit.org/show_bug.cgi?id=266276</a>
<a href="https://rdar.apple.com/117690962">rdar://117690962</a>

Reviewed by Alan Baradlay.

* LayoutTests/TestExpectations:
* Source/WebCore/layout/integration/inline/LayoutIntegrationPagination.cpp:
(WebCore::LayoutIntegration::computeAdjustmentsForPagination):

Don&apos;t try to set a widow break if there are no lines to move to the next page.

Canonical link: <a href="https://commits.webkit.org/271932@main">https://commits.webkit.org/271932@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5c68c6051ddf0243bf88f8166df4a38c774877a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30082 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8746 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31396 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32584 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27197 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30752 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10944 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5993 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27219 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30381 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7335 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25652 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6261 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6422 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26746 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33920 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27430 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27177 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32599 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6362 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4534 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30398 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8112 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7128 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7116 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6890 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->