### PR TITLE
[Filters] GraphicsContext filters have to apply clipping to the target context before drawing

### DIFF
--- a/LayoutTests/css3/filters/drop-shadow-filter-overflow-expected.html
+++ b/LayoutTests/css3/filters/drop-shadow-filter-overflow-expected.html
@@ -1,0 +1,24 @@
+<style>
+    .container {
+        position: absolute;
+        left: 10px;
+        top: 10px;
+        height: 200px;
+        width: 200px;
+        overflow: hidden;
+        border: 1px green solid;
+    }
+    .box {
+        position: absolute;
+        left: 100px;
+        top: 150px;
+        width: 100px;
+        height: 100px;
+        background: green;
+    }
+</style>
+<body>
+    <div class="container">
+        <div class="box"></div>
+    </div>
+</body>

--- a/LayoutTests/css3/filters/drop-shadow-filter-overflow.html
+++ b/LayoutTests/css3/filters/drop-shadow-filter-overflow.html
@@ -1,0 +1,25 @@
+<style>
+    .container {
+        position: absolute;
+        left: 10px;
+        top: 10px;
+        height: 200px;
+        width: 200px;
+        overflow: hidden;
+        border: 1px green solid;
+    }
+    .box {
+        position: absolute;
+        left: 100px;
+        top: 150px;
+        width: 100px;
+        height: 100px;
+        background: green;
+        filter: drop-shadow(black 10px 10px 0px);
+    }
+</style>
+<body>
+    <div class="container">
+        <div class="box"></div>
+    </div>
+</body>

--- a/Source/WebCore/platform/graphics/filters/FilterImageTargetSwitcher.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterImageTargetSwitcher.cpp
@@ -56,7 +56,7 @@ GraphicsContext* FilterImageTargetSwitcher::drawingContext(GraphicsContext& cont
     return m_sourceImage ? &m_sourceImage->context() : &context;
 }
 
-void FilterImageTargetSwitcher::beginClipAndDrawSourceImage(GraphicsContext& destinationContext, const FloatRect& repaintRect)
+void FilterImageTargetSwitcher::beginClipAndDrawSourceImage(GraphicsContext& destinationContext, const FloatRect& repaintRect, const FloatRect&)
 {
     if (auto* context = drawingContext(destinationContext)) {
         context->save();

--- a/Source/WebCore/platform/graphics/filters/FilterImageTargetSwitcher.h
+++ b/Source/WebCore/platform/graphics/filters/FilterImageTargetSwitcher.h
@@ -41,8 +41,10 @@ private:
 
     bool hasSourceImage() const override { return m_sourceImage; }
 
-    void beginClipAndDrawSourceImage(GraphicsContext& destinationContext, const FloatRect& repaintRect) override;
+    void beginClipAndDrawSourceImage(GraphicsContext& destinationContext, const FloatRect& repaintRect, const FloatRect& clipRect) override;
     void endClipAndDrawSourceImage(GraphicsContext& destinationContext) override;
+
+    void beginDrawSourceImage(GraphicsContext&) override { }
     void endDrawSourceImage(GraphicsContext& destinationContext) override;
 
     RefPtr<ImageBuffer> m_sourceImage;

--- a/Source/WebCore/platform/graphics/filters/FilterStyleTargetSwitcher.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterStyleTargetSwitcher.cpp
@@ -37,6 +37,16 @@ FilterStyleTargetSwitcher::FilterStyleTargetSwitcher(Filter& filter, const Float
 {
 }
 
+void FilterStyleTargetSwitcher::beginClipAndDrawSourceImage(GraphicsContext& destinationContext, const FloatRect&, const FloatRect& clipRect)
+{
+    for (auto& filterStyle : m_filterStyles) {
+        destinationContext.save();
+        destinationContext.clip(intersection(filterStyle.imageRect, clipRect));
+        destinationContext.setStyle(filterStyle.style);
+        destinationContext.beginTransparencyLayer(1);
+    }
+}
+
 void FilterStyleTargetSwitcher::beginDrawSourceImage(GraphicsContext& destinationContext)
 {
     for (auto& filterStyle : m_filterStyles) {

--- a/Source/WebCore/platform/graphics/filters/FilterStyleTargetSwitcher.h
+++ b/Source/WebCore/platform/graphics/filters/FilterStyleTargetSwitcher.h
@@ -36,6 +36,9 @@ public:
     FilterStyleTargetSwitcher(Filter&, const FloatRect &sourceImageRect);
 
 private:
+    void beginClipAndDrawSourceImage(GraphicsContext& destinationContext, const FloatRect& repaintRect, const FloatRect& clipRect) override;
+    void endClipAndDrawSourceImage(GraphicsContext& destinationContext) override { endDrawSourceImage(destinationContext); }
+
     void beginDrawSourceImage(GraphicsContext& destinationContext) override;
     void endDrawSourceImage(GraphicsContext& destinationContext) override;
 

--- a/Source/WebCore/platform/graphics/filters/FilterTargetSwitcher.h
+++ b/Source/WebCore/platform/graphics/filters/FilterTargetSwitcher.h
@@ -46,11 +46,11 @@ public:
 
     virtual bool hasSourceImage() const { return false; }
 
-    virtual void beginClipAndDrawSourceImage(GraphicsContext& destinationContext, const FloatRect&) { beginDrawSourceImage(destinationContext); }
-    virtual void endClipAndDrawSourceImage(GraphicsContext& destinationContext) { endDrawSourceImage(destinationContext); }
+    virtual void beginClipAndDrawSourceImage(GraphicsContext& destinationContext, const FloatRect& repaintRect, const FloatRect& clipRect) = 0;
+    virtual void endClipAndDrawSourceImage(GraphicsContext& destinationContext) = 0;
 
-    virtual void beginDrawSourceImage(GraphicsContext&) { }
-    virtual void endDrawSourceImage(GraphicsContext&) { }
+    virtual void beginDrawSourceImage(GraphicsContext& destinationContext) = 0;
+    virtual void endDrawSourceImage(GraphicsContext& destinationContext) = 0;
 
 protected:
     FilterTargetSwitcher(Filter&);

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -1106,8 +1106,8 @@ private:
     void clearLayerScrollableArea();
 
     RenderLayerFilters* filtersForPainting(GraphicsContext&, OptionSet<PaintLayerFlag>) const;
-    GraphicsContext* setupFilters(GraphicsContext& destinationContext, LayerPaintingInfo&, OptionSet<PaintLayerFlag>, const LayoutSize& offsetFromRoot);
-    void applyFilters(GraphicsContext& originalContext, const LayerPaintingInfo&, OptionSet<PaintBehavior>, const LayerFragments&);
+    GraphicsContext* setupFilters(GraphicsContext& destinationContext, LayerPaintingInfo&, OptionSet<PaintLayerFlag>, const LayoutSize& offsetFromRoot, const ClipRect& backgroundRect);
+    void applyFilters(GraphicsContext& originalContext, const LayerPaintingInfo&, OptionSet<PaintBehavior>, const ClipRect& backgroundRect);
 
     void paintLayer(GraphicsContext&, const LayerPaintingInfo&, OptionSet<PaintLayerFlag>);
     void paintLayerWithEffects(GraphicsContext&, const LayerPaintingInfo&, OptionSet<PaintLayerFlag>);

--- a/Source/WebCore/rendering/RenderLayerFilters.cpp
+++ b/Source/WebCore/rendering/RenderLayerFilters.cpp
@@ -134,7 +134,7 @@ IntOutsets RenderLayerFilters::calculateOutsets(RenderElement& renderer, const F
     return CSSFilter::calculateOutsets(renderer, operations, targetBoundingBox);
 }
 
-GraphicsContext* RenderLayerFilters::beginFilterEffect(RenderElement& renderer, GraphicsContext& context, const LayoutRect& filterBoxRect, const LayoutRect& dirtyRect, const LayoutRect& layerRepaintRect)
+GraphicsContext* RenderLayerFilters::beginFilterEffect(RenderElement& renderer, GraphicsContext& context, const LayoutRect& filterBoxRect, const LayoutRect& dirtyRect, const LayoutRect& layerRepaintRect, const LayoutRect& clipRect)
 {
     auto expandedDirtyRect = dirtyRect;
     auto targetBoundingBox = intersection(filterBoxRect, dirtyRect);
@@ -195,7 +195,7 @@ GraphicsContext* RenderLayerFilters::beginFilterEffect(RenderElement& renderer, 
     if (!m_targetSwitcher)
         return nullptr;
 
-    m_targetSwitcher->beginClipAndDrawSourceImage(context, m_repaintRect);
+    m_targetSwitcher->beginClipAndDrawSourceImage(context, m_repaintRect, clipRect);
 
     return m_targetSwitcher->drawingContext(context);
 }

--- a/Source/WebCore/rendering/RenderLayerFilters.h
+++ b/Source/WebCore/rendering/RenderLayerFilters.h
@@ -70,7 +70,7 @@ public:
     // Per render
     LayoutRect repaintRect() const { return m_repaintRect; }
 
-    GraphicsContext* beginFilterEffect(RenderElement&, GraphicsContext&, const LayoutRect& filterBoxRect, const LayoutRect& dirtyRect, const LayoutRect& layerRepaintRect);
+    GraphicsContext* beginFilterEffect(RenderElement&, GraphicsContext&, const LayoutRect& filterBoxRect, const LayoutRect& dirtyRect, const LayoutRect& layerRepaintRect, const LayoutRect& clipRect);
     void applyFilterEffect(GraphicsContext& destinationContext);
 
 private:


### PR DESCRIPTION
#### ddf4bec3e947abd7bf96aa06ec84f91e1a32d162
<pre>
[Filters] GraphicsContext filters have to apply clipping to the target context before drawing
<a href="https://bugs.webkit.org/show_bug.cgi?id=266383">https://bugs.webkit.org/show_bug.cgi?id=266383</a>
<a href="https://rdar.apple.com/118522654">rdar://118522654</a>

Reviewed by Simon Fraser.

Before applying the filter style and calling `beginTransparencyLayer()`, the
clipping rectangle of the target element has to be applied to the destination
GraphicsContext. Otherwise the hidden overflow drawing will appear once the
`endTransparencyLayer()` is called.

RenderLayer::paintLayerContents() needs to calculate the clipping rectangle
before calling setupFilters() so it can be passed to FilterStyleTargetSwitcher.

beginClipAndDrawSourceImage() and endClipAndDrawSourceImage() will be called
when applying CSSFilter. beginDrawSourceImage() and endDrawSourceImage() will
be called when applying the top-level SVGFilter since we clip to the bounding
rectangle of the root element.

* LayoutTests/css3/filters/drop-shadow-filter-overflow-expected.html: Added.
* LayoutTests/css3/filters/drop-shadow-filter-overflow.html: Added.
* Source/WebCore/platform/graphics/filters/FilterImageTargetSwitcher.cpp:
(WebCore::FilterImageTargetSwitcher::beginClipAndDrawSourceImage):
* Source/WebCore/platform/graphics/filters/FilterImageTargetSwitcher.h:
* Source/WebCore/platform/graphics/filters/FilterStyleTargetSwitcher.cpp:
(WebCore::FilterStyleTargetSwitcher::beginClipAndDrawSourceImage):
* Source/WebCore/platform/graphics/filters/FilterStyleTargetSwitcher.h:
* Source/WebCore/platform/graphics/filters/FilterTargetSwitcher.h:
(WebCore::FilterTargetSwitcher::beginClipAndDrawSourceImage): Deleted.
(WebCore::FilterTargetSwitcher::endClipAndDrawSourceImage): Deleted.
(WebCore::FilterTargetSwitcher::beginDrawSourceImage): Deleted.
(WebCore::FilterTargetSwitcher::endDrawSourceImage): Deleted.
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::setupFilters):
(WebCore::RenderLayer::applyFilters):
(WebCore::RenderLayer::paintLayerContents):
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayerFilters.cpp:
(WebCore::RenderLayerFilters::beginFilterEffect):
* Source/WebCore/rendering/RenderLayerFilters.h:

Canonical link: <a href="https://commits.webkit.org/272078@main">https://commits.webkit.org/272078@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ea1381d30992b5d725422718e597c6d84249c25

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30504 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9177 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32124 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33011 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27596 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31207 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11414 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6418 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27539 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30812 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7715 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27333 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6623 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6763 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27186 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34348 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27784 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27681 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32933 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6755 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4889 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30756 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8499 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/26956 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7228 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7501 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7296 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->