### PR TITLE
[WASM] SEGV in JSC::Wasm::FunctionParser<JSC::Wasm::LLIntGenerator>::parseExpression

### DIFF
--- a/JSTests/wasm/gc/bug260516.js
+++ b/JSTests/wasm/gc/bug260516.js
@@ -1,0 +1,65 @@
+//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+
+import { compile, instantiate } from "./wast-wrapper.js";
+
+function module(bytes, valid = true) {
+  let buffer = new ArrayBuffer(bytes.length);
+  let view = new Uint8Array(buffer);
+  for (let i = 0; i < bytes.length; ++i) {
+    view[i] = bytes.charCodeAt(i);
+  }
+  return new WebAssembly.Module(buffer);
+}
+
+// This disassembly is not complete as some unused types were elided by wasm-dis.
+/*
+ * (module
+ *  (type $0 (sub (func (param i32 i32 i32) (result i32))))
+ *  (type $1 (func))
+ *  (memory $0 16 32)
+ *  (table $0 1 1 funcref)
+ *  (elem $0 (i32.const 0) $0)
+ *  (tag $tag$0)
+ *  (export "" (func $0))
+ *  (func $0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ *   (drop
+ *    (call $0
+ *     (i32.const 697894484)
+ *     (i32.const -157833023)
+ *     (i32.const -434794502)
+ *    )
+ *   )
+ *   (drop
+ *    (call $0
+ *     (i32.const 769991768)
+ *     (i32.const 631785841)
+ *     (i32.const 1294656724)
+ *    )
+ *   )
+ *   (drop
+ *    (loop $label$1 (result (ref null $0))
+ *     (ref.cast (ref null $0)
+ *      (table.get $0
+ *       (block $label$2 (result i32)
+ *        (select
+ *         (i32.const 487924244)
+ *         (i32.const -306468332)
+ *         (i32.const -69)
+ *        )
+ *       )
+ *      )
+ *     )
+ *    )
+ *   )
+ *   (drop
+ *    (block $label$3 (type 8)
+ *     (ref.func $0)
+ *    )
+ *   )
+ *   (block $label$4 (type 9)
+ *    (i32.const 1855060810)
+ *   )
+ *  )
+ * )
+ */
+new WebAssembly.Instance(module("\x00\x61\x73\x6d\x01\x00\x00\x00\x01\xb6\x80\x80\x80\x00\x0a\x50\x00\x5f\x00\x50\x00\x5f\x00\x50\x00\x5f\x00\x50\x00\x5f\x00\x50\x00\x5e\x7f\x01\x50\x00\x5e\x7f\x01\x50\x00\x60\x03\x7f\x7f\x7f\x01\x7f\x60\x00\x00\x50\x00\x60\x01\x63\x06\x01\x70\x50\x00\x60\x01\x70\x01\x7f\x03\x82\x80\x80\x80\x00\x01\x06\x04\x85\x80\x80\x80\x00\x01\x70\x01\x01\x01\x05\x84\x80\x80\x80\x00\x01\x01\x10\x20\x0d\x83\x80\x80\x80\x00\x01\x00\x07\x07\x88\x80\x80\x80\x00\x01\x04\x6d\x61\x69\x6e\x00\x00\x09\x8b\x80\x80\x80\x00\x01\x06\x00\x41\x00\x0b\x70\x01\xd2\x00\x0b\x0a\xda\x80\x80\x80\x00\x01\x58\x00\x41\xd4\x8c\xe4\xcc\x02\x41\xc1\xd1\xde\xb4\x7f\x41\xfa\x9f\xd6\xb0\x7e\x10\x00\x1a\x41\xd8\xc8\x94\xef\x02\x41\xf1\x92\xa1\xad\x02\x41\xd4\xc9\xab\xe9\x04\x10\x00\x1a\x03\x63\x06\x02\x7f\x41\x94\xc4\xd4\xe8\x01\x41\x94\xd4\xee\xed\x7e\x41\xbb\x7f\x1b\x0b\x25\x00\xfb\x17\x06\x0b\x02\x08\x1a\xd2\x00\x0b\x02\x09\x1a\x41\xca\xf6\xc7\xf4\x06\x0b\x0b"));


### PR DESCRIPTION
#### 06ddd6593c2d8c55ebbb70ff1433eba574b81bb7
<pre>
[WASM] SEGV in JSC::Wasm::FunctionParser&lt;JSC::Wasm::LLIntGenerator&gt;::parseExpression
<a href="https://bugs.webkit.org/show_bug.cgi?id=260516">https://bugs.webkit.org/show_bug.cgi?id=260516</a>

Reviewed by Justin Michaud.

Adds test for already-fixed bug.

* JSTests/wasm/gc/bug260516.js: Added.
(module):

Canonical link: <a href="https://commits.webkit.org/272049@main">https://commits.webkit.org/272049@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d352074958b1d067a10310b981ca4bbe848cf006

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30394 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9068 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32002 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32902 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27493 "Built successfully") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11295 "Hash d3520749 for PR 21693 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6303 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27451 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30702 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7613 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27258 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6525 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6669 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34240 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/26101 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27699 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27585 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32860 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/30501 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6652 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4797 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30683 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8407 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/36943 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7213 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7399 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7953 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7195 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->