### PR TITLE
Adopt the ServiceExtensions framework for async text input support

### DIFF
--- a/Source/WebCore/platform/ios/WebEvent.mm
+++ b/Source/WebCore/platform/ios/WebEvent.mm
@@ -48,7 +48,7 @@ using WebCore::windowsKeyCodeForCharCode;
 
 @implementation WebEvent {
 #if HAVE(UI_ASYNC_TEXT_INTERACTION)
-    RetainPtr<UIKeyEvent> _originalUIKeyEvent;
+    RetainPtr<WebSEKeyEvent> _originalKeyEvent;
 #endif
 }
 
@@ -496,14 +496,14 @@ static NSString *normalizedStringWithAppKitCompatibilityMapping(NSString *charac
 
 #if HAVE(UI_ASYNC_TEXT_INTERACTION)
 
-@implementation WebEvent (UIAsyncTextInputSupport)
+@implementation WebEvent (WebSEKeyEventSupport)
 
-static inline WebEventType webEventType(UIKeyEventType type)
+static inline WebEventType webEventType(WebSEKeyEventType type)
 {
     switch (type) {
-    case UIKeyEventKeyDown:
+    case WebSEKeyEventKeyDown:
         return WebEventKeyDown;
-    case UIKeyEventKeyUp:
+    case WebSEKeyEventKeyUp:
         return WebEventKeyUp;
     }
     ASSERT_NOT_REACHED();
@@ -526,7 +526,7 @@ static inline WebEventFlags webEventModifierFlags(UIKeyModifierFlags flags)
     return modifiers;
 }
 
-static inline bool isChangingKeyModifiers(UIKeyEvent *event)
+static inline bool isChangingKeyModifiers(WebSEKeyEvent *event)
 {
     switch (event.keyCode) {
     case VK_LWIN:
@@ -544,7 +544,7 @@ static inline bool isChangingKeyModifiers(UIKeyEvent *event)
     }
 }
 
-- (instancetype)initWithUIKeyEvent:(UIKeyEvent *)event
+- (instancetype)initWithKeyEvent:(WebSEKeyEvent *)event
 {
     if (!(self = [super init]))
         return nil;
@@ -563,14 +563,14 @@ static inline bool isChangingKeyModifiers(UIKeyEvent *event)
     _charactersIgnoringModifiers = [event.charactersIgnoringModifiers retain];
     _tabKey = NO; // FIXME: Populate this field appropriately.
     _keyRepeating = event.keyRepeating;
-    _originalUIKeyEvent = event;
+    _originalKeyEvent = event;
 
     return self;
 }
 
-- (UIKeyEvent *)originalUIKeyEvent
+- (WebSEKeyEvent *)originalKeyEvent
 {
-    return _originalUIKeyEvent.get();
+    return _originalKeyEvent.get();
 }
 
 @end

--- a/Source/WebCore/platform/ios/WebSEDefinitions.h
+++ b/Source/WebCore/platform/ios/WebSEDefinitions.h
@@ -25,18 +25,11 @@
 
 #pragma once
 
-#if HAVE(UI_ASYNC_TEXT_INTERACTION)
+#if HAVE(SERVICEEXTENSIONS) && defined(__OBJC__) && __OBJC__
+#import <ServiceExtensions/ServiceExtensions.h>
+#import <ServiceExtensions/ServiceExtensions_Private.h>
+#endif
 
-#import "WebSEDefinitions.h"
-#import <WebCore/WebEvent.h>
-
-@class WebSEKeyEvent;
-
-@interface WebEvent (WebSEKeyEventSupport)
-
-- (instancetype)initWithKeyEvent:(WebSEKeyEvent *)event;
-@property (nonatomic, readonly) WebSEKeyEvent *originalKeyEvent;
-
-@end
-
-#endif // HAVE(UI_ASYNC_TEXT_INTERACTION)
+#if USE(APPLE_INTERNAL_SDK)
+#import <WebKitAdditions/WebSEDefinitionsAdditions.h>
+#endif

--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -1222,27 +1222,6 @@ typedef NS_ENUM(NSUInteger, _UIScrollDeviceCategory) {
 
 @end
 
-@protocol UIAsyncTextInput_Staging_117155812 <UIAsyncTextInput>
-
-- (void)deleteInDirection:(UITextStorageDirection)direction toGranularity:(UITextGranularity)granularity;
-- (void)moveInDirection:(UITextStorageDirection)direction byGranularity:(UITextGranularity)granularity;
-- (void)extendInDirection:(UITextStorageDirection)direction byGranularity:(UITextGranularity)granularity;
-- (void)moveInLayoutDirection:(UITextLayoutDirection)direction;
-- (void)extendInLayoutDirection:(UITextLayoutDirection)direction;
-
-@end
-
-@protocol UIExtendedTextInputTraits_Staging_117880911<UITextInputTraits>
-@optional
-
-@property (nonatomic, readonly) BOOL isSingleLineDocument;
-@property (nonatomic, readonly) BOOL typingAdaptationDisabled;
-@property (nonatomic, readonly) UIColor *insertionPointColor;
-@property (nonatomic, readonly) UIColor *selectionBarColor;
-@property (nonatomic, readonly) UIColor *selectionHighlightColor;
-
-@end
-
 #if !defined(UI_DIRECTIONAL_TEXT_RANGE_STRUCT)
 
 typedef struct {
@@ -1257,9 +1236,7 @@ typedef struct {
 @end
 
 @protocol UIAsyncTextInputDelegate_Staging<UIAsyncTextInputDelegate>
-- (void)invalidateTextEntryContext; // Added in rdar://118536368.
 - (void)deferReplaceTextActionToSystem:(id)sender; // Added in rdar://118307558.
-- (void)provideCandidateUISuggestions:(NSArray<UITextSuggestion*> *)suggestions; // Added in rdar://117914235.
 @end
 
 #endif // HAVE(UI_ASYNC_TEXT_INTERACTION)

--- a/Source/WebKit/Shared/DocumentEditingContext.h
+++ b/Source/WebKit/Shared/DocumentEditingContext.h
@@ -28,6 +28,7 @@
 #if PLATFORM(IOS_FAMILY)
 
 #include "ArgumentCoders.h"
+#include "WKSEDefinitions.h"
 #include <WebCore/AttributedString.h>
 #include <WebCore/ElementContext.h>
 #include <WebCore/FloatRect.h>
@@ -35,6 +36,7 @@
 #include <wtf/OptionSet.h>
 #include <wtf/Vector.h>
 
+OBJC_CLASS WKSETextDocumentContext;
 OBJC_CLASS UIWKDocumentContext;
 
 namespace WebKit {
@@ -62,7 +64,8 @@ struct DocumentEditingContextRequest {
 };
 
 struct DocumentEditingContext {
-    UIWKDocumentContext *toPlatformContext(OptionSet<WebKit::DocumentEditingContextRequest::Options>);
+    WKSETextDocumentContext *toPlatformContext(OptionSet<DocumentEditingContextRequest::Options>);
+    UIWKDocumentContext *toLegacyPlatformContext(OptionSet<DocumentEditingContextRequest::Options>);
 
     WebCore::AttributedString contextBefore;
     WebCore::AttributedString selectedText;

--- a/Source/WebKit/Shared/DocumentEditingContext.mm
+++ b/Source/WebKit/Shared/DocumentEditingContext.mm
@@ -40,7 +40,31 @@ static inline NSRange toNSRange(DocumentEditingContext::Range range)
     return NSMakeRange(range.location, range.length);
 }
 
-UIWKDocumentContext *DocumentEditingContext::toPlatformContext(OptionSet<DocumentEditingContextRequest::Options> options)
+#if HAVE(UI_WK_DOCUMENT_CONTEXT)
+
+template <typename ContextType>
+void setOptionalEditingContextProperties(const DocumentEditingContext& context, ContextType *platformContext, OptionSet<DocumentEditingContextRequest::Options> options)
+{
+    for (auto& rect : context.textRects)
+        [platformContext addTextRect:rect.rect forCharacterRange:toNSRange(rect.range)];
+
+    [platformContext setAnnotatedText:context.annotatedText.nsAttributedString().get()];
+
+#if HAVE(AUTOCORRECTION_ENHANCEMENTS)
+    if (options.contains(DocumentEditingContextRequest::Options::AutocorrectedRanges)) {
+        auto ranges = createNSArray(context.autocorrectedRanges, [&] (DocumentEditingContext::Range range) {
+            return [NSValue valueWithRange:toNSRange(range)];
+        });
+
+        if ([platformContext respondsToSelector:@selector(setAutocorrectedRanges:)])
+            [platformContext setAutocorrectedRanges:ranges.get()];
+    }
+#endif // HAVE(AUTOCORRECTION_ENHANCEMENTS)
+}
+
+#endif // HAVE(UI_WK_DOCUMENT_CONTEXT)
+
+UIWKDocumentContext *DocumentEditingContext::toLegacyPlatformContext(OptionSet<DocumentEditingContextRequest::Options> options)
 {
 #if HAVE(UI_WK_DOCUMENT_CONTEXT)
     auto platformContext = adoptNS([[UIWKDocumentContext alloc] init]);
@@ -58,24 +82,38 @@ UIWKDocumentContext *DocumentEditingContext::toPlatformContext(OptionSet<Documen
     }
 
     [platformContext setSelectedRangeInMarkedText:toNSRange(selectedRangeInMarkedText)];
-
-    for (const auto& rect : textRects)
-        [platformContext addTextRect:rect.rect forCharacterRange:toNSRange(rect.range)];
-
-    [platformContext setAnnotatedText:annotatedText.nsAttributedString().get()];
-
-#if HAVE(AUTOCORRECTION_ENHANCEMENTS)
-    if (options.contains(DocumentEditingContextRequest::Options::AutocorrectedRanges)) {
-        auto ranges = createNSArray(autocorrectedRanges, [&] (DocumentEditingContext::Range range) {
-            return [NSValue valueWithRange:toNSRange(range)];
-        });
-
-        if ([platformContext respondsToSelector:@selector(setAutocorrectedRanges:)])
-            [platformContext setAutocorrectedRanges:ranges.get()];
-    }
-#endif
+    setOptionalEditingContextProperties(*this, platformContext.get(), options);
 
     return platformContext.autorelease();
+#else
+    UNUSED_PARAM(options);
+    return nil;
+#endif
+}
+
+WKSETextDocumentContext *DocumentEditingContext::toPlatformContext(OptionSet<DocumentEditingContextRequest::Options> options)
+{
+#if HAVE(UI_WK_DOCUMENT_CONTEXT)
+#if SERVICE_EXTENSIONS_TEXT_INPUT_IS_AVAILABLE
+    RetainPtr<WKSETextDocumentContext> platformContext;
+    if (options.contains(DocumentEditingContextRequest::Options::AttributedText)) {
+        platformContext = adoptNS([[WKSETextDocumentContext alloc] initWithAttributedSelectedText:selectedText.nsAttributedString().get()
+            contextBefore:contextBefore.nsAttributedString().get()
+            contextAfter:contextAfter.nsAttributedString().get()
+            markedText:markedText.nsAttributedString().get()
+            selectedRangeInMarkedText:toNSRange(selectedRangeInMarkedText)]);
+    } else {
+        platformContext = adoptNS([[WKSETextDocumentContext alloc] initWithSelectedText:[selectedText.nsAttributedString() string]
+            contextBefore:[contextBefore.nsAttributedString() string]
+            contextAfter:[contextAfter.nsAttributedString() string]
+            markedText:[markedText.nsAttributedString() string]
+            selectedRangeInMarkedText:toNSRange(selectedRangeInMarkedText)]);
+    }
+    setOptionalEditingContextProperties(*this, platformContext.get(), options);
+    return platformContext.autorelease();
+#else
+    return toLegacyPlatformContext(options);
+#endif
 #else
     UNUSED_PARAM(options);
     return nil;

--- a/Source/WebKit/UIProcess/API/ios/WKSEDefinitions.h
+++ b/Source/WebKit/UIProcess/API/ios/WKSEDefinitions.h
@@ -25,6 +25,11 @@
 
 #pragma once
 
+#if HAVE(SERVICEEXTENSIONS) && defined(__OBJC__) && __OBJC__
+#import <ServiceExtensions/ServiceExtensions.h>
+#import <ServiceExtensions/ServiceExtensions_Private.h>
+#endif
+
 #if USE(APPLE_INTERNAL_SDK)
 
 #import <WebKitAdditions/WKSEDefinitionsAdditions.h>
@@ -36,4 +41,57 @@
 
 #endif
 
-
+#ifndef SERVICE_EXTENSIONS_TEXT_INPUT_IS_AVAILABLE
+#define SERVICE_EXTENSIONS_TEXT_INPUT_IS_AVAILABLE 0
+#define WKSETextSuggestion                                      UITextSuggestion
+#define WKSEAutoFillTextSuggestion                              UITextAutofillSuggestion
+#define WKSEKeyEvent                                            UIKeyEvent
+#define WKSEKeyEventContext                                     UIKeyEventContext
+#define WKSETextDocumentContext                                 UIWKDocumentContext
+#define WKSETextDocumentRequest                                 UIWKDocumentRequest
+#define WKSETextDocumentRequestFlags                            UIWKDocumentRequestFlags
+#define WKSETextDocumentRequestNone                             UIWKDocumentRequestNone
+#define WKSETextDocumentRequestText                             UIWKDocumentRequestText
+#define WKSETextDocumentRequestAttributed                       UIWKDocumentRequestAttributed
+#define WKSETextDocumentRequestRects                            UIWKDocumentRequestRects
+#define WKSETextDocumentRequestSpatial                          UIWKDocumentRequestSpatial
+#define WKSETextDocumentRequestAnnotation                       UIWKDocumentRequestAnnotation
+#define WKSETextDocumentRequestMarkedTextRects                  UIWKDocumentRequestMarkedTextRects
+#define WKSETextDocumentRequestSpatialAndCurrentSelection       UIWKDocumentRequestSpatialAndCurrentSelection
+#define WKSETextDocumentRequestAutocorrectedRanges              UIWKDocumentRequestAutocorrectedRanges
+#define WKSEDirectionalTextRange                                UIDirectionalTextRange
+#define WKSETextReplacementOptions                              UITextReplacementOptions
+#define WKSETextReplacementOptionsNone                          UITextReplacementOptionsNone
+#define WKSETextReplacementOptionsAddUnderline                  UITextReplacementOptionsAddUnderline
+#define WKSEShiftKeyState                                       UIShiftKeyState
+#define WKSEShiftKeyStateNone                                   UIShiftKeyStateNone
+#define WKSEShiftKeyStateShifted                                UIShiftKeyStateShifted
+#define WKSEShiftKeyStateCapsLocked                             UIShiftKeyStateCapsLocked
+#define WKSEExtendedTextInputTraits                             UIExtendedTextInputTraits
+#define WKSETextInput                                           UIAsyncTextInputClient
+#define WKSETextInputDelegate                                   UIAsyncTextInputDelegate
+#define WKSETextInteraction                                     UIAsyncTextInteraction
+#define WKSETextInteractionDelegate                             UIAsyncTextInteractionDelegate
+#define WKSEGestureType                                         UIWKGestureType
+#define WKSEGestureLoupe                                        UIWKGestureLoupe
+#define WKSEGestureOneFingerTap                                 UIWKGestureOneFingerTap
+#define WKSEGestureTapAndAHalf                                  UIWKGestureTapAndAHalf
+#define WKSEGestureDoubleTap                                    UIWKGestureDoubleTap
+#define WKSEGestureOneFingerDoubleTap                           UIWKGestureOneFingerDoubleTap
+#define WKSEGestureOneFingerTripleTap                           UIWKGestureOneFingerTripleTap
+#define WKSEGestureTwoFingerSingleTap                           UIWKGestureTwoFingerSingleTap
+#define WKSEGestureTwoFingerRangedSelectGesture                 UIWKGestureTwoFingerRangedSelectGesture
+#define WKSEGesturePhraseBoundary                               UIWKGesturePhraseBoundary
+#define WKSESelectionTouch                                      UIWKSelectionTouch
+#define WKSESelectionTouchStarted                               UIWKSelectionTouchStarted
+#define WKSESelectionTouchMoved                                 UIWKSelectionTouchMoved
+#define WKSESelectionTouchEnded                                 UIWKSelectionTouchEnded
+#define WKSESelectionTouchEndedMovingForward                    UIWKSelectionTouchEndedMovingForward
+#define WKSESelectionTouchEndedMovingBackward                   UIWKSelectionTouchEndedMovingBackward
+#define WKSESelectionTouchEndedNotMoving                        UIWKSelectionTouchEndedNotMoving
+#define WKSESelectionFlags                                      UIWKSelectionFlags
+#define WKSESelectionFlagsNone                                  UIWKNone
+#define WKSEWordIsNearTap                                       UIWKWordIsNearTap
+#define WKSESelectionFlipped                                    UIWKSelectionFlipped
+#define WKSEPhraseBoundaryChanged                               UIWKPhraseBoundaryChanged
+#endif // !defined(SERVICE_EXTENSIONS_TEXT_INPUT_IS_AVAILABLE)

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewPrivateForTestingIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewPrivateForTestingIOS.h
@@ -33,7 +33,7 @@
 @class _WKTextInputContext;
 @class UIEventAttribution;
 @class UIGestureRecognizer;
-@class UIWKDocumentContext;
+@class WKSEDocumentContext;
 @class UIWKDocumentRequest;
 @class UITapGestureRecognizer;
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1005,7 +1005,7 @@ public:
     void requestEvasionRectsAboveSelection(CompletionHandler<void(const Vector<WebCore::FloatRect>&)>&&);
     void updateSelectionWithDelta(int64_t locationDelta, int64_t lengthDelta, CompletionHandler<void()>&&);
     WebCore::FloatRect selectionBoundingRectInRootViewCoordinates() const;
-    void requestDocumentEditingContext(DocumentEditingContextRequest, CompletionHandler<void(DocumentEditingContext)>&&);
+    void requestDocumentEditingContext(DocumentEditingContextRequest&&, CompletionHandler<void(DocumentEditingContext&&)>&&);
     void generateSyntheticEditingCommand(SyntheticEditingCommandType);
     void showDataDetectorsUIForPositionInformation(const InteractionInformationAtPosition&);
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -455,7 +455,7 @@ struct ImageAnalysisContextMenuActionData {
 
 #if ENABLE(DATALIST_ELEMENT)
     RetainPtr<UIView <WKFormControl>> _dataListTextSuggestionsInputView;
-    RetainPtr<NSArray<UITextSuggestion *>> _dataListTextSuggestions;
+    RetainPtr<NSArray<WKSETextSuggestion *>> _dataListTextSuggestions;
     WeakObjCPtr<WKDataListSuggestionsControl> _dataListSuggestionsControl;
 #endif
 
@@ -583,7 +583,7 @@ struct ImageAnalysisContextMenuActionData {
     std::optional<WebKit::RemoveBackgroundData> _removeBackgroundData;
 #endif
 #if HAVE(UI_ASYNC_TEXT_INTERACTION)
-    __weak id<UIAsyncTextInputDelegate_Staging> _asyncSystemInputDelegate;
+    __weak id<WKSETextInputDelegate> _asyncSystemInputDelegate;
 #endif
 }
 
@@ -612,7 +612,7 @@ struct ImageAnalysisContextMenuActionData {
     , UIDragInteractionDelegate
 #endif
 #if HAVE(UI_ASYNC_TEXT_INTERACTION_DELEGATE)
-    , UIAsyncTextInteractionDelegate
+    , WKSETextInteractionDelegate
 #endif
 >
 
@@ -642,7 +642,7 @@ struct ImageAnalysisContextMenuActionData {
 
 #if ENABLE(DATALIST_ELEMENT)
 @property (nonatomic, strong) UIView <WKFormControl> *dataListTextSuggestionsInputView;
-@property (nonatomic, strong) NSArray<UITextSuggestion *> *dataListTextSuggestions;
+@property (nonatomic, strong) NSArray<WKSETextSuggestion *> *dataListTextSuggestions;
 #endif
 
 - (void)setUpInteraction;
@@ -695,7 +695,7 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(DECLARE_WKCONTENTVIEW_ACTION_FOR_WEB_VIEW)
 - (void)_didNotHandleTapAsClick:(const WebCore::IntPoint&)point;
 - (void)_didHandleTapAsHover;
 - (void)_didCompleteSyntheticClick;
-- (void)_provideSuggestionsToInputDelegate:(NSArray<UITextSuggestion *> *)suggestions;
+- (void)_provideSuggestionsToInputDelegate:(NSArray<WKSETextSuggestion *> *)suggestions;
 
 - (void)_didGetTapHighlightForRequest:(WebKit::TapIdentifier)requestID color:(const WebCore::Color&)color quads:(const Vector<WebCore::FloatQuad>&)highlightedQuads topLeftRadius:(const WebCore::IntSize&)topLeftRadius topRightRadius:(const WebCore::IntSize&)topRightRadius bottomLeftRadius:(const WebCore::IntSize&)bottomLeftRadius bottomRightRadius:(const WebCore::IntSize&)bottomRightRadius nodeHasBuiltInClickHandling:(BOOL)nodeHasBuiltInClickHandling;
 

--- a/Source/WebKit/UIProcess/ios/WKExtendedTextInputTraits.h
+++ b/Source/WebKit/UIProcess/ios/WKExtendedTextInputTraits.h
@@ -28,10 +28,11 @@
 #if PLATFORM(IOS_FAMILY)
 
 #import "UIKitSPI.h"
+#import "WKSEDefinitions.h"
 
 @interface WKExtendedTextInputTraits : NSObject
 #if HAVE(UI_ASYNC_TEXT_INTERACTION)
-    <UIExtendedTextInputTraits_Staging_117880911>
+    <WKSEExtendedTextInputTraits>
 #endif
 
 @property (nonatomic) UITextAutocapitalizationType autocapitalizationType;

--- a/Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.h
+++ b/Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.h
@@ -28,6 +28,7 @@
 #if PLATFORM(IOS_FAMILY)
 
 #import "UIKitSPI.h"
+#import "WKSEDefinitions.h"
 
 @class WKContentView;
 
@@ -41,9 +42,9 @@
 - (void)selectionChanged;
 - (void)setGestureRecognizers;
 - (void)willStartScrollingOverflow;
-- (void)selectionChangedWithGestureAt:(CGPoint)point withGesture:(UIWKGestureType)gestureType withState:(UIGestureRecognizerState)gestureState withFlags:(UIWKSelectionFlags)flags;
+- (void)selectionChangedWithGestureAt:(CGPoint)point withGesture:(WKSEGestureType)gestureType withState:(UIGestureRecognizerState)gestureState withFlags:(WKSESelectionFlags)flags;
 - (void)showDictionaryFor:(NSString *)selectedTerm fromRect:(CGRect)presentationRect;
-- (void)selectionChangedWithTouchAt:(CGPoint)point withSelectionTouch:(UIWKSelectionTouch)touch withFlags:(UIWKSelectionFlags)flags;
+- (void)selectionChangedWithTouchAt:(CGPoint)point withSelectionTouch:(WKSESelectionTouch)touch withFlags:(WKSESelectionFlags)flags;
 - (void)lookup:(NSString *)textWithContext withRange:(NSRange)range fromRect:(CGRect)presentationRect;
 - (void)showShareSheetFor:(NSString *)selectedTerm fromRect:(CGRect)presentationRect;
 - (void)showTextServiceFor:(NSString *)selectedTerm fromRect:(CGRect)presentationRect;

--- a/Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm
+++ b/Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm
@@ -30,16 +30,12 @@
 #if PLATFORM(IOS_FAMILY)
 
 #import "WKContentViewInteraction.h"
-#import <wtf/SoftLinking.h>
-
-SOFT_LINK_FRAMEWORK(UIKit) // NOLINT
-SOFT_LINK_CLASS_OPTIONAL(UIKit, UIAsyncTextInteraction)
 
 @implementation WKTextInteractionWrapper {
     __weak WKContentView *_view;
     RetainPtr<UIWKTextInteractionAssistant> _textInteractionAssistant;
 #if HAVE(UI_ASYNC_TEXT_INTERACTION)
-    RetainPtr<UIAsyncTextInteraction> _asyncTextInteraction;
+    RetainPtr<WKSETextInteraction> _asyncTextInteraction;
     RetainPtr<NSTimer> _showEditMenuTimer;
     BOOL _showEditMenuAfterNextSelectionChange;
 #endif
@@ -52,9 +48,8 @@ SOFT_LINK_CLASS_OPTIONAL(UIKit, UIAsyncTextInteraction)
         return nil;
 
 #if HAVE(UI_ASYNC_TEXT_INTERACTION)
-    static bool hasAsyncTextInteraction = !!getUIAsyncTextInteractionClass();
-    if (hasAsyncTextInteraction && view.shouldUseAsyncInteractions) {
-        _asyncTextInteraction = adoptNS([allocUIAsyncTextInteractionInstance() init]);
+    if (view.shouldUseAsyncInteractions) {
+        _asyncTextInteraction = adoptNS([[WKSETextInteraction alloc] init]);
 #if HAVE(UI_ASYNC_TEXT_INTERACTION_DELEGATE)
         [_asyncTextInteraction setDelegate:view];
 #endif
@@ -158,9 +153,9 @@ SOFT_LINK_CLASS_OPTIONAL(UIKit, UIAsyncTextInteraction)
 #endif
 }
 
-- (void)selectionChangedWithGestureAt:(CGPoint)point withGesture:(UIWKGestureType)gestureType withState:(UIGestureRecognizerState)gestureState withFlags:(UIWKSelectionFlags)flags
+- (void)selectionChangedWithGestureAt:(CGPoint)point withGesture:(WKSEGestureType)gestureType withState:(UIGestureRecognizerState)gestureState withFlags:(WKSESelectionFlags)flags
 {
-    [_textInteractionAssistant selectionChangedWithGestureAt:point withGesture:gestureType withState:gestureState withFlags:flags];
+    [_textInteractionAssistant selectionChangedWithGestureAt:point withGesture:static_cast<UIWKGestureType>(gestureType) withState:gestureState withFlags:static_cast<UIWKSelectionFlags>(flags)];
 #if HAVE(UI_ASYNC_TEXT_INTERACTION)
     [_asyncTextInteraction selectionChangedWithGestureAt:point withGesture:gestureType withState:gestureState withFlags:flags];
 #endif
@@ -174,9 +169,9 @@ SOFT_LINK_CLASS_OPTIONAL(UIKit, UIAsyncTextInteraction)
 #endif
 }
 
-- (void)selectionChangedWithTouchAt:(CGPoint)point withSelectionTouch:(UIWKSelectionTouch)touch withFlags:(UIWKSelectionFlags)flags
+- (void)selectionChangedWithTouchAt:(CGPoint)point withSelectionTouch:(WKSESelectionTouch)touch withFlags:(WKSESelectionFlags)flags
 {
-    [_textInteractionAssistant selectionChangedWithTouchAt:point withSelectionTouch:touch withFlags:flags];
+    [_textInteractionAssistant selectionChangedWithTouchAt:point withSelectionTouch:static_cast<UIWKSelectionTouch>(touch) withFlags:static_cast<UIWKSelectionFlags>(flags)];
 #if HAVE(UI_ASYNC_TEXT_INTERACTION)
     [_asyncTextInteraction selectionChangedWithTouchAt:point withSelectionTouch:touch withFlags:flags];
 #endif

--- a/Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.h
+++ b/Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.h
@@ -26,13 +26,15 @@
 #if ENABLE(DATALIST_ELEMENT) && PLATFORM(IOS_FAMILY)
 
 #import "UIKitSPI.h"
+#import "WKSEDefinitions.h"
 #import "WebDataListSuggestionsDropdown.h"
 #import <wtf/RetainPtr.h>
 #import <wtf/Vector.h>
 
 OBJC_CLASS WKContentView;
 
-@interface WKDataListTextSuggestion : UITextSuggestion
+@interface WKDataListTextSuggestion : WKSETextSuggestion
++ (instancetype)textSuggestionWithInputText:(NSString *)inputText;
 @end
 
 @interface WKDataListSuggestionsControl : NSObject

--- a/Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.mm
@@ -80,6 +80,16 @@ static NSString * const suggestionCellReuseIdentifier = @"WKDataListSuggestionCe
 @end
 
 @implementation WKDataListTextSuggestion
+
++ (instancetype)textSuggestionWithInputText:(NSString *)inputText
+{
+#if SERVICE_EXTENSIONS_TEXT_INPUT_IS_AVAILABLE
+    return [[[super alloc] initWithInputText:inputText] autorelease];
+#else
+    return [super textSuggestionWithInputText:inputText];
+#endif
+}
+
 @end
 
 #pragma mark - WebDataListSuggestionsDropdownIOS

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -1210,14 +1210,14 @@ WebCore::FloatRect WebPageProxy::selectionBoundingRectInRootViewCoordinates() co
     return bounds;
 }
 
-void WebPageProxy::requestDocumentEditingContext(WebKit::DocumentEditingContextRequest request, CompletionHandler<void(WebKit::DocumentEditingContext)>&& completionHandler)
+void WebPageProxy::requestDocumentEditingContext(WebKit::DocumentEditingContextRequest&& request, CompletionHandler<void(WebKit::DocumentEditingContext&&)>&& completionHandler)
 {
     if (!hasRunningProcess()) {
         completionHandler({ });
         return;
     }
 
-    sendWithAsyncReply(Messages::WebPage::RequestDocumentEditingContext(request), WTFMove(completionHandler));
+    sendWithAsyncReply(Messages::WebPage::RequestDocumentEditingContext(WTFMove(request)), WTFMove(completionHandler));
 }
 
 #if ENABLE(DRAG_SUPPORT)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -938,7 +938,7 @@ public:
     void setForceAlwaysUserScalable(bool);
 
     void updateSelectionWithDelta(int64_t locationDelta, int64_t lengthDelta, CompletionHandler<void()>&&);
-    void requestDocumentEditingContext(WebKit::DocumentEditingContextRequest, CompletionHandler<void(WebKit::DocumentEditingContext)>&&);
+    void requestDocumentEditingContext(WebKit::DocumentEditingContextRequest&&, CompletionHandler<void(WebKit::DocumentEditingContext&&)>&&);
     bool shouldAllowSingleClickToChangeSelection(WebCore::Node& targetNode, const WebCore::VisibleSelection& newSelection);
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -4835,7 +4835,7 @@ static VisiblePositionRange constrainRangeToSelection(const VisiblePositionRange
     return { position, position };
 }
 
-void WebPage::requestDocumentEditingContext(DocumentEditingContextRequest request, CompletionHandler<void(DocumentEditingContext)>&& completionHandler)
+void WebPage::requestDocumentEditingContext(DocumentEditingContextRequest&& request, CompletionHandler<void(DocumentEditingContext&&)>&& completionHandler)
 {
     if (!request.options.contains(DocumentEditingContextRequest::Options::Text) && !request.options.contains(DocumentEditingContextRequest::Options::AttributedText)) {
         completionHandler({ });
@@ -5027,7 +5027,7 @@ void WebPage::requestDocumentEditingContext(DocumentEditingContextRequest reques
         }
     }
 
-    completionHandler(context);
+    completionHandler(WTFMove(context));
 }
 
 bool WebPage::shouldAllowSingleClickToChangeSelection(WebCore::Node& targetNode, const WebCore::VisibleSelection& newSelection)


### PR DESCRIPTION
#### e6a7b742d24d37554294e235e5026cd9b86abc04
<pre>
Adopt the ServiceExtensions framework for async text input support
<a href="https://bugs.webkit.org/show_bug.cgi?id=266302">https://bugs.webkit.org/show_bug.cgi?id=266302</a>
<a href="https://rdar.apple.com/119568570">rdar://119568570</a>

Reviewed by Tim Horton.

Adopt `WKSE*`-prefixed objects, which are aliased to the new classes, protocols, or types and
constants exposed from the ServiceExtensions framework (if available), or otherwise aliased to the
`UIAsync*` SPI names.

No change in behavior; see below for more details.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/ios/WebEvent.mm:
(webEventType):
(isChangingKeyModifiers):
(-[WebEvent initWithKeyEvent:]):
(-[WebEvent originalKeyEvent]):
(-[WebEvent initWithUIKeyEvent:]): Deleted.
(-[WebEvent originalUIKeyEvent]): Deleted.
* Source/WebCore/platform/ios/WebEventPrivate.h:
* Source/WebCore/platform/ios/WebSEDefinitions.h: Copied from Source/WebKit/UIProcess/API/ios/WKSEDefinitions.h.
* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/Shared/DocumentEditingContext.h:
* Source/WebKit/Shared/DocumentEditingContext.mm:
(WebKit::setOptionalEditingContextProperties):
(WebKit::DocumentEditingContext::toLegacyPlatformContext):
(WebKit::DocumentEditingContext::toPlatformContext):
* Source/WebKit/UIProcess/API/ios/WKSEDefinitions.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewPrivateForTestingIOS.h:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _updateRuntimeProtocolConformanceIfNeeded]):
(-[WKContentView textInteractionGesture:shouldBeginAtPoint:]):
(toGestureType):
(toWKSEGestureType):
(toSelectionTouch):
(toWKSESelectionTouch):
(toWKSESelectionFlags):
(toSelectionFlags):
(selectionChangedWithGesture):
(selectionChangedWithTouch):
(-[WKContentView changeSelectionWithGestureAt:withGesture:withState:]):
(-[WKContentView changeSelectionWithGestureAt:withGesture:withState:withFlags:]):
(-[WKContentView changeSelectionWithTouchAt:withSelectionTouch:baseIsStart:withFlags:]):
(-[WKContentView changeSelectionWithTouchesFrom:to:withGesture:withState:]):
(logTextInteraction):
(-[WKContentView insertTextSuggestion:]):
(shiftKeyState):
(-[WKContentView _deferKeyEventToInputMethodEditing:]):
(-[WKContentView _interpretKeyEvent:isCharEvent:]):
(-[WKContentView dataListTextSuggestions]):
(-[WKContentView setDataListTextSuggestions:]):
(-[WKContentView updateTextSuggestionsForInputDelegate]):
(-[WKContentView _provideSuggestionsToInputDelegate:]):
(-[WKContentView _provideUITextSuggestionsToInputDelegate:]):
(toWebRequest):
(-[WKContentView requestDocumentContext:completionHandler:]):

Make the completion handler here take an `NSObject`, representing either a `UIWKDocumentRequest` or
the replacement class from ServiceExtensions. This allows us to maintain both binary and source
compatibility in all the following cases:

-   Against iOS 17, which doesn&apos;t have async text input support at all, or against versions of iOS
    17 that have `UIAsyncTextInput` but not the replacement APIs in ServiceExtensions. We fall back
    to `UIWKDocumentContext` here.

-   Building/running against versions of iOS 17 that have both `UIAsyncTextInput` and the requisite
    APIs in ServiceExtensions, but have `UIKit/async_text_input` disabled by default — here, we use
    the new ServiceExtensions API objects and flags (which, for the most part, maintain binary
    compatibility), with the exception of `WKSETextDocumentRequest`. In the completion handler, if
    async text input is disabled, we return a `UIWKDocumentRequest` to maintain binary
    compatibility.

-   Lastly, building/running against versions of iOS 17 that have both `UIAsyncTextInput` and the
    requisite APIs in ServiceExtensions, and enable `UIKit/async_text_input` by default. Here, we
    return the new `WKSETextDocumentRequest`.

(-[WKContentView selectPositionAtPoint:withContextRequest:completionHandler:]):
(-[WKContentView asyncSystemInputDelegate]):
(-[WKContentView setAsyncSystemInputDelegate:]):
(-[WKContentView handleAsyncKeyEvent:withCompletionHandler:]):
(-[WKContentView replaceText:withText:options:withCompletionHandler:]):
(-[WKContentView requestTextContextForAutocorrectionWithCompletionHandler:]):

Refactor this code to use `WebKit::DocumentEditingContext` to create the document context, to avoid
having to duplicate messy logic for initializing either of the two `WKSETextDocumentRequest` types,
depending on the SDK version. Note: we don&apos;t need to consult the async text input feature flag here
and return a legacy `UIWKDocumentRequest`, since this codepath is only ever invoked in the async
text input codepath to begin with.

(-[WKContentView adjustSelection:completionHandler:]):
(-[WKContentView shiftKeyStateChangedFrom:to:]):
(-[WKContentView selectionWillChange:]):
(-[WKContentView selectionDidChange:]):
(toUIWKGestureType): Deleted.
(toUIWKSelectionTouch): Deleted.
(toUIWKSelectionFlags): Deleted.
* Source/WebKit/UIProcess/ios/WKExtendedTextInputTraits.h:
* Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.h:
* Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm:
(-[WKTextInteractionWrapper initWithView:]):
(-[WKTextInteractionWrapper selectionChangedWithGestureAt:withGesture:withState:withFlags:]):
(-[WKTextInteractionWrapper selectionChangedWithTouchAt:withSelectionTouch:withFlags:]):
(SOFT_LINK_CLASS_OPTIONAL): Deleted.
* Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.h:
* Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.mm:
(+[WKDataListTextSuggestion textSuggestionWithInputText:]):
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::requestDocumentEditingContext):

Drive-by fixes: make both the completion handler and method itself take rvalue references, instead
of passing by value.

* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::requestDocumentEditingContext):

Canonical link: <a href="https://commits.webkit.org/272018@main">https://commits.webkit.org/272018@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b1426e461f7a8a4ad2114307bdf822142a43fbc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30358 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9035 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31970 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32865 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27469 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31058 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11258 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6271 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27427 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30666 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7582 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/27236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6492 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6643 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27063 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34204 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/27675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/27564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32829 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6625 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4776 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30645 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8383 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7191 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/7375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7165 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->