### PR TITLE
REGRESSION(iOS17): [ iOS17 wk2 ] accessibility/ios-simulator/input-type-time.html is a constant failure.

### DIFF
--- a/LayoutTests/accessibility/ios-simulator/input-type-time-expected.txt
+++ b/LayoutTests/accessibility/ios-simulator/input-type-time-expected.txt
@@ -6,9 +6,9 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 PASS timeinput.description is 'AXLabel: (Between: 07:00 AM-09:00 AM)'
 PASS timeinput.isIgnored is false
-PASS timeinput.stringValue is 'AXValue: 8:00 AM'
+PASS timeinput.stringValue is 'AXValue: 8:00 AM'
 PASS timeinput2.description is 'AXLabel: '
-PASS timeinput2.stringValue is 'AXValue: 8:00 AM'
+PASS timeinput2.stringValue is 'AXValue: 8:00 AM'
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/accessibility/ios-simulator/input-type-time.html
+++ b/LayoutTests/accessibility/ios-simulator/input-type-time.html
@@ -1,6 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
+<meta charset=utf-8>
 <script>
 var successfullyParsed = false;
 </script>
@@ -26,9 +27,9 @@ var successfullyParsed = false;
         shouldBeFalse("timeinput.isIgnored");
         
         // Test value is exposed in AXValue.
-        shouldBe("timeinput.stringValue", "'AXValue: 8:00 AM'");
+        shouldBe("timeinput.stringValue", "'AXValue: 8:00 AM'");
         shouldBe("timeinput2.description", "'AXLabel: '");
-        shouldBe("timeinput2.stringValue", "'AXValue: 8:00 AM'");
+        shouldBe("timeinput2.stringValue", "'AXValue: 8:00 AM'");
     }
 
     successfullyParsed = true;
@@ -37,4 +38,3 @@ var successfullyParsed = false;
 <script src="../../resources/js-test-post.js"></script>
 </body>
 </html>
-

--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -2427,8 +2427,6 @@ webkit.org/b/261957 media/audio-play-with-video-element-interrupted.html [ Pass 
 # Requires the fix in rdar://108457321.
 css3/scroll-snap/ios/scroll-snap-mainframe-pinch-out.html [ Skip ]
 
-webkit.org/b/263048 accessibility/ios-simulator/input-type-time.html [ Failure ]
-
 webkit.org/b/263052 fast/events/ios/keydown-keyup-keypress-keys-in-non-editable-using-chinese-keyboard.html [ Skip ]
 
 webkit.org/b/263662 fast/forms/listbox-bidi-align.html [ Failure ]


### PR DESCRIPTION
#### 7f798b86786a69fa32a8d351effc50b343cbc325
<pre>
REGRESSION(iOS17): [ iOS17 wk2 ] accessibility/ios-simulator/input-type-time.html is a constant failure.
<a href="https://bugs.webkit.org/show_bug.cgi?id=263048">https://bugs.webkit.org/show_bug.cgi?id=263048</a>
<a href="https://rdar.apple.com/116837628">rdar://116837628</a>

Reviewed by Chris Fleizach.

CLDR 42 replaced U+0020 with U+202F when formatting dates. That does
not seem like a sustainable change, but here it is.

As such nothing regressed with regards to what this test was testing.

* LayoutTests/accessibility/ios-simulator/input-type-time-expected.txt:
* LayoutTests/accessibility/ios-simulator/input-type-time.html:
* LayoutTests/platform/ios-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/272041@main">https://commits.webkit.org/272041@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3304d451523cfa5aba965563b7f8d00b731da1e6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30416 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9090 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32026 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32927 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27512 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11321 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6327 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27470 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30724 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7640 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27271 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6546 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6690 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27106 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34264 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27713 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27603 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32874 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6673 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4817 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30697 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8424 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/26869 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7415 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3937 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7215 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->