### PR TITLE
Open source build fix for "[Xcode] Symlink to missing headers and check in missing TBDs, instead of mutating the public SDK"

### DIFF
--- a/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj
+++ b/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj
@@ -23616,6 +23616,7 @@
 				"$(PROJECT_DIR)/Configurations/libwebrtc.exp",
 				"$(PROJECT_DIR)/Configurations/libwebrtc.testing.exp",
 				"$(PROJECT_DIR)/Configurations/libwebrtc.debug.exp",
+				"$(WK_DERIVED_SDK_HEADERS_DIR)",
 			);
 			name = "Generate Export Files";
 			outputFileListPaths = (


### PR DESCRIPTION
#### 0657884b0ee81915a1aa46826d77cfeee7700a95
<pre>
Open source build fix for &quot;[Xcode] Symlink to missing headers and check in missing TBDs, instead of mutating the public SDK&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=259831">https://bugs.webkit.org/show_bug.cgi?id=259831</a>
<a href="https://rdar.apple.com/problem/113764577">rdar://problem/113764577</a>

Unreviewed build fix.

Re-apply <a href="https://commits.webkit.org/267370@main">https://commits.webkit.org/267370@main</a> because it got undone in
a libwebrtc sync.

* Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj:

Originally-landed-as: 267370@main (4ee5a0c63c10). <a href="https://bugs.webkit.org/show_bug.cgi?id=266423">https://bugs.webkit.org/show_bug.cgi?id=266423</a>
Canonical link: <a href="https://commits.webkit.org/272063@main">https://commits.webkit.org/272063@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d587c79096e8175200684029cf2bad545b0faee

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30505 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9178 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32126 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33012 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/27597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11416 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6419 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/27526 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30813 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/7716 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27334 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6609 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/6764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/27187 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34349 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27786 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27682 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/32934 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6756 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4890 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30757 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8500 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7216 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/7498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7297 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->