### PR TITLE
Stop using CheckedPtr with DOMWrapperWorld

### DIFF
--- a/Source/WebCore/bindings/js/DOMWrapperWorld.h
+++ b/Source/WebCore/bindings/js/DOMWrapperWorld.h
@@ -22,8 +22,8 @@
 #pragma once
 
 #include "JSDOMGlobalObject.h"
-#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
@@ -31,7 +31,7 @@ class WindowProxy;
 
 typedef HashMap<void*, JSC::Weak<JSC::JSObject>> DOMObjectWrapperMap;
 
-class DOMWrapperWorld : public RefCounted<DOMWrapperWorld>, public CanMakeCheckedPtr {
+class DOMWrapperWorld : public RefCounted<DOMWrapperWorld>, public CanMakeSingleThreadWeakPtr<DOMWrapperWorld> {
 public:
     enum class Type {
         Normal,   // Main (e.g. Page)

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp
@@ -37,7 +37,7 @@
 namespace WebKit {
 using namespace WebCore;
 
-typedef HashMap<CheckedPtr<DOMWrapperWorld>, CheckedPtr<InjectedBundleScriptWorld>> WorldMap;
+using WorldMap = HashMap<SingleThreadWeakRef<DOMWrapperWorld>, CheckedPtr<InjectedBundleScriptWorld>>;
 
 static WorldMap& allWorlds()
 {
@@ -91,14 +91,14 @@ InjectedBundleScriptWorld::InjectedBundleScriptWorld(DOMWrapperWorld& world, con
     : m_world(world)
     , m_name(name)
 {
-    ASSERT(!allWorlds().contains(m_world.ptr()));
-    allWorlds().add(m_world.ptr(), this);
+    ASSERT(!allWorlds().contains(m_world.get()));
+    allWorlds().add(m_world.get(), this);
 }
 
 InjectedBundleScriptWorld::~InjectedBundleScriptWorld()
 {
-    ASSERT(allWorlds().contains(m_world.ptr()));
-    allWorlds().remove(m_world.ptr());
+    ASSERT(allWorlds().contains(m_world.get()));
+    allWorlds().remove(m_world.get());
 }
 
 const DOMWrapperWorld& InjectedBundleScriptWorld::coreWorld() const

--- a/Source/WebKitLegacy/mac/WebView/WebScriptWorld.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebScriptWorld.mm
@@ -40,7 +40,7 @@
 @implementation WebScriptWorldPrivate
 @end
 
-using WorldMap = HashMap<CheckedRef<WebCore::DOMWrapperWorld>, WebScriptWorld*>;
+using WorldMap = HashMap<SingleThreadWeakRef<WebCore::DOMWrapperWorld>, WebScriptWorld*>;
 static WorldMap& allWorlds()
 {
     static WorldMap& map = *new WorldMap;


### PR DESCRIPTION
#### b22cc9a66eeaa34e1c4d48bba25e7ea6d1793c3d
<pre>
Stop using CheckedPtr with DOMWrapperWorld
<a href="https://bugs.webkit.org/show_bug.cgi?id=266424">https://bugs.webkit.org/show_bug.cgi?id=266424</a>

Reviewed by Ryosuke Niwa.

Use WeakPtr instead to get more actionable crashes.

* Source/WebCore/bindings/js/DOMWrapperWorld.h:
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp:
(WebKit::InjectedBundleScriptWorld::InjectedBundleScriptWorld):
(WebKit::InjectedBundleScriptWorld::~InjectedBundleScriptWorld):
* Source/WebKitLegacy/mac/WebView/WebScriptWorld.mm:

Canonical link: <a href="https://commits.webkit.org/272072@main">https://commits.webkit.org/272072@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0e3c1ccdd0ff95123295e10b024fed7f11e3aa5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30500 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9173 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32120 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33007 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27595 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31203 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11410 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6414 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27528 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30808 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7711 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27330 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6611 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6759 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27180 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34344 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27779 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27675 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32937 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6752 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4886 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30770 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8496 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7486 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3954 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7293 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->