### PR TITLE
[WPE] Unreviewed, fix non-unified build after 27330@main

### DIFF
--- a/Source/WebKit/UIProcess/wpe/WebPageProxyWPE.cpp
+++ b/Source/WebKit/UIProcess/wpe/WebPageProxyWPE.cpp
@@ -30,6 +30,7 @@
 #include "InputMethodState.h"
 #include "PageClientImpl.h"
 #include <WebCore/PlatformEvent.h>
+#include <wpe/wpe-platform.h>
 
 #if ENABLE(ACCESSIBILITY)
 #include <atk/atk.h>

--- a/Source/WebKit/WPEPlatform/wpe/WPEKeymapXKB.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEKeymapXKB.cpp
@@ -27,6 +27,7 @@
 #include "WPEKeymapXKB.h"
 
 #include <sys/mman.h>
+#include <unistd.h>
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/glib/WTFGType.h>
 #include <xkbcommon/xkbcommon.h>

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp
@@ -35,12 +35,16 @@
 #include "WPEWaylandSeat.h"
 #include "linux-dmabuf-unstable-v1-client-protocol.h"
 #include "xdg-shell-client-protocol.h"
-#include <epoxy/egl.h>
 #include <gio/gio.h>
 #include <wtf/HashSet.h>
 #include <wtf/Vector.h>
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/glib/WTFGType.h>
+
+// These includes need to be in this order because wayland-egl.h defines WL_EGL_PLATFORM
+// and egl.h checks that to decide whether it's Wayland platform.
+#include <wayland-egl.h>
+#include <epoxy/egl.h>
 
 /**
  * WPEDisplayWayland:

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp
@@ -31,7 +31,6 @@
 #include "WPEWaylandSHMPool.h"
 #include "linux-dmabuf-unstable-v1-client-protocol.h"
 #include "xdg-shell-client-protocol.h"
-#include <epoxy/egl.h>
 #include <fcntl.h>
 #include <gio/gio.h>
 #include <sys/mman.h>
@@ -43,6 +42,12 @@
 #include <wtf/glib/WTFGType.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/WTFString.h>
+
+// These includes need to be in this order because wayland-egl.h defines WL_EGL_PLATFORM
+// and egl.h checks that to decide whether it's Wayland platform.
+#include <wayland-client-protocol.h>
+#include <wayland-egl.h>
+#include <epoxy/egl.h>
 
 #ifndef EGL_WL_create_wayland_buffer_from_image
 typedef struct wl_buffer *(EGLAPIENTRYP PFNEGLCREATEWAYLANDBUFFERFROMIMAGEWL)(EGLDisplay dpy, EGLImageKHR image);


### PR DESCRIPTION
#### 8c8709a0194cb58a87f2e4045bcf0438c84c3c86
<pre>
[WPE] Unreviewed, fix non-unified build after 27330@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=265286">https://bugs.webkit.org/show_bug.cgi?id=265286</a>

Add missing headers.

* Source/WebKit/UIProcess/wpe/WebPageProxyWPE.cpp:
* Source/WebKit/WPEPlatform/wpe/WPEKeymapXKB.cpp:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp:

Canonical link: <a href="https://commits.webkit.org/271924@main">https://commits.webkit.org/271924@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/04b48ecd2be9014522a51e43c4f8eaa57550b4b2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30093 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8757 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31406 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32595 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27207 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10956 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6004 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/27228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30392 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7344 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25659 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6273 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/6429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33932 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27438 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27185 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/32609 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6372 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/4543 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30410 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8122 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7126 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3879 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6900 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->