### PR TITLE
Import close-watcher WPT tests

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5513,6 +5513,31 @@ webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/WorkerGlobalSc
 webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/trusted-types-navigation.html [ Pass Failure ]
 webkit.org/b/274088 imported/w3c/web-platform-tests/trusted-types/Element-setAttribute-respects-Elements-node-documents-globals-CSP.html [ Pass Failure ]
 
+# Close watchers aren't implemented yet
+webkit.org/b/263305 imported/w3c/web-platform-tests/close-watcher/user-activation/n-activate-preventDefault.html?dialog [ Skip ]
+webkit.org/b/263305 imported/w3c/web-platform-tests/close-watcher/user-activation/ny-activate-preventDefault.html?dialog [ Skip ]
+webkit.org/b/263305 imported/w3c/web-platform-tests/close-watcher/user-activation/n-activate.html?dialog [ Skip ]
+webkit.org/b/263305 imported/w3c/web-platform-tests/close-watcher/user-activation/yn-activate.html?dialog [ Skip ]
+webkit.org/b/263305 imported/w3c/web-platform-tests/close-watcher/user-activation/n-closerequest-n.html?dialog [ Skip ]
+webkit.org/b/263305 imported/w3c/web-platform-tests/close-watcher/user-activation/nn-activate-dialog.html [ Skip ]
+webkit.org/b/263305 imported/w3c/web-platform-tests/close-watcher/user-activation/nn-dialog.html [ Skip ]
+webkit.org/b/263305 imported/w3c/web-platform-tests/close-watcher/user-activation/nnn-dialog.html [ Skip ]
+webkit.org/b/263305 imported/w3c/web-platform-tests/close-watcher/user-activation/ynn-dialog.html [ Skip ]
+webkit.org/b/263305 imported/w3c/web-platform-tests/close-watcher/user-activation/nyyn-dialog.html [ Skip ]
+webkit.org/b/263305 imported/w3c/web-platform-tests/close-watcher/user-activation/nyyyn-dialog.html [ Skip ]
+webkit.org/b/263305 imported/w3c/web-platform-tests/close-watcher/user-activation/n-destroy-n.html?dialog [ Skip ]
+webkit.org/b/263305 imported/w3c/web-platform-tests/close-watcher/user-activation/y.html?dialog [ Skip ]
+webkit.org/b/263305 imported/w3c/web-platform-tests/close-watcher/user-activation/n.html?dialog [ Skip ]
+webkit.org/b/263305 imported/w3c/web-platform-tests/close-watcher/user-activation/ny.html?dialog [ Skip ]
+webkit.org/b/263305 imported/w3c/web-platform-tests/close-watcher/user-activation/yn.html?dialog [ Skip ]
+webkit.org/b/263305 imported/w3c/web-platform-tests/close-watcher/user-activation/yyn.html?dialog [ Skip ]
+webkit.org/b/263305 imported/w3c/web-platform-tests/close-watcher/user-activation/yy.html?dialog [ Skip ]
+webkit.org/b/263305 imported/w3c/web-platform-tests/close-watcher/user-activation/yyy.html?dialog [ Skip ]
+webkit.org/b/263305 imported/w3c/web-platform-tests/close-watcher/user-activation/nnn-popovers.html [ Skip ]
+webkit.org/b/263305 imported/w3c/web-platform-tests/close-watcher/user-activation/nyn-popovers.html [ Skip ]
+webkit.org/b/263305 imported/w3c/web-platform-tests/close-watcher/user-activation/yyy-popovers.html [ Skip ]
+
+
 # These tests are image failures
 imported/w3c/web-platform-tests/css/css-scroll-anchoring/vertical-rl-viewport-size-change-000.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-scroll-anchoring/vertical-rl-viewport-size-change-001.html [ Skip ]

--- a/LayoutTests/imported/w3c/resources/import-expectations.json
+++ b/LayoutTests/imported/w3c/resources/import-expectations.json
@@ -32,7 +32,7 @@
     "web-platform-tests/clear-site-data": "import",
     "web-platform-tests/client-hints": "skip",
     "web-platform-tests/clipboard-apis": "import",
-    "web-platform-tests/close-watcher": "skip",
+    "web-platform-tests/close-watcher": "import",
     "web-platform-tests/common": "import",
     "web-platform-tests/compat": "import",
     "web-platform-tests/compression": "import",

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/META.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/META.yml
@@ -1,0 +1,4 @@
+spec: https://wicg.github.io/close-watcher/
+suggested_reviewers:
+  - domenic
+  - natechapin

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/abortsignal-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/abortsignal-expected.txt
@@ -1,0 +1,11 @@
+
+FAIL already-aborted AbortSignal then requestClose() fires no events Can't find variable: CloseWatcher
+FAIL abortController.abort() then requestClose() fires no events Can't find variable: CloseWatcher
+FAIL requestClose() then abortController.abort() fires only one close event Can't find variable: CloseWatcher
+FAIL already-aborted AbortSignal then Esc key fires no events promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CloseWatcher"
+FAIL abortController.abort() then close via Esc key fires no events promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CloseWatcher"
+FAIL Esc key then abortController.abort() fires only one close event promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CloseWatcher"
+FAIL abortController.abort()ing a free CloseWatcher allows a new one to be created without a user activation Can't find variable: CloseWatcher
+FAIL abortController.abort() inside oncancel promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CloseWatcher"
+FAIL abortController.abort() inside onclose is benign Can't find variable: CloseWatcher
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/abortsignal.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/abortsignal.html
@@ -1,0 +1,123 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="resources/helpers.js"></script>
+
+<body>
+<script>
+// TODO(domenic): maybe update createRecordingCloseWatcher() to allow passing args and use it?
+
+test(() => {
+  let watcher = new CloseWatcher({ signal: AbortSignal.abort() });
+  let oncancel_called = false;
+  let onclose_called = false;
+  watcher.oncancel = () => oncancel_called = true;
+  watcher.onclose = () => onclose_called = true;
+
+  watcher.requestClose();
+
+  assert_false(oncancel_called);
+  assert_false(onclose_called);
+}, "already-aborted AbortSignal then requestClose() fires no events");
+
+test(() => {
+  let controller = new AbortController();
+  let watcher = new CloseWatcher({ signal: controller.signal });
+  let oncancel_called = false;
+  let onclose_called = false;
+  watcher.oncancel = () => oncancel_called = true;
+  watcher.onclose = () => onclose_called = true;
+
+  controller.abort();
+  watcher.requestClose();
+
+  assert_false(oncancel_called);
+  assert_false(onclose_called);
+}, "abortController.abort() then requestClose() fires no events");
+
+test(() => {
+  let controller = new AbortController();
+  let watcher = new CloseWatcher({ signal: controller.signal });
+  let oncancel_call_count_ = 0;
+  let onclose_call_count_ = 0;
+  watcher.oncancel = () => oncancel_call_count_++;
+  watcher.onclose = () => onclose_call_count_++;
+
+  watcher.requestClose();
+  controller.abort();
+
+  assert_equals(oncancel_call_count_, 1);
+  assert_equals(onclose_call_count_, 1);
+}, "requestClose() then abortController.abort() fires only one close event");
+
+promise_test(async () => {
+  let watcher = new CloseWatcher({ signal: AbortSignal.abort() });
+  let oncancel_called = false;
+  let onclose_called = false;
+  watcher.oncancel = () => oncancel_called = true;
+  watcher.onclose = () => onclose_called = true;
+
+  await sendCloseRequest();
+
+  assert_false(oncancel_called);
+  assert_false(onclose_called);
+}, "already-aborted AbortSignal then Esc key fires no events");
+
+promise_test(async t => {
+  let controller = new AbortController();
+  let watcher = new CloseWatcher({ signal: controller.signal });
+  let oncancel_called = false;
+  let onclose_called = false;
+  watcher.oncancel = () => oncancel_called = true;
+  watcher.onclose = () => onclose_called = true;
+
+  controller.abort();
+  await sendCloseRequest();
+
+  assert_false(oncancel_called);
+  assert_false(onclose_called);
+}, "abortController.abort() then close via Esc key fires no events");
+
+promise_test(async t => {
+  let controller = new AbortController();
+  let watcher = new CloseWatcher({ signal: controller.signal });
+  let oncancel_call_count_ = 0;
+  let onclose_call_count_ = 0;
+  watcher.oncancel = () => oncancel_call_count_++;
+  watcher.onclose = () => onclose_call_count_++;
+
+  await sendCloseRequest();
+  controller.abort();
+
+  assert_equals(oncancel_call_count_, 1);
+  assert_equals(onclose_call_count_, 1);
+}, "Esc key then abortController.abort() fires only one close event");
+
+test(t => {
+  let controller = new AbortController();
+  let watcher = new CloseWatcher({ signal: controller.signal });
+  controller.abort();
+  let watcher2 = new CloseWatcher();
+  t.add_cleanup(() => watcher2.destroy());
+}, "abortController.abort()ing a free CloseWatcher allows a new one to be created without a user activation");
+
+promise_test(async t => {
+  let controller = new AbortController();
+  let watcher = new CloseWatcher({ signal: controller.signal });
+  watcher.oncancel = () => { controller.abort(); }
+  watcher.onclose = t.unreached_func("onclose");
+  await test_driver.bless("give user activation so that cancel will fire", () => {
+    watcher.requestClose();
+  });
+}, "abortController.abort() inside oncancel");
+
+test(t => {
+  let controller = new AbortController();
+  let watcher = new CloseWatcher({ signal: controller.signal });
+  watcher.onclose = () => { controller.abort(); }
+  watcher.requestClose();
+}, "abortController.abort() inside onclose is benign");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/basic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/basic-expected.txt
@@ -1,0 +1,9 @@
+
+FAIL requestClose() with no user activation Can't find variable: CloseWatcher
+FAIL destroy() then requestClose() Can't find variable: CloseWatcher
+FAIL close() then requestClose() Can't find variable: CloseWatcher
+FAIL requestClose() then destroy() Can't find variable: CloseWatcher
+FAIL close() then destroy() Can't find variable: CloseWatcher
+FAIL destroy() then close request promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CloseWatcher"
+FAIL Close request then destroy() promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CloseWatcher"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/basic.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/basic.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="resources/helpers.js"></script>
+
+<body>
+<script>
+test(t => {
+  let events = [];
+  let watcher = createRecordingCloseWatcher(t, events);
+
+  watcher.requestClose();
+
+  assert_array_equals(events, ["cancel[cancelable=false]", "close"]);
+}, "requestClose() with no user activation");
+
+test(t => {
+  let events = [];
+  let watcher = createRecordingCloseWatcher(t, events);
+
+  watcher.destroy();
+  watcher.requestClose();
+
+  assert_array_equals(events, []);
+}, "destroy() then requestClose()");
+
+test(t => {
+  let events = [];
+  let watcher = createRecordingCloseWatcher(t, events);
+
+  watcher.close();
+  assert_array_equals(events, ["close"]);
+
+  watcher.requestClose();
+  assert_array_equals(events, ["close"]);
+}, "close() then requestClose()");
+
+test(t => {
+  let events = [];
+  let watcher = createRecordingCloseWatcher(t, events);
+
+  watcher.requestClose();
+  assert_array_equals(events, ["cancel[cancelable=false]", "close"]);
+
+  watcher.destroy();
+  assert_array_equals(events, ["cancel[cancelable=false]", "close"]);
+}, "requestClose() then destroy()");
+
+test(t => {
+  let events = [];
+  let watcher = createRecordingCloseWatcher(t, events);
+
+  watcher.close();
+  assert_array_equals(events, ["close"]);
+
+  watcher.destroy();
+  assert_array_equals(events, ["close"]);
+}, "close() then destroy()");
+
+promise_test(async t => {
+  let events = [];
+  let watcher = createRecordingCloseWatcher(t, events);
+
+  watcher.destroy();
+  await sendCloseRequest();
+
+  assert_array_equals(events, []);
+}, "destroy() then close request");
+
+promise_test(async t => {
+  let events = [];
+  let watcher = createRecordingCloseWatcher(t, events);
+
+  await sendCloseRequest();
+  watcher.destroy();
+
+  assert_array_equals(events, ["cancel[cancelable=false]", "close"]);
+}, "Close request then destroy()");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/esc-key/README.md
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/esc-key/README.md
@@ -1,0 +1,4 @@
+Tests in this directory are around the interaction of the Esc key specifically,
+not the general concept of close requests. Ideally, all other tests would work
+as-is if you changed the implementation of `sendCloseRequest()`. These tests
+assume that Esc is the close request for the platform being tested.

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/esc-key/keydown-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/esc-key/keydown-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL A keydown listener can prevent the Esc keypress from being interpreted as a close request promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CloseWatcher"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/esc-key/keydown.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/esc-key/keydown.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="../resources/helpers.js"></script>
+
+<body>
+<script>
+promise_test(async t => {
+  let events = [];
+  let watcher = createRecordingCloseWatcher(t, events);
+
+  window.onkeydown = e => e.preventDefault();
+
+  await sendEscKey();
+
+  assert_array_equals(events, []);
+}, "A keydown listener can prevent the Esc keypress from being interpreted as a close request");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/esc-key/keypress-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/esc-key/keypress-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL A keypress listener can NOT prevent the Esc keypress from being interpreted as a close request promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CloseWatcher"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/esc-key/keypress.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/esc-key/keypress.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="../resources/helpers.js"></script>
+
+<body>
+<script>
+promise_test(async t => {
+  let events = [];
+  let watcher = createRecordingCloseWatcher(t, events);
+
+  window.onkeypress = e => e.preventDefault();
+
+  await sendEscKey();
+
+  assert_array_equals(events, ["cancel[cancelable=false]", "close"]);
+}, "A keypress listener can NOT prevent the Esc keypress from being interpreted as a close request");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/esc-key/keyup-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/esc-key/keyup-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL A keyup listener can NOT prevent the Esc keypress from being interpreted as a close request promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CloseWatcher"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/esc-key/keyup.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/esc-key/keyup.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="../resources/helpers.js"></script>
+
+<body>
+<script>
+promise_test(async t => {
+  let events = [];
+  let watcher = createRecordingCloseWatcher(t, events);
+
+  window.onkeyup = e => e.preventDefault();
+
+  await sendEscKey();
+
+  assert_array_equals(events, ["cancel[cancelable=false]", "close"]);
+}, "A keyup listener can NOT prevent the Esc keypress from being interpreted as a close request");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/esc-key/not-user-activation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/esc-key/not-user-activation-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Esc key does not count as user activation, so if it is the sole user interaction, cancel is cancelable=false promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CloseWatcher"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/esc-key/not-user-activation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/esc-key/not-user-activation.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="../resources/helpers.js"></script>
+
+<body>
+<script>
+promise_test(async t => {
+  let events = [];
+  let watcher = createRecordingCloseWatcher(t, events);
+
+  await sendEscKey();
+
+  assert_array_equals(events, ["cancel[cancelable=false]", "close"]);
+}, "Esc key does not count as user activation, so if it is the sole user interaction, cancel is cancelable=false");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/esc-key/synthetic-keyboard-event-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/esc-key/synthetic-keyboard-event-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL close via synthesized Esc key must not work Can't find variable: CloseWatcher
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/esc-key/synthetic-keyboard-event.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/esc-key/synthetic-keyboard-event.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="../resources/helpers.js"></script>
+
+<body>
+<script>
+test(t => {
+  let events = [];
+  let watcher = createRecordingCloseWatcher(t, events);
+
+  let keydown = new KeyboardEvent("keydown", {key: "Escape", keyCode: 27});
+  window.dispatchEvent(keydown);
+  let keyup = new KeyboardEvent("keyup", {key: "Escape", keyCode: 27});
+  window.dispatchEvent(keyup);
+
+  assert_array_equals(events, []);
+
+  let keyup2 = document.createEvent("Event");
+  keyup2.initEvent("keyup", true);
+  window.dispatchEvent(keyup2);
+
+  assert_array_equals(events, []);
+}, "close via synthesized Esc key must not work");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/esc-key/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/esc-key/w3c-import.log
@@ -1,0 +1,22 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/esc-key/README.md
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/esc-key/keydown.html
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/esc-key/keypress.html
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/esc-key/keyup.html
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/esc-key/not-user-activation.html
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/esc-key/synthetic-keyboard-event.html

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/event-properties-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/event-properties-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL cancel and close event properties are correct promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CloseWatcher"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/event-properties.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/event-properties.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="resources/helpers.js"></script>
+
+<body>
+<script>
+promise_test(async t => {
+  let closeEvent, cancelEvent;
+  const watcher = new CloseWatcher();
+  watcher.oncancel = e => { cancelEvent = e; };
+  watcher.onclose = e => { closeEvent = e; };
+
+  await test_driver.bless("call requestClose()", () => watcher.requestClose());
+
+  assert_equals(cancelEvent.constructor, Event, "cancel constructor");
+  assert_false(cancelEvent.bubbles, "cancel bubles");
+  assert_true(cancelEvent.cancelable, "cancel cancelable");
+
+  assert_equals(closeEvent.constructor, Event, "close constructor");
+  assert_false(closeEvent.bubbles, "close bubles");
+  assert_false(closeEvent.cancelable, "close cancelable");
+}, "cancel and close event properties are correct");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/frame-removal-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/frame-removal-expected.txt
@@ -1,0 +1,9 @@
+
+
+FAIL detaching the iframe during the cancel event promise_test: Unhandled rejection with value: object "TypeError: undefined is not a constructor (evaluating 'new i.contentWindow.CloseWatcher()')"
+FAIL detaching the iframe during the close event promise_test: Unhandled rejection with value: object "TypeError: undefined is not a constructor (evaluating 'new i.contentWindow.CloseWatcher()')"
+FAIL detaching the iframe then calling destroy() promise_test: Unhandled rejection with value: object "TypeError: undefined is not a constructor (evaluating 'new i.contentWindow.CloseWatcher()')"
+FAIL detaching the iframe then calling close() promise_test: Unhandled rejection with value: object "TypeError: undefined is not a constructor (evaluating 'new i.contentWindow.CloseWatcher()')"
+FAIL detaching the iframe then calling requestClose() promise_test: Unhandled rejection with value: object "TypeError: undefined is not a constructor (evaluating 'new i.contentWindow.CloseWatcher()')"
+FAIL detaching the iframe then constructing a CloseWatcher assert_throws_dom: function "() => new iCloseWatcher()" threw object "TypeError: undefined is not a constructor (evaluating 'new iCloseWatcher()')" that is not a DOMException InvalidStateError: property "code" is equal to undefined, expected 11
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/frame-removal.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/frame-removal.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+<script>
+promise_test(async (t) => {
+  const i = await setupIframe();
+  const watcher = new i.contentWindow.CloseWatcher();
+  watcher.oncancel = () => i.remove();
+  watcher.onclose = () => t.unreached_func("close event must not fire");
+
+  watcher.requestClose();
+}, "detaching the iframe during the cancel event");
+
+promise_test(async (t) => {
+  const i = await setupIframe();
+  const watcher = new i.contentWindow.CloseWatcher();
+  watcher.onclose = () => i.remove();
+
+  watcher.requestClose();
+}, "detaching the iframe during the close event");
+
+promise_test(async (t) => {
+  const i = await setupIframe();
+  const watcher = new i.contentWindow.CloseWatcher();
+  i.remove();
+
+  watcher.destroy();
+}, "detaching the iframe then calling destroy()");
+
+promise_test(async (t) => {
+  const i = await setupIframe();
+  const watcher = new i.contentWindow.CloseWatcher();
+  watcher.oncancel = () => t.unreached_func("cancel event must not fire");
+  watcher.onclose = () => t.unreached_func("close event must not fire");
+  i.remove();
+
+  watcher.close();
+}, "detaching the iframe then calling close()");
+
+promise_test(async (t) => {
+  const i = await setupIframe();
+  const watcher = new i.contentWindow.CloseWatcher();
+  watcher.oncancel = () => t.unreached_func("cancel event must not fire");
+  watcher.onclose = () => t.unreached_func("close event must not fire");
+  i.remove();
+
+  watcher.requestClose();
+}, "detaching the iframe then calling requestClose()");
+
+promise_test(async (t) => {
+  const i = await setupIframe();
+  const iCloseWatcher = i.contentWindow.CloseWatcher;
+  const iDOMException = i.contentWindow.DOMException;
+  i.remove();
+
+  assert_throws_dom("InvalidStateError", iDOMException, () => new iCloseWatcher());
+}, "detaching the iframe then constructing a CloseWatcher");
+
+function setupIframe() {
+  return new Promise(resolve => {
+    const i = document.createElement("iframe");
+    i.onload = () => resolve(i);
+    i.src = "/common/blank.html";
+    document.body.append(i);
+  });
+}
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/inside-event-listeners-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/inside-event-listeners-expected.txt
@@ -1,0 +1,8 @@
+
+FAIL destroy() inside oncancel promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CloseWatcher"
+FAIL destroy() inside onclose Can't find variable: CloseWatcher
+FAIL close() inside oncancel promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CloseWatcher"
+FAIL close() inside onclose Can't find variable: CloseWatcher
+FAIL requestClose() inside oncancel promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CloseWatcher"
+FAIL requestClose() inside onclose Can't find variable: CloseWatcher
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/inside-event-listeners.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/inside-event-listeners.html
@@ -1,0 +1,94 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="resources/helpers.js"></script>
+
+<body>
+<script>
+promise_test(async t => {
+  let events = [];
+  let watcher = createRecordingCloseWatcher(t, events);
+
+  watcher.oncancel = () => { watcher.destroy(); }
+
+  await test_driver.bless("give user activation so that cancel will fire", () => {
+    watcher.requestClose();
+  });
+  assert_array_equals(events, ["cancel[cancelable=true]"]);
+
+  watcher.requestClose();
+  assert_array_equals(events, ["cancel[cancelable=true]"], "since it was inactive, no more events fired");
+}, "destroy() inside oncancel");
+
+test(t => {
+  let events = [];
+  let watcher = createRecordingCloseWatcher(t, events);
+
+  watcher.onclose = () => { watcher.destroy(); }
+
+  watcher.requestClose();
+  assert_array_equals(events, ["cancel[cancelable=false]", "close"]);
+
+  watcher.requestClose();
+  assert_array_equals(events, ["cancel[cancelable=false]", "close"], "since it was inactive, no more events fired");
+}, "destroy() inside onclose");
+
+promise_test(async t => {
+  let events = [];
+  let watcher = createRecordingCloseWatcher(t, events);
+
+  watcher.oncancel = () => { watcher.close(); }
+
+  await test_driver.bless("give user activation so that cancel will fire", () => {
+    watcher.requestClose();
+  });
+  assert_array_equals(events, ["cancel[cancelable=true]", "close"]);
+
+  watcher.requestClose();
+  assert_array_equals(events, ["cancel[cancelable=true]", "close"], "since it was inactive, no more events fired");
+}, "close() inside oncancel");
+
+test(t => {
+  let events = [];
+  let watcher = createRecordingCloseWatcher(t, events);
+
+  watcher.onclose = () => { watcher.close(); }
+
+  watcher.requestClose();
+  assert_array_equals(events, ["cancel[cancelable=false]", "close"]);
+
+  watcher.requestClose();
+  assert_array_equals(events, ["cancel[cancelable=false]", "close"], "since it was inactive, no more events fired");
+}, "close() inside onclose");
+
+promise_test(async t => {
+  let events = [];
+  let watcher = createRecordingCloseWatcher(t, events);
+
+  watcher.oncancel = () => { watcher.requestClose(); }
+
+  await test_driver.bless("give user activation so that cancel will fire", () => {
+    watcher.requestClose();
+  });
+  assert_array_equals(events, ["cancel[cancelable=true]", "close"]);
+
+  watcher.requestClose();
+  assert_array_equals(events, ["cancel[cancelable=true]", "close"], "since it was inactive, no more events fired");
+}, "requestClose() inside oncancel");
+
+test(t => {
+  let events = [];
+  let watcher = createRecordingCloseWatcher(t, events);
+
+  watcher.onclose = () => { watcher.requestClose(); }
+
+  watcher.requestClose();
+  assert_array_equals(events, ["cancel[cancelable=false]", "close"]);
+
+  watcher.requestClose();
+  assert_array_equals(events, ["cancel[cancelable=false]", "close"], "since it was inactive, no more events fired");
+}, "requestClose() inside onclose");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/resources/helpers.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/resources/helpers.js
@@ -1,0 +1,80 @@
+window.createRecordingCloseWatcher = (t, events, name, type, parentWatcher) => {
+  let watcher = null;
+  if (type === 'dialog') {
+    watcher = document.createElement('dialog');
+    watcher.textContent = 'hello world';
+    t.add_cleanup(() => watcher.remove());
+    if (parentWatcher?.appendChild) {
+      parentWatcher.appendChild(watcher);
+    } else {
+      document.body.appendChild(watcher);
+    }
+    watcher.showModal();
+  } else if (type === 'popover') {
+    watcher = document.createElement('div');
+    watcher.setAttribute('popover', 'auto');
+    watcher.textContent = 'hello world';
+    t.add_cleanup(() => watcher.remove());
+    if (parentWatcher?.appendChild) {
+      parentWatcher.appendChild(watcher);
+    } else {
+      document.body.appendChild(watcher);
+    }
+    watcher.showPopover();
+  } else {
+    watcher = new CloseWatcher();
+    t.add_cleanup(() => watcher.destroy());
+  }
+
+  const prefix = name === undefined ? '' : name + ' ';
+  watcher.addEventListener('cancel', e => {
+    const cancelable = e.cancelable ? '[cancelable=true]' : '[cancelable=false]';
+    events.push(prefix + 'cancel' + cancelable);
+  });
+  watcher.addEventListener('close', () => {
+    events.push(prefix + 'close');
+  });
+
+  return watcher;
+};
+
+window.createBlessedRecordingCloseWatcher = async (t, events, name, type, parentWatcher) => {
+  await maybeTopLayerBless(parentWatcher);
+  return createRecordingCloseWatcher(t, events, name, type, parentWatcher);
+};
+
+window.destroyCloseWatcher = (watcher) => {
+  if (watcher instanceof HTMLElement) {
+    watcher.remove();
+  } else {
+    watcher.destroy();
+  }
+};
+
+window.sendEscKey = () => {
+  // Esc is \uE00C, *not* \uu001B; see https://w3c.github.io/webdriver/#keyboard-actions.
+  //
+  // It's important to target document.body, and not any element that might stop receiving events
+  // if a popover or dialog is making that element inert.
+  return test_driver.send_keys(document.body, '\uE00C');
+};
+
+// For now, we always use the Esc keypress as our close request. In
+// theory, in the future, we could add a WebDriver command or similar
+// for the close request, which would allow different tests on platforms
+// with different close requests. In that case, we'd update this
+// function, but not update the sendEscKey function above.
+window.sendCloseRequest = window.sendEscKey;
+
+window.maybeTopLayerBless = (watcher) => {
+  if (watcher instanceof HTMLElement) {
+    return blessTopLayer(watcher);
+  }
+  return test_driver.bless();
+};
+
+window.waitForPotentialCloseEvent = () => {
+  // CloseWatchers fire close events synchronously, but dialog elements wait
+  // for a rAF before firing them.
+  return new Promise(requestAnimationFrame);
+};

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/resources/w3c-import.log
@@ -1,0 +1,17 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/resources/helpers.js

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/README.md
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/README.md
@@ -1,0 +1,25 @@
+# Close watcher user activation tests
+
+These tests are all in separate files (or test variants) because we need to be
+sure we're starting from zero user activation.
+
+## Note on variants vs. `-dialog` and `-CloseWatcher` files
+
+We endeavor to have all the tests in these files cover both `<dialog>` elements
+and the `CloseWatcher` API. (And sometimes the `popover=""` attribute.)
+
+When the test expectations are the same for both `<dialog>` and `CloseWatcher`,
+we use WPT's variants feature.
+
+However, in some cases different expectations are necessary. This is because
+`<dialog>`s queue a task to fire their `close` event, and do not queue a task
+to fire their `cancel` event. Thus, when you have two `<dialog>`s grouped
+together, you get the somewhat-strange behavior of both `cancel`s firing first,
+then both `close`s. Whereas `CloseWatcher`s do not have this issue; both events
+fire synchronously.
+
+(Note that scheduling the `cancel` event for `<dialog>`s is not really possible,
+since it would then fire after the dialog has been closed in the DOM and
+visually. So the only reasonable fix for this would be to stop scheduling the
+`close` event for dialogs. That's risky from a compat standpoint, so for now,
+we test the strange behavior.)

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/n-activate-preventDefault.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/n-activate-preventDefault.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<meta name=variant content="?dialog">
+<meta name=variant content="?CloseWatcher">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/common/top-layer.js"></script>
+<script src="../resources/helpers.js"></script>
+
+<body>
+<script>
+const type = location.search.substring(1);
+
+promise_test(async t => {
+  const events = [];
+  const watcher = createRecordingCloseWatcher(t, events, undefined, type);
+  watcher.addEventListener("cancel", e => e.preventDefault());
+
+  await maybeTopLayerBless(watcher);
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+
+  assert_array_equals(events, ["cancel[cancelable=true]"]);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["cancel[cancelable=true]", "cancel[cancelable=false]", "close"]);
+}, "Create a close watcher without user activation that preventDefault()s cancel; send user activation");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/n-activate-preventDefault_CloseWatcher-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/n-activate-preventDefault_CloseWatcher-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Create a close watcher without user activation that preventDefault()s cancel; send user activation promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CloseWatcher"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/n-activate-preventDefault_dialog-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/n-activate-preventDefault_dialog-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Create a close watcher without user activation that preventDefault()s cancel; send user activation assert_array_equals: lengths differ, expected array ["cancel[cancelable=true]", "cancel[cancelable=false]", "close"] length 3, got ["cancel[cancelable=true]", "cancel[cancelable=true]"] length 2
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/n-activate.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/n-activate.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<meta name=variant content="?dialog">
+<meta name=variant content="?CloseWatcher">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/common/top-layer.js"></script>
+<script src="../resources/helpers.js"></script>
+
+<body>
+<script>
+const type = location.search.substring(1);
+
+promise_test(async t => {
+  const events = [];
+
+  const watcher = createRecordingCloseWatcher(t, events, undefined, type);
+
+  await maybeTopLayerBless(watcher);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["cancel[cancelable=true]", "close"]);
+}, "Create a close watcher without user activation; send user activation");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/n-activate_CloseWatcher-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/n-activate_CloseWatcher-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Create a close watcher without user activation; send user activation promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CloseWatcher"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/n-activate_dialog-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/n-activate_dialog-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Create a close watcher without user activation; send user activation assert_array_equals: lengths differ, expected array ["cancel[cancelable=true]", "close"] length 2, got ["cancel[cancelable=true]"] length 1
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/n-closerequest-n.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/n-closerequest-n.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<meta name=variant content="?dialog">
+<meta name=variant content="?CloseWatcher">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/common/top-layer.js"></script>
+<script src="../resources/helpers.js"></script>
+
+<body>
+<script>
+const type = location.search.substring(1);
+promise_test(async t => {
+  const events = [];
+
+  createRecordingCloseWatcher(t, events, "watcher1", type);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["watcher1 cancel[cancelable=false]", "watcher1 close"]);
+
+  createRecordingCloseWatcher(t, events, "watcher2", type);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["watcher1 cancel[cancelable=false]", "watcher1 close", "watcher2 cancel[cancelable=false]", "watcher2 close"]);
+}, "Create a close watcher without user activation; send a close request; create a close watcher without user activation");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/n-closerequest-n_CloseWatcher-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/n-closerequest-n_CloseWatcher-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Create a close watcher without user activation; send a close request; create a close watcher without user activation promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CloseWatcher"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/n-closerequest-n_dialog-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/n-closerequest-n_dialog-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Create a close watcher without user activation; send a close request; create a close watcher without user activation assert_array_equals: lengths differ, expected array ["watcher1 cancel[cancelable=false]", "watcher1 close"] length 2, got ["watcher1 cancel[cancelable=true]"] length 1
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/n-destroy-n.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/n-destroy-n.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<meta name=variant content="?dialog">
+<meta name=variant content="?CloseWatcher">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/common/top-layer.js"></script>
+<script src="../resources/helpers.js"></script>
+
+<body>
+<script>
+const type = location.search.substring(1);
+
+promise_test(async t => {
+  const events = [];
+
+  const watcher1 = createRecordingCloseWatcher(t, events, "watcher1", type);
+
+  destroyCloseWatcher(watcher1);
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, []);
+
+  createRecordingCloseWatcher(t, events, "watcher2", type);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["watcher2 cancel[cancelable=false]", "watcher2 close"]);
+}, "Create a close watcher without user activation; destroy the close watcher; create a close watcher without user activation");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/n-destroy-n_CloseWatcher-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/n-destroy-n_CloseWatcher-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Create a close watcher without user activation; destroy the close watcher; create a close watcher without user activation promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CloseWatcher"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/n-destroy-n_dialog-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/n-destroy-n_dialog-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Create a close watcher without user activation; destroy the close watcher; create a close watcher without user activation assert_array_equals: expected property 0 to be "watcher2 cancel[cancelable=false]" but got "watcher2 cancel[cancelable=true]" (expected array ["watcher2 cancel[cancelable=false]", "watcher2 close"] got ["watcher2 cancel[cancelable=true]", "watcher2 close"])
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/n.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/n.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<meta name=variant content="?dialog">
+<meta name=variant content="?CloseWatcher">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/common/top-layer.js"></script>
+<script src="../resources/helpers.js"></script>
+
+<body>
+<script>
+const type = location.search.substring(1);
+
+promise_test(async t => {
+  const events = [];
+
+  createRecordingCloseWatcher(t, events, undefined, type);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["cancel[cancelable=false]", "close"]);
+}, "Create a close watcher without user activation");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/n_CloseWatcher-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/n_CloseWatcher-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Create a close watcher without user activation promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CloseWatcher"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/n_dialog-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/n_dialog-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Create a close watcher without user activation assert_array_equals: lengths differ, expected array ["cancel[cancelable=false]", "close"] length 2, got ["cancel[cancelable=true]"] length 1
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nn-CloseWatcher-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nn-CloseWatcher-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Create two close watchers without user activation promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CloseWatcher"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nn-CloseWatcher.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nn-CloseWatcher.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/common/top-layer.js"></script>
+<script src="../resources/helpers.js"></script>
+
+<body>
+<script>
+const type = "CloseWatcher";
+
+promise_test(async t => {
+  const events = [];
+
+  createRecordingCloseWatcher(t, events, "watcher1", type);
+  createRecordingCloseWatcher(t, events, "watcher2", type);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["watcher2 cancel[cancelable=false]", "watcher2 close", "watcher1 cancel[cancelable=false]", "watcher1 close"]);
+}, "Create two close watchers without user activation");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nn-activate-CloseWatcher-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nn-activate-CloseWatcher-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Create two CloseWatchers without user activation; send user activation promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CloseWatcher"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nn-activate-CloseWatcher.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nn-activate-CloseWatcher.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/common/top-layer.js"></script>
+<script src="../resources/helpers.js"></script>
+
+<body>
+<script>
+const type = "CloseWatcher";
+
+promise_test(async t => {
+  const events = [];
+
+  createRecordingCloseWatcher(t, events, "watcher1", type);
+  const watcher2 = createRecordingCloseWatcher(t, events, "watcher2", type);
+
+  await maybeTopLayerBless(watcher2);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["watcher2 cancel[cancelable=true]", "watcher2 close", "watcher1 cancel[cancelable=true]", "watcher1 close"]);
+}, "Create two CloseWatchers without user activation; send user activation");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nn-activate-dialog-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nn-activate-dialog-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Create two dialogs without user activation; send user activation assert_array_equals: lengths differ, expected array ["watcher2 cancel[cancelable=true]", "watcher1 cancel[cancelable=true]", "watcher2 close", "watcher1 close"] length 4, got ["watcher2 cancel[cancelable=true]"] length 1
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nn-activate-dialog.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nn-activate-dialog.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/common/top-layer.js"></script>
+<script src="../resources/helpers.js"></script>
+
+<body>
+<script>
+const type = "dialog";
+
+promise_test(async t => {
+  const events = [];
+
+  createRecordingCloseWatcher(t, events, "watcher1", type);
+  const watcher2 = createRecordingCloseWatcher(t, events, "watcher2", type);
+
+  await maybeTopLayerBless(watcher2);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["watcher2 cancel[cancelable=true]", "watcher1 cancel[cancelable=true]", "watcher2 close", "watcher1 close"]);
+}, "Create two dialogs without user activation; send user activation");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nn-dialog-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nn-dialog-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Create two close watchers without user activation assert_array_equals: lengths differ, expected array ["watcher2 cancel[cancelable=false]", "watcher1 cancel[cancelable=false]", "watcher2 close", "watcher1 close"] length 4, got ["watcher2 cancel[cancelable=true]"] length 1
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nn-dialog.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nn-dialog.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/common/top-layer.js"></script>
+<script src="../resources/helpers.js"></script>
+
+<body>
+<script>
+const type = "dialog";
+
+promise_test(async t => {
+  const events = [];
+
+  createRecordingCloseWatcher(t, events, "watcher1", type);
+  createRecordingCloseWatcher(t, events, "watcher2", type);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["watcher2 cancel[cancelable=false]", "watcher1 cancel[cancelable=false]", "watcher2 close", "watcher1 close"]);
+}, "Create two close watchers without user activation");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nnn-CloseWatcher-dialog-popover-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nnn-CloseWatcher-dialog-popover-expected.txt
@@ -1,0 +1,4 @@
+button
+
+FAIL Create a CloseWatcher without user activation; create a dialog without user activation; create a popover without user activation promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CloseWatcher"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nnn-CloseWatcher-dialog-popover.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nnn-CloseWatcher-dialog-popover.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<link rel=author href="mailto:jarhar@chromium.org">
+<link rel=help href="https://github.com/whatwg/html/pull/9462">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/common/top-layer.js"></script>
+<script src="../resources/helpers.js"></script>
+
+<button id=b0>button</button>
+
+<dialog id=dialog>
+  <button id=b1>button</button>
+  <div id=popover popover=auto>popover</div>
+</dialog>
+
+<script>
+promise_test(async t => {
+  const events = [];
+  const closeWatcher = createRecordingCloseWatcher(t, events, 'CloseWatcher', 'CloseWatcher');
+  const dialog = createRecordingCloseWatcher(t, events, 'dialog', 'dialog');
+  const popover = createRecordingCloseWatcher(t, events, 'popover', 'popover');
+  assert_true(dialog.hasAttribute('open'), 'The dialog should be open.');
+  assert_true(popover.matches(':popover-open'), 'The popover should be open.');
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+
+  assert_false(popover.matches(':popover-open'), 'The popover should be closed.');
+  assert_false(dialog.hasAttribute('open'), 'The dialog should be closed.');
+  assert_array_equals(events, ['dialog cancel[cancelable=false]', 'CloseWatcher cancel[cancelable=false]', 'CloseWatcher close', 'dialog close']);
+}, 'Create a CloseWatcher without user activation; create a dialog without user activation; create a popover without user activation');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nnn-CloseWatcher-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nnn-CloseWatcher-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Create three close watchers without user activation promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CloseWatcher"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nnn-CloseWatcher.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nnn-CloseWatcher.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/common/top-layer.js"></script>
+<script src="../resources/helpers.js"></script>
+
+<body>
+<script>
+const type = "CloseWatcher";
+
+promise_test(async t => {
+  const events = [];
+
+  createRecordingCloseWatcher(t, events, "watcher1", type);
+  createRecordingCloseWatcher(t, events, "watcher2", type);
+  createRecordingCloseWatcher(t, events, "watcher3", type);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["watcher3 cancel[cancelable=false]", "watcher3 close", "watcher2 cancel[cancelable=false]", "watcher2 close", "watcher1 cancel[cancelable=false]", "watcher1 close"]);
+}, "Create three close watchers without user activation");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nnn-dialog-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nnn-dialog-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Create three close watchers without user activation assert_array_equals: lengths differ, expected array ["watcher3 cancel[cancelable=false]", "watcher2 cancel[cancelable=false]", "watcher1 cancel[cancelable=false]", "watcher3 close", "watcher2 close", "watcher1 close"] length 6, got ["watcher3 cancel[cancelable=true]"] length 1
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nnn-dialog.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nnn-dialog.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/common/top-layer.js"></script>
+<script src="../resources/helpers.js"></script>
+
+<body>
+<script>
+const type = "dialog";
+
+promise_test(async t => {
+  const events = [];
+
+  createRecordingCloseWatcher(t, events, "watcher1", type);
+  createRecordingCloseWatcher(t, events, "watcher2", type);
+  createRecordingCloseWatcher(t, events, "watcher3", type);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["watcher3 cancel[cancelable=false]", "watcher2 cancel[cancelable=false]", "watcher1 cancel[cancelable=false]", "watcher3 close", "watcher2 close", "watcher1 close"]);
+}, "Create three close watchers without user activation");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nnn-popovers-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nnn-popovers-expected.txt
@@ -1,0 +1,4 @@
+b0 b1 b2
+
+FAIL Create three popovers without user activation assert_false: p1 should be closed. expected false got true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nnn-popovers.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nnn-popovers.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<link rel=author href="mailto:jarhar@chromium.org">
+<link rel=help href="https://github.com/whatwg/html/pull/9462">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="../resources/helpers.js"></script>
+
+<button id=b0>b0</button>
+
+<div id=p1 popover=auto>
+  <button id=b1>b1</button>
+
+  <div id=p2 popover=auto>
+    <button id=b2>b2</button>
+
+    <div id=p3 popover=auto>p3</div>
+  </div>
+</div>
+
+<script>
+promise_test(async () => {
+  p1.showPopover();
+  p2.showPopover();
+  p3.showPopover();
+  assert_true(p1.matches(':popover-open'), 'p1 should be open.');
+  assert_true(p2.matches(':popover-open'), 'p2 should be open.');
+  assert_true(p3.matches(':popover-open'), 'p3 should be open.');
+
+  await sendCloseRequest();
+  assert_false(p1.matches(':popover-open'), 'p1 should be closed.');
+  assert_false(p2.matches(':popover-open'), 'p2 should be closed.');
+  assert_false(p3.matches(':popover-open'), 'p3 should be closed.');
+}, 'Create three popovers without user activation');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/ny-activate-preventDefault.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/ny-activate-preventDefault.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<meta name=variant content="?dialog">
+<meta name=variant content="?CloseWatcher">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/common/top-layer.js"></script>
+<script src="../resources/helpers.js"></script>
+
+<body>
+<script>
+const type = location.search.substring(1);
+
+promise_test(async t => {
+  const events = [];
+
+  const watcher1 = createRecordingCloseWatcher(t, events, "watcher1", type);
+  const watcher2 = await createBlessedRecordingCloseWatcher(t, events, "watcher2", type, watcher1);
+  watcher2.addEventListener("cancel", e => e.preventDefault());
+
+  await maybeTopLayerBless(watcher2);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["watcher2 cancel[cancelable=true]"]);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["watcher2 cancel[cancelable=true]", "watcher2 cancel[cancelable=false]", "watcher2 close"]);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["watcher2 cancel[cancelable=true]", "watcher2 cancel[cancelable=false]", "watcher2 close", "watcher1 cancel[cancelable=false]", "watcher1 close"]);
+}, "Create a close watcher without user activation; create a close watcher with user activation that preventDefault()s cancel; send user activation");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/ny-activate-preventDefault_CloseWatcher-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/ny-activate-preventDefault_CloseWatcher-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Create a close watcher without user activation; create a close watcher with user activation that preventDefault()s cancel; send user activation promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CloseWatcher"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/ny-activate-preventDefault_dialog-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/ny-activate-preventDefault_dialog-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Create a close watcher without user activation; create a close watcher with user activation that preventDefault()s cancel; send user activation assert_array_equals: lengths differ, expected array ["watcher2 cancel[cancelable=true]", "watcher2 cancel[cancelable=false]", "watcher2 close"] length 3, got ["watcher2 cancel[cancelable=true]", "watcher2 cancel[cancelable=true]"] length 2
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/ny.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/ny.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<meta name=variant content="?dialog">
+<meta name=variant content="?CloseWatcher">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/common/top-layer.js"></script>
+<script src="../resources/helpers.js"></script>
+
+<body>
+<script>
+const type = location.search.substring(1);
+
+promise_test(async t => {
+  const events = [];
+
+  const watcher1 = createRecordingCloseWatcher(t, events, "watcher1", type);
+  await createBlessedRecordingCloseWatcher(t, events, "watcher2", type, watcher1);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["watcher2 cancel[cancelable=false]", "watcher2 close"]);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["watcher2 cancel[cancelable=false]", "watcher2 close", "watcher1 cancel[cancelable=false]", "watcher1 close"]);
+}, "Create a close watcher without user activation; create a close watcher with user activation");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/ny_CloseWatcher-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/ny_CloseWatcher-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Create a close watcher without user activation; create a close watcher with user activation promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CloseWatcher"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/ny_dialog-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/ny_dialog-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Create a close watcher without user activation; create a close watcher with user activation assert_array_equals: lengths differ, expected array ["watcher2 cancel[cancelable=false]", "watcher2 close"] length 2, got ["watcher2 cancel[cancelable=true]"] length 1
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nyn-popovers-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nyn-popovers-expected.txt
@@ -1,0 +1,4 @@
+b0 b1 b2
+
+FAIL Create a popover without user activation; create a popover with user activation; create a popover without user activation assert_false: first escape: p2 should be closed. expected false got true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nyn-popovers.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nyn-popovers.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<link rel=author href="mailto:jarhar@chromium.org">
+<link rel=help href="https://github.com/whatwg/html/pull/9462">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="../resources/helpers.js"></script>
+
+<button id=b0>b0</button>
+
+<div id=p1 popover=auto>
+  <button id=b1>b1</button>
+
+  <div id=p2 popover=auto>
+    <button id=b2>b2</button>
+
+    <div id=p3 popover=auto>p3</div>
+  </div>
+</div>
+
+<script>
+promise_test(async () => {
+  p1.showPopover();
+  await test_driver.click(b1);
+  p2.showPopover();
+  p3.showPopover();
+  assert_true(p1.matches(':popover-open'), 'p1 should be open.');
+  assert_true(p2.matches(':popover-open'), 'p2 should be open.');
+  assert_true(p3.matches(':popover-open'), 'p3 should be open.');
+
+  await sendCloseRequest();
+  assert_true(p1.matches(':popover-open'), 'first escape: p1 should be open.');
+  assert_false(p2.matches(':popover-open'), 'first escape: p2 should be closed.');
+  assert_false(p3.matches(':popover-open'), 'first escape: p3 should be closed.');
+
+  await sendCloseRequest();
+  assert_false(p1.matches(':popover-open'), 'second escape: p1 should be closed.');
+  assert_false(p2.matches(':popover-open'), 'second escape: p2 should be closed.');
+  assert_false(p3.matches(':popover-open'), 'second escape: p3 should be closed.');
+}, 'Create a popover without user activation; create a popover with user activation; create a popover without user activation');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nyn.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nyn.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<meta name=variant content="?dialog">
+<meta name=variant content="?CloseWatcher">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="../resources/helpers.js"></script>
+
+<body>
+<script>
+const type = location.search.substring(1);
+
+promise_test(async t => {
+  const events = [];
+
+  const watcher1 = createRecordingCloseWatcher(t, events, "watcher1");
+  await createBlessedRecordingCloseWatcher(t, events, "watcher2", type, watcher1);
+  createRecordingCloseWatcher(t, events, "watcher3");
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["watcher3 cancel[cancelable=false]", "watcher3 close", "watcher2 cancel[cancelable=false]", "watcher2 close"]);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["watcher3 cancel[cancelable=false]", "watcher3 close", "watcher2 cancel[cancelable=false]", "watcher2 close", "watcher1 cancel[cancelable=false]", "watcher1 close"]);
+}, "Create a close watcher without user activation; create a close watcher with user activation; create a close watcher without user activation");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nyn_CloseWatcher-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nyn_CloseWatcher-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Create a close watcher without user activation; create a close watcher with user activation; create a close watcher without user activation promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CloseWatcher"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nyn_dialog-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nyn_dialog-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Create a close watcher without user activation; create a close watcher with user activation; create a close watcher without user activation promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CloseWatcher"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nynn-destroy.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nynn-destroy.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<meta name=variant content="?dialog">
+<meta name=variant content="?CloseWatcher">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="../resources/helpers.js"></script>
+
+<body>
+<script>
+const type = location.search.substring(1);
+
+promise_test(async t => {
+  const events = [];
+
+  const watcher1 = createRecordingCloseWatcher(t, events, "watcher1");
+  const watcher2 = await createBlessedRecordingCloseWatcher(t, events, "watcher2", type, watcher1);
+  createRecordingCloseWatcher(t, events, "watcher3");
+  createRecordingCloseWatcher(t, events, "watcher4");
+
+  destroyCloseWatcher(watcher2);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["watcher4 cancel[cancelable=false]", "watcher4 close", "watcher3 cancel[cancelable=false]", "watcher3 close"]);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["watcher4 cancel[cancelable=false]", "watcher4 close", "watcher3 cancel[cancelable=false]", "watcher3 close", "watcher1 cancel[cancelable=false]", "watcher1 close"]);
+}, "Create a close watcher without user activation; create a close watcher with user activation; create two close watchers without user activation; remove the second close watcher");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nynn-destroy_CloseWatcher-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nynn-destroy_CloseWatcher-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Create a close watcher without user activation; create a close watcher with user activation; create two close watchers without user activation; remove the second close watcher promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CloseWatcher"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nynn-destroy_dialog-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nynn-destroy_dialog-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Create a close watcher without user activation; create a close watcher with user activation; create two close watchers without user activation; remove the second close watcher promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CloseWatcher"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nynn.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nynn.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<meta name=variant content="?dialog">
+<meta name=variant content="?CloseWatcher">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="../resources/helpers.js"></script>
+
+<body>
+<script>
+const type = location.search.substring(1);
+
+promise_test(async t => {
+  const events = [];
+
+  const watcher1 = createRecordingCloseWatcher(t, events, "watcher1");
+  await createBlessedRecordingCloseWatcher(t, events, "watcher2", type, watcher1);
+  createRecordingCloseWatcher(t, events, "watcher3");
+  createRecordingCloseWatcher(t, events, "watcher4");
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["watcher4 cancel[cancelable=false]", "watcher4 close", "watcher3 cancel[cancelable=false]", "watcher3 close", "watcher2 cancel[cancelable=false]", "watcher2 close"]);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["watcher4 cancel[cancelable=false]", "watcher4 close", "watcher3 cancel[cancelable=false]", "watcher3 close", "watcher2 cancel[cancelable=false]", "watcher2 close", "watcher1 cancel[cancelable=false]", "watcher1 close"]);
+}, "Create a close watcher without user activation; create a close watcher with user activation; create two close watchers without user activation");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nynn_CloseWatcher-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nynn_CloseWatcher-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Create a close watcher without user activation; create a close watcher with user activation; create two close watchers without user activation promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CloseWatcher"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nynn_dialog-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nynn_dialog-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Create a close watcher without user activation; create a close watcher with user activation; create two close watchers without user activation promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CloseWatcher"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nyyn-CloseWatcher-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nyyn-CloseWatcher-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Create a close watcher without user activation; create two close watchers with user activation; create a close watcher without user activation promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CloseWatcher"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nyyn-CloseWatcher.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nyyn-CloseWatcher.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/common/top-layer.js"></script>
+<script src="../resources/helpers.js"></script>
+
+<body>
+<script>
+const type = "CloseWatcher";
+
+promise_test(async t => {
+  const events = [];
+
+  const watcher1 = createRecordingCloseWatcher(t, events, "watcher1", type);
+  const watcher2 = await createBlessedRecordingCloseWatcher(t, events, "watcher2", type, watcher1);
+  const watcher3 = await createBlessedRecordingCloseWatcher(t, events, "watcher3", type, watcher2);
+  createRecordingCloseWatcher(t, events, "watcher4", type);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["watcher4 cancel[cancelable=false]", "watcher4 close", "watcher3 cancel[cancelable=false]", "watcher3 close"]);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["watcher4 cancel[cancelable=false]", "watcher4 close", "watcher3 cancel[cancelable=false]", "watcher3 close", "watcher2 cancel[cancelable=false]", "watcher2 close"]);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["watcher4 cancel[cancelable=false]", "watcher4 close", "watcher3 cancel[cancelable=false]", "watcher3 close", "watcher2 cancel[cancelable=false]", "watcher2 close", "watcher1 cancel[cancelable=false]", "watcher1 close"]);
+}, "Create a close watcher without user activation; create two close watchers with user activation; create a close watcher without user activation");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nyyn-dialog-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nyyn-dialog-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Create a close watcher without user activation; create two close watchers with user activation; create a close watcher without user activation assert_array_equals: lengths differ, expected array ["watcher4 cancel[cancelable=false]", "watcher3 cancel[cancelable=false]", "watcher4 close", "watcher3 close"] length 4, got ["watcher4 cancel[cancelable=true]"] length 1
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nyyn-dialog.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nyyn-dialog.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/common/top-layer.js"></script>
+<script src="../resources/helpers.js"></script>
+
+<body>
+<script>
+const type = "dialog";
+
+promise_test(async t => {
+  const events = [];
+
+  const watcher1 = createRecordingCloseWatcher(t, events, "watcher1", type);
+  const watcher2 = await createBlessedRecordingCloseWatcher(t, events, "watcher2", type, watcher1);
+  const watcher3 = await createBlessedRecordingCloseWatcher(t, events, "watcher3", type, watcher2);
+  createRecordingCloseWatcher(t, events, "watcher4", type);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["watcher4 cancel[cancelable=false]", "watcher3 cancel[cancelable=false]", "watcher4 close", "watcher3 close"]);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["watcher4 cancel[cancelable=false]", "watcher3 cancel[cancelable=false]", "watcher4 close", "watcher3 close", "watcher2 cancel[cancelable=false]", "watcher2 close"]);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["watcher4 cancel[cancelable=false]", "watcher3 cancel[cancelable=false]", "watcher4 close", "watcher3 close", "watcher2 cancel[cancelable=false]", "watcher2 close", "watcher1 cancel[cancelable=false]", "watcher1 close"]);
+}, "Create a close watcher without user activation; create two close watchers with user activation; create a close watcher without user activation");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nyyyn-CloseWatcher-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nyyyn-CloseWatcher-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Create a close watcher without user activation; create three close watchers with user activation; create a close watcher without user activation promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CloseWatcher"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nyyyn-CloseWatcher.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nyyyn-CloseWatcher.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/common/top-layer.js"></script>
+<script src="../resources/helpers.js"></script>
+
+<body>
+<script>
+const type = "CloseWatcher";
+
+promise_test(async t => {
+  const events = [];
+  const watcher1 = createRecordingCloseWatcher(t, events, "watcher1", type);
+  const watcher2 = await createBlessedRecordingCloseWatcher(t, events, "watcher2", type, watcher1);
+  const watcher3 = await createBlessedRecordingCloseWatcher(t, events, "watcher3", type, watcher2);
+  await createBlessedRecordingCloseWatcher(t, events, "watcher4", type, watcher3);
+  createRecordingCloseWatcher(t, events, "watcher5", type);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["watcher5 cancel[cancelable=false]", "watcher5 close", "watcher4 cancel[cancelable=false]", "watcher4 close"]);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["watcher5 cancel[cancelable=false]", "watcher5 close", "watcher4 cancel[cancelable=false]", "watcher4 close", "watcher3 cancel[cancelable=false]", "watcher3 close"]);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["watcher5 cancel[cancelable=false]", "watcher5 close", "watcher4 cancel[cancelable=false]", "watcher4 close", "watcher3 cancel[cancelable=false]", "watcher3 close", "watcher2 cancel[cancelable=false]", "watcher2 close"]);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["watcher5 cancel[cancelable=false]", "watcher5 close", "watcher4 cancel[cancelable=false]", "watcher4 close", "watcher3 cancel[cancelable=false]", "watcher3 close", "watcher2 cancel[cancelable=false]", "watcher2 close", "watcher1 cancel[cancelable=false]", "watcher1 close"]);
+}, "Create a close watcher without user activation; create three close watchers with user activation; create a close watcher without user activation");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nyyyn-dialog-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nyyyn-dialog-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Create a close watcher without user activation; create three close watchers with user activation; create a close watcher without user activation assert_array_equals: lengths differ, expected array ["watcher5 cancel[cancelable=false]", "watcher4 cancel[cancelable=false]", "watcher5 close", "watcher4 close"] length 4, got ["watcher5 cancel[cancelable=true]"] length 1
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nyyyn-dialog.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nyyyn-dialog.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/common/top-layer.js"></script>
+<script src="../resources/helpers.js"></script>
+
+<body>
+<script>
+const type = "dialog";
+
+promise_test(async t => {
+  const events = [];
+  const watcher1 = createRecordingCloseWatcher(t, events, "watcher1", type);
+  const watcher2 = await createBlessedRecordingCloseWatcher(t, events, "watcher2", type, watcher1);
+  const watcher3 = await createBlessedRecordingCloseWatcher(t, events, "watcher3", type, watcher2);
+  await createBlessedRecordingCloseWatcher(t, events, "watcher4", type, watcher3);
+  createRecordingCloseWatcher(t, events, "watcher5", type);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["watcher5 cancel[cancelable=false]", "watcher4 cancel[cancelable=false]", "watcher5 close", "watcher4 close"]);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["watcher5 cancel[cancelable=false]", "watcher4 cancel[cancelable=false]", "watcher5 close", "watcher4 close", "watcher3 cancel[cancelable=false]", "watcher3 close"]);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["watcher5 cancel[cancelable=false]", "watcher4 cancel[cancelable=false]", "watcher5 close", "watcher4 close", "watcher3 cancel[cancelable=false]", "watcher3 close", "watcher2 cancel[cancelable=false]", "watcher2 close"]);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["watcher5 cancel[cancelable=false]", "watcher4 cancel[cancelable=false]", "watcher5 close", "watcher4 close", "watcher3 cancel[cancelable=false]", "watcher3 close", "watcher2 cancel[cancelable=false]", "watcher2 close", "watcher1 cancel[cancelable=false]", "watcher1 close"]);
+}, "Create a close watcher without user activation; create three close watchers with user activation; create a close watcher without user activation");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/w3c-import.log
@@ -1,0 +1,51 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/README.md
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/n-activate-preventDefault.html
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/n-activate.html
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/n-closerequest-n.html
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/n-destroy-n.html
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/n.html
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nn-CloseWatcher.html
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nn-activate-CloseWatcher.html
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nn-activate-dialog.html
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nn-dialog.html
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nnn-CloseWatcher-dialog-popover.html
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nnn-CloseWatcher.html
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nnn-dialog.html
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nnn-popovers.html
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/ny-activate-preventDefault.html
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/ny.html
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nyn-popovers.html
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nyn.html
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nynn-destroy.html
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nynn.html
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nyyn-CloseWatcher.html
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nyyn-dialog.html
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nyyyn-CloseWatcher.html
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nyyyn-dialog.html
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/y.html
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yn-activate.html
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yn.html
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/ynn-CloseWatcher.html
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/ynn-dialog.html
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yy.html
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yyn.html
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yyy-CloseWatcher-dialog-popover.html
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yyy-activate-CloseWatcher-dialog-popover.html
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yyy-popovers.html
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yyy.html

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/y.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/y.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<meta name=variant content="?dialog">
+<meta name=variant content="?CloseWatcher">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/common/top-layer.js"></script>
+<script src="../resources/helpers.js"></script>
+
+<body>
+<script>
+const type = location.search.substring(1);
+
+promise_test(async t => {
+  const events = [];
+
+  await createBlessedRecordingCloseWatcher(t, events, undefined, type);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["cancel[cancelable=true]", "close"]);
+}, "Create a close watcher with user activation");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/y_CloseWatcher-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/y_CloseWatcher-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Create a close watcher with user activation promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CloseWatcher"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/y_dialog-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/y_dialog-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Create a close watcher with user activation assert_array_equals: lengths differ, expected array ["cancel[cancelable=true]", "close"] length 2, got ["cancel[cancelable=true]"] length 1
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yn-activate.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yn-activate.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<meta name=variant content="?dialog">
+<meta name=variant content="?CloseWatcher">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/common/top-layer.js"></script>
+<script src="../resources/helpers.js"></script>
+
+<body>
+<script>
+const type = location.search.substring(1);
+
+promise_test(async t => {
+  const events = [];
+
+  await createBlessedRecordingCloseWatcher(t, events, "watcher1", type);
+  const watcher2 = createRecordingCloseWatcher(t, events, "watcher2", type);
+
+  await maybeTopLayerBless(watcher2);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["watcher2 cancel[cancelable=true]", "watcher2 close"]);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["watcher2 cancel[cancelable=true]", "watcher2 close", "watcher1 cancel[cancelable=true]", "watcher1 close"]);
+}, "Create a close watcher with user activation; create a close watcher without user activation; send user activation");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yn-activate_CloseWatcher-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yn-activate_CloseWatcher-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Create a close watcher with user activation; create a close watcher without user activation; send user activation promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CloseWatcher"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yn-activate_dialog-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yn-activate_dialog-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Create a close watcher with user activation; create a close watcher without user activation; send user activation assert_array_equals: lengths differ, expected array ["watcher2 cancel[cancelable=true]", "watcher2 close"] length 2, got ["watcher2 cancel[cancelable=true]"] length 1
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yn.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yn.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<meta name=variant content="?dialog">
+<meta name=variant content="?CloseWatcher">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/common/top-layer.js"></script>
+<script src="../resources/helpers.js"></script>
+
+<body>
+<script>
+const type = location.search.substring(1);
+
+promise_test(async t => {
+  const events = [];
+
+  await createBlessedRecordingCloseWatcher(t, events, "watcher1", type);
+  createRecordingCloseWatcher(t, events, "watcher2", type);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["watcher2 cancel[cancelable=false]", "watcher2 close"]);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["watcher2 cancel[cancelable=false]", "watcher2 close", "watcher1 cancel[cancelable=false]", "watcher1 close"]);
+}, "Create a close watcher with user activation; create a close watcher without user activation");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yn_CloseWatcher-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yn_CloseWatcher-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Create a close watcher with user activation; create a close watcher without user activation promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CloseWatcher"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yn_dialog-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yn_dialog-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Create a close watcher with user activation; create a close watcher without user activation assert_array_equals: lengths differ, expected array ["watcher2 cancel[cancelable=false]", "watcher2 close"] length 2, got ["watcher2 cancel[cancelable=true]"] length 1
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/ynn-CloseWatcher-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/ynn-CloseWatcher-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Create a close watcher with user activation; create two close watchers without user activation promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CloseWatcher"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/ynn-CloseWatcher.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/ynn-CloseWatcher.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/common/top-layer.js"></script>
+<script src="../resources/helpers.js"></script>
+
+<body>
+<script>
+const type = "CloseWatcher";
+
+promise_test(async t => {
+  const events = [];
+
+  await createBlessedRecordingCloseWatcher(t, events, "watcher1", type);
+  createRecordingCloseWatcher(t, events, "watcher2", type);
+  createRecordingCloseWatcher(t, events, "watcher3", type);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["watcher3 cancel[cancelable=false]", "watcher3 close", "watcher2 cancel[cancelable=false]", "watcher2 close"]);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["watcher3 cancel[cancelable=false]", "watcher3 close", "watcher2 cancel[cancelable=false]", "watcher2 close", "watcher1 cancel[cancelable=false]", "watcher1 close"]);
+}, "Create a close watcher with user activation; create two close watchers without user activation");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/ynn-dialog-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/ynn-dialog-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Create a close watcher with user activation; create two close watchers without user activation assert_array_equals: lengths differ, expected array ["watcher3 cancel[cancelable=false]", "watcher2 cancel[cancelable=false]", "watcher3 close", "watcher2 close"] length 4, got ["watcher3 cancel[cancelable=true]"] length 1
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/ynn-dialog.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/ynn-dialog.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/common/top-layer.js"></script>
+<script src="../resources/helpers.js"></script>
+
+<body>
+<script>
+const type = "dialog";
+
+promise_test(async t => {
+  const events = [];
+
+  await createBlessedRecordingCloseWatcher(t, events, "watcher1", type);
+  createRecordingCloseWatcher(t, events, "watcher2", type);
+  createRecordingCloseWatcher(t, events, "watcher3", type);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["watcher3 cancel[cancelable=false]", "watcher2 cancel[cancelable=false]", "watcher3 close", "watcher2 close"]);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["watcher3 cancel[cancelable=false]", "watcher2 cancel[cancelable=false]", "watcher3 close", "watcher2 close", "watcher1 cancel[cancelable=false]", "watcher1 close"]);
+}, "Create a close watcher with user activation; create two close watchers without user activation");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yy.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yy.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<meta name=variant content="?dialog">
+<meta name=variant content="?CloseWatcher">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/common/top-layer.js"></script>
+<script src="../resources/helpers.js"></script>
+
+<body>
+<script>
+const type = location.search.substring(1);
+
+promise_test(async t => {
+  const events = [];
+
+  const watcher1 = await createBlessedRecordingCloseWatcher(t, events, "watcher1", type);
+  await createBlessedRecordingCloseWatcher(t, events, "watcher2", type, watcher1);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["watcher2 cancel[cancelable=true]", "watcher2 close"]);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["watcher2 cancel[cancelable=true]", "watcher2 close", "watcher1 cancel[cancelable=true]", "watcher1 close"]);
+}, "Create two close watchers with user activation");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yy_CloseWatcher-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yy_CloseWatcher-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Create two close watchers with user activation promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CloseWatcher"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yy_dialog-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yy_dialog-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Create two close watchers with user activation assert_array_equals: lengths differ, expected array ["watcher2 cancel[cancelable=true]", "watcher2 close"] length 2, got ["watcher2 cancel[cancelable=true]"] length 1
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yyn.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yyn.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<meta name=variant content="?dialog">
+<meta name=variant content="?CloseWatcher">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/common/top-layer.js"></script>
+<script src="../resources/helpers.js"></script>
+
+<body>
+<script>
+const type = location.search.substring(1);
+
+promise_test(async t => {
+  const events = [];
+
+  const watcher1 = await createBlessedRecordingCloseWatcher(t, events, "watcher1", type);
+  await createBlessedRecordingCloseWatcher(t, events, "watcher2", type, watcher1);
+  createRecordingCloseWatcher(t, events, "watcher3", type);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["watcher3 cancel[cancelable=false]", "watcher3 close"]);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["watcher3 cancel[cancelable=false]", "watcher3 close", "watcher2 cancel[cancelable=false]", "watcher2 close"]);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["watcher3 cancel[cancelable=false]", "watcher3 close", "watcher2 cancel[cancelable=false]", "watcher2 close", "watcher1 cancel[cancelable=false]", "watcher1 close"]);
+}, "Create two close watchers with user activation; create a close watcher without user activation");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yyn_CloseWatcher-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yyn_CloseWatcher-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Create two close watchers with user activation; create a close watcher without user activation promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CloseWatcher"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yyn_dialog-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yyn_dialog-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Create two close watchers with user activation; create a close watcher without user activation assert_array_equals: lengths differ, expected array ["watcher3 cancel[cancelable=false]", "watcher3 close"] length 2, got ["watcher3 cancel[cancelable=true]"] length 1
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yyy-CloseWatcher-dialog-popover-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yyy-CloseWatcher-dialog-popover-expected.txt
@@ -1,0 +1,4 @@
+button
+
+FAIL Create a CloseWatcher with user activation; create a dialog with user activation; create a popover with user activation promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CloseWatcher"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yyy-CloseWatcher-dialog-popover.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yyy-CloseWatcher-dialog-popover.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<link rel=author href="mailto:jarhar@chromium.org">
+<link rel=help href="https://github.com/whatwg/html/pull/9462">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/common/top-layer.js"></script>
+<script src="../resources/helpers.js"></script>
+
+<button id=b0>button</button>
+
+<dialog id=dialog>
+  <button id=b1>button</button>
+  <div id=popover popover=auto>popover</div>
+</dialog>
+
+<script>
+promise_test(async t => {
+  const events = [];
+  const closeWatcher = await createBlessedRecordingCloseWatcher(t, events, 'CloseWatcher', 'CloseWatcher');
+  const dialog = await createBlessedRecordingCloseWatcher(t, events, 'dialog', 'dialog');
+  const popover = await createBlessedRecordingCloseWatcher(t, events, 'popover', 'popover', dialog);
+  assert_true(dialog.hasAttribute('open'), 'The dialog should be open.');
+  assert_true(popover.matches(':popover-open'), 'The popover should be open.');
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_false(popover.matches(':popover-open'), 'First close request: The popover should be closed.');
+  assert_true(dialog.hasAttribute('open'), 'First close request: The dialog should be open.');
+  assert_array_equals(events, []);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_false(popover.matches(':popover-open'), 'Second close request: The popover should be closed.');
+  assert_false(dialog.hasAttribute('open'), 'Second close request: The dialog should be closed.');
+  assert_array_equals(events, ['dialog cancel[cancelable=true]', 'dialog close']);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_false(popover.matches(':popover-open'), 'Third close request: The popover should be closed.');
+  assert_false(dialog.hasAttribute('open'), 'Third close request: The dialog should be closed.');
+  assert_array_equals(events, ['dialog cancel[cancelable=true]', 'dialog close', 'CloseWatcher cancel[cancelable=true]', 'CloseWatcher close']);
+}, 'Create a CloseWatcher with user activation; create a dialog with user activation; create a popover with user activation');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yyy-activate-CloseWatcher-dialog-popover-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yyy-activate-CloseWatcher-dialog-popover-expected.txt
@@ -1,0 +1,4 @@
+button
+
+FAIL Create a CloseWatcher with user activation; create a dialog with user activation; create a popover with user activation; sending user activation before each close request promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CloseWatcher"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yyy-activate-CloseWatcher-dialog-popover.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yyy-activate-CloseWatcher-dialog-popover.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<link rel=author href="mailto:jarhar@chromium.org">
+<link rel=help href="https://github.com/whatwg/html/pull/9462">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/common/top-layer.js"></script>
+<script src="../resources/helpers.js"></script>
+
+<button id=b0>button</button>
+
+<dialog id=dialog>
+  <button id=b1>button</button>
+  <div id=popover popover=auto>popover</div>
+</dialog>
+
+<script>
+promise_test(async t => {
+  const events = [];
+  const closeWatcher = await createBlessedRecordingCloseWatcher(t, events, 'CloseWatcher', 'CloseWatcher');
+  const dialog = await createBlessedRecordingCloseWatcher(t, events, 'dialog', 'dialog');
+  const popover = await createBlessedRecordingCloseWatcher(t, events, 'popover', 'popover', dialog);
+  assert_true(dialog.hasAttribute('open'), 'The dialog should be open.');
+  assert_true(popover.matches(':popover-open'), 'The popover should be open.');
+
+  await blessTopLayer(popover);
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_false(popover.matches(':popover-open'), 'First close request: The popover should be closed.');
+  assert_true(dialog.hasAttribute('open'), 'First close request: The dialog should be open.');
+  assert_array_equals(events, []);
+
+  await blessTopLayer(dialog);
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_false(popover.matches(':popover-open'), 'Second close request: The popover should be closed.');
+  assert_false(dialog.hasAttribute('open'), 'Second close request: The dialog should be closed.');
+  assert_array_equals(events, ['dialog cancel[cancelable=true]', 'dialog close']);
+
+  await test_driver.bless();
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_false(popover.matches(':popover-open'), 'Third close request: The popover should be closed.');
+  assert_false(dialog.hasAttribute('open'), 'Third close request: The dialog should be closed.');
+  assert_array_equals(events, ['dialog cancel[cancelable=true]', 'dialog close', 'CloseWatcher cancel[cancelable=true]', 'CloseWatcher close']);
+}, 'Create a CloseWatcher with user activation; create a dialog with user activation; create a popover with user activation; sending user activation before each close request');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yyy-popovers-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yyy-popovers-expected.txt
@@ -1,0 +1,4 @@
+b0
+
+PASS Create three popovers with user activation
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yyy-popovers.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yyy-popovers.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<link rel=author href="mailto:jarhar@chromium.org">
+<link rel=help href="https://github.com/whatwg/html/pull/9462">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="../resources/helpers.js"></script>
+
+<button id=b0>b0</button>
+
+<div id=p1 popover=auto>
+  <button id=b1>b1</button>
+
+  <div id=p2 popover=auto>
+    <button id=b2>b2</button>
+
+    <div id=p3 popover=auto>p3</div>
+  </div>
+</div>
+
+<script>
+promise_test(async () => {
+  await test_driver.click(b0);
+  p1.showPopover();
+  await test_driver.click(b1);
+  p2.showPopover();
+  await test_driver.click(b2);
+  p3.showPopover();
+  assert_true(p1.matches(':popover-open'), 'p1 should be open.');
+  assert_true(p2.matches(':popover-open'), 'p2 should be open.');
+  assert_true(p3.matches(':popover-open'), 'p3 should be open.');
+
+  await sendCloseRequest();
+  assert_true(p1.matches(':popover-open'), 'first escape: p1 should be open.');
+  assert_true(p2.matches(':popover-open'), 'first escape: p2 should be open.');
+  assert_false(p3.matches(':popover-open'), 'first escape: p3 should be closed.');
+
+  await sendCloseRequest();
+  assert_true(p1.matches(':popover-open'), 'second escape: p1 should be open.');
+  assert_false(p2.matches(':popover-open'), 'second escape: p2 should be closed.');
+  assert_false(p3.matches(':popover-open'), 'second escape: p3 should be closed.');
+
+  await sendCloseRequest();
+  assert_false(p1.matches(':popover-open'), 'third escape: p1 should be closed.');
+  assert_false(p2.matches(':popover-open'), 'third escape: p2 should be closed.');
+  assert_false(p3.matches(':popover-open'), 'third escape: p3 should be closed.');
+}, 'Create three popovers with user activation');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yyy.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yyy.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<meta name=variant content="?dialog">
+<meta name=variant content="?CloseWatcher">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/common/top-layer.js"></script>
+<script src="../resources/helpers.js"></script>
+
+<body>
+<script>
+const type = location.search.substring(1);
+
+promise_test(async t => {
+  const events = [];
+
+  const watcher1 = await createBlessedRecordingCloseWatcher(t, events, "watcher1", type);
+  const watcher2 = await createBlessedRecordingCloseWatcher(t, events, "watcher2", type, watcher1);
+  await createBlessedRecordingCloseWatcher(t, events, "watcher3", type, watcher2);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["watcher3 cancel[cancelable=true]", "watcher3 close"]);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["watcher3 cancel[cancelable=true]", "watcher3 close", "watcher2 cancel[cancelable=true]", "watcher2 close"]);
+
+  await sendCloseRequest();
+  await waitForPotentialCloseEvent();
+  assert_array_equals(events, ["watcher3 cancel[cancelable=true]", "watcher3 close", "watcher2 cancel[cancelable=true]", "watcher2 close", "watcher1 cancel[cancelable=true]", "watcher1 close"]);
+}, "Create three close watchers with user activation");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yyy_CloseWatcher-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yyy_CloseWatcher-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Create three close watchers with user activation promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CloseWatcher"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yyy_dialog-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yyy_dialog-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Create three close watchers with user activation assert_array_equals: lengths differ, expected array ["watcher3 cancel[cancelable=true]", "watcher3 close"] length 2, got ["watcher3 cancel[cancelable=true]"] length 1
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/w3c-import.log
@@ -1,0 +1,22 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/META.yml
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/abortsignal.html
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/basic.html
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/event-properties.html
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/frame-removal.html
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/inside-event-listeners.html

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-close-request-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-close-request-expected.txt
@@ -1,4 +1,4 @@
 Inside popover 1 Inside popover 2
 
-FAIL Popover close request behavior promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: sendCloseRequest"
+FAIL Popover close request behavior promise_test: Unhandled rejection with value: object "Error: element send_keys intercepted error"
 


### PR DESCRIPTION
#### 4e0e3b849e9f3f82af1c8253da4750ea4da065e2
<pre>
Import close-watcher WPT tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=266379">https://bugs.webkit.org/show_bug.cgi?id=266379</a>

Reviewed by Tim Nguyen.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/43ae6cd615fad8cd6df2cade33ad48bfb9f285cb">https://github.com/web-platform-tests/wpt/commit/43ae6cd615fad8cd6df2cade33ad48bfb9f285cb</a>

* LayoutTests/imported/w3c/resources/import-expectations.json:
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/META.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/abortsignal-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/abortsignal.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/basic-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/basic.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/esc-key/README.md: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/esc-key/keydown-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/esc-key/keydown.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/esc-key/keypress-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/esc-key/keypress.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/esc-key/keyup-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/esc-key/keyup.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/esc-key/not-user-activation-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/esc-key/not-user-activation.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/esc-key/synthetic-keyboard-event-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/esc-key/synthetic-keyboard-event.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/esc-key/w3c-import.log: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/event-properties-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/event-properties.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/frame-removal-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/frame-removal.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/inside-event-listeners-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/inside-event-listeners.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/resources/helpers.js: Added.
(window.createRecordingCloseWatcher):
(window.createBlessedRecordingCloseWatcher.async t):
(window.destroyCloseWatcher):
(window.sendEscKey):
(window.maybeTopLayerBless):
(window.waitForPotentialCloseEvent):
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/resources/w3c-import.log: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/README.md: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/n-activate-preventDefault.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/n-activate-preventDefault_CloseWatcher-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/n-activate-preventDefault_dialog-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/n-activate.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/n-activate_CloseWatcher-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/n-activate_dialog-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/n-closerequest-n.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/n-closerequest-n_CloseWatcher-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/n-closerequest-n_dialog-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/n-destroy-n.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/n-destroy-n_CloseWatcher-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/n-destroy-n_dialog-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/n.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/n_CloseWatcher-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/n_dialog-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nn-CloseWatcher-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nn-CloseWatcher.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nn-activate-CloseWatcher-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nn-activate-CloseWatcher.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nn-activate-dialog-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nn-activate-dialog.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nn-dialog-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nn-dialog.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nnn-CloseWatcher-dialog-popover-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nnn-CloseWatcher-dialog-popover.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nnn-CloseWatcher-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nnn-CloseWatcher.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nnn-dialog-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nnn-dialog.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nnn-popovers-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nnn-popovers.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/ny-activate-preventDefault.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/ny-activate-preventDefault_CloseWatcher-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/ny-activate-preventDefault_dialog-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/ny.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/ny_CloseWatcher-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/ny_dialog-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nyn-popovers-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nyn-popovers.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nyn.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nyn_CloseWatcher-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nyn_dialog-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nynn-destroy.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nynn-destroy_CloseWatcher-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nynn-destroy_dialog-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nynn.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nynn_CloseWatcher-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nynn_dialog-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nyyn-CloseWatcher-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nyyn-CloseWatcher.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nyyn-dialog-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nyyn-dialog.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nyyyn-CloseWatcher-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nyyyn-CloseWatcher.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nyyyn-dialog-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nyyyn-dialog.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/w3c-import.log: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/y.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/y_CloseWatcher-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/y_dialog-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yn-activate.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yn-activate_CloseWatcher-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yn-activate_dialog-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yn.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yn_CloseWatcher-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yn_dialog-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/ynn-CloseWatcher-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/ynn-CloseWatcher.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/ynn-dialog-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/ynn-dialog.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yy.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yy_CloseWatcher-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yy_dialog-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yyn.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yyn_CloseWatcher-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yyn_dialog-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yyy-CloseWatcher-dialog-popover-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yyy-CloseWatcher-dialog-popover.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yyy-activate-CloseWatcher-dialog-popover-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yyy-activate-CloseWatcher-dialog-popover.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yyy-popovers-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yyy-popovers.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yyy.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yyy_CloseWatcher-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yyy_dialog-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/w3c-import.log: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-close-request-expected.txt:
* LayoutTests/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/279060@main">https://commits.webkit.org/279060@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9569c2c83ae1412dc28d667c8fd1421a8fdb2067

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49252 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28533 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52283 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52048 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45355 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34547 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26154 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40233 "Passed tests") | [⏳ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51353 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26081 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42430 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21354 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23534 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43606 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45458 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44113 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53959 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24333 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20519 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47778 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25606 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42632 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46543 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11443 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26444 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25328 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->