### PR TITLE
Delete some unused GraphicsContextCG and Dynamic Content Scaling code

### DIFF
--- a/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp
@@ -373,11 +373,6 @@ void BifurcatedGraphicsContext::drawNativeImageInternal(NativeImage& nativeImage
     VERIFY_STATE_SYNCHRONIZATION();
 }
 
-bool BifurcatedGraphicsContext::needsCachedNativeImageInvalidationWorkaround(RenderingMode renderingMode)
-{
-    return m_primaryContext.needsCachedNativeImageInvalidationWorkaround(renderingMode) || m_secondaryContext.needsCachedNativeImageInvalidationWorkaround(renderingMode);
-}
-
 void BifurcatedGraphicsContext::drawSystemImage(SystemImage& systemImage, const FloatRect& destinationRect)
 {
     m_primaryContext.drawSystemImage(systemImage, destinationRect);

--- a/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h
+++ b/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h
@@ -103,7 +103,6 @@ public:
     void setMiterLimit(float) final;
 
     void drawNativeImageInternal(NativeImage&, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions = { }) final;
-    bool needsCachedNativeImageInvalidationWorkaround(RenderingMode) final;
     void drawSystemImage(SystemImage&, const FloatRect&) final;
     void drawPattern(NativeImage&, const FloatRect& destRect, const FloatRect& tileRect, const AffineTransform& patternTransform, const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions = { }) final;
     ImageDrawResult drawImage(Image&, const FloatRect& destination, const FloatRect& source, ImagePaintingOptions = { ImageOrientation::Orientation::FromImage }) final;

--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -252,8 +252,6 @@ public:
 
     WEBCORE_EXPORT void drawNativeImage(NativeImage&, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions = { });
 
-    virtual bool needsCachedNativeImageInvalidationWorkaround(RenderingMode) { return true; }
-
     WEBCORE_EXPORT virtual void drawSystemImage(SystemImage&, const FloatRect&);
 
     WEBCORE_EXPORT ImageDrawResult drawImage(Image&, const FloatPoint& destination, ImagePaintingOptions = { ImageOrientation::Orientation::FromImage });

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -403,18 +403,6 @@ void GraphicsContextCG::drawNativeImageInternal(NativeImage& nativeImage, const 
     LOG_WITH_STREAM(Images, stream << "GraphicsContextCG::drawNativeImageInternal " << image.get() << " size " << imageSize << " into " << destRect << " took " << (MonotonicTime::now() - startTime).milliseconds() << "ms");
 }
 
-bool GraphicsContextCG::needsCachedNativeImageInvalidationWorkaround(RenderingMode imageRenderingMode)
-{
-    // Only accelerated images cache CGImageRefs underneath us (when returned by
-    // IOSurface::createImage), and thus need the workaround.
-    if (imageRenderingMode == RenderingMode::Unaccelerated)
-        return false;
-
-    // Accelerated destinations have "live" CGImageRefs, so we only need
-    // the workaround when painting into an unaccelerated context.
-    return renderingMode() == RenderingMode::Unaccelerated;
-}
-
 static void drawPatternCallback(void* info, CGContextRef context)
 {
     CGImageRef image = (CGImageRef)info;

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
@@ -100,7 +100,6 @@ public:
     void setMiterLimit(float) final;
 
     void drawPattern(NativeImage&, const FloatRect& destRect, const FloatRect& tileRect, const AffineTransform& patternTransform, const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions = { }) final;
-    bool needsCachedNativeImageInvalidationWorkaround(RenderingMode) override;
 
     using GraphicsContext::scale;
     void scale(const FloatSize&) final;

--- a/Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingImageBufferBackend.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingImageBufferBackend.h
@@ -67,16 +67,6 @@ protected:
     WebCore::RenderingMode m_renderingMode;
 };
 
-class DynamicContentScalingAcceleratedImageBufferBackend final : public DynamicContentScalingImageBufferBackend {
-    WTF_MAKE_ISO_ALLOCATED(DynamicContentScalingAcceleratedImageBufferBackend);
-    WTF_MAKE_NONCOPYABLE(DynamicContentScalingAcceleratedImageBufferBackend);
-public:
-    static std::unique_ptr<DynamicContentScalingAcceleratedImageBufferBackend> create(const DynamicContentScalingImageBufferBackend::Parameters&, const WebCore::ImageBufferCreationContext&);
-
-protected:
-    DynamicContentScalingAcceleratedImageBufferBackend(const Parameters&, const WebCore::ImageBufferCreationContext&, WebCore::RenderingMode);
-};
-
 }
 
 #endif // ENABLE(RE_DYNAMIC_CONTENT_SCALING)

--- a/Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingImageBufferBackend.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingImageBufferBackend.mm
@@ -63,8 +63,6 @@ public:
     }
 
     bool canUseShadowBlur() const final { return false; }
-
-    bool needsCachedNativeImageInvalidationWorkaround(WebCore::RenderingMode) override { return true; }
 };
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(DynamicContentScalingImageBufferBackend);
@@ -165,23 +163,6 @@ String DynamicContentScalingImageBufferBackend::debugDescription() const
     TextStream stream;
     stream << "DynamicContentScalingImageBufferBackend " << this;
     return stream.release();
-}
-
-#pragma mark - DynamicContentScalingAcceleratedImageBufferBackend
-
-WTF_MAKE_ISO_ALLOCATED_IMPL(DynamicContentScalingAcceleratedImageBufferBackend);
-
-std::unique_ptr<DynamicContentScalingAcceleratedImageBufferBackend> DynamicContentScalingAcceleratedImageBufferBackend::create(const Parameters& parameters, const WebCore::ImageBufferCreationContext& creationContext)
-{
-    if (parameters.backendSize.isEmpty())
-        return nullptr;
-
-    return std::unique_ptr<DynamicContentScalingAcceleratedImageBufferBackend>(new DynamicContentScalingAcceleratedImageBufferBackend(parameters, creationContext, WebCore::RenderingMode::Accelerated));
-}
-
-DynamicContentScalingAcceleratedImageBufferBackend::DynamicContentScalingAcceleratedImageBufferBackend(const Parameters& parameters, const WebCore::ImageBufferCreationContext& creationContext, WebCore::RenderingMode renderingMode)
-    : DynamicContentScalingImageBufferBackend(parameters, creationContext, renderingMode)
-{
 }
 
 }


### PR DESCRIPTION
#### f147f387538df7a313191a0c17404ec5784c841d
<pre>
Delete some unused GraphicsContextCG and Dynamic Content Scaling code
<a href="https://bugs.webkit.org/show_bug.cgi?id=266364">https://bugs.webkit.org/show_bug.cgi?id=266364</a>
<a href="https://rdar.apple.com/119627950">rdar://119627950</a>

Reviewed by Wenson Hsieh.

* Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp:
(WebCore::BifurcatedGraphicsContext::needsCachedNativeImageInvalidationWorkaround): Deleted.
* Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h:
* Source/WebCore/platform/graphics/GraphicsContext.h:
(WebCore::GraphicsContext::needsCachedNativeImageInvalidationWorkaround): Deleted.
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::needsCachedNativeImageInvalidationWorkaround): Deleted.
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.h:
* Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingImageBufferBackend.h:
* Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingImageBufferBackend.mm:
(WebKit::DynamicContentScalingAcceleratedImageBufferBackend::create): Deleted.
(WebKit::DynamicContentScalingAcceleratedImageBufferBackend::DynamicContentScalingAcceleratedImageBufferBackend): Deleted.

Canonical link: <a href="https://commits.webkit.org/272068@main">https://commits.webkit.org/272068@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab31f030888bceaeb64de3dafefd4367ad0574ae

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30319 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8993 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31944 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32828 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27440 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31018 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11190 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6226 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27404 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30627 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7560 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27147 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6466 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6626 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27045 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34168 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27647 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27545 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32810 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6590 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4756 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30623 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8357 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7224 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7346 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7118 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->