### PR TITLE
REGRESSION (271770@main): GPUP crashes under RemoteImageBufferSet::dynamicContentScalingDisplayList

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp
@@ -255,7 +255,9 @@ bool RemoteImageBufferSet::makeBuffersVolatile(OptionSet<BufferInSetType> reques
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
 void RemoteImageBufferSet::dynamicContentScalingDisplayList(CompletionHandler<void(std::optional<WebCore::DynamicContentScalingDisplayList>&&)>&& completionHandler)
 {
-    auto displayList = m_frontBuffer->dynamicContentScalingDisplayList();
+    std::optional<WebCore::DynamicContentScalingDisplayList> displayList;
+    if (m_frontBuffer)
+        displayList = m_frontBuffer->dynamicContentScalingDisplayList();
     completionHandler({ WTFMove(displayList) });
 }
 #endif


### PR DESCRIPTION
#### d384013f6817780822dac09fb899b521f21385e3
<pre>
REGRESSION (271770@main): GPUP crashes under RemoteImageBufferSet::dynamicContentScalingDisplayList
<a href="https://bugs.webkit.org/show_bug.cgi?id=266325">https://bugs.webkit.org/show_bug.cgi?id=266325</a>
<a href="https://rdar.apple.com/119585420">rdar://119585420</a>

Reviewed by Dean Jackson.

* Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp:
(WebKit::RemoteImageBufferSet::dynamicContentScalingDisplayList):
Null-check m_frontBuffer.

Canonical link: <a href="https://commits.webkit.org/271971@main">https://commits.webkit.org/271971@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c2941a8b7e8eec0951b5d75da0bde223f241ee90

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30218 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8887 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31684 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32723 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27335 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11087 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6123 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27321 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30522 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7463 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/26246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6386 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6540 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34063 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/27539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [💥 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27295 "An unexpected error occured. Recent messages:OS: Monterey (12.6.8), Xcode: 14.0; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32715 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6490 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4654 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30530 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8240 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7157 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7245 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7018 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->