### PR TITLE
Correct <input type=checkbox switch> iOS focus ring

### DIFF
--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -78,9 +78,6 @@ public:
 
     void updateControlPartForRenderer(ControlPart&, const RenderObject&) const;
 
-    OptionSet<ControlStyle::State> extractControlStyleStatesForRenderer(const RenderObject&) const;
-    ControlStyle extractControlStyleForRenderer(const RenderBox&) const;
-
     // These methods are called to paint the widget as a background of the RenderObject. A widget's foreground, e.g., the
     // text of a button, is always rendered by the engine itself. The boolean return value indicates
     // whether the CSS border/background should also be painted.
@@ -268,6 +265,9 @@ public:
     float switchPointerTrackingMagnitudeProportion() const { return 0.4f; }
 
 protected:
+    OptionSet<ControlStyle::State> extractControlStyleStatesForRenderer(const RenderObject&) const;
+    ControlStyle extractControlStyleForRenderer(const RenderObject&) const;
+
     virtual bool canPaint(const PaintInfo&, const Settings&, StyleAppearance) const { return true; }
 
     // The platform selection color.
@@ -386,6 +386,8 @@ protected:
     virtual bool paintSwitchTrack(const RenderObject&, const PaintInfo&, const FloatRect&) { return true; }
 
 private:
+    OptionSet<ControlStyle::State> extractControlStyleStatesForRendererInternal(const RenderObject&) const;
+
     void adjustButtonOrCheckboxOrColorWellOrInnerSpinButtonOrRadioOrSwitchStyle(RenderStyle&, const Element*) const;
 
 public:

--- a/Source/WebCore/rendering/RenderThemeIOS.h
+++ b/Source/WebCore/rendering/RenderThemeIOS.h
@@ -117,15 +117,15 @@ private:
     void adjustSearchFieldStyle(RenderStyle&, const Element*) const override;
     void paintSearchFieldDecorations(const RenderBox&, const PaintInfo&, const IntRect&) override;
 
-    Color checkboxRadioBorderColor(OptionSet<ControlStates::States>, OptionSet<StyleColorOptions>);
-    Color checkboxRadioBackgroundColor(bool useAlternateDesign, const RenderStyle&, OptionSet<ControlStates::States>, OptionSet<StyleColorOptions>);
-    RefPtr<Gradient> checkboxRadioBackgroundGradient(const FloatRect&, OptionSet<ControlStates::States>);
-    Color checkboxRadioIndicatorColor(OptionSet<ControlStates::States>, OptionSet<StyleColorOptions>);
+    Color checkboxRadioBorderColor(OptionSet<ControlStyle::State>, OptionSet<StyleColorOptions>);
+    Color checkboxRadioBackgroundColor(bool useAlternateDesign, const RenderStyle&, OptionSet<ControlStyle::State>, OptionSet<StyleColorOptions>);
+    RefPtr<Gradient> checkboxRadioBackgroundGradient(const FloatRect&, OptionSet<ControlStyle::State>);
+    Color checkboxRadioIndicatorColor(OptionSet<ControlStyle::State>, OptionSet<StyleColorOptions>);
 
     bool paintCheckbox(const RenderObject&, const PaintInfo&, const FloatRect&) override;
     bool paintRadio(const RenderObject&, const PaintInfo&, const FloatRect&) override;
 
-    void paintCheckboxRadioInnerShadow(const PaintInfo&, const FloatRoundedRect&, OptionSet<ControlStates::States>);
+    void paintCheckboxRadioInnerShadow(const PaintInfo&, const FloatRoundedRect&, OptionSet<ControlStyle::State>);
 
     bool supportsMeter(StyleAppearance) const final;
     bool paintMeter(const RenderObject&, const PaintInfo&, const IntRect&) final;

--- a/Source/WebCore/rendering/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/RenderThemeIOS.mm
@@ -710,12 +710,12 @@ constexpr auto reducedMotionProgressAnimationMaxOpacity = 0.6f;
 constexpr auto switchHeight = 31.f;
 constexpr auto switchWidth = 51.f;
 
-static bool renderThemePaintSwitchThumb(OptionSet<ControlStates::States>, const RenderObject&, const PaintInfo&, const FloatRect&)
+static bool renderThemePaintSwitchThumb(const OptionSet<ControlStyle::State>, const RenderObject&, const PaintInfo&, const FloatRect&, const Color&)
 {
     return true;
 }
 
-static bool renderThemePaintSwitchTrack(OptionSet<ControlStates::States>, const RenderObject&, const PaintInfo&, const FloatRect&, const Color)
+static bool renderThemePaintSwitchTrack(const OptionSet<ControlStyle::State>, const RenderObject&, const PaintInfo&, const FloatRect&, const Color&)
 {
     return true;
 }
@@ -732,18 +732,21 @@ void RenderThemeIOS::adjustSwitchStyle(RenderStyle& style, const Element* elemen
     style.setWidth({ size * (switchWidth / switchHeight), LengthType::Fixed });
     style.setHeight({ size, LengthType::Fixed });
 
+    if (style.outlineStyleIsAuto() == OutlineIsAuto::On)
+        style.setOutlineStyle(BorderStyle::None);
+
     if (element->isDisabledFormControl())
         style.setOpacity(.4f);
 }
 
 bool RenderThemeIOS::paintSwitchThumb(const RenderObject& renderer, const PaintInfo& paintInfo, const FloatRect& rect)
 {
-    return renderThemePaintSwitchThumb(extractControlStatesForRenderer(renderer), renderer, paintInfo, rect);
+    return renderThemePaintSwitchThumb(extractControlStyleStatesForRenderer(renderer), renderer, paintInfo, rect, systemFocusRingColor());
 }
 
 bool RenderThemeIOS::paintSwitchTrack(const RenderObject& renderer, const PaintInfo& paintInfo, const FloatRect& rect)
 {
-    return renderThemePaintSwitchTrack(extractControlStatesForRenderer(renderer), renderer, paintInfo, rect, systemColor(CSSValueAppleSystemGreen, renderer.styleColorOptions()));
+    return renderThemePaintSwitchTrack(extractControlStyleStatesForRenderer(renderer), renderer, paintInfo, rect, systemColor(CSSValueAppleSystemGreen, renderer.styleColorOptions()));
 }
 
 bool RenderThemeIOS::paintProgressBar(const RenderObject& renderer, const PaintInfo& paintInfo, const IntRect& rect)
@@ -1403,24 +1406,24 @@ void RenderThemeIOS::paintSystemPreviewBadge(Image& image, const PaintInfo& pain
 constexpr auto checkboxRadioBorderWidth = 1.5f;
 constexpr auto checkboxRadioBorderDisabledOpacity = 0.3f;
 
-Color RenderThemeIOS::checkboxRadioBorderColor(OptionSet<ControlStates::States> states, OptionSet<StyleColorOptions> styleColorOptions)
+Color RenderThemeIOS::checkboxRadioBorderColor(OptionSet<ControlStyle::State> states, OptionSet<StyleColorOptions> styleColorOptions)
 {
     auto defaultBorderColor = systemColor(CSSValueAppleSystemSecondaryLabel, styleColorOptions);
 
-    if (!states.contains(ControlStates::States::Enabled))
+    if (!states.contains(ControlStyle::State::Enabled))
         return defaultBorderColor.colorWithAlphaMultipliedBy(checkboxRadioBorderDisabledOpacity);
 
-    if (states.contains(ControlStates::States::Pressed))
+    if (states.contains(ControlStyle::State::Pressed))
         return defaultBorderColor.colorWithAlphaMultipliedBy(pressedStateOpacity);
 
     return defaultBorderColor;
 }
 
-Color RenderThemeIOS::checkboxRadioBackgroundColor(bool useAlternateDesign, const RenderStyle& style, OptionSet<ControlStates::States> states, OptionSet<StyleColorOptions> styleColorOptions)
+Color RenderThemeIOS::checkboxRadioBackgroundColor(bool useAlternateDesign, const RenderStyle& style, OptionSet<ControlStyle::State> states, OptionSet<StyleColorOptions> styleColorOptions)
 {
-    bool isEmpty = !states.containsAny({ ControlStates::States::Checked, ControlStates::States::Indeterminate });
-    bool isEnabled = states.contains(ControlStates::States::Enabled);
-    bool isPressed = states.contains(ControlStates::States::Pressed);
+    bool isEmpty = !states.containsAny({ ControlStyle::State::Checked, ControlStyle::State::Indeterminate });
+    bool isEnabled = states.contains(ControlStyle::State::Enabled);
+    bool isPressed = states.contains(ControlStyle::State::Pressed);
 
     if (useAlternateDesign) {
         // FIXME (rdar://problem/83895064): The disabled state for the alternate appearance is currently unspecified; this is just a guess.
@@ -1443,32 +1446,32 @@ Color RenderThemeIOS::checkboxRadioBackgroundColor(bool useAlternateDesign, cons
     return enabledBackgroundColor;
 }
 
-RefPtr<Gradient> RenderThemeIOS::checkboxRadioBackgroundGradient(const FloatRect& rect, OptionSet<ControlStates::States> states)
+RefPtr<Gradient> RenderThemeIOS::checkboxRadioBackgroundGradient(const FloatRect& rect, OptionSet<ControlStyle::State> states)
 {
-    bool isPressed = states.contains(ControlStates::States::Pressed);
+    bool isPressed = states.contains(ControlStyle::State::Pressed);
     if (isPressed)
         return nullptr;
 
-    bool isEmpty = !states.containsAny({ ControlStates::States::Checked, ControlStates::States::Indeterminate });
+    bool isEmpty = !states.containsAny({ ControlStyle::State::Checked, ControlStyle::State::Indeterminate });
     auto gradient = Gradient::create(Gradient::LinearData { rect.minXMinYCorner(), rect.maxXMaxYCorner() }, { ColorInterpolationMethod::SRGB { }, AlphaPremultiplication::Unpremultiplied });
     gradient->addColorStop({ 0.0f, DisplayP3<float> { 0, 0, 0, isEmpty ? 0.05f : 0.125f }});
     gradient->addColorStop({ 1.0f, DisplayP3<float> { 0, 0, 0, 0 }});
     return gradient;
 }
 
-Color RenderThemeIOS::checkboxRadioIndicatorColor(OptionSet<ControlStates::States> states, OptionSet<StyleColorOptions> styleColorOptions)
+Color RenderThemeIOS::checkboxRadioIndicatorColor(OptionSet<ControlStyle::State> states, OptionSet<StyleColorOptions> styleColorOptions)
 {
-    if (!states.contains(ControlStates::States::Enabled))
+    if (!states.contains(ControlStyle::State::Enabled))
         return systemColor(CSSValueAppleSystemTertiaryLabel, styleColorOptions);
 
     Color enabledIndicatorColor = systemColor(CSSValueAppleSystemLabel, styleColorOptions | StyleColorOptions::UseDarkAppearance);
-    if (states.contains(ControlStates::States::Pressed))
+    if (states.contains(ControlStyle::State::Pressed))
         return enabledIndicatorColor.colorWithAlphaMultipliedBy(pressedStateOpacity);
 
     return enabledIndicatorColor;
 }
 
-void RenderThemeIOS::paintCheckboxRadioInnerShadow(const PaintInfo& paintInfo, const FloatRoundedRect& roundedRect, OptionSet<ControlStates::States> states)
+void RenderThemeIOS::paintCheckboxRadioInnerShadow(const PaintInfo& paintInfo, const FloatRoundedRect& roundedRect, OptionSet<ControlStyle::State> states)
 {
     auto& context = paintInfo.context();
     GraphicsContextStateSaver stateSaver { context };
@@ -1484,7 +1487,7 @@ void RenderThemeIOS::paintCheckboxRadioInnerShadow(const PaintInfo& paintInfo, c
     const FloatSize innerShadowOffset { 2, 2 };
     constexpr auto innerShadowBlur = 3.0f;
 
-    bool isEmpty = !states.containsAny({ ControlStates::States::Checked, ControlStates::States::Indeterminate });
+    bool isEmpty = !states.containsAny({ ControlStyle::State::Checked, ControlStyle::State::Indeterminate });
     auto firstShadowColor = DisplayP3<float> { 0, 0, 0, isEmpty ? 0.05f : 0.1f };
     context.setDropShadow({ innerShadowOffset, innerShadowBlur, firstShadowColor, ShadowRadiusMode::Default });
     context.setFillColor(Color::black);
@@ -1520,13 +1523,13 @@ bool RenderThemeIOS::paintCheckbox(const RenderObject& box, const PaintInfo& pai
 
     FloatRoundedRect checkboxRect(rect, FloatRoundedRect::Radii(checkboxCornerRadius * rect.height() / checkboxHeight));
 
-    auto controlStates = extractControlStatesForRenderer(box);
+    auto controlStates = extractControlStyleStatesForRenderer(box);
     auto styleColorOptions = box.styleColorOptions();
 
     auto backgroundColor = checkboxRadioBackgroundColor(useAlternateDesign, box.style(), controlStates, styleColorOptions);
 
-    bool checked = controlStates.contains(ControlStates::States::Checked);
-    bool indeterminate = controlStates.contains(ControlStates::States::Indeterminate);
+    bool checked = controlStates.contains(ControlStyle::State::Checked);
+    bool indeterminate = controlStates.contains(ControlStyle::State::Indeterminate);
     bool empty = !checked && !indeterminate;
 
     if (empty) {
@@ -1600,14 +1603,14 @@ bool RenderThemeIOS::paintRadio(const RenderObject& box, const PaintInfo& paintI
     auto& context = paintInfo.context();
     GraphicsContextStateSaver stateSaver(context);
 
-    auto controlStates = extractControlStatesForRenderer(box);
+    auto controlStates = extractControlStyleStatesForRenderer(box);
     auto styleColorOptions = box.styleColorOptions();
 
     auto backgroundColor = checkboxRadioBackgroundColor(useAlternateDesign, box.style(), controlStates, styleColorOptions);
 
     FloatRoundedRect radioRect { rect, FloatRoundedRect::Radii(rect.width() / 2, rect.height() / 2) };
 
-    if (controlStates.contains(ControlStates::States::Checked)) {
+    if (controlStates.contains(ControlStyle::State::Checked)) {
         context.setFillColor(backgroundColor);
         context.fillEllipse(rect);
 


### PR DESCRIPTION
#### efe35104221863220f85ae234adc7081454180a0
<pre>
Correct &lt;input type=checkbox switch&gt; iOS focus ring
<a href="https://bugs.webkit.org/show_bug.cgi?id=266281">https://bugs.webkit.org/show_bug.cgi?id=266281</a>
<a href="https://rdar.apple.com/119555352">rdar://119555352</a>

Reviewed by Aditya Keerthi.

Make RenderThemeIOS build on ControlStyle::State rather than
ControlStates::States. The ControlStates architecture is dated, does
not account for shadow hosts, and should probably be disappeared
entirely. This is an incremental step towards that goal.

Then provide the switch&apos;s thumb painting code has access to the system
outline color.

And ensure that by default we don&apos;t draw an outline for a switch on
iOS. Web developers can override this by using a non-auto outline-style
value, but that will not draw the outline around the thumb.

* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::extractControlStyleStatesForRendererInternal const):
(WebCore::adjustRendererForAppearance):
(WebCore::RenderTheme::extractControlStyleStatesForRenderer const):
(WebCore::RenderTheme::extractControlStyleForRenderer const):
* Source/WebCore/rendering/RenderTheme.h:
* Source/WebCore/rendering/RenderThemeIOS.h:
* Source/WebCore/rendering/RenderThemeIOS.mm:
(WebCore::renderThemePaintSwitchThumb):
(WebCore::renderThemePaintSwitchTrack):
(WebCore::RenderThemeIOS::adjustSwitchStyle const):
(WebCore::RenderThemeIOS::paintSwitchThumb):
(WebCore::RenderThemeIOS::paintSwitchTrack):
(WebCore::RenderThemeIOS::checkboxRadioBorderColor):
(WebCore::RenderThemeIOS::checkboxRadioBackgroundColor):
(WebCore::RenderThemeIOS::checkboxRadioBackgroundGradient):
(WebCore::RenderThemeIOS::checkboxRadioIndicatorColor):
(WebCore::RenderThemeIOS::paintCheckboxRadioInnerShadow):
(WebCore::RenderThemeIOS::paintCheckbox):
(WebCore::RenderThemeIOS::paintRadio):

Canonical link: <a href="https://commits.webkit.org/272020@main">https://commits.webkit.org/272020@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a87d4792556d3ac7c671e52ac4f88e5023737f5a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30406 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9081 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32016 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32916 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27503 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31108 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11310 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6317 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/27462 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30714 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7630 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/27265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6538 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6681 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/27099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34254 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/27705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/27594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/32868 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6663 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4808 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30691 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8416 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/7407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3927 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7206 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->