### PR TITLE
[web-animations] percentage transform values are incorrect if `width` and `height` are animated

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-percent-with-width-and-height-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-percent-with-width-and-height-expected.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+
+div {
+    width: 200px;
+    height: 200px;
+    background-color: black;
+    transform: translate(50%, 50%);
+}
+
+</style>
+</head>
+<body>
+<div></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-percent-with-width-and-height-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-percent-with-width-and-height-ref.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+
+div {
+    width: 200px;
+    height: 200px;
+    background-color: black;
+    transform: translate(50%, 50%);
+}
+
+</style>
+</head>
+<body>
+<div></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-percent-with-width-and-height-separate-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-percent-with-width-and-height-separate-expected.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+
+div {
+    width: 200px;
+    height: 200px;
+    background-color: black;
+    transform: translate(50%, 50%);
+}
+
+</style>
+</head>
+<body>
+<div></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-percent-with-width-and-height-separate-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-percent-with-width-and-height-separate-ref.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+
+div {
+    width: 200px;
+    height: 200px;
+    background-color: black;
+    transform: translate(50%, 50%);
+}
+
+</style>
+</head>
+<body>
+<div></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-percent-with-width-and-height-separate.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-percent-with-width-and-height-separate.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<title>Animating the "transform" property with a percent value while also animating "width" and "height" using two separate animations</title>
+<link rel="help" href="https://drafts.csswg.org/css-transforms/">
+<link rel="match" href="transform-percent-with-width-and-height-separate-ref.html">
+<script src="../../../common/reftest-wait.js"></script>
+<style>
+
+div {
+    width: 10px;
+    height: 10px;
+    background-color: black;
+    animation-duration: 10s;
+    animation-name: size, transform;
+}
+
+@keyframes size {
+    0.000000001%, to {
+        width: 200px;
+        height: 200px;
+    }
+}
+
+@keyframes transform {
+    0.000000001%, to {
+        transform: translate(50%, 50%);
+    }
+}
+
+</style>
+</head>
+<body>
+<div></div>
+<script>
+(async function() {
+    await Promise.all(document.getAnimations().map(animation => animation.ready));
+    await new Promise(requestAnimationFrame);
+    await new Promise(requestAnimationFrame);
+    takeScreenshot();
+})();
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-percent-with-width-and-height.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-percent-with-width-and-height.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<title>Animating the "transform" property with percent values while also animating "width" and "height"</title>
+<link rel="help" href="https://drafts.csswg.org/css-transforms/">
+<link rel="match" href="transform-percent-with-width-and-height-ref.html">
+<script src="../../../common/reftest-wait.js"></script>
+<style>
+
+div {
+    width: 10px;
+    height: 10px;
+    background-color: black;
+    animation: anim 10s linear forwards;
+}
+
+@keyframes anim {
+    0.000000001%, to {
+        width: 200px;
+        height: 200px;
+        transform: translate(50%, 50%);
+    }
+}
+
+</style>
+</head>
+<body>
+<div></div>
+<script>
+(async function() {
+    await Promise.all(document.getAnimations().map(animation => animation.ready));
+    await new Promise(requestAnimationFrame);
+    await new Promise(requestAnimationFrame);
+    takeScreenshot();
+})();
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/translate-percent-with-width-and-height-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/translate-percent-with-width-and-height-expected.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+
+div {
+    width: 200px;
+    height: 200px;
+    background-color: black;
+    translate: 50%, 50%;
+}
+
+</style>
+</head>
+<body>
+<div></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/translate-percent-with-width-and-height-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/translate-percent-with-width-and-height-ref.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+
+div {
+    width: 200px;
+    height: 200px;
+    background-color: black;
+    translate: 50%, 50%;
+}
+
+</style>
+</head>
+<body>
+<div></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/translate-percent-with-width-and-height-separate-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/translate-percent-with-width-and-height-separate-expected.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+
+div {
+    width: 200px;
+    height: 200px;
+    background-color: black;
+    translate: 50% 50%;
+}
+
+</style>
+</head>
+<body>
+<div></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/translate-percent-with-width-and-height-separate-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/translate-percent-with-width-and-height-separate-ref.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+
+div {
+    width: 200px;
+    height: 200px;
+    background-color: black;
+    translate: 50% 50%;
+}
+
+</style>
+</head>
+<body>
+<div></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/translate-percent-with-width-and-height-separate.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/translate-percent-with-width-and-height-separate.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<title>Animating the "translate" property with a percent value while also animating "width" and "height" using two separate animations</title>
+<link rel="help" href="https://drafts.csswg.org/css-transforms/">
+<link rel="match" href="translate-percent-with-width-and-height-separate-ref.html">
+<script src="../../../common/reftest-wait.js"></script>
+<style>
+
+div {
+    width: 10px;
+    height: 10px;
+    background-color: black;
+    animation-duration: 10s;
+    animation-name: size, translate;
+}
+
+@keyframes size {
+    0.000000001%, to {
+        width: 200px;
+        height: 200px;
+    }
+}
+
+@keyframes translate {
+    0.000000001%, to {
+        translate: 50% 50%;
+    }
+}
+
+</style>
+</head>
+<body>
+<div></div>
+<script>
+(async function() {
+    await Promise.all(document.getAnimations().map(animation => animation.ready));
+    await new Promise(requestAnimationFrame);
+    await new Promise(requestAnimationFrame);
+    takeScreenshot();
+})();
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/translate-percent-with-width-and-height.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/translate-percent-with-width-and-height.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<title>Animating the "translate" property with percent values while also animating "width" and "height"</title>
+<link rel="help" href="https://drafts.csswg.org/css-transforms/">
+<link rel="match" href="translate-percent-with-width-and-height-ref.html">
+<script src="../../../common/reftest-wait.js"></script>
+<style>
+
+div {
+    width: 10px;
+    height: 10px;
+    background-color: black;
+    animation: anim 10s linear forwards;
+}
+
+@keyframes anim {
+    0.000000001%, to {
+        width: 200px;
+        height: 200px;
+        translate: 50%, 50%;
+    }
+}
+
+</style>
+</head>
+<body>
+<div></div>
+<script>
+(async function() {
+    await Promise.all(document.getAnimations().map(animation => animation.ready));
+    await new Promise(requestAnimationFrame);
+    await new Promise(requestAnimationFrame);
+    takeScreenshot();
+})();
+</script>
+</body>
+</html>

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -232,6 +232,7 @@ private:
     void computeHasExplicitlyInheritedKeyframeProperty();
     void computeHasAcceleratedPropertyOverriddenByCascadeProperty();
     void computeHasReferenceFilter();
+    void computeHasSizeDependentTransform();
     void abilityToBeAcceleratedDidChange();
     void updateAcceleratedAnimationIfNecessary();
 
@@ -302,6 +303,9 @@ private:
     bool m_hasExplicitlyInheritedKeyframeProperty { false };
     bool m_hasAcceleratedPropertyOverriddenByCascadeProperty { false };
     bool m_hasReferenceFilter { false };
+    bool m_hasWidthDependentTransform { false };
+    bool m_hasHeightDependentTransform { false };
+    bool m_animatesSizeAndSizeDependentTransform { false };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 6ab17cf692e2176ae76cd00a44e48fb608faaf46
<pre>
[web-animations] percentage transform values are incorrect if `width` and `height` are animated
<a href="https://bugs.webkit.org/show_bug.cgi?id=211986">https://bugs.webkit.org/show_bug.cgi?id=211986</a>
<a href="https://rdar.apple.com/63309680">rdar://63309680</a>

Reviewed by Simon Fraser.

When animating the `transform` or `translate` property, we resolve percentage values for translate
operations to fixed values. However, if the element also has an animation of `width` or `height`,
the resolved translation values will no longer be correct while the animation is in flight.

In that case, we need to detect such a case and turn off acceleration support.

* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-percent-with-width-and-height-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-percent-with-width-and-height-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-percent-with-width-and-height-separate-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-percent-with-width-and-height-separate-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-percent-with-width-and-height-separate.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-percent-with-width-and-height.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/translate-percent-with-width-and-height-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/translate-percent-with-width-and-height-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/translate-percent-with-width-and-height-separate-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/translate-percent-with-width-and-height-separate-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/translate-percent-with-width-and-height-separate.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/translate-percent-with-width-and-height.html: Added.
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::setBlendingKeyframes):
(WebCore::KeyframeEffect::canBeAccelerated const):
(WebCore::KeyframeEffect::applyPendingAcceleratedActions):
(WebCore::KeyframeEffect::computeHasSizeDependentTransform):
* Source/WebCore/animation/KeyframeEffect.h:

Canonical link: <a href="https://commits.webkit.org/272022@main">https://commits.webkit.org/272022@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21fd56e8ab7665332a53323661056943eee697fd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30403 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9078 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32012 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32912 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27500 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31104 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11306 "Hash 21fd56e8 for PR 21732 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6313 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/27458 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30711 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/11306 "Hash 21fd56e8 for PR 21732 does not build (failure)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/27264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6534 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/11306 "Hash 21fd56e8 for PR 21732 does not build (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27095 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34250 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/11306 "Hash 21fd56e8 for PR 21732 does not build (failure)") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/27592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32864 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6661 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4805 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30687 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8413 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/26858 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7405 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3928 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7204 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->