### PR TITLE
Many PaymentRequest tests are now passing

### DIFF
--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -84,19 +84,6 @@ http/tests/ssl/applepay [ Pass ]
 webkit.org/b/212975 http/tests/ssl/applepay/PaymentRequest.https.html [ Pass Timeout ]
 
 http/tests/paymentrequest [ Pass ]
-http/tests/paymentrequest/ApplePayModifier-automaticReloadPaymentRequest.https.html [ Skip ]
-http/tests/paymentrequest/ApplePayModifier-additionalLineItems.https.html [ Skip ]
-http/tests/paymentrequest/ApplePayModifier-additionalShippingMethods.https.html [ Skip ]
-http/tests/paymentrequest/ApplePayModifier-deferredPaymentRequest.https.html [ Skip ]
-http/tests/paymentrequest/ApplePayModifier-multiTokenContexts.https.html [ Skip ]
-http/tests/paymentrequest/ApplePayModifier-recurringPaymentRequest.https.html [ Skip ]
-http/tests/paymentrequest/ApplePayModifier-total.https.html [ Skip ]
-http/tests/paymentrequest/ApplePayPaymentCompleteDetails-orderDetails.https.html [ Skip ]
-http/tests/paymentrequest/paymentmethodchange-couponCode.https.html [ Skip ]
-http/tests/paymentrequest/paymentrequest-applePayLaterAvailability.https.html [ Skip ]
-http/tests/paymentrequest/paymentrequest-couponCode.https.html [ Skip ]
-http/tests/paymentrequest/paymentrequest-shippingContactEditingMode.https.html [ Skip ]
-http/tests/paymentrequest/paymentrequest-supportsCouponCode.https.html [ Skip ]
 imported/w3c/web-platform-tests/payment-request [ Pass ]
 webkit.org/b/175611 imported/w3c/web-platform-tests/payment-request/allowpaymentrequest/allowpaymentrequest-attribute-cross-origin-bc-containers.https.html [ Skip ]
 webkit.org/b/175611 imported/w3c/web-platform-tests/payment-request/allowpaymentrequest/no-attribute-cross-origin-bc-containers.https.html [ Skip ]
@@ -107,8 +94,7 @@ webkit.org/b/175611 imported/w3c/web-platform-tests/payment-request/allowpayment
 webkit.org/b/175611 imported/w3c/web-platform-tests/payment-request/allowpayment/no-attribute-cross-origin-bc-containers.https.html [ Skip ]
 webkit.org/b/175611 imported/w3c/web-platform-tests/payment-request/allowpayment/removing-allowpaymentrequest.https.sub.html [ Skip ]
 webkit.org/b/175611 imported/w3c/web-platform-tests/payment-request/allowpayment/setting-allowpaymentrequest.https.sub.html [ Skip ]
-imported/w3c/web-platform-tests/payment-request/payment-request-canmakepayment-method.https.html [ Skip ]
-imported/w3c/web-platform-tests/payment-request/payment-request-hasenrolledinstrument-method.tentative.https.html [ Skip ]
+imported/w3c/web-platform-tests/payment-request/payment-request-hasenrolledinstrument-method.tentative.https.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/payment-request/show-method-optional-promise-rejects.https.html [ DumpJSConsoleLogInStdErr ]
 
 # This test is failing due to lack of user activation.
@@ -1026,14 +1012,6 @@ editing/input/emacs-ctrl-o.html [ Failure ]
 fast/images/animated-gif-webkit-transform.html
 
 webkit.org/b/145432 media/video-transformed-by-javascript.html [ Failure ]
-
-# webkit.org/b/238908 Global expectations for these until baselines are resolved
-http/tests/paymentrequest/payment-address-attributes-and-toJSON-method.https.html [ DumpJSConsoleLogInStdErr ]
-http/tests/paymentrequest/payment-request-change-shipping-option.https.html [ DumpJSConsoleLogInStdErr ]
-http/tests/paymentrequest/payment-response-retry-method.https.html [ DumpJSConsoleLogInStdErr ]
-http/tests/paymentrequest/updateWith-shippingOptions.https.html [ DumpJSConsoleLogInStdErr Pass Failure ]
-imported/w3c/web-platform-tests/payment-request/payment-request-constructor.https.sub.html [ DumpJSConsoleLogInStdErr ]
-imported/w3c/web-platform-tests/payment-request/payment-request-shippingOption-attribute.https.html [ DumpJSConsoleLogInStdErr ]
 
 # Latest iOS failures as of Sept 1, 2015
 webkit.org/b/149087 http/tests/cache/disk-cache/disk-cache-validation-back-navigation-policy.html [ Pass Timeout ]

--- a/LayoutTests/platform/mac-monterey-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-monterey-wk2/TestExpectations
@@ -43,3 +43,10 @@ swipe/pushState-cached-back-swipe.html [ Pass Timeout ]
 
 # Asserts on pre-Sonoma macOS: rdar://116291539
 [ Debug ] http/tests/site-isolation/window-properties.html [ Skip ]
+
+# These features were introduced in macOS Ventura.
+http/tests/paymentrequest/ApplePayModifier-automaticReloadPaymentRequest.https.html [ Skip ]
+http/tests/paymentrequest/ApplePayModifier-deferredPaymentRequest.https.html [ Skip ]
+http/tests/paymentrequest/ApplePayModifier-multiTokenContexts.https.html [ Skip ]
+http/tests/paymentrequest/ApplePayModifier-recurringPaymentRequest.https.html [ Skip ]
+http/tests/paymentrequest/ApplePayPaymentCompleteDetails-orderDetails.https.html [ Skip ]

--- a/LayoutTests/platform/mac-ventura-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-ventura-wk2/TestExpectations
@@ -37,3 +37,6 @@ webkit.org/b/261444 [ Debug x86_64 ] http/tests/security/referrer-policy-header.
 
 # webkit.org/b/263955 Twelve css WPTs are failing with async overflow scrolling enabled on macOS
 imported/w3c/web-platform-tests/css/cssom-view/scroll-behavior-smooth-positions.html [ Failure ]
+
+# This feature was introduced in macOS Sonoma.
+http/tests/paymentrequest/paymentrequest-applePayLaterAvailability.https.html [ Skip ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -65,19 +65,6 @@ fast/visual-viewport/rubberbanding-viewport-rects-header-footer.html  [ Pass ]
 webkit.org/b/229423 [ BigSur Debug arm64 ] http/tests/paymentrequest/payment-response-reference-cycle-leak.https.html [ Pass Crash ]
 
 http/tests/paymentrequest [ Pass ]
-http/tests/paymentrequest/ApplePayModifier-automaticReloadPaymentRequest.https.html [ Skip ]
-http/tests/paymentrequest/ApplePayModifier-multiTokenContexts.https.html [ Skip ]
-http/tests/paymentrequest/ApplePayModifier-additionalLineItems.https.html [ Skip ]
-http/tests/paymentrequest/ApplePayModifier-additionalShippingMethods.https.html [ Skip ]
-http/tests/paymentrequest/ApplePayModifier-deferredPaymentRequest.https.html [ Skip ]
-http/tests/paymentrequest/ApplePayModifier-recurringPaymentRequest.https.html [ Skip ]
-http/tests/paymentrequest/ApplePayModifier-total.https.html [ Skip ]
-http/tests/paymentrequest/ApplePayPaymentCompleteDetails-orderDetails.https.html [ Skip ]
-http/tests/paymentrequest/paymentrequest-applePayLaterAvailability.https.html [ Skip ]
-http/tests/paymentrequest/paymentmethodchange-couponCode.https.html [ Skip ]
-http/tests/paymentrequest/paymentrequest-couponCode.https.html [ Skip ]
-http/tests/paymentrequest/paymentrequest-shippingContactEditingMode.https.html [ Skip ]
-http/tests/paymentrequest/paymentrequest-supportsCouponCode.https.html [ Skip ]
 http/tests/inspector/paymentrequest [ Pass ]
 imported/w3c/web-platform-tests/payment-request [ Pass ]
 webkit.org/b/175611 imported/w3c/web-platform-tests/payment-request/allowpaymentrequest/allowpaymentrequest-attribute-cross-origin-bc-containers.https.html [ Skip ]
@@ -90,8 +77,6 @@ webkit.org/b/175611 imported/w3c/web-platform-tests/payment-request/allowpayment
 webkit.org/b/175611 imported/w3c/web-platform-tests/payment-request/allowpayment/removing-allowpaymentrequest.https.sub.html [ Skip ]
 webkit.org/b/175611 imported/w3c/web-platform-tests/payment-request/allowpayment/setting-allowpaymentrequest.https.sub.html [ Skip ]
 imported/w3c/web-platform-tests/payment-request/payment-request-hasenrolledinstrument-method.tentative.https.html [ DumpJSConsoleLogInStdErr ]
-imported/w3c/web-platform-tests/payment-request/payment-request-canmakepayment-method.https.html [ DumpJSConsoleLogInStdErr ]
-imported/w3c/web-platform-tests/payment-request/show-method-optional-promise-rejects.https.html [ DumpJSConsoleLogInStdErr ]
 
 # These tests are checking that WebContent is terminated when performing an invalid IPC operation for WK2.
 # They crash in debug (as expected) so we skip them there. <rdar://problem/117742950>
@@ -567,15 +552,6 @@ webkit.org/b/139820 fast/frames/lots-of-iframes.html [ Pass Timeout ]
 
 webkit.org/b/145432 media/video-transformed-by-javascript.html [ Failure ]
 
-# webkit.org/b/238908 Global expectations for these until baselines are resolved
-http/tests/paymentrequest/payment-address-attributes-and-toJSON-method.https.html [ DumpJSConsoleLogInStdErr ]
-http/tests/inspector/paymentrequest/payment-request-internal-properties.https.html [ DumpJSConsoleLogInStdErr ]
-http/tests/paymentrequest/payment-request-change-shipping-option.https.html [ DumpJSConsoleLogInStdErr ]
-http/tests/paymentrequest/payment-response-retry-method.https.html [ DumpJSConsoleLogInStdErr ]
-http/tests/paymentrequest/updateWith-shippingOptions.https.html [ DumpJSConsoleLogInStdErr ]
-imported/w3c/web-platform-tests/payment-request/payment-request-constructor.https.sub.html [ DumpJSConsoleLogInStdErr ]
-imported/w3c/web-platform-tests/payment-request/payment-request-shippingOption-attribute.https.html [ DumpJSConsoleLogInStdErr ]
-
 # A lot of the disk-cache tests are flaky on mac-wk2
 webkit.org/b/149087 [ Debug ] http/tests/cache/disk-cache/disk-cache-validation-no-body.html [ Pass Failure Timeout ]
 webkit.org/b/149087 [ Debug ] http/tests/cache/disk-cache/disk-cache-validation.html [ Pass Failure Timeout ]
@@ -893,15 +869,6 @@ webkit.org/b/185994 fast/text/user-installed-fonts/shadow-postscript-family.html
 fast/text/user-installed-fonts/extended-character.html [ Pass ]
 fast/text/user-installed-fonts/extended-character-with-user-font.html [ Pass ]
 
-# <rdar://problem/25010307>
-http/tests/ssl/applepay/ApplePayError.html [ Pass ]
-http/tests/ssl/applepay/ApplePaySessionV3.html [ Pass ]
-http/tests/ssl/applepay/ApplePaySessionV4.html [ Pass ]
-http/tests/ssl/applepay/ApplePaySessionV5.html [ Pass ]
-http/tests/ssl/applepay/ApplePayRequestShippingContactV3.https.html [ Pass ]
-http/tests/ssl/applepay/ApplePayShippingAddressChangeEventErrorsV3.https.html [ Pass ]
-accessibility/mac/apple-pay-labels.html [ Pass ]
-accessibility/mac/apple-pay-session-v4.html [ Pass ]
 # <rdar://problem/31634451>
 http/tests/resourceLoadStatistics/cookies-with-and-without-user-interaction.html [ Pass ]
 http/tests/resourceLoadStatistics/cookie-deletion.html [ Pass ]


### PR DESCRIPTION
#### b780dcec56a9366a46589888b7ad9f807abaf610
<pre>
Many PaymentRequest tests are now passing
<a href="https://bugs.webkit.org/show_bug.cgi?id=266330">https://bugs.webkit.org/show_bug.cgi?id=266330</a>
<a href="https://rdar.apple.com/119599179">rdar://119599179</a>

Unreviewed test expectations gardening.

A lot of tests under `http/tests/paymentrequest/` were previously skipped
on both macOS and iOS because they tested for features yet to be
available in public versions of PassKit. This is no longer the case, so
we can safely unskip these tests. The only kink comes from having to
single out some tests to skip on macOS Monterey. These tests happen to be
testing features available from macOS Ventura-onwards only.

Some more tests still do not require the DumpJSConsoleLogInStdErr
classification, either because they are not producing JS console logs or
because their expectations have been rebaselined to reflect the console
log. We also unskip these tests.

* LayoutTests/platform/ios-wk2/TestExpectations:
* LayoutTests/platform/mac-monterey-wk2/TestExpectations:
* LayoutTests/platform/mac-ventura-wk2/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/272027@main">https://commits.webkit.org/272027@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98393e0b471bf356021f7d483cd06c40c46aa06b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30404 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9079 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32014 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32914 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27501 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11322 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6315 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27460 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30713 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7643 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/27266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6536 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6693 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27100 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34252 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/27715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27596 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32866 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6662 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4809 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30689 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8414 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7203 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7406 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7205 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->