### PR TITLE
Make Page refcounted and replace CheckedPtr with RefPtr for stack variables

### DIFF
--- a/Source/WebCore/Modules/permissions/MainThreadPermissionObserver.cpp
+++ b/Source/WebCore/Modules/permissions/MainThreadPermissionObserver.cpp
@@ -34,7 +34,7 @@
 
 namespace WebCore {
 
-MainThreadPermissionObserver::MainThreadPermissionObserver(ThreadSafeWeakPtr<PermissionStatus>&& permissionStatus, ScriptExecutionContextIdentifier contextIdentifier, PermissionState state, PermissionDescriptor descriptor, PermissionQuerySource source, WeakPtr<Page>&& page, ClientOrigin&& origin)
+MainThreadPermissionObserver::MainThreadPermissionObserver(ThreadSafeWeakPtr<PermissionStatus>&& permissionStatus, ScriptExecutionContextIdentifier contextIdentifier, PermissionState state, PermissionDescriptor descriptor, PermissionQuerySource source, SingleThreadWeakPtr<Page>&& page, ClientOrigin&& origin)
     : m_permissionStatus(WTFMove(permissionStatus))
     , m_contextIdentifier(contextIdentifier)
     , m_state(state)

--- a/Source/WebCore/Modules/permissions/MainThreadPermissionObserver.h
+++ b/Source/WebCore/Modules/permissions/MainThreadPermissionObserver.h
@@ -42,7 +42,7 @@ class MainThreadPermissionObserver final : public PermissionObserver {
     WTF_MAKE_NONCOPYABLE(MainThreadPermissionObserver);
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    MainThreadPermissionObserver(ThreadSafeWeakPtr<PermissionStatus>&&, ScriptExecutionContextIdentifier, PermissionState, PermissionDescriptor, PermissionQuerySource, WeakPtr<Page>&&, ClientOrigin&&);
+    MainThreadPermissionObserver(ThreadSafeWeakPtr<PermissionStatus>&&, ScriptExecutionContextIdentifier, PermissionState, PermissionDescriptor, PermissionQuerySource, SingleThreadWeakPtr<Page>&&, ClientOrigin&&);
     ~MainThreadPermissionObserver();
 
 private:
@@ -52,14 +52,14 @@ private:
     const ClientOrigin& origin() const final { return m_origin; }
     PermissionDescriptor descriptor() const final { return m_descriptor; }
     PermissionQuerySource source() const final { return m_source; }
-    const WeakPtr<Page>& page() const final { return m_page; }
+    const SingleThreadWeakPtr<Page>& page() const final { return m_page; }
 
     ThreadSafeWeakPtr<PermissionStatus> m_permissionStatus;
     ScriptExecutionContextIdentifier m_contextIdentifier;
     PermissionState m_state;
     PermissionDescriptor m_descriptor;
     PermissionQuerySource m_source;
-    WeakPtr<Page> m_page;
+    SingleThreadWeakPtr<Page> m_page;
     ClientOrigin m_origin;
 };
 

--- a/Source/WebCore/Modules/permissions/PermissionController.h
+++ b/Source/WebCore/Modules/permissions/PermissionController.h
@@ -46,7 +46,7 @@ public:
     WEBCORE_EXPORT static void setSharedController(Ref<PermissionController>&&);
     
     virtual ~PermissionController() = default;
-    virtual void query(ClientOrigin&&, PermissionDescriptor, const WeakPtr<Page>&, PermissionQuerySource, CompletionHandler<void(std::optional<PermissionState>)>&&) = 0;
+    virtual void query(ClientOrigin&&, PermissionDescriptor, const SingleThreadWeakPtr<Page>&, PermissionQuerySource, CompletionHandler<void(std::optional<PermissionState>)>&&) = 0;
     virtual void addObserver(PermissionObserver&) = 0;
     virtual void removeObserver(PermissionObserver&) = 0;
     virtual void permissionChanged(PermissionName, const SecurityOriginData&) = 0;
@@ -59,7 +59,7 @@ public:
     static Ref<DummyPermissionController> create() { return adoptRef(*new DummyPermissionController); }
 private:
     DummyPermissionController() = default;
-    void query(ClientOrigin&&, PermissionDescriptor, const WeakPtr<Page>&, PermissionQuerySource, CompletionHandler<void(std::optional<PermissionState>)>&& callback) final { callback({ }); }
+    void query(ClientOrigin&&, PermissionDescriptor, const SingleThreadWeakPtr<Page>&, PermissionQuerySource, CompletionHandler<void(std::optional<PermissionState>)>&& callback) final { callback({ }); }
     void addObserver(PermissionObserver&) final { }
     void removeObserver(PermissionObserver&) final { }
     void permissionChanged(PermissionName, const SecurityOriginData&) final { }

--- a/Source/WebCore/Modules/permissions/PermissionObserver.h
+++ b/Source/WebCore/Modules/permissions/PermissionObserver.h
@@ -46,7 +46,7 @@ public:
     virtual const ClientOrigin& origin() const = 0;
     virtual PermissionDescriptor descriptor() const = 0;
     virtual PermissionQuerySource source() const = 0;
-    virtual const WeakPtr<Page>& page() const = 0;
+    virtual const SingleThreadWeakPtr<Page>& page() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/permissions/PermissionStatus.cpp
+++ b/Source/WebCore/Modules/permissions/PermissionStatus.cpp
@@ -54,14 +54,14 @@ static HashMap<MainThreadPermissionObserverIdentifier, std::unique_ptr<MainThrea
     return map;
 }
 
-Ref<PermissionStatus> PermissionStatus::create(ScriptExecutionContext& context, PermissionState state, PermissionDescriptor descriptor, PermissionQuerySource source, WeakPtr<Page>&& page)
+Ref<PermissionStatus> PermissionStatus::create(ScriptExecutionContext& context, PermissionState state, PermissionDescriptor descriptor, PermissionQuerySource source, SingleThreadWeakPtr<Page>&& page)
 {
     auto status = adoptRef(*new PermissionStatus(context, state, descriptor, source, WTFMove(page)));
     status->suspendIfNeeded();
     return status;
 }
 
-PermissionStatus::PermissionStatus(ScriptExecutionContext& context, PermissionState state, PermissionDescriptor descriptor, PermissionQuerySource source, WeakPtr<Page>&& page)
+PermissionStatus::PermissionStatus(ScriptExecutionContext& context, PermissionState state, PermissionDescriptor descriptor, PermissionQuerySource source, SingleThreadWeakPtr<Page>&& page)
     : ActiveDOMObject(&context)
     , m_state(state)
     , m_descriptor(descriptor)

--- a/Source/WebCore/Modules/permissions/PermissionStatus.h
+++ b/Source/WebCore/Modules/permissions/PermissionStatus.h
@@ -42,7 +42,7 @@ class ScriptExecutionContext;
 class PermissionStatus final : public ActiveDOMObject, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<PermissionStatus>, public EventTarget  {
     WTF_MAKE_ISO_ALLOCATED(PermissionStatus);
 public:
-    static Ref<PermissionStatus> create(ScriptExecutionContext&, PermissionState, PermissionDescriptor, PermissionQuerySource, WeakPtr<Page>&&);
+    static Ref<PermissionStatus> create(ScriptExecutionContext&, PermissionState, PermissionDescriptor, PermissionQuerySource, SingleThreadWeakPtr<Page>&&);
     ~PermissionStatus();
 
     PermissionState state() const { return m_state; }
@@ -54,7 +54,7 @@ public:
     using ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref;
 
 private:
-    PermissionStatus(ScriptExecutionContext&, PermissionState, PermissionDescriptor, PermissionQuerySource, WeakPtr<Page>&&);
+    PermissionStatus(ScriptExecutionContext&, PermissionState, PermissionDescriptor, PermissionQuerySource, SingleThreadWeakPtr<Page>&&);
 
     // ActiveDOMObject
     const char* activeDOMObjectName() const final;

--- a/Source/WebCore/Scripts/SettingsTemplates/InternalSettingsGenerated.h.erb
+++ b/Source/WebCore/Scripts/SettingsTemplates/InternalSettingsGenerated.h.erb
@@ -49,7 +49,7 @@ public:
 <%- end -%>
 
 private:
-    WeakPtr<Page> m_page;
+    SingleThreadWeakPtr<Page> m_page;
 
 <%- for @setting in @allSettingsSet.settings do -%>
 <%- if @setting.excludeFromInternalSettings == false and @setting.idlType -%>

--- a/Source/WebCore/accessibility/atspi/AccessibilityRootAtspi.h
+++ b/Source/WebCore/accessibility/atspi/AccessibilityRootAtspi.h
@@ -64,7 +64,7 @@ private:
     static GDBusInterfaceVTable s_socketFunctions;
     static GDBusInterfaceVTable s_componentFunctions;
 
-    WeakPtr<Page> m_page;
+    SingleThreadWeakPtr<Page> m_page;
     String m_path;
     String m_parentUniqueName;
     String m_parentPath;

--- a/Source/WebCore/bindings/js/ScriptController.cpp
+++ b/Source/WebCore/bindings/js/ScriptController.cpp
@@ -297,7 +297,7 @@ void ScriptController::initScriptForWindowProxy(JSWindowProxy& windowProxy)
     if (RefPtr document = m_frame.document())
         document->checkedContentSecurityPolicy()->didCreateWindowProxy(windowProxy);
 
-    if (CheckedPtr page = m_frame.page()) {
+    if (RefPtr page = m_frame.page()) {
         windowProxy.attachDebugger(page->debugger());
         windowProxy.window()->setProfileGroup(page->group().identifier());
         windowProxy.window()->setConsoleClient(page->console());

--- a/Source/WebCore/dom/BroadcastChannel.cpp
+++ b/Source/WebCore/dom/BroadcastChannel.cpp
@@ -114,12 +114,12 @@ void BroadcastChannel::MainThreadBridge::ensureOnMainThread(Function<void(Page*)
 
     Ref protectedThis { *this };
     if (auto* document = dynamicDowncast<Document>(*context)) {
-        task(document->checkedPage().get());
+        task(document->protectedPage().get());
         return;
     }
 
     downcast<WorkerGlobalScope>(*context).thread().workerLoaderProxy().postTaskToLoader([protectedThis = WTFMove(protectedThis), task = WTFMove(task)](auto& context) {
-        task(downcast<Document>(context).checkedPage().get());
+        task(downcast<Document>(context).protectedPage().get());
     });
 }
 

--- a/Source/WebCore/dom/ConstantPropertyMap.cpp
+++ b/Source/WebCore/dom/ConstantPropertyMap.cpp
@@ -132,7 +132,7 @@ Ref<Document> ConstantPropertyMap::protectedDocument() const
 
 void ConstantPropertyMap::updateConstantsForSafeAreaInsets()
 {
-    CheckedPtr page = m_document->page();
+    RefPtr page = m_document->page();
     FloatBoxExtent unobscuredSafeAreaInsets = page ? page->unobscuredSafeAreaInsets() : FloatBoxExtent();
     setValueForProperty(ConstantProperty::SafeAreaInsetTop, variableDataForPositivePixelLength(unobscuredSafeAreaInsets.top()));
     setValueForProperty(ConstantProperty::SafeAreaInsetRight, variableDataForPositivePixelLength(unobscuredSafeAreaInsets.right()));
@@ -148,7 +148,7 @@ void ConstantPropertyMap::didChangeSafeAreaInsets()
 
 void ConstantPropertyMap::updateConstantsForFullscreen()
 {
-    CheckedPtr page = m_document->page();
+    RefPtr page = m_document->page();
     FloatBoxExtent fullscreenInsets = page ? page->fullscreenInsets() : FloatBoxExtent();
     setValueForProperty(ConstantProperty::FullscreenInsetTop, variableDataForPositivePixelLength(fullscreenInsets.top()));
     setValueForProperty(ConstantProperty::FullscreenInsetRight, variableDataForPositivePixelLength(fullscreenInsets.right()));

--- a/Source/WebCore/dom/DataTransfer.cpp
+++ b/Source/WebCore/dom/DataTransfer.cpp
@@ -220,13 +220,13 @@ String DataTransfer::readStringFromPasteboard(Document& document, const String& 
     }
 
     if (!is<StaticPasteboard>(*m_pasteboard) && lowercaseType == "text/uri-list"_s) {
-        return readURLsFromPasteboardAsString(document.checkedPage().get(), *m_pasteboard, [] (auto&) {
+        return readURLsFromPasteboardAsString(document.protectedPage().get(), *m_pasteboard, [] (auto&) {
             return true;
         });
     }
 
     auto string = m_pasteboard->readString(lowercaseType);
-    if (CheckedPtr page = document.page())
+    if (RefPtr page = document.page())
         return page->applyLinkDecorationFiltering(string, LinkDecorationFilteringTrigger::Paste);
 
     return string;
@@ -279,7 +279,7 @@ void DataTransfer::setDataFromItemList(Document& document, const String& type, c
         sanitizedData = data; // Nothing to sanitize.
 
     if (type == "text/uri-list"_s || type == textPlainContentTypeAtom()) {
-        if (CheckedPtr page = document.page())
+        if (RefPtr page = document.page())
             sanitizedData = page->applyLinkDecorationFiltering(sanitizedData, LinkDecorationFilteringTrigger::Copy);
     }
 

--- a/Source/WebCore/dom/DeviceOrientationAndMotionAccessController.cpp
+++ b/Source/WebCore/dom/DeviceOrientationAndMotionAccessController.cpp
@@ -63,7 +63,7 @@ DeviceOrientationOrMotionPermissionState DeviceOrientationAndMotionAccessControl
 
 void DeviceOrientationAndMotionAccessController::shouldAllowAccess(const Document& document, Function<void(DeviceOrientationOrMotionPermissionState)>&& callback)
 {
-    CheckedPtr page = document.page();
+    RefPtr page = document.page();
     RefPtr frame = document.frame();
     if (!page || !frame)
         return callback(DeviceOrientationOrMotionPermissionState::Denied);

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -663,7 +663,7 @@ public:
     inline LocalFrameView* view() const; // Defined in LocalFrame.h.
     RefPtr<LocalFrameView> protectedView() const;
     inline Page* page() const; // Defined in Page.h.
-    inline CheckedPtr<Page> checkedPage() const; // Defined in Page.h.
+    inline RefPtr<Page> protectedPage() const; // Defined in Page.h.
     const Settings& settings() const { return m_settings.get(); }
     Ref<Settings> protectedSettings() const;
     EditingBehavior editingBehavior() const;

--- a/Source/WebCore/dom/DocumentMarkerController.cpp
+++ b/Source/WebCore/dom/DocumentMarkerController.cpp
@@ -124,7 +124,7 @@ void DocumentMarkerController::invalidateRectsForAllMarkers()
             marker.invalidate();
     }
 
-    if (CheckedPtr page = m_document->page())
+    if (RefPtr page = m_document->page())
         page->chrome().client().didInvalidateDocumentMarkerRects();
 }
 
@@ -139,7 +139,7 @@ void DocumentMarkerController::invalidateRectsForMarkersInNode(Node& node)
     for (auto& marker : *markers)
         marker.invalidate();
 
-    if (CheckedPtr page = m_document->page())
+    if (RefPtr page = m_document->page())
         page->chrome().client().didInvalidateDocumentMarkerRects();
 }
 

--- a/Source/WebCore/dom/DocumentStorageAccess.cpp
+++ b/Source/WebCore/dom/DocumentStorageAccess.cpp
@@ -113,7 +113,7 @@ void DocumentStorageAccess::hasStorageAccess(Ref<DeferredPromise>&& promise)
         promise->resolve<IDLBoolean>(false);
         return;
     }
-    CheckedPtr page = frame->page();
+    RefPtr page = frame->page();
     if (!page) {
         ASSERT_NOT_REACHED();
         promise->resolve<IDLBoolean>(false);
@@ -186,7 +186,7 @@ void DocumentStorageAccess::requestStorageAccess(Ref<DeferredPromise>&& promise)
         promise->reject();
         return;
     }
-    CheckedPtr page = frame->page();
+    RefPtr page = frame->page();
     if (!page) {
         ASSERT_NOT_REACHED();
         promise->reject();
@@ -269,7 +269,7 @@ void DocumentStorageAccess::requestStorageAccessQuirk(RegistrableDomain&& reques
     auto topFrameDomain = RegistrableDomain(document->topDocument().url());
 
     RefPtr frame = document->frame();
-    frame->checkedPage()->chrome().client().requestStorageAccess(WTFMove(requestingDomain), WTFMove(topFrameDomain), *frame, m_storageAccessScope, [this, weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler)] (RequestStorageAccessResult result) mutable {
+    frame->protectedPage()->chrome().client().requestStorageAccess(WTFMove(requestingDomain), WTFMove(topFrameDomain), *frame, m_storageAccessScope, [this, weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler)] (RequestStorageAccessResult result) mutable {
         if (!weakThis)
             return;
 

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -431,7 +431,7 @@ static bool isCompatibilityMouseEvent(const MouseEvent& mouseEvent)
 enum class ShouldIgnoreMouseEvent : bool { No, Yes };
 static ShouldIgnoreMouseEvent dispatchPointerEventIfNeeded(Element& element, const MouseEvent& mouseEvent, const PlatformMouseEvent& platformEvent, bool& didNotSwallowEvent)
 {
-    if (CheckedPtr page = element.document().page()) {
+    if (RefPtr page = element.document().page()) {
         auto& pointerCaptureController = page->pointerCaptureController();
 #if ENABLE(TOUCH_EVENTS)
         if (platformEvent.pointerId() != mousePointerID && mouseEvent.type() != eventNames().clickEvent && pointerCaptureController.preventsCompatibilityMouseEventsForIdentifier(platformEvent.pointerId()))
@@ -2793,7 +2793,7 @@ bool Element::hasEffectiveLangState() const
 
 void Element::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
-    if (CheckedPtr page = document().page()) {
+    if (RefPtr page = document().page()) {
 #if ENABLE(POINTER_LOCK)
         page->pointerLockController().elementWasRemoved(*this);
 #endif
@@ -3601,7 +3601,7 @@ void Element::focus(const FocusOptions& options)
 
     Ref document { this->document() };
     if (document->focusedElement() == this) {
-        if (CheckedPtr page = document->page())
+        if (RefPtr page = document->page())
             page->chrome().client().elementDidRefocus(*this, options);
         return;
     }
@@ -3621,7 +3621,7 @@ void Element::focus(const FocusOptions& options)
     if (RefPtr root = shadowRootWithDelegatesFocus(*this)) {
         RefPtr currentlyFocusedElement = document->focusedElement();
         if (root->containsIncludingShadowDOM(currentlyFocusedElement.get())) {
-            if (CheckedPtr page = document->page())
+            if (RefPtr page = document->page())
                 page->chrome().client().elementDidRefocus(*currentlyFocusedElement, options);
             return;
         }
@@ -3632,7 +3632,7 @@ void Element::focus(const FocusOptions& options)
     } else if (!isProgramaticallyFocusable(*newTarget))
         return;
 
-    if (CheckedPtr page = document->page()) {
+    if (RefPtr page = document->page()) {
         Ref frame = *document->frame();
         if (!frame->hasHadUserInteraction() && !frame->isMainFrame() && !document->topOrigin().isSameOriginDomain(document->securityOrigin()))
             return;
@@ -3743,14 +3743,14 @@ void Element::dispatchFocusOutEventIfNeeded(RefPtr<Element>&& newFocusedElement)
 
 void Element::dispatchFocusEvent(RefPtr<Element>&& oldFocusedElement, const FocusOptions& options)
 {
-    if (CheckedPtr page = document().page())
+    if (RefPtr page = document().page())
         page->chrome().client().elementDidFocus(*this, options);
     dispatchEvent(FocusEvent::create(eventNames().focusEvent, Event::CanBubble::No, Event::IsCancelable::No, document().windowProxy(), 0, WTFMove(oldFocusedElement)));
 }
 
 void Element::dispatchBlurEvent(RefPtr<Element>&& newFocusedElement)
 {
-    if (CheckedPtr page = document().page())
+    if (RefPtr page = document().page())
         page->chrome().client().elementDidBlur(*this);
     dispatchEvent(FocusEvent::create(eventNames().blurEvent, Event::CanBubble::No, Event::IsCancelable::No, document().windowProxy(), 0, WTFMove(newFocusedElement)));
 }
@@ -4504,21 +4504,21 @@ void Element::setIFrameFullscreenFlag(bool flag)
 
 ExceptionOr<void> Element::setPointerCapture(int32_t pointerId)
 {
-    if (CheckedPtr page  =document().page())
+    if (RefPtr page = document().page())
         return page->pointerCaptureController().setPointerCapture(this, pointerId);
     return { };
 }
 
 ExceptionOr<void> Element::releasePointerCapture(int32_t pointerId)
 {
-    if (CheckedPtr page = document().page())
+    if (RefPtr page = document().page())
         return page->pointerCaptureController().releasePointerCapture(this, pointerId);
     return { };
 }
 
 bool Element::hasPointerCapture(int32_t pointerId)
 {
-    if (CheckedPtr page = document().page())
+    if (RefPtr page = document().page())
         return page->pointerCaptureController().hasPointerCapture(this, pointerId);
     return false;
 }
@@ -4527,7 +4527,7 @@ bool Element::hasPointerCapture(int32_t pointerId)
 
 void Element::requestPointerLock()
 {
-    if (CheckedPtr page = document().page())
+    if (RefPtr page = document().page())
         page->pointerLockController().requestPointerLock(this);
 }
 

--- a/Source/WebCore/dom/ExtensionStyleSheets.cpp
+++ b/Source/WebCore/dom/ExtensionStyleSheets.cpp
@@ -128,7 +128,7 @@ void ExtensionStyleSheets::updateInjectedStyleSheetCache() const
     m_injectedAuthorStyleSheets.clear();
     m_injectedStyleSheetToSource.clear();
 
-    CheckedPtr owningPage = m_document->page();
+    RefPtr owningPage = m_document->page();
     if (!owningPage)
         return;
 

--- a/Source/WebCore/dom/ImageOverlay.cpp
+++ b/Source/WebCore/dom/ImageOverlay.cpp
@@ -208,7 +208,7 @@ void removeOverlaySoonIfNeeded(HTMLElement& element)
             overlay->remove();
 
 #if ENABLE(IMAGE_ANALYSIS)
-        if (CheckedPtr page = element->document().page())
+        if (RefPtr page = element->document().page())
             page->resetTextRecognitionResult(*element);
 #endif
     });
@@ -607,7 +607,7 @@ void updateWithTextRecognitionResult(HTMLElement& element, const TextRecognition
     }
 
     if (!result.dataDetectors.isEmpty()) {
-        CheckedPtr page = document->page();
+        RefPtr page = document->page();
         if (auto* overlayController = page ? page->imageOverlayControllerIfExists() : nullptr)
             overlayController->textRecognitionResultsChanged(element);
     }
@@ -695,7 +695,7 @@ void updateWithTextRecognitionResult(HTMLElement& element, const TextRecognition
         frame->eventHandler().scheduleCursorUpdate();
 
     if (cacheTextRecognitionResults == CacheTextRecognitionResults::Yes) {
-        if (CheckedPtr page = document->page())
+        if (RefPtr page = document->page())
             page->cacheTextRecognitionResult(element, containerRect, result);
     }
 }

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -791,7 +791,7 @@ bool Node::isContentRichlyEditable() const
 
 void Node::inspect()
 {
-    if (CheckedPtr page = document().page())
+    if (RefPtr page = document().page())
         page->inspectorController().inspect(this);
 }
 

--- a/Source/WebCore/dom/PseudoElement.cpp
+++ b/Source/WebCore/dom/PseudoElement.cpp
@@ -65,14 +65,14 @@ Ref<PseudoElement> PseudoElement::create(Element& host, PseudoId pseudoId)
 {
     Ref pseudoElement = adoptRef(*new PseudoElement(host, pseudoId));
 
-    InspectorInstrumentation::pseudoElementCreated(host.document().checkedPage().get(), pseudoElement.get());
+    InspectorInstrumentation::pseudoElementCreated(host.document().protectedPage().get(), pseudoElement.get());
 
     return pseudoElement;
 }
 
 void PseudoElement::clearHostElement()
 {
-    InspectorInstrumentation::pseudoElementDestroyed(document().checkedPage().get(), *this);
+    InspectorInstrumentation::pseudoElementDestroyed(document().protectedPage().get(), *this);
 
     Styleable::fromElement(*this).elementWasRemoved();
 

--- a/Source/WebCore/dom/ScriptedAnimationController.cpp
+++ b/Source/WebCore/dom/ScriptedAnimationController.cpp
@@ -109,7 +109,7 @@ ScriptedAnimationController::CallbackId ScriptedAnimationController::registerCal
     callback->m_firedOrCancelled = false;
     callback->m_id = callbackId;
     RefPtr<ImminentlyScheduledWorkScope> workScope;
-    if (CheckedPtr page = this->page())
+    if (RefPtr page = this->page())
         workScope = page->opportunisticTaskScheduler().makeScheduledWorkScope();
     m_callbackDataList.append({ WTFMove(callback), UserGestureIndicator::currentUserGesture(), WTFMove(workScope) });
 
@@ -188,7 +188,7 @@ void ScriptedAnimationController::serviceRequestAnimationFrameCallbacks(ReducedR
 
 void ScriptedAnimationController::scheduleAnimation()
 {
-    if (CheckedPtr page = this->page())
+    if (RefPtr page = this->page())
         page->scheduleRenderingUpdate(RenderingUpdateStep::AnimationFrameCallbacks);
 }
 

--- a/Source/WebCore/dom/VisitedLinkState.cpp
+++ b/Source/WebCore/dom/VisitedLinkState.cpp
@@ -116,7 +116,7 @@ InsideLink VisitedLinkState::determineLinkStateSlowCase(const Element& element)
     if (!frame)
         return InsideLink::InsideUnvisited;
 
-    CheckedPtr page = frame->page();
+    RefPtr page = frame->page();
     if (!page)
         return InsideLink::InsideUnvisited;
 

--- a/Source/WebCore/dom/WindowEventLoop.h
+++ b/Source/WebCore/dom/WindowEventLoop.h
@@ -89,7 +89,7 @@ private:
     HashSet<RefPtr<MutationObserver>> m_activeObservers;
     HashSet<RefPtr<MutationObserver>> m_suspendedObservers;
 
-    WeakHashMap<Page, MonotonicTime> m_pagesWithRenderingOpportunity;
+    SingleThreadWeakHashMap<Page, MonotonicTime> m_pagesWithRenderingOpportunity;
 
     std::unique_ptr<CustomElementQueue> m_customElementQueue;
     bool m_processingBackupElementQueue { false };

--- a/Source/WebCore/dom/mac/ImageControlsMac.cpp
+++ b/Source/WebCore/dom/mac/ImageControlsMac.cpp
@@ -151,7 +151,7 @@ bool handleEvent(HTMLElement& element, Event& event)
     if (!frame)
         return false;
 
-    CheckedPtr page = element.document().page();
+    RefPtr page = element.document().page();
     if (!page)
         return false;
     

--- a/Source/WebCore/editing/ReplaceSelectionCommand.cpp
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.cpp
@@ -188,7 +188,7 @@ ReplacementFragment::ReplacementFragment(RefPtr<DocumentFragment>&& inputFragmen
         return;
     }
 
-    auto page = createPageForSanitizingWebContent();
+    Ref page = createPageForSanitizingWebContent();
     RefPtr localMainFrame = dynamicDowncast<LocalFrame>(page->mainFrame());
     if (!localMainFrame)
         return;

--- a/Source/WebCore/editing/SelectionGeometryGatherer.cpp
+++ b/Source/WebCore/editing/SelectionGeometryGatherer.cpp
@@ -68,7 +68,7 @@ SelectionGeometryGatherer::Notifier::Notifier(SelectionGeometryGatherer& gathere
 
 SelectionGeometryGatherer::Notifier::~Notifier()
 {
-    CheckedPtr page = m_gatherer.m_renderView->view().frame().page();
+    RefPtr page = m_gatherer.m_renderView->view().frame().page();
     if (!page)
         return;
 

--- a/Source/WebCore/editing/SpellChecker.cpp
+++ b/Source/WebCore/editing/SpellChecker.cpp
@@ -116,7 +116,7 @@ SpellChecker::~SpellChecker()
 
 TextCheckerClient* SpellChecker::client() const
 {
-    CheckedPtr page = m_document->page();
+    RefPtr page = m_document->page();
     if (!page)
         return nullptr;
     return page->editorClient().textChecker();

--- a/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
+++ b/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
@@ -448,7 +448,7 @@ static std::optional<MarkupAndArchive> extractMarkupAndArchive(SharedBuffer& buf
 
 static String sanitizeMarkupWithArchive(LocalFrame& frame, Document& destinationDocument, MarkupAndArchive& markupAndArchive, MSOListQuirks msoListQuirks, const std::function<bool(const String)>& canShowMIMETypeAsHTML)
 {
-    auto page = createPageForSanitizingWebContent();
+    Ref page = createPageForSanitizingWebContent();
     auto* localMainFrame = dynamicDowncast<LocalFrame>(page->mainFrame());
     if (!localMainFrame)
         return String();
@@ -680,7 +680,7 @@ bool WebContentReader::readPlainText(const String& text)
         return false;
 
     String precomposedString = [text precomposedStringWithCanonicalMapping];
-    if (CheckedPtr page = frame().page())
+    if (RefPtr page = frame().page())
         precomposedString = page->applyLinkDecorationFiltering(precomposedString, LinkDecorationFilteringTrigger::Paste);
 
     addFragment(createFragmentFromText(m_context, precomposedString));

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -183,11 +183,11 @@ void removeSubresourceURLAttributes(Ref<DocumentFragment>&& fragment, Function<b
         element->removeAttribute(attribute);
 }
 
-std::unique_ptr<Page> createPageForSanitizingWebContent()
+Ref<Page> createPageForSanitizingWebContent()
 {
     auto pageConfiguration = pageConfigurationWithEmptyClients(std::nullopt, PAL::SessionID::defaultSessionID());
     
-    auto page = makeUnique<Page>(WTFMove(pageConfiguration));
+    Ref page = Page::create(WTFMove(pageConfiguration));
 #if ENABLE(VIDEO)
     page->settings().setMediaEnabled(false);
 #endif
@@ -220,7 +220,7 @@ std::unique_ptr<Page> createPageForSanitizingWebContent()
 
 String sanitizeMarkup(const String& rawHTML, MSOListQuirks msoListQuirks, std::optional<Function<void(DocumentFragment&)>> fragmentSanitizer)
 {
-    auto page = createPageForSanitizingWebContent();
+    Ref page = createPageForSanitizingWebContent();
     RefPtr localMainFrame = dynamicDowncast<LocalFrame>(page->mainFrame());
     if (!localMainFrame)
         return String();

--- a/Source/WebCore/editing/markup.h
+++ b/Source/WebCore/editing/markup.h
@@ -56,7 +56,7 @@ struct SimpleRange;
 void replaceSubresourceURLs(Ref<DocumentFragment>&&, HashMap<AtomString, AtomString>&&);
 void removeSubresourceURLAttributes(Ref<DocumentFragment>&&, Function<bool(const URL&)> shouldRemoveURL);
 
-std::unique_ptr<Page> createPageForSanitizingWebContent();
+Ref<Page> createPageForSanitizingWebContent();
 enum class MSOListQuirks : bool { CheckIfNeeded, Disabled };
 String sanitizeMarkup(const String&, MSOListQuirks = MSOListQuirks::Disabled, std::optional<Function<void(DocumentFragment&)>> fragmentSanitizer = std::nullopt);
 String sanitizedMarkupForFragmentInDocument(Ref<DocumentFragment>&&, Document&, MSOListQuirks, const String& originalMarkup);

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -415,7 +415,7 @@ void HTMLElement::attributeChanged(const QualifiedName& name, const AtomString& 
         return;
     case AttributeNames::inputmodeAttr:
         if (Ref document = this->document(); this == document->focusedElement()) {
-            if (CheckedPtr page = document->page())
+            if (RefPtr page = document->page())
                 page->chrome().client().focusedElementDidChangeInputMode(*this, canonicalInputMode());
         }
         return;

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -816,7 +816,7 @@ void HTMLSelectElement::setRecalcListItems()
         cache->childrenChanged(this);
 
     if (Ref document = this->document(); this == document->focusedElement()) {
-        if (CheckedPtr page = document->page())
+        if (RefPtr page = document->page())
             page->chrome().client().focusedSelectElementDidChangeOptions(*this);
     }
 }

--- a/Source/WebCore/inspector/InspectorFrontendAPIDispatcher.h
+++ b/Source/WebCore/inspector/InspectorFrontendAPIDispatcher.h
@@ -90,7 +90,7 @@ private:
     void invalidatePendingResponses();
     ValueOrException evaluateExpression(const String&);
 
-    WeakPtr<Page> m_frontendPage;
+    SingleThreadWeakPtr<Page> m_frontendPage;
     Vector<std::pair<String, EvaluationResultHandler>> m_queuedEvaluations;
     HashMap<Ref<DOMPromise>, EvaluationResultHandler> m_pendingResponses;
     bool m_frontendLoaded { false };

--- a/Source/WebCore/inspector/InspectorFrontendClientLocal.h
+++ b/Source/WebCore/inspector/InspectorFrontendClientLocal.h
@@ -145,7 +145,7 @@ private:
     std::optional<bool> evaluationResultToBoolean(InspectorFrontendAPIDispatcher::EvaluationResult);
 
     InspectorController* m_inspectedPageController { nullptr };
-    WeakPtr<Page> m_frontendPage;
+    SingleThreadWeakPtr<Page> m_frontendPage;
     // TODO(yurys): this ref shouldn't be needed.
     RefPtr<InspectorFrontendHost> m_frontendHost;
     std::unique_ptr<InspectorFrontendClientLocal::Settings> m_settings;

--- a/Source/WebCore/inspector/InspectorFrontendHost.h
+++ b/Source/WebCore/inspector/InspectorFrontendHost.h
@@ -187,7 +187,7 @@ private:
     WEBCORE_EXPORT InspectorFrontendHost(InspectorFrontendClient*, Page* frontendPage);
 
     InspectorFrontendClient* m_client;
-    WeakPtr<Page> m_frontendPage;
+    SingleThreadWeakPtr<Page> m_frontendPage;
 #if ENABLE(CONTEXT_MENUS)
     FrontendMenuProvider* m_menuProvider;
 #endif

--- a/Source/WebCore/inspector/PageDebugger.cpp
+++ b/Source/WebCore/inspector/PageDebugger.cpp
@@ -123,14 +123,13 @@ void PageDebugger::runEventLoopWhilePausedInternal()
 {
     TimerBase::fireTimersInNestedEventLoop();
 
-    m_page.incrementNestedRunLoopCount();
+    // Protect the page during the execution of the nested run loop.
+    Ref protectedPage = m_page;
 
     while (!m_doneProcessingDebuggerEvents) {
         if (!platformShouldContinueRunningEventLoopWhilePaused())
             break;
     }
-
-    m_page.decrementNestedRunLoopCount();
 }
 
 bool PageDebugger::isContentScript(JSGlobalObject* state) const

--- a/Source/WebCore/loader/DocumentThreadableLoader.cpp
+++ b/Source/WebCore/loader/DocumentThreadableLoader.cpp
@@ -157,7 +157,7 @@ DocumentThreadableLoader::DocumentThreadableLoader(Document& document, Threadabl
         m_options.httpHeadersToKeep = httpHeadersToKeepFromCleaning(request.httpHeaderFields());
 
     bool shouldDisableCORS = document.isRunningUserScripts() && LegacySchemeRegistry::isUserExtensionScheme(request.url().protocol());
-    if (CheckedPtr page = document.page())
+    if (RefPtr page = document.page())
         shouldDisableCORS |= page->shouldDisableCorsForRequestTo(request.url());
 
     if (shouldDisableCORS) {
@@ -223,7 +223,7 @@ void DocumentThreadableLoader::makeCrossOriginAccessRequest(ResourceRequest&& re
             return;
 
         m_simpleRequest = false;
-        if (CheckedPtr page = document().page(); page && CrossOriginPreflightResultCache::singleton().canSkipPreflight(page->sessionID(), securityOrigin().toString(), request.url(), m_options.storedCredentialsPolicy, request.httpMethod(), request.httpHeaderFields()))
+        if (RefPtr page = document().page(); page && CrossOriginPreflightResultCache::singleton().canSkipPreflight(page->sessionID(), securityOrigin().toString(), request.url(), m_options.storedCredentialsPolicy, request.httpMethod(), request.httpHeaderFields()))
             preflightSuccess(WTFMove(request));
         else
             makeCrossOriginAccessRequestWithPreflight(WTFMove(request));

--- a/Source/WebCore/loader/SubframeLoader.cpp
+++ b/Source/WebCore/loader/SubframeLoader.cpp
@@ -225,7 +225,7 @@ bool FrameLoader::SubframeLoader::requestObject(HTMLPlugInImageElement& ownerEle
     bool useFallback;
     if (shouldUsePlugin(completedURL, mimeType, hasFallbackContent, useFallback)) {
         bool success = requestPlugin(ownerElement, completedURL, mimeType, paramNames, paramValues, useFallback);
-        logPluginRequest(document->checkedPage().get(), mimeType, completedURL);
+        logPluginRequest(document->protectedPage().get(), mimeType, completedURL);
         return success;
     }
 
@@ -254,7 +254,7 @@ LocalFrame* FrameLoader::SubframeLoader::loadOrRedirectSubframe(HTMLFrameOwnerEl
         }
 
         if (RefPtr localFrame = dynamicDowncast<LocalFrame>(*frame); localFrame && localFrame->loader().isComplete()) {
-            if (CheckedPtr page = localFrame->page())
+            if (RefPtr page = localFrame->page())
                 page->willChangeLocationInCompletelyLoadedSubframe();
         }
 

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -62,7 +62,7 @@ public:
     FrameTree& tree() const { return m_treeNode; }
     FrameIdentifier frameID() const { return m_frameID; }
     inline Page* page() const; // Defined in Page.h.
-    inline CheckedPtr<Page> checkedPage() const; // Defined in Page.h.
+    inline RefPtr<Page> protectedPage() const; // Defined in Page.h.
     WEBCORE_EXPORT std::optional<PageIdentifier> pageID() const;
     Settings& settings() const { return m_settings.get(); }
     Frame& mainFrame() const { return m_mainFrame.get(); }
@@ -104,7 +104,7 @@ protected:
 private:
     virtual DOMWindow* virtualWindow() const = 0;
 
-    WeakPtr<Page> m_page;
+    SingleThreadWeakPtr<Page> m_page;
     const FrameIdentifier m_frameID;
     mutable FrameTree m_treeNode;
     Ref<WindowProxy> m_windowProxy;

--- a/Source/WebCore/page/ImageAnalysisQueue.h
+++ b/Source/WebCore/page/ImageAnalysisQueue.h
@@ -80,7 +80,7 @@ private:
     // FIXME: Refactor the source and target LIDs into either a std::pair<> of strings, or its own named struct.
     String m_sourceLanguageIdentifier;
     String m_targetLanguageIdentifier;
-    WeakPtr<Page> m_page;
+    SingleThreadWeakPtr<Page> m_page;
     Timer m_resumeProcessingTimer;
     WeakHashMap<HTMLImageElement, URL, WeakPtrImplWithEventTargetData> m_queuedElements;
     PriorityQueue<Task, firstIsHigherPriority> m_queue;

--- a/Source/WebCore/page/ImageOverlayController.h
+++ b/Source/WebCore/page/ImageOverlayController.h
@@ -91,7 +91,7 @@ private:
     void platformUpdateElementUnderMouse(LocalFrame&, Element* elementUnderMouse);
     bool platformHandleMouseEvent(const PlatformMouseEvent&);
 
-    WeakPtr<Page> m_page;
+    SingleThreadWeakPtr<Page> m_page;
     RefPtr<PageOverlay> m_overlay;
     WeakPtr<HTMLElement, WeakPtrImplWithEventTargetData> m_hostElementForSelection;
     Vector<FloatQuad> m_selectionQuads;

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -395,7 +395,7 @@ bool LocalDOMWindow::canShowModalDialog(const LocalFrame& frame)
         }
     }
 
-    CheckedPtr page = frame.page();
+    RefPtr page = frame.page();
     return page && page->chrome().canRunModal();
 }
 
@@ -432,7 +432,7 @@ void LocalDOMWindow::didSecureTransitionTo(Document& document)
 
 void LocalDOMWindow::prewarmLocalStorageIfNecessary()
 {
-    CheckedPtr page = this->page();
+    RefPtr page = this->page();
 
     // No need to prewarm for ephemeral sessions since the data is in memory only.
     if (!page || page->usesEphemeralSession())
@@ -480,7 +480,7 @@ Page* LocalDOMWindow::page() const
     return frame() ? frame()->page() : nullptr;
 }
 
-CheckedPtr<Page> LocalDOMWindow::checkedPage() const
+RefPtr<Page> LocalDOMWindow::protectedPage() const
 {
     return page();
 }
@@ -817,7 +817,7 @@ bool LocalDOMWindow::shouldHaveWebKitNamespaceForWorld(DOMWrapperWorld& world)
     if (!frame)
         return false;
 
-    CheckedPtr page = frame->page();
+    RefPtr page = frame->page();
     if (!page)
         return false;
 
@@ -836,7 +836,7 @@ WebKitNamespace* LocalDOMWindow::webkitNamespace()
 {
     if (!isCurrentlyDisplayedInFrame())
         return nullptr;
-    CheckedPtr page = frame()->page();
+    RefPtr page = frame()->page();
     if (!page)
         return nullptr;
     if (!m_webkitNamespace)
@@ -861,7 +861,7 @@ ExceptionOr<Storage*> LocalDOMWindow::sessionStorage()
     if (m_sessionStorage)
         return m_sessionStorage.get();
 
-    CheckedPtr page = document->page();
+    RefPtr page = document->page();
     if (!page)
         return nullptr;
 
@@ -884,7 +884,7 @@ ExceptionOr<Storage*> LocalDOMWindow::localStorage()
     if (document->canAccessResource(ScriptExecutionContext::ResourceType::LocalStorage) == ScriptExecutionContext::HasResourceAccess::No)
         return Exception { ExceptionCode::SecurityError };
 
-    CheckedPtr page = document->page();
+    RefPtr page = document->page();
     // FIXME: We should consider supporting access/modification to local storage
     // after calling window.close(). See <https://bugs.webkit.org/show_bug.cgi?id=135330>.
     if (!page || !page->isClosing()) {
@@ -1037,7 +1037,7 @@ void LocalDOMWindow::focus(LocalDOMWindow& incumbentWindow)
         if (!openerFrame || openerFrame == frame || incumbentWindow.frame() != openerFrame)
             return false;
 
-        CheckedPtr page = openerFrame->page();
+        RefPtr page = openerFrame->page();
         return page && page->isVisibleAndActive();
     }());
 }
@@ -1048,7 +1048,7 @@ void LocalDOMWindow::focus(bool allowFocus)
     if (!frame)
         return;
 
-    CheckedPtr page = frame->page();
+    RefPtr page = frame->page();
     if (!page)
         return;
 
@@ -1075,7 +1075,7 @@ void LocalDOMWindow::blur()
     if (!frame)
         return;
 
-    CheckedPtr page = frame->page();
+    RefPtr page = frame->page();
     if (!page)
         return;
 
@@ -1101,7 +1101,7 @@ void LocalDOMWindow::close()
     if (!frame)
         return;
 
-    CheckedPtr page = frame->page();
+    RefPtr page = frame->page();
     if (!page)
         return;
 
@@ -1133,7 +1133,7 @@ void LocalDOMWindow::print()
     if (!frame)
         return;
 
-    CheckedPtr page = frame->page();
+    RefPtr page = frame->page();
     if (!page)
         return;
 
@@ -1177,7 +1177,7 @@ void LocalDOMWindow::alert(const String& message)
         return;
     }
 
-    CheckedPtr page = frame->page();
+    RefPtr page = frame->page();
     if (!page)
         return;
 
@@ -1206,7 +1206,7 @@ bool LocalDOMWindow::confirmForBindings(const String& message)
         return false;
     }
 
-    CheckedPtr page = frame->page();
+    RefPtr page = frame->page();
     if (!page)
         return false;
 
@@ -1235,7 +1235,7 @@ String LocalDOMWindow::prompt(const String& message, const String& defaultValue)
         return String();
     }
 
-    CheckedPtr page = frame->page();
+    RefPtr page = frame->page();
     if (!page)
         return String();
 
@@ -1286,7 +1286,7 @@ int LocalDOMWindow::outerHeight() const
     if (!frame)
         return 0;
 
-    CheckedPtr page = frame->page();
+    RefPtr page = frame->page();
     if (!page)
         return 0;
 
@@ -1314,7 +1314,7 @@ int LocalDOMWindow::outerWidth() const
     if (!frame)
         return 0;
 
-    CheckedPtr page = frame->page();
+    RefPtr page = frame->page();
     if (!page)
         return 0;
 
@@ -1382,7 +1382,7 @@ int LocalDOMWindow::screenX() const
     if (!frame)
         return 0;
 
-    CheckedPtr page = frame->page();
+    RefPtr page = frame->page();
     if (!page || page->fingerprintingProtectionsEnabled())
         return 0;
 
@@ -1395,7 +1395,7 @@ int LocalDOMWindow::screenY() const
     if (!frame)
         return 0;
 
-    CheckedPtr page = frame->page();
+    RefPtr page = frame->page();
     if (!page || page->fingerprintingProtectionsEnabled())
         return 0;
 
@@ -1464,7 +1464,7 @@ bool LocalDOMWindow::closed() const
     if (!frame)
         return true;
 
-    CheckedPtr page = frame->page();
+    RefPtr page = frame->page();
     return !page || page->isClosing();
 }
 
@@ -1738,7 +1738,7 @@ double LocalDOMWindow::devicePixelRatio() const
     if (!frame)
         return 0.0;
 
-    CheckedPtr page = frame->page();
+    RefPtr page = frame->page();
     if (!page)
         return 0.0;
 
@@ -1829,7 +1829,7 @@ void LocalDOMWindow::moveBy(int x, int y) const
     if (!allowedToChangeWindowGeometry())
         return;
 
-    CheckedPtr page = frame()->page();
+    RefPtr page = frame()->page();
     auto fr = page->chrome().windowRect();
     auto update = fr;
     update.move(x, y);
@@ -1841,7 +1841,7 @@ void LocalDOMWindow::moveTo(int x, int y) const
     if (!allowedToChangeWindowGeometry())
         return;
 
-    CheckedPtr page = frame()->page();
+    RefPtr page = frame()->page();
     auto fr = page->chrome().windowRect();
 
     auto sr = screenAvailableRect(page->mainFrame().virtualView());
@@ -1856,7 +1856,7 @@ void LocalDOMWindow::resizeBy(int x, int y) const
     if (!allowedToChangeWindowGeometry())
         return;
 
-    CheckedPtr page = frame()->page();
+    RefPtr page = frame()->page();
     auto fr = page->chrome().windowRect();
     auto dest = fr.size() + LayoutSize(x, y);
     LayoutRect update(fr.location(), dest);
@@ -1868,7 +1868,7 @@ void LocalDOMWindow::resizeTo(int width, int height) const
     if (!allowedToChangeWindowGeometry())
         return;
 
-    CheckedPtr page = frame()->page();
+    RefPtr page = frame()->page();
     auto fr = page->chrome().windowRect();
     auto dest = LayoutSize(width, height);
     LayoutRect update(fr.location(), dest);
@@ -2072,7 +2072,7 @@ DeviceOrientationController* LocalDOMWindow::deviceOrientationController() const
 #if PLATFORM(IOS_FAMILY)
     return document() ? &document()->deviceOrientationController() : nullptr;
 #else
-    return DeviceOrientationController::from(checkedPage().get());
+    return DeviceOrientationController::from(protectedPage().get());
 #endif
 }
 
@@ -2081,7 +2081,7 @@ DeviceMotionController* LocalDOMWindow::deviceMotionController() const
 #if PLATFORM(IOS_FAMILY)
     return document() ? &document()->deviceMotionController() : nullptr;
 #else
-    return DeviceMotionController::from(checkedPage().get());
+    return DeviceMotionController::from(protectedPage().get());
 #endif
 }
 
@@ -2237,7 +2237,7 @@ void LocalDOMWindow::incrementScrollEventListenersCount()
     RefPtr document = this->document();
     if (++m_scrollEventListenerCount == 1 && document == &document->topDocument()) {
         if (RefPtr frame = this->frame(); frame && frame->page())
-            frame->checkedPage()->chrome().client().setNeedsScrollNotifications(*frame, true);
+            frame->protectedPage()->chrome().client().setNeedsScrollNotifications(*frame, true);
     }
 }
 
@@ -2247,7 +2247,7 @@ void LocalDOMWindow::decrementScrollEventListenersCount()
     if (!--m_scrollEventListenerCount && document == &document->topDocument()) {
         RefPtr frame = this->frame();
         if (frame && frame->page() && document->backForwardCacheState() == Document::NotInBackForwardCache)
-            frame->checkedPage()->chrome().client().setNeedsScrollNotifications(*frame, false);
+            frame->protectedPage()->chrome().client().setNeedsScrollNotifications(*frame, false);
     }
 }
 
@@ -2608,7 +2608,7 @@ ExceptionOr<RefPtr<LocalFrame>> LocalDOMWindow::createWindow(const String& urlSt
         newFrame->setOpener(&openerFrame);
 
     if (created)
-        newFrame->checkedPage()->setOpenedByDOM();
+        newFrame->protectedPage()->setOpenedByDOM();
 
     RefPtr localNewFrame = dynamicDowncast<LocalFrame>(newFrame);
     if (localNewFrame && localNewFrame->document()->domWindow()->isInsecureScriptAccess(activeWindow, completedURL.string()))
@@ -2653,7 +2653,7 @@ ExceptionOr<RefPtr<WindowProxy>> LocalDOMWindow::open(LocalDOMWindow& activeWind
         urlString = "about:blank"_s;
 
 #if ENABLE(CONTENT_EXTENSIONS)
-    CheckedPtr page = firstFrame->page();
+    RefPtr page = firstFrame->page();
     RefPtr firstFrameDocument = firstFrame->document();
 
     RefPtr localFrame = dynamicDowncast<LocalFrame>(firstFrame->mainFrame());
@@ -2753,13 +2753,13 @@ void LocalDOMWindow::showModalDialog(const String& urlString, const String& dial
 
 void LocalDOMWindow::enableSuddenTermination()
 {
-    if (CheckedPtr page = this->page())
+    if (RefPtr page = this->page())
         page->chrome().enableSuddenTermination();
 }
 
 void LocalDOMWindow::disableSuddenTermination()
 {
-    if (CheckedPtr page = this->page())
+    if (RefPtr page = this->page())
         page->chrome().disableSuddenTermination();
 }
 

--- a/Source/WebCore/page/LocalDOMWindow.h
+++ b/Source/WebCore/page/LocalDOMWindow.h
@@ -409,7 +409,7 @@ public:
     bool mayReuseForNavigation() const { return m_mayReuseForNavigation; }
 
     Page* page() const;
-    CheckedPtr<Page> checkedPage() const;
+    RefPtr<Page> protectedPage() const;
 
     WEBCORE_EXPORT static void forEachWindowInterestedInStorageEvents(const Function<void(LocalDOMWindow&)>&);
 

--- a/Source/WebCore/page/OpportunisticTaskScheduler.cpp
+++ b/Source/WebCore/page/OpportunisticTaskScheduler.cpp
@@ -48,7 +48,7 @@ OpportunisticTaskScheduler::~OpportunisticTaskScheduler() = default;
 
 void OpportunisticTaskScheduler::rescheduleIfNeeded(MonotonicTime deadline)
 {
-    auto page = checkedPage();
+    RefPtr page = m_page.get();
     if (page->isWaitingForLoadToFinish() || !page->isVisibleAndActive())
         return;
 
@@ -59,11 +59,6 @@ void OpportunisticTaskScheduler::rescheduleIfNeeded(MonotonicTime deadline)
     m_currentDeadline = deadline;
     m_runLoopObserver->invalidate();
     m_runLoopObserver->schedule();
-}
-
-CheckedPtr<Page> OpportunisticTaskScheduler::checkedPage() const
-{
-    return m_page.get();
 }
 
 Ref<ImminentlyScheduledWorkScope> OpportunisticTaskScheduler::makeScheduledWorkScope()
@@ -81,7 +76,7 @@ void OpportunisticTaskScheduler::runLoopObserverFired()
     if (UNLIKELY(!m_page))
         return;
 
-    auto page = checkedPage();
+    RefPtr page = m_page.get();
     if (page->isWaitingForLoadToFinish())
         return;
 

--- a/Source/WebCore/page/OpportunisticTaskScheduler.h
+++ b/Source/WebCore/page/OpportunisticTaskScheduler.h
@@ -119,9 +119,8 @@ private:
     bool isPageInactiveOrLoading() const;
 
     bool shouldAllowOpportunisticallyScheduledTasks() const;
-    CheckedPtr<Page> checkedPage() const;
 
-    WeakPtr<Page> m_page;
+    SingleThreadWeakPtr<Page> m_page;
     uint64_t m_imminentlyScheduledWorkCount { 0 };
     uint64_t m_runloopCountAfterBeingScheduled { 0 };
     MonotonicTime m_currentDeadline;

--- a/Source/WebCore/page/PageGroup.h
+++ b/Source/WebCore/page/PageGroup.h
@@ -45,7 +45,7 @@ public:
 
     WEBCORE_EXPORT static PageGroup* pageGroup(const String& groupName);
 
-    const WeakHashSet<Page>& pages() const { return m_pages; }
+    const SingleThreadWeakHashSet<Page>& pages() const { return m_pages; }
 
     void addPage(Page&);
     void removePage(Page&);
@@ -61,7 +61,7 @@ public:
 
 private:
     String m_name;
-    WeakHashSet<Page> m_pages;
+    SingleThreadWeakHashSet<Page> m_pages;
 
     unsigned m_identifier;
 

--- a/Source/WebCore/page/PageOverlay.h
+++ b/Source/WebCore/page/PageOverlay.h
@@ -131,7 +131,7 @@ private:
     void fadeAnimationTimerFired();
 
     Client& m_client;
-    WeakPtr<Page> m_page;
+    SingleThreadWeakPtr<Page> m_page;
 
     Timer m_fadeAnimationTimer;
     WallTime m_fadeAnimationStartTime;

--- a/Source/WebCore/page/SettingsBase.h
+++ b/Source/WebCore/page/SettingsBase.h
@@ -167,7 +167,7 @@ protected:
     void sampleBufferContentKeySessionSupportEnabledChanged();
 #endif
 
-    WeakPtr<Page> m_page;
+    SingleThreadWeakPtr<Page> m_page;
 
     Seconds m_minimumDOMTimerInterval;
 

--- a/Source/WebCore/page/UserContentProvider.h
+++ b/Source/WebCore/page/UserContentProvider.h
@@ -84,7 +84,7 @@ protected:
     WEBCORE_EXPORT void invalidateInjectedStyleSheetCacheInAllFramesInAllPages();
 
 private:
-    WeakHashSet<Page> m_pages;
+    SingleThreadWeakHashSet<Page> m_pages;
     WeakHashSet<UserContentProviderInvalidationClient> m_userMessageHandlerInvalidationClients;
 };
 

--- a/Source/WebCore/page/VisitedLinkStore.h
+++ b/Source/WebCore/page/VisitedLinkStore.h
@@ -50,7 +50,7 @@ public:
     WEBCORE_EXPORT void invalidateStylesForLink(SharedStringHash);
 
 private:
-    WeakHashSet<Page> m_pages;
+    SingleThreadWeakHashSet<Page> m_pages;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/ios/EventHandlerIOS.mm
+++ b/Source/WebCore/page/ios/EventHandlerIOS.mm
@@ -105,7 +105,7 @@ inline CurrentEventScope::~CurrentEventScope()
 
 bool EventHandler::wheelEvent(WebEvent *event)
 {
-    CheckedPtr page = m_frame->page();
+    RefPtr page = m_frame->page();
     if (!page)
         return false;
 
@@ -145,7 +145,7 @@ void EventHandler::touchEvent(WebEvent *event)
 
 bool EventHandler::tabsToAllFormControls(KeyboardEvent* event) const
 {
-    CheckedPtr page = m_frame->page();
+    RefPtr page = m_frame->page();
     if (!page)
         return false;
 
@@ -185,7 +185,7 @@ bool EventHandler::keyEvent(WebEvent *event)
 
 void EventHandler::focusDocumentView()
 {
-    CheckedPtr page = m_frame->page();
+    RefPtr page = m_frame->page();
     if (!page)
         return;
 
@@ -268,7 +268,7 @@ bool EventHandler::passMouseDownEventToWidget(Widget* pWidget)
         return true;
     }
 
-    CheckedPtr page = m_frame->page();
+    RefPtr page = m_frame->page();
     if (!page)
         return true;
 

--- a/Source/WebCore/page/mac/EventHandlerMac.mm
+++ b/Source/WebCore/page/mac/EventHandlerMac.mm
@@ -144,7 +144,7 @@ inline CurrentEventScope::~CurrentEventScope()
 
 bool EventHandler::wheelEvent(NSEvent *event)
 {
-    CheckedPtr page = m_frame->page();
+    RefPtr page = m_frame->page();
     if (!page)
         return false;
 
@@ -175,7 +175,7 @@ bool EventHandler::keyEvent(NSEvent *event)
 
 void EventHandler::focusDocumentView()
 {
-    CheckedPtr page = m_frame->page();
+    RefPtr page = m_frame->page();
     if (!page)
         return;
 
@@ -259,7 +259,7 @@ bool EventHandler::passMouseDownEventToWidget(Widget* pWidget)
         return true;
     }
 
-    CheckedPtr page = m_frame->page();
+    RefPtr page = m_frame->page();
     if (!page)
         return true;
 
@@ -734,7 +734,7 @@ bool EventHandler::passMouseReleaseEventToSubframe(MouseEventWithHitTestResults&
 PlatformMouseEvent EventHandler::currentPlatformMouseEvent() const
 {
     NSView *windowView = nil;
-    if (CheckedPtr page = m_frame->page())
+    if (RefPtr page = m_frame->page())
         windowView = page->chrome().platformPageClient();
     return PlatformEventFactory::createPlatformMouseEvent(currentNSEvent(), correspondingPressureEvent(), windowView);
 }
@@ -746,7 +746,7 @@ bool EventHandler::eventActivatedView(const PlatformMouseEvent& event) const
 
 bool EventHandler::tabsToAllFormControls(KeyboardEvent* event) const
 {
-    CheckedPtr page = m_frame->page();
+    RefPtr page = m_frame->page();
     if (!page)
         return false;
 
@@ -861,7 +861,7 @@ static WeakPtr<ScrollableArea> scrollableAreaForContainerNode(ContainerNode& con
 
 void EventHandler::determineWheelEventTarget(const PlatformWheelEvent& wheelEvent, RefPtr<Element>& wheelEventTarget, WeakPtr<ScrollableArea>& scrollableArea, bool& isOverWidget)
 {
-    CheckedPtr page = m_frame->page();
+    RefPtr page = m_frame->page();
     if (!page)
         return;
 
@@ -1038,7 +1038,7 @@ static IntSize autoscrollAdjustmentFactorForScreenBoundaries(const IntPoint& scr
 
 IntPoint EventHandler::targetPositionInWindowForSelectionAutoscroll() const
 {
-    CheckedPtr page = m_frame->page();
+    RefPtr page = m_frame->page();
     if (!page)
         return valueOrDefault(m_lastKnownMousePosition);
 

--- a/Source/WebCore/page/scrolling/ScrollingCoordinator.h
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinator.h
@@ -224,7 +224,7 @@ protected:
 
     virtual void willCommitTree() { }
 
-    WeakPtr<Page> m_page; // FIXME: ideally this would be a reference but it gets nulled on async teardown.
+    SingleThreadWeakPtr<Page> m_page; // FIXME: ideally this would be a WeakRef but it gets nulled on async teardown.
 
 private:
     virtual bool hasVisibleSlowRepaintViewportConstrainedObjects(const LocalFrameView&) const;

--- a/Source/WebCore/platform/mac/DataDetectorHighlight.h
+++ b/Source/WebCore/platform/mac/DataDetectorHighlight.h
@@ -95,7 +95,7 @@ private:
     void didFinishFadeOutAnimation();
 
     WeakPtr<DataDetectorHighlightClient> m_client;
-    WeakPtr<Page> m_page;
+    SingleThreadWeakPtr<Page> m_page;
     RetainPtr<DDHighlightRef> m_highlight;
     SimpleRange m_range;
     Ref<GraphicsLayer> m_graphicsLayer;

--- a/Source/WebCore/plugins/PluginInfoProvider.h
+++ b/Source/WebCore/plugins/PluginInfoProvider.h
@@ -47,7 +47,7 @@ public:
 private:
     virtual void refreshPlugins() = 0;
 
-    WeakHashSet<Page> m_pages;
+    SingleThreadWeakHashSet<Page> m_pages;
 };
 
 }

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1595,7 +1595,7 @@ void RenderElement::didRemoveCachedImageClient(CachedImage& cachedImage)
 
 void RenderElement::scheduleRenderingUpdateForImage(CachedImage&)
 {
-    if (CheckedPtr page = document().page())
+    if (RefPtr page = document().page())
         page->scheduleRenderingUpdate(RenderingUpdateStep::Images);
 }
 

--- a/Source/WebCore/svg/graphics/SVGImage.cpp
+++ b/Source/WebCore/svg/graphics/SVGImage.cpp
@@ -471,7 +471,7 @@ EncodedDataStatus SVGImage::dataChanged(bool allDataReceived)
         // This will become an issue when SVGImage will be able to load other
         // SVGImage objects, but we're safe now, because SVGImage can only be
         // loaded by a top-level document.
-        m_page = makeUnique<Page>(WTFMove(pageConfiguration));
+        m_page = Page::create(WTFMove(pageConfiguration));
 #if ENABLE(VIDEO)
         m_page->settings().setMediaEnabled(false);
 #endif

--- a/Source/WebCore/svg/graphics/SVGImage.h
+++ b/Source/WebCore/svg/graphics/SVGImage.h
@@ -98,7 +98,7 @@ private:
     ImageDrawResult drawForContainer(GraphicsContext&, const FloatSize containerSize, float containerZoom, const URL& initialFragmentURL, const FloatRect& dstRect, const FloatRect& srcRect, ImagePaintingOptions = { });
     void drawPatternForContainer(GraphicsContext&, const FloatSize& containerSize, float containerZoom, const URL& initialFragmentURL, const FloatRect& srcRect, const AffineTransform&, const FloatPoint& phase, const FloatSize& spacing, const FloatRect&, ImagePaintingOptions = { });
 
-    std::unique_ptr<Page> m_page;
+    RefPtr<Page> m_page;
     FloatSize m_intrinsicSize;
 
     Timer m_startAnimationTimer;

--- a/Source/WebCore/testing/InternalSettings.h
+++ b/Source/WebCore/testing/InternalSettings.h
@@ -165,7 +165,7 @@ private:
         bool m_shouldDeactivateAudioSession;
     };
 
-    WeakPtr<Page> m_page;
+    SingleThreadWeakPtr<Page> m_page;
     Backup m_backup;
 };
 

--- a/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp
@@ -64,7 +64,7 @@ static ThreadSafeWeakHashSet<ServiceWorkerThreadProxy>& allServiceWorkerThreadPr
     return set;
 }
 
-ServiceWorkerThreadProxy::ServiceWorkerThreadProxy(UniqueRef<Page>&& page, ServiceWorkerContextData&& contextData, ServiceWorkerData&& workerData, String&& userAgent, WorkerThreadMode workerThreadMode, CacheStorageProvider& cacheStorageProvider, std::unique_ptr<NotificationClient>&& notificationClient)
+ServiceWorkerThreadProxy::ServiceWorkerThreadProxy(Ref<Page>&& page, ServiceWorkerContextData&& contextData, ServiceWorkerData&& workerData, String&& userAgent, WorkerThreadMode workerThreadMode, CacheStorageProvider& cacheStorageProvider, std::unique_ptr<NotificationClient>&& notificationClient)
     : m_page(WTFMove(page))
     , m_document(*dynamicDowncast<LocalFrame>(m_page->mainFrame())->document())
 #if ENABLE(REMOTE_INSPECTOR)

--- a/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h
@@ -100,7 +100,7 @@ public:
     WEBCORE_EXPORT void setInspectable(bool);
 
 private:
-    WEBCORE_EXPORT ServiceWorkerThreadProxy(UniqueRef<Page>&&, ServiceWorkerContextData&&, ServiceWorkerData&&, String&& userAgent, WorkerThreadMode, CacheStorageProvider&, std::unique_ptr<NotificationClient>&&);
+    WEBCORE_EXPORT ServiceWorkerThreadProxy(Ref<Page>&&, ServiceWorkerContextData&&, ServiceWorkerData&&, String&& userAgent, WorkerThreadMode, CacheStorageProvider&, std::unique_ptr<NotificationClient>&&);
 
     WEBCORE_EXPORT static void networkStateChanged(bool isOnLine);
     bool postTaskForModeToWorkerOrWorkletGlobalScope(ScriptExecutionContext::Task&&, const String& mode);
@@ -118,7 +118,7 @@ private:
     // WorkerBadgeProxy
     void setAppBadge(std::optional<uint64_t>) final;
 
-    UniqueRef<Page> m_page;
+    Ref<Page> m_page;
     Ref<Document> m_document;
 #if ENABLE(REMOTE_INSPECTOR)
     std::unique_ptr<ServiceWorkerDebuggable> m_remoteDebuggable;

--- a/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp
+++ b/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp
@@ -95,7 +95,7 @@ bool SharedWorkerThreadProxy::hasInstances()
     return !allSharedWorkerThreadProxies().isEmpty();
 }
 
-SharedWorkerThreadProxy::SharedWorkerThreadProxy(UniqueRef<Page>&& page, SharedWorkerIdentifier sharedWorkerIdentifier, const ClientOrigin& clientOrigin, WorkerFetchResult&& workerFetchResult, WorkerOptions&& workerOptions, WorkerInitializationData&& initializationData, CacheStorageProvider& cacheStorageProvider)
+SharedWorkerThreadProxy::SharedWorkerThreadProxy(Ref<Page>&& page, SharedWorkerIdentifier sharedWorkerIdentifier, const ClientOrigin& clientOrigin, WorkerFetchResult&& workerFetchResult, WorkerOptions&& workerOptions, WorkerInitializationData&& initializationData, CacheStorageProvider& cacheStorageProvider)
     : m_page(WTFMove(page))
     , m_document(*dynamicDowncast<LocalFrame>(m_page->mainFrame())->document())
     , m_contextIdentifier(*initializationData.clientIdentifier)

--- a/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.h
+++ b/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.h
@@ -59,7 +59,7 @@ public:
     void setAsTerminatingOrTerminated() { m_isTerminatingOrTerminated = true; }
 
 private:
-    WEBCORE_EXPORT SharedWorkerThreadProxy(UniqueRef<Page>&&, SharedWorkerIdentifier, const ClientOrigin&, WorkerFetchResult&&, WorkerOptions&&, WorkerInitializationData&&, CacheStorageProvider&);
+    WEBCORE_EXPORT SharedWorkerThreadProxy(Ref<Page>&&, SharedWorkerIdentifier, const ClientOrigin&, WorkerFetchResult&&, WorkerOptions&&, WorkerInitializationData&&, CacheStorageProvider&);
 
     bool postTaskForModeToWorkerOrWorkletGlobalScope(ScriptExecutionContext::Task&&, const String& mode);
 
@@ -88,7 +88,7 @@ private:
 
     ReportingClient* reportingClient() const final;
 
-    UniqueRef<Page> m_page;
+    Ref<Page> m_page;
     Ref<Document> m_document;
     ScriptExecutionContextIdentifier m_contextIdentifier;
     Ref<SharedWorkerThread> m_workerThread;

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -1388,7 +1388,7 @@ JSValueRef PDFPlugin::jsPDFDocPrint(JSContextRef ctx, JSObjectRef function, JSOb
     if (!coreFrame)
         return JSValueMakeUndefined(ctx);
 
-    CheckedPtr page = coreFrame->page();
+    RefPtr page = coreFrame->page();
     if (!page)
         return JSValueMakeUndefined(ctx);
 
@@ -1628,7 +1628,7 @@ void PDFPlugin::teardown()
 void PDFPlugin::paintControlForLayerInContext(CALayer *layer, CGContextRef context)
 {
 #if PLATFORM(MAC)
-    CheckedPtr page = this->page();
+    RefPtr page = this->page();
     if (!page)
         return;
     LocalDefaultSystemAppearance localAppearance(page->useDarkAppearance());
@@ -1739,7 +1739,7 @@ FloatRect PDFPlugin::convertFromPDFViewToScreen(const FloatRect& rect) const
     return WebCore::Accessibility::retrieveValueFromMainThread<WebCore::FloatRect>([&] () -> WebCore::FloatRect {
         FloatRect updatedRect = rect;
         updatedRect.setLocation(convertFromPDFViewToRootView(IntPoint(updatedRect.location())));
-        CheckedPtr page = this->page();
+        RefPtr page = this->page();
         if (!page)
             return { };
         return page->chrome().rootViewToScreen(enclosingIntRect(updatedRect));

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -288,7 +288,7 @@ IntRect PDFPluginBase::boundsOnScreen() const
     return WebCore::Accessibility::retrieveValueFromMainThread<WebCore::IntRect>([&] () -> WebCore::IntRect {
         FloatRect bounds = FloatRect(FloatPoint(), size());
         FloatRect rectInRootViewCoordinates = valueOrDefault(m_rootViewToPluginTransform.inverse()).mapRect(bounds);
-        CheckedPtr page = this->page();
+        RefPtr page = this->page();
         if (!page)
             return { };
         return page->chrome().rootViewToScreen(enclosingIntRect(rectInRootViewCoordinates));
@@ -337,7 +337,7 @@ void PDFPluginBase::setScrollOffset(const ScrollOffset& offset)
 
 bool PDFPluginBase::isActive() const
 {
-    if (CheckedPtr page = this->page())
+    if (RefPtr page = this->page())
         return page->focusController().isActive();
 
     return false;
@@ -345,7 +345,7 @@ bool PDFPluginBase::isActive() const
 
 bool PDFPluginBase::forceUpdateScrollbarsOnMainThreadForPerformanceTesting() const
 {
-    if (CheckedPtr page = this->page())
+    if (RefPtr page = this->page())
         return page->settings().scrollingPerformanceTestingEnabled();
 
     return false;
@@ -373,7 +373,7 @@ ScrollPosition PDFPluginBase::maximumScrollPosition() const
 
 float PDFPluginBase::deviceScaleFactor() const
 {
-    if (CheckedPtr page = this->page())
+    if (RefPtr page = this->page())
         return page->deviceScaleFactor();
     return 1;
 }
@@ -500,7 +500,7 @@ Ref<Scrollbar> PDFPluginBase::createScrollbar(ScrollbarOrientation orientation)
     Ref widget = Scrollbar::createNativeScrollbar(*this, orientation, ScrollbarWidth::Auto);
     didAddScrollbar(widget.ptr(), orientation);
 
-    if (CheckedPtr page = this->page()) {
+    if (RefPtr page = this->page()) {
         if (page->isMonitoringWheelEvents())
             scrollAnimator().setWheelEventTestMonitor(page->wheelEventTestMonitor());
     }
@@ -540,7 +540,7 @@ IntRect PDFPluginBase::frameForHUDInRootViewCoordinates() const
 
 bool PDFPluginBase::hudEnabled() const
 {
-    if (CheckedPtr page = this->page())
+    if (RefPtr page = this->page())
         return page->settings().pdfPluginHUDEnabled();
     return false;
 }

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -83,7 +83,7 @@ void UnifiedPDFPlugin::teardown()
     if (m_rootLayer)
         m_rootLayer->removeFromParent();
 
-    CheckedPtr page = this->page();
+    RefPtr page = this->page();
     if (m_scrollingNodeID && page) {
         RefPtr scrollingCoordinator = page->scrollingCoordinator();
         scrollingCoordinator->unparentChildrenAndDestroyNode(m_scrollingNodeID);
@@ -119,7 +119,7 @@ void UnifiedPDFPlugin::installPDFDocument()
 
 RefPtr<GraphicsLayer> UnifiedPDFPlugin::createGraphicsLayer(const String& name, GraphicsLayer::Type layerType)
 {
-    CheckedPtr page = this->page();
+    RefPtr page = this->page();
     if (!page)
         return nullptr;
 
@@ -131,7 +131,7 @@ RefPtr<GraphicsLayer> UnifiedPDFPlugin::createGraphicsLayer(const String& name, 
 
 void UnifiedPDFPlugin::scheduleRenderingUpdate()
 {
-    CheckedPtr page = this->page();
+    RefPtr page = this->page();
     if (!page)
         return;
 
@@ -140,7 +140,7 @@ void UnifiedPDFPlugin::scheduleRenderingUpdate()
 
 void UnifiedPDFPlugin::updateLayerHierarchy()
 {
-    CheckedPtr page = this->page();
+    RefPtr page = this->page();
     if (!page)
         return;
 
@@ -202,7 +202,7 @@ void UnifiedPDFPlugin::updateLayerHierarchy()
 
 void UnifiedPDFPlugin::didChangeSettings()
 {
-    CheckedPtr page = this->page();
+    RefPtr page = this->page();
     if (!page)
         return;
     Settings& settings = page->settings();
@@ -225,7 +225,7 @@ void UnifiedPDFPlugin::notifyFlushRequired(const GraphicsLayer*)
 
 void UnifiedPDFPlugin::didChangeIsInWindow()
 {
-    CheckedPtr page = this->page();
+    RefPtr page = this->page();
     if (!page || !m_contentsLayer)
         return;
     m_contentsLayer->tiledBacking()->setIsInWindow(page->isInWindow());
@@ -307,7 +307,7 @@ float UnifiedPDFPlugin::deviceScaleFactor() const
 
 float UnifiedPDFPlugin::pageScaleFactor() const
 {
-    if (CheckedPtr page = this->page())
+    if (RefPtr page = this->page())
         return m_view->pageScaleFactor();
     return 1;
 }
@@ -330,7 +330,7 @@ void UnifiedPDFPlugin::setPageScaleFactor(double scale, std::optional<WebCore::I
         return;
     }
 
-    CheckedPtr page = this->page();
+    RefPtr page = this->page();
     if (!page)
         return;
 
@@ -443,7 +443,7 @@ void UnifiedPDFPlugin::invalidateScrollCornerRect(const WebCore::IntRect&)
 
 void UnifiedPDFPlugin::updateScrollingExtents()
 {
-    CheckedPtr page = this->page();
+    RefPtr page = this->page();
     if (!page)
         return;
     auto& scrollingCoordinator = *page->scrollingCoordinator();

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
@@ -183,7 +183,7 @@ void WebSWContextManagerConnection::installServiceWorker(ServiceWorkerContextDat
 #endif
 
         auto lastNavigationWasAppInitiated = contextData.lastNavigationWasAppInitiated;
-        auto page = makeUniqueRef<Page>(WTFMove(pageConfiguration));
+        Ref page = Page::create(WTFMove(pageConfiguration));
         if (m_preferencesStore) {
             WebPage::updateSettingsGenerated(*m_preferencesStore, page->settings());
             page->settings().setStorageBlockingPolicy(static_cast<StorageBlockingPolicy>(m_preferencesStore->getUInt32ValueForKey(WebPreferencesKey::storageBlockingPolicyKey())));

--- a/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp
@@ -110,7 +110,7 @@ void WebSharedWorkerContextManagerConnection::launchSharedWorker(WebCore::Client
 
     pageConfiguration.clientForMainFrame = UniqueRef<WebCore::LocalFrameLoaderClient>(makeUniqueRef<RemoteWorkerFrameLoaderClient>(m_webPageProxyID, m_pageID, m_userAgent));
 
-    auto page = makeUniqueRef<WebCore::Page>(WTFMove(pageConfiguration));
+    Ref page = WebCore::Page::create(WTFMove(pageConfiguration));
     if (m_preferencesStore) {
         WebPage::updateSettingsGenerated(*m_preferencesStore, page->settings());
         page->settings().setStorageBlockingPolicy(static_cast<WebCore::StorageBlockingPolicy>(m_preferencesStore->getUInt32ValueForKey(WebPreferencesKey::storageBlockingPolicyKey())));

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPermissionController.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPermissionController.cpp
@@ -58,7 +58,7 @@ WebPermissionController::~WebPermissionController()
     WebProcess::singleton().removeMessageReceiver(Messages::WebPermissionController::messageReceiverName());
 }
 
-void WebPermissionController::query(WebCore::ClientOrigin&& origin, WebCore::PermissionDescriptor descriptor, const WeakPtr<WebCore::Page>& page, WebCore::PermissionQuerySource source, CompletionHandler<void(std::optional<WebCore::PermissionState>)>&& completionHandler)
+void WebPermissionController::query(WebCore::ClientOrigin&& origin, WebCore::PermissionDescriptor descriptor, const SingleThreadWeakPtr<WebCore::Page>& page, WebCore::PermissionQuerySource source, CompletionHandler<void(std::optional<WebCore::PermissionState>)>&& completionHandler)
 {
     std::optional<WebPageProxyIdentifier> proxyIdentifier;
     if (source == WebCore::PermissionQuerySource::Window || source == WebCore::PermissionQuerySource::DedicatedWorker) {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPermissionController.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPermissionController.h
@@ -56,7 +56,7 @@ private:
     explicit WebPermissionController(WebProcess&);
 
     // WebCore::PermissionController
-    void query(WebCore::ClientOrigin&&, WebCore::PermissionDescriptor, const WeakPtr<WebCore::Page>&, WebCore::PermissionQuerySource, CompletionHandler<void(std::optional<WebCore::PermissionState>)>&&) final;
+    void query(WebCore::ClientOrigin&&, WebCore::PermissionDescriptor, const SingleThreadWeakPtr<WebCore::Page>&, WebCore::PermissionQuerySource, CompletionHandler<void(std::optional<WebCore::PermissionState>)>&&) final;
     void addObserver(WebCore::PermissionObserver&) final;
     void removeObserver(WebCore::PermissionObserver&) final;
     void permissionChanged(WebCore::PermissionName, const WebCore::SecurityOriginData&) final;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2167,7 +2167,7 @@ private:
 
     WebCore::PageIdentifier m_identifier;
 
-    std::unique_ptr<WebCore::Page> m_page;
+    RefPtr<WebCore::Page> m_page;
     Ref<WebFrame> m_mainFrame;
 
     RefPtr<WebPageGroupProxy> m_pageGroup;

--- a/Source/WebKitLegacy/Storage/WebStorageNamespaceProvider.h
+++ b/Source/WebKitLegacy/Storage/WebStorageNamespaceProvider.h
@@ -58,7 +58,7 @@ private:
     void copySessionStorageNamespace(WebCore::Page&, WebCore::Page&) final;
 
     const String m_localStorageDatabasePath;
-    WeakHashMap<WebCore::Page, HashMap<WebCore::SecurityOriginData, RefPtr<WebCore::StorageNamespace>>> m_sessionStorageNamespaces;
+    SingleThreadWeakHashMap<WebCore::Page, HashMap<WebCore::SecurityOriginData, RefPtr<WebCore::StorageNamespace>>> m_sessionStorageNamespaces;
 };
 
 } // namespace WebKit

--- a/Source/WebKitLegacy/WebCoreSupport/PageStorageSessionProvider.h
+++ b/Source/WebKitLegacy/WebCoreSupport/PageStorageSessionProvider.h
@@ -48,5 +48,5 @@ public:
     }
 
 private:
-    WeakPtr<WebCore::Page> m_page;
+    SingleThreadWeakPtr<WebCore::Page> m_page;
 };

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.h
@@ -104,7 +104,7 @@ private:
 
     WeakObjCPtr<WebView> m_inspectedWebView;
     RetainPtr<WebNodeHighlighter> m_highlighter;
-    WeakPtr<WebCore::Page> m_frontendPage;
+    SingleThreadWeakPtr<WebCore::Page> m_frontendPage;
     std::unique_ptr<WebInspectorFrontendClient> m_frontendClient;
 };
 

--- a/Source/WebKitLegacy/mac/WebView/WebMediaPlaybackTargetPicker.h
+++ b/Source/WebKitLegacy/mac/WebView/WebMediaPlaybackTargetPicker.h
@@ -68,7 +68,7 @@ private:
     void playbackTargetPickerWasDismissed(WebCore::PlaybackTargetClientContextIdentifier) final;
     RetainPtr<PlatformView> platformView() const final;
 
-    WeakPtr<WebCore::Page> m_page;
+    SingleThreadWeakPtr<WebCore::Page> m_page;
     WeakObjCPtr<WebView> m_webView;
 };
 

--- a/Source/WebKitLegacy/mac/WebView/WebMediaPlaybackTargetPicker.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebMediaPlaybackTargetPicker.mm
@@ -38,7 +38,7 @@ std::unique_ptr<WebMediaPlaybackTargetPicker> WebMediaPlaybackTargetPicker::crea
 }
 
 WebMediaPlaybackTargetPicker::WebMediaPlaybackTargetPicker(WebView *webView, WebCore::Page& page)
-    : m_page(&page)
+    : m_page(page)
     , m_webView(webView)
 {
 }

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -790,38 +790,6 @@ static WebCore::StorageBlockingPolicy core(WebStorageBlockingPolicy storageBlock
     }
 }
 
-namespace WebKit {
-
-class DeferredPageDestructor {
-public:
-    static void createDeferredPageDestructor(std::unique_ptr<WebCore::Page> page)
-    {
-        new DeferredPageDestructor(WTFMove(page));
-    }
-
-private:
-    DeferredPageDestructor(std::unique_ptr<WebCore::Page> page)
-        : m_page(WTFMove(page))
-    {
-        tryDestruction();
-    }
-
-    void tryDestruction()
-    {
-        if (m_page->insideNestedRunLoop()) {
-            m_page->whenUnnested([this] { tryDestruction(); });
-            return;
-        }
-
-        m_page = nullptr;
-        delete this;
-    }
-
-    std::unique_ptr<WebCore::Page> m_page;
-};
-
-} // namespace WebKit
-
 #if PLATFORM(IOS_FAMILY) && ENABLE(DRAG_SUPPORT)
 
 @implementation WebUITextIndicatorData
@@ -1550,19 +1518,19 @@ static void WebKitInitializeGamepadProviderIfNecessary()
     pageConfiguration.pluginInfoProvider = &WebPluginInfoProvider::singleton();
     pageConfiguration.storageNamespaceProvider = &_private->group->storageNamespaceProvider();
     pageConfiguration.visitedLinkStore = &_private->group->visitedLinkStore();
-    _private->page = new WebCore::Page(WTFMove(pageConfiguration));
+    _private->page = WebCore::Page::create(WTFMove(pageConfiguration));
     storageProvider->setPage(*_private->page);
 
     _private->page->setGroupName(groupName);
 
 #if ENABLE(GEOLOCATION)
-    WebCore::provideGeolocationTo(_private->page, *new WebGeolocationClient(self));
+    WebCore::provideGeolocationTo(_private->page.get(), *new WebGeolocationClient(self));
 #endif
 #if ENABLE(NOTIFICATIONS)
-    WebCore::provideNotification(_private->page, new WebNotificationClient(self));
+    WebCore::provideNotification(_private->page.get(), new WebNotificationClient(self));
 #endif
 #if ENABLE(ENCRYPTED_MEDIA)
-    WebCore::provideMediaKeySystemTo(*_private->page, WebMediaKeySystemClient::singleton());
+    WebCore::provideMediaKeySystemTo(*_private->page.get(), WebMediaKeySystemClient::singleton());
 #endif
 
 #if ENABLE(REMOTE_INSPECTOR)
@@ -1594,7 +1562,7 @@ static void WebKitInitializeGamepadProviderIfNecessary()
     if ([[NSUserDefaults standardUserDefaults] objectForKey:WebSmartInsertDeleteEnabled])
         [self setSmartInsertDeleteEnabled:[[NSUserDefaults standardUserDefaults] boolForKey:WebSmartInsertDeleteEnabled]];
 
-    [WebFrame _createMainFrameWithPage:_private->page frameName:frameName frameView:frameView.get()];
+    [WebFrame _createMainFrameWithPage:_private->page.get() frameName:frameName frameView:frameView.get()];
 
 #if PLATFORM(IOS_FAMILY)
     NSRunLoop *runLoop = WebThreadNSRunLoop();
@@ -1801,7 +1769,7 @@ static void WebKitInitializeGamepadProviderIfNecessary()
     pageConfiguration.visitedLinkStore = &_private->group->visitedLinkStore();
     pageConfiguration.pluginInfoProvider = &WebPluginInfoProvider::singleton();
 
-    _private->page = new WebCore::Page(WTFMove(pageConfiguration));
+    _private->page = WebCore::Page::create(WTFMove(pageConfiguration));
     storageProvider->setPage(*_private->page);
 
     [self setSmartInsertDeleteEnabled:YES];
@@ -1840,7 +1808,7 @@ static void WebKitInitializeGamepadProviderIfNecessary()
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_wakWindowScreenScaleChanged:) name:WAKWindowScreenScaleDidChangeNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_wakWindowVisibilityChanged:) name:WAKWindowVisibilityDidChangeNotification object:nil];
 
-    [WebFrame _createMainFrameWithSimpleHTMLDocumentWithPage:_private->page frameView:frameView.get() style:style];
+    [WebFrame _createMainFrameWithSimpleHTMLDocumentWithPage:_private->page.get() frameView:frameView.get() style:style];
 
     [self _addToAllWebViewsSet];
 
@@ -1929,7 +1897,7 @@ static void WebKitInitializeGamepadProviderIfNecessary()
 - (CGRect)_dataInteractionCaretRect
 {
     WebThreadLock();
-    if (auto* page = _private->page)
+    if (RefPtr page = _private->page)
         return page->dragCaretController().caretRectInRootViewCoordinates();
 
     return { };
@@ -2036,7 +2004,7 @@ static void WebKitInitializeGamepadProviderIfNecessary()
 - (void)_didConcludeEditDrag
 {
     _private->dataOperationTextIndicator = nullptr;
-    auto* page = _private->page;
+    RefPtr page = _private->page;
     if (!page)
         return;
 
@@ -2476,9 +2444,7 @@ static bool fastDocumentTeardownEnabled()
     // Deleteing the WebCore::Page will clear the back/forward cache so we call destroy on
     // all the plug-ins in the back/forward cache to break any retain cycles.
     // See comment in HistoryItem::releaseAllPendingPageCaches() for more information.
-    auto* page = _private->page;
     _private->page = nullptr;
-    WebKit::DeferredPageDestructor::createDeferredPageDestructor(std::unique_ptr<WebCore::Page>(page));
 
 #if !PLATFORM(IOS_FAMILY)
     if (_private->hasSpellCheckerDocumentTag) {
@@ -2707,7 +2673,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (NakedPtr<WebCore::Page>)page
 {
-    return _private->page;
+    return _private->page.get();
 }
 
 #if !PLATFORM(IOS_FAMILY)
@@ -3350,7 +3316,7 @@ IGNORE_WARNINGS_END
     if (_private->_didPerformFirstNavigation)
         return;
 
-    auto* page = _private->page;
+    RefPtr page = _private->page;
     if (!page)
         return;
 
@@ -4060,7 +4026,7 @@ IGNORE_WARNINGS_END
 
 - (void)_executeCoreCommandByName:(NSString *)name value:(NSString *)value
 {
-    if (auto* page = _private->page)
+    if (RefPtr page = _private->page)
         page->focusController().focusedOrMainFrame().editor().command(name).execute(value);
 }
 
@@ -8849,7 +8815,7 @@ FORWARD(toggleUnderline)
 #if PLATFORM(IOS_FAMILY)
 - (void)_scheduleRenderingUpdateForPendingTileCacheRepaint
 {
-    if (auto* page = _private->page)
+    if (RefPtr page = _private->page)
         page->scheduleRenderingUpdate(WebCore::RenderingUpdateStep::LayerFlush);
 }
 #endif
@@ -9682,7 +9648,7 @@ static NSTextAlignment nsTextAlignmentFromRenderStyle(const WebCore::RenderStyle
 {
 #if ENABLE(GEOLOCATION)
     if (_private && _private->page)
-        WebCore::GeolocationController::from(_private->page)->positionChanged(core(position));
+        WebCore::GeolocationController::from(_private->page.get())->positionChanged(core(position));
 #endif // ENABLE(GEOLOCATION)
 }
 
@@ -9691,7 +9657,7 @@ static NSTextAlignment nsTextAlignmentFromRenderStyle(const WebCore::RenderStyle
 #if ENABLE(GEOLOCATION)
     if (_private && _private->page) {
         auto geolocatioError = WebCore::GeolocationError::create(WebCore::GeolocationError::PositionUnavailable, errorMessage);
-        WebCore::GeolocationController::from(_private->page)->errorOccurred(geolocatioError.get());
+        WebCore::GeolocationController::from(_private->page.get())->errorOccurred(geolocatioError.get());
     }
 #endif // ENABLE(GEOLOCATION)
 }
@@ -9743,7 +9709,7 @@ static NSTextAlignment nsTextAlignmentFromRenderStyle(const WebCore::RenderStyle
 - (NSString *)_notificationIDForTesting:(JSValueRef)jsNotification
 {
 #if ENABLE(NOTIFICATIONS)
-    auto* page = _private->page;
+    RefPtr page = _private->page;
     if (!page)
         return 0;
     JSContextRef context = [[self mainFrame] globalContext];
@@ -9757,7 +9723,7 @@ static NSTextAlignment nsTextAlignmentFromRenderStyle(const WebCore::RenderStyle
 - (void)_clearNotificationPermissionState
 {
 #if ENABLE(NOTIFICATIONS)
-    auto* page = _private->page;
+    RefPtr page = _private->page;
     if (page)
         static_cast<WebNotificationClient*>(WebCore::NotificationController::clientFrom(*page))->clearNotificationPermissionState();
 #endif

--- a/Source/WebKitLegacy/mac/WebView/WebViewData.h
+++ b/Source/WebKitLegacy/mac/WebView/WebViewData.h
@@ -33,6 +33,7 @@
 #import <pal/spi/cocoa/AVKitSPI.h>
 #endif
 #import <WebCore/AlternativeTextClient.h>
+#import <WebCore/Page.h>
 #import <WebCore/WebCoreKeyboardUIMode.h>
 #import <wtf/HashMap.h>
 #import <wtf/Lock.h>
@@ -47,7 +48,6 @@
 namespace WebCore {
 class AlternativeTextUIController;
 class HistoryItem;
-class Page;
 class RunLoopObserver;
 class TextIndicatorWindow;
 class ValidationBubble;
@@ -119,7 +119,7 @@ class WebSelectionServiceController;
 // FIXME: This should be renamed to WebViewData.
 @interface WebViewPrivate : NSObject {
 @public
-    WebCore::Page* page;
+    RefPtr<WebCore::Page> page;
     RefPtr<WebViewGroup> group;
 
     id UIDelegate;


### PR DESCRIPTION
#### 23c37146256e9c7382894cda4d929cda2a5b78c6
<pre>
Make Page refcounted and replace CheckedPtr with RefPtr for stack variables
<a href="https://bugs.webkit.org/show_bug.cgi?id=266368">https://bugs.webkit.org/show_bug.cgi?id=266368</a>
<a href="https://rdar.apple.com/118965945">rdar://118965945</a>

Reviewed by Brent Fulgham.

* Source/WebCore/Modules/permissions/MainThreadPermissionObserver.cpp:
(WebCore::MainThreadPermissionObserver::MainThreadPermissionObserver):
* Source/WebCore/Modules/permissions/MainThreadPermissionObserver.h:
* Source/WebCore/Modules/permissions/PermissionController.h:
* Source/WebCore/Modules/permissions/PermissionObserver.h:
* Source/WebCore/Modules/permissions/PermissionStatus.cpp:
(WebCore::PermissionStatus::create):
(WebCore::PermissionStatus::PermissionStatus):
* Source/WebCore/Modules/permissions/PermissionStatus.h:
* Source/WebCore/Scripts/SettingsTemplates/InternalSettingsGenerated.h.erb:
* Source/WebCore/accessibility/atspi/AccessibilityRootAtspi.h:
* Source/WebCore/bindings/js/ScriptController.cpp:
(WebCore::ScriptController::initScriptForWindowProxy):
* Source/WebCore/dom/BroadcastChannel.cpp:
(WebCore::BroadcastChannel::MainThreadBridge::ensureOnMainThread):
* Source/WebCore/dom/ConstantPropertyMap.cpp:
(WebCore::ConstantPropertyMap::updateConstantsForSafeAreaInsets):
(WebCore::ConstantPropertyMap::updateConstantsForFullscreen):
* Source/WebCore/dom/DataTransfer.cpp:
(WebCore::DataTransfer::readStringFromPasteboard const):
(WebCore::DataTransfer::setDataFromItemList):
* Source/WebCore/dom/DeviceOrientationAndMotionAccessController.cpp:
(WebCore::DeviceOrientationAndMotionAccessController::shouldAllowAccess):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::configureSharedLogger):
(WebCore::Document::childrenChanged):
(WebCore::Document::setVisualUpdatesAllowed):
(WebCore::Document::willBeRemovedFromFrame):
(WebCore::Document::appHighlightRegistry):
(WebCore::Document::implicitClose):
(WebCore::Document::minimumDOMTimerInterval const):
(WebCore::Document::domTimerAlignmentInterval const):
(WebCore::Document::idbConnectionProxy):
(WebCore::Document::createRTCDataChannelRemoteHandlerConnection):
(WebCore::Document::dispatchDisabledAdaptationsDidChangeForMainFrame):
(WebCore::Document::viewportArguments const):
(WebCore::Document::updateViewportArguments):
(WebCore::Document::themeColorChanged):
(WebCore::Document::processColorScheme):
(WebCore::Document::processWebAppOrientations):
(WebCore::Document::prepareMouseEvent):
(WebCore::Document::runScrollSteps):
(WebCore::Document::updateIsPlayingMedia):
(WebCore::Document::invalidateRenderingDependentRegions):
(WebCore::Document::setFocusedElement):
(WebCore::Document::cookie):
(WebCore::Document::setCookie):
(WebCore::Document::shouldMaskURLForBindingsInternal const):
(WebCore::Document::setBackForwardCacheState):
(WebCore::Document::suspend):
(WebCore::Document::resume):
(WebCore::Document::registerForCaptionPreferencesChangedCallbacks):
(WebCore::Document::addConsoleMessage):
(WebCore::Document::addMessage):
(WebCore::Document::postTask):
(WebCore::Document::serviceRequestVideoFrameCallbacks):
(WebCore::Document::exitPointerLock):
(WebCore::Document::requestIdleCallback):
(WebCore::Document::wheelEventHandlersChanged):
(WebCore::Document::deviceScaleFactor const):
(WebCore::Document::useSystemAppearance const):
(WebCore::Document::useDarkAppearance const):
(WebCore::Document::useElevatedUserInterfaceLevel const):
(WebCore::Document::didAssociateFormControl):
(WebCore::Document::didAssociateFormControlsTimerFired):
(WebCore::Document::didLoadResourceSynchronously):
(WebCore::Document::wrapCryptoKey):
(WebCore::Document::unwrapCryptoKey):
(WebCore::Document::hasFocus const):
(WebCore::Document::addPlaybackTargetPickerClient):
(WebCore::Document::removePlaybackTargetPickerClient):
(WebCore::Document::showPlaybackTargetPicker):
(WebCore::Document::playbackTargetPickerClientStateDidChange):
(WebCore::Document::scheduleRenderingUpdate):
(WebCore::Document::logger):
(WebCore::Document::didLogMessage):
(WebCore::Document::notificationClient):
(WebCore::Document::graphicsClient):
(WebCore::Document::sessionID const):
(WebCore::Document::noiseInjectionHashSalt const):
(WebCore::Document::mediaKeysStorageDirectory):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/DocumentMarkerController.cpp:
(WebCore::DocumentMarkerController::invalidateRectsForAllMarkers):
(WebCore::DocumentMarkerController::invalidateRectsForMarkersInNode):
* Source/WebCore/dom/DocumentStorageAccess.cpp:
(WebCore::DocumentStorageAccess::hasStorageAccess):
(WebCore::DocumentStorageAccess::requestStorageAccess):
(WebCore::DocumentStorageAccess::requestStorageAccessQuirk):
* Source/WebCore/dom/Element.cpp:
(WebCore::dispatchPointerEventIfNeeded):
(WebCore::Element::removedFromAncestor):
(WebCore::Element::focus):
(WebCore::Element::dispatchFocusEvent):
(WebCore::Element::dispatchBlurEvent):
(WebCore::Element::setPointerCapture):
(WebCore::Element::releasePointerCapture):
(WebCore::Element::hasPointerCapture):
(WebCore::Element::requestPointerLock):
* Source/WebCore/dom/ExtensionStyleSheets.cpp:
(WebCore::ExtensionStyleSheets::updateInjectedStyleSheetCache const):
* Source/WebCore/dom/ImageOverlay.cpp:
(WebCore::ImageOverlay::removeOverlaySoonIfNeeded):
(WebCore::ImageOverlay::updateWithTextRecognitionResult):
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::inspect):
* Source/WebCore/dom/PseudoElement.cpp:
(WebCore::PseudoElement::create):
(WebCore::PseudoElement::clearHostElement):
* Source/WebCore/dom/ScriptedAnimationController.cpp:
(WebCore::ScriptedAnimationController::registerCallback):
(WebCore::ScriptedAnimationController::scheduleAnimation):
* Source/WebCore/dom/VisitedLinkState.cpp:
(WebCore::VisitedLinkState::determineLinkStateSlowCase):
* Source/WebCore/dom/WindowEventLoop.h:
* Source/WebCore/dom/mac/ImageControlsMac.cpp:
(WebCore::ImageControlsMac::handleEvent):
* Source/WebCore/editing/ReplaceSelectionCommand.cpp:
(WebCore::ReplacementFragment::ReplacementFragment):
* Source/WebCore/editing/SelectionGeometryGatherer.cpp:
(WebCore::SelectionGeometryGatherer::Notifier::~Notifier):
* Source/WebCore/editing/SpellChecker.cpp:
(WebCore::SpellChecker::client const):
* Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm:
(WebCore::sanitizeMarkupWithArchive):
(WebCore::WebContentReader::readPlainText):
* Source/WebCore/editing/markup.cpp:
(WebCore::createPageForSanitizingWebContent):
(WebCore::sanitizeMarkup):
* Source/WebCore/editing/markup.h:
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::attributeChanged):
* Source/WebCore/html/HTMLSelectElement.cpp:
(WebCore::HTMLSelectElement::setRecalcListItems):
* Source/WebCore/inspector/InspectorFrontendAPIDispatcher.h:
* Source/WebCore/inspector/InspectorFrontendClientLocal.h:
* Source/WebCore/inspector/InspectorFrontendHost.h:
* Source/WebCore/inspector/PageDebugger.cpp:
(WebCore::PageDebugger::runEventLoopWhilePausedInternal):
* Source/WebCore/loader/DocumentThreadableLoader.cpp:
(WebCore::DocumentThreadableLoader::DocumentThreadableLoader):
(WebCore::DocumentThreadableLoader::makeCrossOriginAccessRequest):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::ForbidPromptsScope::ForbidPromptsScope):
(WebCore::ForbidPromptsScope::~ForbidPromptsScope):
(WebCore::ForbidSynchronousLoadsScope::ForbidSynchronousLoadsScope):
(WebCore::ForbidSynchronousLoadsScope::~ForbidSynchronousLoadsScope):
(WebCore::FrameLoader::FrameProgressTracker::progressCompleted):
(WebCore::FrameLoader::checkCompletenessNow):
(WebCore::FrameLoader::setOpener):
(WebCore::FrameLoader::provisionalLoadStarted):
(WebCore::FrameLoader::loadFrameRequest):
(WebCore::FrameLoader::loadWithDocumentLoader):
(WebCore::FrameLoader::setState):
(WebCore::FrameLoader::commitProvisionalLoad):
(WebCore::FrameLoader::subresourceCachePolicy const):
(WebCore::FrameLoader::checkLoadCompleteForThisFrame):
(WebCore::FrameLoader::updateRequestAndAddExtraFields):
(WebCore::FrameLoader::loadResourceSynchronously):
(WebCore::FrameLoader::shouldClose):
(WebCore::FrameLoader::dispatchBeforeUnloadEvent):
(WebCore::FrameLoader::continueLoadAfterNavigationPolicy):
(WebCore::FrameLoader::continueLoadAfterNewWindowPolicy):
(WebCore::FrameLoader::loadedResourceFromMemoryCache):
(WebCore::FrameLoader::dispatchDidClearWindowObjectInWorld):
(WebCore::FrameLoader::didChangeTitle):
(WebCore::FrameLoader::dispatchDidCommitLoad):
(WebCore::createWindow):
(WebCore::FrameLoader::switchBrowsingContextsGroup):
* Source/WebCore/loader/SubframeLoader.cpp:
(WebCore::FrameLoader::SubframeLoader::requestObject):
(WebCore::FrameLoader::SubframeLoader::loadOrRedirectSubframe):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::canMouseDownStartSelect):
(WebCore::EventHandler::eventMayStartDrag const):
(WebCore::EventHandler::updateDragSourceActionsAllowed const):
(WebCore::EventHandler::startAutoHideCursorTimer):
(WebCore::EventHandler::autoHideCursorTimerFired):
(WebCore::EventHandler::handleMousePressEvent):
(WebCore::EventHandler::mouseMoved):
(WebCore::EventHandler::handleMouseMoveEvent):
(WebCore::EventHandler::handleMouseReleaseEvent):
(WebCore::EventHandler::updateMouseEventTargetNode):
(WebCore::EventHandler::clearElementUnderMouse):
(WebCore::EventHandler::dispatchMouseEvent):
(WebCore::EventHandler::handleWheelEventInternal):
(WebCore::EventHandler::clearLatchedState):
(WebCore::EventHandler::scheduleCursorUpdate):
(WebCore::EventHandler::dispatchFakeMouseMoveEventSoon):
(WebCore::EventHandler::textRecognitionHoverTimerFired):
(WebCore::EventHandler::internalKeyEvent):
(WebCore::EventHandler::dragCancelled):
(WebCore::EventHandler::dragSourceEndedAt):
(WebCore::EventHandler::dispatchDragStartEventOnSourceElement):
(WebCore::EventHandler::handleDrag):
(WebCore::EventHandler::tabsToLinks const):
(WebCore::EventHandler::defaultBackspaceEventHandler):
(WebCore::EventHandler::beginKeyboardScrollGesture):
(WebCore::EventHandler::defaultArrowEventHandler):
(WebCore::EventHandler::defaultTabEventHandler):
(WebCore::EventHandler::focusDocumentView):
* Source/WebCore/page/Frame.h:
* Source/WebCore/page/ImageAnalysisQueue.h:
* Source/WebCore/page/ImageOverlayController.h:
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::canShowModalDialog):
(WebCore::LocalDOMWindow::prewarmLocalStorageIfNecessary):
(WebCore::LocalDOMWindow::protectedPage const):
(WebCore::LocalDOMWindow::shouldHaveWebKitNamespaceForWorld):
(WebCore::LocalDOMWindow::webkitNamespace):
(WebCore::LocalDOMWindow::focus):
(WebCore::LocalDOMWindow::blur):
(WebCore::LocalDOMWindow::close):
(WebCore::LocalDOMWindow::print):
(WebCore::LocalDOMWindow::alert):
(WebCore::LocalDOMWindow::confirmForBindings):
(WebCore::LocalDOMWindow::prompt):
(WebCore::LocalDOMWindow::outerHeight const):
(WebCore::LocalDOMWindow::outerWidth const):
(WebCore::LocalDOMWindow::screenX const):
(WebCore::LocalDOMWindow::screenY const):
(WebCore::LocalDOMWindow::closed const):
(WebCore::LocalDOMWindow::devicePixelRatio const):
(WebCore::LocalDOMWindow::moveBy const):
(WebCore::LocalDOMWindow::moveTo const):
(WebCore::LocalDOMWindow::resizeBy const):
(WebCore::LocalDOMWindow::resizeTo const):
(WebCore::LocalDOMWindow::deviceOrientationController const):
(WebCore::LocalDOMWindow::deviceMotionController const):
(WebCore::LocalDOMWindow::incrementScrollEventListenersCount):
(WebCore::LocalDOMWindow::decrementScrollEventListenersCount):
(WebCore::LocalDOMWindow::createWindow):
(WebCore::LocalDOMWindow::open):
(WebCore::LocalDOMWindow::enableSuddenTermination):
(WebCore::LocalDOMWindow::disableSuddenTermination):
(WebCore::LocalDOMWindow::checkedPage const): Deleted.
* Source/WebCore/page/LocalDOMWindow.h:
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::LocalFrame):
(WebCore::LocalFrame::setDocument):
(WebCore::LocalFrame::orientation const):
(WebCore::LocalFrame::injectUserScripts):
(WebCore::LocalFrame::willDetachPage):
(WebCore::LocalFrame::setPageAndTextZoomFactors):
(WebCore::LocalFrame::frameScaleFactor const):
(WebCore::LocalFrame::screenSize const):
(WebCore::LocalFrame::documentURLDidChange):
* Source/WebCore/page/OpportunisticTaskScheduler.cpp:
(WebCore::OpportunisticTaskScheduler::rescheduleIfNeeded):
(WebCore::OpportunisticTaskScheduler::runLoopObserverFired):
(WebCore::OpportunisticTaskScheduler::checkedPage const): Deleted.
* Source/WebCore/page/OpportunisticTaskScheduler.h:
* Source/WebCore/page/Page.cpp:
(WebCore::allPages):
(WebCore::Page::forEachPage):
(WebCore::networkStateChanged):
(WebCore::createMainFrame):
(WebCore::Page::create):
(WebCore::m_historyItemClient):
(WebCore::Page::~Page):
(WebCore::Page::incrementNestedRunLoopCount): Deleted.
(WebCore::Page::decrementNestedRunLoopCount): Deleted.
(WebCore::Page::whenUnnested): Deleted.
* Source/WebCore/page/Page.h:
(WebCore::Frame::protectedPage const):
(WebCore::Document::protectedPage const):
(WebCore::Page::insideNestedRunLoop const): Deleted.
(WebCore::Frame::checkedPage const): Deleted.
(WebCore::Document::checkedPage const): Deleted.
* Source/WebCore/page/PageGroup.h:
(WebCore::PageGroup::pages const):
* Source/WebCore/page/PageOverlay.h:
* Source/WebCore/page/SettingsBase.h:
* Source/WebCore/page/UserContentProvider.h:
* Source/WebCore/page/VisitedLinkStore.h:
* Source/WebCore/page/ios/EventHandlerIOS.mm:
(WebCore::EventHandler::wheelEvent):
(WebCore::EventHandler::tabsToAllFormControls const):
(WebCore::EventHandler::focusDocumentView):
(WebCore::EventHandler::passMouseDownEventToWidget):
* Source/WebCore/page/mac/EventHandlerMac.mm:
(WebCore::EventHandler::wheelEvent):
(WebCore::EventHandler::focusDocumentView):
(WebCore::EventHandler::passMouseDownEventToWidget):
(WebCore::EventHandler::currentPlatformMouseEvent const):
(WebCore::EventHandler::tabsToAllFormControls const):
(WebCore::EventHandler::determineWheelEventTarget):
(WebCore::EventHandler::targetPositionInWindowForSelectionAutoscroll const):
* Source/WebCore/page/scrolling/ScrollingCoordinator.h:
* Source/WebCore/platform/mac/DataDetectorHighlight.h:
* Source/WebCore/plugins/PluginInfoProvider.h:
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::scheduleRenderingUpdateForImage):
* Source/WebCore/svg/graphics/SVGImage.cpp:
(WebCore::SVGImage::dataChanged):
* Source/WebCore/svg/graphics/SVGImage.h:
* Source/WebCore/testing/InternalSettings.h:
* Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp:
(WebCore::ServiceWorkerThreadProxy::ServiceWorkerThreadProxy):
* Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h:
* Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp:
(WebCore::SharedWorkerThreadProxy::SharedWorkerThreadProxy):
* Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(WebKit::PDFPlugin::jsPDFDocPrint):
(WebKit::PDFPlugin::paintControlForLayerInContext):
(WebKit::PDFPlugin::convertFromPDFViewToScreen const):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::boundsOnScreen const):
(WebKit::PDFPluginBase::isActive const):
(WebKit::PDFPluginBase::forceUpdateScrollbarsOnMainThreadForPerformanceTesting const):
(WebKit::PDFPluginBase::deviceScaleFactor const):
(WebKit::PDFPluginBase::createScrollbar):
(WebKit::PDFPluginBase::hudEnabled const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::teardown):
(WebKit::UnifiedPDFPlugin::createGraphicsLayer):
(WebKit::UnifiedPDFPlugin::scheduleRenderingUpdate):
(WebKit::UnifiedPDFPlugin::updateLayerHierarchy):
(WebKit::UnifiedPDFPlugin::didChangeSettings):
(WebKit::UnifiedPDFPlugin::didChangeIsInWindow):
(WebKit::UnifiedPDFPlugin::pageScaleFactor const):
(WebKit::UnifiedPDFPlugin::setPageScaleFactor):
(WebKit::UnifiedPDFPlugin::updateScrollingExtents):
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp:
(WebKit::WebSWContextManagerConnection::installServiceWorker):
* Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp:
(WebKit::WebSharedWorkerContextManagerConnection::launchSharedWorker):
* Source/WebKit/WebProcess/WebCoreSupport/WebPermissionController.cpp:
(WebKit::WebPermissionController::query):
* Source/WebKit/WebProcess/WebCoreSupport/WebPermissionController.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_historyItemClient):
(WebKit::WebPage::close):
(WebKit::DeferredPageDestructor::createDeferredPageDestructor): Deleted.
(WebKit::DeferredPageDestructor::DeferredPageDestructor): Deleted.
(WebKit::DeferredPageDestructor::tryDestruction): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKitLegacy/Storage/WebStorageNamespaceProvider.h:
* Source/WebKitLegacy/WebCoreSupport/PageStorageSessionProvider.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.h:
* Source/WebKitLegacy/mac/WebView/WebMediaPlaybackTargetPicker.h:
* Source/WebKitLegacy/mac/WebView/WebMediaPlaybackTargetPicker.mm:
(WebMediaPlaybackTargetPicker::WebMediaPlaybackTargetPicker):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView _commonInitializationWithFrameName:groupName:]):
(-[WebView _didConcludeEditDrag]):
(-[WebView _close]):
(-[WebView page]):
(-[WebView _checkDidPerformFirstNavigation]):
(-[WebView _executeCoreCommandByName:value:]):
(-[WebView _geolocationDidChangePosition:]):
(-[WebView _geolocationDidFailWithMessage:]):
(-[WebView _notificationIDForTesting:]):
(-[WebView _clearNotificationPermissionState]):
(WebKit::DeferredPageDestructor::createDeferredPageDestructor): Deleted.
(WebKit::DeferredPageDestructor::DeferredPageDestructor): Deleted.
(WebKit::DeferredPageDestructor::tryDestruction): Deleted.
* Source/WebKitLegacy/mac/WebView/WebViewData.h:

Canonical link: <a href="https://commits.webkit.org/272060@main">https://commits.webkit.org/272060@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/17b6150d08a388e6ec68fa8f11b499046c97a4b3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30365 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9039 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31974 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32872 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27472 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31065 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11264 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6275 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27431 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30673 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7587 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27247 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6501 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6647 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27066 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34211 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27678 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27567 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32838 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6628 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4781 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30656 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8386 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7378 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3951 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7168 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->