### PR TITLE
Fix attachment tests -folder-icon, -type-attribute, -default-icon

### DIFF
--- a/LayoutTests/fast/attachment/attachment-default-icon-expected.html
+++ b/LayoutTests/fast/attachment/attachment-default-icon-expected.html
@@ -1,6 +1,10 @@
 <!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true ] -->
-<html>
+<html class="reftest-wait">
 <body>
 <attachment id="attachment" title="  " type="public.data"></attachment>
+<script src="resources/attachment-test-utils.js"></script>
+<script>
+takeExpectedScreenshotWhenAttachmentsSettled();
+</script>
 </body>
 </html>

--- a/LayoutTests/fast/attachment/attachment-default-icon.html
+++ b/LayoutTests/fast/attachment/attachment-default-icon.html
@@ -1,6 +1,10 @@
 <!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true ] -->
-<html>
+<html class="reftest-wait">
 <body>
 <attachment title="   "></attachment>
+<script src="resources/attachment-test-utils.js"></script>
+<script>
+takeActualScreenshotWhenAttachmentsSettled();
+</script>
 </body>
 </html>

--- a/LayoutTests/fast/attachment/attachment-folder-icon-expected.html
+++ b/LayoutTests/fast/attachment/attachment-folder-icon-expected.html
@@ -1,8 +1,9 @@
 <!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true ] -->
-<html>
+<html class="reftest-wait">
 <body>
 <attachment title=" "></attachment>
 <attachment title=" "></attachment>
+<script src="resources/attachment-test-utils.js"></script>
 <script>
 if (window.internals)
     file = window.internals.createFile("resources/");
@@ -10,6 +11,8 @@ if (window.internals)
 var attachments = document.getElementsByTagName("attachment");
 for (var i = 0; i < attachments.length; i++)
     attachments[i].file = file;
+
+takeExpectedScreenshotWhenAttachmentsSettled();
 </script>
 </body>
 </html>

--- a/LayoutTests/fast/attachment/attachment-folder-icon.html
+++ b/LayoutTests/fast/attachment/attachment-folder-icon.html
@@ -1,7 +1,11 @@
 <!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true ] -->
-<html>
+<html class="reftest-wait">
 <body>
 <attachment title=" " type="multipart/x-folder"></attachment>
 <attachment title=" " type="application/vnd.apple.folder"></attachment>
+<script src="resources/attachment-test-utils.js"></script>
+<script>
+takeActualScreenshotWhenAttachmentsSettled();
+</script>
 </body>
 </html>

--- a/LayoutTests/fast/attachment/attachment-type-attribute-expected.html
+++ b/LayoutTests/fast/attachment/attachment-type-attribute-expected.html
@@ -1,13 +1,16 @@
 <!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true ] -->
-<html>
+<html class="reftest-wait">
 <body>
 <attachment id="attachment" title="  "></attachment>
+<script src="resources/attachment-test-utils.js"></script>
 <script>
 var file;
 if (window.internals)
     file = window.internals.createFile("resources/test-file.txt");
 
 document.getElementById("attachment").file = file;
+
+takeExpectedScreenshotWhenAttachmentsSettled();
 </script>
 </body>
 </html>

--- a/LayoutTests/fast/attachment/attachment-type-attribute.html
+++ b/LayoutTests/fast/attachment/attachment-type-attribute.html
@@ -1,6 +1,10 @@
 <!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true ] -->
-<html>
+<html class="reftest-wait">
 <body>
 <attachment type="text/plain" title="  "></attachment>
+<script src="resources/attachment-test-utils.js"></script>
+<script>
+takeActualScreenshotWhenAttachmentsSettled();
+</script>
 </body>
 </html>

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1871,6 +1871,9 @@ imported/w3c/web-platform-tests/html/rendering/replaced-elements/embedded-conten
 # "reftest-wait" blocks attachment rendering.
 webkit.org/b/263367 fast/attachment/attachment-icon-from-file-extension.html [ Skip ]
 webkit.org/b/263367 fast/attachment/attachment-uti.html [ Skip ]
+webkit.org/b/265962 fast/attachment/attachment-folder-icon.html [ Skip ]
+webkit.org/b/265962 fast/attachment/attachment-type-attribute.html [ Skip ]
+webkit.org/b/265962 fast/attachment/attachment-default-icon.html [ Skip ]
 
 # <rdar://problem/42625657> REGRESSION (Mojave): 12 fast/images tests timing out on WK1
 fast/images/animated-heics-draw.html [ Skip ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1955,11 +1955,6 @@ http/wpt/opener/child-access-parent-via-windowproxy.html [ Pass ]
 http/wpt/opener/iframe-access-top-via-windowproxy.html [ Pass ]
 http/wpt/opener/parent-access-child-via-windowproxy.html [ Pass ]
 
-# rdar://119272478 (REGRESSION ( Sonoma?): [ Sonoma Release wk2 ] 3 tests in fast/attachment are a flaky failure with image diff)
-[ Sonoma+ Release ] fast/attachment/attachment-folder-icon.html [ Pass Failure ]
-[ Sonoma+ Release ] fast/attachment/attachment-type-attribute.html [ Pass Failure ]
-[ Sonoma+ Release ] fast/attachment/attachment-default-icon.html [ Pass Failure ]
-
 webkit.org/b/265957 [ Release ] fullscreen/full-screen-layer-dump.html [ Pass Failure ]
 
 # rdar://102425691 ([ New Test ](256068@main): [ Ventura+ ] http/wpt/webcodecs/videoFrame-colorSpace.html is a consistent failure)


### PR DESCRIPTION
#### d773ccf904e47e3e0f2426a956073fca8cdc2d54
<pre>
Fix attachment tests -folder-icon, -type-attribute, -default-icon
<a href="https://bugs.webkit.org/show_bug.cgi?id=265962">https://bugs.webkit.org/show_bug.cgi?id=265962</a>
<a href="https://rdar.apple.com/119272478">rdar://119272478</a>

Reviewed by Tim Nguyen.

Let the attachments settle with the expected icons before taking a
screenshot.

* LayoutTests/fast/attachment/attachment-default-icon-expected.html:
* LayoutTests/fast/attachment/attachment-default-icon.html:
* LayoutTests/fast/attachment/attachment-folder-icon-expected.html:
* LayoutTests/fast/attachment/attachment-folder-icon.html:
* LayoutTests/fast/attachment/attachment-type-attribute-expected.html:
* LayoutTests/fast/attachment/attachment-type-attribute.html:
* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/272293@main">https://commits.webkit.org/272293@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d86d56803d8a64501ab7709e52b8b3db2c831b5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30615 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9298 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32271 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33111 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27677 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11587 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6549 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27586 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30924 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7793 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27410 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6678 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6832 "Too many flaky failures: imported/w3c/web-platform-tests/css/css-cascade/scope-hover.html, imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-below-viewport-partially-onscreen-new.html, imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-below-viewport-partially-onscreen-old.html, imported/w3c/web-platform-tests/css/selectors/invalidation/user-valid-user-invalid.html, imported/w3c/web-platform-tests/css/selectors/user-invalid.html, imported/w3c/web-platform-tests/css/selectors/valid-invalid-form-fieldset.html, imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-allowed-for-all.https.sub.html, imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch.tentative.html, imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/move_iframe_in_dom_01.html, imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative.html, imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/readwrite-readonly.html, imported/w3c/web-platform-tests/webrtc-extensions/RTCRtpSynchronizationSource-senderCaptureTimeOffset.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27269 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34447 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27864 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27761 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33000 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6854 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4961 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30827 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8585 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/27045 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7340 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7582 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7411 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->