### PR TITLE
Register application in the WebProcess on Catalyst

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/LaunchServicesSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/LaunchServicesSPI.h
@@ -158,8 +158,6 @@ OSStatus _LSSetApplicationInformationItem(LSSessionID, LSASNRef, CFStringRef key
 CFTypeRef _LSCopyApplicationInformationItem(LSSessionID, LSASNRef, CFTypeRef);
 CFArrayRef _LSCopyMatchingApplicationsWithItems(LSSessionID, CFIndex count, CFTypeRef *keys, CFTypeRef *values);
 
-OSStatus _RegisterApplication(CFDictionaryRef, ProcessSerialNumber*);
-
 typedef void (^ _LSOpenCompletionHandler)(LSASNRef, Boolean, CFErrorRef);
 void _LSOpenURLsUsingBundleIdentifierWithCompletionHandler(CFArrayRef, CFStringRef, CFDictionaryRef, _LSOpenCompletionHandler);
 
@@ -173,6 +171,8 @@ WTF_EXTERN_C_BEGIN
 
 typedef bool (^LSServerConnectionAllowedBlock) (CFDictionaryRef optionsRef);
 void _LSSetApplicationLaunchServicesServerConnectionStatus(uint64_t flags, LSServerConnectionAllowedBlock block);
+
+OSStatus _RegisterApplication(CFDictionaryRef, ProcessSerialNumber*);
 
 WTF_EXTERN_C_END
 

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -441,7 +441,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     parameters.mobileGestaltExtensionHandle = process.createMobileGestaltSandboxExtensionIfNeeded();
 
-#if PLATFORM(MAC)
+#if PLATFORM(MAC) || PLATFORM(MACCATALYST)
     if (auto launchServicesExtensionHandle = SandboxExtension::createHandleForMachLookup("com.apple.coreservices.launchservicesd"_s, std::nullopt))
         parameters.launchServicesExtensionHandle = WTFMove(*launchServicesExtensionHandle);
 #endif

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -428,7 +428,7 @@ public:
     void addAllowedFirstPartyForCookies(WebCore::RegistrableDomain&&);
     bool allowsFirstPartyForCookies(const URL&);
 
-#if PLATFORM(MAC)
+#if PLATFORM(MAC) || PLATFORM(MACCATALYST)
     void revokeLaunchServicesSandboxExtension();
 #endif
 
@@ -760,7 +760,8 @@ private:
 
     String m_uiProcessName;
     WebCore::RegistrableDomain m_registrableDomain;
-
+#endif
+#if PLATFORM(MAC) || PLATFORM(MACCATALYST)
     RefPtr<SandboxExtension> m_launchServicesExtension;
 #endif
 

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -452,7 +452,7 @@ void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& para
     method_setImplementation(method, (IMP)preventAppKitFromContactingLaunchServices);
 #endif
 
-#if PLATFORM(MAC) && ENABLE(WEBPROCESS_NSRUNLOOP)
+#if PLATFORM(MAC) || PLATFORM(MACCATALYST)
     if (parameters.launchServicesExtensionHandle) {
         if ((m_launchServicesExtension = SandboxExtension::create(WTFMove(*parameters.launchServicesExtensionHandle)))) {
             bool ok = m_launchServicesExtension->consume();
@@ -462,7 +462,12 @@ void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& para
 
     // Register the application. This will also check in with Launch Services.
     _RegisterApplication(nullptr, nullptr);
-    
+#if PLATFORM(MACCATALYST)
+    revokeLaunchServicesSandboxExtension();
+#endif
+#endif
+
+#if PLATFORM(MAC)
     // Update process name while holding the Launch Services sandbox extension
     updateProcessName(IsInProcessInitialization::Yes);
 
@@ -1502,7 +1507,9 @@ void WebProcess::openDirectoryCacheInvalidated(SandboxExtension::Handle&& handle
     if (bootstrapExtension)
         bootstrapExtension->revoke();
 }
+#endif
 
+#if PLATFORM(MAC) || PLATFORM(MACCATALYST)
 void WebProcess::revokeLaunchServicesSandboxExtension()
 {
     if (m_launchServicesExtension) {


### PR DESCRIPTION
#### 735eaa9151f8e86163800991b2e65f5ed5c8acfd
<pre>
Register application in the WebProcess on Catalyst
<a href="https://bugs.webkit.org/show_bug.cgi?id=266350">https://bugs.webkit.org/show_bug.cgi?id=266350</a>
<a href="https://rdar.apple.com/119217913">rdar://119217913</a>

Reviewed by Brent Fulgham.

Call _RegisterApplication on Catalyst while holding a XPC sandbox extension. Calling this function
without the sandbox extension will crash.

* Source/WebCore/PAL/pal/spi/cocoa/LaunchServicesSPI.h
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
* Source/WebKit/WebProcess/WebProcess.h
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::platformInitializeWebProcess):

Canonical link: <a href="https://commits.webkit.org/272023@main">https://commits.webkit.org/272023@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d11152a35a9b72531fc111f4b6d8b9045b188ec0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30348 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9030 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31965 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32857 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27464 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31048 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11250 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6266 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27420 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30656 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7573 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/27209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6486 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6635 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27055 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34197 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27663 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27557 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6620 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4772 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30637 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8378 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7197 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7370 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7160 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->