### PR TITLE
Make `WriteRichTextDataWhenCopyingOrDragging` default to async text input enablement

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -8007,7 +8007,7 @@ WriteRichTextDataWhenCopyingOrDragging:
     WebKitLegacy:
       default: true
     WebKit:
-      "HAVE(PASTEBOARD_CONVERSION_FROM_HTML_TO_RTF)" : false
+      "PLATFORM(IOS_FAMILY)": WebKit::defaultWriteRichTextDataWhenCopyingOrDragging()
       default: true
     WebCore:
       default: true

--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.h
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.h
@@ -42,6 +42,7 @@ bool defaultShouldPrintBackgrounds();
 bool defaultAlternateFormControlDesignEnabled();
 bool defaultVideoFullscreenRequiresElementFullscreen();
 bool defaultUseAsyncUIKitInteractions();
+bool defaultWriteRichTextDataWhenCopyingOrDragging();
 #if ENABLE(TEXT_AUTOSIZING)
 bool defaultTextAutosizingUsesIdempotentMode();
 #endif

--- a/Source/WebKit/Shared/ios/WebPreferencesDefaultValuesIOS.mm
+++ b/Source/WebKit/Shared/ios/WebPreferencesDefaultValuesIOS.mm
@@ -87,6 +87,26 @@ bool defaultUseAsyncUIKitInteractions()
     return enabled;
 }
 
+bool defaultWriteRichTextDataWhenCopyingOrDragging()
+{
+    // While this is keyed off of the same underlying system feature flag as
+    // "Async UIKit Interactions", there are a couple of key differences:
+    // 1. The logic is inverted, since versions of iOS with the requisite support
+    //    for async text input *no longer* require WebKit to write RTF and
+    //    attributed string data.
+    // 2. This is not constrained by the same idiom check as async interactions,
+    //    since underlying system support is present across all PLATFORM(IOS)
+    //    configurations.
+    static bool shouldWrite = true;
+#if PLATFORM(IOS)
+    static std::once_flag flag;
+    std::call_once(flag, [] {
+        shouldWrite = !os_feature_enabled(UIKit, async_text_input);
+    });
+#endif
+    return shouldWrite;
+}
+
 } // namespace WebKit
 
 #endif // PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### 60184379683caa98c767e52cda3a3179955692e2
<pre>
Make `WriteRichTextDataWhenCopyingOrDragging` default to async text input enablement
<a href="https://bugs.webkit.org/show_bug.cgi?id=266321">https://bugs.webkit.org/show_bug.cgi?id=266321</a>

Reviewed by Megan Gardner and Abrar Rahman Protyasha.

Make `UIKit/async_text_input` enablement state also influence whether or not we attempt to write
RTF/attributed string data to the pasteboard when copying or dragging.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebKit/Shared/WebPreferencesDefaultValues.h:
* Source/WebKit/Shared/ios/WebPreferencesDefaultValuesIOS.mm:
(WebKit::defaultWriteRichTextDataWhenCopyingOrDragging):

Canonical link: <a href="https://commits.webkit.org/271974@main">https://commits.webkit.org/271974@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b73c67fabd4028eb3d0619e9e4824e365e1da03

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30211 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8879 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31676 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32715 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27327 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11080 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6116 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27315 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30514 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7456 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/26242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6378 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6525 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/26942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34055 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/25950 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/27534 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [💥 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27287 "An unexpected error occured. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32707 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/30338 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6483 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4646 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30519 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8233 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/36785 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7158 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7238 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7918 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7011 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->