### PR TITLE
Test for "segmentation fault in Source/JavaScriptCore/wasm/WasmTypeDefinition.h:324"

### DIFF
--- a/JSTests/wasm/gc/bug258801.js
+++ b/JSTests/wasm/gc/bug258801.js
@@ -1,0 +1,39 @@
+//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+
+import * as assert from "../assert.js";
+function module(bytes, valid = true) {
+  let buffer = new ArrayBuffer(bytes.length);
+  let view = new Uint8Array(buffer);
+  for (let i = 0; i < bytes.length; ++i) {
+    view[i] = bytes.charCodeAt(i);
+  }
+  return new WebAssembly.Module(buffer);
+}
+
+/*
+ * (module
+ *  (type $0 (sub (array (mut i32))))
+ *  (type $1 (func (param (ref null $0))))
+ *  (type $2 (sub (func (param i32 i32 i32) (result i32))))
+ *  (memory $0 16 32)
+ *  (table $0 1 1 funcref)
+ *  (elem $0 (i32.const 0) $0)
+ *  (tag $tag$0 (param (ref null $0)))
+ *  (export "main" (func $0))
+ *  (func $0 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ *   (throw $tag$0
+ *    (block $label$1 (result (ref null $0))
+ *     (block $label$2 (result (ref null $0))
+ *      (ref.null none)
+ *     )
+ *    )
+ *   )
+ *  )
+ * )
+ */
+let m = new WebAssembly.Instance(module("\x00\x61\x73\x6d\x01\x00\x00\x00\x01\x9c\x80\x80\x80\x00\x05\x50\x00\x5f\x00\x50\x00\x5f\x00\x50\x00\x5e\x7f\x01\x50\x00\x60\x03\x7f\x7f\x7f\x01\x7f\x60\x01\x63\x02\x00\x03\x82\x80\x80\x80\x00\x01\x03\x04\x85\x80\x80\x80\x00\x01\x70\x01\x01\x01\x05\x84\x80\x80\x80\x00\x01\x01\x10\x20\x0d\x83\x80\x80\x80\x00\x01\x00\x04\x07\x88\x80\x80\x80\x00\x01\x04\x6d\x61\x69\x6e\x00\x00\x09\x8b\x80\x80\x80\x00\x01\x06\x00\x41\x00\x0b\x70\x01\xd2\x00\x0b\x0a\x96\x80\x80\x80\x00\x01\x14\x00\x02\x63\x02\x02\x63\x02\xd0\x02\x0b\x0b\x08\x00\x41\xec\xa1\x98\xe3\x7d\x0b"));
+
+assert.throws(
+  () => m.exports.main(),
+  WebAssembly.Exception
+);


### PR DESCRIPTION
#### 3c1e139e1cd3b7137433e8f2df8fc42655a5d64d
<pre>
Test for &quot;segmentation fault in Source/JavaScriptCore/wasm/WasmTypeDefinition.h:324&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=258801">https://bugs.webkit.org/show_bug.cgi?id=258801</a>

Reviewed by Justin Michaud.

Adds test for fixed bug.

* JSTests/wasm/gc/bug258801.js: Added.
(module):

Canonical link: <a href="https://commits.webkit.org/271951@main">https://commits.webkit.org/271951@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09ccda0a637051c895e4ecc22ec9712a5b82ab49

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30137 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8802 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31451 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32641 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27252 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11002 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6047 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/27269 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30437 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7387 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25704 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6324 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6468 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33978 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/25884 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27480 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27230 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32650 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/30271 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6415 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4581 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30465 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8165 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/36711 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7141 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7169 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7904 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6944 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->