### PR TITLE
Add namespace qualifiers to a bunch of jsc types

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssemblerCodeRef.cpp
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerCodeRef.cpp
@@ -55,7 +55,7 @@ CString MacroAssemblerCodeRefBase::disassembly(CodePtr<DisassemblyPtrTag> codePt
 
 bool shouldDumpDisassemblyFor(CodeBlock* codeBlock)
 {
-    if (codeBlock && JITCode::isOptimizingJIT(codeBlock->jitType()) && Options::dumpDFGDisassembly())
+    if (codeBlock && JSC::JITCode::isOptimizingJIT(codeBlock->jitType()) && Options::dumpDFGDisassembly())
         return true;
     return Options::dumpDisassembly();
 }

--- a/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
+++ b/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
@@ -107,8 +107,6 @@
 
 Nop
 
-Breakpoint
-
 Add32 U:G:32, U:G:32, ZD:G:32
     Imm, Tmp, Tmp
     Tmp, Tmp, Tmp

--- a/Source/JavaScriptCore/bytecode/CallLinkInfo.h
+++ b/Source/JavaScriptCore/bytecode/CallLinkInfo.h
@@ -459,7 +459,7 @@ struct UnlinkedCallLinkInfo {
     }
 };
 
-struct BaselineUnlinkedCallLinkInfo : public UnlinkedCallLinkInfo {
+struct BaselineUnlinkedCallLinkInfo : public JSC::UnlinkedCallLinkInfo {
     BytecodeIndex bytecodeIndex; // Currently, only used by baseline, so this can trivially produce a CodeOrigin.
 
 #if ENABLE(JIT)

--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -839,7 +839,7 @@ CodeBlock::~CodeBlock()
     // to the CodeBlock. However, its lifecycle is tied directly to the CodeBlock, and
     // will be automatically cleared when the CodeBlock destructs.
 
-    if (JITCode::isOptimizingJIT(jitType()))
+    if (JSC::JITCode::isOptimizingJIT(jitType()))
         jitCode()->dfgCommon()->clearWatchpoints();
 #endif
 
@@ -875,7 +875,7 @@ CodeBlock::~CodeBlock()
         stubInfo.deref();
         return IterationStatus::Continue;
     });
-    if (JITCode::isOptimizingJIT(jitType())) {
+    if (JSC::JITCode::isOptimizingJIT(jitType())) {
 #if ENABLE(DFG_JIT)
         if (auto* jitData = dfgJITData())
             delete jitData;
@@ -990,7 +990,7 @@ CodeBlock* CodeBlock::specialOSREntryBlockOrNull()
 #if ENABLE(FTL_JIT)
     if (jitType() != JITType::DFGJIT)
         return nullptr;
-    DFG::JITCode* jitCode = m_jitCode->dfg();
+    auto* jitCode = m_jitCode->dfg();
     return jitCode->osrEntryBlock();
 #else // ENABLE(FTL_JIT)
     return 0;
@@ -1003,7 +1003,7 @@ size_t CodeBlock::estimatedSize(JSCell* cell, VM& vm)
     size_t extraMemoryAllocated = 0;
     if (thisObject->m_metadata)
         extraMemoryAllocated += thisObject->m_metadata->sizeInBytesForGC();
-    RefPtr<JITCode> jitCode = thisObject->m_jitCode;
+    RefPtr<JSC::JITCode> jitCode = thisObject->m_jitCode;
     if (jitCode && !jitCode->isShared())
         extraMemoryAllocated += jitCode->size();
     return Base::estimatedSize(cell, vm) + extraMemoryAllocated;
@@ -1014,7 +1014,7 @@ inline void CodeBlock::forEachStructureStubInfo(Func func)
 {
     UNUSED_PARAM(func);
 #if ENABLE(JIT)
-    if (JITCode::isOptimizingJIT(jitType())) {
+    if (JSC::JITCode::isOptimizingJIT(jitType())) {
 #if ENABLE(DFG_JIT)
         for (auto* stubInfo : jitCode()->dfgCommon()->m_stubInfos) {
             if (func(*stubInfo) == IterationStatus::Done)
@@ -1094,7 +1094,7 @@ bool CodeBlock::shouldVisitStrongly(const ConcurrentJSLocker& locker, Visitor& v
     // Interpreter and Baseline JIT CodeBlocks don't need to be jettisoned when
     // their weak references go stale. So if a basline JIT CodeBlock gets
     // scanned, we can assume that this means that it's live.
-    if (!JITCode::isOptimizingJIT(jitType()))
+    if (!JSC::JITCode::isOptimizingJIT(jitType()))
         return true;
 
     return false;
@@ -1105,7 +1105,7 @@ template bool CodeBlock::shouldVisitStrongly(const ConcurrentJSLocker&, SlotVisi
 
 bool CodeBlock::shouldJettisonDueToWeakReference(VM& vm)
 {
-    if (!JITCode::isOptimizingJIT(jitType()))
+    if (!JSC::JITCode::isOptimizingJIT(jitType()))
         return false;
     return !vm.heap.isMarked(this);
 }
@@ -1247,7 +1247,7 @@ void CodeBlock::propagateTransitions(const ConcurrentJSLocker&, Visitor& visitor
 #endif // ENABLE(JIT)
     
 #if ENABLE(DFG_JIT)
-    if (JITCode::isOptimizingJIT(jitType())) {
+    if (JSC::JITCode::isOptimizingJIT(jitType())) {
         DFG::CommonData* dfgCommon = m_jitCode->dfgCommon();
         
         dfgCommon->recordedStatuses.markIfCheap(visitor);
@@ -1300,7 +1300,7 @@ void CodeBlock::determineLiveness(const ConcurrentJSLocker&, Visitor& visitor)
     // In rare and weird cases, this could be called on a baseline CodeBlock. One that I found was
     // that we might decide that the CodeBlock should be jettisoned due to old age, so the
     // isMarked check doesn't protect us.
-    if (!JITCode::isOptimizingJIT(jitType()))
+    if (!JSC::JITCode::isOptimizingJIT(jitType()))
         return;
     
     DFG::CommonData* dfgCommon = m_jitCode->dfgCommon();
@@ -1571,7 +1571,7 @@ void CodeBlock::finalizeLLIntInlineCaches()
 void CodeBlock::finalizeJITInlineCaches()
 {
 #if ENABLE(DFG_JIT)
-    if (JITCode::isOptimizingJIT(jitType())) {
+    if (JSC::JITCode::isOptimizingJIT(jitType())) {
         for (auto* callLinkInfo : m_jitCode->dfgCommon()->m_callLinkInfos)
             callLinkInfo->visitWeak(vm());
         if (auto* jitData = dfgJITData()) {
@@ -1612,7 +1612,7 @@ void CodeBlock::finalizeUnconditionally(VM& vm, CollectionScope)
 #endif
 
 #if ENABLE(DFG_JIT)
-    if (JITCode::isOptimizingJIT(jitType())) {
+    if (JSC::JITCode::isOptimizingJIT(jitType())) {
         DFG::CommonData* dfgCommon = m_jitCode->dfgCommon();
         dfgCommon->recordedStatuses.finalize(vm);
     }
@@ -1621,10 +1621,10 @@ void CodeBlock::finalizeUnconditionally(VM& vm, CollectionScope)
     auto updateActivity = [&] {
         if (!VM::useUnlinkedCodeBlockJettisoning())
             return;
-        JITCode* jitCode = m_jitCode.get();
+        auto* jitCode = m_jitCode.get();
         float count = 0;
         bool alwaysActive = false;
-        switch (JITCode::jitTypeFor(jitCode)) {
+        switch (JSC::JITCode::jitTypeFor(jitCode)) {
         case JITType::None:
         case JITType::HostCallThunk:
             return;
@@ -1679,7 +1679,7 @@ void CodeBlock::getICStatusMap(const ConcurrentJSLocker&, ICStatusMap& result)
             result.add(stubInfo.codeOrigin, ICStatus()).iterator->value.stubInfo = &stubInfo;
             return IterationStatus::Continue;
         });
-        if (JITCode::isOptimizingJIT(jitType())) {
+        if (JSC::JITCode::isOptimizingJIT(jitType())) {
 #if ENABLE(DFG_JIT)
             DFG::CommonData* dfgCommon = m_jitCode->dfgCommon();
             for (auto* callLinkInfo : dfgCommon->m_callLinkInfos)
@@ -1746,7 +1746,7 @@ CallLinkInfo* CodeBlock::getCallLinkInfoForBytecodeIndex(const ConcurrentJSLocke
     }
 
 #if ENABLE(DFG_JIT)
-    if (JITCode::isOptimizingJIT(jitType())) {
+    if (JSC::JITCode::isOptimizingJIT(jitType())) {
         DFG::CommonData* dfgCommon = m_jitCode->dfgCommon();
         for (auto* callLinkInfo : dfgCommon->m_callLinkInfos) {
             if (callLinkInfo->codeOrigin() == CodeOrigin(index))
@@ -1839,7 +1839,7 @@ void CodeBlock::stronglyVisitStrongReferences(const ConcurrentJSLocker& locker, 
         stubInfo.visitAggregate(visitor);
         return IterationStatus::Continue;
     });
-    if (JITCode::isOptimizingJIT(jitType())) {
+    if (JSC::JITCode::isOptimizingJIT(jitType())) {
 #if ENABLE(DFG_JIT)
         DFG::CommonData* dfgCommon = m_jitCode->dfgCommon();
         dfgCommon->recordedStatuses.visitAggregate(visitor);
@@ -1855,7 +1855,7 @@ void CodeBlock::stronglyVisitWeakReferences(const ConcurrentJSLocker&, Visitor& 
     UNUSED_PARAM(visitor);
 
 #if ENABLE(DFG_JIT)
-    if (!JITCode::isOptimizingJIT(jitType()))
+    if (!JSC::JITCode::isOptimizingJIT(jitType()))
         return;
     
     DFG::CommonData* dfgCommon = m_jitCode->dfgCommon();
@@ -1897,7 +1897,7 @@ CodeBlock* CodeBlock::baselineVersion()
         return this;
     CodeBlock* result = replacement();
     if (!result) {
-        if (JITCode::isOptimizingJIT(selfJITType)) {
+        if (JSC::JITCode::isOptimizingJIT(selfJITType)) {
             // The replacement can be null if we've had a memory clean up and the executable
             // has been purged of its codeBlocks (see ExecutableBase::clearCode()). Regardless,
             // the current codeBlock is still live on the stack, and as an optimizing JIT
@@ -1961,7 +1961,7 @@ HandlerInfo* CodeBlock::handlerForIndex(unsigned index, RequiredHandler required
 DisposableCallSiteIndex CodeBlock::newExceptionHandlingCallSiteIndex(CallSiteIndex originalCallSite)
 {
 #if ENABLE(DFG_JIT)
-    RELEASE_ASSERT(JITCode::isOptimizingJIT(jitType()));
+    RELEASE_ASSERT(JSC::JITCode::isOptimizingJIT(jitType()));
     RELEASE_ASSERT(canGetCodeOrigin(originalCallSite));
     ASSERT(!!handlerForIndex(originalCallSite.bits()));
     CodeOrigin originalOrigin = codeOrigin(originalCallSite);
@@ -2214,7 +2214,7 @@ void CodeBlock::jettison(Profiler::JettisonReason reason, ReoptimizationMode mod
     // 2) Make sure that if we call the owner executable, then we shouldn't call this CodeBlock.
 
 #if ENABLE(DFG_JIT)
-    if (JITCode::isOptimizingJIT(jitType()))
+    if (JSC::JITCode::isOptimizingJIT(jitType()))
         jitCode()->dfgCommon()->clearWatchpoints();
     
     if (reason != Profiler::JettisonDueToOldAge) {
@@ -2371,7 +2371,7 @@ void CodeBlock::noticeIncomingCall(CallFrame* callerFrame)
         return;
     }
     
-    if (JITCode::isOptimizingJIT(callerCodeBlock->jitType())) {
+    if (JSC::JITCode::isOptimizingJIT(callerCodeBlock->jitType())) {
         m_shouldAlwaysBeInlined = false;
         dataLogLnIf(Options::verboseCallLink(), "    Clearing SABI bcause caller was already optimized.");
         return;
@@ -2451,7 +2451,7 @@ unsigned CodeBlock::numberOfDFGCompiles()
         return (m_hasBeenCompiledWithFTL ? 1 : 0) + m_reoptimizationRetryCounter;
     }
     CodeBlock* replacement = this->replacement();
-    return ((replacement && JITCode::isOptimizingJIT(replacement->jitType())) ? 1 : 0) + m_reoptimizationRetryCounter;
+    return ((replacement && JSC::JITCode::isOptimizingJIT(replacement->jitType())) ? 1 : 0) + m_reoptimizationRetryCounter;
 }
 
 int32_t CodeBlock::codeTypeThresholdMultiplier() const
@@ -2640,7 +2640,7 @@ void CodeBlock::setOptimizationThresholdBasedOnCompilationResult(CompilationResu
     
     switch (result) {
     case CompilationSuccessful:
-        RELEASE_ASSERT(replacement && JITCode::isOptimizingJIT(replacement->jitType()));
+        RELEASE_ASSERT(replacement && JSC::JITCode::isOptimizingJIT(replacement->jitType()));
         optimizeNextInvocation();
         return;
     case CompilationFailed:
@@ -2669,7 +2669,7 @@ void CodeBlock::setOptimizationThresholdBasedOnCompilationResult(CompilationResu
     
 uint32_t CodeBlock::adjustedExitCountThreshold(uint32_t desiredThreshold)
 {
-    ASSERT(JITCode::isOptimizingJIT(jitType()));
+    ASSERT(JSC::JITCode::isOptimizingJIT(jitType()));
     // Compute this the lame way so we don't saturate. This is called infrequently
     // enough that this loop won't hurt us.
     unsigned result = desiredThreshold;
@@ -2741,7 +2741,7 @@ DFG::CodeOriginPool& CodeBlock::codeOrigins()
 
 size_t CodeBlock::numberOfDFGIdentifiers() const
 {
-    if (!JITCode::isOptimizingJIT(jitType()))
+    if (!JSC::JITCode::isOptimizingJIT(jitType()))
         return 0;
     
     return m_jitCode->dfgCommon()->m_dfgIdentifiers.size();
@@ -2753,7 +2753,7 @@ const Identifier& CodeBlock::identifier(int index) const
     size_t unlinkedIdentifiers = unlinkedCode->numberOfIdentifiers();
     if (static_cast<unsigned>(index) < unlinkedIdentifiers)
         return unlinkedCode->identifier(index);
-    ASSERT(JITCode::isOptimizingJIT(jitType()));
+    ASSERT(JSC::JITCode::isOptimizingJIT(jitType()));
     return m_jitCode->dfgCommon()->m_dfgIdentifiers[index - unlinkedIdentifiers];
 }
 #endif // ENABLE(DFG_JIT)
@@ -2782,7 +2782,7 @@ bool CodeBlock::hasIdentifier(UniquedStringImpl* uid)
             }
 #if ENABLE(DFG_JIT)
             if (numberOfDFGIdentifiers) {
-                ASSERT(JITCode::isOptimizingJIT(jitType()));
+                ASSERT(JSC::JITCode::isOptimizingJIT(jitType()));
                 auto& dfgIdentifiers = m_jitCode->dfgCommon()->m_dfgIdentifiers;
                 for (unsigned index = 0; index < numberOfDFGIdentifiers; ++index) {
                     const Identifier& identifier = dfgIdentifiers[index];
@@ -2802,7 +2802,7 @@ bool CodeBlock::hasIdentifier(UniquedStringImpl* uid)
             return true;
     }
 #if ENABLE(DFG_JIT)
-    ASSERT(JITCode::isOptimizingJIT(jitType()));
+    ASSERT(JSC::JITCode::isOptimizingJIT(jitType()));
     auto& dfgIdentifiers = m_jitCode->dfgCommon()->m_dfgIdentifiers;
     for (unsigned index = 0; index < numberOfDFGIdentifiers; ++index) {
         const Identifier& identifier = dfgIdentifiers[index];
@@ -2976,14 +2976,14 @@ bool CodeBlock::shouldOptimizeNowFromBaseline()
 #if ENABLE(DFG_JIT)
 void CodeBlock::tallyFrequentExitSites()
 {
-    ASSERT(JITCode::isOptimizingJIT(jitType()));
+    ASSERT(JSC::JITCode::isOptimizingJIT(jitType()));
     ASSERT(JITCode::isBaselineCode(alternative()->jitType()));
     
     CodeBlock* profiledBlock = alternative();
     
     switch (jitType()) {
     case JITType::DFGJIT: {
-        DFG::JITCode* jitCode = m_jitCode->dfg();
+        auto* jitCode = m_jitCode->dfg();
         for (auto& exit : jitCode->m_osrExit)
             exit.considerAddingAsFrequentExitSite(profiledBlock);
         break;
@@ -2994,7 +2994,7 @@ void CodeBlock::tallyFrequentExitSites()
         // There is no easy way to avoid duplicating this code since the FTL::JITCode::m_osrExit
         // vector contains a totally different type, that just so happens to behave like
         // DFG::JITCode::m_osrExit.
-        FTL::JITCode* jitCode = m_jitCode->ftl();
+        auto* jitCode = m_jitCode->ftl();
         for (auto& exit : jitCode->m_osrExit)
             exit.considerAddingAsFrequentExitSite(profiledBlock);
         break;
@@ -3249,14 +3249,14 @@ void CodeBlock::addBreakpoint(unsigned numBreakpoints)
 {
     m_numBreakpoints += numBreakpoints;
     ASSERT(m_numBreakpoints);
-    if (JITCode::isOptimizingJIT(jitType()))
+    if (JSC::JITCode::isOptimizingJIT(jitType()))
         jettison(Profiler::JettisonDueToDebuggerBreakpoint);
 }
 
 void CodeBlock::setSteppingMode(CodeBlock::SteppingMode mode)
 {
     m_steppingMode = mode;
-    if (mode == SteppingModeEnabled && JITCode::isOptimizingJIT(jitType()))
+    if (mode == SteppingModeEnabled && JSC::JITCode::isOptimizingJIT(jitType()))
         jettison(Profiler::JettisonDueToDebuggerStepping);
 }
 
@@ -3502,7 +3502,7 @@ bool CodeBlock::canInstallVMTrapBreakpoints() const
     // This function may be called from a signal handler. We need to be
     // careful to not call anything that is not signal handler safe, e.g.
     // we should not perturb the refCount of m_jitCode.
-    if (!JITCode::isOptimizingJIT(jitType()))
+    if (!JSC::JITCode::isOptimizingJIT(jitType()))
         return false;
     if (m_jitCode->isUnlinked())
         return false;

--- a/Source/JavaScriptCore/bytecode/CodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.h
@@ -319,7 +319,7 @@ public:
     // Exactly equivalent to codeBlock->ownerExecutable()->newReplacementCodeBlockFor(codeBlock->specializationKind())
     CodeBlock* newReplacement();
     
-    void setJITCode(Ref<JITCode>&& code)
+    void setJITCode(Ref<JSC::JITCode>&& code)
     {
         if (!code->isShared())
             heap()->reportExtraMemoryAllocated(this, code->size());
@@ -329,12 +329,12 @@ public:
         m_jitCode = WTFMove(code);
     }
 
-    RefPtr<JITCode> jitCode() { return m_jitCode; }
+    RefPtr<JSC::JITCode> jitCode() { return m_jitCode; }
     static ptrdiff_t jitCodeOffset() { return OBJECT_OFFSETOF(CodeBlock, m_jitCode); }
     JITType jitType() const
     {
-        JITCode* jitCode = m_jitCode.get();
-        JITType result = JITCode::jitTypeFor(jitCode);
+        auto* jitCode = m_jitCode.get();
+        JITType result = JSC::JITCode::jitTypeFor(jitCode);
         return result;
     }
 
@@ -440,7 +440,7 @@ public:
     // Having code origins implies that there has been some inlining.
     bool hasCodeOrigins()
     {
-        return JITCode::isOptimizingJIT(jitType());
+        return JSC::JITCode::isOptimizingJIT(jitType());
     }
         
     bool canGetCodeOrigin(CallSiteIndex index)
@@ -504,7 +504,7 @@ public:
     
     const BitVector& bitVector(size_t i) { return m_unlinkedCode->bitVector(i); }
 
-    Heap* heap() const { return &m_vm->heap; }
+    JSC::Heap* heap() const { return &m_vm->heap; }
     JSGlobalObject* globalObject() { return m_globalObject.get(); }
 
     static ptrdiff_t offsetOfGlobalObject() { return OBJECT_OFFSETOF(CodeBlock, m_globalObject); }
@@ -531,7 +531,7 @@ public:
     }
     BaselineJITData* baselineJITData()
     {
-        if (!JITCode::isOptimizingJIT(jitType()))
+        if (!JSC::JITCode::isOptimizingJIT(jitType()))
             return bitwise_cast<BaselineJITData*>(m_jitData);
         return nullptr;
     }
@@ -546,7 +546,7 @@ public:
 
     DFG::JITData* dfgJITData()
     {
-        if (JITCode::isOptimizingJIT(jitType()))
+        if (JSC::JITCode::isOptimizingJIT(jitType()))
             return bitwise_cast<DFG::JITData*>(m_jitData);
         return nullptr;
     }
@@ -956,7 +956,7 @@ private:
     uint16_t m_optimizationDelayCounter { 0 };
     uint16_t m_reoptimizationRetryCounter { 0 };
     StructureWatchpointMap m_llintGetByIdWatchpointMap;
-    RefPtr<JITCode> m_jitCode;
+    RefPtr<JSC::JITCode> m_jitCode;
 #if ENABLE(JIT)
 public:
     void* m_jitData { nullptr };

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -495,7 +495,7 @@ const ScalarRegisterSet& InlineCacheCompiler::calculateLiveRegistersForCallAndEx
         m_liveRegistersToPreserveAtExceptionHandlingCallSite = m_jit->codeBlock()->jitCode()->liveRegistersToPreserveAtExceptionHandlingCallSite(m_jit->codeBlock(), m_stubInfo->callSiteIndex).buildScalarRegisterSet();
         m_needsToRestoreRegistersIfException = m_liveRegistersToPreserveAtExceptionHandlingCallSite.numberOfSetRegisters() > 0;
         if (m_needsToRestoreRegistersIfException)
-            RELEASE_ASSERT(JITCode::isOptimizingJIT(m_jit->codeBlock()->jitType()));
+            RELEASE_ASSERT(JSC::JITCode::isOptimizingJIT(m_jit->codeBlock()->jitType()));
 
         auto liveRegistersForCall = RegisterSetBuilder(m_liveRegistersToPreserveAtExceptionHandlingCallSite.toRegisterSet(), m_allocator->usedRegisters());
         if (m_jit->codeBlock()->useDataIC())
@@ -4143,7 +4143,7 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
         // We set these to indicate to the stub to remove itself from the CodeBlock's
         // exception handler table when it is deallocated.
         codeBlockThatOwnsExceptionHandlers = codeBlock;
-        ASSERT(JITCode::isOptimizingJIT(codeBlockThatOwnsExceptionHandlers->jitType()));
+        ASSERT(JSC::JITCode::isOptimizingJIT(codeBlockThatOwnsExceptionHandlers->jitType()));
         callSiteIndexForExceptionHandling = this->callSiteIndexForExceptionHandling();
     }
 

--- a/Source/JavaScriptCore/bytecode/Repatch.cpp
+++ b/Source/JavaScriptCore/bytecode/Repatch.cpp
@@ -2131,7 +2131,7 @@ void linkPolymorphicCall(JSGlobalObject* globalObject, CallFrame* callFrame, Cal
 #if ASSERT_ENABLED
             // It needs to be LLInt or Baseline since we are using returnFromBaselineGenerator.
             if (!isWebAssembly)
-                ASSERT(!JITCode::isOptimizingJIT(callerCodeBlock->jitType()));
+                ASSERT(!JSC::JITCode::isOptimizingJIT(callerCodeBlock->jitType()));
 #endif
             if (callLinkInfo.isTailCall()) {
                 stubJit.move(CCallHelpers::TrustedImmPtr(vm.getCTIStub(CommonJITThunkID::ReturnFromBaseline).code().untaggedPtr()), GPRInfo::regT4);

--- a/Source/JavaScriptCore/bytecode/StructureStubInfo.h
+++ b/Source/JavaScriptCore/bytecode/StructureStubInfo.h
@@ -553,7 +553,7 @@ struct UnlinkedStructureStubInfo {
     CodeLocationLabel<JITStubRoutinePtrTag> slowPathStartLocation;
 };
 
-struct BaselineUnlinkedStructureStubInfo : UnlinkedStructureStubInfo {
+struct BaselineUnlinkedStructureStubInfo : JSC::UnlinkedStructureStubInfo {
     BytecodeIndex bytecodeIndex;
 };
 

--- a/Source/JavaScriptCore/dfg/DFGJITCompiler.cpp
+++ b/Source/JavaScriptCore/dfg/DFGJITCompiler.cpp
@@ -593,7 +593,7 @@ std::tuple<CompileTimeStructureStubInfo, StructureStubInfoIndex> JITCompiler::ad
 {
     if (m_graph.m_plan.isUnlinked()) {
         unsigned index = m_unlinkedStubInfos.size();
-        UnlinkedStructureStubInfo* stubInfo = &m_unlinkedStubInfos.alloc();
+        DFG::UnlinkedStructureStubInfo* stubInfo = &m_unlinkedStubInfos.alloc();
         return std::tuple { stubInfo, StructureStubInfoIndex { index } };
     }
     StructureStubInfo* stubInfo = jitCode()->common.m_stubInfos.add();

--- a/Source/JavaScriptCore/dfg/DFGJITCompiler.h
+++ b/Source/JavaScriptCore/dfg/DFGJITCompiler.h
@@ -301,7 +301,7 @@ public:
         return result;
     }
 
-    RefPtr<JITCode> jitCode() { return m_jitCode; }
+    RefPtr<DFG::JITCode> jitCode() { return m_jitCode; }
     
     Vector<Label>& blockHeads() { return m_blockHeads; }
 
@@ -419,7 +419,7 @@ protected:
 
     std::unique_ptr<Disassembler> m_disassembler;
     
-    RefPtr<JITCode> m_jitCode;
+    RefPtr<DFG::JITCode> m_jitCode;
     
     // Vector of calls out from JIT code, including exception handler information.
     // Count of the number of CallRecords with exception handlers.

--- a/Source/JavaScriptCore/dfg/DFGJITFinalizer.cpp
+++ b/Source/JavaScriptCore/dfg/DFGJITFinalizer.cpp
@@ -39,7 +39,7 @@ namespace JSC { namespace DFG {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(JITFinalizer);
 
-JITFinalizer::JITFinalizer(Plan& plan, Ref<JITCode>&& jitCode, std::unique_ptr<LinkBuffer> linkBuffer, CodePtr<JSEntryPtrTag> withArityCheck)
+JITFinalizer::JITFinalizer(Plan& plan, Ref<DFG::JITCode>&& jitCode, std::unique_ptr<LinkBuffer> linkBuffer, CodePtr<JSEntryPtrTag> withArityCheck)
     : Finalizer(plan)
     , m_jitCode(WTFMove(jitCode))
     , m_linkBuffer(WTFMove(linkBuffer))

--- a/Source/JavaScriptCore/dfg/DFGJITFinalizer.h
+++ b/Source/JavaScriptCore/dfg/DFGJITFinalizer.h
@@ -37,7 +37,7 @@ namespace JSC { namespace DFG {
 class JITFinalizer final : public Finalizer {
     WTF_MAKE_TZONE_ALLOCATED(JITFinalizer);
 public:
-    JITFinalizer(Plan&, Ref<JITCode>&&, std::unique_ptr<LinkBuffer>, CodePtr<JSEntryPtrTag> withArityCheck = CodePtr<JSEntryPtrTag>(CodePtr<JSEntryPtrTag>::EmptyValue));
+    JITFinalizer(Plan&, Ref<DFG::JITCode>&&, std::unique_ptr<LinkBuffer>, CodePtr<JSEntryPtrTag> withArityCheck = CodePtr<JSEntryPtrTag>(CodePtr<JSEntryPtrTag>::EmptyValue));
     ~JITFinalizer() final;
     
     size_t codeSize() final;
@@ -46,7 +46,7 @@ public:
 
 private:
     
-    Ref<JITCode> m_jitCode;
+    Ref<DFG::JITCode> m_jitCode;
     std::unique_ptr<LinkBuffer> m_linkBuffer;
     CodePtr<JSEntryPtrTag> m_withArityCheck;
 };

--- a/Source/JavaScriptCore/dfg/DFGOSREntry.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOSREntry.cpp
@@ -94,7 +94,7 @@ void OSREntryData::dump(PrintStream& out) const
 SUPPRESS_ASAN
 void* prepareOSREntry(VM& vm, CallFrame* callFrame, CodeBlock* codeBlock, BytecodeIndex bytecodeIndex)
 {
-    ASSERT(JITCode::isOptimizingJIT(codeBlock->jitType()));
+    ASSERT(JSC::JITCode::isOptimizingJIT(codeBlock->jitType()));
     ASSERT(codeBlock->alternative());
     ASSERT(codeBlock->alternative()->jitType() == JITType::BaselineJIT);
     ASSERT(codeBlock->jitCode()->dfgCommon()->isStillValid());

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -4316,7 +4316,7 @@ JSC_DEFINE_JIT_OPERATION(operationTriggerReoptimizationNow, void, (CodeBlock* co
     // Otherwise, the replacement must be optimized code. Use this as an opportunity
     // to check our logic.
     ASSERT(codeBlock->hasOptimizedReplacement());
-    ASSERT(JITCode::isOptimizingJIT(optimizedCodeBlock->jitType()));
+    ASSERT(JSC::JITCode::isOptimizingJIT(optimizedCodeBlock->jitType()));
     
     bool didTryToEnterIntoInlinedLoops = false;
     for (InlineCallFrame* inlineCallFrame = exit->m_codeOrigin.inlineCallFrame(); inlineCallFrame; inlineCallFrame = inlineCallFrame->directCaller.inlineCallFrame()) {

--- a/Source/JavaScriptCore/dfg/DFGPlan.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPlan.cpp
@@ -701,7 +701,7 @@ void Plan::cleanMustHandleValuesIfNecessary()
     }
 }
 
-std::unique_ptr<JITData> Plan::tryFinalizeJITData(const JITCode& jitCode)
+std::unique_ptr<JITData> Plan::tryFinalizeJITData(const DFG::JITCode& jitCode)
 {
     auto osrExitThunk = m_vm->getCTIStub(osrExitGenerationThunkGenerator).retagged<OSRExitPtrTag>();
     auto exits = JITData::ExitVector::createWithSizeAndConstructorArguments(jitCode.m_osrExit.size(), osrExitThunk);

--- a/Source/JavaScriptCore/dfg/DFGPlan.h
+++ b/Source/JavaScriptCore/dfg/DFGPlan.h
@@ -103,7 +103,7 @@ public:
     DeferredCompilationCallback* callback() const { return m_callback.get(); }
     void setCallback(Ref<DeferredCompilationCallback>&& callback) { m_callback = WTFMove(callback); }
 
-    std::unique_ptr<JITData> tryFinalizeJITData(const JITCode&);
+    std::unique_ptr<JITData> tryFinalizeJITData(const DFG::JITCode&);
 
 private:
     CompilationPath compileInThreadImpl() override;

--- a/Source/JavaScriptCore/ftl/FTLJITFinalizer.h
+++ b/Source/JavaScriptCore/ftl/FTLJITFinalizer.h
@@ -65,7 +65,7 @@ public:
     
     Vector<CCallHelpers::Jump> lazySlowPathGeneratorJumps;
     GeneratedFunction function;
-    RefPtr<JITCode> jitCode;
+    RefPtr<FTL::JITCode> jitCode;
 };
 
 } } // namespace JSC::FTL

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -13207,10 +13207,10 @@ IGNORE_CLANG_WARNINGS_END
                 RefPtr<OSRExitHandle> handle = descriptor->emitOSRExitLater(
                     *state, UncountableInvalidation, origin, params, nodeIndex, 0);
 
-                RefPtr<JITCode> jitCode = state->jitCode.get();
+                RefPtr<FTL::JITCode> jitCode = state->jitCode;
 
                 jit.addLinkTask(
-                    [=] (LinkBuffer& linkBuffer) {
+                    [=, protectedJitCode = jitCode] (LinkBuffer& linkBuffer) {
                         JumpReplacement jumpReplacement(
                             linkBuffer.locationOf<JSInternalPtrTag>(label),
                             linkBuffer.locationOf<OSRExitPtrTag>(handle->label));
@@ -20326,7 +20326,7 @@ IGNORE_CLANG_WARNINGS_END
                         // runs before or after any other late paths that we might depend on, like
                         // the exception thunk.
 
-                        RefPtr<JITCode> jitCode = state->jitCode;
+                        RefPtr<FTL::JITCode> jitCode = state->jitCode;
                         jit.addLinkTask(
                             [=] (LinkBuffer& linkBuffer) {
                                 std::unique_ptr<LazySlowPath> lazySlowPath = makeUnique<LazySlowPath>();
@@ -20337,12 +20337,12 @@ IGNORE_CLANG_WARNINGS_END
 
                                 CallSiteIndex callSiteIndex =
                                     jitCode->common.codeOrigins->addUniqueCallSiteIndex(origin);
-                                    
+
                                 lazySlowPath->initialize(
                                         linkedPatchableJump, linkedDone,
                                         exceptionTarget->label(linkBuffer), usedRegisters,
                                         callSiteIndex, generator);
-                                    
+
                                 jitCode->lazySlowPaths[index] = WTFMove(lazySlowPath);
                             });
                     });

--- a/Source/JavaScriptCore/ftl/FTLState.h
+++ b/Source/JavaScriptCore/ftl/FTLState.h
@@ -80,7 +80,7 @@ public:
     DFG::Graph& graph;
     std::unique_ptr<B3::Procedure> proc;
     bool allocationFailed { false }; // Throw out the compilation once B3 returns.
-    RefPtr<JITCode> jitCode;
+    RefPtr<FTL::JITCode> jitCode;
     GeneratedFunction generatedFunction;
     JITFinalizer* finalizer;
     // Top-level exception handler. Jump here if you know that you have to genericUnwind() and there

--- a/Source/JavaScriptCore/heap/AbstractSlotVisitor.h
+++ b/Source/JavaScriptCore/heap/AbstractSlotVisitor.h
@@ -139,7 +139,7 @@ public:
 
     VM& vm();
     const VM& vm() const;
-    Heap* heap() const;
+    JSC::Heap* heap() const;
 
     virtual void append(const ConservativeRoots&) = 0;
 
@@ -222,7 +222,7 @@ protected:
 
     size_t m_visitCount { 0 };
 
-    Heap& m_heap;
+    JSC::Heap& m_heap;
     ReferrerContext* m_context { nullptr };
     CString m_codeName;
 

--- a/Source/JavaScriptCore/heap/AbstractSlotVisitorInlines.h
+++ b/Source/JavaScriptCore/heap/AbstractSlotVisitorInlines.h
@@ -98,14 +98,14 @@ inline AbstractSlotVisitor::ReferrerContext::~ReferrerContext()
     m_visitor.m_context = m_previous;
 }
 
-inline AbstractSlotVisitor::AbstractSlotVisitor(Heap& heap, CString codeName, ConcurrentPtrHashSet& opaqueRoots)
+inline AbstractSlotVisitor::AbstractSlotVisitor(JSC::Heap& heap, CString codeName, ConcurrentPtrHashSet& opaqueRoots)
     : m_heap(heap)
     , m_codeName(codeName)
     , m_opaqueRoots(opaqueRoots)
 {
 }
 
-inline Heap* AbstractSlotVisitor::heap() const
+inline JSC::Heap* AbstractSlotVisitor::heap() const
 {
     return &m_heap;
 }

--- a/Source/JavaScriptCore/heap/AlignedMemoryAllocator.cpp
+++ b/Source/JavaScriptCore/heap/AlignedMemoryAllocator.cpp
@@ -40,7 +40,7 @@ AlignedMemoryAllocator::~AlignedMemoryAllocator()
 {
 }
 
-void AlignedMemoryAllocator::registerDirectory(Heap& heap, BlockDirectory* directory)
+void AlignedMemoryAllocator::registerDirectory(JSC::Heap& heap, BlockDirectory* directory)
 {
     RELEASE_ASSERT(!directory->nextDirectoryInAlignedMemoryAllocator());
     

--- a/Source/JavaScriptCore/heap/AllocatingScope.h
+++ b/Source/JavaScriptCore/heap/AllocatingScope.h
@@ -31,7 +31,7 @@ namespace JSC {
 
 class AllocatingScope {
 public:
-    AllocatingScope(Heap& heap)
+    AllocatingScope(JSC::Heap& heap)
         : m_heap(heap)
     {
         RELEASE_ASSERT(m_heap.m_mutatorState == MutatorState::Running);
@@ -45,7 +45,7 @@ public:
     }
 
 private:
-    Heap& m_heap;
+    JSC::Heap& m_heap;
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/heap/AllocatorInlines.h
+++ b/Source/JavaScriptCore/heap/AllocatorInlines.h
@@ -30,7 +30,7 @@
 
 namespace JSC {
 
-ALWAYS_INLINE void* Allocator::allocate(Heap& heap, size_t cellSize, GCDeferralContext* context, AllocationFailureMode mode) const
+ALWAYS_INLINE void* Allocator::allocate(JSC::Heap& heap, size_t cellSize, GCDeferralContext* context, AllocationFailureMode mode) const
 {
     return m_localAllocator->allocate(heap, cellSize, context, mode);
 }

--- a/Source/JavaScriptCore/heap/BlockDirectory.cpp
+++ b/Source/JavaScriptCore/heap/BlockDirectory.cpp
@@ -110,7 +110,7 @@ MarkedBlock::Handle* BlockDirectory::findBlockForAllocation(LocalAllocator& allo
     }
 }
 
-MarkedBlock::Handle* BlockDirectory::tryAllocateBlock(Heap& heap)
+MarkedBlock::Handle* BlockDirectory::tryAllocateBlock(JSC::Heap& heap)
 {
     SuperSamplerScope superSamplerScope(false);
     

--- a/Source/JavaScriptCore/heap/CellContainer.h
+++ b/Source/JavaScriptCore/heap/CellContainer.h
@@ -59,7 +59,7 @@ public:
     }
     
     VM& vm() const;
-    Heap* heap() const;
+    JSC::Heap* heap() const;
     
     explicit operator bool() const { return !!m_encodedPointer; }
     

--- a/Source/JavaScriptCore/heap/CellContainerInlines.h
+++ b/Source/JavaScriptCore/heap/CellContainerInlines.h
@@ -40,7 +40,7 @@ inline VM& CellContainer::vm() const
     return markedBlock().vm();
 }
 
-inline Heap* CellContainer::heap() const
+inline JSC::Heap* CellContainer::heap() const
 {
     return &vm().heap;
 }

--- a/Source/JavaScriptCore/heap/CollectingScope.h
+++ b/Source/JavaScriptCore/heap/CollectingScope.h
@@ -31,7 +31,7 @@ namespace JSC {
 
 class CollectingScope {
 public:
-    CollectingScope(Heap& heap)
+    CollectingScope(JSC::Heap& heap)
         : m_heap(heap)
         , m_oldState(m_heap.m_mutatorState)
     {
@@ -44,7 +44,7 @@ public:
     }
 
 private:
-    Heap& m_heap;
+    JSC::Heap& m_heap;
     MutatorState m_oldState;
 };
 

--- a/Source/JavaScriptCore/heap/CompleteSubspace.cpp
+++ b/Source/JavaScriptCore/heap/CompleteSubspace.cpp
@@ -35,7 +35,7 @@
 
 namespace JSC {
 
-CompleteSubspace::CompleteSubspace(CString name, Heap& heap, const HeapCellType& heapCellType, AlignedMemoryAllocator* alignedMemoryAllocator)
+CompleteSubspace::CompleteSubspace(CString name, JSC::Heap& heap, const HeapCellType& heapCellType, AlignedMemoryAllocator* alignedMemoryAllocator)
     : Subspace(name, heap)
 {
     initialize(heapCellType, alignedMemoryAllocator);

--- a/Source/JavaScriptCore/heap/ConservativeRoots.cpp
+++ b/Source/JavaScriptCore/heap/ConservativeRoots.cpp
@@ -37,7 +37,7 @@
 
 namespace JSC {
 
-ConservativeRoots::ConservativeRoots(Heap& heap)
+ConservativeRoots::ConservativeRoots(JSC::Heap& heap)
     : m_roots(m_inlineRoots)
     , m_size(0)
     , m_capacity(inlineCapacity)

--- a/Source/JavaScriptCore/heap/ConservativeRoots.h
+++ b/Source/JavaScriptCore/heap/ConservativeRoots.h
@@ -58,7 +58,7 @@ private:
     HeapCell** m_roots;
     size_t m_size;
     size_t m_capacity;
-    Heap& m_heap;
+    JSC::Heap& m_heap;
     HeapCell* m_inlineRoots[inlineCapacity];
 };
 

--- a/Source/JavaScriptCore/heap/DeferGC.h
+++ b/Source/JavaScriptCore/heap/DeferGC.h
@@ -53,7 +53,7 @@ public:
     ~DeferGCForAWhile();
 
 private:
-    Heap& m_heap;
+    JSC::Heap& m_heap;
 };
 
 class DisallowGC : public DisallowScope<DisallowGC> {

--- a/Source/JavaScriptCore/heap/EdenGCActivityCallback.cpp
+++ b/Source/JavaScriptCore/heap/EdenGCActivityCallback.cpp
@@ -30,7 +30,7 @@
 
 namespace JSC {
 
-EdenGCActivityCallback::EdenGCActivityCallback(Heap& heap, Synchronousness synchronousness)
+EdenGCActivityCallback::EdenGCActivityCallback(JSC::Heap& heap, Synchronousness synchronousness)
     : GCActivityCallback(heap, synchronousness)
 {
 }
@@ -43,12 +43,12 @@ void EdenGCActivityCallback::doCollection(VM& vm)
     vm.heap.collect(m_synchronousness, CollectionScope::Eden);
 }
 
-Seconds EdenGCActivityCallback::lastGCLength(Heap& heap)
+Seconds EdenGCActivityCallback::lastGCLength(JSC::Heap& heap)
 {
     return heap.lastEdenGCLength();
 }
 
-double EdenGCActivityCallback::deathRate(Heap& heap)
+double EdenGCActivityCallback::deathRate(JSC::Heap& heap)
 {
     size_t sizeBefore = heap.sizeBeforeLastEdenCollection();
     size_t sizeAfter = heap.sizeAfterLastEdenCollection();

--- a/Source/JavaScriptCore/heap/EdenGCActivityCallback.h
+++ b/Source/JavaScriptCore/heap/EdenGCActivityCallback.h
@@ -31,7 +31,7 @@ namespace JSC {
 
 class EdenGCActivityCallback : public GCActivityCallback {
 public:
-    static RefPtr<EdenGCActivityCallback> tryCreate(Heap& heap, Synchronousness synchronousness = Synchronousness::Async)
+    static RefPtr<EdenGCActivityCallback> tryCreate(JSC::Heap& heap, Synchronousness synchronousness = Synchronousness::Async)
     {
         return s_shouldCreateGCTimer ? adoptRef(new EdenGCActivityCallback(heap, synchronousness)) : nullptr;
     }

--- a/Source/JavaScriptCore/heap/FullGCActivityCallback.cpp
+++ b/Source/JavaScriptCore/heap/FullGCActivityCallback.cpp
@@ -31,7 +31,7 @@
 
 namespace JSC {
 
-FullGCActivityCallback::FullGCActivityCallback(Heap& heap, Synchronousness synchronousness)
+FullGCActivityCallback::FullGCActivityCallback(JSC::Heap& heap, Synchronousness synchronousness)
     : GCActivityCallback(heap, synchronousness)
 {
 }
@@ -40,7 +40,7 @@ FullGCActivityCallback::~FullGCActivityCallback() = default;
 
 void FullGCActivityCallback::doCollection(VM& vm)
 {
-    Heap& heap = vm.heap;
+    JSC::Heap& heap = vm.heap;
     setDidGCRecently(false);
 
 #if !PLATFORM(IOS_FAMILY) || PLATFORM(MACCATALYST)
@@ -55,12 +55,12 @@ void FullGCActivityCallback::doCollection(VM& vm)
     heap.collect(m_synchronousness, CollectionScope::Full);
 }
 
-Seconds FullGCActivityCallback::lastGCLength(Heap& heap)
+Seconds FullGCActivityCallback::lastGCLength(JSC::Heap& heap)
 {
     return heap.lastFullGCLength();
 }
 
-double FullGCActivityCallback::deathRate(Heap& heap)
+double FullGCActivityCallback::deathRate(JSC::Heap& heap)
 {
     size_t sizeBefore = heap.sizeBeforeLastFullCollection();
     size_t sizeAfter = heap.sizeAfterLastFullCollection();

--- a/Source/JavaScriptCore/heap/FullGCActivityCallback.h
+++ b/Source/JavaScriptCore/heap/FullGCActivityCallback.h
@@ -31,7 +31,7 @@ namespace JSC {
 
 class FullGCActivityCallback : public GCActivityCallback {
 public:
-    static RefPtr<FullGCActivityCallback> tryCreate(Heap& heap, Synchronousness synchronousness = Synchronousness::Async)
+    static RefPtr<FullGCActivityCallback> tryCreate(JSC::Heap& heap, Synchronousness synchronousness = Synchronousness::Async)
     {
         return s_shouldCreateGCTimer ? adoptRef(new FullGCActivityCallback(heap, synchronousness)) : nullptr;
     }

--- a/Source/JavaScriptCore/heap/GCActivityCallback.cpp
+++ b/Source/JavaScriptCore/heap/GCActivityCallback.cpp
@@ -38,7 +38,7 @@ bool GCActivityCallback::s_shouldCreateGCTimer = true;
 
 const double timerSlop = 2.0; // Fudge factor to avoid performance cost of resetting timer.
 
-GCActivityCallback::GCActivityCallback(Heap& heap, Synchronousness synchronousness)
+GCActivityCallback::GCActivityCallback(JSC::Heap& heap, Synchronousness synchronousness)
     : GCActivityCallback(heap.vm(), synchronousness)
 {
 }
@@ -57,7 +57,7 @@ void GCActivityCallback::doWork(VM& vm)
         return;
     
     ASSERT(vm.currentThreadIsHoldingAPILock());
-    Heap& heap = vm.heap;
+    JSC::Heap& heap = vm.heap;
     if (heap.isDeferred()) {
         scheduleTimer(0_s);
         return;
@@ -77,7 +77,7 @@ void GCActivityCallback::scheduleTimer(Seconds newDelay)
     setTimeUntilFire(newDelay);
 }
 
-void GCActivityCallback::didAllocate(Heap& heap, size_t bytes)
+void GCActivityCallback::didAllocate(JSC::Heap& heap, size_t bytes)
 {
     // The first byte allocated in an allocation cycle will report 0 bytes to didAllocate. 
     // We pretend it's one byte so that we don't ignore this allocation entirely.

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -187,7 +187,7 @@ public:
             m_before = MonotonicTime::now();
     }
     
-    TimingScope(Heap& heap, const char* name)
+    TimingScope(JSC::Heap& heap, const char* name)
         : TimingScope(heap.collectionScope(), name)
     {
     }
@@ -197,7 +197,7 @@ public:
         m_scope = scope;
     }
     
-    void setScope(Heap& heap)
+    void setScope(JSC::Heap& heap)
     {
         setScope(heap.collectionScope());
     }
@@ -222,7 +222,7 @@ private:
 
 class Heap::HeapThread final : public AutomaticThread {
 public:
-    HeapThread(const AbstractLocker& locker, Heap& heap)
+    HeapThread(const AbstractLocker& locker, JSC::Heap& heap)
         : AutomaticThread(locker, heap.m_threadLock, heap.m_threadCondition.copyRef())
         , m_heap(heap)
     {
@@ -264,7 +264,7 @@ private:
         m_heap.m_collectorThreadIsRunning = false;
     }
 
-    Heap& m_heap;
+    JSC::Heap& m_heap;
 };
 
 #define INIT_SERVER_ISO_SUBSPACE(name, heapCellType, type) \
@@ -2986,7 +2986,7 @@ void Heap::addCoreConstraints()
     m_constraintSet->add(
         "O", "Output",
         MAKE_MARKING_CONSTRAINT_EXECUTOR_PAIR(([] (auto& visitor) {
-            Heap* heap = visitor.heap();
+            JSC::Heap* heap = visitor.heap();
 
             // The `visitor2` argument is strangely named because the WinCairo port
             // gets confused  and thinks we're trying to capture the outer visitor

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -290,8 +290,8 @@ class Heap {
 public:
     friend class JIT;
     friend class DFG::SpeculativeJIT;
-    static Heap* heap(const JSValue); // 0 for immediate values
-    static Heap* heap(const HeapCell*);
+    static JSC::Heap* heap(const JSValue); // 0 for immediate values
+    static JSC::Heap* heap(const HeapCell*);
 
     // This constant determines how many blocks we iterate between checks of our 
     // deadline when calling Heap::isPagedOut. Decreasing it will cause us to detect 

--- a/Source/JavaScriptCore/heap/HeapCell.h
+++ b/Source/JavaScriptCore/heap/HeapCell.h
@@ -73,7 +73,7 @@ public:
     // We currently only use this hack for callees to make CallFrame::vm() fast. It's not
     // recommended to use it for too many other things, since the large allocation cutoff is
     // a runtime option and its default value is small (400 bytes).
-    Heap* heap() const;
+    JSC::Heap* heap() const;
     VM& vm() const;
     
     size_t cellSize() const;

--- a/Source/JavaScriptCore/heap/HeapCellInlines.h
+++ b/Source/JavaScriptCore/heap/HeapCellInlines.h
@@ -54,7 +54,7 @@ ALWAYS_INLINE PreciseAllocation& HeapCell::preciseAllocation() const
     return *PreciseAllocation::fromCell(const_cast<HeapCell*>(this));
 }
 
-ALWAYS_INLINE Heap* HeapCell::heap() const
+ALWAYS_INLINE JSC::Heap* HeapCell::heap() const
 {
     return &vm().heap;
 }

--- a/Source/JavaScriptCore/heap/HeapInlines.h
+++ b/Source/JavaScriptCore/heap/HeapInlines.h
@@ -42,14 +42,14 @@ ALWAYS_INLINE VM& Heap::vm() const
     return *bitwise_cast<VM*>(bitwise_cast<uintptr_t>(this) - OBJECT_OFFSETOF(VM, heap));
 }
 
-ALWAYS_INLINE Heap* Heap::heap(const HeapCell* cell)
+ALWAYS_INLINE JSC::Heap* Heap::heap(const HeapCell* cell)
 {
     if (!cell)
         return nullptr;
     return cell->heap();
 }
 
-inline Heap* Heap::heap(const JSValue v)
+inline JSC::Heap* Heap::heap(const JSValue v)
 {
     if (!v.isCell())
         return nullptr;

--- a/Source/JavaScriptCore/heap/HeapIterationScope.h
+++ b/Source/JavaScriptCore/heap/HeapIterationScope.h
@@ -37,10 +37,10 @@ public:
     ~HeapIterationScope();
 
 private:
-    Heap& m_heap;
+    JSC::Heap& m_heap;
 };
 
-inline HeapIterationScope::HeapIterationScope(Heap& heap)
+inline HeapIterationScope::HeapIterationScope(JSC::Heap& heap)
     : m_heap(heap)
 {
     m_heap.willStartIterating();

--- a/Source/JavaScriptCore/heap/HeapUtil.h
+++ b/Source/JavaScriptCore/heap/HeapUtil.h
@@ -46,7 +46,7 @@ public:
     // before liveness data is cleared to be accurate.
     template<typename Func>
     static void findGCObjectPointersForMarking(
-        Heap& heap, HeapVersion markingVersion, HeapVersion newlyAllocatedVersion, TinyBloomFilter<uintptr_t> filter,
+        JSC::Heap& heap, HeapVersion markingVersion, HeapVersion newlyAllocatedVersion, TinyBloomFilter<uintptr_t> filter,
         void* passedPointer, const Func& func)
     {
         const HashSet<MarkedBlock*>& set = heap.objectSpace().blocks().set();
@@ -134,7 +134,7 @@ public:
             tryPointer(alignedPointer - candidate->cellSize());
     }
     
-    static bool isPointerGCObjectJSCell(Heap& heap, TinyBloomFilter<uintptr_t> filter, JSCell* pointer)
+    static bool isPointerGCObjectJSCell(JSC::Heap& heap, TinyBloomFilter<uintptr_t> filter, JSCell* pointer)
     {
         // It could point to a large allocation.
         if (pointer->isPreciseAllocation()) {
@@ -176,7 +176,7 @@ public:
     
     // This does not find the cell if the pointer is pointing at the middle of a JSCell.
     static bool isValueGCObject(
-        Heap& heap, TinyBloomFilter<uintptr_t> filter, JSValue value)
+        JSC::Heap& heap, TinyBloomFilter<uintptr_t> filter, JSValue value)
     {
         ASSERT(heap.objectSpace().preciseAllocationSet());
         if (!value.isCell())

--- a/Source/JavaScriptCore/heap/IncrementalSweeper.cpp
+++ b/Source/JavaScriptCore/heap/IncrementalSweeper.cpp
@@ -53,7 +53,7 @@ void IncrementalSweeper::scheduleTimer()
     setTimeUntilFire(sweepTimeSlice * sweepTimeMultiplier);
 }
 
-IncrementalSweeper::IncrementalSweeper(Heap* heap)
+IncrementalSweeper::IncrementalSweeper(JSC::Heap* heap)
     : Base(heap->vm())
     , m_currentDirectory(nullptr)
 {
@@ -132,7 +132,7 @@ bool IncrementalSweeper::sweepNextBlock(VM& vm, SweepTrigger trigger)
     return vm.heap.sweepNextLogicallyEmptyWeakBlock();
 }
 
-void IncrementalSweeper::startSweeping(Heap& heap)
+void IncrementalSweeper::startSweeping(JSC::Heap& heap)
 {
     scheduleTimer();
     m_currentDirectory = heap.objectSpace().firstDirectory();

--- a/Source/JavaScriptCore/heap/IsoSubspace.cpp
+++ b/Source/JavaScriptCore/heap/IsoSubspace.cpp
@@ -36,7 +36,7 @@ namespace JSC {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(IsoSubspace);
 
-IsoSubspace::IsoSubspace(CString name, Heap& heap, const HeapCellType& heapCellType, size_t size, uint8_t numberOfLowerTierCells, std::unique_ptr<IsoMemoryAllocatorBase>&& allocator)
+IsoSubspace::IsoSubspace(CString name, JSC::Heap& heap, const HeapCellType& heapCellType, size_t size, uint8_t numberOfLowerTierCells, std::unique_ptr<IsoMemoryAllocatorBase>&& allocator)
     : Subspace(name, heap)
     , m_directory(WTF::roundUpToMultipleOf<MarkedBlock::atomSize>(size))
     , m_isoAlignedMemoryAllocator(allocator ? WTFMove(allocator) : makeUnique<IsoAlignedMemoryAllocator>(name))

--- a/Source/JavaScriptCore/heap/IsoSubspacePerVM.cpp
+++ b/Source/JavaScriptCore/heap/IsoSubspacePerVM.cpp
@@ -41,7 +41,7 @@ IsoSubspacePerVM::~IsoSubspacePerVM()
     UNREACHABLE_FOR_PLATFORM();
 }
 
-IsoSubspace& IsoSubspacePerVM::isoSubspaceforHeap(LockHolder&, Heap& heap)
+IsoSubspace& IsoSubspacePerVM::isoSubspaceforHeap(LockHolder&, JSC::Heap& heap)
 {
     auto result = m_subspacePerHeap.add(&heap, nullptr);
     if (result.isNewEntry) {
@@ -68,7 +68,7 @@ GCClient::IsoSubspace& IsoSubspacePerVM::clientIsoSubspaceforVM(VM& vm)
     return *result.iterator->value;
 }
 
-void IsoSubspacePerVM::releaseIsoSubspace(Heap& heap)
+void IsoSubspacePerVM::releaseIsoSubspace(JSC::Heap& heap)
 {
     IsoSubspace* subspace;
     {

--- a/Source/JavaScriptCore/heap/LocalAllocator.cpp
+++ b/Source/JavaScriptCore/heap/LocalAllocator.cpp
@@ -109,7 +109,7 @@ void LocalAllocator::stopAllocatingForGood()
     reset();
 }
 
-void* LocalAllocator::allocateSlowCase(Heap& heap, size_t cellSize, GCDeferralContext* deferralContext, AllocationFailureMode failureMode)
+void* LocalAllocator::allocateSlowCase(JSC::Heap& heap, size_t cellSize, GCDeferralContext* deferralContext, AllocationFailureMode failureMode)
 {
     SuperSamplerScope superSamplerScope(false);
     ASSERT(heap.vm().currentThreadIsHoldingAPILock());
@@ -250,7 +250,7 @@ void* LocalAllocator::tryAllocateIn(MarkedBlock::Handle* block, size_t cellSize)
     return result;
 }
 
-void LocalAllocator::doTestCollectionsIfNeeded(Heap& heap, GCDeferralContext* deferralContext)
+void LocalAllocator::doTestCollectionsIfNeeded(JSC::Heap& heap, GCDeferralContext* deferralContext)
 {
     if (LIKELY(!Options::slowPathAllocsBetweenGCs()))
         return;

--- a/Source/JavaScriptCore/heap/LocalAllocatorInlines.h
+++ b/Source/JavaScriptCore/heap/LocalAllocatorInlines.h
@@ -30,7 +30,7 @@
 
 namespace JSC {
 
-ALWAYS_INLINE void* LocalAllocator::allocate(Heap& heap, size_t cellSize, GCDeferralContext* deferralContext, AllocationFailureMode failureMode)
+ALWAYS_INLINE void* LocalAllocator::allocate(JSC::Heap& heap, size_t cellSize, GCDeferralContext* deferralContext, AllocationFailureMode failureMode)
 {
     VM& vm = heap.vm();
     if constexpr (validateDFGDoesGC)

--- a/Source/JavaScriptCore/heap/MarkStackMergingConstraint.cpp
+++ b/Source/JavaScriptCore/heap/MarkStackMergingConstraint.cpp
@@ -34,7 +34,7 @@ namespace JSC {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(MarkStackMergingConstraint);
 
-MarkStackMergingConstraint::MarkStackMergingConstraint(Heap& heap)
+MarkStackMergingConstraint::MarkStackMergingConstraint(JSC::Heap& heap)
     : MarkingConstraint("Msm", "Mark Stack Merging", ConstraintVolatility::GreyedByExecution)
     , m_heap(heap)
 {

--- a/Source/JavaScriptCore/heap/MarkStackMergingConstraint.h
+++ b/Source/JavaScriptCore/heap/MarkStackMergingConstraint.h
@@ -48,7 +48,7 @@ private:
     void executeImpl(AbstractSlotVisitor&) final;
     void executeImpl(SlotVisitor&) final;
     
-    Heap& m_heap;
+    JSC::Heap& m_heap;
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/heap/MarkedBlock.cpp
+++ b/Source/JavaScriptCore/heap/MarkedBlock.cpp
@@ -44,7 +44,7 @@ static size_t balance;
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(MarkedBlock);
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(MarkedBlockHandle);
 
-MarkedBlock::Handle* MarkedBlock::tryCreate(Heap& heap, AlignedMemoryAllocator* alignedMemoryAllocator)
+MarkedBlock::Handle* MarkedBlock::tryCreate(JSC::Heap& heap, AlignedMemoryAllocator* alignedMemoryAllocator)
 {
     if (computeBalance) {
         balance++;
@@ -59,7 +59,7 @@ MarkedBlock::Handle* MarkedBlock::tryCreate(Heap& heap, AlignedMemoryAllocator* 
     return new Handle(heap, alignedMemoryAllocator, blockSpace);
 }
 
-MarkedBlock::Handle::Handle(Heap& heap, AlignedMemoryAllocator* alignedMemoryAllocator, void* blockSpace)
+MarkedBlock::Handle::Handle(JSC::Heap& heap, AlignedMemoryAllocator* alignedMemoryAllocator, void* blockSpace)
     : m_alignedMemoryAllocator(alignedMemoryAllocator)
     , m_weakSet(heap.vm())
     , m_block(new (NotNull, blockSpace) MarkedBlock(heap.vm(), *this))
@@ -69,7 +69,7 @@ MarkedBlock::Handle::Handle(Heap& heap, AlignedMemoryAllocator* alignedMemoryAll
 
 MarkedBlock::Handle::~Handle()
 {
-    Heap& heap = *this->heap();
+    JSC::Heap& heap = *this->heap();
     if (computeBalance) {
         balance--;
         if (!(balance % 10))

--- a/Source/JavaScriptCore/heap/MarkedBlock.h
+++ b/Source/JavaScriptCore/heap/MarkedBlock.h
@@ -130,7 +130,7 @@ public:
         BlockDirectory* directory() const;
         Subspace* subspace() const;
         AlignedMemoryAllocator* alignedMemoryAllocator() const;
-        Heap* heap() const;
+        JSC::Heap* heap() const;
         inline MarkedSpace* space() const;
         VM& vm() const;
         WeakSet& weakSet();
@@ -336,7 +336,7 @@ public:
     const Handle& handle() const;
         
     VM& vm() const;
-    inline Heap* heap() const;
+    inline JSC::Heap* heap() const;
     inline MarkedSpace* space() const;
 
     static bool isAtomAligned(const void*);
@@ -488,7 +488,7 @@ inline AlignedMemoryAllocator* MarkedBlock::Handle::alignedMemoryAllocator() con
     return m_alignedMemoryAllocator;
 }
 
-inline Heap* MarkedBlock::Handle::heap() const
+inline JSC::Heap* MarkedBlock::Handle::heap() const
 {
     return m_weakSet.heap();
 }

--- a/Source/JavaScriptCore/heap/MarkedBlockInlines.h
+++ b/Source/JavaScriptCore/heap/MarkedBlockInlines.h
@@ -50,7 +50,7 @@ inline bool MarkedBlock::hasAnyNewlyAllocated()
     return !isNewlyAllocatedStale();
 }
 
-inline Heap* MarkedBlock::heap() const
+inline JSC::Heap* MarkedBlock::heap() const
 {
     return &vm().heap;
 }

--- a/Source/JavaScriptCore/heap/MarkedSpace.cpp
+++ b/Source/JavaScriptCore/heap/MarkedSpace.cpp
@@ -177,7 +177,7 @@ void MarkedSpace::initializeSizeClassForStepSize()
         });
 }
 
-MarkedSpace::MarkedSpace(Heap* heap)
+MarkedSpace::MarkedSpace(JSC::Heap* heap)
 {
     ASSERT_UNUSED(heap, heap == &this->heap());
     initializeSizeClassForStepSize();

--- a/Source/JavaScriptCore/heap/MarkedSpace.h
+++ b/Source/JavaScriptCore/heap/MarkedSpace.h
@@ -96,7 +96,7 @@ public:
     MarkedSpace(Heap*);
     ~MarkedSpace();
     
-    Heap& heap() const;
+    JSC::Heap& heap() const;
     
     void lastChanceToFinalize(); // Must call stopAllocatingForGood first.
     void freeMemory();

--- a/Source/JavaScriptCore/heap/MarkedSpaceInlines.h
+++ b/Source/JavaScriptCore/heap/MarkedSpaceInlines.h
@@ -30,7 +30,7 @@
 
 namespace JSC {
 
-ALWAYS_INLINE Heap& MarkedSpace::heap() const
+ALWAYS_INLINE JSC::Heap& MarkedSpace::heap() const
 {
     return *bitwise_cast<Heap*>(bitwise_cast<uintptr_t>(this) - OBJECT_OFFSETOF(Heap, m_objectSpace));
 }

--- a/Source/JavaScriptCore/heap/MarkingConstraintSet.cpp
+++ b/Source/JavaScriptCore/heap/MarkingConstraintSet.cpp
@@ -37,7 +37,7 @@ namespace JSC {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(MarkingConstraintSet);
 
-MarkingConstraintSet::MarkingConstraintSet(Heap& heap)
+MarkingConstraintSet::MarkingConstraintSet(JSC::Heap& heap)
     : m_heap(heap)
 {
 }

--- a/Source/JavaScriptCore/heap/MarkingConstraintSet.h
+++ b/Source/JavaScriptCore/heap/MarkingConstraintSet.h
@@ -87,7 +87,7 @@ private:
 
     bool executeConvergenceImpl(SlotVisitor&);
     
-    Heap& m_heap;
+    JSC::Heap& m_heap;
     BitVector m_unexecutedRoots;
     BitVector m_unexecutedOutgrowths;
     Vector<std::unique_ptr<MarkingConstraint>> m_set;

--- a/Source/JavaScriptCore/heap/MarkingConstraintSolver.h
+++ b/Source/JavaScriptCore/heap/MarkingConstraintSolver.h
@@ -85,7 +85,7 @@ private:
         MarkingConstraint* constraint { nullptr };
     };
     
-    Heap& m_heap;
+    JSC::Heap& m_heap;
     SlotVisitor& m_mainVisitor;
     MarkingConstraintSet& m_set;
     BitVector m_executed;

--- a/Source/JavaScriptCore/heap/PreciseAllocation.cpp
+++ b/Source/JavaScriptCore/heap/PreciseAllocation.cpp
@@ -40,7 +40,7 @@ static inline bool isAlignedForPreciseAllocation(void* memory)
     return !(allocatedPointer & (PreciseAllocation::alignment - 1));
 }
 
-PreciseAllocation* PreciseAllocation::tryCreate(Heap& heap, size_t size, Subspace* subspace, unsigned indexInSpace)
+PreciseAllocation* PreciseAllocation::tryCreate(JSC::Heap& heap, size_t size, Subspace* subspace, unsigned indexInSpace)
 {
     if constexpr (validateDFGDoesGC)
         heap.vm().verifyCanGC();
@@ -120,7 +120,7 @@ PreciseAllocation* PreciseAllocation::tryReallocate(size_t size, Subspace* subsp
 }
 
 
-PreciseAllocation* PreciseAllocation::tryCreateForLowerTier(Heap& heap, size_t size, Subspace* subspace, uint8_t lowerTierIndex)
+PreciseAllocation* PreciseAllocation::tryCreateForLowerTier(JSC::Heap& heap, size_t size, Subspace* subspace, uint8_t lowerTierIndex)
 {
     if constexpr (validateDFGDoesGC)
         heap.vm().verifyCanGC();
@@ -147,7 +147,7 @@ PreciseAllocation* PreciseAllocation::tryCreateForLowerTier(Heap& heap, size_t s
 
 PreciseAllocation* PreciseAllocation::reuseForLowerTier()
 {
-    Heap& heap = *this->heap();
+    JSC::Heap& heap = *this->heap();
     size_t size = m_cellSize;
     Subspace* subspace = m_subspace;
     bool adjustedAlignment = m_adjustedAlignment;
@@ -167,7 +167,7 @@ PreciseAllocation* PreciseAllocation::reuseForLowerTier()
     return preciseAllocation;
 }
 
-PreciseAllocation::PreciseAllocation(Heap& heap, size_t size, Subspace* subspace, unsigned indexInSpace, bool adjustedAlignment)
+PreciseAllocation::PreciseAllocation(JSC::Heap& heap, size_t size, Subspace* subspace, unsigned indexInSpace, bool adjustedAlignment)
     : m_indexInSpace(indexInSpace)
     , m_cellSize(size)
     , m_isNewlyAllocated(true)

--- a/Source/JavaScriptCore/heap/PreciseAllocation.h
+++ b/Source/JavaScriptCore/heap/PreciseAllocation.h
@@ -71,7 +71,7 @@ public:
     
     void lastChanceToFinalize();
     
-    Heap* heap() const { return m_weakSet.heap(); }
+    JSC::Heap* heap() const { return m_weakSet.heap(); }
     VM& vm() const { return m_weakSet.vm(); }
     WeakSet& weakSet() { return m_weakSet; }
 

--- a/Source/JavaScriptCore/heap/PreventCollectionScope.h
+++ b/Source/JavaScriptCore/heap/PreventCollectionScope.h
@@ -31,7 +31,7 @@ namespace JSC {
 
 class PreventCollectionScope {
 public:
-    PreventCollectionScope(Heap& heap)
+    PreventCollectionScope(JSC::Heap& heap)
         : m_heap(heap)
     {
         m_heap.preventCollection();
@@ -43,7 +43,7 @@ public:
     }
 
 private:
-    Heap& m_heap;
+    JSC::Heap& m_heap;
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/heap/ReleaseHeapAccessScope.h
+++ b/Source/JavaScriptCore/heap/ReleaseHeapAccessScope.h
@@ -39,7 +39,7 @@ namespace JSC {
 // you are waiting.
 class ReleaseHeapAccessScope {
 public:
-    ReleaseHeapAccessScope(Heap& heap)
+    ReleaseHeapAccessScope(JSC::Heap& heap)
         : m_heap(heap)
     {
         m_heap.releaseAccess();
@@ -51,12 +51,12 @@ public:
     }
 
 private:
-    Heap& m_heap;
+    JSC::Heap& m_heap;
 };
 
 class ReleaseHeapAccessIfNeededScope {
 public:
-    ReleaseHeapAccessIfNeededScope(Heap& heap)
+    ReleaseHeapAccessIfNeededScope(JSC::Heap& heap)
         : m_heap(heap)
     {
         hadHeapAccess = m_heap.hasAccess();
@@ -71,7 +71,7 @@ public:
     }
 
 private:
-    Heap& m_heap;
+    JSC::Heap& m_heap;
     bool hadHeapAccess { false };
 };
 

--- a/Source/JavaScriptCore/heap/RunningScope.h
+++ b/Source/JavaScriptCore/heap/RunningScope.h
@@ -31,7 +31,7 @@ namespace JSC {
 
 class RunningScope {
 public:
-    RunningScope(Heap& heap)
+    RunningScope(JSC::Heap& heap)
         : m_heap(heap)
         , m_oldState(m_heap.m_mutatorState)
     {
@@ -44,7 +44,7 @@ public:
     }
 
 private:
-    Heap& m_heap;
+    JSC::Heap& m_heap;
     MutatorState m_oldState;
 };
 

--- a/Source/JavaScriptCore/heap/SlotVisitor.cpp
+++ b/Source/JavaScriptCore/heap/SlotVisitor.cpp
@@ -78,7 +78,7 @@ static void validate(JSCell* cell)
 }
 #endif
 
-SlotVisitor::SlotVisitor(Heap& heap, CString codeName)
+SlotVisitor::SlotVisitor(JSC::Heap& heap, CString codeName)
     : Base(heap, codeName, heap.m_opaqueRoots)
     , m_markingVersion(MarkedSpace::initialVersion)
 #if ASSERT_ENABLED

--- a/Source/JavaScriptCore/heap/SpaceTimeMutatorScheduler.cpp
+++ b/Source/JavaScriptCore/heap/SpaceTimeMutatorScheduler.cpp
@@ -55,7 +55,7 @@ private:
     double m_bytesAllocatedThisCycle;
 };
 
-SpaceTimeMutatorScheduler::SpaceTimeMutatorScheduler(Heap& heap)
+SpaceTimeMutatorScheduler::SpaceTimeMutatorScheduler(JSC::Heap& heap)
     : m_heap(heap)
     , m_period(Seconds::fromMilliseconds(Options::concurrentGCPeriodMS()))
 {

--- a/Source/JavaScriptCore/heap/SpaceTimeMutatorScheduler.h
+++ b/Source/JavaScriptCore/heap/SpaceTimeMutatorScheduler.h
@@ -76,7 +76,7 @@ private:
     double phase(const Snapshot&);
     bool shouldBeResumed(const Snapshot&);
     
-    Heap& m_heap;
+    JSC::Heap& m_heap;
     Seconds m_period;
     State m_state { Normal };
     

--- a/Source/JavaScriptCore/heap/StochasticSpaceTimeMutatorScheduler.cpp
+++ b/Source/JavaScriptCore/heap/StochasticSpaceTimeMutatorScheduler.cpp
@@ -54,7 +54,7 @@ private:
     double m_bytesAllocatedThisCycle;
 };
 
-StochasticSpaceTimeMutatorScheduler::StochasticSpaceTimeMutatorScheduler(Heap& heap)
+StochasticSpaceTimeMutatorScheduler::StochasticSpaceTimeMutatorScheduler(JSC::Heap& heap)
     : m_heap(heap)
     , m_minimumPause(Seconds::fromMilliseconds(Options::minimumGCPauseMS()))
     , m_pauseScale(Options::gcPauseScale())

--- a/Source/JavaScriptCore/heap/StochasticSpaceTimeMutatorScheduler.h
+++ b/Source/JavaScriptCore/heap/StochasticSpaceTimeMutatorScheduler.h
@@ -74,7 +74,7 @@ private:
     double headroomFullness(const Snapshot&);
     double mutatorUtilization(const Snapshot&);
     
-    Heap& m_heap;
+    JSC::Heap& m_heap;
     State m_state { Normal };
     
     WeakRandom m_random;

--- a/Source/JavaScriptCore/heap/Subspace.cpp
+++ b/Source/JavaScriptCore/heap/Subspace.cpp
@@ -37,7 +37,7 @@ namespace JSC {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(Subspace);
 
-Subspace::Subspace(CString name, Heap& heap)
+Subspace::Subspace(CString name, JSC::Heap& heap)
     : m_space(heap.objectSpace())
     , m_name(name)
 {
@@ -49,7 +49,7 @@ void Subspace::initialize(const HeapCellType& heapCellType, AlignedMemoryAllocat
     m_alignedMemoryAllocator = alignedMemoryAllocator;
     m_directoryForEmptyAllocation = m_alignedMemoryAllocator->firstDirectory();
 
-    Heap& heap = m_space.heap();
+    JSC::Heap& heap = m_space.heap();
     heap.objectSpace().m_subspaces.append(this);
     m_alignedMemoryAllocator->registerSubspace(this);
 }

--- a/Source/JavaScriptCore/heap/SweepingScope.h
+++ b/Source/JavaScriptCore/heap/SweepingScope.h
@@ -31,7 +31,7 @@ namespace JSC {
 
 class SweepingScope {
 public:
-    SweepingScope(Heap& heap)
+    SweepingScope(JSC::Heap& heap)
         : m_heap(heap)
         , m_oldState(m_heap.m_mutatorState)
     {
@@ -44,7 +44,7 @@ public:
     }
 
 private:
-    Heap& m_heap;
+    JSC::Heap& m_heap;
     MutatorState m_oldState;
 };
 

--- a/Source/JavaScriptCore/heap/VerifierSlotVisitor.cpp
+++ b/Source/JavaScriptCore/heap/VerifierSlotVisitor.cpp
@@ -102,7 +102,7 @@ void VerifierSlotVisitor::OpaqueRootData::addMarkerData(MarkerData&& marker)
     m_marker = WTFMove(marker);
 }
 
-VerifierSlotVisitor::VerifierSlotVisitor(Heap& heap)
+VerifierSlotVisitor::VerifierSlotVisitor(JSC::Heap& heap)
     : Base(heap, "Verifier", m_opaqueRootStorage)
 {
     m_needsExtraOpaqueRootHandling = true;

--- a/Source/JavaScriptCore/heap/WeakBlock.cpp
+++ b/Source/JavaScriptCore/heap/WeakBlock.cpp
@@ -36,14 +36,14 @@ namespace JSC {
 
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(WeakBlock);
 
-WeakBlock* WeakBlock::create(Heap& heap, CellContainer container)
+WeakBlock* WeakBlock::create(JSC::Heap& heap, CellContainer container)
 {
     heap.didAllocateBlock(WeakBlock::blockSize);
     return new (NotNull, WeakBlockMalloc::malloc(blockSize)) WeakBlock(container);
 
 }
 
-void WeakBlock::destroy(Heap& heap, WeakBlock* block)
+void WeakBlock::destroy(JSC::Heap& heap, WeakBlock* block)
 {
     block->~WeakBlock();
     WeakBlockMalloc::free(block);

--- a/Source/JavaScriptCore/heap/WeakSet.cpp
+++ b/Source/JavaScriptCore/heap/WeakSet.cpp
@@ -36,7 +36,7 @@ WeakSet::~WeakSet()
     if (isOnList())
         remove();
     
-    Heap& heap = *this->heap();
+    JSC::Heap& heap = *this->heap();
     WeakBlock* next = nullptr;
     for (WeakBlock* block = m_blocks.head(); block; block = next) {
         next = block->next();

--- a/Source/JavaScriptCore/heap/WeakSet.h
+++ b/Source/JavaScriptCore/heap/WeakSet.h
@@ -50,7 +50,7 @@ public:
     ~WeakSet();
     void lastChanceToFinalize();
     
-    Heap* heap() const;
+    JSC::Heap* heap() const;
     VM& vm() const;
 
     bool isEmpty() const;

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -97,7 +97,7 @@ JSValue eval(CallFrame* callFrame, JSValue thisValue, JSScope* callerScopeChain,
     CodeBlock* callerBaselineCodeBlock = callerCodeBlock;
     BytecodeIndex bytecodeIndex = callerCallSiteIndex.bytecodeIndex();
 #if ENABLE(DFG_JIT)
-    if (JITCode::isOptimizingJIT(callerCodeBlock->jitType())) {
+    if (JSC::JITCode::isOptimizingJIT(callerCodeBlock->jitType())) {
         CodeOrigin codeOrigin = callerCodeBlock->codeOrigin(callerCallSiteIndex);
         callerBaselineCodeBlock = baselineCodeBlockForOriginAndBaselineCodeBlock(codeOrigin, callerCodeBlock->baselineAlternative());
         bytecodeIndex = codeOrigin.bytecodeIndex();
@@ -511,7 +511,7 @@ ALWAYS_INLINE static HandlerInfo* findExceptionHandler(StackVisitor& visitor, Co
 
     CallFrame* callFrame = visitor->callFrame();
     unsigned exceptionHandlerIndex;
-    if (JITCode::isOptimizingJIT(codeBlock->jitType()))
+    if (JSC::JITCode::isOptimizingJIT(codeBlock->jitType()))
         exceptionHandlerIndex = callFrame->callSiteIndex().bits();
     else
         exceptionHandlerIndex = callFrame->bytecodeIndex().offset();
@@ -562,7 +562,7 @@ CatchInfo::CatchInfo(const HandlerInfo* handler, CodeBlock* codeBlock)
         // with this bytecode offset in the machine frame is utterly meaningless
         // and can cause an overflow. OSR exit properly exits to handler->target
         // in the proper frame.
-        if (!JITCode::isOptimizingJIT(codeBlock->jitType()))
+        if (!JSC::JITCode::isOptimizingJIT(codeBlock->jitType()))
             m_catchPCForInterpreter = { codeBlock->instructions().at(handler->target).ptr() };
         else
             m_catchPCForInterpreter = { static_cast<JSInstruction*>(nullptr) };
@@ -1056,7 +1056,7 @@ failedJSONP:
     if (scope->structure()->isUncacheableDictionary())
         scope->flattenDictionaryObject(vm);
 
-    RefPtr<JITCode> jitCode;
+    RefPtr<JSC::JITCode> jitCode;
     ProtoCallFrame protoCallFrame;
     {
         DeferTraps deferTraps(vm); // We can't jettison this code if we're about to run it.
@@ -1151,7 +1151,7 @@ ALWAYS_INLINE JSValue Interpreter::executeCallImpl(VM& vm, JSObject* function, c
             return scope.exception();
     }
 
-    RefPtr<JITCode> jitCode;
+    RefPtr<JSC::JITCode> jitCode;
     ProtoCallFrame protoCallFrame;
     {
         DeferTraps deferTraps(vm); // We can't jettison this code if we're about to run it.
@@ -1244,7 +1244,7 @@ JSObject* Interpreter::executeConstruct(JSObject* constructor, const CallData& c
             return nullptr;
     }
 
-    RefPtr<JITCode> jitCode;
+    RefPtr<JSC::JITCode> jitCode;
     ProtoCallFrame protoCallFrame;
     {
         DeferTraps deferTraps(vm); // We can't jettison this code if we're about to run it.
@@ -1463,7 +1463,7 @@ JSValue Interpreter::executeEval(EvalExecutable* eval, JSValue thisValue, JSScop
     else
         callee = JSCallee::create(vm, globalObject, scope);
 
-    RefPtr<JITCode> jitCode;
+    RefPtr<JSC::JITCode> jitCode;
     ProtoCallFrame protoCallFrame;
     {
         DeferTraps deferTraps(vm); // We can't jettison this code if we're about to run it.
@@ -1522,7 +1522,7 @@ JSValue Interpreter::executeModuleProgram(JSModuleRecord* record, ModuleProgramE
 
     const unsigned numberOfArguments = static_cast<unsigned>(AbstractModuleRecord::Argument::NumberOfArguments);
     JSCallee* callee = JSCallee::create(vm, globalObject, scope);
-    RefPtr<JITCode> jitCode;
+    RefPtr<JSC::JITCode> jitCode;
 
     ProtoCallFrame protoCallFrame;
     EncodedJSValue args[numberOfArguments] = {

--- a/Source/JavaScriptCore/interpreter/Interpreter.h
+++ b/Source/JavaScriptCore/interpreter/Interpreter.h
@@ -136,9 +136,9 @@ using JSOrWasmInstruction = std::variant<const JSInstruction*, const WasmInstruc
         const CLoopStack& cloopStack() const { return m_cloopStack; }
 #endif
         
-        static inline Opcode getOpcode(OpcodeID);
+        static inline JSC::Opcode getOpcode(OpcodeID);
 
-        static inline OpcodeID getOpcodeID(Opcode);
+        static inline OpcodeID getOpcodeID(JSC::Opcode);
 
 #if ASSERT_ENABLED
         static bool isOpcode(Opcode);

--- a/Source/JavaScriptCore/interpreter/InterpreterInlines.h
+++ b/Source/JavaScriptCore/interpreter/InterpreterInlines.h
@@ -63,7 +63,7 @@ inline CallFrame* calleeFrameForVarargs(CallFrame* callFrame, unsigned numUsedSt
     return CallFrame::create(callFrame->registers() - paddedCalleeFrameOffset);
 }
 
-inline Opcode Interpreter::getOpcode(OpcodeID id)
+inline JSC::Opcode Interpreter::getOpcode(OpcodeID id)
 {
     return LLInt::getOpcode(id);
 }
@@ -71,7 +71,7 @@ inline Opcode Interpreter::getOpcode(OpcodeID id)
 // This function is only available as a debugging tool for development work.
 // It is not currently used except in a RELEASE_ASSERT to ensure that it is
 // working properly.
-inline OpcodeID Interpreter::getOpcodeID(Opcode opcode)
+inline OpcodeID Interpreter::getOpcodeID(JSC::Opcode opcode)
 {
 #if ENABLE(COMPUTED_GOTO_OPCODES)
     ASSERT(isOpcode(opcode));

--- a/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.cpp
+++ b/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.cpp
@@ -190,7 +190,7 @@ Ref<PolymorphicAccessJITStubRoutine> createICJITStubRoutine(
     }
     
     if (codeBlockForExceptionHandlers) {
-        RELEASE_ASSERT(JITCode::isOptimizingJIT(codeBlockForExceptionHandlers->jitType()));
+        RELEASE_ASSERT(JSC::JITCode::isOptimizingJIT(codeBlockForExceptionHandlers->jitType()));
         auto stub = adoptRef(*new GCAwareJITStubRoutineWithExceptionHandler(code, vm, WTFMove(cases), WTFMove(weakStructures), owner, cells, WTFMove(callLinkInfos), codeBlockForExceptionHandlers, exceptionHandlerCallSiteIndex));
         stub->makeGCAware(vm);
         return stub;

--- a/Source/JavaScriptCore/jit/JITCode.h
+++ b/Source/JavaScriptCore/jit/JITCode.h
@@ -139,7 +139,7 @@ public:
 #endif
 
 
-class JITCode : public ThreadSafeRefCounted<JITCode> {
+class JITCode : public ThreadSafeRefCounted<JSC::JITCode> {
 public:
     template<PtrTag tag> using CodeRef = MacroAssemblerCodeRef<tag>;
 
@@ -301,7 +301,7 @@ public:
 
     const RegisterAtOffsetList* calleeSaveRegisters() const;
 
-    static ptrdiff_t offsetOfJITType() { return OBJECT_OFFSETOF(JITCode, m_jitType); }
+    static ptrdiff_t offsetOfJITType() { return OBJECT_OFFSETOF(JSC::JITCode, m_jitType); }
 
 private:
     const JITType m_jitType;
@@ -311,7 +311,7 @@ protected:
     CodePtr<JSEntryPtrTag> m_addressForCall;
 };
 
-class JITCodeWithCodeRef : public JITCode {
+class JITCodeWithCodeRef : public JSC::JITCode {
 protected:
     JITCodeWithCodeRef(JITType);
     JITCodeWithCodeRef(CodeRef<JSEntryPtrTag>, JITType, JITCode::ShareAttribute);

--- a/Source/JavaScriptCore/jit/JITInlineCacheGenerator.h
+++ b/Source/JavaScriptCore/jit/JITInlineCacheGenerator.h
@@ -83,7 +83,7 @@ public:
     void generateDFGDataICFastPath(DFG::JITCompiler&, StructureStubInfoIndex, GPRReg stubInfoGPR);
 #endif
 
-    UnlinkedStructureStubInfo* m_unlinkedStubInfo { nullptr };
+    JSC::UnlinkedStructureStubInfo* m_unlinkedStubInfo { nullptr };
 
     template<typename StubInfo>
     static void setUpStubInfoImpl(StubInfo& stubInfo, AccessType accessType, CodeOrigin codeOrigin, CallSiteIndex callSiteIndex, const RegisterSetBuilder& usedRegisters)

--- a/Source/JavaScriptCore/jit/JITMathIC.h
+++ b/Source/JavaScriptCore/jit/JITMathIC.h
@@ -140,7 +140,7 @@ public:
 #endif
         };
 
-        bool shouldEmitProfiling = !JITCode::isOptimizingJIT(codeBlock->jitType());
+        bool shouldEmitProfiling = !JSC::JITCode::isOptimizingJIT(codeBlock->jitType());
 
         if (m_generateFastPathOnRepatch) {
 

--- a/Source/JavaScriptCore/jit/JITOperations.cpp
+++ b/Source/JavaScriptCore/jit/JITOperations.cpp
@@ -2530,7 +2530,7 @@ JSC_DEFINE_JIT_OPERATION(operationOptimize, UGPRPair, (VM* vmPointer, uint32_t b
     }
     
     CodeBlock* optimizedCodeBlock = codeBlock->replacement();
-    ASSERT(optimizedCodeBlock && JITCode::isOptimizingJIT(optimizedCodeBlock->jitType()));
+    ASSERT(optimizedCodeBlock && JSC::JITCode::isOptimizingJIT(optimizedCodeBlock->jitType()));
     
     if (void* dataBuffer = DFG::prepareOSREntry(vm, callFrame, optimizedCodeBlock, bytecodeIndex)) {
         CODEBLOCK_LOG_EVENT(optimizedCodeBlock, "osrEntry", ("at bc#", bytecodeIndex));

--- a/Source/JavaScriptCore/jit/JITThunks.cpp
+++ b/Source/JavaScriptCore/jit/JITThunks.cpp
@@ -260,7 +260,7 @@ NativeExecutable* JITThunks::hostFunctionStub(VM& vm, TaggedNativeFunction funct
         }
     }
 
-    RefPtr<JITCode> forCall;
+    RefPtr<JSC::JITCode> forCall;
     if (generator) {
         MacroAssemblerCodeRef<JSEntryPtrTag> entry = generator(vm).retagged<JSEntryPtrTag>();
         forCall = adoptRef(new DirectJITCode(entry, entry.code(), JITType::HostCallThunk, intrinsic));
@@ -269,7 +269,7 @@ NativeExecutable* JITThunks::hostFunctionStub(VM& vm, TaggedNativeFunction funct
     else
         forCall = adoptRef(new NativeJITCode(MacroAssemblerCodeRef<JSEntryPtrTag>::createSelfManagedCodeRef(ctiNativeCall(vm).retagged<JSEntryPtrTag>()), JITType::HostCallThunk, intrinsic));
     
-    Ref<JITCode> forConstruct = adoptRef(*new NativeJITCode(MacroAssemblerCodeRef<JSEntryPtrTag>::createSelfManagedCodeRef(ctiNativeConstruct(vm).retagged<JSEntryPtrTag>()), JITType::HostCallThunk, NoIntrinsic));
+    Ref<JSC::JITCode> forConstruct = adoptRef(*new NativeJITCode(MacroAssemblerCodeRef<JSEntryPtrTag>::createSelfManagedCodeRef(ctiNativeConstruct(vm).retagged<JSEntryPtrTag>()), JITType::HostCallThunk, NoIntrinsic));
     
     NativeExecutable* nativeExecutable = NativeExecutable::create(vm, forCall.releaseNonNull(), function, WTFMove(forConstruct), constructor, implementationVisibility, name);
     {

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -3986,7 +3986,7 @@ void CommandLine::parseArguments(int argc, char** argv)
             continue;
         }
         if (!strcmp(arg, "--disableOptionsFreezingForTesting")) {
-            Config::disableFreezingForTesting();
+            JSC::Config::disableFreezingForTesting();
             continue;
         }
 
@@ -4232,7 +4232,7 @@ extern const JITOperationAnnotation endOfJITOperationsInShell __asm("section$end
 int jscmain(int argc, char** argv)
 {
     // Need to override and enable restricted options before we start parsing options below.
-    Config::enableRestrictedOptions();
+    JSC::Config::enableRestrictedOptions();
 
     WTF::initializeMainThread();
 

--- a/Source/JavaScriptCore/llint/LLIntData.h
+++ b/Source/JavaScriptCore/llint/LLIntData.h
@@ -43,9 +43,9 @@ typedef void (*LLIntCode)();
 
 namespace LLInt {
 
-extern "C" JS_EXPORT_PRIVATE Opcode g_opcodeMap[numOpcodeIDs + numWasmOpcodeIDs];
-extern "C" JS_EXPORT_PRIVATE Opcode g_opcodeMapWide16[numOpcodeIDs + numWasmOpcodeIDs];
-extern "C" JS_EXPORT_PRIVATE Opcode g_opcodeMapWide32[numOpcodeIDs + numWasmOpcodeIDs];
+extern "C" JS_EXPORT_PRIVATE JSC::Opcode g_opcodeMap[numOpcodeIDs + numWasmOpcodeIDs];
+extern "C" JS_EXPORT_PRIVATE JSC::Opcode g_opcodeMapWide16[numOpcodeIDs + numWasmOpcodeIDs];
+extern "C" JS_EXPORT_PRIVATE JSC::Opcode g_opcodeMapWide32[numOpcodeIDs + numWasmOpcodeIDs];
 
 class Data {
 
@@ -57,15 +57,15 @@ private:
 
     friend JSInstruction* exceptionInstructions();
     friend WasmInstruction* wasmExceptionInstructions();
-    friend Opcode* opcodeMap();
-    friend Opcode* opcodeMapWide16();
-    friend Opcode* opcodeMapWide32();
-    friend Opcode getOpcode(OpcodeID);
-    friend Opcode getOpcodeWide16(OpcodeID);
-    friend Opcode getOpcodeWide32(OpcodeID);
-    friend const Opcode* getOpcodeAddress(OpcodeID);
-    friend const Opcode* getOpcodeWide16Address(OpcodeID);
-    friend const Opcode* getOpcodeWide32Address(OpcodeID);
+    friend JSC::Opcode* opcodeMap();
+    friend JSC::Opcode* opcodeMapWide16();
+    friend JSC::Opcode* opcodeMapWide32();
+    friend JSC::Opcode getOpcode(OpcodeID);
+    friend JSC::Opcode getOpcodeWide16(OpcodeID);
+    friend JSC::Opcode getOpcodeWide32(OpcodeID);
+    friend const JSC::Opcode* getOpcodeAddress(OpcodeID);
+    friend const JSC::Opcode* getOpcodeWide16Address(OpcodeID);
+    friend const JSC::Opcode* getOpcodeWide32Address(OpcodeID);
     template<PtrTag tag> friend CodePtr<tag> getCodePtr(OpcodeID);
     template<PtrTag tag> friend CodePtr<tag> getWide16CodePtr(OpcodeID);
     template<PtrTag tag> friend CodePtr<tag> getWide32CodePtr(OpcodeID);
@@ -84,22 +84,22 @@ inline WasmInstruction* wasmExceptionInstructions()
     return bitwise_cast<WasmInstruction*>(g_jscConfig.llint.wasmExceptionInstructions);
 }
 
-inline Opcode* opcodeMap()
+inline JSC::Opcode* opcodeMap()
 {
     return g_opcodeMap;
 }
 
-inline Opcode* opcodeMapWide16()
+inline JSC::Opcode* opcodeMapWide16()
 {
     return g_opcodeMapWide16;
 }
 
-inline Opcode* opcodeMapWide32()
+inline JSC::Opcode* opcodeMapWide32()
 {
     return g_opcodeMapWide32;
 }
 
-inline Opcode getOpcode(OpcodeID id)
+inline JSC::Opcode getOpcode(OpcodeID id)
 {
 #if ENABLE(COMPUTED_GOTO_OPCODES)
     return g_opcodeMap[id];
@@ -108,7 +108,7 @@ inline Opcode getOpcode(OpcodeID id)
 #endif
 }
 
-inline Opcode getOpcodeWide16(OpcodeID id)
+inline JSC::Opcode getOpcodeWide16(OpcodeID id)
 {
 #if ENABLE(COMPUTED_GOTO_OPCODES)
     return g_opcodeMapWide16[id];
@@ -118,7 +118,7 @@ inline Opcode getOpcodeWide16(OpcodeID id)
 #endif
 }
 
-inline Opcode getOpcodeWide32(OpcodeID id)
+inline JSC::Opcode getOpcodeWide32(OpcodeID id)
 {
 #if ENABLE(COMPUTED_GOTO_OPCODES)
     return g_opcodeMapWide32[id];
@@ -130,24 +130,24 @@ inline Opcode getOpcodeWide32(OpcodeID id)
 
 
 #if ENABLE(COMPUTED_GOTO_OPCODES)
-inline const Opcode* getOpcodeAddress(OpcodeID id)
+inline const JSC::Opcode* getOpcodeAddress(OpcodeID id)
 {
     return &g_opcodeMap[id];
 }
 
-inline const Opcode* getOpcodeWide16Address(OpcodeID id)
+inline const JSC::Opcode* getOpcodeWide16Address(OpcodeID id)
 {
     return &g_opcodeMapWide16[id];
 }
 
-inline const Opcode* getOpcodeWide32Address(OpcodeID id)
+inline const JSC::Opcode* getOpcodeWide32Address(OpcodeID id)
 {
     return &g_opcodeMapWide32[id];
 }
 #endif
 
 template<PtrTag tag>
-ALWAYS_INLINE CodePtr<tag> getCodePtrImpl(const Opcode opcode, const void* opcodeAddress)
+ALWAYS_INLINE CodePtr<tag> getCodePtrImpl(const JSC::Opcode opcode, const void* opcodeAddress)
 {
     void* opcodeValue = reinterpret_cast<void*>(opcode);
     void* untaggedOpcode = untagAddressDiversifiedCodePtr<BytecodePtrTag>(opcodeValue, opcodeAddress);
@@ -163,7 +163,7 @@ template<PtrTag tag>
 ALWAYS_INLINE CodePtr<tag> getCodePtr(OpcodeID opcodeID)
 {
 #if ENABLE(COMPUTED_GOTO_OPCODES)
-    const Opcode* opcode = getOpcodeAddress(opcodeID);
+    const JSC::Opcode* opcode = getOpcodeAddress(opcodeID);
     return getCodePtrImpl<tag>(*opcode, opcode);
 #else
     return getCodePtrImpl<tag>(getOpcode(opcodeID), nullptr);
@@ -174,7 +174,7 @@ template<PtrTag tag>
 ALWAYS_INLINE CodePtr<tag> getWide16CodePtr(OpcodeID opcodeID)
 {
 #if ENABLE(COMPUTED_GOTO_OPCODES)
-    const Opcode* opcode = getOpcodeWide16Address(opcodeID);
+    const JSC::Opcode* opcode = getOpcodeWide16Address(opcodeID);
     return getCodePtrImpl<tag>(*opcode, opcode);
 #else
     return getCodePtrImpl<tag>(getOpcodeWide16(opcodeID), nullptr);
@@ -185,7 +185,7 @@ template<PtrTag tag>
 ALWAYS_INLINE CodePtr<tag> getWide32CodePtr(OpcodeID opcodeID)
 {
 #if ENABLE(COMPUTED_GOTO_OPCODES)
-    const Opcode* opcode = getOpcodeWide32Address(opcodeID);
+    const JSC::Opcode* opcode = getOpcodeWide32Address(opcodeID);
     return getCodePtrImpl<tag>(*opcode, opcode);
 #else
     return getCodePtrImpl<tag>(getOpcodeWide32(opcodeID), nullptr);
@@ -257,7 +257,7 @@ ALWAYS_INLINE void* getWide32CodePtr(OpcodeID id)
 }
 #endif // ENABLE(JIT)
 
-inline Opcode getOpcode(WasmOpcodeID id)
+inline JSC::Opcode getOpcode(WasmOpcodeID id)
 {
 #if ENABLE(COMPUTED_GOTO_OPCODES)
     return g_opcodeMap[numOpcodeIDs + id];
@@ -266,7 +266,7 @@ inline Opcode getOpcode(WasmOpcodeID id)
 #endif
 }
 
-inline Opcode getOpcodeWide16(WasmOpcodeID id)
+inline JSC::Opcode getOpcodeWide16(WasmOpcodeID id)
 {
 #if ENABLE(COMPUTED_GOTO_OPCODES)
     return g_opcodeMapWide16[numOpcodeIDs + id];
@@ -276,7 +276,7 @@ inline Opcode getOpcodeWide16(WasmOpcodeID id)
 #endif
 }
 
-inline Opcode getOpcodeWide32(WasmOpcodeID id)
+inline JSC::Opcode getOpcodeWide32(WasmOpcodeID id)
 {
 #if ENABLE(COMPUTED_GOTO_OPCODES)
     return g_opcodeMapWide32[numOpcodeIDs + id];
@@ -287,17 +287,17 @@ inline Opcode getOpcodeWide32(WasmOpcodeID id)
 }
 
 #if ENABLE(COMPUTED_GOTO_OPCODES)
-inline const Opcode* getOpcodeAddress(WasmOpcodeID id)
+inline const JSC::Opcode* getOpcodeAddress(WasmOpcodeID id)
 {
     return &g_opcodeMap[numOpcodeIDs + id];
 }
 
-inline const Opcode* getOpcodeWide16Address(WasmOpcodeID id)
+inline const JSC::Opcode* getOpcodeWide16Address(WasmOpcodeID id)
 {
     return &g_opcodeMapWide16[numOpcodeIDs + id];
 }
 
-inline const Opcode* getOpcodeWide32Address(WasmOpcodeID id)
+inline const JSC::Opcode* getOpcodeWide32Address(WasmOpcodeID id)
 {
     return &g_opcodeMapWide32[numOpcodeIDs + id];
 }
@@ -307,7 +307,7 @@ template<PtrTag tag>
 ALWAYS_INLINE CodePtr<tag> getCodePtr(WasmOpcodeID opcodeID)
 {
 #if ENABLE(COMPUTED_GOTO_OPCODES)
-    const Opcode* opcode = getOpcodeAddress(opcodeID);
+    const JSC::Opcode* opcode = getOpcodeAddress(opcodeID);
     return getCodePtrImpl<tag>(*opcode, opcode);
 #else
     return getCodePtrImpl<tag>(getOpcode(opcodeID), nullptr);
@@ -318,7 +318,7 @@ template<PtrTag tag>
 ALWAYS_INLINE CodePtr<tag> getWide16CodePtr(WasmOpcodeID opcodeID)
 {
 #if ENABLE(COMPUTED_GOTO_OPCODES)
-    const Opcode* opcode = getOpcodeWide16Address(opcodeID);
+    const JSC::Opcode* opcode = getOpcodeWide16Address(opcodeID);
     return getCodePtrImpl<tag>(*opcode, opcode);
 #else
     return getCodePtrImpl<tag>(getOpcodeWide16(opcodeID), nullptr);
@@ -329,7 +329,7 @@ template<PtrTag tag>
 ALWAYS_INLINE CodePtr<tag> getWide32CodePtr(WasmOpcodeID opcodeID)
 {
 #if ENABLE(COMPUTED_GOTO_OPCODES)
-    const Opcode* opcode = getOpcodeWide32Address(opcodeID);
+    const JSC::Opcode* opcode = getOpcodeWide32Address(opcodeID);
     return getCodePtrImpl<tag>(*opcode, opcode);
 #else
     return getCodePtrImpl<tag>(getOpcodeWide32(opcodeID), nullptr);

--- a/Source/JavaScriptCore/runtime/EvalExecutable.h
+++ b/Source/JavaScriptCore/runtime/EvalExecutable.h
@@ -48,7 +48,7 @@ public:
         return bitwise_cast<UnlinkedEvalCodeBlock*>(Base::unlinkedCodeBlock());
     }
 
-    Ref<JITCode> generatedJITCode()
+    Ref<JSC::JITCode> generatedJITCode()
     {
         return generatedJITCodeForCall();
     }

--- a/Source/JavaScriptCore/runtime/ExecutableBase.h
+++ b/Source/JavaScriptCore/runtime/ExecutableBase.h
@@ -106,19 +106,19 @@ public:
     DECLARE_EXPORT_INFO;
 
 public:
-    Ref<JITCode> generatedJITCodeForCall() const
+    Ref<JSC::JITCode> generatedJITCodeForCall() const
     {
         ASSERT(m_jitCodeForCall);
         return *m_jitCodeForCall;
     }
 
-    Ref<JITCode> generatedJITCodeForConstruct() const
+    Ref<JSC::JITCode> generatedJITCodeForConstruct() const
     {
         ASSERT(m_jitCodeForConstruct);
         return *m_jitCodeForConstruct;
     }
         
-    Ref<JITCode> generatedJITCodeFor(CodeSpecializationKind kind) const
+    Ref<JSC::JITCode> generatedJITCodeFor(CodeSpecializationKind kind) const
     {
         if (kind == CodeForCall)
             return generatedJITCodeForCall();
@@ -233,8 +233,8 @@ public:
     void dump(PrintStream&) const;
         
 protected:
-    RefPtr<JITCode> m_jitCodeForCall;
-    RefPtr<JITCode> m_jitCodeForConstruct;
+    RefPtr<JSC::JITCode> m_jitCodeForCall;
+    RefPtr<JSC::JITCode> m_jitCodeForConstruct;
     CodePtr<JSEntryPtrTag> m_jitCodeForCallWithArityCheck;
     CodePtr<JSEntryPtrTag> m_jitCodeForConstructWithArityCheck;
 };

--- a/Source/JavaScriptCore/runtime/ModuleProgramExecutable.h
+++ b/Source/JavaScriptCore/runtime/ModuleProgramExecutable.h
@@ -59,7 +59,7 @@ public:
         return bitwise_cast<UnlinkedModuleProgramCodeBlock*>(Base::unlinkedCodeBlock());
     }
 
-    Ref<JITCode> generatedJITCode()
+    Ref<JSC::JITCode> generatedJITCode()
     {
         return generatedJITCodeForCall();
     }

--- a/Source/JavaScriptCore/runtime/NativeExecutable.cpp
+++ b/Source/JavaScriptCore/runtime/NativeExecutable.cpp
@@ -35,7 +35,7 @@ namespace JSC {
 
 const ClassInfo NativeExecutable::s_info = { "NativeExecutable"_s, &ExecutableBase::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(NativeExecutable) };
 
-NativeExecutable* NativeExecutable::create(VM& vm, Ref<JITCode>&& callThunk, TaggedNativeFunction function, Ref<JITCode>&& constructThunk, TaggedNativeFunction constructor, ImplementationVisibility implementationVisibility, const String& name)
+NativeExecutable* NativeExecutable::create(VM& vm, Ref<JSC::JITCode>&& callThunk, TaggedNativeFunction function, Ref<JSC::JITCode>&& constructThunk, TaggedNativeFunction constructor, ImplementationVisibility implementationVisibility, const String& name)
 {
     NativeExecutable* executable;
     executable = new (NotNull, allocateCell<NativeExecutable>(vm)) NativeExecutable(vm, function, constructor, implementationVisibility);
@@ -58,7 +58,7 @@ Structure* NativeExecutable::createStructure(VM& vm, JSGlobalObject* globalObjec
     return Structure::create(vm, globalObject, proto, TypeInfo(NativeExecutableType, StructureFlags), info());
 }
 
-void NativeExecutable::finishCreation(VM& vm, Ref<JITCode>&& callThunk, Ref<JITCode>&& constructThunk, const String& name)
+void NativeExecutable::finishCreation(VM& vm, Ref<JSC::JITCode>&& callThunk, Ref<JSC::JITCode>&& constructThunk, const String& name)
 {
     Base::finishCreation(vm);
     m_jitCodeForCall = WTFMove(callThunk);

--- a/Source/JavaScriptCore/runtime/NativeExecutable.h
+++ b/Source/JavaScriptCore/runtime/NativeExecutable.h
@@ -37,7 +37,7 @@ public:
     typedef ExecutableBase Base;
     static constexpr unsigned StructureFlags = Base::StructureFlags | StructureIsImmortal;
 
-    static NativeExecutable* create(VM&, Ref<JITCode>&& callThunk, TaggedNativeFunction, Ref<JITCode>&& constructThunk, TaggedNativeFunction constructor, ImplementationVisibility, const String& name);
+    static NativeExecutable* create(VM&, Ref<JSC::JITCode>&& callThunk, TaggedNativeFunction, Ref<JSC::JITCode>&& constructThunk, TaggedNativeFunction constructor, ImplementationVisibility, const String& name);
 
     static void destroy(JSCell*);
     
@@ -91,7 +91,7 @@ public:
 
 private:
     NativeExecutable(VM&, TaggedNativeFunction, TaggedNativeFunction constructor, ImplementationVisibility);
-    void finishCreation(VM&, Ref<JITCode>&& callThunk, Ref<JITCode>&& constructThunk, const String& name);
+    void finishCreation(VM&, Ref<JSC::JITCode>&& callThunk, Ref<JSC::JITCode>&& constructThunk, const String& name);
 
     JSString* toStringSlow(JSGlobalObject*);
 

--- a/Source/JavaScriptCore/runtime/ObjectConstructor.h
+++ b/Source/JavaScriptCore/runtime/ObjectConstructor.h
@@ -34,9 +34,9 @@ JSC_DECLARE_HOST_FUNCTION(objectConstructorKeys);
 
 class ObjectPrototype;
 
-class ObjectConstructor final : public InternalFunction {
+class ObjectConstructor final : public JSC::InternalFunction {
 public:
-    typedef InternalFunction Base;
+    typedef JSC::InternalFunction Base;
     static constexpr unsigned StructureFlags = Base::StructureFlags | HasStaticPropertyTable;
 
     static ObjectConstructor* create(VM& vm, JSGlobalObject* globalObject, Structure* structure, ObjectPrototype* objectPrototype)
@@ -54,7 +54,7 @@ private:
     ObjectConstructor(VM&, Structure*);
     void finishCreation(VM&, JSGlobalObject*, ObjectPrototype*);
 };
-STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(ObjectConstructor, InternalFunction);
+STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(ObjectConstructor, JSC::InternalFunction);
 
 inline JSFinalObject* constructEmptyObject(VM& vm, Structure* structure)
 {

--- a/Source/JavaScriptCore/runtime/ProgramExecutable.h
+++ b/Source/JavaScriptCore/runtime/ProgramExecutable.h
@@ -65,7 +65,7 @@ public:
         return bitwise_cast<UnlinkedProgramCodeBlock*>(Base::unlinkedCodeBlock());
     }
 
-    Ref<JITCode> generatedJITCode()
+    Ref<JSC::JITCode> generatedJITCode()
     {
         return generatedJITCodeForCall();
     }

--- a/Source/JavaScriptCore/runtime/ScriptExecutable.cpp
+++ b/Source/JavaScriptCore/runtime/ScriptExecutable.cpp
@@ -553,7 +553,7 @@ void ScriptExecutable::visitCodeBlockEdge(Visitor& visitor, CodeBlock* codeBlock
     if (codeBlock->shouldVisitStrongly(locker, visitor))
         visitor.appendUnbarriered(codeBlock);
 
-    if (JITCode::isOptimizingJIT(codeBlock->jitType())) {
+    if (JSC::JITCode::isOptimizingJIT(codeBlock->jitType())) {
         // If we jettison ourselves we'll install our alternative, so make sure that it
         // survives GC even if we don't.
         visitor.append(codeBlock->m_alternative);

--- a/Source/JavaScriptCore/runtime/VMTraps.cpp
+++ b/Source/JavaScriptCore/runtime/VMTraps.cpp
@@ -187,7 +187,7 @@ void VMTraps::invalidateCodeBlocksOnStack(Locker<Lock>&, CallFrame* topCallFrame
 
     while (callFrame) {
         CodeBlock* codeBlock = callFrame->isNativeCalleeFrame() ? nullptr : callFrame->codeBlock();
-        if (codeBlock && JITCode::isOptimizingJIT(codeBlock->jitType()))
+        if (codeBlock && JSC::JITCode::isOptimizingJIT(codeBlock->jitType()))
             codeBlock->jettison(Profiler::JettisonDueToVMTraps);
         callFrame = callFrame->callerFrame(entryFrame);
     }

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -766,13 +766,13 @@ static const struct CompactHashIndex staticCustomAccessorTableIndex[5] = {
 };
 #endif
 
-static const struct HashTableValue staticCustomAccessorTableValues[3] = {
-    { "testStaticAccessor"_s, static_cast<unsigned>(PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, testStaticAccessorGetter, testStaticAccessorPutter } },
-    { "testStaticAccessorDontEnum"_s, PropertyAttribute::CustomAccessor | PropertyAttribute::DontEnum, NoIntrinsic, { HashTableValue::GetterSetterType, testStaticAccessorGetter, testStaticAccessorPutter } },
-    { "testStaticAccessorReadOnly"_s, PropertyAttribute::CustomAccessor | PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly, NoIntrinsic, { HashTableValue::GetterSetterType, testStaticAccessorGetter, nullptr } },
+static const struct JSC::HashTableValue staticCustomAccessorTableValues[3] = {
+    { "testStaticAccessor"_s, static_cast<unsigned>(PropertyAttribute::CustomAccessor), NoIntrinsic, { JSC::HashTableValue::GetterSetterType, testStaticAccessorGetter, testStaticAccessorPutter } },
+    { "testStaticAccessorDontEnum"_s, PropertyAttribute::CustomAccessor | PropertyAttribute::DontEnum, NoIntrinsic, { JSC::HashTableValue::GetterSetterType, testStaticAccessorGetter, testStaticAccessorPutter } },
+    { "testStaticAccessorReadOnly"_s, PropertyAttribute::CustomAccessor | PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly, NoIntrinsic, { JSC::HashTableValue::GetterSetterType, testStaticAccessorGetter, nullptr } },
 };
 
-static const struct HashTable staticCustomAccessorTable =
+static const struct JSC::HashTable staticCustomAccessorTable =
     { 3, 3, PropertyAttribute::ReadOnly | PropertyAttribute::DontEnum | PropertyAttribute::CustomAccessor, nullptr, staticCustomAccessorTableValues, staticCustomAccessorTableIndex };
 
 class StaticCustomAccessor : public JSNonFinalObject {
@@ -872,14 +872,14 @@ static const struct CompactHashIndex staticCustomValueTableIndex[5] = {
 };
 #endif
 
-static const struct HashTableValue staticCustomValueTableValues[4] = {
-    { "testStaticValue"_s, static_cast<unsigned>(PropertyAttribute::CustomValue), NoIntrinsic, { HashTableValue::GetterSetterType, testStaticValueGetter, testStaticValuePutter } },
-    { "testStaticValueNoSetter"_s, PropertyAttribute::CustomValue | PropertyAttribute::DontEnum, NoIntrinsic, { HashTableValue::GetterSetterType, testStaticValueGetter, nullptr } },
-    { "testStaticValueReadOnly"_s, PropertyAttribute::CustomValue | PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly, NoIntrinsic, { HashTableValue::GetterSetterType, testStaticValueGetter, nullptr } },
-    { "testStaticValueSetFlag"_s, static_cast<unsigned>(PropertyAttribute::CustomValue), NoIntrinsic, { HashTableValue::GetterSetterType, testStaticValueGetter, testStaticValuePutterSetFlag } },
+static const struct JSC::HashTableValue staticCustomValueTableValues[4] = {
+    { "testStaticValue"_s, static_cast<unsigned>(PropertyAttribute::CustomValue), NoIntrinsic, { JSC::HashTableValue::GetterSetterType, testStaticValueGetter, testStaticValuePutter } },
+    { "testStaticValueNoSetter"_s, PropertyAttribute::CustomValue | PropertyAttribute::DontEnum, NoIntrinsic, { JSC::HashTableValue::GetterSetterType, testStaticValueGetter, nullptr } },
+    { "testStaticValueReadOnly"_s, PropertyAttribute::CustomValue | PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly, NoIntrinsic, { JSC::HashTableValue::GetterSetterType, testStaticValueGetter, nullptr } },
+    { "testStaticValueSetFlag"_s, static_cast<unsigned>(PropertyAttribute::CustomValue), NoIntrinsic, { JSC::HashTableValue::GetterSetterType, testStaticValueGetter, testStaticValuePutterSetFlag } },
 };
 
-static const struct HashTable staticCustomValueTable =
+static const struct JSC::HashTable staticCustomValueTable =
     { 4, 3, PropertyAttribute::ReadOnly | PropertyAttribute::DontEnum | PropertyAttribute::CustomValue, nullptr, staticCustomValueTableValues, staticCustomValueTableIndex };
 
 class StaticCustomValue : public JSNonFinalObject {
@@ -976,13 +976,13 @@ static const struct CompactHashIndex staticDontDeleteDontEnumTableIndex[5] = {
 };
 #endif
 
-static const struct HashTableValue staticDontDeleteDontEnumTableValues[3] = {
-    { "dontEnum"_s, static_cast<unsigned>(PropertyAttribute::Function | PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::NativeFunctionType, staticDontDeleteDontEnumMethod, 0 } },
-    { "dontDelete"_s, static_cast<unsigned>(PropertyAttribute::Function | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::NativeFunctionType, staticDontDeleteDontEnumMethod, 0 } },
-    { "dontDeleteDontEnum"_s, static_cast<unsigned>(PropertyAttribute::Function | PropertyAttribute::DontDelete | PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::NativeFunctionType, staticDontDeleteDontEnumMethod, 0 } },
+static const struct JSC::HashTableValue staticDontDeleteDontEnumTableValues[3] = {
+    { "dontEnum"_s, static_cast<unsigned>(PropertyAttribute::Function | PropertyAttribute::DontEnum), NoIntrinsic, { JSC::HashTableValue::NativeFunctionType, staticDontDeleteDontEnumMethod, 0 } },
+    { "dontDelete"_s, static_cast<unsigned>(PropertyAttribute::Function | PropertyAttribute::DontDelete), NoIntrinsic, { JSC::HashTableValue::NativeFunctionType, staticDontDeleteDontEnumMethod, 0 } },
+    { "dontDeleteDontEnum"_s, static_cast<unsigned>(PropertyAttribute::Function | PropertyAttribute::DontDelete | PropertyAttribute::DontEnum), NoIntrinsic, { JSC::HashTableValue::NativeFunctionType, staticDontDeleteDontEnumMethod, 0 } },
 };
 
-static const struct HashTable staticDontDeleteDontEnumTable =
+static const struct JSC::HashTable staticDontDeleteDontEnumTable =
     { 3, 3, PropertyAttribute::DontEnum | PropertyAttribute::DontDelete, nullptr, staticDontDeleteDontEnumTableValues, staticDontDeleteDontEnumTableIndex };
 
 class ObjectDoingSideEffectPutWithoutCorrectSlotStatus : public JSNonFinalObject {


### PR DESCRIPTION
#### 861cce42f1988e8ac5b7269dbe43a8e54cd79c62
<pre>
Add namespace qualifiers to a bunch of jsc types
<a href="https://bugs.webkit.org/show_bug.cgi?id=266361">https://bugs.webkit.org/show_bug.cgi?id=266361</a>
<a href="https://rdar.apple.com/119627072">rdar://119627072</a>

Reviewed by Mark Lam.

In local builds, accidentally including the wrong headers together
(especially with unified sources) causes ambiguity. It was a mistake
to name these classes the same thing, but this should help guard
against these kinds of build failures in the future.

* Source/JavaScriptCore/assembler/MacroAssemblerCodeRef.cpp:
(JSC::shouldDumpDisassemblyFor):
* Source/JavaScriptCore/b3/air/AirOpcode.opcodes:
* Source/JavaScriptCore/bytecode/CallLinkInfo.h:
* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::~CodeBlock):
(JSC::CodeBlock::specialOSREntryBlockOrNull):
(JSC::CodeBlock::estimatedSize):
(JSC::CodeBlock::forEachStructureStubInfo):
(JSC::CodeBlock::shouldVisitStrongly):
(JSC::CodeBlock::shouldJettisonDueToWeakReference):
(JSC::CodeBlock::propagateTransitions):
(JSC::CodeBlock::determineLiveness):
(JSC::CodeBlock::finalizeJITInlineCaches):
(JSC::CodeBlock::finalizeUnconditionally):
(JSC::CodeBlock::getICStatusMap):
(JSC::CodeBlock::getCallLinkInfoForBytecodeIndex):
(JSC::CodeBlock::stronglyVisitStrongReferences):
(JSC::CodeBlock::stronglyVisitWeakReferences):
(JSC::CodeBlock::baselineVersion):
(JSC::CodeBlock::newExceptionHandlingCallSiteIndex):
(JSC::CodeBlock::jettison):
(JSC::CodeBlock::noticeIncomingCall):
(JSC::CodeBlock::numberOfDFGCompiles):
(JSC::CodeBlock::setOptimizationThresholdBasedOnCompilationResult):
(JSC::CodeBlock::adjustedExitCountThreshold):
(JSC::CodeBlock::numberOfDFGIdentifiers const):
(JSC::CodeBlock::identifier const):
(JSC::CodeBlock::hasIdentifier):
(JSC::CodeBlock::tallyFrequentExitSites):
(JSC::CodeBlock::addBreakpoint):
(JSC::CodeBlock::setSteppingMode):
(JSC::CodeBlock::canInstallVMTrapBreakpoints const):
* Source/JavaScriptCore/bytecode/CodeBlock.h:
(JSC::CodeBlock::setJITCode):
(JSC::CodeBlock::jitCode):
(JSC::CodeBlock::jitType const):
(JSC::CodeBlock::hasCodeOrigins):
(JSC::CodeBlock::heap const):
(JSC::CodeBlock::baselineJITData):
(JSC::CodeBlock::dfgJITData):
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheCompiler::calculateLiveRegistersForCallAndExceptionHandling):
(JSC::InlineCacheCompiler::regenerate):
* Source/JavaScriptCore/bytecode/Repatch.cpp:
(JSC::linkPolymorphicCall):
* Source/JavaScriptCore/bytecode/StructureStubInfo.h:
* Source/JavaScriptCore/dfg/DFGJITCompiler.cpp:
(JSC::DFG::JITCompiler::addStructureStubInfo):
* Source/JavaScriptCore/dfg/DFGJITCompiler.h:
(JSC::DFG::JITCompiler::jitCode):
* Source/JavaScriptCore/dfg/DFGJITFinalizer.cpp:
(JSC::DFG::JITFinalizer::JITFinalizer):
* Source/JavaScriptCore/dfg/DFGJITFinalizer.h:
* Source/JavaScriptCore/dfg/DFGOSREntry.cpp:
(JSC::DFG::prepareOSREntry):
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGPlan.cpp:
(JSC::DFG::Plan::tryFinalizeJITData):
* Source/JavaScriptCore/dfg/DFGPlan.h:
* Source/JavaScriptCore/ftl/FTLJITFinalizer.h:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/ftl/FTLState.h:
* Source/JavaScriptCore/heap/AbstractSlotVisitor.h:
* Source/JavaScriptCore/heap/AbstractSlotVisitorInlines.h:
(JSC::AbstractSlotVisitor::AbstractSlotVisitor):
(JSC::AbstractSlotVisitor::heap const):
* Source/JavaScriptCore/heap/AlignedMemoryAllocator.cpp:
(JSC::AlignedMemoryAllocator::registerDirectory):
* Source/JavaScriptCore/heap/AllocatingScope.h:
(JSC::AllocatingScope::AllocatingScope):
* Source/JavaScriptCore/heap/AllocatorInlines.h:
(JSC::Allocator::allocate const):
* Source/JavaScriptCore/heap/BlockDirectory.cpp:
(JSC::BlockDirectory::tryAllocateBlock):
* Source/JavaScriptCore/heap/CellContainer.h:
* Source/JavaScriptCore/heap/CellContainerInlines.h:
(JSC::CellContainer::heap const):
* Source/JavaScriptCore/heap/CollectingScope.h:
(JSC::CollectingScope::CollectingScope):
* Source/JavaScriptCore/heap/CompleteSubspace.cpp:
(JSC::CompleteSubspace::CompleteSubspace):
* Source/JavaScriptCore/heap/ConservativeRoots.cpp:
(JSC::ConservativeRoots::ConservativeRoots):
* Source/JavaScriptCore/heap/ConservativeRoots.h:
* Source/JavaScriptCore/heap/DeferGC.h:
* Source/JavaScriptCore/heap/EdenGCActivityCallback.cpp:
(JSC::EdenGCActivityCallback::EdenGCActivityCallback):
(JSC::EdenGCActivityCallback::lastGCLength):
(JSC::EdenGCActivityCallback::deathRate):
* Source/JavaScriptCore/heap/EdenGCActivityCallback.h:
(JSC::EdenGCActivityCallback::tryCreate):
* Source/JavaScriptCore/heap/FullGCActivityCallback.cpp:
(JSC::FullGCActivityCallback::FullGCActivityCallback):
(JSC::FullGCActivityCallback::doCollection):
(JSC::FullGCActivityCallback::lastGCLength):
(JSC::FullGCActivityCallback::deathRate):
* Source/JavaScriptCore/heap/FullGCActivityCallback.h:
(JSC::FullGCActivityCallback::tryCreate):
* Source/JavaScriptCore/heap/GCActivityCallback.cpp:
(JSC::GCActivityCallback::GCActivityCallback):
(JSC::GCActivityCallback::doWork):
(JSC::GCActivityCallback::didAllocate):
* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::addCoreConstraints):
* Source/JavaScriptCore/heap/Heap.h:
* Source/JavaScriptCore/heap/HeapCell.h:
* Source/JavaScriptCore/heap/HeapCellInlines.h:
(JSC::HeapCell::heap const):
* Source/JavaScriptCore/heap/HeapInlines.h:
(JSC::Heap::heap):
* Source/JavaScriptCore/heap/HeapIterationScope.h:
(JSC::HeapIterationScope::HeapIterationScope):
* Source/JavaScriptCore/heap/HeapUtil.h:
(JSC::HeapUtil::findGCObjectPointersForMarking):
(JSC::HeapUtil::isPointerGCObjectJSCell):
(JSC::HeapUtil::isValueGCObject):
* Source/JavaScriptCore/heap/IncrementalSweeper.cpp:
(JSC::IncrementalSweeper::IncrementalSweeper):
(JSC::IncrementalSweeper::startSweeping):
* Source/JavaScriptCore/heap/IsoSubspace.cpp:
(JSC::IsoSubspace::IsoSubspace):
* Source/JavaScriptCore/heap/IsoSubspacePerVM.cpp:
(JSC::IsoSubspacePerVM::isoSubspaceforHeap):
(JSC::IsoSubspacePerVM::releaseIsoSubspace):
* Source/JavaScriptCore/heap/LocalAllocator.cpp:
(JSC::LocalAllocator::allocateSlowCase):
(JSC::LocalAllocator::doTestCollectionsIfNeeded):
* Source/JavaScriptCore/heap/LocalAllocatorInlines.h:
(JSC::LocalAllocator::allocate):
* Source/JavaScriptCore/heap/MarkStackMergingConstraint.cpp:
(JSC::MarkStackMergingConstraint::MarkStackMergingConstraint):
* Source/JavaScriptCore/heap/MarkStackMergingConstraint.h:
* Source/JavaScriptCore/heap/MarkedBlock.cpp:
(JSC::MarkedBlock::tryCreate):
(JSC::MarkedBlock::Handle::Handle):
(JSC::MarkedBlock::Handle::~Handle):
* Source/JavaScriptCore/heap/MarkedBlock.h:
(JSC::MarkedBlock::Handle::heap const):
* Source/JavaScriptCore/heap/MarkedBlockInlines.h:
(JSC::MarkedBlock::heap const):
* Source/JavaScriptCore/heap/MarkedSpace.cpp:
(JSC::MarkedSpace::MarkedSpace):
* Source/JavaScriptCore/heap/MarkedSpace.h:
* Source/JavaScriptCore/heap/MarkedSpaceInlines.h:
(JSC::MarkedSpace::heap const):
* Source/JavaScriptCore/heap/MarkingConstraintSet.cpp:
(JSC::MarkingConstraintSet::MarkingConstraintSet):
* Source/JavaScriptCore/heap/MarkingConstraintSet.h:
* Source/JavaScriptCore/heap/MarkingConstraintSolver.h:
* Source/JavaScriptCore/heap/PreciseAllocation.cpp:
(JSC::PreciseAllocation::tryCreate):
(JSC::PreciseAllocation::tryCreateForLowerTier):
(JSC::PreciseAllocation::reuseForLowerTier):
(JSC::PreciseAllocation::PreciseAllocation):
* Source/JavaScriptCore/heap/PreciseAllocation.h:
(JSC::PreciseAllocation::heap const):
* Source/JavaScriptCore/heap/PreventCollectionScope.h:
(JSC::PreventCollectionScope::PreventCollectionScope):
* Source/JavaScriptCore/heap/ReleaseHeapAccessScope.h:
(JSC::ReleaseHeapAccessScope::ReleaseHeapAccessScope):
(JSC::ReleaseHeapAccessIfNeededScope::ReleaseHeapAccessIfNeededScope):
* Source/JavaScriptCore/heap/RunningScope.h:
(JSC::RunningScope::RunningScope):
* Source/JavaScriptCore/heap/SlotVisitor.cpp:
(JSC::SlotVisitor::SlotVisitor):
* Source/JavaScriptCore/heap/SpaceTimeMutatorScheduler.cpp:
(JSC::SpaceTimeMutatorScheduler::SpaceTimeMutatorScheduler):
* Source/JavaScriptCore/heap/SpaceTimeMutatorScheduler.h:
* Source/JavaScriptCore/heap/StochasticSpaceTimeMutatorScheduler.cpp:
(JSC::StochasticSpaceTimeMutatorScheduler::StochasticSpaceTimeMutatorScheduler):
* Source/JavaScriptCore/heap/StochasticSpaceTimeMutatorScheduler.h:
* Source/JavaScriptCore/heap/Subspace.cpp:
(JSC::Subspace::Subspace):
(JSC::Subspace::initialize):
* Source/JavaScriptCore/heap/SweepingScope.h:
(JSC::SweepingScope::SweepingScope):
* Source/JavaScriptCore/heap/VerifierSlotVisitor.cpp:
(JSC::VerifierSlotVisitor::VerifierSlotVisitor):
* Source/JavaScriptCore/heap/WeakBlock.cpp:
(JSC::WeakBlock::create):
(JSC::WeakBlock::destroy):
* Source/JavaScriptCore/heap/WeakSet.cpp:
(JSC::WeakSet::~WeakSet):
* Source/JavaScriptCore/heap/WeakSet.h:
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::eval):
(JSC::findExceptionHandler):
(JSC::CatchInfo::CatchInfo):
(JSC::Interpreter::executeProgram):
(JSC::Interpreter::executeCallImpl):
(JSC::Interpreter::executeConstruct):
(JSC::Interpreter::executeEval):
(JSC::Interpreter::executeModuleProgram):
* Source/JavaScriptCore/interpreter/Interpreter.h:
* Source/JavaScriptCore/interpreter/InterpreterInlines.h:
(JSC::Interpreter::getOpcode):
(JSC::Interpreter::getOpcodeID):
* Source/JavaScriptCore/jit/CCallHelpers.h:
(JSC::CCallHelpers::brk):
* Source/JavaScriptCore/jit/GCAwareJITStubRoutine.cpp:
(JSC::createICJITStubRoutine):
* Source/JavaScriptCore/jit/JITCode.h:
(JSC::JITCode::offsetOfJITType):
* Source/JavaScriptCore/jit/JITInlineCacheGenerator.h:
* Source/JavaScriptCore/jit/JITMathIC.h:
(JSC::JITMathIC::generateOutOfLine):
* Source/JavaScriptCore/jit/JITOperations.cpp:
(JSC::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/jit/JITThunks.cpp:
(JSC::JITThunks::hostFunctionStub):
* Source/JavaScriptCore/jsc.cpp:
(CommandLine::parseArguments):
(jscmain):
* Source/JavaScriptCore/llint/LLIntData.h:
(JSC::LLInt::opcodeMap):
(JSC::LLInt::opcodeMapWide16):
(JSC::LLInt::opcodeMapWide32):
(JSC::LLInt::getOpcode):
(JSC::LLInt::getOpcodeWide16):
(JSC::LLInt::getOpcodeWide32):
(JSC::LLInt::getOpcodeAddress):
(JSC::LLInt::getOpcodeWide16Address):
(JSC::LLInt::getOpcodeWide32Address):
(JSC::LLInt::getCodePtrImpl):
(JSC::LLInt::getCodePtr):
(JSC::LLInt::getWide16CodePtr):
(JSC::LLInt::getWide32CodePtr):
* Source/JavaScriptCore/runtime/EvalExecutable.h:
(JSC::EvalExecutable::generatedJITCode):
* Source/JavaScriptCore/runtime/ExecutableBase.h:
(JSC::ExecutableBase::generatedJITCodeForCall const):
(JSC::ExecutableBase::generatedJITCodeForConstruct const):
(JSC::ExecutableBase::generatedJITCodeFor const):
* Source/JavaScriptCore/runtime/ModuleProgramExecutable.h:
* Source/JavaScriptCore/runtime/NativeExecutable.cpp:
(JSC::NativeExecutable::create):
(JSC::NativeExecutable::finishCreation):
* Source/JavaScriptCore/runtime/NativeExecutable.h:
* Source/JavaScriptCore/runtime/ObjectConstructor.h:
* Source/JavaScriptCore/runtime/ProgramExecutable.h:
* Source/JavaScriptCore/runtime/ScriptExecutable.cpp:
(JSC::ScriptExecutable::visitCodeBlockEdge):
* Source/JavaScriptCore/runtime/VMTraps.cpp:
(JSC::VMTraps::invalidateCodeBlocksOnStack):
* Source/JavaScriptCore/tools/JSDollarVM.cpp:

Canonical link: <a href="https://commits.webkit.org/272035@main">https://commits.webkit.org/272035@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/430543698ac3e80abca54d4e1bc7d39fa869c530

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30452 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9126 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32071 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32964 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27549 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31155 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11360 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6365 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/27499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30761 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/7672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/27301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/6578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/6724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/27144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34301 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/26152 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/27741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/27642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/32902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/30559 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6707 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4850 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/30726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/8454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/36997 "Built successfully") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/7444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7960 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3934 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7251 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->