### PR TITLE
[WPE][Tools] cross-toolchain-helper: add libbacktrace, libportal and change CPU frequency governor for RPis

### DIFF
--- a/Tools/yocto/meta-openembedded_backport-libbacktrace-patch-to-mickledore-branch.patch
+++ b/Tools/yocto/meta-openembedded_backport-libbacktrace-patch-to-mickledore-branch.patch
@@ -1,0 +1,28 @@
+diff --git a/sources/meta-openembedded/meta-oe/recipes-extended/libbacktrace/libbacktrace_git.bb b/sources/meta-openembedded/meta-oe/recipes-extended/libbacktrace/libbacktrace_git.bb
+index 609e55f4a..46fa81866 100644
+--- a/sources/meta-openembedded/meta-oe/recipes-extended/libbacktrace/libbacktrace_git.bb
++++ b/sources/meta-openembedded/meta-oe/recipes-extended/libbacktrace/libbacktrace_git.bb
+@@ -11,20 +11,17 @@ DEPENDS += "libunwind"
+ SRC_URI = "git://github.com/ianlancetaylor/libbacktrace;protocol=https;branch=master"
+ 
+ PV = "1.0+git${SRCPV}"
+-SRCREV = "4f57c999716847e45505b3df170150876b545088"
++SRCREV = "9ae4f4ae4481b1e69d38ed810980d33103544613"
+ 
+ S = "${WORKDIR}/git"
+ 
+ inherit autotools
+ 
+-EXTR_OECONF += "--with-system-libunwind"
+-
+-CFLAGS += "-fPIC"
++EXTRA_OECONF += "--with-system-libunwind --enable-shared --disable-static"
+ 
+ do_configure() {
+     oe_runconf
+ }
+ 
+-# libunwind does not support RISCV yet
+-COMPATIBLE_HOST:riscv64 = "null"
++# libunwind does not support RISCV32 yet
+ COMPATIBLE_HOST:riscv32 = "null"

--- a/Tools/yocto/riscv/manifest.xml
+++ b/Tools/yocto/riscv/manifest.xml
@@ -8,9 +8,9 @@
 
   <!-- Yocto version: mickledore -->
 
-  <project remote="yocto"  revision="5f453b96a67acfefbabef9680a02c3763b1ac3dd" name="poky" path="sources/poky"/>
-  <project remote="github" revision="d71a08b3d8fc69d3213c10885af9cc693056a8bd" name="openembedded/meta-openembedded" path="sources/meta-openembedded"/>
-  <project remote="github" revision="6efab161f76e2548780fc2a6dc97e8b20aeba7b6" name="riscv/meta-riscv" path="sources/meta-riscv"/>
-  <project remote="github" revision="26f728f6c62c61c9656b8865309fa267d6f8b70b" name="Igalia/meta-webkit.git" path="sources/meta-webkit"/>
+  <project remote="yocto"  revision="7235399a86b134e57d5eb783d7f1f57ca0439ae5" name="poky" path="sources/poky"/>
+  <project remote="github" revision="f29290563cb821fae95340ba959749641c69ed7f" name="openembedded/meta-openembedded" path="sources/meta-openembedded"/>
+  <project remote="github" revision="84924c3b4a794f5a11be8e39e99c970aa96c05be" name="riscv/meta-riscv" path="sources/meta-riscv"/>
+  <project remote="github" revision="d14b0311f852651a0b0a48c4bc5be7cdde7ab2af" name="Igalia/meta-webkit.git" path="sources/meta-webkit"/>
 
 </manifest>

--- a/Tools/yocto/rpi/manifest.xml
+++ b/Tools/yocto/rpi/manifest.xml
@@ -8,9 +8,9 @@
 
   <!-- Yocto version: mickledore -->
 
-  <project remote="yocto"  revision="5f453b96a67acfefbabef9680a02c3763b1ac3dd" name="poky" path="sources/poky"/>
-  <project remote="github" revision="d71a08b3d8fc69d3213c10885af9cc693056a8bd" name="openembedded/meta-openembedded" path="sources/meta-openembedded"/>
-  <project remote="yocto"  revision="aa0aed9a08d6578a18c4eeb3b44ed8354a57ebee" name="meta-raspberrypi" path="sources/meta-raspberrypi"/>
-  <project remote="github" revision="26f728f6c62c61c9656b8865309fa267d6f8b70b" name="Igalia/meta-webkit.git" path="sources/meta-webkit"/>
+  <project remote="yocto"  revision="7235399a86b134e57d5eb783d7f1f57ca0439ae5" name="poky" path="sources/poky"/>
+  <project remote="github" revision="f29290563cb821fae95340ba959749641c69ed7f" name="openembedded/meta-openembedded" path="sources/meta-openembedded"/>
+  <project remote="yocto"  revision="9c81413d0b6f41f14f0f9c504d19e312c5b9958f" name="meta-raspberrypi" path="sources/meta-raspberrypi"/>
+  <project remote="github" revision="d14b0311f852651a0b0a48c4bc5be7cdde7ab2af" name="Igalia/meta-webkit.git" path="sources/meta-webkit"/>
 
 </manifest>

--- a/Tools/yocto/targets.conf
+++ b/Tools/yocto/targets.conf
@@ -38,6 +38,7 @@ conf_bblayers_path = rpi/bblayers.conf
 conf_local_path = rpi/local-rpi3-32bits-mesa.conf
 image_basename = webkit-dev-ci-tools
 image_types = tar.xz wic.xz wic.bmap
+patch_file_path = meta-openembedded_backport-libbacktrace-patch-to-mickledore-branch.patch
 environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DWPE_COG_PLATFORMS=drm,headless,wayland -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"
 
 [rpi3-32bits-userland]
@@ -46,6 +47,7 @@ conf_bblayers_path = rpi/bblayers.conf
 conf_local_path = rpi/local-rpi3-32bits-userland.conf
 image_basename = webkit-dev-ci-tools
 image_types = tar.xz wic.xz wic.bmap
+patch_file_path = meta-openembedded_backport-libbacktrace-patch-to-mickledore-branch.patch
 # WTR and MiniBrowser require wpbackend-fdo, with wpbackend-rdk we can only build cog
 environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DENABLE_MINIBROWSER=OFF -DENABLE_API_TESTS=OFF -DENABLE_LAYOUT_TESTS=OFF -DWPE_COG_PLATFORMS=none -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"
 
@@ -55,6 +57,7 @@ conf_bblayers_path = rpi/bblayers.conf
 conf_local_path = rpi/local-rpi4-32bits-mesa.conf
 image_basename = webkit-dev-ci-tools
 image_types = tar.xz wic.xz wic.bmap
+patch_file_path = meta-openembedded_backport-libbacktrace-patch-to-mickledore-branch.patch
 environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DWPE_COG_PLATFORMS=drm,headless,wayland -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"
 
 # ARM 64-bits targets (AArch64)
@@ -65,6 +68,7 @@ conf_bblayers_path = rpi/bblayers.conf
 conf_local_path = rpi/local-rpi3-64bits-mesa.conf
 image_basename = webkit-dev-ci-tools
 image_types = tar.xz wic.xz wic.bmap
+patch_file_path = meta-openembedded_backport-libbacktrace-patch-to-mickledore-branch.patch
 environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DWPE_COG_PLATFORMS=drm,headless,wayland -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"
 
 [rpi4-64bits-mesa]
@@ -73,6 +77,7 @@ conf_bblayers_path = rpi/bblayers.conf
 conf_local_path = rpi/local-rpi4-64bits-mesa.conf
 image_basename = webkit-dev-ci-tools
 image_types = tar.xz wic.xz wic.bmap
+patch_file_path = meta-openembedded_backport-libbacktrace-patch-to-mickledore-branch.patch
 environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DWPE_COG_PLATFORMS=drm,headless,wayland -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"
 
 [qemu-riscv64]
@@ -81,4 +86,5 @@ conf_bblayers_path = riscv/bblayers.conf
 conf_local_path = riscv/local-qemu-riscv64.conf
 image_basename = webkit-dev-ci-tools
 image_types = tar.xz wic.xz wic.bmap
+patch_file_path = meta-openembedded_backport-libbacktrace-patch-to-mickledore-branch.patch
 environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DWPE_COG_PLATFORMS=drm,headless,wayland -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"


### PR DESCRIPTION
#### aeda796b741149873575615d8e79224a7b264ef5
<pre>
[WPE][Tools] cross-toolchain-helper: add libbacktrace, libportal and change CPU frequency governor for RPis
<a href="https://bugs.webkit.org/show_bug.cgi?id=266353">https://bugs.webkit.org/show_bug.cgi?id=266353</a>

Reviewed by Philippe Normand.

This updates the Yocto layers used for the RPi build with the following major changes:

 - meta-webkit: include libbacktrace and libportal into the base build.
   libbacktrace is required by the default build of WPE now and libportal is required by Cog since bug 266351

 - meta-raspberrypi: stop setting &quot;powersave&quot; as the default CPU frequency governor and use
   &quot;schedutil&quot; instead. This will likely mean a big change in the performance results of all tests.
   See <a href="https://github.com/agherzan/meta-raspberrypi/pull/1243">https://github.com/agherzan/meta-raspberrypi/pull/1243</a> for context.

 - poky, meta-openembedded: just update to the last version of the Mickledore branch

 - backport a change landed in meta-openembedded master to the Mickledore branch that
   updates libbacktrace to allow building it on riscv64.

* Tools/yocto/meta-openembedded_backport-libbacktrace-patch-to-mickledore-branch.patch: Added.
* Tools/yocto/riscv/manifest.xml:
* Tools/yocto/rpi/manifest.xml:
* Tools/yocto/targets.conf:

Canonical link: <a href="https://commits.webkit.org/272030@main">https://commits.webkit.org/272030@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d15501b77459e5d4cbf516fa0a534fb3c32b7fb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30286 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8960 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31814 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32795 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27406 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30983 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11157 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6193 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27387 "Failure limit exceed. At least found 7 new test failures: imported/w3c/web-platform-tests/compat/webkit-box-rtl-flex.html, imported/w3c/web-platform-tests/css/css-break/become-unfragmented-001.html, imported/w3c/web-platform-tests/css/css-pseudo/first-line-with-inline-block.html, imported/w3c/web-platform-tests/css/css-text/hyphens/hyphens-auto-last-word-001.html, imported/w3c/web-platform-tests/css/css-text/text-encoding/shaping-no-join-001.html, imported/w3c/web-platform-tests/css/css-text/text-encoding/shaping-no-join-002.html, imported/w3c/web-platform-tests/css/css-text/text-encoding/shaping-no-join-003.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30594 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7537 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/26813 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6441 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6605 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27000 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34135 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27623 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27482 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32796 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6559 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4736 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30617 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8306 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7315 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3931 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7085 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->