### PR TITLE
[CSS] Implement :scope in @scope prelude

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-evaluation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-evaluation-expected.txt
@@ -4,9 +4,9 @@ PASS Scope can not match its own root without :scope
 PASS Selecting self with :scope
 PASS Single scope with limit
 PASS Single scope, :scope pseudo in main selector
-FAIL Single scope, :scope pseudo in to-selector assert_equals: expected "rgb(0, 0, 0)" but got "rgb(0, 128, 0)"
-FAIL Multiple scopes, :scope pseudo in to-selector assert_equals: expected "rgb(0, 0, 0)" but got "rgb(0, 128, 0)"
-FAIL Inner @scope with :scope in from-selector assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS Single scope, :scope pseudo in to-selector
+PASS Multiple scopes, :scope pseudo in to-selector
+PASS Inner @scope with :scope in from-selector
 PASS Multiple scopes from same @scope-rule, only one limited
 PASS Multiple scopes from same @scope-rule, both limited
 PASS Nested scopes
@@ -15,7 +15,7 @@ PASS Nested scopes, with to-selector
 PASS :scope selecting itself
 PASS The scoping limit is not in scope
 PASS Simulated inclusive scoping limit
-FAIL Scope with no elements assert_equals: expected "rgb(0, 0, 0)" but got "rgb(0, 128, 0)"
+PASS Scope with no elements
 PASS :scope direct adjacent sibling
 PASS :scope indirect adjacent sibling
 PASS Relative selector inside @scope

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-invalidation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-invalidation-expected.txt
@@ -19,7 +19,7 @@ PASS Element becoming root via + combinator
 PASS :not(scope) in subject
 PASS :not(scope) in ancestor
 PASS :not(scope) in limit subject
-FAIL :not(scope) in limit ancestor assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS :not(scope) in limit ancestor
 FAIL :nth-child() in scope root assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 PASS :nth-child() in scope limit
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-nesting-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-nesting-expected.txt
@@ -1,13 +1,13 @@
 
-FAIL Nesting-selector in <scope-end> assert_equals: expected "auto" but got "1"
-FAIL Implicit :scope in <scope-end> assert_equals: expected "1" but got "42"
-PASS Relative selectors in <scope-end>
+PASS Nesting-selector in <scope-end>
+FAIL Implicit :scope in <scope-end> assert_equals: expected "1" but got "auto"
+FAIL Relative selectors in <scope-end> assert_equals: expected "1" but got "auto"
 PASS Nesting-selector in the scope's <stylesheet>
 PASS Nesting-selector within :scope rule
 PASS Nesting-selector within :scope rule (double nested)
 PASS @scope nested within style rule
 PASS Parent pseudo class within scope-start
-FAIL Parent pseudo class within scope-end assert_equals: limit element is not in scope expected "auto" but got "1"
+PASS Parent pseudo class within scope-end
 FAIL Parent pseudo class within body of nested @scope assert_equals: non-matching: DIVb c expected "auto" but got "1"
 FAIL Implicit rule within nested @scope  assert_equals: expected "1" but got "auto"
 FAIL Implicit rule within nested @scope (proximity) assert_equals: expected "1" but got "2"

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-visited-cssom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-visited-cssom-expected.txt
@@ -13,6 +13,6 @@ PASS :not(:visited) as scoping root, :scope
 PASS :not(:link) as scoping root, :scope
 PASS :link as scoping limit
 FAIL :visited as scoping limit assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 255, 255)"
-PASS :not(:link) as scoping limit
+FAIL :not(:link) as scoping limit assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 255, 255)"
 PASS :not(:visited) as scoping limit
 


### PR DESCRIPTION
#### f99c196be2946f17e35e52ff6e4355643943df9b
<pre>
[CSS] Implement :scope in @scope prelude
<a href="https://bugs.webkit.org/show_bug.cgi?id=266405">https://bugs.webkit.org/show_bug.cgi?id=266405</a>
<a href="https://rdar.apple.com/119661541">rdar://119661541</a>

Reviewed by Antti Koivisto.

:scope in &lt;scope-start&gt; represents the outter scoping root,
:scope in &lt;scope-end&gt; represents the inner scoping root.

<a href="https://drafts.csswg.org/css-cascade-6/#scope-limits">https://drafts.csswg.org/css-cascade-6/#scope-limits</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-evaluation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-invalidation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-nesting-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-visited-cssom-expected.txt:
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::scopeRulesMatch):

Canonical link: <a href="https://commits.webkit.org/272065@main">https://commits.webkit.org/272065@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/008f16eb47daae7947cb62fc47d29975fa2412f5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30441 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9115 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32060 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32953 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27538 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31144 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11349 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6354 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27483 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30750 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7660 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27296 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6560 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6745 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27136 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34290 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27731 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27636 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32888 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6698 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4842 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30712 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8448 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7221 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7438 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7240 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->