### PR TITLE
Track observedness of unsigned results in DFG backwards propagation phase

### DIFF
--- a/JSTests/stress/observable-urshift-result.js
+++ b/JSTests/stress/observable-urshift-result.js
@@ -1,0 +1,14 @@
+function opt(){
+    var x = -19278.05 >>> NaN;
+    var y = x + -19278.05;
+    var z = y >> 0;
+    return z;
+}
+
+let a = opt();
+for(let i = 0; i < 20000; i++)
+    opt();
+let b = opt();
+
+if (a !== b)
+    throw 'Expected ' + a + ' === ' + b

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -444,9 +444,9 @@ private:
             
         case UInt32ToNumber: {
             fixIntConvertingEdge(node->child1());
-            if (bytecodeCanTruncateInteger(node->arithNodeFlags()))
+            if (bytecodeCanTruncateInteger(node->arithNodeFlags()) && !bytecodeCanObserveUnsigned(node->arithNodeFlags()))
                 node->convertToIdentity();
-            else if (node->canSpeculateInt32(FixupPass))
+            else if (node->canSpeculateInt32(FixupPass) && !bytecodeCanObserveUnsigned(node->arithNodeFlags()))
                 node->setArithMode(Arith::CheckOverflow);
             else {
                 node->setArithMode(Arith::DoOverflow);

--- a/Source/JavaScriptCore/dfg/DFGNodeFlags.cpp
+++ b/Source/JavaScriptCore/dfg/DFGNodeFlags.cpp
@@ -122,6 +122,9 @@ void dumpNodeFlags(PrintStream& actualOut, NodeFlags flags)
     if (flags & NodeIsFlushed)
         out.print(comma, "IsFlushed");
     
+    if (flags & NodeBytecodeObservesUnsigned)
+        out.print(comma, "UnsignedObserved");
+
     CString string = out.toCString();
     if (!string.length())
         actualOut.print("<empty>");

--- a/Source/JavaScriptCore/dfg/DFGNodeFlags.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeFlags.h
@@ -65,16 +65,17 @@ namespace JSC { namespace DFG {
 #define NodeBytecodeUsesAsOther          0x20000 // The result of this computation may be used in a context that distinguishes between NaN and other things (like undefined).
 #define NodeBytecodeUsesAsInt            0x40000 // The result of this computation is known to be used in a context that prefers, but does not require, integer values.
 #define NodeBytecodePrefersArrayIndex    0x80000 // The result of this computation is known to be used in a context that strongly prefers integer values, to the point that we should avoid using doubles if at all possible.
-#define NodeBytecodeUsesAsArrayIndex     (NodeBytecodeUsesAsNumber | NodeBytecodeNeedsNaNOrInfinity | NodeBytecodeUsesAsOther | NodeBytecodeUsesAsInt | NodeBytecodePrefersArrayIndex)
+#define NodeBytecodeObservesUnsigned     0x100000 // The result of this computation is known to be used in a context that can observe the unsignedness of a result.
+#define NodeBytecodeUsesAsArrayIndex     (NodeBytecodeUsesAsNumber | NodeBytecodeNeedsNaNOrInfinity | NodeBytecodeUsesAsOther | NodeBytecodeUsesAsInt | NodeBytecodePrefersArrayIndex | NodeBytecodeObservesUnsigned)
 #define NodeBytecodeUsesAsValue          (NodeBytecodeUsesAsNumber | NodeBytecodeNeedsNegZero | NodeBytecodeNeedsNaNOrInfinity | NodeBytecodeUsesAsOther)
-#define NodeBytecodeBackPropMask         (NodeBytecodeUsesAsNumber | NodeBytecodeNeedsNegZero | NodeBytecodeNeedsNaNOrInfinity | NodeBytecodeUsesAsOther | NodeBytecodeUsesAsInt | NodeBytecodePrefersArrayIndex)
+#define NodeBytecodeBackPropMask         (NodeBytecodeUsesAsNumber | NodeBytecodeNeedsNegZero | NodeBytecodeNeedsNaNOrInfinity | NodeBytecodeUsesAsOther | NodeBytecodeUsesAsInt | NodeBytecodePrefersArrayIndex | NodeBytecodeObservesUnsigned)
 
 #define NodeArithFlagsMask               (NodeBehaviorMask | NodeBytecodeBackPropMask)
 
-#define NodeIsFlushed                   0x100000 // Computed by CPSRethreadingPhase, will tell you which local nodes are backwards-reachable from a Flush.
+#define NodeIsFlushed                   0x200000 // Computed by CPSRethreadingPhase, will tell you which local nodes are backwards-reachable from a Flush.
 
-#define NodeMiscFlag1                   0x200000
-#define NodeMiscFlag2                   0x400000
+#define NodeMiscFlag1                   0x400000
+#define NodeMiscFlag2                   0x800000
 
 typedef uint32_t NodeFlags;
 
@@ -96,6 +97,11 @@ static inline bool bytecodeCanIgnoreNegativeZero(NodeFlags flags)
 static inline bool bytecodeCanIgnoreNaNAndInfinity(NodeFlags flags)
 {
     return !(flags & NodeBytecodeNeedsNaNOrInfinity);
+}
+
+static inline bool bytecodeCanObserveUnsigned(NodeFlags flags)
+{
+    return flags & NodeBytecodeObservesUnsigned;
 }
 
 enum RareCaseProfilingSource {


### PR DESCRIPTION
#### 86171daaa4ab2bd566ef707078e965feab67fb75
<pre>
Track observedness of unsigned results in DFG backwards propagation phase
<a href="https://bugs.webkit.org/show_bug.cgi?id=265272">https://bugs.webkit.org/show_bug.cgi?id=265272</a>
<a href="https://rdar.apple.com/118731614">rdar://118731614</a>

Reviewed by NOBODY (OOPS!).

Adds a new DFG node flag indicating whether or not unsigned results can be
observed by subsequent operations. For example, a multiplication behaves
differently if we interpret an Int32 input as a large unsigned number or a
negative number. Currently, arithmetic operations and array indices are
considered to observe signed v.s. unsigned results, while bitwise operations
don&apos;t observe signedness and don&apos;t propagate unsigned observedness to their
children.

When an unsigned result is observable, we pessimize the fixup phase of
UInt32ToNumber: we prevent it from being turned into an Identity, which would
simply pass along the Int32 to the next user, who would interpret it as
signed; and force it into the DoOverflow arithmetic mode, without which we
expect to return a signed Int32, and will OSR exit if we exceed that range. We
could be smarter about this and try and profile if we ever overflow the Int32
range here, and continue to speculate Int32 if so; but given this is a rare
operation and we don&apos;t bother profiling it at all currently, I think this is
the path of least resistance for now.

* JSTests/stress/observable-urshift-result.js: Added.
(opt):
* Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp:
(JSC::DFG::BackwardsPropagationPhase::propagate):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGNodeFlags.cpp:
(JSC::DFG::dumpNodeFlags):
* Source/JavaScriptCore/dfg/DFGNodeFlags.h:
(JSC::DFG::bytecodeCanObserveUnsigned):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/86171daaa4ab2bd566ef707078e965feab67fb75

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30350 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9032 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32050 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32859 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27466 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11252 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6268 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27422 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30658 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7581 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27285 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6488 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6642 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27121 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34199 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/26075 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27674 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27624 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32825 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/30472 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6622 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4775 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30641 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8380 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/36915 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7372 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7945 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7162 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->