### PR TITLE
Some build/link cleanup

### DIFF
--- a/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm
@@ -85,11 +85,6 @@ template<> Class getClass<PKPayment>()
     return PAL::getPKPaymentClass();
 }
 
-template<> Class getClass<PKContact>()
-{
-    return PAL::getPKContactClass();
-}
-
 template<> Class getClass<PKPaymentMerchantSession>()
 {
     return PAL::getPKPaymentMerchantSessionClass();
@@ -644,11 +639,6 @@ std::optional<WebCore::DataDetectorElementInfo> ArgumentCoder<WebCore::DataDetec
 #endif // ENABLE(DATA_DETECTION)
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
-
-template<> Class getClass<AVOutputContext>()
-{
-    return PAL::getAVOutputContextClass();
-}
 
 void ArgumentCoder<WebCore::MediaPlaybackTargetContext>::encodePlatformData(Encoder& encoder, const WebCore::MediaPlaybackTargetContext& target)
 {

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1148,7 +1148,6 @@
 		512F58F812A88A5400629530 /* WKAuthenticationDecisionListener.h in Headers */ = {isa = PBXBuildFile; fileRef = 512F58F012A88A5400629530 /* WKAuthenticationDecisionListener.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		512F58FA12A88A5400629530 /* WKCredential.h in Headers */ = {isa = PBXBuildFile; fileRef = 512F58F212A88A5400629530 /* WKCredential.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		512F58FC12A88A5400629530 /* WKProtectionSpace.h in Headers */ = {isa = PBXBuildFile; fileRef = 512F58F412A88A5400629530 /* WKProtectionSpace.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		5131D5442AE9D4370016EF39 /* ArgumentCodersCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = A175C44B21AA331B000037D0 /* ArgumentCodersCocoa.mm */; };
 		5131D5452AE9D5140016EF39 /* ArgumentCodersCF.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1AAF0C4912B16334008E49E2 /* ArgumentCodersCF.cpp */; };
 		5131D5462AE9D5230016EF39 /* CoreTextHelpers.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C739E852347BCF600C621EC /* CoreTextHelpers.mm */; };
 		51367F592AA2EB7A00776C4E /* com.apple.WebKit.webpushd.relocatable.mac.sb in Resources */ = {isa = PBXBuildFile; fileRef = 51DAAEBF2AA198DE00DB2AA4 /* com.apple.WebKit.webpushd.relocatable.mac.sb */; };
@@ -18179,7 +18178,6 @@
 			files = (
 				5131D5452AE9D5140016EF39 /* ArgumentCodersCF.cpp in Sources */,
 				51FFD3092AE9A9FC00B0AB70 /* ArgumentCodersCocoa.mm in Sources */,
-				5131D5442AE9D4370016EF39 /* ArgumentCodersCocoa.mm in Sources */,
 				5187BDEA2AFF5419008A6EE5 /* CoreIPCArray.mm in Sources */,
 				5157AE032B23C34700C0E095 /* CoreIPCContacts.mm in Sources */,
 				5187BDEE2B005E16008A6EE5 /* CoreIPCDictionary.mm in Sources */,


### PR DESCRIPTION
#### 8e97f894b076c23c78e14ca6e9e842ec64126a7c
<pre>
Some build/link cleanup
<a href="https://bugs.webkit.org/show_bug.cgi?id=266304">https://bugs.webkit.org/show_bug.cgi?id=266304</a>
<a href="https://rdar.apple.com/119575178">rdar://119575178</a>

Reviewed by Alex Christensen.

- Two getClass&lt;&gt; implementations were double defined
- ArgumentCodersCocoa.mm was somehow being included to build twice

* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm:
(IPC::getClass&lt;PKContact&gt;): Deleted.
(IPC::getClass&lt;AVOutputContext&gt;): Deleted.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/272066@main">https://commits.webkit.org/272066@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c1ed2d778950f9f12ebe4e935285b3da2d0dab5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30169 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8833 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31922 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32670 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27282 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11034 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6076 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/27283 "Build was cancelled. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 69 flakes 269 failures 1 missing results; Uploaded test results; 30 flakes 238 failures 1 missing results; Compiled WebKit (cancelled)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30469 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7416 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27049 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6340 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6492 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34010 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/27509 "Build was cancelled. Recent messages:OS: Sonoma (14.0), Xcode: 15.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27523 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32669 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6444 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4607 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30479 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8194 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7223 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7198 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6972 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->