### PR TITLE
[JHBuild] [WPE] Upgrade wayland and wayland-protocols

### DIFF
--- a/Tools/jhbuild/jhbuild-minimal.modules
+++ b/Tools/jhbuild/jhbuild-minimal.modules
@@ -32,6 +32,8 @@
       <dep package="atk"/>
       <dep package="at-spi2-atk"/>
       <dep package="libsoup"/>
+      <dep package="wayland"/>
+      <dep package="wayland-protocols"/>
     </dependencies>
   </metamodule>
 
@@ -64,8 +66,8 @@
       href="https://dri.freedesktop.org"/>
   <repository type="tarball" name="mesa.freedesktop.org"
       href="https://mesa.freedesktop.org"/>
-  <repository type="tarball" name="wayland.freedesktop.org"
-      href="http://wayland.freedesktop.org"/>
+  <repository type="git" name="git.freedesktop.org/wayland"
+      href="https://gitlab.freedesktop.org/wayland"/>
   <repository type="tarball" name="llvm.org"
       href="http://llvm.org"/>
   <repository type="tarball" name="webkitgtk-jhbuild-mirror"
@@ -248,5 +250,17 @@
       <patch file="libjxl-add-cmake-flag-provision-dependencies.patch" strip="1"/>
     </branch>
   </cmake>
+
+  <meson id="wayland" mesonargs="-Dtests=false -Ddocumentation=false -Ddtd_validation=false">
+    <branch tag="1.20.0"
+            checkoutdir="wayland-protocols"
+            repo="git.freedesktop.org/wayland" />
+  </meson>
+
+  <meson id="wayland-protocols">
+    <branch tag="1.25"
+            checkoutdir="wayland-protocols"
+            repo="git.freedesktop.org/wayland" />
+  </meson>
 
 </moduleset>

--- a/Tools/wpe/jhbuild.modules
+++ b/Tools/wpe/jhbuild.modules
@@ -24,6 +24,7 @@
       <dep package="libxml2"/>
       <dep package="openjpeg"/>
       <dep package="shared-mime-info"/>
+      <dep package="wayland"/>
       <dep package="wayland-protocols"/>
       <dep package="wpebackend-fdo"/>
       <dep package="xdg-dbus-proxy"/>
@@ -43,8 +44,8 @@
       href="http://cairographics.org"/>
   <repository type="tarball" name="freedesktop.org"
       href="http://www.freedesktop.org"/>
-  <repository type="tarball" name="wayland.freedesktop.org"
-      href="http://wayland.freedesktop.org"/>
+  <repository type="git" name="git.freedesktop.org/wayland"
+      href="https://gitlab.freedesktop.org/wayland"/>
   <repository type="git" name="github.com"
       href="https://github.com"/>
   <repository type="tarball" name="github-tarball"
@@ -224,12 +225,17 @@
             version="1.5.4" repo="github-tarball"/>
   </autotools>
 
-  <autotools id="wayland-protocols" autogen-sh="configure">
-    <branch module="releases/wayland-protocols-${version}.tar.xz"
-            version="1.12"
-	    repo="wayland.freedesktop.org"
-	    hash="sha256:3b19e8a9e1e19474756a7069db23b90ca9b8ebb438448c6063b4a7fc89b7c8b2"/>
-  </autotools>
+  <meson id="wayland" mesonargs="-Dtests=false -Ddocumentation=false -Ddtd_validation=false">
+    <branch tag="1.20.0"
+            checkoutdir="wayland-protocols"
+            repo="git.freedesktop.org/wayland" />
+  </meson>
+
+  <meson id="wayland-protocols">
+    <branch tag="1.25"
+            checkoutdir="wayland-protocols"
+            repo="git.freedesktop.org/wayland" />
+  </meson>
 
   <meson id="graphene">
     <branch repo="github.com"


### PR DESCRIPTION
#### 53052964ad1908e2ab321dc05f7b367f05e10996
<pre>
[JHBuild] [WPE] Upgrade wayland and wayland-protocols
<a href="https://bugs.webkit.org/show_bug.cgi?id=266278">https://bugs.webkit.org/show_bug.cgi?id=266278</a>

Reviewed by Carlos Garcia Campos.

After 271330@main, WPE build fails in systems featuring wayland &lt; 1.20 and
wayland-protocols &lt; 1.25.

* Tools/jhbuild/jhbuild-minimal.modules:
* Tools/wpe/jhbuild.modules:

Canonical link: <a href="https://commits.webkit.org/271926@main">https://commits.webkit.org/271926@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87f9d3484d921cb1858b6c138374d185f1448342

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30092 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8756 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31405 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32594 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27206 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30765 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10955 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6003 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/27227 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30391 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7343 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25660 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6272 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/6428 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26754 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33931 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27437 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27186 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32608 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6371 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4542 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30409 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8121 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7126 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7125 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6899 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->