### PR TITLE
[WebGPU] Fix redundant move in return statement in expansion of macro WTFMove

### DIFF
--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.cpp
@@ -63,7 +63,7 @@ Ref<WebCore::WebGPU::RenderPassEncoder> RemoteCommandEncoderProxy::beginRenderPa
 
     auto result = RemoteRenderPassEncoderProxy::create(*this, m_convertToBackingContext, identifier);
     result->setLabel(WTFMove(convertedDescriptor->label));
-    return WTFMove(result);
+    return result;
 }
 
 Ref<WebCore::WebGPU::ComputePassEncoder> RemoteCommandEncoderProxy::beginComputePass(const std::optional<WebCore::WebGPU::ComputePassDescriptor>& descriptor)
@@ -83,7 +83,7 @@ Ref<WebCore::WebGPU::ComputePassEncoder> RemoteCommandEncoderProxy::beginCompute
 
     auto result = RemoteComputePassEncoderProxy::create(*this, m_convertToBackingContext, identifier);
     result->setLabel(WTFMove(convertedDescriptor->label));
-    return WTFMove(result);
+    return result;
 }
 
 void RemoteCommandEncoderProxy::copyBufferToBuffer(


### PR DESCRIPTION
#### 512102a14ecc30ddde7126b52bd5156ed2e1849b
<pre>
[WebGPU] Fix redundant move in return statement in expansion of macro WTFMove
<a href="https://bugs.webkit.org/show_bug.cgi?id=266398">https://bugs.webkit.org/show_bug.cgi?id=266398</a>

Reviewed by Mike Wyrzykowski.

This change fix a trivial build error in WPEWebKit and WebKitGTK when
ENABLE_GPU_PROCESS=ON.

* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.cpp:
(WebKit::WebGPU::RemoteCommandEncoderProxy::beginRenderPass):
(WebKit::WebGPU::RemoteCommandEncoderProxy::beginComputePass):

Canonical link: <a href="https://commits.webkit.org/272045@main">https://commits.webkit.org/272045@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23582c98694b432fb96b9345ce32a1ae67b15022

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30425 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9099 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32035 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32936 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27521 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11332 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6336 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27476 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30733 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7652 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27283 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6552 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6704 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34273 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27723 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27620 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32880 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6682 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4854 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30703 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8433 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7211 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7424 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7224 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->