### PR TITLE
Use CheckedPtr<Element> / CheckedRef<Element> less for non-stack variables

### DIFF
--- a/Source/WebCore/dom/Attr.h
+++ b/Source/WebCore/dom/Attr.h
@@ -78,7 +78,7 @@ private:
 
     // Attr wraps either an element/name, or a name/value pair (when it's a standalone Node.)
     // Note that m_name is always set, but m_element/m_standaloneValue may be null.
-    CheckedPtr<Element> m_element;
+    WeakPtr<Element, WeakPtrImplWithEventTargetData> m_element;
     QualifiedName m_name;
     AtomString m_standaloneValue;
 

--- a/Source/WebCore/dom/DatasetDOMStringMap.h
+++ b/Source/WebCore/dom/DatasetDOMStringMap.h
@@ -27,7 +27,7 @@
 
 #include "ExceptionOr.h"
 #include "ScriptWrappable.h"
-#include <wtf/CheckedRef.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore {
 
@@ -57,7 +57,7 @@ public:
 private:
     const AtomString* item(const String& name) const;
 
-    CheckedRef<Element> m_element;
+    WeakRef<Element, WeakPtrImplWithEventTargetData> m_element;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -7954,7 +7954,7 @@ static Element* findNearestCommonComposedAncestor(Element* elementA, Element* el
     if (elementA == elementB)
         return elementA;
 
-    HashSet<CheckedRef<Element>> ancestorChain;
+    HashSet<Ref<Element>> ancestorChain;
     for (auto* element = elementA; element; element = element->parentElementInComposedTree())
         ancestorChain.add(*element);
 
@@ -8841,12 +8841,12 @@ std::optional<FrameIdentifier> Document::frameID() const
 
 void Document::registerArticleElement(Element& article)
 {
-    m_articleElements.add(&article);
+    m_articleElements.add(article);
 }
 
 void Document::unregisterArticleElement(Element& article)
 {
-    m_articleElements.remove(&article);
+    m_articleElements.remove(article);
     if (m_mainArticleElement == &article)
         m_mainArticleElement = nullptr;
 }
@@ -8882,7 +8882,7 @@ void Document::updateMainArticleElementAfterLayout()
             secondTallestArticleHeight = tallestArticleHeight;
             tallestArticleHeight = height;
             tallestArticleWidth = box ? box->width().toFloat() : 0;
-            tallestArticle = article.get();
+            tallestArticle = article.ptr();
         } else if (height >= secondTallestArticleHeight)
             secondTallestArticleHeight = height;
     }

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -2081,7 +2081,7 @@ private:
 
     std::unique_ptr<Style::Update> m_pendingRenderTreeUpdate;
 
-    CheckedPtr<Element> m_cssTarget;
+    WeakPtr<Element, WeakPtrImplWithEventTargetData> m_cssTarget;
 
     std::unique_ptr<LazyLoadImageObserver> m_lazyLoadImageObserver;
 
@@ -2139,8 +2139,8 @@ private:
     WeakPtr<HTMLMediaElement, WeakPtrImplWithEventTargetData> m_mediaElementShowingTextTrack;
 #endif
 
-    CheckedPtr<Element> m_mainArticleElement;
-    HashSet<CheckedPtr<Element>> m_articleElements;
+    WeakPtr<Element, WeakPtrImplWithEventTargetData> m_mainArticleElement;
+    HashSet<WeakRef<Element, WeakPtrImplWithEventTargetData>> m_articleElements;
 
     WeakHashSet<VisibilityChangeClient> m_visibilityStateCallbackClients;
 

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2896,7 +2896,7 @@ void Element::addShadowRoot(Ref<ShadowRoot>&& newShadowRoot)
 
         ensureElementRareData().setShadowRoot(WTFMove(newShadowRoot));
 
-        shadowRoot->setHost(this);
+        shadowRoot->setHost(*this);
         shadowRoot->setParentTreeScope(treeScope());
 
         NodeVector postInsertionNotificationTargets;

--- a/Source/WebCore/dom/NamedNodeMap.h
+++ b/Source/WebCore/dom/NamedNodeMap.h
@@ -27,6 +27,7 @@
 #include "Element.h"
 #include "ExceptionOr.h"
 #include "ScriptWrappable.h"
+#include <wtf/WeakRef.h>
 
 namespace WebCore {
 
@@ -59,7 +60,7 @@ public:
     Ref<Element> protectedElement() const;
 
 private:
-    CheckedRef<Element> m_element;
+    WeakRef<Element, WeakPtrImplWithEventTargetData> m_element;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/RadioButtonGroups.cpp
+++ b/Source/WebCore/dom/RadioButtonGroups.cpp
@@ -47,8 +47,8 @@ private:
     bool isValid() const;
     void setCheckedButton(HTMLInputElement*);
 
-    HashSet<CheckedRef<HTMLInputElement>> m_members;
-    CheckedPtr<HTMLInputElement> m_checkedButton;
+    HashSet<WeakRef<HTMLInputElement, WeakPtrImplWithEventTargetData>> m_members;
+    WeakPtr<HTMLInputElement, WeakPtrImplWithEventTargetData> m_checkedButton;
     size_t m_requiredCount { 0 };
 };
 

--- a/Source/WebCore/dom/ScriptElement.h
+++ b/Source/WebCore/dom/ScriptElement.h
@@ -128,7 +128,7 @@ private:
 
     virtual bool isScriptPreventedByAttributes() const { return false; }
 
-    CheckedRef<Element> m_element;
+    WeakRef<Element, WeakPtrImplWithEventTargetData> m_element;
     OrdinalNumber m_startLineNumber { OrdinalNumber::beforeFirst() };
     JSC::SourceTaintedOrigin m_taintedOrigin;
     ParserInserted m_parserInserted : bitWidthOfParserInserted;

--- a/Source/WebCore/dom/ShadowRoot.cpp
+++ b/Source/WebCore/dom/ShadowRoot.cpp
@@ -51,7 +51,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(ShadowRoot);
 
 struct SameSizeAsShadowRoot : public DocumentFragment, public TreeScope {
     uint8_t flagsAndModes[3];
-    CheckedPtr<Element> host;
+    WeakPtr<Element, WeakPtrImplWithEventTargetData> host;
     void* styleSheetList;
     void* styleScope;
     void* slotAssignment;

--- a/Source/WebCore/dom/ShadowRoot.h
+++ b/Source/WebCore/dom/ShadowRoot.h
@@ -97,7 +97,7 @@ public:
 
     Element* host() const { return m_host.get(); }
     RefPtr<Element> protectedHost() const { return m_host.get(); }
-    void setHost(CheckedPtr<Element>&& host) { m_host = WTFMove(host); }
+    void setHost(WeakPtr<Element, WeakPtrImplWithEventTargetData>&& host) { m_host = WTFMove(host); }
 
     ExceptionOr<void> setHTMLUnsafe(const String&);
 
@@ -168,7 +168,7 @@ private:
     ShadowRootMode m_mode { ShadowRootMode::UserAgent };
     SlotAssignmentMode m_slotAssignmentMode { SlotAssignmentMode::Named };
 
-    CheckedPtr<Element> m_host;
+    WeakPtr<Element, WeakPtrImplWithEventTargetData> m_host;
     RefPtr<StyleSheetList> m_styleSheetList;
 
     std::unique_ptr<Style::Scope> m_styleScope;

--- a/Source/WebCore/dom/SimulatedClick.cpp
+++ b/Source/WebCore/dom/SimulatedClick.cpp
@@ -86,7 +86,7 @@ bool simulateClick(Element& element, Event* underlyingEvent, SimulatedClickMouse
     if (element.isDisabledFormControl())
         return false;
 
-    static MainThreadNeverDestroyed<HashSet<CheckedRef<Element>>> elementsDispatchingSimulatedClicks;
+    static MainThreadNeverDestroyed<HashSet<Ref<Element>>> elementsDispatchingSimulatedClicks;
     if (!elementsDispatchingSimulatedClicks.get().add(element).isNewEntry)
         return false;
 

--- a/Source/WebCore/html/HTMLCollection.h
+++ b/Source/WebCore/html/HTMLCollection.h
@@ -33,8 +33,8 @@ namespace WebCore {
 class CollectionNamedElementCache {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    inline const Vector<CheckedRef<Element>>* findElementsWithId(const AtomString& id) const;
-    inline const Vector<CheckedRef<Element>>* findElementsWithName(const AtomString& name) const;
+    inline const Vector<WeakRef<Element, WeakPtrImplWithEventTargetData>>* findElementsWithId(const AtomString& id) const;
+    inline const Vector<WeakRef<Element, WeakPtrImplWithEventTargetData>>* findElementsWithName(const AtomString& name) const;
     const Vector<AtomString>& propertyNames() const { return m_propertyNames; }
     
     inline void appendToIdCache(const AtomString& id, Element&);
@@ -44,9 +44,9 @@ public:
     inline size_t memoryCost() const;
 
 private:
-    typedef HashMap<AtomStringImpl*, Vector<CheckedRef<Element>>> StringToElementsMap;
+    typedef HashMap<AtomStringImpl*, Vector<WeakRef<Element, WeakPtrImplWithEventTargetData>>> StringToElementsMap;
 
-    inline const Vector<CheckedRef<Element>>* find(const StringToElementsMap&, const AtomString& key) const;
+    inline const Vector<WeakRef<Element, WeakPtrImplWithEventTargetData>>* find(const StringToElementsMap&, const AtomString& key) const;
     inline void append(StringToElementsMap&, const AtomString& key, Element&);
 
     StringToElementsMap m_idMap;

--- a/Source/WebCore/html/HTMLCollectionInlines.h
+++ b/Source/WebCore/html/HTMLCollectionInlines.h
@@ -37,12 +37,12 @@ inline ContainerNode& HTMLCollection::rootNode() const
     return ownerNode();
 }
 
-inline const Vector<CheckedRef<Element>>* CollectionNamedElementCache::findElementsWithId(const AtomString& id) const
+inline const Vector<WeakRef<Element, WeakPtrImplWithEventTargetData>>* CollectionNamedElementCache::findElementsWithId(const AtomString& id) const
 {
     return find(m_idMap, id);
 }
 
-inline const Vector<CheckedRef<Element>>* CollectionNamedElementCache::findElementsWithName(const AtomString& name) const
+inline const Vector<WeakRef<Element, WeakPtrImplWithEventTargetData>>* CollectionNamedElementCache::findElementsWithName(const AtomString& name) const
 {
     return find(m_nameMap, name);
 }
@@ -66,7 +66,7 @@ inline void CollectionNamedElementCache::didPopulate()
         reportExtraMemoryAllocatedForCollectionIndexCache(cost);
 }
 
-inline const Vector<CheckedRef<Element>>* CollectionNamedElementCache::find(const StringToElementsMap& map, const AtomString& key) const
+inline const Vector<WeakRef<Element, WeakPtrImplWithEventTargetData>>* CollectionNamedElementCache::find(const StringToElementsMap& map, const AtomString& key) const
 {
     ASSERT(m_didPopulate);
     auto it = map.find(key.impl());
@@ -77,7 +77,7 @@ inline void CollectionNamedElementCache::append(StringToElementsMap& map, const 
 {
     if (!m_idMap.contains(key.impl()) && !m_nameMap.contains(key.impl()))
         m_propertyNames.append(key);
-    map.add(key.impl(), Vector<CheckedRef<Element>>()).iterator->value.append(element);
+    map.add(key.impl(), Vector<WeakRef<Element, WeakPtrImplWithEventTargetData>>()).iterator->value.append(element);
 }
 
 inline bool HTMLCollection::isRootedAtTreeScope() const


### PR DESCRIPTION
#### 12e1fe4f7f33197ac8b7093bf2b66a850090a74f
<pre>
Use CheckedPtr&lt;Element&gt; / CheckedRef&lt;Element&gt; less for non-stack variables
<a href="https://bugs.webkit.org/show_bug.cgi?id=266286">https://bugs.webkit.org/show_bug.cgi?id=266286</a>

Reviewed by Ryosuke Niwa.

Use CheckedPtr&lt;Element&gt; / CheckedRef&lt;Element&gt; less for non-stack variables
since it introduces crashes that are not actionable.

Use WeakRef&lt;Element&gt; / WeakPtr&lt;Element&gt; instead.

This tested as performance neutral on Speedometer 2 &amp; 3.

* Source/WebCore/dom/Attr.h:
* Source/WebCore/dom/DatasetDOMStringMap.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::findNearestCommonComposedAncestor):
(WebCore::Document::registerArticleElement):
(WebCore::Document::unregisterArticleElement):
(WebCore::Document::updateMainArticleElementAfterLayout):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::addShadowRoot):
* Source/WebCore/dom/NamedNodeMap.h:
* Source/WebCore/dom/RadioButtonGroups.cpp:
* Source/WebCore/dom/ScriptElement.h:
* Source/WebCore/dom/ShadowRoot.cpp:
* Source/WebCore/dom/ShadowRoot.h:
* Source/WebCore/dom/SimulatedClick.cpp:
(WebCore::simulateClick):
* Source/WebCore/html/HTMLCollection.h:
* Source/WebCore/html/HTMLCollectionInlines.h:
(WebCore::CollectionNamedElementCache::findElementsWithId const):
(WebCore::CollectionNamedElementCache::findElementsWithName const):
(WebCore::CollectionNamedElementCache::find const):
(WebCore::CollectionNamedElementCache::append):

Canonical link: <a href="https://commits.webkit.org/271949@main">https://commits.webkit.org/271949@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1f2847e21607c55842119df358b63877c06e19c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30118 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8783 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31432 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32622 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27233 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30793 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10983 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6028 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27248 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30418 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7369 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25684 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6297 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6452 "Found 10 new test failures: imported/w3c/web-platform-tests/css/css-cascade/scope-hover.html, imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-below-viewport-partially-onscreen-new.html, imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-below-viewport-partially-onscreen-old.html, imported/w3c/web-platform-tests/css/selectors/invalidation/user-valid-user-invalid.html, imported/w3c/web-platform-tests/css/selectors/user-invalid.html, imported/w3c/web-platform-tests/css/selectors/valid-invalid-form-fieldset.html, imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch.tentative.html, imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative.html, imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/readwrite-readonly.html, imported/w3c/web-platform-tests/webrtc-extensions/RTCRtpSynchronizationSource-senderCaptureTimeOffset.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26777 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33959 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27462 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27210 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32639 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6397 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4567 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30456 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8146 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7150 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3888 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6925 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->