### PR TITLE
[WGSL] Add support for modf

### DIFF
--- a/Source/WebGPU/WGSL/Constraints.cpp
+++ b/Source/WebGPU/WGSL/Constraints.cpp
@@ -167,6 +167,11 @@ const Type* concretize(const Type* type, TypeStore& types)
                 auto* exp = concretize(primitiveStruct.values[PrimitiveStruct::FrexpResult::exp], types);
                 return types.frexpResultType(fract, exp);
             }
+            case PrimitiveStruct::ModfResult::kind: {
+                auto* fract = concretize(primitiveStruct.values[PrimitiveStruct::ModfResult::fract], types);
+                auto* whole = concretize(primitiveStruct.values[PrimitiveStruct::ModfResult::whole], types);
+                return types.modfResultType(fract, whole);
+            }
             }
         },
         [&](const Pointer&) -> const Type* {

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -298,6 +298,28 @@ void FunctionDefinitionWriter::emitNecessaryHelpers()
         m_stringBuilder.append(m_indent, "}\n\n");
     }
 
+    if (m_callGraph.ast().usesModf()) {
+        m_stringBuilder.append(m_indent, "template<typename T, typename U>\n");
+        m_stringBuilder.append(m_indent, "struct __modf_result {\n");
+        {
+            IndentationScope scope(m_indent);
+            m_stringBuilder.append(m_indent, "T fract;\n");
+            m_stringBuilder.append(m_indent, "U whole;\n");
+        }
+        m_stringBuilder.append(m_indent, "};\n\n");
+
+        m_stringBuilder.append(m_indent, "template<typename T>\n");
+        m_stringBuilder.append(m_indent, "__modf_result<T, T> __wgslModf(T value)\n");
+        m_stringBuilder.append(m_indent, "{\n");
+        {
+            IndentationScope scope(m_indent);
+            m_stringBuilder.append(m_indent, "__modf_result<T, T> result;\n");
+            m_stringBuilder.append(m_indent, "result.fract = modf(value, result.whole);\n");
+            m_stringBuilder.append(m_indent, "return result;\n");
+        }
+        m_stringBuilder.append(m_indent, "}\n\n");
+    }
+
     if (m_callGraph.ast().usesPackedStructs()) {
         m_callGraph.ast().clearUsesPackedStructs();
 
@@ -1652,6 +1674,7 @@ void FunctionDefinitionWriter::visit(const Type* type, AST::CallExpression& call
             { "fwidthFine", "fwidth"_s },
             { "insertBits", "insert_bits"_s },
             { "inverseSqrt", "rsqrt"_s },
+            { "modf", "__wgslModf"_s },
             { "reverseBits", "reverse_bits"_s },
         };
         static constexpr SortedArrayMap mappedNames { directMappings };

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -1035,6 +1035,8 @@ void TypeChecker::visit(AST::CallExpression& call)
                 m_shaderModule.setUsesWorkgroupUniformLoad();
             else if (targetName == "frexp"_s)
                 m_shaderModule.setUsesFrexp();
+            else if (targetName == "modf"_s)
+                m_shaderModule.setUsesModf();
             target.m_inferredType = result;
             return;
         }

--- a/Source/WebGPU/WGSL/TypeDeclarations.rb
+++ b/Source/WebGPU/WGSL/TypeDeclarations.rb
@@ -736,7 +736,21 @@ function :modf, {
     must_use: true,
     const: true,
 
-    # FIXME: this needs the special return types __modf_result_*
+    [].(f32) => __modf_result_f32,
+    [].(f16) => __modf_result_f16,
+    [].(abstract_float) => __modf_result_abstract,
+
+    [].(vec2[f32]) => __modf_result_vec2_f32,
+    [].(vec2[f16]) => __modf_result_vec2_f16,
+    [].(vec2[abstract_float]) => __modf_result_vec2_abstract,
+
+    [].(vec3[f32]) => __modf_result_vec3_f32,
+    [].(vec3[f16]) => __modf_result_vec3_f16,
+    [].(vec3[abstract_float]) => __modf_result_vec3_abstract,
+
+    [].(vec4[f32]) => __modf_result_vec4_f32,
+    [].(vec4[f16]) => __modf_result_vec4_f16,
+    [].(vec4[abstract_float]) => __modf_result_vec4_abstract,
 }
 
 # 16.5.43

--- a/Source/WebGPU/WGSL/TypeStore.cpp
+++ b/Source/WebGPU/WGSL/TypeStore.cpp
@@ -250,6 +250,21 @@ const Type* TypeStore::frexpResultType(const Type* fract, const Type* exp)
     return type;
 }
 
+const Type* TypeStore::modfResultType(const Type* fract, const Type* whole)
+{
+    PrimitiveStructKey key { PrimitiveStruct::ModfResult::kind, fract };
+    const Type* type = m_cache.find(key);
+    if (type)
+        return type;
+
+    FixedVector<const Type*> values(2);
+    values[PrimitiveStruct::ModfResult::fract] = fract;
+    values[PrimitiveStruct::ModfResult::whole] = whole;
+    type = allocateType<PrimitiveStruct>("__modf_result"_s, PrimitiveStruct::ModfResult::kind, values);
+    m_cache.insert(key, type);
+    return type;
+}
+
 template<typename TypeKind, typename... Arguments>
 const Type* TypeStore::allocateType(Arguments&&... arguments)
 {

--- a/Source/WebGPU/WGSL/TypeStore.h
+++ b/Source/WebGPU/WGSL/TypeStore.h
@@ -104,6 +104,7 @@ public:
     const Type* atomicType(const Type*);
     const Type* typeConstructorType(ASCIILiteral, std::function<const Type*(AST::ElaboratedTypeExpression&)>&&);
     const Type* frexpResultType(const Type*, const Type*);
+    const Type* modfResultType(const Type*, const Type*);
 
 private:
     template<typename TypeKind, typename... Arguments>

--- a/Source/WebGPU/WGSL/Types.cpp
+++ b/Source/WebGPU/WGSL/Types.cpp
@@ -70,6 +70,9 @@ void Type::dump(PrintStream& out) const
             case PrimitiveStruct::FrexpResult::kind:
                 out.print(*structure.values[PrimitiveStruct::FrexpResult::fract]);
                 break;
+            case PrimitiveStruct::ModfResult::kind:
+                out.print(*structure.values[PrimitiveStruct::ModfResult::fract]);
+                break;
             }
             out.print(">");
         },
@@ -255,6 +258,8 @@ ConversionRank conversionRank(const Type* from, const Type* to)
         switch (kind) {
         case PrimitiveStruct::FrexpResult::kind:
             return conversionRank(fromPrimitiveStruct->values[PrimitiveStruct::FrexpResult::fract], toPrimitiveStruct->values[PrimitiveStruct::FrexpResult::fract]);
+        case PrimitiveStruct::ModfResult::kind:
+            return conversionRank(fromPrimitiveStruct->values[PrimitiveStruct::ModfResult::fract], toPrimitiveStruct->values[PrimitiveStruct::ModfResult::fract]);
         }
     }
 

--- a/Source/WebGPU/WGSL/Types.h
+++ b/Source/WebGPU/WGSL/Types.h
@@ -133,6 +133,7 @@ struct PrimitiveStruct {
 private:
     enum Kind : uint8_t {
         FrexpResult,
+        ModfResult,
     };
 
 public:
@@ -149,8 +150,22 @@ public:
         static constexpr SortedArrayMap map { mapEntries };
     };
 
+    struct ModfResult {
+        static constexpr Kind kind = Kind::ModfResult;
+        static constexpr unsigned fract = 0;
+        static constexpr unsigned whole = 1;
+
+        static constexpr std::pair<ComparableASCIILiteral, unsigned> mapEntries[] {
+            { "fract", fract },
+            { "whole", whole },
+        };
+
+        static constexpr SortedArrayMap map { mapEntries };
+    };
+
     static constexpr SortedArrayMap<std::pair<ComparableASCIILiteral, unsigned>[2]> keys[] {
         FrexpResult::map,
+        ModfResult::map,
     };
 
     String name;

--- a/Source/WebGPU/WGSL/WGSLShaderModule.h
+++ b/Source/WebGPU/WGSL/WGSLShaderModule.h
@@ -88,6 +88,9 @@ public:
     bool usesFrexp() const { return m_usesFrexp; }
     void setUsesFrexp() { m_usesFrexp = true; }
 
+    bool usesModf() const { return m_usesModf; }
+    void setUsesModf() { m_usesModf = true; }
+
     template<typename T>
     std::enable_if_t<std::is_base_of_v<AST::Node, T>, void> replace(T* current, T&& replacement)
     {
@@ -240,6 +243,7 @@ private:
     bool m_usesDivision { false };
     bool m_usesModulo { false };
     bool m_usesFrexp { false };
+    bool m_usesModf { false };
     OptionSet<Extension> m_enabledExtensions;
     OptionSet<LanguageFeature> m_requiredFeatures;
     Configuration m_configuration;

--- a/Source/WebGPU/WGSL/generator/main.rb
+++ b/Source/WebGPU/WGSL/generator/main.rb
@@ -520,6 +520,21 @@ module DSL
         __frexp_result_vec4_f16 = Constructor.new(:frexpResult, [vec4[f16], vec4[i32]])
         __frexp_result_vec4_f32 = Constructor.new(:frexpResult, [vec4[f32], vec4[i32]])
 
+        __modf_result_abstract = Constructor.new(:modfResult, [abstract_float, abstract_float])
+        __modf_result_f16 = Constructor.new(:modfResult, [f16, f16])
+        __modf_result_f32 = Constructor.new(:modfResult, [f32, f32])
+
+        __modf_result_vec2_abstract = Constructor.new(:modfResult, [vec2[abstract_float], vec2[abstract_float]])
+        __modf_result_vec2_f16 = Constructor.new(:modfResult, [vec2[f16], vec2[f16]])
+        __modf_result_vec2_f32 = Constructor.new(:modfResult, [vec2[f32], vec2[f32]])
+
+        __modf_result_vec3_abstract = Constructor.new(:modfResult, [vec3[abstract_float], vec3[abstract_float]])
+        __modf_result_vec3_f16 = Constructor.new(:modfResult, [vec3[f16], vec3[f16]])
+        __modf_result_vec3_f32 = Constructor.new(:modfResult, [vec3[f32], vec3[f32]])
+
+        __modf_result_vec4_abstract = Constructor.new(:modfResult, [vec4[abstract_float], vec4[abstract_float]])
+        __modf_result_vec4_f16 = Constructor.new(:modfResult, [vec4[f16], vec4[f16]])
+        __modf_result_vec4_f32 = Constructor.new(:modfResult, [vec4[f32], vec4[f32]])
         EOS
     end
 

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -2280,9 +2280,77 @@ fn testMix()
 }
 
 // 16.5.42
+// RUN: %metal-compile testModf
+@compute @workgroup_size(1)
 fn testModf()
 {
-    // FIXME: this needs the special return types __modf_result_*
+    {
+      let x: f32 = 1.5;
+      let y: f16 = 1.5;
+      let r1 = modf(x);
+      let r2 = modf(y);
+      const r3 = modf(1.5);
+      const r4 = modf(1.5f);
+      const r5 = modf(1.5h);
+
+      let r6: f32 = modf(x).fract;
+      let r7: f16 = modf(y).whole;
+      const r8: f32 = modf(1.5).fract;
+      const r9: f16 = modf(1.5).whole;
+      const r10: f32 = modf(1.5f).fract;
+      const r11: f16 = modf(1.5h).whole;
+    }
+
+    {
+      let x: vec2<f32> = vec2(1.5);
+      let y: vec2<f16> = vec2(1.5);
+      let r1 = modf(x);
+      let r2 = modf(y);
+      const r3 = modf(vec2(1.5));
+      const r4 = modf(vec2(1.5f));
+      const r5 = modf(vec2(1.5h));
+
+      let r6: vec2<f32> = modf(x).fract;
+      let r7: vec2<f16> = modf(y).whole;
+      const r8: vec2<f32> = modf(vec2(1.5)).fract;
+      const r9: vec2<f16> = modf(vec2(1.5)).whole;
+      const r10: vec2<f32> = modf(vec2(1.5f)).fract;
+      const r11: vec2<f16> = modf(vec2(1.5h)).whole;
+    }
+
+    {
+      let x: vec3<f32> = vec3(1.5);
+      let y: vec3<f16> = vec3(1.5);
+      let r1 = modf(x);
+      let r2 = modf(y);
+      const r3 = modf(vec3(1.5));
+      const r4 = modf(vec3(1.5f));
+      const r5 = modf(vec3(1.5h));
+
+      let r6: vec3<f32> = modf(x).fract;
+      let r7: vec3<f16> = modf(y).whole;
+      const r8: vec3<f32> = modf(vec3(1.5)).fract;
+      const r9: vec3<f16> = modf(vec3(1.5)).whole;
+      const r10: vec3<f32> = modf(vec3(1.5f)).fract;
+      const r11: vec3<f16> = modf(vec3(1.5h)).whole;
+    }
+
+    {
+      let x: vec4<f32> = vec4(1.5);
+      let y: vec4<f16> = vec4(1.5);
+      let r1 = modf(x);
+      let r2 = modf(y);
+      const r3 = modf(vec4(1.5));
+      const r4 = modf(vec4(1.5f));
+      const r5 = modf(vec4(1.5h));
+
+      let r6: vec4<f32> = modf(x).fract;
+      let r7: vec4<f16> = modf(y).whole;
+      const r8: vec4<f32> = modf(vec4(1.5)).fract;
+      const r9: vec4<f16> = modf(vec4(1.5)).whole;
+      const r10: vec4<f32> = modf(vec4(1.5f)).fract;
+      const r11: vec4<f16> = modf(vec4(1.5h)).whole;
+    }
 }
 
 // 16.5.43


### PR DESCRIPTION
#### e08624c047ca6e878045654e67cb0c56fe9cdb4d
<pre>
[WGSL] Add support for modf
<a href="https://bugs.webkit.org/show_bug.cgi?id=266413">https://bugs.webkit.org/show_bug.cgi?id=266413</a>
<a href="https://rdar.apple.com/119667950">rdar://119667950</a>

Reviewed by Mike Wyrzykowski.

Implement modf now that we support primitive structs

* Source/WebGPU/WGSL/ConstantFunctions.h:
(WGSL::CONSTANT_FUNCTION):
* Source/WebGPU/WGSL/Constraints.cpp:
(WGSL::concretize):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::emitNecessaryHelpers):
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
* Source/WebGPU/WGSL/TypeDeclarations.rb:
* Source/WebGPU/WGSL/TypeStore.cpp:
(WGSL::TypeStore::modfResultType):
* Source/WebGPU/WGSL/TypeStore.h:
* Source/WebGPU/WGSL/Types.cpp:
(WGSL::Type::dump const):
(WGSL::conversionRank):
* Source/WebGPU/WGSL/Types.h:
* Source/WebGPU/WGSL/WGSLShaderModule.h:
(WGSL::ShaderModule::usesModf const):
(WGSL::ShaderModule::setUsesModf):
* Source/WebGPU/WGSL/generator/main.rb:
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/272115@main">https://commits.webkit.org/272115@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee6b03db653b5d00824b85da98700d9c90eb46fc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30462 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9135 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32082 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32974 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27557 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11371 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6376 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27502 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30771 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7680 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27309 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6581 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6732 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34311 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27749 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27652 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32906 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6716 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4860 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30730 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8463 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7250 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7453 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7260 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->