### PR TITLE
REGRESSION (271535@main): [ macOS Release wk2 ] fullscreen/full-screen-layer-dump.html is a frequent failure

### DIFF
--- a/LayoutTests/fullscreen/full-screen-layer-dump.html
+++ b/LayoutTests/fullscreen/full-screen-layer-dump.html
@@ -26,7 +26,7 @@ body {
                     out.innerText = "Test passes if you see a contents layer 3x the size and with a negative offset equal to the size:\n\n";
                     out.innerText += internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_CONTENT_LAYERS);
                     document.webkitCancelFullScreen();
-                }, 0)
+                }, 100)
             } else 
                 testRunner.notifyDone();
         });

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2001,7 +2001,5 @@ http/wpt/opener/parent-access-child-via-windowproxy.html [ Pass ]
 
 webkit.org/b/265954 [ Ventura+ Release x86_64 ] media/video-audio-session-mode.html [ Crash ]
 
-webkit.org/b/265957 [ Release ] fullscreen/full-screen-layer-dump.html [ Pass Failure ]
-
 # rdar://102425691 ([ New Test ](256068@main): [ Ventura+ ] http/wpt/webcodecs/videoFrame-colorSpace.html is a consistent failure)
 [ Ventura+ ] http/wpt/webcodecs/videoFrame-colorSpace.html [ Pass Failure ]


### PR DESCRIPTION
#### 38fee45725dc09f9b50d0a52f3da8b8b502acb45
<pre>
REGRESSION (271535@main): [ macOS Release wk2 ] fullscreen/full-screen-layer-dump.html is a frequent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=265957">https://bugs.webkit.org/show_bug.cgi?id=265957</a>

Reviewed by NOBODY (OOPS!).

This test is failing because it&apos;s not waiting enough to
dump the layer tree. Increasing the timeout to 100 ms seems
to be more than enough for it to pass.

Tested this in mac, release and debug, iterating 100 times,
no failures.

* LayoutTests/fullscreen/full-screen-layer-dump.html:
* LayoutTests/platform/mac-wk2/TestExpectations:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38fee45725dc09f9b50d0a52f3da8b8b502acb45

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30250 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8921 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31838 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32758 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27370 "Built successfully") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11365 "Failed to checkout and rebase branch from PR 21687") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6158 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27353 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30557 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7498 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27011 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6413 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6587 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27019 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34098 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/27730 "Build was cancelled. Recent messages:OS: Sonoma (14.0), Xcode: 15.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27517 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32748 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6524 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4695 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30562 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8272 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/26773 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7278 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7050 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->