### PR TITLE
`history.scrollRestoration = 'manual'` should not prevent scrolling when navigating to a fragment URL

### DIFF
--- a/LayoutTests/fast/scrolling/resources/test-page-with-anchor.html
+++ b/LayoutTests/fast/scrolling/resources/test-page-with-anchor.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>div { margin-top: 800px; }</style>
+<script>
+history.scrollRestoration = "manual";
+</script>
+</head>
+<body>
+<div id="anchor">Anchor</div>
+</body>
+</html>

--- a/LayoutTests/fast/scrolling/scroll-restoration-manual-initial-load-expected.txt
+++ b/LayoutTests/fast/scrolling/scroll-restoration-manual-initial-load-expected.txt
@@ -1,0 +1,11 @@
+`history.scrollRestoration = 'manual'` should not prevent scrolling to a fragment for non-history navigations
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+* Navigating to fragment URL
+PASS w.scrollY > 0 became true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/scroll-restoration-manual-initial-load.html
+++ b/LayoutTests/fast/scrolling/scroll-restoration-manual-initial-load.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script>
+description("`history.scrollRestoration = 'manual'` should not prevent scrolling to a fragment for non-history navigations");
+jsTestIsAsync = true;
+
+onload = () => {
+    debug("* Navigating to fragment URL");
+    w = open("resources/test-page-with-anchor.html#anchor");
+    w.onload = () => {
+        setTimeout(() => {
+            shouldBecomeEqual("w.scrollY > 0", "true", finishJSTest);
+        }, 0);
+    }
+};
+</script>
+</body>
+</html>

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -3449,9 +3449,20 @@ bool FrameLoader::shouldPerformFragmentNavigation(bool isFormSubmission, const S
         && !stateMachine().isDisplayingInitialEmptyDocument();
 }
 
-static bool itemAllowsScrollRestoration(HistoryItem* historyItem)
+static bool itemAllowsScrollRestoration(HistoryItem* historyItem, FrameLoadType loadType)
 {
-    return !historyItem || historyItem->shouldRestoreScrollPosition();
+    if (!historyItem)
+        return true;
+
+    switch (loadType) {
+    case FrameLoadType::Back:
+    case FrameLoadType::Forward:
+    case FrameLoadType::IndexedBackForward:
+        return historyItem->shouldRestoreScrollPosition();
+    default:
+        break;
+    }
+    return true;
 }
 
 static bool isSameDocumentReload(bool isNewNavigation, FrameLoadType loadType)
@@ -3466,14 +3477,13 @@ void FrameLoader::scrollToFragmentWithParentBoundary(const URL& url, bool isNewN
     if (!view || !document)
         return;
 
-    if (isSameDocumentReload(isNewNavigation, m_loadType) || itemAllowsScrollRestoration(history().currentItem())) {
+    if (isSameDocumentReload(isNewNavigation, m_loadType) || itemAllowsScrollRestoration(history().currentItem(), m_loadType)) {
         // https://html.spec.whatwg.org/multipage/browsing-the-web.html#try-to-scroll-to-the-fragment
         if (!document->haveStylesheetsLoaded())
             document->setGotoAnchorNeededAfterStylesheetsLoad(true);
         else
             view->scrollToFragment(url);
     }
-
 }
 
 bool FrameLoader::shouldClose()


### PR DESCRIPTION
#### cbf0c91dd0ee88be69b552f4b18bbb148ce55013
<pre>
`history.scrollRestoration = &apos;manual&apos;` should not prevent scrolling when navigating to a fragment URL
<a href="https://bugs.webkit.org/show_bug.cgi?id=266299">https://bugs.webkit.org/show_bug.cgi?id=266299</a>
<a href="https://rdar.apple.com/108846524">rdar://108846524</a>

Reviewed by Darin Adler and Simon Fraser.

When navigating to a fragment URL, `history.scrollRestoration = &apos;manual&apos;` should only
prevent automatic scrolling to the fragment is the navigation is a history navigation.

Previously, we mistakenly applied to logic to any navigation type.

* LayoutTests/fast/scrolling/resources/test-page-with-anchor.html: Added.
* LayoutTests/fast/scrolling/scroll-restoration-manual-initial-load.html: Added.
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::loadInSameDocument):
(WebCore::FrameLoader::scrollToFragmentWithParentBoundary):
(WebCore::itemAllowsScrollRestoration): Deleted.
(WebCore::isSameDocumentReload): Deleted.
* Source/WebCore/loader/FrameLoader.h:

Canonical link: <a href="https://commits.webkit.org/271967@main">https://commits.webkit.org/271967@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70cf162fefa93e60af2f804ce665fdef1c4f1778

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30172 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8838 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31556 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32675 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27287 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30849 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11039 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6079 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27287 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30474 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7420 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25732 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6346 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6496 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26832 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34015 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/27527 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27266 "Found 1 new test failure: tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-mainframe-vertical-then-horizontal.html (failure)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/32677 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; 46 flakes 112 failures 1 missing results; Uploaded test results; 16 flakes 93 failures 1 missing results; Compiled WebKit (cancelled)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6446 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4612 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30489 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8197 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/26629 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7154 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7201 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6974 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->