### PR TITLE
Make JSC stress tests CLoop aware.

### DIFF
--- a/JSTests/stress/codeblock-destructor-access-unlinkedcodeblock.js
+++ b/JSTests/stress/codeblock-destructor-access-unlinkedcodeblock.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited || $buildType == "debug"
+//@ skip if $memoryLimited || $buildType == "debug" || $cloop
 //@ runDefault("--returnEarlyFromInfiniteLoopsForFuzzing=1")
 //@ slow!
 

--- a/Tools/Scripts/run-javascriptcore-tests
+++ b/Tools/Scripts/run-javascriptcore-tests
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2005-2017 Apple Inc.  All rights reserved.
+# Copyright (C) 2005-2023 Apple Inc.  All rights reserved.
 # Copyright (C) 2007 Eric Seidel <eric@webkit.org>
 #
 # Redistribution and use in source and binary forms, with or without
@@ -103,6 +103,7 @@ my $runMozillaTests = RUN_IF_NO_TESTS_SPECIFIED;
 # on the JSC stress test or mozilla tests.
 my $runJITStressTests = 1;
 
+my $runCLoopMode = 0;
 my $runQuickMode = 0;
 
 my $forceCollectContinuously = 0;
@@ -340,6 +341,7 @@ GetOptions(
     'jsc-stress!' => \$runJSCStress,
     'mozilla-tests!' => \$runMozillaTests,
     'jit-stress-tests!' => \$runJITStressTests,
+    'cloop' => \$runCLoopMode,
     'quick!' => \$runQuickMode,
     'fail-fast!' => \$failFast,
     'force-collectContinuously!' => \$forceCollectContinuously,
@@ -850,6 +852,10 @@ sub runJSCStressTests
     if ($envVars ne "") {
             push(@jscStressDriverCmd, "--env-vars");
             push(@jscStressDriverCmd, $envVars);
+    }
+
+    if ($runCLoopMode) {
+        push(@jscStressDriverCmd, "--cloop");
     }
 
     if ($runQuickMode) {

--- a/Tools/Scripts/run-jsc-stress-tests
+++ b/Tools/Scripts/run-jsc-stress-tests
@@ -146,6 +146,7 @@ end
 
 $jscPath = nil
 $doNotMessWithVMPath = false
+$cloop = false
 $jitTests = true
 $memoryLimited = false
 $outputDir = Pathname.new("results")
@@ -231,6 +232,7 @@ jscArg = nil
 GetoptLong.new(['--help', '-h', GetoptLong::NO_ARGUMENT],
                ['--jsc', '-j', GetoptLong::REQUIRED_ARGUMENT],
                ['--no-copy', GetoptLong::NO_ARGUMENT],
+               ['--cloop', GetoptLong::NO_ARGUMENT],
                ['--memory-limited', GetoptLong::NO_ARGUMENT],
                ['--no-jit', GetoptLong::NO_ARGUMENT],
                ['--force-collectContinuously', GetoptLong::NO_ARGUMENT],
@@ -273,6 +275,9 @@ GetoptLong.new(['--help', '-h', GetoptLong::NO_ARGUMENT],
         $doNotMessWithVMPath = true
     when '--output-dir'
         $outputDir = Pathname.new(arg)
+    when '--cloop'
+        $cloop = true
+        $jitTests = false
     when '--memory-limited'
         $memoryLimited = true
     when '--no-jit'
@@ -591,8 +596,8 @@ $hostOS = determineOS unless $hostOS
 $architecture = determineArchitecture unless $architecture
 $isFTLPlatform = !($architecture == "x86" || $architecture == "arm" || $architecture == "mips" || $architecture == "riscv64" || $hostOS == "windows" || $hostOS == "playstation")
 # Special case armv7 and windows, we want to run the wasm tests temporarily without B3/Air support
-$isWasmPlatform = $isFTLPlatform || $architecture == "arm" || ($hostOS == "windows" && $architecture == "x86_64")
-$isSIMDPlatform = $isFTLPlatform && ($architecture == "arm64" || $architecture == "x86_64")
+$isWasmPlatform = (not $cloop) && ($isFTLPlatform || $architecture == "arm" || ($hostOS == "windows" && $architecture == "x86_64"))
+$isSIMDPlatform = $isWasmPlatform && ($architecture == "arm64" || $architecture == "x86_64")
 
 # This is meant for skipping execution of tests than require a lot of address
 # space. Cf. $memoryLimited, which is meant for tests that actually make use of


### PR DESCRIPTION
#### 4d6f500cb8b4c840a8eb76305c2ae7c0ec75af59
<pre>
Make JSC stress tests CLoop aware.
<a href="https://bugs.webkit.org/show_bug.cgi?id=266336">https://bugs.webkit.org/show_bug.cgi?id=266336</a>
<a href="https://rdar.apple.com/119612009">rdar://119612009</a>

Reviewed by Justin Michaud.

Add a --cloop option to run-javascriptcore-tests and run-jsc-stress-tests.  This should be used when running
the JSC tests on a CLoop build.  --cloop automatically implies --no-jit.

Skip JIT tests and Wasm tests when running cloop.

Also skip JSTests/stress/codeblock-destructor-access-unlinkedcodeblock.js when running CLoop.  It is too slow
for CLoop builds.

* JSTests/stress/codeblock-destructor-access-unlinkedcodeblock.js:
* Tools/Scripts/run-javascriptcore-tests:
(runJSCStressTests):
* Tools/Scripts/run-jsc-stress-tests:

Canonical link: <a href="https://commits.webkit.org/271983@main">https://commits.webkit.org/271983@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8426bc322f3dfab8056bc60ad7758d34a6406da6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30247 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8918 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31723 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32755 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27367 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30935 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11116 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6155 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/27351 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30554 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/7489 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/26684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6411 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/6562 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/26972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34095 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/25988 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/27569 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/27347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/32746 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/30378 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6521 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/4692 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30557 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8269 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/36821 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7275 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7927 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3904 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7047 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->