### PR TITLE
Stop using CheckedPtr / CheckedRef in TreeScopeOrderedMap.h

### DIFF
--- a/Source/WebCore/dom/TreeScope.cpp
+++ b/Source/WebCore/dom/TreeScope.cpp
@@ -189,7 +189,7 @@ RefPtr<Element> TreeScope::getElementById(StringView elementId) const
     return nullptr;
 }
 
-const Vector<CheckedRef<Element>>* TreeScope::getAllElementsById(const AtomString& elementId) const
+const Vector<WeakRef<Element, WeakPtrImplWithEventTargetData>>* TreeScope::getAllElementsById(const AtomString& elementId) const
 {
     if (elementId.isEmpty())
         return nullptr;
@@ -353,7 +353,7 @@ void TreeScope::removeLabel(const AtomString& forAttributeValue, HTMLLabelElemen
     m_labelsByForAttribute->remove(forAttributeValue, element);
 }
 
-const Vector<CheckedRef<Element>>* TreeScope::labelElementsForId(const AtomString& forAttributeValue)
+const Vector<WeakRef<Element, WeakPtrImplWithEventTargetData>>* TreeScope::labelElementsForId(const AtomString& forAttributeValue)
 {
     if (forAttributeValue.isEmpty())
         return nullptr;

--- a/Source/WebCore/dom/TreeScope.h
+++ b/Source/WebCore/dom/TreeScope.h
@@ -83,7 +83,7 @@ public:
     WEBCORE_EXPORT RefPtr<Element> getElementById(const AtomString&) const;
     WEBCORE_EXPORT RefPtr<Element> getElementById(const String&) const;
     RefPtr<Element> getElementById(StringView) const;
-    const Vector<CheckedRef<Element>>* getAllElementsById(const AtomString&) const;
+    const Vector<WeakRef<Element, WeakPtrImplWithEventTargetData>>* getAllElementsById(const AtomString&) const;
     inline bool hasElementWithId(const AtomString&) const; // Defined in TreeScopeInlines.h.
     inline bool containsMultipleElementsWithId(const AtomString& id) const; // Defined in TreeScopeInlines.h.
     void addElementById(const AtomString& elementId, Element&, bool notifyObservers = true);
@@ -117,7 +117,7 @@ public:
     bool shouldCacheLabelsByForAttribute() const { return !!m_labelsByForAttribute; }
     void addLabel(const AtomString& forAttributeValue, HTMLLabelElement&);
     void removeLabel(const AtomString& forAttributeValue, HTMLLabelElement&);
-    const Vector<CheckedRef<Element>>* labelElementsForId(const AtomString& forAttributeValue);
+    const Vector<WeakRef<Element, WeakPtrImplWithEventTargetData>>* labelElementsForId(const AtomString& forAttributeValue);
 
     WEBCORE_EXPORT RefPtr<Element> elementFromPoint(double clientX, double clientY);
     WEBCORE_EXPORT Vector<RefPtr<Element>> elementsFromPoint(double clientX, double clientY);

--- a/Source/WebCore/dom/TreeScopeOrderedMap.cpp
+++ b/Source/WebCore/dom/TreeScopeOrderedMap.cpp
@@ -64,7 +64,7 @@ void TreeScopeOrderedMap::add(const AtomString& key, Element& element, const Tre
 
 #if ASSERT_ENABLED || ENABLE(SECURITY_ASSERTIONS)
     ASSERT_WITH_SECURITY_IMPLICATION(!entry.registeredElements.contains(&element));
-    entry.registeredElements.add(&element);
+    entry.registeredElements.add(element);
 #endif
 
     if (addResult.isNewEntry)
@@ -85,7 +85,7 @@ void TreeScopeOrderedMap::remove(const AtomString& key, Element& element)
     RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(it != m_map.end());
 
     MapEntry& entry = it->value;
-    ASSERT_WITH_SECURITY_IMPLICATION(entry.registeredElements.remove(&element));
+    ASSERT_WITH_SECURITY_IMPLICATION(entry.registeredElements.remove(element));
     RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(entry.count);
     if (entry.count == 1) {
         RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!entry.element || entry.element == &element);
@@ -126,7 +126,7 @@ inline RefPtr<Element> TreeScopeOrderedMap::get(const AtomString& key, const Tre
             continue;
         entry.element = element.ptr();
         RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(&element->treeScope() == &scope);
-        ASSERT_WITH_SECURITY_IMPLICATION(entry.registeredElements.contains(entry.element));
+        ASSERT_WITH_SECURITY_IMPLICATION(entry.registeredElements.contains(entry.element.get()));
         return element;
     }
 
@@ -150,7 +150,7 @@ inline RefPtr<Element> TreeScopeOrderedMap::get(const AtomString& key, const Tre
 }
 
 template <typename KeyMatchingFunction>
-inline Vector<CheckedRef<Element>>* TreeScopeOrderedMap::getAll(const AtomString& key, const TreeScope& scope, const KeyMatchingFunction& keyMatches) const
+inline Vector<WeakRef<Element, WeakPtrImplWithEventTargetData>>* TreeScopeOrderedMap::getAll(const AtomString& key, const TreeScope& scope, const KeyMatchingFunction& keyMatches) const
 {
     ASSERT_WITH_SECURITY_IMPLICATION(!key.isNull());
     m_map.checkConsistency();
@@ -206,7 +206,7 @@ RefPtr<HTMLImageElement> TreeScopeOrderedMap::getElementByUsemap(const AtomStrin
     }));
 }
 
-const Vector<CheckedRef<Element>>* TreeScopeOrderedMap::getElementsByLabelForAttribute(const AtomString& key, const TreeScope& scope) const
+const Vector<WeakRef<Element, WeakPtrImplWithEventTargetData>>* TreeScopeOrderedMap::getElementsByLabelForAttribute(const AtomString& key, const TreeScope& scope) const
 {
     return getAll(key, scope, [] (const AtomString& key, const Element& element) {
         return is<HTMLLabelElement>(element) && element.attributeWithoutSynchronization(forAttr) == key;
@@ -227,7 +227,7 @@ RefPtr<Element> TreeScopeOrderedMap::getElementByDocumentNamedItem(const AtomStr
     });
 }
 
-const Vector<CheckedRef<Element>>* TreeScopeOrderedMap::getAllElementsById(const AtomString& key, const TreeScope& scope) const
+const Vector<WeakRef<Element, WeakPtrImplWithEventTargetData>>* TreeScopeOrderedMap::getAllElementsById(const AtomString& key, const TreeScope& scope) const
 {
     return getAll(key, scope, [] (const AtomString& key, const Element& element) {
         return element.getIdAttribute() == key;

--- a/Source/WebCore/dom/TreeScopeOrderedMap.h
+++ b/Source/WebCore/dom/TreeScopeOrderedMap.h
@@ -31,10 +31,10 @@
 #pragma once
 
 #include "Element.h"
-#include <wtf/CheckedPtr.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/Vector.h>
+#include <wtf/WeakPtr.h>
 #include <wtf/text/AtomString.h>
 
 namespace WebCore {
@@ -60,11 +60,11 @@ public:
     RefPtr<Element> getElementByName(const AtomString&, const TreeScope&) const;
     RefPtr<HTMLMapElement> getElementByMapName(const AtomString&, const TreeScope&) const;
     RefPtr<HTMLImageElement> getElementByUsemap(const AtomString&, const TreeScope&) const;
-    const Vector<CheckedRef<Element>>* getElementsByLabelForAttribute(const AtomString&, const TreeScope&) const;
+    const Vector<WeakRef<Element, WeakPtrImplWithEventTargetData>>* getElementsByLabelForAttribute(const AtomString&, const TreeScope&) const;
     RefPtr<Element> getElementByWindowNamedItem(const AtomString&, const TreeScope&) const;
     RefPtr<Element> getElementByDocumentNamedItem(const AtomString&, const TreeScope&) const;
 
-    const Vector<CheckedRef<Element>>* getAllElementsById(const AtomString&, const TreeScope&) const;
+    const Vector<WeakRef<Element, WeakPtrImplWithEventTargetData>>* getAllElementsById(const AtomString&, const TreeScope&) const;
 
     const Vector<AtomString> keys() const;
 
@@ -72,7 +72,7 @@ private:
     template <typename KeyMatchingFunction>
     RefPtr<Element> get(const AtomString&, const TreeScope&, const KeyMatchingFunction&) const;
     template <typename KeyMatchingFunction>
-    Vector<CheckedRef<Element>>* getAll(const AtomString&, const TreeScope&, const KeyMatchingFunction&) const;
+    Vector<WeakRef<Element, WeakPtrImplWithEventTargetData>>* getAll(const AtomString&, const TreeScope&, const KeyMatchingFunction&) const;
 
     struct MapEntry {
         MapEntry() { }
@@ -81,11 +81,11 @@ private:
             , count(1)
         { }
 
-        CheckedPtr<Element> element;
+        WeakPtr<Element, WeakPtrImplWithEventTargetData> element;
         unsigned count { 0 };
-        Vector<CheckedRef<Element>> orderedList;
+        Vector<WeakRef<Element, WeakPtrImplWithEventTargetData>> orderedList;
 #if ASSERT_ENABLED || ENABLE(SECURITY_ASSERTIONS)
-        HashSet<CheckedPtr<Element>> registeredElements;
+        HashSet<WeakRef<Element, WeakPtrImplWithEventTargetData>> registeredElements;
 #endif
     };
 


### PR DESCRIPTION
#### 23026ae16e81f45dc1e4ecdac96c24eeb905e7a6
<pre>
Stop using CheckedPtr / CheckedRef in TreeScopeOrderedMap.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=266370">https://bugs.webkit.org/show_bug.cgi?id=266370</a>

Reviewed by Ryosuke Niwa.

Stop using CheckedPtr / CheckedRef in TreeScopeOrderedMap.h. Use WeakPtr / WeakRef
instead to generate more actionable crashes. This tested as performance neutral on
Speedometer 2 &amp; 3.

* Source/WebCore/dom/TreeScope.cpp:
(WebCore::TreeScope::getAllElementsById const):
(WebCore::TreeScope::labelElementsForId):
* Source/WebCore/dom/TreeScope.h:
* Source/WebCore/dom/TreeScopeOrderedMap.cpp:
(WebCore::TreeScopeOrderedMap::add):
(WebCore::TreeScopeOrderedMap::remove):
(WebCore::TreeScopeOrderedMap::get const):
(WebCore::TreeScopeOrderedMap::getAll const):
(WebCore::TreeScopeOrderedMap::getElementsByLabelForAttribute const):
(WebCore::TreeScopeOrderedMap::getAllElementsById const):
* Source/WebCore/dom/TreeScopeOrderedMap.h:

Canonical link: <a href="https://commits.webkit.org/272015@main">https://commits.webkit.org/272015@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8f725c3b3bf833d9d534d424aac8c16b5986766

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30336 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9021 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31956 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32846 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27455 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31036 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11253 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6260 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27416 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30644 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/7577 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/27206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6481 "Found 1 new API test failure: /WPE/TestResources:/webkit/WebKitWebView/sync-request-on-max-conns (failure)") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/6639 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/27053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34186 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/27671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/27555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32819 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6611 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/4769 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30633 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/8369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7189 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/7361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7151 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->