### PR TITLE
[web-animations] rename and move KeyframeList

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -561,6 +561,7 @@ animation/AnimationEffectTiming.cpp
 animation/AnimationEventBase.cpp
 animation/AnimationPlaybackEvent.cpp
 animation/AnimationTimeline.cpp
+animation/BlendingKeyframes.cpp
 animation/CSSAnimation.cpp
 animation/CSSAnimationEvent.cpp
 animation/CSSPropertyAnimation.cpp
@@ -2709,7 +2710,6 @@ rendering/style/GapLength.cpp
 rendering/style/GridPosition.cpp
 rendering/style/GridPositionsResolver.cpp
 rendering/style/GridTrackSize.cpp
-rendering/style/KeyframeList.cpp
 rendering/style/ListStyleType.cpp
 rendering/style/NinePieceImage.cpp
 rendering/style/OffsetRotation.cpp

--- a/Source/WebCore/animation/BlendingKeyframes.h
+++ b/Source/WebCore/animation/BlendingKeyframes.h
@@ -43,9 +43,9 @@ namespace Style {
 class Resolver;
 }
 
-class KeyframeValue final : public KeyframeInterpolation::Keyframe {
+class BlendingKeyframe final : public KeyframeInterpolation::Keyframe {
 public:
-    KeyframeValue(double offset, std::unique_ptr<RenderStyle> style)
+    BlendingKeyframe(double offset, std::unique_ptr<RenderStyle> style)
         : m_offset(offset)
         , m_style(WTFMove(style))
     {
@@ -55,7 +55,7 @@ public:
     double offset() const final { return m_offset; }
     std::optional<CompositeOperation> compositeOperation() const final { return m_compositeOperation; }
     bool animatesProperty(KeyframeInterpolation::Property) const final;
-    bool isKeyframeValue() const final { return true; }
+    bool isBlendingKeyframe() const final { return true; }
 
     void addProperty(const AnimatableCSSProperty&);
     const HashSet<AnimatableCSSProperty>& properties() const { return m_properties; }
@@ -82,21 +82,21 @@ private:
     bool m_containsDirectionAwareProperty { false };
 };
 
-class KeyframeList {
+class BlendingKeyframes {
 public:
-    explicit KeyframeList(const AtomString& animationName)
+    explicit BlendingKeyframes(const AtomString& animationName)
         : m_animationName(animationName)
     {
     }
-    ~KeyframeList();
+    ~BlendingKeyframes();
 
-    KeyframeList& operator=(KeyframeList&&) = default;
-    bool operator==(const KeyframeList&) const;
+    BlendingKeyframes& operator=(BlendingKeyframes&&) = default;
+    bool operator==(const BlendingKeyframes&) const;
 
     const AtomString& animationName() const { return m_animationName; }
     
-    void insert(KeyframeValue&&);
-    
+    void insert(BlendingKeyframe&&);
+
     void addProperty(const AnimatableCSSProperty&);
     bool containsProperty(const AnimatableCSSProperty&) const;
     const HashSet<AnimatableCSSProperty>& properties() const { return m_properties; }
@@ -107,9 +107,9 @@ public:
     void clear();
     bool isEmpty() const { return m_keyframes.isEmpty(); }
     size_t size() const { return m_keyframes.size(); }
-    const KeyframeValue& operator[](size_t index) const { return m_keyframes[index]; }
+    const BlendingKeyframe& operator[](size_t index) const { return m_keyframes[index]; }
 
-    void copyKeyframes(KeyframeList&);
+    void copyKeyframes(const BlendingKeyframes&);
     bool hasImplicitKeyframes() const;
     void fillImplicitKeyframes(const KeyframeEffect&, const RenderStyle& elementStyle);
 
@@ -127,7 +127,7 @@ public:
 
 private:
     AtomString m_animationName;
-    Vector<KeyframeValue> m_keyframes; // Kept sorted by key.
+    Vector<BlendingKeyframe> m_keyframes; // Kept sorted by key.
     HashSet<AnimatableCSSProperty> m_properties; // The properties being animated.
     bool m_usesRelativeFontWeight { false };
     bool m_containsCSSVariableReferences { false };
@@ -137,4 +137,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_KEYFRAME_INTERPOLATION_KEYFRAME(KeyframeValue, isKeyframeValue());
+SPECIALIZE_TYPE_TRAITS_KEYFRAME_INTERPOLATION_KEYFRAME(BlendingKeyframe, isBlendingKeyframe());

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -27,6 +27,7 @@
 
 #include "AnimationEffect.h"
 #include "AnimationEffectPhase.h"
+#include "BlendingKeyframes.h"
 #include "CSSPropertyBlendingClient.h"
 #include "CompositeOperation.h"
 #include "CompositeOperationOrAuto.h"
@@ -36,7 +37,6 @@
 #include "IterationCompositeOperation.h"
 #include "KeyframeEffectOptions.h"
 #include "KeyframeInterpolation.h"
-#include "KeyframeList.h"
 #include "RenderStyle.h"
 #include "Styleable.h"
 #include "WebAnimationTypes.h"
@@ -150,7 +150,7 @@ public:
     std::optional<unsigned> transformFunctionListPrefix() const override;
 
     void computeDeclarativeAnimationBlendingKeyframes(const RenderStyle* oldStyle, const RenderStyle& newStyle, const Style::ResolutionContext&);
-    const KeyframeList& blendingKeyframes() const { return m_blendingKeyframes; }
+    const BlendingKeyframes& blendingKeyframes() const { return m_blendingKeyframes; }
     const HashSet<AnimatableCSSProperty>& animatedProperties();
     bool animatesProperty(const AnimatableCSSProperty&) const;
 
@@ -214,7 +214,7 @@ private:
     void updateAcceleratedActions();
     void setAnimatedPropertiesInStyle(RenderStyle&, double iterationProgress, double currentIteration);
     const TimingFunction* timingFunctionForKeyframeAtIndex(size_t) const;
-    const TimingFunction* timingFunctionForBlendingKeyframe(const KeyframeValue&) const;
+    const TimingFunction* timingFunctionForBlendingKeyframe(const BlendingKeyframe&) const;
     Ref<const Animation> backingAnimationForCompositedRenderer() const;
     void computedNeedsForcedLayout();
     void computeStackingContextImpact();
@@ -224,7 +224,7 @@ private:
     void computeCSSAnimationBlendingKeyframes(const RenderStyle& unanimatedStyle, const Style::ResolutionContext&);
     void computeCSSTransitionBlendingKeyframes(const RenderStyle& oldStyle, const RenderStyle& newStyle);
     void computeAcceleratedPropertiesState();
-    void setBlendingKeyframes(KeyframeList&&);
+    void setBlendingKeyframes(BlendingKeyframes&&);
     bool isTargetingTransformRelatedProperty() const;
     void checkForMatchingTransformFunctionLists();
     void computeHasImplicitKeyframeForAcceleratedProperty();
@@ -278,7 +278,7 @@ private:
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
 
     AtomString m_keyframesName;
-    KeyframeList m_blendingKeyframes { emptyAtom() };
+    BlendingKeyframes m_blendingKeyframes { emptyAtom() };
     HashSet<AnimatableCSSProperty> m_animatedProperties;
     Vector<ParsedKeyframe> m_parsedKeyframes;
     Vector<AcceleratedAction> m_pendingAcceleratedActions;

--- a/Source/WebCore/animation/KeyframeInterpolation.h
+++ b/Source/WebCore/animation/KeyframeInterpolation.h
@@ -45,7 +45,7 @@ public:
         virtual bool animatesProperty(Property) const = 0;
 
         virtual bool isAcceleratedEffectKeyframe() const { return false; }
-        virtual bool isKeyframeValue() const { return false; }
+        virtual bool isBlendingKeyframe() const { return false; }
 
         virtual ~Keyframe() = default;
     };

--- a/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
@@ -28,6 +28,7 @@
 
 #include "AnimationEffect.h"
 #include "AnimationEffectPhase.h"
+#include "BlendingKeyframes.h"
 #include "CSSAnimation.h"
 #include "CSSPropertyNames.h"
 #include "CSSTransition.h"
@@ -43,7 +44,6 @@
 #include "JSExecState.h"
 #include "JSWebAnimation.h"
 #include "KeyframeEffect.h"
-#include "KeyframeList.h"
 #include "LocalFrame.h"
 #include "MutableStyleProperties.h"
 #include "Page.h"

--- a/Source/WebCore/platform/animation/AcceleratedEffect.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.cpp
@@ -29,12 +29,12 @@
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
 
 #include "AnimationEffect.h"
+#include "BlendingKeyframes.h"
 #include "CSSPropertyAnimation.h"
 #include "CSSPropertyNames.h"
 #include "DeclarativeAnimation.h"
 #include "Document.h"
 #include "KeyframeEffect.h"
-#include "KeyframeList.h"
 #include "LayoutSize.h"
 #include "WebAnimation.h"
 #include "WebAnimationTypes.h"

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -32,7 +32,7 @@ namespace WebCore {
 class Animation;
 class ContentData;
 class ControlStates;
-class KeyframeList;
+class BlendingKeyframes;
 class ReferencedSVGResources;
 class RenderBlock;
 class RenderStyle;
@@ -263,7 +263,7 @@ public:
     RenderObject* attachRendererInternal(RenderPtr<RenderObject> child, RenderObject* beforeChild);
     RenderPtr<RenderObject> detachRendererInternal(RenderObject&);
 
-    virtual bool startAnimation(double /* timeOffset */, const Animation&, const KeyframeList&) { return false; }
+    virtual bool startAnimation(double /* timeOffset */, const Animation&, const BlendingKeyframes&) { return false; }
     virtual void animationPaused(double /* timeOffset */, const String& /* name */) { }
     virtual void animationFinished(const String& /* name */) { }
     virtual void transformRelatedPropertyDidChange() { }

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -29,6 +29,7 @@
 
 #include "BackgroundPainter.h"
 #include "BitmapImage.h"
+#include "BlendingKeyframes.h"
 #include "CanvasRenderingContext.h"
 #include "CSSPropertyNames.h"
 #include "CachedImage.h"
@@ -46,7 +47,6 @@
 #include "HTMLPlugInElement.h"
 #include "HTMLVideoElement.h"
 #include "InspectorInstrumentation.h"
-#include "KeyframeList.h"
 #include "LayerAncestorClippingStack.h"
 #include "LocalFrame.h"
 #include "LocalFrameView.h"
@@ -3954,7 +3954,7 @@ void RenderLayerBacking::verifyNotPainting()
 }
 #endif
 
-bool RenderLayerBacking::startAnimation(double timeOffset, const Animation& animation, const KeyframeList& keyframes)
+bool RenderLayerBacking::startAnimation(double timeOffset, const Animation& animation, const BlendingKeyframes& keyframes)
 {
     bool shouldApplyAnimationsToTargetRenderer = renderer().isRenderBox() || renderer().isSVGLayerAwareRenderer();
 

--- a/Source/WebCore/rendering/RenderLayerBacking.h
+++ b/Source/WebCore/rendering/RenderLayerBacking.h
@@ -36,7 +36,7 @@
 
 namespace WebCore {
 
-class KeyframeList;
+class BlendingKeyframes;
 class PaintedContentsInfo;
 class RegionContext;
 class RenderLayerCompositor;
@@ -175,7 +175,7 @@ public:
     void contentChanged(ContentChangeType);
 
     // Interface to start, finish, suspend and resume animations
-    bool startAnimation(double timeOffset, const Animation&, const KeyframeList&);
+    bool startAnimation(double timeOffset, const Animation&, const BlendingKeyframes&);
     void animationPaused(double timeOffset, const String& name);
     void animationFinished(const String& name);
     void transformRelatedPropertyDidChange();

--- a/Source/WebCore/rendering/RenderLayerModelObject.cpp
+++ b/Source/WebCore/rendering/RenderLayerModelObject.cpp
@@ -249,7 +249,7 @@ std::optional<LayoutRect> RenderLayerModelObject::cachedLayerClippedOverflowRect
     return hasLayer() ? layer()->cachedClippedOverflowRect() : std::nullopt;
 }
 
-bool RenderLayerModelObject::startAnimation(double timeOffset, const Animation& animation, const KeyframeList& keyframes)
+bool RenderLayerModelObject::startAnimation(double timeOffset, const Animation& animation, const BlendingKeyframes& keyframes)
 {
     if (!layer() || !layer()->backing())
         return false;

--- a/Source/WebCore/rendering/RenderLayerModelObject.h
+++ b/Source/WebCore/rendering/RenderLayerModelObject.h
@@ -28,7 +28,7 @@
 
 namespace WebCore {
 
-class KeyframeList;
+class BlendingKeyframes;
 class RenderLayer;
 class RenderSVGResourceClipper;
 class RenderSVGResourceMasker;
@@ -64,7 +64,7 @@ public:
 
     std::optional<LayoutRect> cachedLayerClippedOverflowRect() const;
 
-    bool startAnimation(double timeOffset, const Animation&, const KeyframeList&) override;
+    bool startAnimation(double timeOffset, const Animation&, const BlendingKeyframes&) override;
     void animationPaused(double timeOffset, const String& name) override;
     void animationFinished(const String& name) override;
     void transformRelatedPropertyDidChange() override;

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -30,6 +30,7 @@
 #include "config.h"
 #include "StyleResolver.h"
 
+#include "BlendingKeyframes.h"
 #include "CSSCustomPropertyValue.h"
 #include "CSSFontSelector.h"
 #include "CSSKeyframeRule.h"
@@ -46,7 +47,6 @@
 #include "ElementRuleCollector.h"
 #include "FrameSelection.h"
 #include "InspectorInstrumentation.h"
-#include "KeyframeList.h"
 #include "LocalFrame.h"
 #include "LocalFrameView.h"
 #include "Logging.h"
@@ -292,7 +292,7 @@ ResolvedStyle Resolver::styleForElement(const Element& element, const Resolution
     return { state.takeStyle(), WTFMove(elementStyleRelations), collector.releaseMatchResult() };
 }
 
-std::unique_ptr<RenderStyle> Resolver::styleForKeyframe(const Element& element, const RenderStyle& elementStyle, const ResolutionContext& context, const StyleRuleKeyframe& keyframe, KeyframeValue& keyframeValue)
+std::unique_ptr<RenderStyle> Resolver::styleForKeyframe(const Element& element, const RenderStyle& elementStyle, const ResolutionContext& context, const StyleRuleKeyframe& keyframe, BlendingKeyframe& blendingKeyframe)
 {
     // Add all the animating properties to the keyframe.
     bool hasRevert = false;
@@ -302,14 +302,14 @@ std::unique_ptr<RenderStyle> Resolver::styleForKeyframe(const Element& element, 
         // because they are not animated; they just describe the composite operation and timing
         // function between this keyframe and the next.
         if (CSSProperty::isDirectionAwareProperty(unresolvedProperty))
-            keyframeValue.setContainsDirectionAwareProperty(true);
+            blendingKeyframe.setContainsDirectionAwareProperty(true);
         if (auto* value = propertyReference.value()) {
             auto resolvedProperty = CSSProperty::resolveDirectionAwareProperty(unresolvedProperty, elementStyle.direction(), elementStyle.writingMode());
             if (resolvedProperty != CSSPropertyAnimationTimingFunction && resolvedProperty != CSSPropertyAnimationComposition) {
                 if (value->isCustomPropertyValue())
-                    keyframeValue.addProperty(downcast<CSSCustomPropertyValue>(*value).name());
+                    blendingKeyframe.addProperty(downcast<CSSCustomPropertyValue>(*value).name());
                 else
-                    keyframeValue.addProperty(resolvedProperty);
+                    blendingKeyframe.addProperty(resolvedProperty);
             }
             if (isValueID(*value, CSSValueRevert))
                 hasRevert = true;
@@ -429,7 +429,7 @@ Vector<Ref<StyleRuleKeyframe>> Resolver::keyframeRulesForName(const AtomString& 
     return deduplicatedKeyframes;
 }
 
-void Resolver::keyframeStylesForAnimation(const Element& element, const RenderStyle& elementStyle, const ResolutionContext& context, KeyframeList& list)
+void Resolver::keyframeStylesForAnimation(const Element& element, const RenderStyle& elementStyle, const ResolutionContext& context, BlendingKeyframes& list)
 {
     list.clear();
 
@@ -441,16 +441,16 @@ void Resolver::keyframeStylesForAnimation(const Element& element, const RenderSt
     for (auto& keyframeRule : keyframeRules) {
         // Add this keyframe style to all the indicated key times
         for (auto key : keyframeRule->keys()) {
-            KeyframeValue keyframeValue(0, nullptr);
-            keyframeValue.setStyle(styleForKeyframe(element, elementStyle, context, keyframeRule.get(), keyframeValue));
-            keyframeValue.setOffset(key);
+            BlendingKeyframe blendingKeyframe(0, nullptr);
+            blendingKeyframe.setStyle(styleForKeyframe(element, elementStyle, context, keyframeRule.get(), blendingKeyframe));
+            blendingKeyframe.setOffset(key);
             if (auto timingFunctionCSSValue = keyframeRule->properties().getPropertyCSSValue(CSSPropertyAnimationTimingFunction))
-                keyframeValue.setTimingFunction(TimingFunction::createFromCSSValue(*timingFunctionCSSValue.get()));
+                blendingKeyframe.setTimingFunction(TimingFunction::createFromCSSValue(*timingFunctionCSSValue.get()));
             if (auto compositeOperationCSSValue = keyframeRule->properties().getPropertyCSSValue(CSSPropertyAnimationComposition)) {
                 if (auto compositeOperation = toCompositeOperation(*compositeOperationCSSValue))
-                    keyframeValue.setCompositeOperation(*compositeOperation);
+                    blendingKeyframe.setCompositeOperation(*compositeOperation);
             }
-            list.insert(WTFMove(keyframeValue));
+            list.insert(WTFMove(blendingKeyframe));
             list.updatePropertiesMetadata(keyframeRule->properties());
         }
     }

--- a/Source/WebCore/style/StyleResolver.h
+++ b/Source/WebCore/style/StyleResolver.h
@@ -38,11 +38,11 @@
 
 namespace WebCore {
 
+class BlendingKeyframe;
+class BlendingKeyframes;
 class CSSStyleSheet;
 class Document;
 class Element;
-class KeyframeList;
-class KeyframeValue;
 class RenderStyle;
 class RuleData;
 class RuleSet;
@@ -91,7 +91,7 @@ public:
 
     ResolvedStyle styleForElement(const Element&, const ResolutionContext&, RuleMatchingBehavior = RuleMatchingBehavior::MatchAllRules);
 
-    void keyframeStylesForAnimation(const Element&, const RenderStyle& elementStyle, const ResolutionContext&, KeyframeList&);
+    void keyframeStylesForAnimation(const Element&, const RenderStyle& elementStyle, const ResolutionContext&, BlendingKeyframes&);
 
     WEBCORE_EXPORT std::optional<ResolvedStyle> styleForPseudoElement(const Element&, const PseudoElementRequest&, const ResolutionContext&);
 
@@ -113,7 +113,7 @@ public:
 
     void addCurrentSVGFontFaceRules();
 
-    std::unique_ptr<RenderStyle> styleForKeyframe(const Element&, const RenderStyle& elementStyle, const ResolutionContext&, const StyleRuleKeyframe&, KeyframeValue&);
+    std::unique_ptr<RenderStyle> styleForKeyframe(const Element&, const RenderStyle& elementStyle, const ResolutionContext&, const StyleRuleKeyframe&, BlendingKeyframe&);
     bool isAnimationNameValid(const String&);
 
     // These methods will give back the set of rules that matched for a given element (or a pseudo-element).


### PR DESCRIPTION
#### 11d1cdb0666c38b6daf52511b645db1b8d89b793
<pre>
[web-animations] rename and move KeyframeList
<a href="https://bugs.webkit.org/show_bug.cgi?id=266409">https://bugs.webkit.org/show_bug.cgi?id=266409</a>
<a href="https://rdar.apple.com/119663662">rdar://119663662</a>

Reviewed by Antti Koivisto.

The `KeyframeList` class is used almost exclusively in the animation code, so we move it
under the &quot;animation&quot; directory. We also refer to such keyframes as &quot;blending keyframes&quot;
in the animation code, so we take this opportunity to also rename `KeyframeList` as
`BlendingKeyframes` and `KeyframeValue` as `BlendingKeyframe`.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/animation/BlendingKeyframes.cpp: Renamed from Source/WebCore/rendering/style/KeyframeList.cpp.
(WebCore::BlendingKeyframes::clear):
(WebCore::BlendingKeyframes::operator== const):
(WebCore::BlendingKeyframes::insert):
(WebCore::BlendingKeyframes::hasImplicitKeyframes const):
(WebCore::BlendingKeyframes::copyKeyframes):
(WebCore::zeroPercentKeyframe):
(WebCore::hundredPercentKeyframe):
(WebCore::BlendingKeyframes::fillImplicitKeyframes):
(WebCore::BlendingKeyframes::containsAnimatableCSSProperty const):
(WebCore::BlendingKeyframes::containsDirectionAwareProperty const):
(WebCore::BlendingKeyframes::usesContainerUnits const):
(WebCore::BlendingKeyframes::addProperty):
(WebCore::BlendingKeyframes::containsProperty const):
(WebCore::BlendingKeyframes::usesRelativeFontWeight const):
(WebCore::BlendingKeyframes::hasCSSVariableReferences const):
(WebCore::BlendingKeyframes::hasColorSetToCurrentColor const):
(WebCore::BlendingKeyframes::hasPropertySetToCurrentColor const):
(WebCore::BlendingKeyframes::propertiesSetToInherit const):
(WebCore::BlendingKeyframes::updatePropertiesMetadata):
(WebCore::BlendingKeyframe::addProperty):
(WebCore::BlendingKeyframe::animatesProperty const):
* Source/WebCore/animation/BlendingKeyframes.h: Renamed from Source/WebCore/rendering/style/KeyframeList.h.
(WebCore::BlendingKeyframes::BlendingKeyframes):
(WebCore::BlendingKeyframes::animationName const):
(WebCore::BlendingKeyframes::properties const):
(WebCore::BlendingKeyframes::isEmpty const):
(WebCore::BlendingKeyframes::size const):
(WebCore::BlendingKeyframes::operator[] const):
(WebCore::BlendingKeyframes::begin const):
(WebCore::BlendingKeyframes::end const):
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::copyPropertiesFromSource):
(WebCore::KeyframeEffect::getKeyframes):
(WebCore::KeyframeEffect::updateBlendingKeyframes):
(WebCore::KeyframeEffect::setBlendingKeyframes):
(WebCore::KeyframeEffect::computeCSSAnimationBlendingKeyframes):
(WebCore::KeyframeEffect::computeCSSTransitionBlendingKeyframes):
(WebCore::KeyframeEffect::setAnimatedPropertiesInStyle):
(WebCore::KeyframeEffect::timingFunctionForBlendingKeyframe const):
(WebCore::KeyframeEffect::applyPendingAcceleratedActions):
(WebCore::KeyframeEffect::timingFunctionForKeyframe const):
* Source/WebCore/animation/KeyframeEffect.h:
* Source/WebCore/animation/KeyframeInterpolation.h:
(WebCore::KeyframeInterpolation::Keyframe::isBlendingKeyframe const):
(WebCore::KeyframeInterpolation::Keyframe::isKeyframeValue const): Deleted.
* Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp:
* Source/WebCore/platform/animation/AcceleratedEffect.cpp:
* Source/WebCore/rendering/RenderElement.h:
(WebCore::RenderElement::startAnimation):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::startAnimation):
* Source/WebCore/rendering/RenderLayerBacking.h:
* Source/WebCore/rendering/RenderLayerModelObject.cpp:
(WebCore::RenderLayerModelObject::startAnimation):
* Source/WebCore/rendering/RenderLayerModelObject.h:
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::styleForKeyframe):
(WebCore::Style::Resolver::keyframeStylesForAnimation):
* Source/WebCore/style/StyleResolver.h:

Canonical link: <a href="https://commits.webkit.org/272055@main">https://commits.webkit.org/272055@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d5cf64fd45a925f53f7b48bf64adb744bb1979b0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30449 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9123 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32068 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32961 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27546 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31152 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11357 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6362 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27491 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30758 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7668 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27299 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6570 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6720 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27141 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34298 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27737 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27639 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32898 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6704 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4847 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30722 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8451 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7441 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3947 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7248 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->