### PR TITLE
[Flatpak] Update nightly runner script for 23.08 SDK and GTK4 builds

### DIFF
--- a/Tools/Scripts/webkit-flatpak-run-nightly
+++ b/Tools/Scripts/webkit-flatpak-run-nightly
@@ -29,13 +29,14 @@ import urllib.request
 from html.parser import HTMLParser
 
 REPO = "https://software.igalia.com/flatpak-refs/webkit-sdk.flatpakrepo"
-SDK_BRANCH = "22.08"
+SDK_BRANCH = "23.08"
 USER_DIR = os.path.expanduser("~/.cache/wk-nightly")
 
 def spinning_cursor():
     while True:
         for cursor in '|/-\\':
             yield cursor
+
 
 # FIXME: Might be worth adding some JSON file listing builds on the servers.
 class MyHTMLParser(HTMLParser):
@@ -44,7 +45,7 @@ class MyHTMLParser(HTMLParser):
         if tag != "a":
             return
         for (name, value) in attrs:
-            if name == "href" and (value.startswith("release") or value.startswith("debug")):
+            if name == "href" and (value.startswith("release") or value.startswith("debug")) and 'main' in value:
                 self.builds.append(value)
 
 def flatpak(*args, env=None, stdout=None):
@@ -70,9 +71,9 @@ def get_build_path(platform, build_type, revision_number):
     return os.path.join(tempfile.gettempdir(), dirname)
 
 def get_revision_number(build_name):
-    match = re.match(r'.*_([0-9@a-z]+)_\d+\.zip$', build_name)
+    match = re.match(r'.*_([0-9%40a-z]+)_\d+\.zip$', build_name)
     if match:
-        return match.groups()[0]
+        return match.groups()[0].replace('%40', '@')
 
 def ensure_extracted_build(args):
     build_type = args.build_type.lower()
@@ -124,6 +125,8 @@ def run(path, build_type, args):
     }
     flatpak("run", "--die-with-parent", "--user",
             f"--env=PATH=/app/webkit/WebKitBuild/{build_type}/bin:/usr/bin",
+            f"--env=LD_LIBRARY_PATH=/app/webkit/WebKitBuild/{build_type}/lib",
+            f"--env=WEBKIT_INJECTED_BUNDLE_PATH=/app/webkit/WebKitBuild/{build_type}/lib",
             "--device=dri",
             "--share=ipc",
             "--share=network",
@@ -150,8 +153,10 @@ def main(args):
     type_group.add_argument("--release", help="Download a release build.",
                             dest='build_type', action="store_const", const="Release")
     platform_group = parser.add_mutually_exclusive_group()
-    platform_group.add_argument('--gtk', action='store_const', dest='platform', const='webkitgtk',
-                                help='Download and run GTK port build artefacts')
+    platform_group.add_argument('--gtk', action='store_const', dest='platform', const='webkitgtk4',
+                                help='Download and run GTK port build artifacts')
+    platform_group.add_argument('--gtk3', action='store_const', dest='platform', const='webkitgtk',
+                                help='Download and run GTK3 port build artifacts')
     platform_group.add_argument('--wpe', action='store_const', dest='platform', const='wpewebkit',
                                 help=('Download and run WPE port build artefacts'))
     parser.add_argument("command", nargs=argparse.REMAINDER, help="Command to execute (example: MiniBrowser, jsc)")
@@ -218,7 +223,6 @@ def bwrap_main(args):
     os.execvpe(bwrap_args[0], bwrap_args + args, os.environ)
 
 if __name__ == "__main__":
-    ld_library_path = os.environ.get("LD_LIBRARY_PATH", "")
     if '--args' in sys.argv:
         bwrap_main(sys.argv[1:])
     else:


### PR DESCRIPTION
#### 7cf2d601bd748e9e9de768b04e2f7490d39d5b8f
<pre>
[Flatpak] Update nightly runner script for 23.08 SDK and GTK4 builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=266296">https://bugs.webkit.org/show_bug.cgi?id=266296</a>

Reviewed by Michael Catanzaro.

The --gtk option is now for GTK4 builds and a new --gtk3 option is introduced, to test GTK3 builds.

* Tools/Scripts/webkit-flatpak-run-nightly:
(spinning_cursor):
(MyHTMLParser.handle_starttag):
(get_revision_number):
(run):
(main):
(bwrap_main):

Canonical link: <a href="https://commits.webkit.org/271947@main">https://commits.webkit.org/271947@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0c79b669c2e214899b06fb81a7b1fbdfb7d1ed0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30142 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8807 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31456 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32645 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27257 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30817 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11008 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6051 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/27264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30442 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/7395 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/25709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6318 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/6474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/26803 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33982 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/27487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/27236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/32647 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6420 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4585 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30452 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8169 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7138 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7173 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6948 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->