### PR TITLE
[GTK][WPE] Require 'wayland' 1.20 after 272021@main

### DIFF
--- a/Source/cmake/OptionsGTK.cmake
+++ b/Source/cmake/OptionsGTK.cmake
@@ -379,7 +379,7 @@ if (ENABLE_WAYLAND_TARGET)
         message(FATAL_ERROR "Recompile GTK with Wayland backend to use ENABLE_WAYLAND_TARGET")
     endif ()
 
-    find_package(Wayland 1.18 REQUIRED)
+    find_package(Wayland 1.20 REQUIRED)
     find_package(WaylandProtocols 1.24 REQUIRED)
 endif ()
 

--- a/Source/cmake/OptionsWPE.cmake
+++ b/Source/cmake/OptionsWPE.cmake
@@ -304,7 +304,7 @@ if (ENABLE_WPE_PLATFORM)
     endif ()
 
     if (ENABLE_WPE_PLATFORM_WAYLAND)
-        find_package(Wayland 1.18 REQUIRED)
+        find_package(Wayland 1.20 REQUIRED)
         find_package(WaylandProtocols 1.24 REQUIRED)
         SET_AND_EXPOSE_TO_BUILD(ENABLE_WPE_PLATFORM_WAYLAND ON)
         set(WPE_PLATFORM_WAYLAND ON)

--- a/Tools/gtk/jhbuild.modules
+++ b/Tools/gtk/jhbuild.modules
@@ -339,11 +339,11 @@
     </branch>
   </autotools>
 
-  <meson id="wayland" mesonargs="-Ddocumentation=false -Ddtd_validation=false">
+  <meson id="wayland" mesonargs="-Ddocumentation=false -Ddtd_validation=false -Dtests=false">
     <pkg-config>wayland-server.pc</pkg-config>
     <branch module="wayland/wayland"
-            version="1.18.0"
-            tag="1.18.0"
+            version="1.20.0"
+            tag="1.20.0"
             checkoutdir="wayland"
             repo="git.freedesktop.org" />
   </meson>

--- a/Tools/jhbuild/jhbuild-minimal.modules
+++ b/Tools/jhbuild/jhbuild-minimal.modules
@@ -251,11 +251,11 @@
     </branch>
   </cmake>
 
-  <meson id="wayland" mesonargs="-Ddocumentation=false -Ddtd_validation=false">
+  <meson id="wayland" mesonargs="-Ddocumentation=false -Ddtd_validation=false -Dtests=false">
     <pkg-config>wayland-server.pc</pkg-config>
     <branch module="wayland/wayland"
-            version="1.18.0"
-            tag="1.18.0"
+            version="1.20.0"
+            tag="1.20.0"
             checkoutdir="wayland"
             repo="git.freedesktop.org" />
   </meson>

--- a/Tools/wpe/jhbuild.modules
+++ b/Tools/wpe/jhbuild.modules
@@ -225,11 +225,11 @@
             version="1.5.4" repo="github-tarball"/>
   </meson>
 
-  <meson id="wayland" mesonargs="-Ddocumentation=false -Ddtd_validation=false">
+  <meson id="wayland" mesonargs="-Ddocumentation=false -Ddtd_validation=false -Dtests=false">
     <pkg-config>wayland-server.pc</pkg-config>
     <branch module="wayland/wayland"
-            version="1.18.0"
-            tag="1.18.0"
+            version="1.20.0"
+            tag="1.20.0"
             checkoutdir="wayland"
             repo="git.freedesktop.org" />
   </meson>


### PR DESCRIPTION
#### 845bcf162b240d28851bc92da33a0fb5e84f11e0
<pre>
[GTK][WPE] Require &apos;wayland&apos; 1.20 after 272021@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=266394">https://bugs.webkit.org/show_bug.cgi?id=266394</a>

Reviewed by Carlos Garcia Campos.

Fixes linking error. Symbol &apos;wl_proxy_marshal_flags&apos; is only defined
since wayland 1.20.

* Source/cmake/OptionsGTK.cmake:
* Source/cmake/OptionsWPE.cmake:
* Tools/gtk/jhbuild.modules:
* Tools/jhbuild/jhbuild-minimal.modules:
* Tools/wpe/jhbuild.modules:

Canonical link: <a href="https://commits.webkit.org/272026@main">https://commits.webkit.org/272026@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b67e78eea7985218aa6918f50f9bd52618030703

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30411 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9085 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32021 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32922 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27507 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31113 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11316 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6322 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/27468 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30719 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7635 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/27267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6544 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6686 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27103 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34259 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/26111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/27710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27597 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32871 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/30517 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6668 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/4813 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30694 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8419 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/36956 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7199 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7410 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7955 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7210 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->