### PR TITLE
Samesite=Lax is not always working in Safari

### DIFF
--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheSubresourcesEntry.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheSubresourcesEntry.h
@@ -41,11 +41,12 @@ public:
         , m_lastSeen(lastSeen)
         , m_firstSeen(firstSeen)
         , m_isTransient(true) { }
-    SubresourceInfo(Key&& key, WallTime lastSeen, WallTime firstSeen, bool sameSite, bool isAppInitiated, URL&& firstPartyForCookies, WebCore::HTTPHeaderMap&& requestHeaders, WebCore::ResourceLoadPriority priority)
+    SubresourceInfo(Key&& key, WallTime lastSeen, WallTime firstSeen, bool isSameSite, bool isAppInitiated, URL&& firstPartyForCookies, WebCore::HTTPHeaderMap&& requestHeaders, WebCore::ResourceLoadPriority priority)
         : m_key(WTFMove(key))
         , m_lastSeen(lastSeen)
         , m_firstSeen(firstSeen)
         , m_isTransient(false)
+        , m_isSameSite(isSameSite)
         , m_isAppInitiated(isAppInitiated)
         , m_firstPartyForCookies(WTFMove(firstPartyForCookies))
         , m_requestHeaders(WTFMove(requestHeaders))


### PR DESCRIPTION
#### 3096c561acce0ee5b181cd3d16339273d870ebcd
<pre>
Samesite=Lax is not always working in Safari
<a href="https://bugs.webkit.org/show_bug.cgi?id=265634">https://bugs.webkit.org/show_bug.cgi?id=265634</a>
<a href="https://rdar.apple.com/119362503">rdar://119362503</a>

Reviewed by Brent Fulgham and Alex Christensen.

We were not setting isSameSite correctly when reading it from disk cache, which was then triggering different cookies being sent between
speculative loads and the actual would be loads.
Websites could use Vary Cookie headers to handle that case, but they do not tend to.

* Source/WebKit/NetworkProcess/cache/NetworkCacheSubresourcesEntry.h:
(WebKit::NetworkCache::SubresourceInfo::SubresourceInfo):

Canonical link: <a href="https://commits.webkit.org/272062@main">https://commits.webkit.org/272062@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ed88506e92aa565a331dcf485cdb46bf7ecf747

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30471 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9143 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32091 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32980 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27562 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11380 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6385 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27508 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30779 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7688 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27311 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6587 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6738 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34319 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27756 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27655 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32915 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6724 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4866 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30739 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8469 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7218 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7459 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7266 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->