### PR TITLE
REGRESSION(261003@main): [css-contain][css-grid] Size containment is not allowing the track sizing algorithm to distribute extra space to auto tracks

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-inline-size-grid-stretches-auto-rows-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-inline-size-grid-stretches-auto-rows-expected.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-inline-size-grid-stretches-auto-rows.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-inline-size-grid-stretches-auto-rows.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid-2/#algo-stretch">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="grid with inline-size containment, and min-height will still distribute extra space to auto rows">
+<style>
+grid {
+    display: grid;
+    min-height: 100px;
+    grid-template-rows: auto;
+    contain: inline-size;
+}
+.absolute {
+    position: absolute;
+}
+.align-end {
+    align-self: end;
+}
+.item {
+    width: 100px;
+    height: 50px;
+    background-color: green;
+}
+</style>
+</head>
+<body>
+    <p>Test passes if there is a filled green square.</p>
+    <grid>
+        <div class="absolute item"></div>
+        <div class="item align-end"></div>
+    </grid>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-size-grid-stretches-auto-rows-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-size-grid-stretches-auto-rows-expected.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-size-grid-stretches-auto-rows.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-size-grid-stretches-auto-rows.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-contain/#size-containment">
+<link rel="help" href="https://drafts.csswg.org/css-grid-2/#algo-stretch">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="grid with size containment, and min-height will still distribute extra space to auto rows">
+<style>
+grid {
+    display: grid;
+    min-height: 100px;
+    grid-template-rows: auto;
+    contain: size;
+}
+.absolute {
+    position: absolute;
+}
+.align-end {
+    align-self: end;
+}
+.item {
+    width: 100px;
+    height: 50px;
+    background-color: green;
+}
+</style>
+</head>
+<body>
+    <p>Test passes if there is a filled green square.</p>
+    <grid>
+        <div class="absolute item"></div>
+        <div class="item align-end"></div>
+    </grid>
+</body>
+</html>

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -1724,11 +1724,10 @@ void GridTrackSizingAlgorithm::run()
 
     // Step 3.
     m_strategy->maximizeTracks(tracks(m_direction), m_direction == GridTrackSizingDirection::ForColumns ? m_freeSpaceColumns : m_freeSpaceRows);
-    if (m_strategy->isComputingSizeOrInlineSizeContainment() && !m_renderGrid->explicitIntrinsicInnerLogicalSize(m_direction))
-        return;
 
     // Step 4.
-    stretchFlexibleTracks(initialFreeSpace);
+    if (!m_strategy->isComputingSizeOrInlineSizeContainment() || m_renderGrid->explicitIntrinsicInnerLogicalSize(m_direction))
+        stretchFlexibleTracks(initialFreeSpace);
 
     // Step 5.
     stretchAutoTracks();


### PR DESCRIPTION
#### cf2a9868136a77126003c51af66e7e1b13220ae4
<pre>
REGRESSION(261003@main): [css-contain][css-grid] Size containment is not allowing the track sizing algorithm to distribute extra space to auto tracks
<a href="https://bugs.webkit.org/show_bug.cgi?id=260201">https://bugs.webkit.org/show_bug.cgi?id=260201</a>
<a href="https://rdar.apple.com/problem/113915953">rdar://problem/113915953</a>

Reviewed by Brent Fulgham.

Size containment is supposed to size a box as if it had no content, so
for the purposes of grid layout this would mean that we would want to
skip parts of the algorithm that take into consideration the content.

The &quot;Stretch auto Tracks,&quot; portion of the grid track sizing algorithm
should not be skipped, however, as it has nothing to do with the content
of the grid. We should be able to distribute any definite free space
that we computed up to this point.

* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-inline-size-grid-stretches-auto-rows-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-inline-size-grid-stretches-auto-rows.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-size-grid-stretches-auto-rows-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-size-grid-stretches-auto-rows.html: Added.
* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::GridTrackSizingAlgorithm::run):

Canonical link: <a href="https://commits.webkit.org/272085@main">https://commits.webkit.org/272085@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aff15161752052dc914f18aa406cda736284c943

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30366 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9040 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32051 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32874 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27473 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31066 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11265 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6276 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27429 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30674 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7588 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27289 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6499 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6648 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27126 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34212 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27679 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27629 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32833 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6629 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4779 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30650 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8387 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/26889 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7233 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7379 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7169 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->