### PR TITLE
[JSC] Add --top-bytecode-count and --top-function-count options to display-sampling-profiler-output

### DIFF
--- a/Tools/Scripts/display-sampling-profiler-output
+++ b/Tools/Scripts/display-sampling-profiler-output
@@ -43,11 +43,19 @@ $samplingProfilerIgnoreExternalSourceID = false
 $samplingProfilerTopFunctionsCount = 12
 $samplingProfilerTopBytecodesCount = 40
 
-GetoptLong.new(['--ignore-external-source-id', '-s', GetoptLong::NO_ARGUMENT]).each {
+GetoptLong.new(
+  ['--ignore-external-source-id', '-s', GetoptLong::NO_ARGUMENT],
+  ['--top-function-count', '-c', GetoptLong::REQUIRED_ARGUMENT],
+  ['--top-bytecode-count', '-b', GetoptLong::REQUIRED_ARGUMENT],
+).each {
     | opt, arg |
     case opt
     when '--ignore-external-source-id'
       $samplingProfilerIgnoreExternalSourceID = true
+    when '--top-function-count'
+      $samplingProfilerTopFunctionsCount = arg.to_i
+    when '--top-bytecode-count'
+      $samplingProfilerTopBytecodesCount = arg.to_i
     end
 }
 


### PR DESCRIPTION
#### c8f8ed69cb2cc84af4d6820bd1a13710a6e164c8
<pre>
[JSC] Add --top-bytecode-count and --top-function-count options to display-sampling-profiler-output
<a href="https://bugs.webkit.org/show_bug.cgi?id=266327">https://bugs.webkit.org/show_bug.cgi?id=266327</a>
<a href="https://rdar.apple.com/119597908">rdar://119597908</a>

Reviewed by Justin Michaud.

Add --top-bytecode-count and --top-function-count options to display-sampling-profiler-output to see more information easily.

* Tools/Scripts/display-sampling-profiler-output:

Canonical link: <a href="https://commits.webkit.org/272013@main">https://commits.webkit.org/272013@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/458f1168c4767cab73e00fc22883f2ec0a0b1a01

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30225 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8894 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31927 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32730 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27342 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30910 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11094 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6131 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27326 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30529 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7470 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/27047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6391 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6542 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27022 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34070 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27543 "Found 2 new API test failures: TestWebKitAPI.WKWebExtensionAPILocalization.Errors, TestWebKitAPI.WKWebsiteDataStoreConfiguration.TotalQuotaRatioWithPersistedDomain (failure)") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/27521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32721 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6497 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4663 "Found 1 new test failure: fullscreen/full-screen-layer-dump.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30535 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8247 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7252 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3923 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7025 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->