### PR TITLE
[ImageCapture] Reject promises synchronously when track has ended

### DIFF
--- a/LayoutTests/fast/mediastream/image-capture-get-photo-capabilities-expected.txt
+++ b/LayoutTests/fast/mediastream/image-capture-get-photo-capabilities-expected.txt
@@ -1,5 +1,5 @@
 
 
-PASS getPhotoCapabilities() on an 'ended' track should throw "InvalidStateError"
+PASS getPhotoCapabilities() on an 'ended' track should synchronously throw "InvalidStateError"
 PASS Check getPhotoCapabilities()
 

--- a/LayoutTests/fast/mediastream/image-capture-get-photo-capabilities.html
+++ b/LayoutTests/fast/mediastream/image-capture-get-photo-capabilities.html
@@ -20,9 +20,19 @@
             assert_equals(track.readyState, 'ended');
 
             const imageCapture = new ImageCapture(track);
-            return promise_rejects_dom(test, 'InvalidStateError', imageCapture.getPhotoCapabilities())
+            const promise = imageCapture.getPhotoCapabilities();
 
-        }, `getPhotoCapabilities() on an 'ended' track should throw "InvalidStateError"`);
+            let result;
+            promise.then(
+                (value) => { result = value; },
+                (error) => { result = error; }
+            );
+
+            await Promise.resolve();
+            assert_equals(result['name'], 'InvalidStateError');
+            return promise_rejects_dom(test, 'InvalidStateError', promise);
+
+        }, `getPhotoCapabilities() on an 'ended' track should synchronously throw "InvalidStateError"`);
 
         promise_test(async (test) => {
             const stream = await navigator.mediaDevices.getUserMedia({ video: true });

--- a/LayoutTests/fast/mediastream/image-capture-get-photo-settings-expected.txt
+++ b/LayoutTests/fast/mediastream/image-capture-get-photo-settings-expected.txt
@@ -1,6 +1,6 @@
 
 
-PASS getPhotoSettings() on an 'ended' track should throw "InvalidStateError"
+PASS getPhotoSettings() on an 'ended' track should synchronously throw "InvalidStateError"
 PASS "OperationError" should be thrown if the track ends before the promise resolves
 PASS Check getPhotoSettings()
 

--- a/LayoutTests/fast/mediastream/image-capture-get-photo-settings.html
+++ b/LayoutTests/fast/mediastream/image-capture-get-photo-settings.html
@@ -19,9 +19,19 @@
             assert_equals(track.readyState, 'ended');
 
             const imageCapture = new ImageCapture(track);
-            return promise_rejects_dom(test, 'InvalidStateError', imageCapture.getPhotoSettings())
+            const promise = imageCapture.getPhotoSettings();
 
-        }, `getPhotoSettings() on an 'ended' track should throw "InvalidStateError"`);
+            let result;
+            promise.then(
+                (value) => { result = value; },
+                (error) => { result = error; }
+            );
+
+            await Promise.resolve();
+            assert_equals(result['name'], 'InvalidStateError');
+            return promise_rejects_dom(test, 'InvalidStateError', promise);
+
+        }, `getPhotoSettings() on an 'ended' track should synchronously throw "InvalidStateError"`);
 
         promise_test(async (test) => {
             const stream = await navigator.mediaDevices.getUserMedia({ video: { width : 640 } });

--- a/LayoutTests/fast/mediastream/image-capture-take-photo-expected.txt
+++ b/LayoutTests/fast/mediastream/image-capture-take-photo-expected.txt
@@ -1,5 +1,5 @@
 
-PASS 'takePhoto()' on an 'ended' track should throw "InvalidStateError"
+PASS 'takePhoto()' on an 'ended' track should synchronously throw "InvalidStateError"
 PASS "OperationError" should be thrown if the track ends before the 'takePhoto()' promise resolves
 PASS The image returned by 'takePhoto()' should be at least as big as { photoSettings.imageHeight, photoSettings.imageWidth }
 PASS If 'takePhoto()' has to reconfigure capture track, 'mute' and 'unmute' should fire and track size should be restored

--- a/LayoutTests/fast/mediastream/image-capture-take-photo.html
+++ b/LayoutTests/fast/mediastream/image-capture-take-photo.html
@@ -18,9 +18,19 @@
             assert_equals(track.readyState, 'ended');
 
             const imageCapture = new ImageCapture(track);
-            return promise_rejects_dom(test, 'InvalidStateError', imageCapture.takePhoto())
+            const promise = imageCapture.takePhoto();
 
-        }, `'takePhoto()' on an 'ended' track should throw "InvalidStateError"`);
+            let result;
+            promise.then(
+                (value) => { result = value; },
+                (error) => { result = error; }
+            );
+
+            await Promise.resolve();
+            assert_equals(result['name'], 'InvalidStateError');
+            return promise_rejects_dom(test, 'InvalidStateError', promise);
+
+        }, `'takePhoto()' on an 'ended' track should synchronously throw "InvalidStateError"`);
 
         promise_test(async (test) => {
             const stream = await navigator.mediaDevices.getUserMedia({ video: { width : 640 } });

--- a/Source/WebCore/Modules/mediastream/ImageCapture.cpp
+++ b/Source/WebCore/Modules/mediastream/ImageCapture.cpp
@@ -69,6 +69,16 @@ void ImageCapture::takePhoto(PhotoSettings&& settings, DOMPromiseDeferred<IDLInt
     auto identifier = LOGIDENTIFIER;
     ALWAYS_LOG(identifier);
 
+    // https://w3c.github.io/mediacapture-image/#dom-imagecapture-takephoto
+    // If the readyState of track provided in the constructor is not live, return
+    // a promise rejected with a new DOMException whose name is InvalidStateError,
+    // and abort these steps.
+    if (m_track->readyState() == MediaStreamTrack::State::Ended) {
+        ERROR_LOG(identifier, "rejecting promise, track has ended");
+        promise.reject(Exception { ExceptionCode::InvalidStateError, "Track has ended"_s });
+        return;
+    }
+
     m_track->takePhoto(WTFMove(settings))->whenSettled(RunLoop::main(), [this, protectedThis = Ref { *this }, promise = WTFMove(promise), identifier = WTFMove(identifier)] (auto&& result) mutable {
         queueTaskKeepingObjectAlive(*this, TaskSource::ImageCapture, [this, promise = WTFMove(promise), result = WTFMove(result), identifier = WTFMove(identifier)] () mutable {
             if (!result) {
@@ -88,6 +98,16 @@ void ImageCapture::getPhotoCapabilities(DOMPromiseDeferred<IDLDictionary<PhotoCa
     auto identifier = LOGIDENTIFIER;
     ALWAYS_LOG(identifier);
 
+    // https://w3c.github.io/mediacapture-image/#dom-imagecapture-getphotocapabilities
+    // If the readyState of track provided in the constructor is not live, return
+    // a promise rejected with a new DOMException whose name is InvalidStateError,
+    // and abort these steps.
+    if (m_track->readyState() == MediaStreamTrack::State::Ended) {
+        ERROR_LOG(identifier, "rejecting promise, track has ended");
+        promise.reject(Exception { ExceptionCode::InvalidStateError, "Track has ended"_s });
+        return;
+    }
+
     m_track->getPhotoCapabilities()->whenSettled(RunLoop::main(), [this, protectedThis = Ref { *this }, promise = WTFMove(promise), identifier = WTFMove(identifier)] (auto&& result) mutable {
         queueTaskKeepingObjectAlive(*this, TaskSource::ImageCapture, [this, promise = WTFMove(promise), result = WTFMove(result), identifier = WTFMove(identifier)] () mutable {
             if (!result) {
@@ -106,6 +126,16 @@ void ImageCapture::getPhotoSettings(DOMPromiseDeferred<IDLDictionary<PhotoSettin
 {
     auto identifier = LOGIDENTIFIER;
     ALWAYS_LOG(identifier);
+
+    // https://w3c.github.io/mediacapture-image/#ref-for-dom-imagecapture-getphotosettings②
+    // If the readyState of track provided in the constructor is not live, return
+    // a promise rejected with a new DOMException whose name is InvalidStateError,
+    // and abort these steps.
+    if (m_track->readyState() == MediaStreamTrack::State::Ended) {
+        ERROR_LOG(identifier, "rejecting promise, track has ended");
+        promise.reject(Exception { ExceptionCode::InvalidStateError, "Track has ended"_s });
+        return;
+    }
 
     m_track->getPhotoSettings()->whenSettled(RunLoop::main(), [this, protectedThis = Ref { *this }, promise = WTFMove(promise), identifier = WTFMove(identifier)] (auto&& result) mutable {
         queueTaskKeepingObjectAlive(*this, TaskSource::ImageCapture, [this, promise = WTFMove(promise), result = WTFMove(result), identifier = WTFMove(identifier)] () mutable {

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
@@ -307,12 +307,7 @@ MediaStreamTrack::TrackCapabilities MediaStreamTrack::getCapabilities() const
 
 auto MediaStreamTrack::takePhoto(PhotoSettings&& settings) -> Ref<TakePhotoPromise>
 {
-    // https://w3c.github.io/mediacapture-image/#dom-imagecapture-takephoto
-    // If the readyState of track provided in the constructor is not live, return
-    // a promise rejected with a new DOMException whose name is InvalidStateError,
-    // and abort these steps.
-    if (m_ended)
-        return TakePhotoPromise::createAndReject(Exception { ExceptionCode::InvalidStateError, "Track has ended"_s });
+    ASSERT(!m_ended);
 
     return m_private->takePhoto(WTFMove(settings))->whenSettled(RunLoop::main(), [protectedThis = Ref { *this }] (auto&& result) mutable {
 
@@ -334,12 +329,7 @@ auto MediaStreamTrack::takePhoto(PhotoSettings&& settings) -> Ref<TakePhotoPromi
 
 auto MediaStreamTrack::getPhotoCapabilities() -> Ref<PhotoCapabilitiesPromise>
 {
-    // https://w3c.github.io/mediacapture-image/#dom-imagecapture-getphotocapabilities
-    // If the readyState of track provided in the constructor is not live, return
-    // a promise rejected with a new DOMException whose name is InvalidStateError,
-    // and abort these steps.
-    if (m_ended)
-        return PhotoCapabilitiesPromise::createAndReject(Exception { ExceptionCode::InvalidStateError, "Track has ended"_s });
+    ASSERT(!m_ended);
 
     return m_private->getPhotoCapabilities()->whenSettled(RunLoop::main(), [protectedThis = Ref { *this }] (auto&& result) mutable {
 
@@ -360,8 +350,7 @@ auto MediaStreamTrack::getPhotoCapabilities() -> Ref<PhotoCapabilitiesPromise>
 
 auto MediaStreamTrack::getPhotoSettings() -> Ref<PhotoSettingsPromise>
 {
-    if (m_ended)
-        return PhotoSettingsPromise::createAndReject(Exception { ExceptionCode::InvalidStateError, "Track has ended"_s });
+    ASSERT(!m_ended);
 
     return m_private->getPhotoSettings()->whenSettled(RunLoop::main(), [protectedThis = Ref { *this }] (auto&& result) mutable {
 


### PR DESCRIPTION
#### b0a7f8b8febb1740572fb77bf5cc615d30d34b50
<pre>
[ImageCapture] Reject promises synchronously when track has ended
<a href="https://bugs.webkit.org/show_bug.cgi?id=266297">https://bugs.webkit.org/show_bug.cgi?id=266297</a>
<a href="https://rdar.apple.com/119564866">rdar://119564866</a>

Reviewed by Youenn Fablet.

Reject takePhoto, getPhotoCapabilities, and getPhotoSettings promises synchronously
when called after a track has ended to match the spec.

* LayoutTests/fast/mediastream/image-capture-get-photo-capabilities-expected.txt:
* LayoutTests/fast/mediastream/image-capture-get-photo-capabilities.html:
* LayoutTests/fast/mediastream/image-capture-get-photo-settings-expected.txt:
* LayoutTests/fast/mediastream/image-capture-get-photo-settings.html:
* LayoutTests/fast/mediastream/image-capture-take-photo-expected.txt:
* LayoutTests/fast/mediastream/image-capture-take-photo.html:
* Source/WebCore/Modules/mediastream/ImageCapture.cpp:
(WebCore::ImageCapture::takePhoto):
(WebCore::ImageCapture::getPhotoCapabilities):
(WebCore::ImageCapture::getPhotoSettings):
* Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp:
(WebCore::MediaStreamTrack::takePhoto):
(WebCore::MediaStreamTrack::getPhotoCapabilities):
(WebCore::MediaStreamTrack::getPhotoSettings):

Canonical link: <a href="https://commits.webkit.org/274437@main">https://commits.webkit.org/274437@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a575b8389b2fb9bbfd1c37e790dbdd4446dc9fed

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39003 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17936 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41356 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41537 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34720 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41309 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20811 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15284 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32652 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39577 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15106 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33817 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13120 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13076 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34746 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42814 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35406 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35073 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38916 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13815 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11402 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37141 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15421 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/34025 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8747 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15082 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14907 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->