### PR TITLE
[CMake] Allow enabling C++ library assertions if supported

### DIFF
--- a/Source/cmake/OptionsCommon.cmake
+++ b/Source/cmake/OptionsCommon.cmake
@@ -216,6 +216,54 @@ if (USE_OPENMP)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
 endif ()
 
+# Detect the kind of C++ standard library being used, to enable assertions.
+set(CXX_STDLIB_VARIANT "UNKNOWN")
+set(CXX_STDLIB_ASSERTIONS_MACRO)
+set(CXX_STDLIB_TEST_SOURCE "
+    #if defined(__clang__)
+    #include <utility>
+    int main() { return _LIBCPP_VERSION; }
+    #else
+    #error Clang needed for libc++
+    #endif
+")
+check_cxx_source_compiles("${CXX_STDLIB_TEST_SOURCE}" CXX_STDLIB_IS_LIBCPP)
+if (CXX_STDLIB_IS_LIBCPP)
+    set(CXX_STDLIB_VARIANT "LIBCPP")
+    set(CXX_STDLIB_ASSERTIONS_MACRO _LIBCPP_ENABLE_ASSERTIONS)
+else ()
+    set(CXX_STDLIB_TEST_SOURCE "
+    #include <utility>
+    int main() { return _GLIBCXX_RELEASE; }
+    ")
+    check_cxx_source_compiles("${CXX_STDLIB_TEST_SOURCE}" CXX_STDLIB_IS_GLIBCXX)
+    if (CXX_STDLIB_IS_GLIBCXX)
+        set(CXX_STDLIB_VARIANT "GLIBCXX")
+        set(CXX_STDLIB_ASSERTIONS_MACRO _GLIBCXX_ASSERTIONS)
+    endif ()
+endif ()
+message(STATUS "C++ standard library in use: ${CXX_STDLIB_VARIANT}")
+
+if (CXX_STDLIB_ASSERTIONS_MACRO)
+    set(USE_CXX_STDLIB_ASSERTIONS_DEFAULT ON)
+else ()
+    set(USE_CXX_STDLIB_ASSERTIONS_DEFAULT OFF)
+endif ()
+option(USE_CXX_STDLIB_ASSERTIONS
+    "Enable lightweight run-time assertions in the C++ standard library"
+    ${USE_CXX_STDLIB_ASSERTIONS_DEFAULT})
+
+if (USE_CXX_STDLIB_ASSERTIONS)
+    if (CXX_STDLIB_ASSERTIONS_MACRO)
+        message(STATUS "  Assertions enabled, ${CXX_STDLIB_ASSERTIONS_MACRO}=1")
+        add_compile_definitions("${CXX_STDLIB_ASSERTIONS_MACRO}=1")
+    else ()
+        message(STATUS "  Assertions disabled, CXX_STDLIB_ASSERTIONS_MACRO undefined")
+    endif ()
+else ()
+    message(STATUS "  Assertions disabled, USE_CXX_STDLIB_ASSERTIONS=${USE_CXX_STDLIB_ASSERTIONS}")
+endif ()
+
 # GTK and WPE use the GNU installation directories as defaults.
 if (NOT PORT STREQUAL "GTK" AND NOT PORT STREQUAL "WPE")
     set(LIB_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/lib" CACHE PATH "Absolute path to library installation directory")


### PR DESCRIPTION
#### 3b5d8ebc05c0985537639b9eaa92ab722607a2fa
<pre>
[CMake] Allow enabling C++ library assertions if supported
<a href="https://bugs.webkit.org/show_bug.cgi?id=266396">https://bugs.webkit.org/show_bug.cgi?id=266396</a>

Reviewed by Michael Catanzaro.

Detect which C++ library is being used, and for the supported ones apply
the needed compilation options to have their assertions enabled. The
_LIBCPP_VERSION macro is used to detect libc++, and _GLIBCXX_RELEASE for
GNU libstdc++. If any of these C++ libraries are detected, then their
assertions are enabled by default. A new USE_CXX_STDLIB_ASSERTIONS CMake
option may be used used to override the default setting.

This change does not attempt to choose whether to use libc++, and the
mechanism to choose the C++ library being used remains unchanged. To
change e.g. from the GNU library to libc++ one still needs to set
environment variables accordingly before invoking CMake:

  CXX=clang++ CXXFLAGS=&apos;-stdlib=libc++&apos; LDFLAGS=&apos;-stdlib=libc++&apos; cmake ...

* Source/cmake/OptionsCommon.cmake: Add checks to determine which C++
standard library is being used and enable assertions where possible.

Canonical link: <a href="https://commits.webkit.org/290394@main">https://commits.webkit.org/290394@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0839d8b4bf494ff09a436a5361f90523a0450b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89563 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9090 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44422 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94555 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40330 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9479 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17369 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69004 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26638 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92564 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7281 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81287 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49368 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7012 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39436 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/82361 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77366 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36676 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96383 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/88338 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16745 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12296 "Found 3 new test failures: http/tests/pdf/linearized-pdf-in-display-none-iframe.html imported/w3c/web-platform-tests/css/selectors/invalidation/modal-pseudo-class-in-has.html pdf/pdf-in-styled-embed.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77870 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17000 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77090 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77186 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21605 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20192 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9912 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14116 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16758 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/110831 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16499 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26568 "Found 4 new JSC stress test failures: wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.default-wasm, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.wasm-slow-memory, wasm.yaml/wasm/stress/repro_1289.js.default-wasm, wasm.yaml/wasm/stress/repro_1289.js.wasm-collect-continuously (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19950 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18281 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->