### PR TITLE
[Cocoa] Adopt AVSampleBufferAttachContentKey

### DIFF
--- a/Source/WebCore/PAL/pal/cocoa/AVFoundationSoftLink.h
+++ b/Source/WebCore/PAL/pal/cocoa/AVFoundationSoftLink.h
@@ -402,4 +402,7 @@ SOFT_LINK_CONSTANT_MAY_FAIL_FOR_HEADER(PAL, AVFoundation, AVSampleBufferDisplayL
 #define AVSampleBufferDisplayLayerReadyForDisplayDidChangeNotification PAL::get_AVFoundation_AVSampleBufferDisplayLayerReadyForDisplayDidChangeNotification()
 #endif
 
+SOFT_LINK_FUNCTION_FOR_HEADER(PAL, AVFoundation, AVSampleBufferAttachContentKey, BOOL, (CMSampleBufferRef sbuf, AVContentKey *contentKey, NSError **outError), (sbuf, contentKey, outError))
+#define AVSampleBufferAttachContentKey PAL::softLink_AVFoundation_AVSampleBufferAttachContentKey
+
 #endif // USE(AVFOUNDATION)

--- a/Source/WebCore/PAL/pal/cocoa/AVFoundationSoftLink.mm
+++ b/Source/WebCore/PAL/pal/cocoa/AVFoundationSoftLink.mm
@@ -290,4 +290,6 @@ SOFT_LINK_CONSTANT_FOR_SOURCE_WITH_EXPORT(PAL, AVFoundation, AVCaptureMaxAvailab
 SOFT_LINK_CONSTANT_MAY_FAIL_FOR_SOURCE_WITH_EXPORT(PAL, AVFoundation, AVSampleBufferDisplayLayerReadyForDisplayDidChangeNotification, NSNotificationName, PAL_EXPORT)
 #endif
 
+SOFT_LINK_FUNCTION_FOR_SOURCE(PAL, AVFoundation, AVSampleBufferAttachContentKey, BOOL, (CMSampleBufferRef sbuf, AVContentKey *contentKey, NSError **outError), (sbuf, contentKey, outError))
+
 #endif // USE(AVFOUNDATION)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h
@@ -56,6 +56,7 @@ namespace WebCore {
 
 class CDMInstanceSessionFairPlayStreamingAVFObjC;
 class CDMPrivateFairPlayStreaming;
+class MediaSampleAVFObjC;
 struct CDMMediaCapability;
 
 class AVContentKeySessionDelegateClient : public CanMakeWeakPtr<AVContentKeySessionDelegateClient> {
@@ -139,6 +140,8 @@ public:
 
     void sessionKeyStatusesChanged(const CDMInstanceSessionFairPlayStreamingAVFObjC&);
 
+    void attachContentKeyToSample(const MediaSampleAVFObjC&);
+
 #if !RELEASE_LOG_DISABLED
     void setLogIdentifier(const void* logIdentifier) final { m_logIdentifier = logIdentifier; }
     const Logger& logger() const { return m_logger; };
@@ -214,6 +217,8 @@ public:
     const KeyStatusVector& keyStatuses() const { return m_keyStatuses; }
     KeyStatusVector copyKeyStatuses() const;
 
+    void attachContentKeyToSample(const MediaSampleAVFObjC&);
+
 private:
     bool ensureSessionOrGroup(KeyGroupingStrategy);
     bool isLicenseTypeSupported(LicenseType) const;
@@ -227,6 +232,8 @@ private:
 
     std::optional<CDMKeyStatus> protectionStatusForRequest(AVContentKeyRequest *) const;
     void updateProtectionStatus();
+
+    AVContentKey *contentKeyForSample(const MediaSampleAVFObjC&);
 
 #if !RELEASE_LOG_DISABLED
     void setLogIdentifier(const void* logIdentifier) final { m_logIdentifier = logIdentifier; }

--- a/Source/WebKit/Scripts/process-entitlements.sh
+++ b/Source/WebKit/Scripts/process-entitlements.sh
@@ -121,6 +121,7 @@ function mac_process_gpu_entitlements()
         plistbuddy Add :com.apple.private.webkit.use-xpc-endpoint bool YES
         plistbuddy Add :com.apple.rootless.storage.WebKitGPUSandbox bool YES
         plistbuddy Add :com.apple.QuartzCore.webkit-end-points bool YES
+        plistbuddy Add :com.apple.private.coremedia.allow-fps-attachment bool YES
     fi
 }
 


### PR DESCRIPTION
#### dcf4f5aba6923c6d069e22770dd0141a9d864d6d
<pre>
[Cocoa] Adopt AVSampleBufferAttachContentKey
<a href="https://bugs.webkit.org/show_bug.cgi?id=266289">https://bugs.webkit.org/show_bug.cgi?id=266289</a>
<a href="https://rdar.apple.com/115664955">rdar://115664955</a>

Reviewed by Jer Noble.

Adopted AVSampleBufferAttachContentKey as a replacement to adding AVSampleBufferDisplayLayer and
AVSampleBufferAudioRenderer as content key recipients to an AVContentKeySession. This involves
finding the first content key that matches a sample&apos;s key by keyID, then attaching the key to the
sample prior to enqueueing it.

On macOS, this API requires the com.apple.private.coremedia.allow-fps-attachment entitlement; on iOS
it is enabled by an existing entitlement.

No new tests; covered by existing tests.

* Source/WebCore/PAL/pal/cocoa/AVFoundationSoftLink.h:
* Source/WebCore/PAL/pal/cocoa/AVFoundationSoftLink.mm:
* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm:
(WebCore::CDMInstanceFairPlayStreamingAVFObjC::attachContentKeyToSample):
(WebCore::CDMInstanceSessionFairPlayStreamingAVFObjC::contentKeyForSample):
(WebCore::CDMInstanceSessionFairPlayStreamingAVFObjC::attachContentKeyToSample):
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(WebCore::SourceBufferPrivateAVFObjC::destroyRenderers):
(WebCore::SourceBufferPrivateAVFObjC::trackDidChangeEnabled):
(WebCore::SourceBufferPrivateAVFObjC::setCDMInstance):
(WebCore::SourceBufferPrivateAVFObjC::enqueueSample):
(WebCore::SourceBufferPrivateAVFObjC::enqueueSampleBuffer):
(WebCore::SourceBufferPrivateAVFObjC::setVideoLayer):
* Source/WebKit/Scripts/process-entitlements.sh:

Canonical link: <a href="https://commits.webkit.org/271966@main">https://commits.webkit.org/271966@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cecbc2b8de38846598d1e714cd6c8d5481e85395

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30197 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8863 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31660 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32700 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/27312 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30874 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/11065 "Build was cancelled. Recent messages:OS: Sonoma (14.0), Xcode: 15.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6104 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27307 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30499 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/11065 "Build was cancelled. Recent messages:OS: Sonoma (14.0), Xcode: 15.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/26085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6365 "Passed tests") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/6/builds/30350 "Build was cancelled. Recent messages:OS: Unknown (10.15.7), Xcode: 11.7") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/11065 "Build was cancelled. Recent messages:OS: Sonoma (14.0), Xcode: 15.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/26939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34040 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/11065 "Build was cancelled. Recent messages:OS: Sonoma (14.0), Xcode: 15.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/27375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32699 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6471 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4651 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30505 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8221 "Built successfully") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/7155 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Checked out pull request; Reviewed by Jer Noble; Compiled WebKit (warnings); 20 flakes 8 failures; Uploaded test results; layout-tests (exception)") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7226 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3897 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6999 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->