### PR TITLE
REGRESSION (271514@main): MSE Live playback fails on umediaserver.net

### DIFF
--- a/LayoutTests/media/media-source/media-source-append-buffer-durationchange-expected.txt
+++ b/LayoutTests/media/media-source/media-source-append-buffer-durationchange-expected.txt
@@ -1,0 +1,16 @@
+
+RUN(video.src = URL.createObjectURL(source))
+EVENT(sourceopen)
+RUN(source.duration = 0)
+RUN(sourceBuffer = source.addSourceBuffer("video/mock; codecs=mock"))
+RUN(sourceBuffer.appendBuffer(initSegment))
+EXPECTED (sourceBuffer.updating == 'true') OK
+EVENT(updateend)
+EXPECTED (source.duration == '0') OK
+EXPECTED (sourceBuffer.updating == 'false') OK
+RUN(sourceBuffer.appendBuffer(mediaSegment))
+EVENT(durationchange)
+EVENT(updateend)
+EXPECTED (source.duration == '16') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-append-buffer-durationchange.html
+++ b/LayoutTests/media/media-source/media-source-append-buffer-durationchange.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>mock-media-source</title>
+    <script src="mock-media-source.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    var source;
+    var sourceBuffer;
+    var initSegment;
+    var mediaSegment;
+
+    if (window.internals)
+        internals.initializeMockMediaSource();
+
+    function runTest() {
+        findMediaElement();
+
+        source = new MediaSource();
+        waitForEventOn(source, 'sourceopen', sourceOpen);
+        run('video.src = URL.createObjectURL(source)');
+    }
+
+    async function sourceOpen() {
+        run('source.duration = 0');
+        run('sourceBuffer = source.addSourceBuffer("video/mock; codecs=mock")');
+
+        initSegment = makeAInit(100, [makeATrack(1, 'mock', TRACK_KIND.VIDEO)]);
+        run('sourceBuffer.appendBuffer(initSegment)');
+        testExpected('sourceBuffer.updating', true);
+        await Promise.all([ waitForEvent(sourceBuffer, 'update'), waitFor(sourceBuffer, 'updateend') ]);
+        testExpected('source.duration', 0);
+        testExpected('sourceBuffer.updating', false);
+        mediaSegment = concatenateSamples([
+            makeASample(0,  0,  1, 1, 1, SAMPLE_FLAG.SYNC, 0)
+            , makeASample(1,  1,  1, 1, 1, SAMPLE_FLAG.NONE, 0)
+            , makeASample(2,  2,  1, 1, 1, SAMPLE_FLAG.NONE, 0)
+            , makeASample(3,  3,  1, 1, 1, SAMPLE_FLAG.NONE, 0)
+            , makeASample(4,  4,  1, 1, 1, SAMPLE_FLAG.SYNC, 0)
+            , makeASample(5,  5,  1, 1, 1, SAMPLE_FLAG.NONE, 0)
+            , makeASample(6,  6,  1, 1, 1, SAMPLE_FLAG.NONE, 0)
+            , makeASample(7,  7,  1, 1, 1, SAMPLE_FLAG.NONE, 0)
+            , makeASample(8,  8,  1, 1, 1, SAMPLE_FLAG.SYNC, 0)
+            , makeASample(9,  9,  1, 1, 1, SAMPLE_FLAG.NONE, 0)
+            , makeASample(10, 10, 1, 1, 1, SAMPLE_FLAG.NONE, 0)
+            , makeASample(11, 11, 1, 1, 1, SAMPLE_FLAG.NONE, 0)
+            , makeASample(12, 12, 1, 1, 1, SAMPLE_FLAG.SYNC, 0)
+            , makeASample(13, 13, 1, 1, 1, SAMPLE_FLAG.NONE, 0)
+            , makeASample(14, 14, 1, 1, 1, SAMPLE_FLAG.NONE, 0)
+            , makeASample(15, 15, 1, 1, 1, SAMPLE_FLAG.NONE, 0)
+        ]);
+        run('sourceBuffer.appendBuffer(mediaSegment)');
+        await Promise.all([ waitForEvent(sourceBuffer, 'update'), waitFor(sourceBuffer, 'updateend'), waitFor(video, 'durationchange') ]);
+        testExpected('source.duration', 16);
+        endTest();
+    }
+
+    </script>
+</head>
+<body onload="runTest()">
+    <video></video>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm
@@ -95,6 +95,7 @@ MediaSourcePrivate::AddStatus MediaSourcePrivateAVFObjC::addSourceBuffer(const C
     newSourceBuffer->setCDMInstance(m_cdmInstance.get());
 #endif
     outPrivate = newSourceBuffer.copyRef();
+    newSourceBuffer->setMediaSourceDuration(duration());
     m_sourceBuffers.append(WTFMove(newSourceBuffer));
 
     return AddStatus::Ok;

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
@@ -90,6 +90,7 @@ MediaSourcePrivateGStreamer::AddStatus MediaSourcePrivateGStreamer::addSourceBuf
 
     m_sourceBuffers.append(SourceBufferPrivateGStreamer::create(*this, contentType, m_playerPrivate));
     sourceBufferPrivate = m_sourceBuffers.last();
+    sourceBufferPrivate->setMediaSourceDuration(duration());
     return MediaSourcePrivateGStreamer::AddStatus::Ok;
 }
 

--- a/Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.cpp
@@ -68,6 +68,7 @@ MediaSourcePrivate::AddStatus MockMediaSourcePrivate::addSourceBuffer(const Cont
 
     m_sourceBuffers.append(MockSourceBufferPrivate::create(*this));
     outPrivate = m_sourceBuffers.last();
+    outPrivate->setMediaSourceDuration(duration());
 
     return AddStatus::Ok;
 }


### PR DESCRIPTION
#### 9f3ddc119f3ec5ccf79bf50cc76d3e81f03b1cba
<pre>
REGRESSION (271514@main): MSE Live playback fails on umediaserver.net
<a href="https://bugs.webkit.org/show_bug.cgi?id=266385">https://bugs.webkit.org/show_bug.cgi?id=266385</a>
<a href="https://rdar.apple.com/119615258">rdar://119615258</a>

Reviewed by Jer Noble.

Changes in 271514@main exposed an underlying existing issue. The MediaSource&apos;s duration was initialised to NaN
but the GPU process one was initialised to 0. Following 271514@main the inital value would be identical.

If the media source duration was set prior any sourcebuffer being created, we wouldn&apos;t set the SourceBuffer
initial duration, and the step `If the media segment contains data beyond the current duration, then run the duration change algorithm with new duration set to the maximum of the current duration and the [[group end timestamp]].`
would always be skipped.

We set the initial duration to the sourceBuffer when created.

Add tests.

* LayoutTests/media/media-source/media-source-append-buffer-durationchange-expected.txt: Added.
* LayoutTests/media/media-source/media-source-append-buffer-durationchange.html: Added.
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm:
(WebCore::MediaSourcePrivateAVFObjC::addSourceBuffer):
* Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp:
(WebCore::MediaSourcePrivateGStreamer::addSourceBuffer):
* Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.cpp:
(WebCore::MockMediaSourcePrivate::addSourceBuffer):

Canonical link: <a href="https://commits.webkit.org/272025@main">https://commits.webkit.org/272025@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/947f8b1f15dc1a04dfc8258e60d809db61d84f61

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30388 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9062 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31996 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32896 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27488 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31088 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11288 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6297 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27443 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30696 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7605 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/27254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6517 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6660 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27078 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34234 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27694 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27580 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32846 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6646 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4791 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30667 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8402 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/26839 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7201 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7394 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7187 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->