### PR TITLE
Inputs with type=color cannot be focused using keyboard tabs.

### DIFF
--- a/LayoutTests/fast/forms/color/color-input-keyboard-focus-expected.txt
+++ b/LayoutTests/fast/forms/color/color-input-keyboard-focus-expected.txt
@@ -1,0 +1,10 @@
+Make sure that keyboard navigation doesn't skip the input with type color.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS color is color
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/color/color-input-keyboard-focus.html
+++ b/LayoutTests/fast/forms/color/color-input-keyboard-focus.html
@@ -1,0 +1,22 @@
+<html>
+    <head>
+        <script src="../../../resources/js-test.js"></script>
+        <script src="../../../resources/ui-helper.js"></script>
+        <script>
+            async function test()
+            {
+                description("Make sure that keyboard navigation doesn't skip the input with type color.");
+
+                if (window.testRunner) {
+                    testRunner.waitUntilDone();
+                    await UIHelper.keyDown("\t");
+                    shouldBe(document.activeElement.id, document.getElementById("color").id);
+                    testRunner.notifyDone();
+                }
+            }
+        </script>
+    </head>
+    <body onload="test()">
+        <input type="color" id="color">
+    </body>
+</html>

--- a/Source/WebCore/html/ColorInputType.cpp
+++ b/Source/WebCore/html/ColorInputType.cpp
@@ -97,11 +97,7 @@ bool ColorInputType::isMouseFocusable() const
 bool ColorInputType::isKeyboardFocusable(KeyboardEvent*) const
 {
     ASSERT(element());
-#if PLATFORM(IOS_FAMILY)
     return element()->isTextFormControlFocusable();
-#else
-    return false;
-#endif
 }
 
 bool ColorInputType::isPresentingAttachedView() const


### PR DESCRIPTION
#### 72d0cd8b36005b95073231d43cde36c7bacc220d
<pre>
Inputs with type=color cannot be focused using keyboard tabs.
<a href="https://bugs.webkit.org/show_bug.cgi?id=266285">https://bugs.webkit.org/show_bug.cgi?id=266285</a>
<a href="https://rdar.apple.com/problem/119557550">rdar://problem/119557550</a>

Reviewed by NOBODY (OOPS!).

The conditional always returns false for non IOS platforms. Basic testing
(tabbing through a form) seem that removing the conditional works fine.

* LayoutTests/fast/forms/color/color-input-keyboard-focus-expected.txt: Added.
* LayoutTests/fast/forms/color/color-input-keyboard-focus.html: Added.
* Source/WebCore/html/ColorInputType.cpp:
(WebCore::ColorInputType::isKeyboardFocusable const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72d0cd8b36005b95073231d43cde36c7bacc220d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30469 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9141 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32089 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32978 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27560 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31172 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11506 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6383 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27506 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30777 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7733 "Found 1 new test failure: fast/forms/color/color-input-keyboard-focus.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27314 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6585 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6781 "Found 9 new test failures: imported/w3c/web-platform-tests/css/css-cascade/scope-hover.html, imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-below-viewport-partially-onscreen-new.html, imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-below-viewport-partially-onscreen-old.html, imported/w3c/web-platform-tests/css/selectors/invalidation/user-valid-user-invalid.html, imported/w3c/web-platform-tests/css/selectors/user-invalid.html, imported/w3c/web-platform-tests/css/selectors/valid-invalid-form-fieldset.html, imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch.tentative.html, imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative.html, imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/readwrite-readonly.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27161 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34317 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27803 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27658 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32912 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6722 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4864 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30736 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8467 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/26928 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7457 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7264 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->