### PR TITLE
Add <input type=checkbox switch> macOS vertical rendering

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/checkbox-switch-input-computed-style.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/checkbox-switch-input-computed-style.tentative-expected.txt
@@ -1,6 +1,6 @@
 
 
 PASS horizontal-input block size should match height and inline size should match width
-FAIL vertical-lr-input block size should match width and inline size should match height assert_greater_than: expected a number greater than 32 but got 18
-FAIL vertical-rl-input block size should match width and inline size should match height assert_greater_than: expected a number greater than 32 but got 18
+PASS vertical-lr-input block size should match width and inline size should match height
+PASS vertical-rl-input block size should match width and inline size should match height
 

--- a/Source/WebCore/html/CheckboxInputType.h
+++ b/Source/WebCore/html/CheckboxInputType.h
@@ -86,7 +86,7 @@ private:
 
     // FIXME: Consider moving all switch-related state (and methods?) to their own object so
     // CheckboxInputType can stay somewhat small.
-    std::optional<int> m_switchPointerTrackingXPositionStart { std::nullopt };
+    std::optional<int> m_switchPointerTrackingLogicalLeftPositionStart { std::nullopt };
     bool m_hasSwitchVisuallyOnChanged { false };
     bool m_isSwitchVisuallyOn { false };
     Seconds m_switchAnimationVisuallyOnStartTime { 0_s };

--- a/Source/WebCore/platform/Theme.h
+++ b/Source/WebCore/platform/Theme.h
@@ -66,12 +66,6 @@ public:
     virtual void paint(StyleAppearance, OptionSet<ControlStyle::State>, GraphicsContext&, const FloatRect&, bool, const Color&) { }
 #endif
 
-    // Some controls may spill out of their containers (e.g., the check on an OS X checkbox).  When these controls repaint,
-    // the theme needs to communicate this inflated rect to the engine so that it can invalidate the whole control.
-    // The rect passed in is in zoomed coordinates, so the inflation should take that into account and make sure the inflation
-    // amount is also scaled by the zoomFactor.
-    virtual void inflateControlPaintRect(StyleAppearance, FloatRect&, float) const { }
-
     virtual void drawNamedImage(const String&, GraphicsContext&, const FloatSize&) const;
 
     virtual bool userPrefersContrast() const { return false; }

--- a/Source/WebCore/platform/graphics/mac/controls/SwitchMacUtilities.h
+++ b/Source/WebCore/platform/graphics/mac/controls/SwitchMacUtilities.h
@@ -29,10 +29,15 @@
 namespace WebCore::SwitchMacUtilities {
 
 static IntSize cellSize(NSControlSize);
+static FloatSize visualCellSize(NSControlSize, const ControlStyle&);
 static IntOutsets cellOutsets(NSControlSize);
+static IntOutsets visualCellOutsets(NSControlSize, bool);
 static FloatRect rectForBounds(const FloatRect&);
 static NSString *coreUISizeForControlSize(const NSControlSize);
 static float easeInOut(float);
+static FloatRect rectWithTransposedSize(const FloatRect&, bool);
+static FloatRect trackRectForBounds(const FloatRect&, const FloatSize&);
+static void rotateContextForVerticalWritingMode(GraphicsContext&, const FloatRect&);
 
 } // namespace WebCore::SwitchMacUtilities
 

--- a/Source/WebCore/platform/graphics/mac/controls/SwitchThumbMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SwitchThumbMac.mm
@@ -58,29 +58,28 @@ void SwitchThumbMac::draw(GraphicsContext& context, const FloatRoundedRect& bord
 {
     LocalDefaultSystemAppearance localAppearance(style.states.contains(ControlStyle::State::DarkAppearance), style.accentColor);
 
-    bool isOn = owningPart().isOn();
-    bool isRTL = style.states.contains(ControlStyle::State::RightToLeft);
-    bool isEnabled = style.states.contains(ControlStyle::State::Enabled);
-    bool isPressed = style.states.contains(ControlStyle::State::Pressed);
+    auto isOn = owningPart().isOn();
+    auto isRTL = style.states.contains(ControlStyle::State::RightToLeft);
+    auto isVertical = style.states.contains(ControlStyle::State::VerticalWritingMode);
+    auto isEnabled = style.states.contains(ControlStyle::State::Enabled);
+    auto isPressed = style.states.contains(ControlStyle::State::Pressed);
     auto progress = SwitchMacUtilities::easeInOut(owningPart().progress());
 
-    auto borderRectRect = borderRect.rect();
-    auto controlSize = controlSizeForSize(borderRectRect.size(), style);
-    auto size = cellSize(controlSize, style);
-    auto outsets = cellOutsets(controlSize, style);
+    auto logicalBounds = SwitchMacUtilities::rectWithTransposedSize(borderRect.rect(), isVertical);
+    auto controlSize = controlSizeForSize(logicalBounds.size(), style);
+    auto size = SwitchMacUtilities::visualCellSize(controlSize, style);
+    auto outsets = SwitchMacUtilities::visualCellOutsets(controlSize, isVertical);
 
-    size.scale(style.zoomFactor);
-
-    auto trackY = std::max(((borderRectRect.height() - size.height()) / 2.0f), 0.0f);
-    auto trackRect = FloatRect { FloatPoint { borderRectRect.x(), borderRectRect.y() + trackY }, size };
-
+    auto trackRect = SwitchMacUtilities::trackRectForBounds(logicalBounds, size);
     auto inflatedTrackRect = inflatedRect(trackRect, size, outsets, style);
+    if (isVertical)
+        inflatedTrackRect.setSize(inflatedTrackRect.size().transposedSize());
 
     auto drawingThumbLength = inflatedTrackRect.height();
-    auto drawingThumbIsLeft = (!isRTL && !isOn) || (isRTL && isOn);
-    auto drawingThumbXAxis = inflatedTrackRect.width() - drawingThumbLength;
-    auto drawingThumbXAxisProgress = drawingThumbXAxis * progress;
-    auto drawingThumbX = drawingThumbIsLeft ? drawingThumbXAxis - drawingThumbXAxisProgress : drawingThumbXAxisProgress;
+    auto drawingThumbIsLogicallyLeft = (!isRTL && !isOn) || (isRTL && isOn);
+    auto drawingThumbLogicalXAxis = inflatedTrackRect.width() - drawingThumbLength;
+    auto drawingThumbLogicalXAxisProgress = drawingThumbLogicalXAxis * progress;
+    auto drawingThumbX = drawingThumbIsLogicallyLeft ? drawingThumbLogicalXAxis - drawingThumbLogicalXAxisProgress : drawingThumbLogicalXAxisProgress;
     auto drawingThumbRect = NSMakeRect(drawingThumbX, 0, drawingThumbLength, drawingThumbLength);
 
     auto trackBuffer = context.createImageBuffer(inflatedTrackRect.size(), deviceScaleFactor);
@@ -99,6 +98,9 @@ void SwitchThumbMac::draw(GraphicsContext& context, const FloatRoundedRect& bord
         (__bridge NSString *)kCUIUserInterfaceLayoutDirectionKey: (__bridge NSString *)(isRTL ? kCUIUserInterfaceLayoutDirectionRightToLeft : kCUIUserInterfaceLayoutDirectionLeftToRight),
         (__bridge NSString *)kCUIScaleKey: @(deviceScaleFactor),
     }];
+
+    if (isVertical)
+        SwitchMacUtilities::rotateContextForVerticalWritingMode(context, inflatedTrackRect);
 
     context.drawConsumingImageBuffer(WTFMove(trackBuffer), inflatedTrackRect.location());
 }

--- a/Source/WebCore/platform/mac/ThemeMac.h
+++ b/Source/WebCore/platform/mac/ThemeMac.h
@@ -34,6 +34,7 @@ namespace WebCore {
 class ThemeMac final : public ThemeCocoa {
 public:
     static bool supportsLargeFormControls();
+    static void inflateControlPaintRect(StyleAppearance, FloatRect&, float, bool);
 
 private:
     friend NeverDestroyed<ThemeMac>;
@@ -48,8 +49,6 @@ private:
     LengthBox controlBorder(StyleAppearance, const FontCascade&, const LengthBox& zoomedBox, float zoomFactor) const final;
 
     bool controlRequiresPreWhiteSpace(StyleAppearance appearance) const final { return appearance == StyleAppearance::PushButton; }
-
-    void inflateControlPaintRect(StyleAppearance, FloatRect&, float zoomFactor) const final;
 
     bool userPrefersContrast() const final;
     bool userPrefersReducedMotion() const final;

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -1262,7 +1262,7 @@ bool RenderTheme::hasListButtonPressed(const RenderObject& renderer) const
 
 // FIXME: iOS does not use this so arguably this should be better abstracted. Or maybe we should
 // investigate if we can bring the various ports closer together.
-void RenderTheme::adjustButtonOrCheckboxOrColorWellOrInnerSpinButtonOrRadioOrSwitchStyle(RenderStyle& style, const Element* element) const
+void RenderTheme::adjustButtonOrCheckboxOrColorWellOrInnerSpinButtonOrRadioStyle(RenderStyle& style, const Element* element) const
 {
     auto appearance = style.effectiveAppearance();
 
@@ -1351,29 +1351,29 @@ void RenderTheme::adjustButtonOrCheckboxOrColorWellOrInnerSpinButtonOrRadioOrSwi
 
 void RenderTheme::adjustCheckboxStyle(RenderStyle& style, const Element* element) const
 {
-    adjustButtonOrCheckboxOrColorWellOrInnerSpinButtonOrRadioOrSwitchStyle(style, element);
+    adjustButtonOrCheckboxOrColorWellOrInnerSpinButtonOrRadioStyle(style, element);
 }
 
 void RenderTheme::adjustRadioStyle(RenderStyle& style, const Element* element) const
 {
-    adjustButtonOrCheckboxOrColorWellOrInnerSpinButtonOrRadioOrSwitchStyle(style, element);
+    adjustButtonOrCheckboxOrColorWellOrInnerSpinButtonOrRadioStyle(style, element);
 }
 
 #if ENABLE(INPUT_TYPE_COLOR)
 void RenderTheme::adjustColorWellStyle(RenderStyle& style, const Element* element) const
 {
-    adjustButtonOrCheckboxOrColorWellOrInnerSpinButtonOrRadioOrSwitchStyle(style, element);
+    adjustButtonOrCheckboxOrColorWellOrInnerSpinButtonOrRadioStyle(style, element);
 }
 #endif
 
 void RenderTheme::adjustButtonStyle(RenderStyle& style, const Element* element) const
 {
-    adjustButtonOrCheckboxOrColorWellOrInnerSpinButtonOrRadioOrSwitchStyle(style, element);
+    adjustButtonOrCheckboxOrColorWellOrInnerSpinButtonOrRadioStyle(style, element);
 }
 
 void RenderTheme::adjustInnerSpinButtonStyle(RenderStyle& style, const Element* element) const
 {
-    adjustButtonOrCheckboxOrColorWellOrInnerSpinButtonOrRadioOrSwitchStyle(style, element);
+    adjustButtonOrCheckboxOrColorWellOrInnerSpinButtonOrRadioStyle(style, element);
 }
 
 void RenderTheme::adjustMenuListStyle(RenderStyle& style, const Element*) const
@@ -1504,9 +1504,14 @@ void RenderTheme::adjustSliderThumbStyle(RenderStyle& style, const Element* elem
     adjustSliderThumbSize(style, element);
 }
 
-void RenderTheme::adjustSwitchStyle(RenderStyle& style, const Element* element) const
+void RenderTheme::adjustSwitchStyle(RenderStyle& style, const Element*) const
 {
-    adjustButtonOrCheckboxOrColorWellOrInnerSpinButtonOrRadioOrSwitchStyle(style, element);
+    // FIXME: This probably has the same flaw as
+    // RenderTheme::adjustButtonOrCheckboxOrColorWellOrInnerSpinButtonOrRadioStyle() by not taking
+    // min-width/min-height into account.
+    auto controlSize = Theme::singleton().controlSize(StyleAppearance::Switch, style.fontCascade(), { style.logicalWidth(), style.logicalHeight() }, style.effectiveZoom());
+    style.setLogicalWidth(WTFMove(controlSize.width));
+    style.setLogicalHeight(WTFMove(controlSize.height));
 }
 
 void RenderTheme::purgeCaches()

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -388,7 +388,7 @@ protected:
 private:
     OptionSet<ControlStyle::State> extractControlStyleStatesForRendererInternal(const RenderObject&) const;
 
-    void adjustButtonOrCheckboxOrColorWellOrInnerSpinButtonOrRadioOrSwitchStyle(RenderStyle&, const Element*) const;
+    void adjustButtonOrCheckboxOrColorWellOrInnerSpinButtonOrRadioStyle(RenderStyle&, const Element*) const;
 
 public:
     bool isWindowActive(const RenderObject&) const;

--- a/Source/WebCore/rendering/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/RenderThemeIOS.mm
@@ -723,8 +723,6 @@ static bool renderThemePaintSwitchTrack(const OptionSet<ControlStyle::State>, co
 
 void RenderThemeIOS::adjustSwitchStyle(RenderStyle& style, const Element* element) const
 {
-    RenderTheme::adjustSwitchStyle(style, element);
-
     if (!style.width().isAuto() && !style.height().isAuto())
         return;
 

--- a/Source/WebCore/rendering/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/RenderThemeMac.mm
@@ -789,7 +789,7 @@ void RenderThemeMac::adjustRepaintRect(const RenderObject& renderer, FloatRect& 
     case StyleAppearance::PushButton:
     case StyleAppearance::Radio:
     case StyleAppearance::Switch:
-        Theme::singleton().inflateControlPaintRect(renderer.style().effectiveAppearance(), rect, renderer.style().effectiveZoom());
+        ThemeMac::inflateControlPaintRect(renderer.style().effectiveAppearance(), rect, renderer.style().effectiveZoom(), !renderer.style().isHorizontalWritingMode());
         break;
     case StyleAppearance::Menulist: {
         auto zoomLevel = renderer.style().effectiveZoom();


### PR DESCRIPTION
#### 24ebb01cef269ea5bfd77c2abc82d56474206a77
<pre>
Add &lt;input type=checkbox switch&gt; macOS vertical rendering
<a href="https://bugs.webkit.org/show_bug.cgi?id=266347">https://bugs.webkit.org/show_bug.cgi?id=266347</a>

Reviewed by Aditya Keerthi.

This adjusts the logic in CheckboxInputType so pointer tracking is
based on the vertical position when the control is rendered
vertically.

It similarly adjusts the macOS drawing logic, with some additional
special casing for the on label which shows when
&quot;Differentiate without color&quot; is enabled.

Rather than continuing to reuse
adjustButtonOrCheckboxOrColorWellOrInnerSpinButtonOrRadioOrSwitchStyle()
we make switch break from that pattern by selectively copying over the
parts that apply to switch. (Spoiler: setting the logical width and
height.)

And finally, but not least, adjust the repaint size calculation.
<a href="https://bugs.webkit.org/show_bug.cgi?id=266532">https://bugs.webkit.org/show_bug.cgi?id=266532</a> is filed as a follow-up
for this due to an issue with writing-mode:vertical-rl.

* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/checkbox-switch-input-computed-style.tentative-expected.txt:
* Source/WebCore/html/CheckboxInputType.cpp:
(WebCore::switchPointerTrackingLogicalLeftPosition):
(WebCore::CheckboxInputType::startSwitchPointerTracking):
(WebCore::CheckboxInputType::stopSwitchPointerTracking):
(WebCore::CheckboxInputType::isSwitchPointerTracking const):
(WebCore::CheckboxInputType::updateIsSwitchVisuallyOnFromAbsoluteLocation):
* Source/WebCore/html/CheckboxInputType.h:
* Source/WebCore/platform/Theme.h:
(WebCore::Theme::inflateControlPaintRect const): Deleted.
* Source/WebCore/platform/graphics/mac/controls/SwitchMacUtilities.h:
* Source/WebCore/platform/graphics/mac/controls/SwitchMacUtilities.mm:
(WebCore::SwitchMacUtilities::visualCellSize):
(WebCore::SwitchMacUtilities::visualCellOutsets):
(WebCore::SwitchMacUtilities::rectWithTransposedSize):
(WebCore::SwitchMacUtilities::trackRectForBounds):
(WebCore::SwitchMacUtilities::rotateContextForVerticalWritingMode):
* Source/WebCore/platform/graphics/mac/controls/SwitchThumbMac.mm:
(WebCore::SwitchThumbMac::draw):
* Source/WebCore/platform/graphics/mac/controls/SwitchTrackMac.mm:
(WebCore::trackMaskImage):
(WebCore::trackImage):
(WebCore::SwitchTrackMac::draw):
* Source/WebCore/platform/mac/ThemeMac.h:
* Source/WebCore/platform/mac/ThemeMac.mm:
(WebCore::visualSwitchMargins):
(WebCore::ThemeMac::inflateControlPaintRect const):
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::adjustButtonOrCheckboxOrColorWellOrInnerSpinButtonOrRadioStyle const):
(WebCore::RenderTheme::adjustCheckboxStyle const):
(WebCore::RenderTheme::adjustRadioStyle const):
(WebCore::RenderTheme::adjustColorWellStyle const):
(WebCore::RenderTheme::adjustButtonStyle const):
(WebCore::RenderTheme::adjustInnerSpinButtonStyle const):
(WebCore::RenderTheme::adjustSwitchStyle const):
(WebCore::RenderTheme::adjustButtonOrCheckboxOrColorWellOrInnerSpinButtonOrRadioOrSwitchStyle const): Deleted.
* Source/WebCore/rendering/RenderTheme.h:
* Source/WebCore/rendering/RenderThemeIOS.mm:
(WebCore::RenderThemeIOS::adjustSwitchStyle const):
* Source/WebCore/rendering/RenderThemeMac.mm:
(WebCore::RenderThemeMac::adjustRepaintRect):

Canonical link: <a href="https://commits.webkit.org/272405@main">https://commits.webkit.org/272405@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5918ae4a8917ffd5263a33b0b908d51fc47867ee

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31519 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10194 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33224 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34008 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28545 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32290 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12545 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7442 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28159 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31860 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8584 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28128 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7388 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7553 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28036 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35351 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28646 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28483 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33682 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7634 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5650 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31528 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9291 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7405 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8322 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8138 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->