### PR TITLE
Link decoration filtering should be able to be conditional on URL path

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/WebPrivacySPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/WebPrivacySPI.h
@@ -61,6 +61,7 @@ typedef NS_ENUM(NSInteger, WPNetworkAddressVersion) {
 @interface WPLinkFilteringRule : NSObject
 @property (nonatomic, readonly) NSString *queryParameter;
 @property (nonatomic, readonly) NSString *domain;
+@property (nonatomic, readonly) NSString *path;
 @end
 
 @interface WPLinkFilteringData : NSObject
@@ -124,6 +125,12 @@ typedef void (^WPStorageAccessUserAgentStringQuirksDataCompletionHandler)(WPStor
 
 @interface WPStorageAccessUserAgentStringQuirk (Staging_119342418)
 - (void)requestStorageAccessUserAgentStringQuirksData:(WPResourceRequestOptions *)options completionHandler:(WPStorageAccessUserAgentStringQuirksDataCompletionHandler)completion;
+@end
+#endif
+
+#if !defined(HAS_WEB_PRIVACY_LINK_FILTERING_RULE_PATH) && HAVE(WEB_PRIVACY_FRAMEWORK)
+@interface WPLinkFilteringRule (Staging_119590894)
+@property (nonatomic, readonly) NSString *path;
 @end
 #endif
 

--- a/Source/WebCore/page/LinkDecorationFilteringData.h
+++ b/Source/WebCore/page/LinkDecorationFilteringData.h
@@ -26,28 +26,23 @@
 #pragma once
 
 #include "RegistrableDomain.h"
-#include <optional>
 
 namespace WebCore {
 
 struct LinkDecorationFilteringData {
     RegistrableDomain domain;
+    String path;
     String linkDecoration;
 
-    LinkDecorationFilteringData(RegistrableDomain&& domain, const String& linkDecoration)
+    LinkDecorationFilteringData(RegistrableDomain&& domain, String&& path, String&& linkDecoration)
         : domain(WTFMove(domain))
-        , linkDecoration(linkDecoration)
+        , path(WTFMove(path))
+        , linkDecoration(WTFMove(linkDecoration))
     {
     }
 
-    LinkDecorationFilteringData(const String& domain, const String& linkDecoration)
-        : domain(RegistrableDomain { URL { domain } } )
-        , linkDecoration(linkDecoration)
-    {
-    }
-
-    LinkDecorationFilteringData(const String& linkDecoration)
-        : linkDecoration(linkDecoration)
+    LinkDecorationFilteringData(String&& domain, String&& path, String&& linkDecoration)
+        : LinkDecorationFilteringData(RegistrableDomain { URL { WTFMove(domain) } }, WTFMove(path), WTFMove(linkDecoration))
     {
     }
 
@@ -56,6 +51,7 @@ struct LinkDecorationFilteringData {
 
     LinkDecorationFilteringData(LinkDecorationFilteringData&& data)
         : domain(WTFMove(data.domain))
+        , path(WTFMove(data.path))
         , linkDecoration(WTFMove(data.linkDecoration))
     {
     }
@@ -63,6 +59,7 @@ struct LinkDecorationFilteringData {
     LinkDecorationFilteringData& operator=(LinkDecorationFilteringData&& data)
     {
         domain = WTFMove(data.domain);
+        path = WTFMove(data.path);
         linkDecoration = WTFMove(data.linkDecoration);
         return *this;
     }

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
@@ -205,7 +205,7 @@ void LinkDecorationFilteringController::updateStrings(CompletionHandler<void()>&
         else {
             auto rules = [data rules];
             for (WPLinkFilteringRule *rule : rules)
-                result.append(WebCore::LinkDecorationFilteringData { rule.domain, rule.queryParameter });
+                result.append(WebCore::LinkDecorationFilteringData { rule.domain, [rule respondsToSelector:@selector(path)] ? rule.path : @"", rule.queryParameter });
             setCachedStrings(WTFMove(result));
         }
 
@@ -247,7 +247,7 @@ void requestLinkDecorationFilteringData(LinkFilteringRulesCallback&& callback)
         else {
             auto rules = [data rules];
             for (WPLinkFilteringRule *rule : rules)
-                result.append(WebCore::LinkDecorationFilteringData { rule.domain, rule.queryParameter });
+                result.append(WebCore::LinkDecorationFilteringData { rule.domain, { }, rule.queryParameter });
         }
 
         auto callbacks = std::exchange(lookupCallbacks.get(), { });

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6283,6 +6283,7 @@ struct WebCore::RemoteUserInputEventData {
 
 struct WebCore::LinkDecorationFilteringData {
     WebCore::RegistrableDomain domain;
+    String path;
     String linkDecoration;
 };
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2661,8 +2661,11 @@ private:
     Ref<WebHistoryItemClient> m_historyItemClient;
 
 #if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
-    HashSet<String> m_linkDecorationFilteringData;
-    HashMap<WebCore::RegistrableDomain, HashSet<String>> m_domainScopedLinkDecorationFilteringData;
+    struct LinkDecorationFilteringConditionals {
+        HashSet<WebCore::RegistrableDomain> domains;
+        Vector<String> paths;
+    };
+    HashMap<String, LinkDecorationFilteringConditionals> m_linkDecorationFilteringData;
     HashMap<WebCore::RegistrableDomain, HashSet<String>> m_allowedQueryParametersForAdvancedPrivacyProtections;
 #endif
 


### PR DESCRIPTION
#### e375751b5b526c89d630ddccad2e4f2df3ac0d2a
<pre>
Link decoration filtering should be able to be conditional on URL path
<a href="https://bugs.webkit.org/show_bug.cgi?id=266382">https://bugs.webkit.org/show_bug.cgi?id=266382</a>
<a href="https://rdar.apple.com/111189162">rdar://111189162</a>

Reviewed by Wenson Hsieh.

There are situations where we want query parameter removal to only happen for particular URL paths. This
patch adds support to do so.

Since link decoration filtering is now conditional on domains and paths, I removed
`m_domainScopedLinkDecorationFilteringData` and made `m_linkDecorationFilteringData` map from query
parameter to the domain and path conditionals.

I also made changes so that our API tests support testing link decoration filtering by domain and path.

* Source/WebCore/PAL/pal/spi/cocoa/WebPrivacySPI.h:
* Source/WebCore/page/LinkDecorationFilteringData.h:
(WebCore::LinkDecorationFilteringData::LinkDecorationFilteringData):
(WebCore::LinkDecorationFilteringData::operator=):
(WebCore::LinkDecorationFilteringData::linkDecoration): Deleted.
* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm:
(WebKit::LinkDecorationFilteringController::updateStrings):
(WebKit::requestLinkDecorationFilteringData):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::applyLinkDecorationFilteringWithResult):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::setLinkDecorationFilteringData):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm:
(TestWebKitAPI::makeQueryParameterRequestHandler):
(TestWebKitAPI::QueryParameterRequestSwizzler::QueryParameterRequestSwizzler):
(TestWebKitAPI::QueryParameterRequestSwizzler::update):
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/272076@main">https://commits.webkit.org/272076@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60ab0a86563d09c0060caee9cabc2f3016df8e67

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30562 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9244 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32215 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/33059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/27633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31266 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/11530 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6496 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/27552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30870 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/7749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/27371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/6637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/6796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/27226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/34395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/27819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/27721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/34395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/6806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/4921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/34395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/8542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/7537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3958 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/7361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->