### PR TITLE
[WebGPU] CTS validation/debugMarker test does not pass

### DIFF
--- a/LayoutTests/http/tests/webgpu/webgpu/api/validation/debugMarker-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/validation/debugMarker-expected.txt
@@ -1,1 +1,5 @@
-(Populate me when we're ready to investigate this test)
+
+PASS :push_pop_call_count_unbalance,command_encoder:
+PASS :push_pop_call_count_unbalance,render_compute_pass:passType="compute"
+PASS :push_pop_call_count_unbalance,render_compute_pass:passType="render"
+

--- a/Source/WebGPU/WebGPU/CommandEncoder.h
+++ b/Source/WebGPU/WebGPU/CommandEncoder.h
@@ -91,6 +91,7 @@ public:
 
     void runClearEncoder(NSMutableDictionary<NSNumber*, TextureAndClearColor*> *attachmentsToClear, id<MTLTexture> depthStencilAttachmentToClear, bool depthAttachmentToClear, bool stencilAttachmentToClear, float depthClearValue = 0, uint32_t stencilClearValue = 0);
     static void clearTexture(const WGPUImageCopyTexture&, NSUInteger, id<MTLDevice>, id<MTLBlitCommandEncoder>);
+    void makeInvalid() { m_commandBuffer = nil; }
 
 private:
     CommandEncoder(id<MTLCommandBuffer>, Device&);
@@ -103,7 +104,6 @@ private:
     bool validateComputePassDescriptor(const WGPUComputePassDescriptor&) const;
     bool validateRenderPassDescriptor(const WGPURenderPassDescriptor&) const;
 
-    void makeInvalid() { m_commandBuffer = nil; }
     void clearTexture(const WGPUImageCopyTexture&, NSUInteger);
 
     id<MTLCommandBuffer> m_commandBuffer { nil };

--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -1289,7 +1289,8 @@ bool CommandEncoder::validateFinish() const
     if (m_state != EncoderState::Open)
         return false;
 
-    // FIXME: "this.[[debug_group_stack]] must be empty."
+    if (m_debugGroupStackSize)
+        return false;
 
     // FIXME: "Every usage scope contained in this must satisfy the usage scope validation."
 

--- a/Source/WebGPU/WebGPU/ComputePassEncoder.mm
+++ b/Source/WebGPU/WebGPU/ComputePassEncoder.mm
@@ -110,6 +110,11 @@ void ComputePassEncoder::endPass()
         return;
     }
 
+    if (m_debugGroupStackSize || !isValid()) {
+        m_parentEncoder->makeInvalid();
+        return;
+    }
+
     ASSERT(m_pendingTimestampWrites.isEmpty() || m_device->baseCapabilities().counterSamplingAPI == HardwareCapabilities::BaseCapabilities::CounterSamplingAPI::CommandBoundary);
     for (const auto& pendingTimestampWrite : m_pendingTimestampWrites)
         [m_computeCommandEncoder sampleCountersInBuffer:pendingTimestampWrite.querySet->counterSampleBuffer() atSampleIndex:pendingTimestampWrite.queryIndex withBarrier:NO];

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -221,6 +221,11 @@ void RenderPassEncoder::endPass()
         return;
     }
 
+    if (m_debugGroupStackSize || !isValid()) {
+        m_parentEncoder->makeInvalid();
+        return;
+    }
+
     ASSERT(m_pendingTimestampWrites.isEmpty() || m_device->baseCapabilities().counterSamplingAPI == HardwareCapabilities::BaseCapabilities::CounterSamplingAPI::CommandBoundary);
     for (const auto& pendingTimestampWrite : m_pendingTimestampWrites)
         [m_renderCommandEncoder sampleCountersInBuffer:pendingTimestampWrite.querySet->counterSampleBuffer() atSampleIndex:pendingTimestampWrite.queryIndex withBarrier:NO];


### PR DESCRIPTION
#### a286596dc032931aa847f49664c70082632aecf6
<pre>
[WebGPU] CTS validation/debugMarker test does not pass
<a href="https://bugs.webkit.org/show_bug.cgi?id=266420">https://bugs.webkit.org/show_bug.cgi?id=266420</a>
&lt;radar://119673064&gt;

Reviewed by Dan Glastonbury.

Correct validation for debugMarkers and add passing expectations.

* LayoutTests/http/tests/webgpu/webgpu/api/validation/debugMarker-expected.txt:
* Source/WebGPU/WebGPU/CommandEncoder.h:
(WebGPU::CommandEncoder::makeInvalid):
* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::validateFinish const):
* Source/WebGPU/WebGPU/ComputePassEncoder.mm:
(WebGPU::ComputePassEncoder::endPass):
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::endPass):

Canonical link: <a href="https://commits.webkit.org/272092@main">https://commits.webkit.org/272092@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/27d7c122dbdd72137159f14273b52d8dd8ef58d9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30502 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9175 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32122 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33009 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27593 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11412 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6416 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27522 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30810 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7712 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27332 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6606 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6760 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27183 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34346 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27780 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27693 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32938 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6754 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4888 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30761 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8498 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7238 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7500 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7295 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->