### PR TITLE
[scroll-anchoring] YouTube.com jittering in comments and Channel pages

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/focused-element-in-excluded-subtree-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/focused-element-in-excluded-subtree-expected.txt
@@ -1,0 +1,4 @@
+abc
+
+PASS Ensure there is no scroll anchoring adjustment in the main frame.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/focused-element-in-excluded-subtree.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/focused-element-in-excluded-subtree.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-scroll-anchoring/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+
+body { height: 4000px; }
+div { height: 100px; }
+
+.scroller {
+  overflow: scroll;
+  position: fixed;
+  width: 300px;
+  height: 300px;
+  background-color: green;
+}
+
+#posSticky {
+  top: 300px;
+  position: relative;
+  height: 50px;
+  width: 50px;
+  background-color: blue;
+}
+
+#content {
+  background-color: #D3D3D3;
+  height: 50px;
+  width: 50px;
+  position: relative;
+  top: 500px;
+}
+
+</style>
+<div id="scroller" class="scroller">
+    <div id="content"></div>
+
+  <div id="posSticky">
+    <div id="block1" tabindex="-1">abc</div>
+  </div>
+</div>
+
+<script>
+
+// Tests that a focused element doesn't become the 
+// priority candidate of the main frame if it is
+// in an excluded subtree
+
+promise_test(async function() {
+  var scroller = document.querySelector("#scroller");
+  var focusElement = document.querySelector("#block1");
+  focusElement.focus();
+  scroller.scrollBy(0,150);
+  document.scrollingElement.scrollBy(0,100);
+  
+  await new Promise(resolve => {
+     document.addEventListener("scroll", () => step_timeout(resolve, 0));
+   });
+
+  assert_equals(document.scrollingElement.scrollTop, 100);
+}, "Ensure there is no scroll anchoring adjustment in the main frame.");
+
+</script>

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
@@ -141,18 +141,14 @@ bool ScrollAnchoringController::didFindPriorityCandidate(Document& document)
         RefPtr iterElement = candidateElement;
 
         while (iterElement && iterElement.get() != elementForScrollableArea(m_owningScrollableArea)) {
-            if (auto renderer = element->renderer()) {
-                if (renderer->style().overflowAnchor() == OverflowAnchor::None)
-                    return nullptr;
-            }
+            auto candidateResult = examineAnchorCandidate(*iterElement);
+            if (candidateResult == CandidateExaminationResult::Exclude || (iterElement == candidateElement && candidateResult == CandidateExaminationResult::Skip))
+                return nullptr;
             iterElement = iterElement->parentElement();
         }
         if (!iterElement)
             return nullptr;
-        auto candidateResult = examineAnchorCandidate(*candidateElement);
-        if (candidateResult == CandidateExaminationResult::Select || candidateResult == CandidateExaminationResult::Descend)
-            return candidateElement;
-        return nullptr;
+        return candidateElement;
     };
 
     // TODO: need to check if focused element is text editable


### PR DESCRIPTION
#### 7d680c19811737d2f07264bb02add5a612aca841
<pre>
[scroll-anchoring] YouTube.com jittering in comments and Channel pages
<a href="https://bugs.webkit.org/show_bug.cgi?id=266303">https://bugs.webkit.org/show_bug.cgi?id=266303</a>
<a href="https://rdar.apple.com/problem/119568843">rdar://problem/119568843</a>

Reviewed by Simon Fraser.

We should check if a priority candidate is part of an excluded subtree before
selecting it as our anchor node.

* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/focused-element-in-excluded-subtree-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/focused-element-in-excluded-subtree.html: Added.
* Source/WebCore/page/scrolling/ScrollAnchoringController.cpp:
(WebCore::ScrollAnchoringController::didFindPriorityCandidate):

Canonical link: <a href="https://commits.webkit.org/271993@main">https://commits.webkit.org/271993@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f926b3f96066f4b40bd4697faa9c3ebb35229ca9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30270 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8941 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/31845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32778 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27390 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30961 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11139 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6178 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/27379 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30577 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7522 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/26721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6430 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6591 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/31845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34118 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/27604 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/27432 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/32782 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6543 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/4727 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30589 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8291 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/26722 "layout-tests running") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/7173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7297 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3912 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7069 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->