### PR TITLE
REGRESSION (271863@main): [ macOS iOS ] imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback-webrtc.https.html is a flaky failure

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/video-rvfc/idlharness.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/video-rvfc/idlharness.window.html
@@ -1,2 +1,1 @@
-<!doctype html><!-- webkit-test-runner [ RequestVideoFrameCallbackEnabled=true ] -->
-<!-- This file is required for WebKit test infrastructure to run the templated test -->
+<!-- This file is required for WebKit test infrastructure to run the templated test --><!-- webkit-test-runner [ RequestVideoFrameCallbackEnabled=true ] -->

--- a/LayoutTests/imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback-during-xr-session.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback-during-xr-session.https.html
@@ -2,7 +2,7 @@
 <html>
 <title>Test that video.rVFC callbacks started during an XRSession work.</title>
 <body>
-    <canvas/>
+    <canvas></canvas>
 </body>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback-webrtc.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback-webrtc.https.html
@@ -9,8 +9,7 @@
   <div id="log"></div>
   <div>
     <video id="local-view" muted autoplay="autoplay"></video>
-    <video id="remote-view" muted autoplay="autoplay"/>
-    </video>
+    <video id="remote-view" muted autoplay="autoplay"></video>
   </div>
 
   <!-- These files are in place when executing on W3C. -->
@@ -27,9 +26,7 @@
 
   var gFirstConnection = null;
   var gSecondConnection = null;
-  var gCallbackCounter = 0;
   var verify_params = (now, metadata) => {
-    gCallbackCounter = gCallbackCounter + 1;
     assert_greater_than(now, 0);
 
     // Verify all required fields
@@ -43,15 +40,7 @@
     // Verify WebRTC only fields.
     assert_true("rtpTimestamp" in metadata, "rtpTimestamp should be present");
     assert_true("receiveTime" in metadata, "receiveTime should be present");
-    // captureTime is not available until roundtrip time estimation is done.
-    if (gCallbackCounter > 60 || "captureTime" in metadata) {
-      assert_true("captureTime" in metadata, "captureTime should be present");
-      test.done();
-    }
-    else {
-      // Keep requesting callbacks.
-      document.getElementById('remote-view').requestVideoFrameCallback(test.step_func(verify_params));
-    }
+    // Verifying that captureTime is too unreliable to be included in tests.
   }
 
   var verify_local_metadata = (now, metadata) => {
@@ -67,7 +56,7 @@
   // as well as the ICE and DTLS connection are up.
   document.getElementById('remote-view')
       .addEventListener('loadedmetadata', function() {
-    document.getElementById('remote-view').requestVideoFrameCallback(test.step_func(verify_params));
+    document.getElementById('remote-view').requestVideoFrameCallback(test.step_func_done(verify_params));
   });
 
   document.getElementById('local-view')


### PR DESCRIPTION
#### 00ac50ab6b96e925e75429bd0a40f632c1efda1d
<pre>
REGRESSION (271863@main): [ macOS iOS ] imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback-webrtc.https.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=266356">https://bugs.webkit.org/show_bug.cgi?id=266356</a>
<a href="https://rdar.apple.com/119621367">rdar://119621367</a>

Reviewed by Eric Carlson.

captureTime testing was discovered flaky so was removed from WPT.
Let&apos;s resync the tests.

* LayoutTests/imported/w3c/web-platform-tests/video-rvfc/idlharness.window.html:
* LayoutTests/imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback-during-xr-session.https.html:
* LayoutTests/imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback-webrtc.https.html:

Canonical link: <a href="https://commits.webkit.org/272099@main">https://commits.webkit.org/272099@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e328b9a1143209112cc1aef91587f33bb8cec0ee

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30412 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9086 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32022 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32923 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27508 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11317 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6323 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27467 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30720 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7637 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27268 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6543 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6688 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27104 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34260 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27711 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27601 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32872 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6669 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4814 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30695 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8420 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/26867 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7246 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7411 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7211 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->