### PR TITLE
[Cocoa] AVContentKeyRequest is recreated when renewing via -renewExpiringResponseDataForContentKeyRequest:

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h
@@ -259,6 +259,7 @@ private:
 
     Vector<Request> m_pendingRequests;
     Vector<Request> m_requests;
+    std::optional<Request> m_renewingRequest;
 
     LicenseCallback m_requestLicenseCallback;
     LicenseUpdateCallback m_updateLicenseCallback;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
@@ -861,6 +861,7 @@ void CDMInstanceSessionFairPlayStreamingAVFObjC::updateLicense(const String&, Li
             callback(false, std::nullopt, std::nullopt, std::nullopt, Failed);
             return;
         }
+        m_renewingRequest = m_requests.last();
         ALWAYS_LOG(LOGIDENTIFIER, "\"renew\", processing renewal");
         auto session = m_session ? m_session.get() : m_instance->contentKeySession();
         [session renewExpiringResponseDataForContentKeyRequest:request];
@@ -1331,7 +1332,23 @@ void CDMInstanceSessionFairPlayStreamingAVFObjC::didProvideRenewingRequest(AVCon
 
     // The assumption here is that AVContentKeyRequest will only ever notify us of a renewing request as a result of calling
     // -renewExpiringResponseDataForContentKeyRequest: with an existing request.
-    ASSERT(m_requests.contains(m_currentRequest));
+    if (!m_renewingRequest
+        || m_renewingRequest->requests.size() != 1
+        || !m_renewingRequest->requests[0]
+        || ![[m_renewingRequest->requests[0] identifier] isEqual:request.identifier])
+    {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    auto renewingIndex = m_requests.find(*m_renewingRequest);
+    if (renewingIndex == notFound) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    m_requests[renewingIndex] = *m_currentRequest;
+    m_renewingRequest = std::nullopt;
 
     RetainPtr<NSData> appIdentifier;
     if (auto* certificate = m_instance->serverCertificate())


### PR DESCRIPTION
#### d67b38a67e2a4e1f1a5976b3eeed43d245dc5311
<pre>
[Cocoa] AVContentKeyRequest is recreated when renewing via -renewExpiringResponseDataForContentKeyRequest:
<a href="https://bugs.webkit.org/show_bug.cgi?id=266282">https://bugs.webkit.org/show_bug.cgi?id=266282</a>
<a href="https://rdar.apple.com/119555484">rdar://119555484</a>

Reviewed by Andy Estes.

In certain configurations of AVContentKeySession, when a request is renewed via
-renewExpiringResponseDataForContentKeyRequest:, instead of returning the same
AVContentKeyRequest object in the -contentKeySession:didProvideRenewingContentKeyRequest:
delegate callback, it will return an entirely new AVContentKeyRequest. This breaks
WebKit&apos;s renewal path.

To work around this behavior, track the request being renewed in a new ivar, and when
the delegate method is called, use both requests&apos; -identifier property to check
equality. Then replace the old request in the list of m_requests with the new request.

* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm:
(WebCore::CDMInstanceSessionFairPlayStreamingAVFObjC::updateLicense):
(WebCore::CDMInstanceSessionFairPlayStreamingAVFObjC::didProvideRenewingRequest):

Canonical link: <a href="https://commits.webkit.org/271946@main">https://commits.webkit.org/271946@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cadf4e8d30c57fed2f92d971b68a8a9e2cdab3ed

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30117 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8782 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31431 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32621 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27232 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30792 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11006 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6027 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27249 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30417 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7388 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25683 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6298 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/6469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26776 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33958 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27481 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27208 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32634 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6396 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4566 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30435 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8145 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7137 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7149 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6924 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->