### PR TITLE
[Cocoa] sampleBufferContentKeySessionSupportEnabled: Not enqueueing frames during "pending" key state means key state never progresses beyond "pending"

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
@@ -669,8 +669,19 @@ bool CDMInstanceFairPlayStreamingAVFObjC::isAnyKeyUsable(const Keys& keys) const
             continue;
 
         for (auto& keyStatusPair : sessionInterface->keyStatuses()) {
-            if (keyStatusPair.second != CDMInstanceSession::KeyStatus::Usable)
+            switch (keyStatusPair.second) {
+            case CDMInstanceSession::KeyStatus::Expired:
+            case CDMInstanceSession::KeyStatus::Released:
+            case CDMInstanceSession::KeyStatus::InternalError:
+                // Key is unusable.
                 continue;
+            case CDMInstanceSession::KeyStatus::Usable:
+            case CDMInstanceSession::KeyStatus::OutputRestricted:
+            case CDMInstanceSession::KeyStatus::OutputDownscaled:
+            case CDMInstanceSession::KeyStatus::StatusPending:
+                // Key is (potentially) usable.
+                break;
+            }
 
             if (keys.findIf([&] (auto& key) {
                 return key.get() == keyStatusPair.first.get();


### PR DESCRIPTION
#### b8180b2e2e3d8fe4d03e502a7494117794c9467e
<pre>
[Cocoa] sampleBufferContentKeySessionSupportEnabled: Not enqueueing frames during &quot;pending&quot; key state means key state never progresses beyond &quot;pending&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=266284">https://bugs.webkit.org/show_bug.cgi?id=266284</a>
<a href="https://rdar.apple.com/119557042">rdar://119557042</a>

Reviewed by Eric Carlson.

When the state of the AVContentKeyRequest/AVContentKey is &quot;pending&quot;, the AVContentKeySession
is waiting to be connected with an AVSampleBufferDisplayLayer before updating that state to
&quot;usable&quot; or &quot;restricted&quot;. The API contract when the sampleBufferContentKeySessionSupportEnabled
path is enabled is that the client will not enqueue samples for display unless it knows there
is a usable key for that sample. However, due to this behavior, the request/key is stuck in
the &quot;pending&quot; state.

Work around this behavior by still enqueueing samples when in the &quot;pending&quot; state, and in fact,
only block enqueueing samples when the key is in a known-failed state.

* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm:
(WebCore::CDMInstanceFairPlayStreamingAVFObjC::isAnyKeyUsable const):

Canonical link: <a href="https://commits.webkit.org/271944@main">https://commits.webkit.org/271944@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb5a80666b2cf38aa01387850f4d40977d6cc381

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30115 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8780 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31429 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32619 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27230 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30790 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10980 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6025 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27245 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30415 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7367 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25682 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6294 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6450 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26775 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33956 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27460 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27207 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32631 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6394 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4564 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30432 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8143 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7135 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7147 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6922 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->