### PR TITLE
[Nicosia] Adapt RemoteGraphicsContextGLProxyGBM to the Nicosa latest changes

### DIFF
--- a/Source/WebKit/WebProcess/GPU/graphics/gbm/RemoteGraphicsContextGLProxyGBM.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/gbm/RemoteGraphicsContextGLProxyGBM.cpp
@@ -39,13 +39,13 @@
 #include "WebProcess.h"
 #include <WebCore/DMABufObject.h>
 #include <WebCore/GraphicsLayerContentsDisplayDelegate.h>
-#include <WebCore/NicosiaContentLayerTextureMapperImpl.h>
+#include <WebCore/NicosiaContentLayer.h>
 #include <WebCore/TextureMapperFlags.h>
 #include <WebCore/TextureMapperPlatformLayerProxyDMABuf.h>
 
 namespace WebKit {
 
-class NicosiaDisplayDelegate final : public WebCore::GraphicsLayerContentsDisplayDelegate, public Nicosia::ContentLayerTextureMapperImpl::Client {
+class NicosiaDisplayDelegate final : public WebCore::GraphicsLayerContentsDisplayDelegate, public Nicosia::ContentLayer::Client {
 public:
     explicit NicosiaDisplayDelegate(bool isOpaque);
     virtual ~NicosiaDisplayDelegate();
@@ -59,7 +59,7 @@ private:
     // WebCore::GraphicsLayerContentsDisplayDelegate
     Nicosia::PlatformLayer* platformLayer() const final;
 
-    // Nicosia::ContentLayerTextureMapperImpl::Client
+    // Nicosia::ContentLayer::Client
     void swapBuffersIfNeeded() final;
 
     bool m_isOpaque { false };
@@ -70,7 +70,7 @@ private:
 NicosiaDisplayDelegate::NicosiaDisplayDelegate(bool isOpaque)
     : m_isOpaque(isOpaque)
 {
-    m_contentLayer = Nicosia::ContentLayer::create(Nicosia::ContentLayerTextureMapperImpl::createFactory(*this, adoptRef(*new WebCore::TextureMapperPlatformLayerProxyDMABuf)));
+    m_contentLayer = Nicosia::ContentLayer::create(*this, adoptRef(*new WebCore::TextureMapperPlatformLayerProxyDMABuf));
 }
 
 NicosiaDisplayDelegate::~NicosiaDisplayDelegate()
@@ -83,7 +83,7 @@ Nicosia::PlatformLayer* NicosiaDisplayDelegate::platformLayer() const
 
 void NicosiaDisplayDelegate::swapBuffersIfNeeded()
 {
-    auto& proxy = downcast<Nicosia::ContentLayerTextureMapperImpl>(m_contentLayer->impl()).proxy();
+    auto& proxy = m_contentLayer->proxy();
     ASSERT(is<WebCore::TextureMapperPlatformLayerProxyDMABuf>(proxy));
 
     if (!!m_pending.handle) {


### PR DESCRIPTION
#### 7ab52a6c425450f5a640db5940a6e4ccd02e6226
<pre>
[Nicosia] Adapt RemoteGraphicsContextGLProxyGBM to the Nicosa latest changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=266401">https://bugs.webkit.org/show_bug.cgi?id=266401</a>

Reviewed by Carlos Garcia Campos.

This change fixes the build with GPUProcess enabled by adapting the
RemoteGraphicsContextGLProxyGBM according with the changes made in
269998@main (ee8fbcb55b4a):

  Fix GBM GPU: [Nicosia] Simplify NicosiaPlatformLayer
  <a href="https://bugs.webkit.org/show_bug.cgi?id=263775">https://bugs.webkit.org/show_bug.cgi?id=263775</a>

* Source/WebKit/WebProcess/GPU/graphics/gbm/RemoteGraphicsContextGLProxyGBM.cpp:
(WebKit::NicosiaDisplayDelegate::NicosiaDisplayDelegate):
(WebKit::NicosiaDisplayDelegate::swapBuffersIfNeeded):

Canonical link: <a href="https://commits.webkit.org/272042@main">https://commits.webkit.org/272042@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b596feaaa4f95b61e038d9b9fea0177e63fe14f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30427 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9101 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32037 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32938 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27523 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11334 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6338 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27478 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30735 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7650 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27282 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6554 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6702 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34275 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27721 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27619 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32882 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6684 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4833 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30705 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8435 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7210 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7426 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7226 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->