### PR TITLE
Use CheckedPtr<Node> less for non-stack objects

### DIFF
--- a/Source/WebCore/accessibility/AccessibilityNodeObject.h
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.h
@@ -231,7 +231,7 @@ private:
 
     bool isDescendantOfElementType(const HashSet<QualifiedName>&) const;
 
-    CheckedPtr<Node> m_node;
+    WeakPtr<Node, WeakPtrImplWithEventTargetData> m_node;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSStyleSheet.h
+++ b/Source/WebCore/css/CSSStyleSheet.h
@@ -186,7 +186,7 @@ private:
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_constructorDocument;
     WeakHashSet<ContainerNode, WeakPtrImplWithEventTargetData> m_adoptingTreeScopes;
 
-    CheckedPtr<Node> m_ownerNode;
+    WeakPtr<Node, WeakPtrImplWithEventTargetData> m_ownerNode;
     WeakPtr<CSSImportRule> m_ownerRule;
 
     TextPosition m_startPosition;

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -96,9 +96,6 @@ ALWAYS_INLINE auto ContainerNode::removeAllChildrenWithScriptAssertion(ChildChan
     if (UNLIKELY(isDocumentFragmentForInnerOuterHTML())) {
         ScriptDisallowedScope::InMainThread scriptDisallowedScope;
         RELEASE_ASSERT(!connectedSubframeCount() && !hasRareData() && !wrapper());
-#if !DUMP_NODE_STATISTICS
-        ASSERT(!weakPtrFactory().isInitialized());
-#endif
         bool hadElementChild = false;
         while (RefPtr child = m_firstChild) {
             hadElementChild |= is<Element>(*child);

--- a/Source/WebCore/dom/MutationObserverRegistration.h
+++ b/Source/WebCore/dom/MutationObserverRegistration.h
@@ -70,7 +70,7 @@ public:
 
 private:
     Ref<MutationObserver> m_observer;
-    CheckedRef<Node> m_node;
+    WeakRef<Node, WeakPtrImplWithEventTargetData> m_node;
     RefPtr<Node> m_nodeKeptAlive;
     HashSet<GCReachableRef<Node>> m_transientRegistrationNodes;
     MutationObserverOptions m_options;

--- a/Source/WebCore/dom/TemplateContentDocumentFragment.h
+++ b/Source/WebCore/dom/TemplateContentDocumentFragment.h
@@ -52,7 +52,7 @@ private:
 
     bool isTemplateContent() const override { return true; }
 
-    CheckedPtr<const Element> m_host;
+    WeakPtr<const Element, WeakPtrImplWithEventTargetData> m_host;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/parser/HTMLConstructionSite.h
+++ b/Source/WebCore/html/parser/HTMLConstructionSite.h
@@ -232,7 +232,7 @@ private:
     // This is the root ContainerNode to which the parser attaches all newly
     // constructed nodes. It points to a DocumentFragment when parsing fragments
     // and a Document in all other cases.
-    CheckedRef<ContainerNode> m_attachmentRoot;
+    WeakRef<ContainerNode, WeakPtrImplWithEventTargetData> m_attachmentRoot;
     
     RefPtr<HTMLFormElement> m_form;
     mutable HTMLElementStack m_openElements;

--- a/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
@@ -59,6 +59,7 @@
 #include <span>
 #include <wtf/CheckedRef.h>
 #include <wtf/Vector.h>
+#include <wtf/WeakRef.h>
 #include <wtf/text/AtomString.h>
 #include <wtf/text/FastCharacterComparison.h>
 #include <wtf/text/StringParsingBuffer.h>
@@ -230,7 +231,7 @@ public:
 
 private:
     CheckedRef<Document> m_document;
-    CheckedRef<ContainerNode> m_destinationParent;
+    WeakRef<ContainerNode, WeakPtrImplWithEventTargetData> m_destinationParent;
 
     StringParsingBuffer<CharacterType> m_parsingBuffer;
 

--- a/Source/WebCore/xml/XSLStyleSheet.h
+++ b/Source/WebCore/xml/XSLStyleSheet.h
@@ -106,7 +106,7 @@ private:
 
     void clearXSLStylesheetDocument();
 
-    CheckedPtr<Node> m_ownerNode;
+    WeakPtr<Node, WeakPtrImplWithEventTargetData> m_ownerNode;
     String m_originalURL;
     URL m_finalURL;
     bool m_isDisabled { false };

--- a/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp
@@ -57,13 +57,14 @@
 #include <wtf/CheckedPtr.h>
 #include <wtf/HashMap.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/WeakHashMap.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebKit {
 using namespace WebCore;
 using namespace HTMLNames;
 
-using DOMNodeHandleCache = HashMap<CheckedPtr<Node>, CheckedPtr<InjectedBundleNodeHandle>>;
+using DOMNodeHandleCache = WeakHashMap<Node, CheckedPtr<InjectedBundleNodeHandle>, WeakPtrImplWithEventTargetData>;
 
 static DOMNodeHandleCache& domNodeHandleCache()
 {
@@ -87,12 +88,12 @@ RefPtr<InjectedBundleNodeHandle> InjectedBundleNodeHandle::getOrCreate(Node* nod
 
 Ref<InjectedBundleNodeHandle> InjectedBundleNodeHandle::getOrCreate(Node& node)
 {
-    if (auto existingHandle = domNodeHandleCache().get(&node))
+    if (auto existingHandle = domNodeHandleCache().get(node))
         return Ref<InjectedBundleNodeHandle>(*existingHandle);
 
     auto nodeHandle = InjectedBundleNodeHandle::create(node);
     if (nodeHandle->coreNode())
-        domNodeHandleCache().add(nodeHandle->coreNode(), nodeHandle.ptr());
+        domNodeHandleCache().add(*nodeHandle->coreNode(), nodeHandle.ptr());
     return nodeHandle;
 }
 
@@ -112,7 +113,7 @@ InjectedBundleNodeHandle::InjectedBundleNodeHandle(Node& node)
 InjectedBundleNodeHandle::~InjectedBundleNodeHandle()
 {
     if (m_node)
-        domNodeHandleCache().remove(m_node.get());
+        domNodeHandleCache().remove(*m_node);
 }
 
 Node* InjectedBundleNodeHandle::coreNode()
@@ -437,7 +438,7 @@ void InjectedBundleNodeHandle::stop()
 {
     // Invalidate handles to nodes inside documents that are about to be destroyed in order to prevent leaks.
     if (m_node) {
-        domNodeHandleCache().remove(m_node.get());
+        domNodeHandleCache().remove(*m_node);
         m_node = nullptr;
     }
 }


### PR DESCRIPTION
#### 5735433340880c963594a5cb10f20f6af5623889
<pre>
Use CheckedPtr&lt;Node&gt; less for non-stack objects
<a href="https://bugs.webkit.org/show_bug.cgi?id=266416">https://bugs.webkit.org/show_bug.cgi?id=266416</a>

Reviewed by Brent Fulgham.

Use CheckedPtr&lt;Node&gt; less for non-stack objects. Use WeakPtr&lt;Node&gt; instead in
order to generate more actionable crashes. This tested as performance neutral
on Speedometer 2 &amp; 3.

* Source/WebCore/accessibility/AccessibilityNodeObject.h:
* Source/WebCore/css/CSSStyleSheet.h:
* Source/WebCore/dom/MutationObserverRegistration.h:
* Source/WebCore/dom/Node.cpp:
(WebCore::liveNodeSet):
(WebCore::Node::dumpStatistics):
(WebCore::Node::trackForDebugging):
(WebCore::Node::~Node):
* Source/WebCore/dom/TemplateContentDocumentFragment.h:
* Source/WebCore/html/parser/HTMLConstructionSite.h:
* Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp:
* Source/WebCore/xml/XSLStyleSheet.h:
* Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp:
(WebKit::InjectedBundleNodeHandle::getOrCreate):
(WebKit::InjectedBundleNodeHandle::~InjectedBundleNodeHandle):
(WebKit::InjectedBundleNodeHandle::stop):

Canonical link: <a href="https://commits.webkit.org/272079@main">https://commits.webkit.org/272079@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/120ff1a2a20e13f11b8669eee689b57559a63759

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30526 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9219 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32183 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33035 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27611 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31230 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11500 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6472 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27536 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30834 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7728 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27345 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6632 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/6776 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27198 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34372 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27798 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27694 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/32950 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6783 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4902 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30774 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8520 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/7515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3959 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7335 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->