### PR TITLE
[WPE][GTK] Add libportal to the Flatpak SDK

### DIFF
--- a/Tools/buildstream/elements/sdk-platform.bst
+++ b/Tools/buildstream/elements/sdk-platform.bst
@@ -30,6 +30,7 @@ depends:
 - sdk/libevent.bst
 - sdk/libjxl.bst
 - sdk/libmanette.bst
+- sdk/libportal.bst
 - sdk/libsecret.bst
 - sdk/libusrsctp.bst
 - sdk/libwpe.bst

--- a/Tools/buildstream/elements/sdk/libportal.bst
+++ b/Tools/buildstream/elements/sdk/libportal.bst
@@ -1,0 +1,15 @@
+kind: meson
+build-depends:
+- freedesktop-sdk.bst:public-stacks/buildsystem-meson.bst
+
+depends:
+- sdk/gtk+-3.bst
+- sdk/gtk.bst
+
+sources:
+- kind: tar
+  url: github_com:flatpak/libportal/releases/download/0.7.1/libportal-0.7.1.tar.xz
+  ref: 297b90b263fad22190a26b8c7e8ea938fe6b18fb936265e588927179920d3805
+variables:
+  meson-local: >-
+    -Dbackends=gtk3,gtk4


### PR DESCRIPTION
#### 21e78d73f9589487e31742df7787c604b26d2abe
<pre>
[WPE][GTK] Add libportal to the Flatpak SDK
<a href="https://bugs.webkit.org/show_bug.cgi?id=266360">https://bugs.webkit.org/show_bug.cgi?id=266360</a>

Reviewed by NOBODY (OOPS!).

This adds libportal to the Flatpak SDK that is used
by newer versions of Cog.

* Tools/buildstream/elements/sdk-platform.bst:
* Tools/buildstream/elements/sdk/libportal.bst: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21e78d73f9589487e31742df7787c604b26d2abe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30308 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8982 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31808 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32817 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27429 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31007 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11179 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6215 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27397 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30616 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7550 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/26771 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6457 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6617 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26997 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34157 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27637 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27476 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32802 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6579 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4750 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30611 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8326 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7335 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7107 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->