### PR TITLE
[JSC] Improve Object.defineProperties & Object.defineProperty perf via fast iteration in ToPropertyDescriptor

### DIFF
--- a/JSTests/microbenchmarks/define-properties-all-of-keys.js
+++ b/JSTests/microbenchmarks/define-properties-all-of-keys.js
@@ -1,0 +1,115 @@
+const properties = {
+  closed: {
+    get() {
+      return this._writableState ? this._writableState.closed : false;
+    },
+  },
+  destroyed: {
+    get() {
+      return this._writableState ? this._writableState.destroyed : false;
+    },
+    set(value) {
+      if (this._writableState) {
+        this._writableState.destroyed = value;
+      }
+    },
+  },
+  writable: {
+    get() {
+      const w = this._writableState;
+      return (
+        !!w &&
+        w.writable !== false &&
+        !w.destroyed &&
+        !w.errored &&
+        !w.ending &&
+        !w.ended
+      );
+    },
+    set(val) {
+      if (this._writableState) {
+        this._writableState.writable = !!val;
+      }
+    },
+  },
+  writableFinished: {
+    get() {
+      return this._writableState ? this._writableState.finished : false;
+    },
+  },
+  writableObjectMode: {
+    get() {
+      return this._writableState ? this._writableState.objectMode : false;
+    },
+  },
+  writableBuffer: {
+    get() {
+      return this._writableState && this._writableState.getBuffer();
+    },
+  },
+  writableEnded: {
+    get() {
+      return this._writableState ? this._writableState.ending : false;
+    },
+  },
+  writableNeedDrain: {
+    get() {
+      const wState = this._writableState;
+      if (!wState) return false;
+      return !wState.destroyed && !wState.ending && wState.needDrain;
+    },
+  },
+  writableHighWaterMark: {
+    get() {
+      return this._writableState && this._writableState.highWaterMark;
+    },
+  },
+  writableCorked: {
+    get() {
+      return this._writableState ? this._writableState.corked : 0;
+    },
+  },
+  writableLength: {
+    get() {
+      return this._writableState && this._writableState.length;
+    },
+  },
+  errored: {
+    enumerable: false,
+    get() {
+      return this._writableState ? this._writableState.errored : null;
+    },
+  },
+  writableAborted: {
+    enumerable: false,
+    get: function () {
+      return !!(
+        this._writableState.writable !== false &&
+        (this._writableState.destroyed || this._writableState.errored) &&
+        !this._writableState.finished
+      );
+    },
+  },
+};
+
+var count = 10_000;
+
+function test() {
+  var first;
+  {
+    function Hey() {
+      return this;
+    }
+    Object.defineProperties(Hey.prototype, properties);
+    first = Object.getOwnPropertyDescriptors(Hey.prototype);
+  }
+
+  for (let i = 0; i < count; i++) {
+    function Hey() {
+      return this;
+    }
+    Object.defineProperties(Hey.prototype, first);
+  }
+}
+
+test();

--- a/JSTests/microbenchmarks/define-properties-simple.js
+++ b/JSTests/microbenchmarks/define-properties-simple.js
@@ -1,0 +1,106 @@
+const properties = {
+  closed: {
+    get() {
+      return this._writableState ? this._writableState.closed : false;
+    },
+  },
+  destroyed: {
+    get() {
+      return this._writableState ? this._writableState.destroyed : false;
+    },
+    set(value) {
+      if (this._writableState) {
+        this._writableState.destroyed = value;
+      }
+    },
+  },
+  writable: {
+    get() {
+      const w = this._writableState;
+      return (
+        !!w &&
+        w.writable !== false &&
+        !w.destroyed &&
+        !w.errored &&
+        !w.ending &&
+        !w.ended
+      );
+    },
+    set(val) {
+      if (this._writableState) {
+        this._writableState.writable = !!val;
+      }
+    },
+  },
+  writableFinished: {
+    get() {
+      return this._writableState ? this._writableState.finished : false;
+    },
+  },
+  writableObjectMode: {
+    get() {
+      return this._writableState ? this._writableState.objectMode : false;
+    },
+  },
+  writableBuffer: {
+    get() {
+      return this._writableState && this._writableState.getBuffer();
+    },
+  },
+  writableEnded: {
+    get() {
+      return this._writableState ? this._writableState.ending : false;
+    },
+  },
+  writableNeedDrain: {
+    get() {
+      const wState = this._writableState;
+      if (!wState) return false;
+      return !wState.destroyed && !wState.ending && wState.needDrain;
+    },
+  },
+  writableHighWaterMark: {
+    get() {
+      return this._writableState && this._writableState.highWaterMark;
+    },
+  },
+  writableCorked: {
+    get() {
+      return this._writableState ? this._writableState.corked : 0;
+    },
+  },
+  writableLength: {
+    get() {
+      return this._writableState && this._writableState.length;
+    },
+  },
+  errored: {
+    enumerable: false,
+    get() {
+      return this._writableState ? this._writableState.errored : null;
+    },
+  },
+  writableAborted: {
+    enumerable: false,
+    get: function () {
+      return !!(
+        this._writableState.writable !== false &&
+        (this._writableState.destroyed || this._writableState.errored) &&
+        !this._writableState.finished
+      );
+    },
+  },
+};
+
+var count = 10_000;
+
+function test() {
+  for (let i = 0; i < count; i++) {
+    function Hey() {
+      return this;
+    }
+    Object.defineProperties(Hey.prototype, properties);
+  }
+}
+
+test();

--- a/JSTests/microbenchmarks/define-property-simple.js
+++ b/JSTests/microbenchmarks/define-property-simple.js
@@ -1,0 +1,116 @@
+const properties = {
+  closed: {
+    get() {
+      return this._writableState ? this._writableState.closed : false;
+    },
+  },
+  destroyed: {
+    get() {
+      return this._writableState ? this._writableState.destroyed : false;
+    },
+    set(value) {
+      if (this._writableState) {
+        this._writableState.destroyed = value;
+      }
+    },
+  },
+  writable: {
+    get() {
+      const w = this._writableState;
+      return (
+        !!w &&
+        w.writable !== false &&
+        !w.destroyed &&
+        !w.errored &&
+        !w.ending &&
+        !w.ended
+      );
+    },
+    set(val) {
+      if (this._writableState) {
+        this._writableState.writable = !!val;
+      }
+    },
+  },
+  writableFinished: {
+    get() {
+      return this._writableState ? this._writableState.finished : false;
+    },
+  },
+  writableObjectMode: {
+    get() {
+      return this._writableState ? this._writableState.objectMode : false;
+    },
+  },
+  writableBuffer: {
+    get() {
+      return this._writableState && this._writableState.getBuffer();
+    },
+  },
+  writableEnded: {
+    get() {
+      return this._writableState ? this._writableState.ending : false;
+    },
+  },
+  writableNeedDrain: {
+    get() {
+      const wState = this._writableState;
+      if (!wState) return false;
+      return !wState.destroyed && !wState.ending && wState.needDrain;
+    },
+  },
+  writableHighWaterMark: {
+    get() {
+      return this._writableState && this._writableState.highWaterMark;
+    },
+  },
+  writableCorked: {
+    get() {
+      return this._writableState ? this._writableState.corked : 0;
+    },
+  },
+  writableLength: {
+    get() {
+      return this._writableState && this._writableState.length;
+    },
+  },
+  errored: {
+    enumerable: false,
+    get() {
+      return this._writableState ? this._writableState.errored : null;
+    },
+  },
+  writableAborted: {
+    enumerable: false,
+    get: function () {
+      return !!(
+        this._writableState.writable !== false &&
+        (this._writableState.destroyed || this._writableState.errored) &&
+        !this._writableState.finished
+      );
+    },
+  },
+};
+
+var count = 10_000;
+
+function test() {
+  const prop = {
+    enumerable: false,
+    get: function () {
+      return !!(
+        this._writableState.writable !== false &&
+        (this._writableState.destroyed || this._writableState.errored) &&
+        !this._writableState.finished
+      );
+    },
+  };
+  for (let i = 0; i < count; i++) {
+    function Hey() {
+      return this;
+    }
+    Object.defineProperty(Hey.prototype, "writableAborted", prop);
+  }
+}
+
+test();

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -443,6 +443,7 @@ public:
     InlineWatchpointSet m_sharedArrayBufferSpeciesWatchpointSet { ClearWatchpoint };
     InlineWatchpointSet m_typedArrayConstructorSpeciesWatchpointSet { IsWatched };
     InlineWatchpointSet m_typedArrayPrototypeIteratorProtocolWatchpointSet { IsWatched };
+    InlineWatchpointSet m_propertyDescriptorFastPathWatchpointSet { ClearWatchpoint };
 #define DECLARE_TYPED_ARRAY_TYPE_SPECIES_WATCHPOINT_SET(name) \
     InlineWatchpointSet m_typedArray ## name ## SpeciesWatchpointSet { ClearWatchpoint }; \
     InlineWatchpointSet m_typedArray ## name ## IteratorProtocolWatchpointSet { ClearWatchpoint };
@@ -485,6 +486,7 @@ public:
     std::unique_ptr<ObjectPropertyChangeAdaptiveWatchpoint<InlineWatchpointSet>> m_typedArray ## name ## PrototypeConstructorWatchpoint;
     FOR_EACH_TYPED_ARRAY_TYPE(DECLARE_TYPED_ARRAY_TYPE_WATCHPOINT)
 #undef DECLARE_TYPED_ARRAY_TYPE_WATCHPOINT
+    Vector<std::unique_ptr<ObjectAdaptiveStructureWatchpoint>> m_missWatchpoints;
 
     inline std::unique_ptr<ObjectAdaptiveStructureWatchpoint>& typedArrayConstructorSpeciesAbsenceWatchpoint(TypedArrayType);
     inline std::unique_ptr<ObjectAdaptiveStructureWatchpoint>& typedArrayPrototypeSymbolIteratorAbsenceWatchpoint(TypedArrayType);
@@ -518,6 +520,7 @@ public:
     inline InlineWatchpointSet& typedArrayIteratorProtocolWatchpointSet(TypedArrayType);
     InlineWatchpointSet& typedArrayConstructorSpeciesWatchpointSet() { return m_typedArrayConstructorSpeciesWatchpointSet; }
     InlineWatchpointSet& typedArrayPrototypeIteratorProtocolWatchpointSet() { return m_typedArrayPrototypeIteratorProtocolWatchpointSet; }
+    InlineWatchpointSet& propertyDescriptorFastPathWatchpointSet() { return m_propertyDescriptorFastPathWatchpointSet; }
 
     bool isArrayPrototypeIteratorProtocolFastAndNonObservable();
     bool isTypedArrayPrototypeIteratorProtocolFastAndNonObservable(TypedArrayType);
@@ -1046,6 +1049,7 @@ public:
     void installTypedArrayIteratorProtocolWatchpoint(JSObject* prototype, TypedArrayType);
     void installTypedArrayConstructorSpeciesWatchpoint(JSTypedArrayViewConstructor*);
     void installTypedArrayPrototypeIteratorProtocolWatchpoint(JSTypedArrayViewPrototype*);
+    void tryInstallPropertyDescriptorFastPathWatchpoint();
 
     const ImportMap& importMap() const { return m_importMap.get(); }
     ImportMap& importMap() { return m_importMap.get(); }

--- a/Source/JavaScriptCore/runtime/ObjectConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/ObjectConstructor.cpp
@@ -644,7 +644,7 @@ JSC_DEFINE_HOST_FUNCTION(objectConstructorValues, (JSGlobalObject* globalObject,
 }
 
 // https://tc39.github.io/ecma262/#sec-topropertydescriptor
-bool toPropertyDescriptor(JSGlobalObject* globalObject, JSValue in, PropertyDescriptor& desc)
+inline bool toPropertyDescriptor(JSGlobalObject* globalObject, JSValue in, PropertyDescriptor& desc, bool& withoutSideEffect)
 {
     ASSERT(desc.isEmpty());
     VM& vm = globalObject->vm();
@@ -656,44 +656,102 @@ bool toPropertyDescriptor(JSGlobalObject* globalObject, JSValue in, PropertyDesc
     }
     JSObject* description = asObject(in);
 
-    JSValue enumerable = description->getIfPropertyExists(globalObject, vm.propertyNames->enumerable);
-    RETURN_IF_EXCEPTION(scope, false);
-    if (enumerable)
-        desc.setEnumerable(enumerable.toBoolean(globalObject));
+    JSValue enumerable;
+    JSValue configurable;
+    JSValue value;
+    JSValue writable;
+    JSValue get;
+    JSValue set;
 
-    JSValue configurable = description->getIfPropertyExists(globalObject, vm.propertyNames->configurable);
-    RETURN_IF_EXCEPTION(scope, false);
-    if (configurable)
-        desc.setConfigurable(configurable.toBoolean(globalObject));
+    if (globalObject->propertyDescriptorFastPathWatchpointSet().state() == ClearWatchpoint)
+        globalObject->tryInstallPropertyDescriptorFastPathWatchpoint();
 
-    JSValue value = description->getIfPropertyExists(globalObject, vm.propertyNames->value);
-    RETURN_IF_EXCEPTION(scope, false);
-    if (value)
-        desc.setValue(value);
 
-    JSValue writable = description->getIfPropertyExists(globalObject, vm.propertyNames->writable);
-    RETURN_IF_EXCEPTION(scope, false);
-    if (writable)
-        desc.setWritable(writable.toBoolean(globalObject));
-
-    JSValue get = description->getIfPropertyExists(globalObject, vm.propertyNames->get);
-    RETURN_IF_EXCEPTION(scope, false);
-    if (get) {
-        if (!get.isUndefined() && !get.isCallable()) {
-            throwTypeError(globalObject, scope, "Getter must be a function."_s);
-            return false;
+    bool canUseFastPath = false;
+    if (globalObject->propertyDescriptorFastPathWatchpointSet().isStillValid() && globalObject->objectPrototypeChainIsSane() && description->inherits<JSFinalObject>() && description->getPrototypeDirect() == globalObject->objectPrototype() && description->structure()->canPerformFastPropertyEnumeration()) {
+        canUseFastPath = description->fastForEachPropertyWithSideEffectFreeFunctor(vm, [&](const PropertyTableEntry& entry) -> bool {
+            PropertyName propertyName(entry.key());
+            if (propertyName == vm.propertyNames->enumerable)
+                enumerable = description->getDirect(entry.offset());
+            else if (propertyName == vm.propertyNames->configurable)
+                configurable = description->getDirect(entry.offset());
+            else if (propertyName == vm.propertyNames->value)
+                value = description->getDirect(entry.offset());
+            else if (propertyName == vm.propertyNames->writable)
+                writable = description->getDirect(entry.offset());
+            else if (propertyName == vm.propertyNames->get)
+                get = description->getDirect(entry.offset());
+            else if (propertyName == vm.propertyNames->set)
+                set = description->getDirect(entry.offset());
+            return true;
+        });
+        if (canUseFastPath) {
+            if (enumerable)
+                desc.setEnumerable(enumerable.toBoolean(globalObject));
+            if (configurable)
+                desc.setConfigurable(configurable.toBoolean(globalObject));
+            if (value)
+                desc.setValue(value);
+            if (writable)
+                desc.setWritable(writable.toBoolean(globalObject));
+            if (get) {
+                if (!get.isUndefined() && !get.isCallable()) {
+                    throwTypeError(globalObject, scope, "Getter must be a function."_s);
+                    return false;
+                }
+                desc.setGetter(get);
+            }
+            if (set) {
+                if (!set.isUndefined() && !set.isCallable()) {
+                    throwTypeError(globalObject, scope, "Setter must be a function."_s);
+                    return false;
+                }
+                desc.setSetter(set);
+            }
+            withoutSideEffect = true;
         }
-        desc.setGetter(get);
     }
 
-    JSValue set = description->getIfPropertyExists(globalObject, vm.propertyNames->set);
-    RETURN_IF_EXCEPTION(scope, false);
-    if (set) {
-        if (!set.isUndefined() && !set.isCallable()) {
-            throwTypeError(globalObject, scope, "Setter must be a function."_s);
-            return false;
+    if (!canUseFastPath) {
+        enumerable = description->getIfPropertyExists(globalObject, vm.propertyNames->enumerable);
+        RETURN_IF_EXCEPTION(scope, false);
+        if (enumerable)
+            desc.setEnumerable(enumerable.toBoolean(globalObject));
+
+        configurable = description->getIfPropertyExists(globalObject, vm.propertyNames->configurable);
+        RETURN_IF_EXCEPTION(scope, false);
+        if (configurable)
+            desc.setConfigurable(configurable.toBoolean(globalObject));
+
+        value = description->getIfPropertyExists(globalObject, vm.propertyNames->value);
+        RETURN_IF_EXCEPTION(scope, false);
+        if (value)
+            desc.setValue(value);
+
+        writable = description->getIfPropertyExists(globalObject, vm.propertyNames->writable);
+        RETURN_IF_EXCEPTION(scope, false);
+        if (writable)
+            desc.setWritable(writable.toBoolean(globalObject));
+
+        get = description->getIfPropertyExists(globalObject, vm.propertyNames->get);
+        RETURN_IF_EXCEPTION(scope, false);
+        if (get) {
+            if (!get.isUndefined() && !get.isCallable()) {
+                throwTypeError(globalObject, scope, "Getter must be a function."_s);
+                return false;
+            }
+            desc.setGetter(get);
         }
-        desc.setSetter(set);
+
+        set = description->getIfPropertyExists(globalObject, vm.propertyNames->set);
+        RETURN_IF_EXCEPTION(scope, false);
+        if (set) {
+            if (!set.isUndefined() && !set.isCallable()) {
+                throwTypeError(globalObject, scope, "Setter must be a function."_s);
+                return false;
+            }
+            desc.setSetter(set);
+        }
     }
 
     if (!desc.isAccessorDescriptor())
@@ -710,6 +768,12 @@ bool toPropertyDescriptor(JSGlobalObject* globalObject, JSValue in, PropertyDesc
     }
 
     return true;
+}
+
+bool toPropertyDescriptor(JSGlobalObject* globalObject, JSValue value, PropertyDescriptor& desc)
+{
+    bool withoutSideEffect = false;
+    return toPropertyDescriptor(globalObject, value, desc, withoutSideEffect);
 }
 
 JSC_DEFINE_HOST_FUNCTION(objectConstructorDefineProperty, (JSGlobalObject* globalObject, CallFrame* callFrame))
@@ -733,7 +797,7 @@ JSC_DEFINE_HOST_FUNCTION(objectConstructorDefineProperty, (JSGlobalObject* globa
     RELEASE_AND_RETURN(scope, JSValue::encode(obj));
 }
 
-static JSValue defineProperties(JSGlobalObject* globalObject, JSObject* object, JSObject* properties)
+static JSValue definePropertiesSlow(JSGlobalObject* globalObject, JSObject* object, JSObject* properties)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -774,6 +838,92 @@ static JSValue defineProperties(JSGlobalObject* globalObject, JSObject* object, 
         ASSERT(!propertyName.isPrivateName());
 
         object->methodTable()->defineOwnProperty(object, globalObject, propertyName, descriptors[i], true);
+        RETURN_IF_EXCEPTION(scope, { });
+    }
+    return object;
+}
+
+static JSValue defineProperties(JSGlobalObject* globalObject, JSObject* object, JSObject* properties)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    Vector<RefPtr<UniquedStringImpl>, 8> propertyNames;
+    MarkedArgumentBuffer values;
+    bool canUseFastPath = !hasIndexedProperties(properties->indexingType()) && properties->fastForEachPropertyWithSideEffectFreeFunctor(vm, [&](const PropertyTableEntry& entry) -> bool {
+        if (entry.attributes() & PropertyAttribute::DontEnum)
+            return true;
+
+        PropertyName propertyName(entry.key());
+        if (propertyName.isPrivateName())
+            return true;
+
+        propertyNames.append(entry.key());
+        values.appendWithCrashOnOverflow(properties->getDirect(entry.offset()));
+
+        return true;
+    });
+    if (UNLIKELY(!canUseFastPath))
+        RELEASE_AND_RETURN(scope, definePropertiesSlow(globalObject, object, properties));
+
+    unsigned index = 0;
+    unsigned numProperties = propertyNames.size();
+    Vector<PropertyDescriptor> descriptors;
+    MarkedArgumentBuffer markBuffer;
+#define RETURN_IF_EXCEPTION_CLEARING_OVERFLOW(value) do { \
+    if (scope.exception()) { \
+        markBuffer.overflowCheckNotNeeded(); \
+        return value; \
+    } \
+} while (false)
+
+    for (; index < numProperties; ++index) {
+        JSValue prop = values.at(index);
+        bool withoutSideEffect = false;
+        PropertyDescriptor descriptor;
+        toPropertyDescriptor(globalObject, prop, descriptor, withoutSideEffect);
+        RETURN_IF_EXCEPTION_CLEARING_OVERFLOW({ });
+        descriptors.append(descriptor);
+        // Ensure we mark all the values that we're accumulating
+        if (descriptor.isDataDescriptor() && descriptor.value())
+            markBuffer.append(descriptor.value());
+        if (descriptor.isAccessorDescriptor()) {
+            if (descriptor.getter())
+                markBuffer.append(descriptor.getter());
+            if (descriptor.setter())
+                markBuffer.append(descriptor.setter());
+        }
+        if (UNLIKELY(!withoutSideEffect)) // Bail out to the slow code.
+            break;
+    }
+
+    if (UNLIKELY(index < numProperties)) {
+        for (; index < numProperties; ++index) {
+            JSValue prop = properties->get(globalObject, propertyNames[index].get());
+            RETURN_IF_EXCEPTION_CLEARING_OVERFLOW({ });
+            PropertyDescriptor descriptor;
+            toPropertyDescriptor(globalObject, prop, descriptor);
+            RETURN_IF_EXCEPTION_CLEARING_OVERFLOW({ });
+            descriptors.append(descriptor);
+            // Ensure we mark all the values that we're accumulating
+            if (descriptor.isDataDescriptor() && descriptor.value())
+                markBuffer.append(descriptor.value());
+            if (descriptor.isAccessorDescriptor()) {
+                if (descriptor.getter())
+                    markBuffer.append(descriptor.getter());
+                if (descriptor.setter())
+                    markBuffer.append(descriptor.setter());
+            }
+        }
+    }
+
+    RELEASE_ASSERT(!markBuffer.hasOverflowed());
+#undef RETURN_IF_EXCEPTION_CLEARING_OVERFLOW
+
+    for (unsigned index = 0; index < numProperties; index++) {
+        PropertyName propertyName(propertyNames[index].get());
+        ASSERT(!propertyName.isPrivateName());
+        object->methodTable()->defineOwnProperty(object, globalObject, propertyName, descriptors[index], true);
         RETURN_IF_EXCEPTION(scope, { });
     }
     return object;


### PR DESCRIPTION
#### 2432909f3aecc7641714799b06b4f909322bd6db
<pre>
[JSC] Improve Object.defineProperties &amp; Object.defineProperty perf via fast iteration in ToPropertyDescriptor
<a href="https://bugs.webkit.org/show_bug.cgi?id=248754">https://bugs.webkit.org/show_bug.cgi?id=248754</a>
<a href="https://rdar.apple.com/103101281">rdar://103101281</a>

Reviewed by Alexey Shvayka.

This patch set up &quot;writable&quot; &quot;set&quot; &quot;get&quot; &quot;value&quot; &quot;enumerable&quot; &quot;configurable&quot; watchpoints onto Object.prototype so that
we can quickly extract property descriptor from Object.defineProperty / Object.defineProperties descriptor objects.
We also extract these properties by enumerating all properties instead of doing hash table lookup multiple times since
in almost all cases this is faster because property descriptor object should be small.

It broadly improves Object.defineProperty / Object.defineProperties perf.

                                                      ToT                     Patched

    redefine-property-accessor-dictionary        4.5682+-0.0286     ^      3.5888+-0.0287        ^ definitely 1.2729x faster
    define-properties-all-of-keys               12.0816+-0.0671     ^      8.8536+-0.0794        ^ definitely 1.3646x faster
    redefine-property-previous-attributes       41.2230+-0.5076     ^     29.0349+-0.2499        ^ definitely 1.4198x faster
    redefine-property-data-dictionary            3.8830+-0.0141     ^      2.9631+-0.0237        ^ definitely 1.3104x faster
    define-property-simple                       1.3220+-0.0180     ^      1.1180+-0.0131        ^ definitely 1.1825x faster
    redefine-property-data                       3.4071+-0.0218     ^      2.5390+-0.0303        ^ definitely 1.3419x faster
    redefine-property-accessor                   3.9898+-0.0219     ^      2.9743+-0.0300        ^ definitely 1.3414x faster
    define-properties-simple                     9.9033+-0.0381     ^      6.8733+-0.0296        ^ definitely 1.4408x faster

* JSTests/microbenchmarks/define-properties-all-of-keys.js: Added.
(const.properties.destroyed.set if):
(const.properties.writable.set if):
(test.Hey):
(test.):
(test):
* JSTests/microbenchmarks/define-properties-simple.js: Added.
(const.properties.destroyed.set if):
(const.properties.writable.set if):
(test.):
(test):
* JSTests/microbenchmarks/define-property-simple.js: Added.
(const.properties.destroyed.set if):
(const.properties.writable.set if):
(test.):
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::tryInstallPropertyDescriptorFastPathWatchpoint):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
(JSC::JSGlobalObject::propertyDescriptorFastPathWatchpointSet):
* Source/JavaScriptCore/runtime/JSObject.h:
* Source/JavaScriptCore/runtime/JSObjectInlines.h:
(JSC::JSObject::getOwnPropertyIfPropertyExists):
* Source/JavaScriptCore/runtime/ObjectConstructor.cpp:
(JSC::toPropertyDescriptor):
(JSC::definePropertiesSlow):
(JSC::defineProperties):

Canonical link: <a href="https://commits.webkit.org/271972@main">https://commits.webkit.org/271972@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8739b7dc2d12ed1f005c91763afbe04b6b81758c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30221 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8890 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31687 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32726 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27338 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11090 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6126 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/27324 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30525 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7466 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/26247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6389 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/6537 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/26964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34066 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/25960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/27540 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [💥 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27298 "An unexpected error occured. Recent messages:OS: Monterey (12.6.8), Xcode: 14.0; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32718 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/30349 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6493 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4657 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30532 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8243 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/36795 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7248 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7924 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3900 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7021 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->