### PR TITLE
VTTScanner should copy the string it is parsing

### DIFF
--- a/Source/WebCore/html/track/VTTScanner.cpp
+++ b/Source/WebCore/html/track/VTTScanner.cpp
@@ -35,7 +35,8 @@
 namespace WebCore {
 
 VTTScanner::VTTScanner(const String& line)
-    : m_is8Bit(line.is8Bit())
+    : m_source(line)
+    , m_is8Bit(line.is8Bit())
 {
     if (m_is8Bit) {
         m_data.characters8 = line.characters8();

--- a/Source/WebCore/html/track/VTTScanner.h
+++ b/Source/WebCore/html/track/VTTScanner.h
@@ -146,6 +146,7 @@ protected:
         const LChar* characters8;
         const UChar* characters16;
     } m_end;
+    const String m_source;
     bool m_is8Bit;
 };
 


### PR DESCRIPTION
#### 976e6341b4a89ea4c8a4f27185d0219af1ac3189
<pre>
VTTScanner should copy the string it is parsing
<a href="https://bugs.webkit.org/show_bug.cgi?id=266355">https://bugs.webkit.org/show_bug.cgi?id=266355</a>
<a href="https://rdar.apple.com/119621360">rdar://119621360</a>

Reviewed by Chris Dumez.

Store the String to be parsed in a member variable instead of only storing pointers to the
start and end of the String to avoid crashes like the one caused by caused by 270868@main.

* Source/WebCore/html/track/VTTScanner.cpp:
(WebCore::VTTScanner::VTTScanner):
* Source/WebCore/html/track/VTTScanner.h:

Canonical link: <a href="https://commits.webkit.org/272005@main">https://commits.webkit.org/272005@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dbff0ca5c329e9a2b779acf22957a776ebc39fdb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30290 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8964 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31789 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32799 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27410 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30989 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11161 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6197 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27389 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30598 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7536 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/26770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6444 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6604 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26995 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34139 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27621 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27472 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32790 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6563 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4744 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30598 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8310 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7175 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7319 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7089 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->