### PR TITLE
[git-webkit] Connect bug state during reverts

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/revert.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/revert.py
@@ -98,20 +98,21 @@ class Revert(Command):
             args.issue = args.reason
 
         issue = Tracker.from_string(args.issue)
+        commit_bugs_list = list(commit_bugs)
         if not issue and Tracker.instance() and getattr(args, 'update_issue', True):
             if getattr(Tracker.instance(), 'credentials', None):
                 Tracker.instance().credentials(required=True, validate=True)
 
             # Automatically set project, component, and version of new bug
             print('Setting bug properties...')
-            commit_bug = commit_bugs.pop()
+            commit_bug = commit_bugs_list.pop()
             project = commit_bug.project
             component = commit_bug.component
             version = commit_bug.version
 
             # Check whether properties are the same if multiple commits are reverted
-            while len(commit_bugs):
-                commit_bug = commit_bugs.pop()
+            while len(commit_bugs_list):
+                commit_bug = commit_bugs_list.pop()
                 # Setting properties to None will prompt for user input
                 if commit_bug.project != project:
                     project = None
@@ -139,6 +140,10 @@ class Revert(Command):
         rdar = Branch.cc_radar(args, repository, issue)
         if rdar:
             log.info("Created {}".format(rdar))
+
+        for c_bug in commit_bugs:
+            # TODO: relate revert bug
+            c_bug.open(why="{}, tracking revert in {}".format(issue.title, issue.link))
 
         return issue
 


### PR DESCRIPTION
#### 873843c9076d98e9fbbfda2ca8ca83ffe91b036c
<pre>
[git-webkit] Connect bug state during reverts
<a href="https://bugs.webkit.org/show_bug.cgi?id=265595">https://bugs.webkit.org/show_bug.cgi?id=265595</a>
<a href="https://rdar.apple.com/problem/119330079">rdar://problem/119330079</a>

Reviewed by Jonathan Bedard.

Reopens original bugs for all reverted commits and comments reason.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/revert.py:
(Revert.get_issue_info):

Canonical link: <a href="https://commits.webkit.org/272155@main">https://commits.webkit.org/272155@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd36b132b3acab07e10845546cb68e4df6aae5d3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30694 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9373 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32357 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33190 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27747 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31404 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11710 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6630 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27634 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31006 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7900 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27479 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6741 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/30850 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6924 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27348 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34527 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27973 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27834 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33064 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6927 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5027 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30901 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/30485 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8649 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7273 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7650 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7480 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->