### PR TITLE
Inline some functions used in copyCompactAndLinkCode

### DIFF
--- a/Source/JavaScriptCore/assembler/ARM64Assembler.h
+++ b/Source/JavaScriptCore/assembler/ARM64Assembler.h
@@ -260,7 +260,7 @@ public:
     {
     }
     
-    AssemblerBuffer& buffer() { return m_buffer; }
+    ALWAYS_INLINE AssemblerBuffer& buffer() { return m_buffer; }
 
     // (HS, LO, HI, LS) -> (AE, B, A, BE)
     // (VS, VC) -> (O, NO)
@@ -415,8 +415,8 @@ public:
             data.copyTypes = other.data.copyTypes;
             return *this;
         }
-        intptr_t from() const { return data.realTypes.m_from; }
-        void setFrom(const ARM64Assembler* assembler, intptr_t from)
+        ALWAYS_INLINE intptr_t from() const { return data.realTypes.m_from; }
+        ALWAYS_INLINE void setFrom(const ARM64Assembler* assembler, intptr_t from)
         {
 #if CPU(ARM64E)
             data.realTypes.m_to = tagInt(to(assembler), static_cast<PtrTag>(from ^ bitwise_cast<intptr_t>(assembler)));
@@ -425,7 +425,7 @@ public:
 #endif
             data.realTypes.m_from = from;
         }
-        intptr_t to(const ARM64Assembler* assembler) const
+        ALWAYS_INLINE intptr_t to(const ARM64Assembler* assembler) const
         {
 #if CPU(ARM64E)
             return untagInt(data.realTypes.m_to, static_cast<PtrTag>(data.realTypes.m_from ^ bitwise_cast<intptr_t>(assembler)));
@@ -434,15 +434,15 @@ public:
             return data.realTypes.m_to;
 #endif
         }
-        JumpType type() const { return data.realTypes.m_type; }
-        JumpLinkType linkType() const { return data.realTypes.m_linkType; }
-        BranchType branchType() const { return data.realTypes.m_branchType; }
-        void setLinkType(JumpLinkType linkType) { ASSERT(data.realTypes.m_linkType == LinkInvalid); data.realTypes.m_linkType = linkType; }
-        Condition condition() const { return data.realTypes.m_condition; }
-        bool is64Bit() const { return data.realTypes.m_is64Bit; }
-        bool isThunk() const { return data.realTypes.m_isThunk == ThunkOrNot::Thunk; }
-        unsigned bitNumber() const { return data.realTypes.m_bitNumber; }
-        RegisterID compareRegister() const { return data.realTypes.m_compareRegister; }
+        ALWAYS_INLINE JumpType type() const { return data.realTypes.m_type; }
+        ALWAYS_INLINE JumpLinkType linkType() const { return data.realTypes.m_linkType; }
+        ALWAYS_INLINE BranchType branchType() const { return data.realTypes.m_branchType; }
+        ALWAYS_INLINE void setLinkType(JumpLinkType linkType) { ASSERT(data.realTypes.m_linkType == LinkInvalid); data.realTypes.m_linkType = linkType; }
+        ALWAYS_INLINE Condition condition() const { return data.realTypes.m_condition; }
+        ALWAYS_INLINE bool is64Bit() const { return data.realTypes.m_is64Bit; }
+        ALWAYS_INLINE bool isThunk() const { return data.realTypes.m_isThunk == ThunkOrNot::Thunk; }
+        ALWAYS_INLINE unsigned bitNumber() const { return data.realTypes.m_bitNumber; }
+        ALWAYS_INLINE RegisterID compareRegister() const { return data.realTypes.m_compareRegister; }
 
     private:
         union {
@@ -3681,16 +3681,16 @@ public:
 
     // Assembler admin methods:
 
-    static int jumpSizeDelta(JumpType jumpType, JumpLinkType jumpLinkType) { return JUMP_ENUM_SIZE(jumpType) - JUMP_ENUM_SIZE(jumpLinkType); }
+    static ALWAYS_INLINE int jumpSizeDelta(JumpType jumpType, JumpLinkType jumpLinkType) { return JUMP_ENUM_SIZE(jumpType) - JUMP_ENUM_SIZE(jumpLinkType); }
 
-    static bool canCompact(JumpType jumpType)
+    static ALWAYS_INLINE bool canCompact(JumpType jumpType)
     {
         // Fixed jumps cannot be compacted
         // Keep in mind that nearCall and tailCall are encoded as JumpNoCondition.
         return (jumpType == JumpNoCondition) || (jumpType == JumpCondition) || (jumpType == JumpCompareAndBranch) || (jumpType == JumpTestBit);
     }
 
-    static JumpLinkType computeJumpType(LinkRecord& record, const uint8_t* from, const uint8_t* to)
+    static ALWAYS_INLINE JumpLinkType computeJumpType(LinkRecord& record, const uint8_t* from, const uint8_t* to)
     {
         auto computeJumpType = [&](const uint8_t* from, const uint8_t* to) -> JumpLinkType {
             auto jumpType = record.type();
@@ -3820,7 +3820,7 @@ public:
 
 protected:
     template<Datasize size>
-    static bool checkMovk(int insn, int _hw, RegisterID _rd)
+    static ALWAYS_INLINE bool checkMovk(int insn, int _hw, RegisterID _rd)
     {
         Datasize sf;
         MoveWideOp opc;
@@ -3836,7 +3836,7 @@ protected:
             && rd == _rd;
     }
 
-    static void linkPointer(int* address, void* valuePtr, bool flush = false)
+    static ALWAYS_INLINE void linkPointer(int* address, void* valuePtr, bool flush = false)
     {
         Datasize sf;
         MoveWideOp opc;
@@ -3855,7 +3855,7 @@ protected:
     }
 
     template<BranchType type, CopyFunction copy = performJITMemcpy>
-    static void linkJumpOrCall(int* from, const int* fromInstruction, void* to)
+    static ALWAYS_INLINE void linkJumpOrCall(int* from, const int* fromInstruction, void* to)
     {
         static_assert(type == BranchType_JMP || type == BranchType_CALL);
 
@@ -3887,7 +3887,7 @@ protected:
     }
 
     template<BranchTargetType type, CopyFunction copy = performJITMemcpy>
-    static void linkCompareAndBranch(Condition condition, bool is64Bit, RegisterID rt, int* from, const int* fromInstruction, void* to)
+    static ALWAYS_INLINE void linkCompareAndBranch(Condition condition, bool is64Bit, RegisterID rt, int* from, const int* fromInstruction, void* to)
     {
         RELEASE_ASSERT(roundUpToMultipleOf<instructionSize>(from) == from);
         ASSERT(!(reinterpret_cast<intptr_t>(from) & 3));
@@ -3913,7 +3913,7 @@ protected:
     }
 
     template<BranchTargetType type, CopyFunction copy = performJITMemcpy>
-    static void linkConditionalBranch(Condition condition, int* from, const int* fromInstruction, void* to)
+    static ALWAYS_INLINE void linkConditionalBranch(Condition condition, int* from, const int* fromInstruction, void* to)
     {
         RELEASE_ASSERT(roundUpToMultipleOf<instructionSize>(from) == from);
         ASSERT(!(reinterpret_cast<intptr_t>(from) & 3));
@@ -3939,7 +3939,7 @@ protected:
     }
 
     template<BranchTargetType type, CopyFunction copy = performJITMemcpy>
-    static void linkTestAndBranch(Condition condition, unsigned bitNumber, RegisterID rt, int* from, const int* fromInstruction, void* to)
+    static ALWAYS_INLINE void linkTestAndBranch(Condition condition, unsigned bitNumber, RegisterID rt, int* from, const int* fromInstruction, void* to)
     {
         RELEASE_ASSERT(roundUpToMultipleOf<instructionSize>(from) == from);
         ASSERT(!(reinterpret_cast<intptr_t>(from) & 3));
@@ -3966,7 +3966,7 @@ protected:
     }
 
     template<BranchType type>
-    static void relinkJumpOrCall(int* from, const int* fromInstruction, void* to)
+    static ALWAYS_INLINE void relinkJumpOrCall(int* from, const int* fromInstruction, void* to)
     {
         static_assert(type == BranchType_JMP || type == BranchType_CALL);
         if ((type == BranchType_JMP) && disassembleNop(from)) {
@@ -4015,16 +4015,16 @@ protected:
         linkJumpOrCall<type>(from, fromInstruction, to);
     }
 
-    static int* addressOf(void* code, AssemblerLabel label)
+    static ALWAYS_INLINE int* addressOf(void* code, AssemblerLabel label)
     {
         return reinterpret_cast<int*>(static_cast<char*>(code) + label.offset());
     }
 
-    static RegisterID disassembleXOrSp(int reg) { return reg == 31 ? ARM64Registers::sp : static_cast<RegisterID>(reg); }
-    static RegisterID disassembleXOrZr(int reg) { return reg == 31 ? ARM64Registers::zr : static_cast<RegisterID>(reg); }
-    static RegisterID disassembleXOrZrOrSp(bool useZr, int reg) { return reg == 31 ? (useZr ? ARM64Registers::zr : ARM64Registers::sp) : static_cast<RegisterID>(reg); }
+    static ALWAYS_INLINE RegisterID disassembleXOrSp(int reg) { return reg == 31 ? ARM64Registers::sp : static_cast<RegisterID>(reg); }
+    static ALWAYS_INLINE RegisterID disassembleXOrZr(int reg) { return reg == 31 ? ARM64Registers::zr : static_cast<RegisterID>(reg); }
+    static ALWAYS_INLINE RegisterID disassembleXOrZrOrSp(bool useZr, int reg) { return reg == 31 ? (useZr ? ARM64Registers::zr : ARM64Registers::sp) : static_cast<RegisterID>(reg); }
 
-    static bool disassembleAddSubtractImmediate(void* address, Datasize& sf, AddOp& op, SetFlags& S, int& shift, int& imm12, RegisterID& rn, RegisterID& rd)
+    static ALWAYS_INLINE bool disassembleAddSubtractImmediate(void* address, Datasize& sf, AddOp& op, SetFlags& S, int& shift, int& imm12, RegisterID& rn, RegisterID& rd)
     {
         int insn = *static_cast<int*>(address);
         sf = static_cast<Datasize>((insn >> 31) & 1);
@@ -4037,7 +4037,7 @@ protected:
         return (insn & 0x1f000000) == 0x11000000;
     }
 
-    static bool disassembleLoadStoreRegisterUnsignedImmediate(void* address, MemOpSize& size, bool& V, MemOp& opc, int& imm12, RegisterID& rn, RegisterID& rt)
+    static ALWAYS_INLINE bool disassembleLoadStoreRegisterUnsignedImmediate(void* address, MemOpSize& size, bool& V, MemOp& opc, int& imm12, RegisterID& rn, RegisterID& rt)
     {
         int insn = *static_cast<int*>(address);
         size = static_cast<MemOpSize>((insn >> 30) & 3);
@@ -4049,7 +4049,7 @@ protected:
         return (insn & 0x3b000000) == 0x39000000;
     }
 
-    static bool disassembleMoveWideImediate(void* address, Datasize& sf, MoveWideOp& opc, int& hw, uint16_t& imm16, RegisterID& rd)
+    static ALWAYS_INLINE bool disassembleMoveWideImediate(void* address, Datasize& sf, MoveWideOp& opc, int& hw, uint16_t& imm16, RegisterID& rd)
     {
         int insn = *static_cast<int*>(address);
         sf = static_cast<Datasize>((insn >> 31) & 1);
@@ -4060,13 +4060,13 @@ protected:
         return (insn & 0x1f800000) == 0x12800000;
     }
 
-    static bool disassembleNop(void* address)
+    static ALWAYS_INLINE bool disassembleNop(void* address)
     {
         unsigned insn = *static_cast<unsigned*>(address);
         return insn == 0xd503201f;
     }
 
-    static bool disassembleCompareAndBranchImmediate(void* address, Datasize& sf, bool& op, int& imm19, RegisterID& rt)
+    static ALWAYS_INLINE bool disassembleCompareAndBranchImmediate(void* address, Datasize& sf, bool& op, int& imm19, RegisterID& rt)
     {
         int insn = *static_cast<int*>(address);
         sf = static_cast<Datasize>((insn >> 31) & 1);
@@ -4077,7 +4077,7 @@ protected:
         
     }
 
-    static bool disassembleConditionalBranchImmediate(void* address, unsigned& op01, int& imm19, Condition &condition)
+    static ALWAYS_INLINE bool disassembleConditionalBranchImmediate(void* address, unsigned& op01, int& imm19, Condition &condition)
     {
         int insn = *static_cast<int*>(address);
         op01 = ((insn >> 23) & 0x2) | ((insn >> 4) & 0x1);
@@ -4086,7 +4086,7 @@ protected:
         return (insn & 0xfe000000) == 0x54000000;
     }
 
-    static bool disassembleTestAndBranchImmediate(void* address, bool& op, unsigned& bitNumber, int& imm14, RegisterID& rt)
+    static ALWAYS_INLINE bool disassembleTestAndBranchImmediate(void* address, bool& op, unsigned& bitNumber, int& imm14, RegisterID& rt)
     {
         int insn = *static_cast<int*>(address);
         op = (insn >> 24) & 0x1;
@@ -4097,7 +4097,7 @@ protected:
         
     }
 
-    static bool disassembleUnconditionalBranchImmediate(void* address, bool& op, int& imm26)
+    static ALWAYS_INLINE bool disassembleUnconditionalBranchImmediate(void* address, bool& op, int& imm26)
     {
         int insn = *static_cast<int*>(address);
         op = (insn >> 31) & 1;

--- a/Source/JavaScriptCore/assembler/AssemblerBuffer.h
+++ b/Source/JavaScriptCore/assembler/AssemblerBuffer.h
@@ -319,7 +319,7 @@ namespace JSC {
             threadSpecificData->takeBufferIfLarger(WTFMove(m_storage));
         }
 
-        bool isAvailable(unsigned space)
+        ALWAYS_INLINE bool isAvailable(unsigned space)
         {
             return m_index + space <= m_storage.capacity();
         }
@@ -330,7 +330,7 @@ namespace JSC {
                 outOfLineGrow();
         }
 
-        bool isAligned(int alignment) const
+        ALWAYS_INLINE bool isAligned(int alignment) const
         {
             return !(m_index & (alignment - 1));
         }
@@ -343,10 +343,10 @@ namespace JSC {
         void putInt64Unchecked(int64_t value) { putIntegralUnchecked(value); }
         void putInt64(int64_t value) { putIntegral(value); }
 #endif
-        void putIntUnchecked(int32_t value) { putIntegralUnchecked(value); }
-        void putInt(int32_t value) { putIntegral(value); }
+        ALWAYS_INLINE void putIntUnchecked(int32_t value) { putIntegralUnchecked(value); }
+        ALWAYS_INLINE void putInt(int32_t value) { putIntegral(value); }
 
-        size_t codeSize() const
+        ALWAYS_INLINE size_t codeSize() const
         {
             return m_index;
         }
@@ -362,14 +362,14 @@ namespace JSC {
         }
 #endif
 
-        AssemblerLabel label() const
+        ALWAYS_INLINE AssemblerLabel label() const
         {
             return AssemblerLabel(m_index);
         }
 
         unsigned debugOffset() { return m_index; }
 
-        AssemblerData&& releaseAssemblerData()
+        ALWAYS_INLINE AssemblerData&& releaseAssemblerData()
         {
             return WTFMove(m_storage);
         }
@@ -438,12 +438,12 @@ namespace JSC {
 #endif
 
 #if CPU(ARM64E)
-        ARM64EHash<ShouldSign::Yes>& arm64eHash() { return m_hash; }
+        ALWAYS_INLINE ARM64EHash<ShouldSign::Yes>& arm64eHash() { return m_hash; }
 #endif
 
     protected:
         template<typename IntegralType>
-        void putIntegral(IntegralType value)
+        ALWAYS_INLINE void putIntegral(IntegralType value)
         {
             unsigned nextIndex = m_index + sizeof(IntegralType);
             if (UNLIKELY(nextIndex > m_storage.capacity()))
@@ -452,7 +452,7 @@ namespace JSC {
         }
 
         template<typename IntegralType>
-        void putIntegralUnchecked(IntegralType value)
+        ALWAYS_INLINE void putIntegralUnchecked(IntegralType value)
         {
 #if CPU(ARM64)
             static_assert(sizeof(value) == 4);

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -72,7 +72,7 @@ protected:
     static constexpr ptrdiff_t REPATCH_OFFSET_CALL_TO_POINTER = -((Assembler::NUMBER_OF_ADDRESS_ENCODING_INSTRUCTIONS + 1) * INSTRUCTION_SIZE);
 
 public:
-    MacroAssemblerARM64()
+    ALWAYS_INLINE MacroAssemblerARM64()
         : m_dataMemoryTempRegister(this, dataTempRegister)
         , m_cachedMemoryTempRegister(this, memoryTempRegister)
         , m_makeJumpPatchable(false)
@@ -88,14 +88,14 @@ public:
     static constexpr Assembler::JumpType DefaultJump = Assembler::JumpNoConditionFixedSize;
 
     Vector<LinkRecord, 0, UnsafeVectorOverflow>& jumpsToLink() { return m_assembler.jumpsToLink(); }
-    static bool canCompact(JumpType jumpType) { return Assembler::canCompact(jumpType); }
-    static JumpLinkType computeJumpType(LinkRecord& record, const uint8_t* from, const uint8_t* to) { return Assembler::computeJumpType(record, from, to); }
-    static int jumpSizeDelta(JumpType jumpType, JumpLinkType jumpLinkType) { return Assembler::jumpSizeDelta(jumpType, jumpLinkType); }
+    ALWAYS_INLINE static bool canCompact(JumpType jumpType) { return Assembler::canCompact(jumpType); }
+    ALWAYS_INLINE static JumpLinkType computeJumpType(LinkRecord& record, const uint8_t* from, const uint8_t* to) { return Assembler::computeJumpType(record, from, to); }
+    ALWAYS_INLINE static int jumpSizeDelta(JumpType jumpType, JumpLinkType jumpLinkType) { return Assembler::jumpSizeDelta(jumpType, jumpLinkType); }
 
     template <Assembler::CopyFunction copy>
     ALWAYS_INLINE static void link(LinkRecord& record, uint8_t* from, const uint8_t* fromInstruction, uint8_t* to) { return Assembler::link<copy>(record, from, fromInstruction, to); }
 
-    static bool isCompactPtrAlignedAddressOffset(ptrdiff_t value)
+    ALWAYS_INLINE static bool isCompactPtrAlignedAddressOffset(ptrdiff_t value)
     {
         // This is the largest 32-bit access allowed, aligned to 64-bit boundary.
         return !(value & ~0x3ff8);


### PR DESCRIPTION
#### e3f2a6f91ba48a9da351d92f82cd28f37a087f07
<pre>
Inline some functions used in copyCompactAndLinkCode
<a href="https://bugs.webkit.org/show_bug.cgi?id=266362">https://bugs.webkit.org/show_bug.cgi?id=266362</a>
<a href="https://rdar.apple.com/119627634">rdar://119627634</a>

Reviewed by Mark Lam.

Inline some functions used in copyCompactAndLinkCode, since we want
to minimize register spilling there.

* Source/JavaScriptCore/assembler/ARM64Assembler.h:
(JSC::ARM64Assembler::buffer):
(JSC::ARM64Assembler::LinkRecord::from const):
(JSC::ARM64Assembler::LinkRecord::setFrom):
(JSC::ARM64Assembler::LinkRecord::to const):
(JSC::ARM64Assembler::LinkRecord::type const):
(JSC::ARM64Assembler::LinkRecord::linkType const):
(JSC::ARM64Assembler::LinkRecord::branchType const):
(JSC::ARM64Assembler::LinkRecord::setLinkType):
(JSC::ARM64Assembler::LinkRecord::condition const):
(JSC::ARM64Assembler::LinkRecord::is64Bit const):
(JSC::ARM64Assembler::LinkRecord::isThunk const):
(JSC::ARM64Assembler::LinkRecord::bitNumber const):
(JSC::ARM64Assembler::LinkRecord::compareRegister const):
* Source/JavaScriptCore/assembler/AssemblerBuffer.h:
(JSC::AssemblerBuffer::putInt):
(JSC::AssemblerBuffer::releaseAssemblerData):
* Source/JavaScriptCore/assembler/MacroAssemblerARM64.h:
(JSC::MacroAssemblerARM64::MacroAssemblerARM64):
(JSC::MacroAssemblerARM64::jumpsToLink):
(JSC::MacroAssemblerARM64::canCompact):
(JSC::MacroAssemblerARM64::computeJumpType):
(JSC::MacroAssemblerARM64::jumpSizeDelta):
(JSC::MacroAssemblerARM64::isCompactPtrAlignedAddressOffset):

Canonical link: <a href="https://commits.webkit.org/272034@main">https://commits.webkit.org/272034@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/259f2a1761dca08c17931eb72795ee71f32577cc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30450 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9124 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32069 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32962 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27547 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11358 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6363 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/27492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30759 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/7669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/27300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/6571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/6721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/27143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34299 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/26150 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/27738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/27640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/32900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/30557 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6705 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/4848 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/30724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/8452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/36995 "Built successfully") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/7442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7959 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3933 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7249 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->