### PR TITLE
[WGSL] frexp should support f16

### DIFF
--- a/Source/WebGPU/WGSL/ConstantFunctions.h
+++ b/Source/WebGPU/WGSL/ConstantFunctions.h
@@ -1080,10 +1080,11 @@ CONSTANT_FUNCTION(Frexp)
     ASSERT(arguments.size() == 1);
 
     const auto& frexpValue = [&](auto value) -> std::tuple<ConstantValue, ConstantValue> {
-        using Exp = std::conditional_t<std::is_same_v<decltype(value), double>, int64_t, int>;
+        using T = decltype(value);
+        using Exp = std::conditional_t<std::is_same_v<T, double>, int64_t, int>;
         int exp;
         auto fract = std::frexp(value, &exp);
-        return { ConstantValue(fract), ConstantValue(static_cast<Exp>(exp)) };
+        return { ConstantValue(static_cast<T>(fract)), ConstantValue(static_cast<Exp>(exp)) };
     };
 
     const auto& frexpScalar = [&](auto value) {

--- a/Source/WebGPU/WGSL/TypeDeclarations.rb
+++ b/Source/WebGPU/WGSL/TypeDeclarations.rb
@@ -638,19 +638,19 @@ function :frexp, {
     const: true,
 
     [].(f32) => __frexp_result_f32,
-    # [].(f16) => __frexp_result_f16,
+    [].(f16) => __frexp_result_f16,
     [].(abstract_float) => __frexp_result_abstract,
 
     [].(vec2[f32]) => __frexp_result_vec2_f32,
-    # [].(vec2[f16]) => __frexp_result_vec2_f16,
+    [].(vec2[f16]) => __frexp_result_vec2_f16,
     [].(vec2[abstract_float]) => __frexp_result_vec2_abstract,
 
     [].(vec3[f32]) => __frexp_result_vec3_f32,
-    # [].(vec3[f16]) => __frexp_result_vec3_f16,
+    [].(vec3[f16]) => __frexp_result_vec3_f16,
     [].(vec3[abstract_float]) => __frexp_result_vec3_abstract,
 
     [].(vec4[f32]) => __frexp_result_vec4_f32,
-    # [].(vec4[f16]) => __frexp_result_vec4_f16,
+    [].(vec4[f16]) => __frexp_result_vec4_f16,
     [].(vec4[abstract_float]) => __frexp_result_vec4_abstract,
 }
 

--- a/Source/WebGPU/WGSL/generator/main.rb
+++ b/Source/WebGPU/WGSL/generator/main.rb
@@ -505,19 +505,19 @@ module DSL
         # primitive structs
 
         __frexp_result_abstract = Constructor.new(:frexpResult, [abstract_float, abstract_int])
-        # __frexp_result_f16 = Constructor.new(:frexpResult, [f16, i32])
+        __frexp_result_f16 = Constructor.new(:frexpResult, [f16, i32])
         __frexp_result_f32 = Constructor.new(:frexpResult, [f32, i32])
 
         __frexp_result_vec2_abstract = Constructor.new(:frexpResult, [vec2[abstract_float], vec2[abstract_int]])
-        # __frexp_result_vec2_f16 = Constructor.new(:frexpResult, [vec2[f16], vec2[i32]])
+        __frexp_result_vec2_f16 = Constructor.new(:frexpResult, [vec2[f16], vec2[i32]])
         __frexp_result_vec2_f32 = Constructor.new(:frexpResult, [vec2[f32], vec2[i32]])
 
         __frexp_result_vec3_abstract = Constructor.new(:frexpResult, [vec3[abstract_float], vec3[abstract_int]])
-        # __frexp_result_vec3_f16 = Constructor.new(:frexpResult, [vec3[f16], vec3[i32]])
+        __frexp_result_vec3_f16 = Constructor.new(:frexpResult, [vec3[f16], vec3[i32]])
         __frexp_result_vec3_f32 = Constructor.new(:frexpResult, [vec3[f32], vec3[i32]])
 
         __frexp_result_vec4_abstract = Constructor.new(:frexpResult, [vec4[abstract_float], vec4[abstract_int]])
-        # __frexp_result_vec4_f16 = Constructor.new(:frexpResult, [vec4[f16], vec4[i32]])
+        __frexp_result_vec4_f16 = Constructor.new(:frexpResult, [vec4[f16], vec4[i32]])
         __frexp_result_vec4_f32 = Constructor.new(:frexpResult, [vec4[f32], vec4[i32]])
 
         EOS

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -1933,30 +1933,42 @@ fn testFrexp()
 {
     {
       let x: f32 = 1.5;
-      let y = frexp(x);
-      let w = frexp(1.5);
-      let z = frexp(1.5f);
+      let y: f16 = 1.5;
+      let r1 = frexp(x);
+      let r2 = frexp(y);
+      let r3 = frexp(1.5);
+      let r4 = frexp(1.5f);
+      let r5 = frexp(1.5h);
     }
 
     {
       let x: vec2<f32> = vec2(1.5);
-      let y = frexp(x);
-      let w = frexp(vec2(1.5));
-      let z = frexp(vec2(1.5f));
+      let y: vec2<f16> = vec2(1.5);
+      let r1 = frexp(x);
+      let r2 = frexp(y);
+      let r3 = frexp(vec2(1.5));
+      let r4 = frexp(vec2(1.5f));
+      let r5 = frexp(vec2(1.5h));
     }
 
     {
       let x: vec3<f32> = vec3(1.5);
-      let y = frexp(x);
-      let w = frexp(vec3(1.5));
-      let z = frexp(vec3(1.5f));
+      let y: vec3<f16> = vec3(1.5);
+      let r1 = frexp(x);
+      let r2 = frexp(y);
+      let r3 = frexp(vec3(1.5));
+      let r4 = frexp(vec3(1.5f));
+      let r5 = frexp(vec3(1.5h));
     }
 
     {
       let x: vec4<f32> = vec4(1.5);
-      let y = frexp(x);
-      let w = frexp(vec4(1.5));
-      let z = frexp(vec4(1.5f));
+      let y: vec4<f16> = vec4(1.5);
+      let r1 = frexp(x);
+      let r2 = frexp(y);
+      let r3 = frexp(vec4(1.5));
+      let r4 = frexp(vec4(1.5f));
+      let r5 = frexp(vec4(1.5h));
     }
 }
 


### PR DESCRIPTION
#### 9bda9ebbdfb9ab974ce39d7396e6cad533b71a4f
<pre>
[WGSL] frexp should support f16
<a href="https://bugs.webkit.org/show_bug.cgi?id=266348">https://bugs.webkit.org/show_bug.cgi?id=266348</a>
<a href="https://rdar.apple.com/119618161">rdar://119618161</a>

Reviewed by Mike Wyrzykowski.

Frexp was implemented before we support f16, and I forgot to implement it when
f16 landed.

* Source/WebGPU/WGSL/ConstantFunctions.h:
(WGSL::CONSTANT_FUNCTION):
* Source/WebGPU/WGSL/TypeDeclarations.rb:
* Source/WebGPU/WGSL/generator/main.rb:
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/272038@main">https://commits.webkit.org/272038@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4728c5f627e88041024f95c89a3561c6bb13b790

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30276 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8947 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31819 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32783 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27395 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11144 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6183 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27386 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30583 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7524 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/26821 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6440 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6593 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34123 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27605 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27485 "Found 1 new test failure: tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-mainframe-vertical-then-horizontal.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32784 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6548 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4729 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30592 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8298 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7207 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7302 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7077 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->