### PR TITLE
[CSS] Fix @supports nested with declarations

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-048-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-048-expected.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html>
+	<head>
+		<title>CSS Test (Conditional Rules): Mixing @supports and CSS nesting</title>
+		<link rel="author" title="Matthieu Dubet" href="m_dubet@apple.com">
+		<link rel="help" href="http://www.w3.org/TR/css3-conditional/#at-supports">
+		<link rel="match" href="at-supports-048-ref.html">
+		<style>
+			div {
+				background:red;
+				height:100px;
+				width:100px;
+				margin: 10px;
+				border: solid 1px black;
+				background-color: green;
+			}
+	</style>
+	</head>
+
+	<p>Test passes if there are only green rectangles.
+	<div class="test-1"></div>
+	<div class="test-2"></div>
+	<div class="test-3"></div>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-048-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-048-ref.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html>
+	<head>
+		<title>CSS Test (Conditional Rules): Mixing @supports and CSS nesting</title>
+		<link rel="author" title="Matthieu Dubet" href="m_dubet@apple.com">
+		<link rel="help" href="http://www.w3.org/TR/css3-conditional/#at-supports">
+		<link rel="match" href="at-supports-048-ref.html">
+		<style>
+			div {
+				background:red;
+				height:100px;
+				width:100px;
+				margin: 10px;
+				border: solid 1px black;
+				background-color: green;
+			}
+	</style>
+	</head>
+
+	<p>Test passes if there are only green rectangles.
+	<div class="test-1"></div>
+	<div class="test-2"></div>
+	<div class="test-3"></div>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-048.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-048.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html>
+	<head>
+		<title>CSS Test (Conditional Rules): Mixing @supports and CSS nesting</title>
+		<link rel="author" title="Matthieu Dubet" href="m_dubet@apple.com">
+		<link rel="help" href="http://www.w3.org/TR/css3-conditional/#at-supports">
+		<link rel="match" href="at-supports-048-ref.html">
+		<style>
+			div {
+				background:red;
+				height:100px;
+				width:100px;
+				margin: 10px;
+				border: solid 1px black;
+			}
+			.test-1 {
+			    background-color: red;
+			    @supports (background-color: red) {
+			        background-color: green;
+			    }
+			}
+			.test-2 {
+			    background-color: green;
+			    @supports (invalid-declaration: foobar) {
+			        background-color: red;
+			    }
+			}
+			.test-3 {
+			    background-color: green;
+			    @supports (color: red) {
+			        color: red;
+			    }
+			}
+	</style>
+	</head>
+
+	<p>Test passes if there are only green rectangles.
+	<div class="test-1"></div>
+	<div class="test-2"></div>
+	<div class="test-3"></div>
+</html>

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -251,10 +251,16 @@ Vector<double> CSSParserImpl::parseKeyframeKeyList(const String& keyList)
 
 bool CSSParserImpl::supportsDeclaration(CSSParserTokenRange& range)
 {
-    ASSERT(topContext().m_parsedProperties.isEmpty());
-    consumeDeclaration(range, StyleRuleType::Style);
-    bool result = !topContext().m_parsedProperties.isEmpty();
-    topContext().m_parsedProperties.clear();
+    bool result = false;
+
+    // We create a new nesting context to isolate the parsing of the @supports(...) prelude from declarations before or after.
+    // This only concerns the prelude,
+    // (the content of the block will also be in its own nesting context but it's not done here (cf consumeRegularRuleList))
+    runInNewNestingContext([&] {
+        ASSERT(topContext().m_parsedProperties.isEmpty());
+        result = consumeDeclaration(range, StyleRuleType::Style);
+    });
+
     return result;
 }
 


### PR DESCRIPTION
#### 0dd51c9b2c6dbfba7603249bfb0f16abf4a9b2bd
<pre>
[CSS] Fix @supports nested with declarations
<a href="https://bugs.webkit.org/show_bug.cgi?id=259752">https://bugs.webkit.org/show_bug.cgi?id=259752</a>
<a href="https://rdar.apple.com/113652033">rdar://113652033</a>

Reviewed by Antti Koivisto.

Unfortunately, the parser code use local member variables (m_parsedProperties/m_parsedRules)
to store parsing results instead of using return values and the programming language builtin stack.

This patch uses the existing stack mecanism CSSParserImpl::runInNewNestingContext()
to isolate the parsing of the @supports(...) prelude declaration
from the rest of the parsing (specifically, from declarations before or after this @supports rule at the same nesting level)

This fixes code like:

div {
  color: green;
  @supports() {

  }
}

where the `color: green` declaration was being ignored.

* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-048-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-048-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-048.html: Added.
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::supportsDeclaration):

Canonical link: <a href="https://commits.webkit.org/271989@main">https://commits.webkit.org/271989@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9961a5a9af83ff5d25de136436560d14abb01761

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30259 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8930 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31735 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32767 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27379 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30950 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11128 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6167 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/27359 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30566 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7497 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/26690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6421 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6569 "Passed tests") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34107 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27576 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/27423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/32777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6532 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4700 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/30588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8280 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/26708 "layout-tests running") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7162 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7286 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7058 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->