### PR TITLE
Stop using CheckedPtrs with Geolocation

### DIFF
--- a/Source/WebCore/Modules/geolocation/Geolocation.h
+++ b/Source/WebCore/Modules/geolocation/Geolocation.h
@@ -52,7 +52,7 @@ class ScriptExecutionContext;
 class SecurityOrigin;
 struct PositionOptions;
 
-class Geolocation final : public ScriptWrappable, public RefCounted<Geolocation>, public ActiveDOMObject, public CanMakeCheckedPtr {
+class Geolocation final : public ScriptWrappable, public RefCounted<Geolocation>, public CanMakeWeakPtr<Geolocation>, public ActiveDOMObject {
     WTF_MAKE_ISO_ALLOCATED_EXPORT(Geolocation, WEBCORE_EXPORT);
     friend class GeoNotifier;
 public:

--- a/Source/WebKit/WebProcess/Geolocation/GeolocationPermissionRequestManager.cpp
+++ b/Source/WebKit/WebProcess/Geolocation/GeolocationPermissionRequestManager.cpp
@@ -64,8 +64,8 @@ void GeolocationPermissionRequestManager::startRequestForGeolocation(Geolocation
 
     GeolocationIdentifier geolocationID = GeolocationIdentifier::generate();
 
-    m_geolocationToIDMap.set(&geolocation, geolocationID);
-    m_idToGeolocationMap.set(geolocationID, &geolocation);
+    m_geolocationToIDMap.set(geolocation, geolocationID);
+    m_idToGeolocationMap.set(geolocationID, geolocation);
 
     auto webFrame = WebFrame::fromCoreFrame(*frame);
     ASSERT(webFrame);

--- a/Source/WebKit/WebProcess/Geolocation/GeolocationPermissionRequestManager.h
+++ b/Source/WebKit/WebProcess/Geolocation/GeolocationPermissionRequestManager.h
@@ -51,8 +51,8 @@ public:
     void didReceiveGeolocationPermissionDecision(GeolocationIdentifier, const String& authorizationToken);
 
 private:
-    using IDToGeolocationMap = HashMap<GeolocationIdentifier, CheckedPtr<WebCore::Geolocation>>;
-    using GeolocationToIDMap = HashMap<CheckedPtr<WebCore::Geolocation>, GeolocationIdentifier>;
+    using IDToGeolocationMap = HashMap<GeolocationIdentifier, WeakRef<WebCore::Geolocation>>;
+    using GeolocationToIDMap = HashMap<WeakRef<WebCore::Geolocation>, GeolocationIdentifier>;
     IDToGeolocationMap m_idToGeolocationMap;
     GeolocationToIDMap m_geolocationToIDMap;
 


### PR DESCRIPTION
#### 1f20be81cbe14a49cbe37658ed39fdb9bb384bc5
<pre>
Stop using CheckedPtrs with Geolocation
<a href="https://bugs.webkit.org/show_bug.cgi?id=266422">https://bugs.webkit.org/show_bug.cgi?id=266422</a>

Reviewed by Ryosuke Niwa.

Stop using CheckedPtrs with Geolocation. Geolocation is refcounted so we can
use RefPtr&lt;Geolocation&gt; for stack variables and we should be using WeakPtr
for storing as data members or in containers.

* Source/WebCore/Modules/geolocation/Geolocation.h:
* Source/WebKit/WebProcess/Geolocation/GeolocationPermissionRequestManager.cpp:
(WebKit::GeolocationPermissionRequestManager::startRequestForGeolocation):
* Source/WebKit/WebProcess/Geolocation/GeolocationPermissionRequestManager.h:

Canonical link: <a href="https://commits.webkit.org/272073@main">https://commits.webkit.org/272073@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57559b168d43dd7cc0780a6996ea4d0f9072bda7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30496 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9169 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32116 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33003 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27583 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31199 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11406 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6410 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27519 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30804 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7706 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27329 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6602 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6767 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27179 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34341 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27776 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27674 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32928 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6749 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4882 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30752 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8492 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7482 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3955 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7289 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->