### PR TITLE
[css-transitions] `transition` property should use shortest serialization rule

### DIFF
--- a/LayoutTests/fast/css/shorthand-mismatched-list-crash-expected.txt
+++ b/LayoutTests/fast/css/shorthand-mismatched-list-crash-expected.txt
@@ -1,7 +1,7 @@
 Test for WebKit bug 31559: Crash with mismatched lists and shorthands.
 
-PASS para.style.webkitTransition is "width 1s ease 0s, left 1s ease 0s, all 1s ease 0s"
-PASS para.style.webkitTransition is "width 1s ease 0s, left 1s ease 0s, top 0s ease 0s"
+PASS para.style.webkitTransition is "width 1s, left 1s, 1s"
+PASS para.style.webkitTransition is "width 1s, left 1s, top"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/css/shorthand-mismatched-list-crash.html
+++ b/LayoutTests/fast/css/shorthand-mismatched-list-crash.html
@@ -17,14 +17,14 @@
   para.style.webkitTransition = 'width 1s, left 1s, top 1s';
   para.style.webkitTransitionProperty = 'width, left';
 
-  shouldBeEqualToString("para.style.webkitTransition", "width 1s ease 0s, left 1s ease 0s, all 1s ease 0s");
+  shouldBeEqualToString("para.style.webkitTransition", "width 1s, left 1s, 1s");
 
   // Test shorter shorthand
   para.style.webkitTransition = 'width 1s, left 1s';
   para.style.webkitTransitionProperty = 'width, left, top';
 
   // the next line will crash
-  shouldBeEqualToString("para.style.webkitTransition", "width 1s ease 0s, left 1s ease 0s, top 0s ease 0s");
+  shouldBeEqualToString("para.style.webkitTransition", "width 1s, left 1s, top");
 </script>
 <script src="../../resources/js-test-post.js"></script>
 </body>

--- a/LayoutTests/fast/css/transform-inline-style-expected.txt
+++ b/LayoutTests/fast/css/transform-inline-style-expected.txt
@@ -1,6 +1,6 @@
 Tests reading inline style of transition, and -webkit-transform-origin
 https://bugs.webkit.org/show_bug.cgi?id=22594
 
-style: all 1s ease 0s, left 3s cubic-bezier(0.2, 0.3, 0.6, 0.8) 2s
+style: 1s, left 3s cubic-bezier(0.2, 0.3, 0.6, 0.8) 2s
 style: left 30%
 

--- a/LayoutTests/fast/css/transform-inline-style-remove-expected.txt
+++ b/LayoutTests/fast/css/transform-inline-style-remove-expected.txt
@@ -3,7 +3,7 @@ https://bugs.webkit.org/show_bug.cgi?id=22605
 
 All "after" results should be null/empty
 
-transition (before): all 1s ease 0s, left 3s cubic-bezier(0.2, 0.3, 0.6, 0.8) 2s
+transition (before): 1s, left 3s cubic-bezier(0.2, 0.3, 0.6, 0.8) 2s
 transition property (before): all, left
 transition duration (before): 1s, 3s
 transition timing function (before): ease, cubic-bezier(0.2, 0.3, 0.6, 0.8)

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/first-letter-allowed-properties-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/first-letter-allowed-properties-expected.txt
@@ -32,7 +32,7 @@ PASS textUnderlinePosition should be applied to first-letter pseudo elements.
 PASS verticalAlign should be applied to first-letter pseudo elements.
 PASS wordSpacing should be applied to first-letter pseudo elements.
 FAIL position should not be applied to first-letter pseudo elements. assert_equals: expected "static" but got "absolute"
-FAIL transition should not be applied to first-letter pseudo elements. assert_equals: expected "all 0s ease 0s" but got "transform 1s ease 0s"
+FAIL transition should not be applied to first-letter pseudo elements. assert_equals: expected "all" but got "transform 1s"
 PASS transform should not be applied to first-letter pseudo elements.
 FAIL wordBreak should not be applied to first-letter pseudo elements. assert_equals: expected "normal" but got "break-all"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/first-line-allowed-properties-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/first-line-allowed-properties-expected.txt
@@ -34,7 +34,7 @@ FAIL borderRadius should not be applied to first-line pseudo elements. assert_eq
 FAIL margin should not be applied to first-line pseudo elements. assert_equals: expected "0px" but got "10px 20px 30px 40px"
 FAIL padding should not be applied to first-line pseudo elements. assert_equals: expected "0px" but got "10px 20px 30px 40px"
 FAIL position should not be applied to first-line pseudo elements. assert_equals: expected "static" but got "absolute"
-FAIL transition should not be applied to first-line pseudo elements. assert_equals: expected "all 0s ease 0s" but got "transform 1s ease 0s"
+FAIL transition should not be applied to first-line pseudo elements. assert_equals: expected "all" but got "transform 1s"
 PASS transform should not be applied to first-line pseudo elements.
 FAIL wordBreak should not be applied to first-line pseudo elements. assert_equals: expected "normal" but got "break-all"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-behavior.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-behavior.html
@@ -13,17 +13,17 @@ test_computed_value('transition-behavior', 'normal');
 test_valid_value('transition-behavior', 'allow-discrete');
 test_computed_value('transition-behavior', 'allow-discrete');
 
-test_valid_value('transition', 'allow-discrete display', 'display 0s ease 0s allow-discrete');
-test_computed_value('transition', 'allow-discrete display', 'display 0s ease 0s allow-discrete');
+test_valid_value('transition', 'allow-discrete display', 'display allow-discrete');
+test_computed_value('transition', 'allow-discrete display', 'display allow-discrete');
 
-test_valid_value('transition', 'allow-discrete display 3s', 'display 3s ease 0s allow-discrete');
-test_computed_value('transition', 'allow-discrete display 3s', 'display 3s ease 0s allow-discrete');
+test_valid_value('transition', 'allow-discrete display 3s', 'display 3s allow-discrete');
+test_computed_value('transition', 'allow-discrete display 3s', 'display 3s allow-discrete');
 
-test_valid_value('transition', 'allow-discrete display 3s 1s', 'display 3s ease 1s allow-discrete');
-test_computed_value('transition', 'allow-discrete display 3s 1s', 'display 3s ease 1s allow-discrete');
+test_valid_value('transition', 'allow-discrete display 3s 1s', 'display 3s 1s allow-discrete');
+test_computed_value('transition', 'allow-discrete display 3s 1s', 'display 3s 1s allow-discrete');
 
-test_valid_value('transition', 'allow-discrete display 3s ease-in-out', 'display 3s ease-in-out 0s allow-discrete');
-test_computed_value('transition', 'allow-discrete display 3s ease-in-out', 'display 3s ease-in-out 0s allow-discrete');
+test_valid_value('transition', 'allow-discrete display 3s ease-in-out', 'display 3s ease-in-out allow-discrete');
+test_computed_value('transition', 'allow-discrete display 3s ease-in-out', 'display 3s ease-in-out allow-discrete');
 
 test_valid_value('transition', 'allow-discrete display 3s ease-in-out 1s', 'display 3s ease-in-out 1s allow-discrete');
 test_computed_value('transition', 'allow-discrete display 3s ease-in-out 1s', 'display 3s ease-in-out 1s allow-discrete');
@@ -44,14 +44,14 @@ test_computed_value('transition', 'display 3s ease-in-out 1s allow-discrete', 'd
 // Serialization with multiple shorthands, including different order
 test_valid_value('transition',
   'allow-discrete display, normal opacity, color',
-  'display 0s ease 0s allow-discrete, opacity 0s ease 0s, color 0s ease 0s');
+  'display allow-discrete, opacity, color');
 test_computed_value('transition',
   'allow-discrete display, normal opacity, color',
-  'display 0s ease 0s allow-discrete, opacity 0s ease 0s, color 0s ease 0s');
+  'display allow-discrete, opacity, color');
 test_valid_value('transition',
   'normal opacity, color, allow-discrete display',
-  'opacity 0s ease 0s, color 0s ease 0s, display 0s ease 0s allow-discrete');
+  'opacity, color, display allow-discrete');
 test_computed_value('transition',
   'normal opacity, color, allow-discrete display',
-  'opacity 0s ease 0s, color 0s ease 0s, display 0s ease 0s allow-discrete');
+  'opacity, color, display allow-discrete');
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-computed-expected.txt
@@ -7,4 +7,6 @@ PASS Property transition value 'none'
 PASS Property transition value 'top'
 PASS Property transition value '1s -3s cubic-bezier(0, -2, 1, 3) top'
 PASS Property transition value '1s -3s, cubic-bezier(0, -2, 1, 3) top'
+PASS Property transition value 'all, all'
+PASS Transition with a delay but no duration
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-computed.html
@@ -16,17 +16,26 @@
 // <time> || <easing-function> || <time>
 
 test(() => {
-  assert_equals(getComputedStyle(document.getElementById('target')).transition, "all 0s ease 0s");
+  assert_equals(getComputedStyle(document.getElementById('target')).transition, "all");
 }, "Default transition value");
 
-test_computed_value("transition", "1s", "all 1s ease 0s");
-test_computed_value("transition", "cubic-bezier(0, -2, 1, 3)", "all 0s cubic-bezier(0, -2, 1, 3) 0s");
-test_computed_value("transition", "1s -3s", "all 1s ease -3s");
-test_computed_value("transition", "none", "none 0s ease 0s");
-test_computed_value("transition", "top", "top 0s ease 0s");
+test_computed_value("transition", "1s", "1s");
+test_computed_value("transition", "cubic-bezier(0, -2, 1, 3)", "cubic-bezier(0, -2, 1, 3)");
+test_computed_value("transition", "1s -3s", "1s -3s");
+test_computed_value("transition", "none", "none");
+test_computed_value("transition", "top", "top");
 
 test_computed_value("transition", "1s -3s cubic-bezier(0, -2, 1, 3) top", "top 1s cubic-bezier(0, -2, 1, 3) -3s");
-test_computed_value("transition", "1s -3s, cubic-bezier(0, -2, 1, 3) top", "all 1s ease -3s, top 0s cubic-bezier(0, -2, 1, 3) 0s");
+test_computed_value("transition", "1s -3s, cubic-bezier(0, -2, 1, 3) top", "1s -3s, top cubic-bezier(0, -2, 1, 3)");
+
+test_computed_value("transition", "all, all", "all, all");
+
+test(() => {
+  const target = document.getElementById('target');
+  target.style.transition = "initial";
+  target.style.transitionDelay = "1s";
+  assert_equals(getComputedStyle(target).transition, "0s 1s");
+}, "Transition with a delay but no duration");
 
 // TODO: Add test with a single timing-function keyword.
 </script>

--- a/Source/WebCore/css/ShorthandSerializer.cpp
+++ b/Source/WebCore/css/ShorthandSerializer.cpp
@@ -641,13 +641,6 @@ String ShorthandSerializer::serializeLayered() const
         for (unsigned j = 0; j < length(); j++) {
             auto longhand = longhandProperty(j);
 
-            // We always want to force the serialization of the transition longhands,
-            // except for transition-behavior which should only serialize if non-default.
-            if (m_shorthand.id() == CSSPropertyTransition) {
-                if (longhand != CSSPropertyTransitionBehavior)
-                    layerValues.skip(j) = false;
-            }
-
             // A single box value sets both background-origin and background-clip.
             // A single geometry-box value sets both mask-origin and mask-clip.
             // A single geometry-box value sets both mask-origin and -webkit-mask-clip.

--- a/Source/WebCore/platform/animation/Animation.cpp
+++ b/Source/WebCore/platform/animation/Animation.cpp
@@ -140,7 +140,7 @@ bool Animation::animationsMatch(const Animation& other, bool matchProperties) co
     if (!result)
         return false;
 
-    return !matchProperties || (m_property.mode == other.m_property.mode && m_property.animatableProperty == other.m_property.animatableProperty && m_propertySet == other.m_propertySet);
+    return !matchProperties || (m_property == other.m_property && m_propertySet == other.m_propertySet);
 }
 
 auto Animation::initialName() -> const Style::ScopedName&

--- a/Source/WebCore/platform/animation/Animation.h
+++ b/Source/WebCore/platform/animation/Animation.h
@@ -116,6 +116,7 @@ public:
     struct TransitionProperty {
         TransitionMode mode;
         AnimatableCSSProperty animatableProperty;
+        bool operator==(const TransitionProperty& o) const { return mode == o.mode && animatableProperty == o.animatableProperty; }
     };
 
     enum class Direction : uint8_t {


### PR DESCRIPTION
#### 3dee8c9a649aa8cc7d686907b21a6afc6f3132de
<pre>
[css-transitions] `transition` property should use shortest serialization rule
<a href="https://bugs.webkit.org/show_bug.cgi?id=266234">https://bugs.webkit.org/show_bug.cgi?id=266234</a>

Reviewed by Tim Nguyen.

As discussed in <a href="https://github.com/web-platform-tests/wpt/issues/43574">https://github.com/web-platform-tests/wpt/issues/43574</a>, serializing
the `transition` shorthand should always strive to produce the shortest serialization
and omit initial values.

We update the relevant tests, including WPT, to match this expectation and add a new test
for the case where `transition-delay` is not the initial value while `transition-duration`
is since those two properties have the same `&lt;time&gt;` type and `transition-duration` serializes
first.

* LayoutTests/fast/css/shorthand-mismatched-list-crash-expected.txt:
* LayoutTests/fast/css/shorthand-mismatched-list-crash.html:
* LayoutTests/fast/css/transform-inline-style-expected.txt:
* LayoutTests/fast/css/transform-inline-style-remove-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/first-letter-allowed-properties-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/first-line-allowed-properties-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-behavior.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-computed.html:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::addValueForAnimationPropertyToList):
(WebCore::animationShorthandValue):
(WebCore::singleTransitionValue):
(WebCore::transitionShorthandValue):
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle const):
* Source/WebCore/css/ShorthandSerializer.cpp:
(WebCore::ShorthandSerializer::serializeLayered const):
* Source/WebCore/platform/animation/Animation.cpp:
(WebCore::Animation::animationsMatch const):
* Source/WebCore/platform/animation/Animation.h:
(WebCore::Animation::TransitionProperty::operator== const):

Canonical link: <a href="https://commits.webkit.org/272513@main">https://commits.webkit.org/272513@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b96947838ae45893eb9c865a52b795e3d7ff96b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30132 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8797 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31836 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32636 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27247 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30807 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10997 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6042 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27257 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30432 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7382 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/26983 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6310 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6463 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27017 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33983 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27475 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27514 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32652 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6410 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4577 "Found 1 new test failure: fullscreen/full-screen-layer-dump.html (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30458 "Found 1 new API test failure: /WebKitGTK/TestResources:/webkit/WebKitWebView/sync-request-on-max-conns (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8160 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/26771 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7463 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7164 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6939 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->