### PR TITLE
CloneDeserializer::readTerminal() should fail decoding if tag is not exposed to current JS context

### DIFF
--- a/LayoutTests/fast/css/content-visibility-crash-expected.txt
+++ b/LayoutTests/fast/css/content-visibility-crash-expected.txt
@@ -1,0 +1,1 @@
+This test should not crash.

--- a/LayoutTests/fast/css/content-visibility-crash.html
+++ b/LayoutTests/fast/css/content-visibility-crash.html
@@ -1,0 +1,22 @@
+<style>
+html, body {
+    content-visibility: auto;
+}
+</style>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+onload = async () => {
+    let s0 = document.createElement('script');
+    s0.src = 'data:';
+    document.head.appendChild(s0);
+    if ('caches' in window) await caches.has('a');
+    document.styleSheets[0].disabled = true;
+    if ('caches' in window) await caches.has('b');
+    document.styleSheets[0].disabled = false;
+    document.body.offsetTop;
+    setTimeout(function() { document.write('This test should not crash.'); testRunner.notifyDone(); });
+};
+</script>

--- a/LayoutTests/fast/css/create-columns-onload-crash-expected.txt
+++ b/LayoutTests/fast/css/create-columns-onload-crash-expected.txt
@@ -1,0 +1,1 @@
+This test should not crash

--- a/LayoutTests/fast/css/create-columns-onload-crash.html
+++ b/LayoutTests/fast/css/create-columns-onload-crash.html
@@ -1,0 +1,9 @@
+<script>
+    if (window.testRunner)
+        testRunner.dumpAsText();
+  onload = () => {
+    let cssStyleValue = CSSMathValue.parseAll('columns', 'auto')[0];
+    document.body.attributeStyleMap.append('grid-auto-columns', cssStyleValue);
+  };
+</script>
+<div>This test should not crash</div>

--- a/LayoutTests/http/wpt/web-locks/lock-name-length-restriction.https-expected.txt
+++ b/LayoutTests/http/wpt/web-locks/lock-name-length-restriction.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Requested lock name cannot be too long
+

--- a/LayoutTests/http/wpt/web-locks/lock-name-length-restriction.https.html
+++ b/LayoutTests/http/wpt/web-locks/lock-name-length-restriction.https.html
@@ -1,0 +1,11 @@
+<!DOCTYPE HTML>
+<meta charset=utf-8>
+<title>Requested lock name cannot be too long</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+promise_test(async t => {
+  const name = 'x'.repeat(1025);
+  await promise_rejects_dom(t, 'NotSupportedError', navigator.locks.request(name, lock => {}));
+}, "Requested lock name cannot be too long");
+</script>

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -573,6 +573,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     Modules/system-preview/ARKitBadgeSystemImage.h
 
+    Modules/web-locks/WebLock.h
     Modules/web-locks/WebLockIdentifier.h
     Modules/web-locks/WebLockManagerSnapshot.h
     Modules/web-locks/WebLockMode.h

--- a/Source/WebCore/Modules/web-locks/WebLock.h
+++ b/Source/WebCore/Modules/web-locks/WebLock.h
@@ -36,6 +36,8 @@ class WebLock : public RefCounted<WebLock> {
 public:
     static Ref<WebLock> create(WebLockIdentifier, const String& name, WebLockMode);
 
+    static constexpr unsigned maxNameLength = { 1024 };
+
     WebLockIdentifier identifier() const { return m_identifier; }
     const String& name() const { return m_name; }
     WebLockMode mode() const { return m_mode; }

--- a/Source/WebCore/Modules/web-locks/WebLockManager.cpp
+++ b/Source/WebCore/Modules/web-locks/WebLockManager.cpp
@@ -199,6 +199,11 @@ void WebLockManager::request(const String& name, Options&& options, Ref<WebLockG
         return;
     }
 
+    if (name.length() > WebLock::maxNameLength) {
+        releasePromise->reject(NotSupportedError, makeString("Lock name cannot cannot be longer than "_s, WebLock::maxNameLength, " characters"));
+        return;
+    }
+
     if (options.steal && options.ifAvailable) {
         releasePromise->reject(ExceptionCode::NotSupportedError, "WebLockOptions's steal and ifAvailable cannot both be true"_s);
         return;

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -4267,8 +4267,10 @@ private:
     JSValue readTerminal()
     {
         SerializationTag tag = readTag();
-        if (!isTypeExposedToGlobalObject(*m_globalObject, tag))
+        if (!isTypeExposedToGlobalObject(*m_globalObject, tag)) {
+            fail();
             return JSValue();
+        }
         switch (tag) {
         case UndefinedTag:
             return jsUndefined();

--- a/Source/WebCore/dom/ContentVisibilityDocumentState.cpp
+++ b/Source/WebCore/dom/ContentVisibilityDocumentState.cpp
@@ -115,7 +115,10 @@ bool ContentVisibilityDocumentState::checkRelevancyOfContentVisibilityElement(El
     };
     if (relevancyToCheck.contains(ContentRelevancy::OnScreen)) {
         auto viewportProximityIterator = m_elementViewportProximities.find(target);
-        setRelevancyValue(ContentRelevancy::OnScreen, viewportProximityIterator->value == ViewportProximity::Near);
+        auto viewportProximity = ViewportProximity::Far;
+        if (viewportProximityIterator != m_elementViewportProximities.end())
+            viewportProximity = viewportProximityIterator->value;
+        setRelevancyValue(ContentRelevancy::OnScreen, viewportProximity == ViewportProximity::Near);
     }
 
     if (relevancyToCheck.contains(ContentRelevancy::Focused))

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -1136,6 +1136,9 @@ inline GridTrackSize BuilderConverter::createGridTrackSize(const CSSValue& value
     if (is<CSSPrimitiveValue>(value))
         return GridTrackSize(createGridTrackBreadth(downcast<CSSPrimitiveValue>(value), builderState));
 
+    if (!is<CSSFunctionValue>(value))
+        return GridTrackSize(GridLength(0));
+
     const auto& function = downcast<CSSFunctionValue>(value);
 
     if (function.length() == 1)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -204,8 +204,13 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTree(IPC::Connection& connectio
         }
     }
 
-    for (auto& transaction : transactions)
+    WeakPtr weakThis { *this };
+
+    for (auto& transaction : transactions) {
         commitLayerTreeTransaction(connection, transaction.first, transaction.second);
+        if (!weakThis)
+            return;
+    }
 
     // Keep IOSurface send rights alive until the transaction is commited, otherwise we will
     // prematurely drop the only reference to them, and `inUse` will be wrong for a brief window.

--- a/Source/WebKit/UIProcess/WebLockRegistryProxy.cpp
+++ b/Source/WebKit/UIProcess/WebLockRegistryProxy.cpp
@@ -31,6 +31,7 @@
 #include "WebLockRegistryProxyMessages.h"
 #include "WebProcessProxy.h"
 #include "WebsiteDataStore.h"
+#include <WebCore/WebLock.h>
 #include <WebCore/WebLockIdentifier.h>
 #include <WebCore/WebLockManagerSnapshot.h>
 #include <WebCore/WebLockRegistry.h>
@@ -54,6 +55,7 @@ void WebLockRegistryProxy::requestLock(WebCore::ClientOrigin&& clientOrigin, Web
 {
     MESSAGE_CHECK(lockIdentifier.processIdentifier() == m_process.coreProcessIdentifier());
     MESSAGE_CHECK(clientID.processIdentifier() == m_process.coreProcessIdentifier());
+    MESSAGE_CHECK(name.length() <= WebCore::WebLock::maxNameLength);
     m_hasEverRequestedLocks = true;
 
     auto* dataStore = m_process.websiteDataStore();


### PR DESCRIPTION
#### 52e69289eef53f0f8b4dfb78d14fcef441eb41c8
<pre>
CloneDeserializer::readTerminal() should fail decoding if tag is not exposed to current JS context
<a href="https://bugs.webkit.org/show_bug.cgi?id=262921">https://bugs.webkit.org/show_bug.cgi?id=262921</a>
<a href="https://rdar.apple.com/115756703">rdar://115756703</a>

Reviewed by Mark Lam.

In 265678@main, I added a check to make sure the type getting deserialized was exposed to the
current JS context (e.g. audio worklet contexts don&apos;t have access to many of the types that
Window context do). I added an early return when detecting this but failed to call `fail()`
to explicitly fail decoding.

* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneDeserializer::readTerminal):

Originally-landed-as: 267815.245@safari-7617-branch (bf21fed44b35). rdar://119577123
</pre>
----------------------------------------------------------------------
#### c2f69240da39dfcfcfae24dfeeafc64969adb51a
<pre>
Restrict the length of requested web locks names
<a href="https://bugs.webkit.org/show_bug.cgi?id=262920">https://bugs.webkit.org/show_bug.cgi?id=262920</a>
<a href="https://rdar.apple.com/116189077">rdar://116189077</a>

Reviewed by Brent Fulgham.

Restrict the length of requested web locks names to prevent abuse.

* LayoutTests/http/wpt/web-locks/lock-name-length-restriction.https-expected.txt: Added.
* LayoutTests/http/wpt/web-locks/lock-name-length-restriction.https.html: Added.
* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/web-locks/WebLock.h:
* Source/WebCore/Modules/web-locks/WebLockManager.cpp:
(WebCore::WebLockManager::request):
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebKit/UIProcess/WebLockRegistryProxy.cpp:
(WebKit::WebLockRegistryProxy::requestLock):

Originally-landed-as: 267815.246@safari-7617-branch (85aba6be5983). rdar://119577065
</pre>
----------------------------------------------------------------------
#### 9f20f309e8e5ec258bacfb82d2033f5810501a3c
<pre>
Check m_elementViewportProximities lookup
<a href="https://bugs.webkit.org/show_bug.cgi?id=262061">https://bugs.webkit.org/show_bug.cgi?id=262061</a>
<a href="https://rdar.apple.com/115978526">rdar://115978526</a>

Reviewed by Tim Nguyen.

It is possible a lookup in m_elementViewportProximities fails
to find an element, in that case do not use the iterator and
treat the viewport proximity as &quot;far&quot;.

* LayoutTests/fast/css/content-visibility-crash-expected.txt: Added.
* LayoutTests/fast/css/content-visibility-crash.html: Added.
* Source/WebCore/dom/ContentVisibilityDocumentState.cpp:
(WebCore::ContentVisibilityDocumentState::checkRelevancyOfContentVisibilityElement const):

Originally-landed-as: 268451.2@webkit-2023.9-embargoed (334d4db2351c). rdar://119566027
</pre>
----------------------------------------------------------------------
#### 8d50d73f433f427664a5b216a9492e09c376519a
<pre>
REGRESSION: OOB read in RemoteLayerTreeDrawingAreaProxy::commitLayerTree
<a href="https://bugs.webkit.org/show_bug.cgi?id=262977">https://bugs.webkit.org/show_bug.cgi?id=262977</a>
&lt;<a href="https://rdar.apple.com/116651090">rdar://116651090</a>&gt;

Reviewed by Tim Horton and Chris Dumez.

Post-commit callbacks can run arbitrary code, including code that results in the drawing
area being removed. It&apos;s not ref-counted, so we can&apos;t prevent its destruction if we recurse
into code that destroys it.

Instead, use a WeakPtr to |this| to check if destruction happens, and avoid doing
any futher work.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction):

Originally-landed-as: 267815.273@safari-7617-branch (5257e528b2d7). rdar://119564982
</pre>
----------------------------------------------------------------------
#### 0eb5b57ca05d3384affc2276473708ded3d3aa64
<pre>
jsc_fuz/wktr: ASSERTION FAILED: is&lt;Target&gt;(source) downcast(Source &amp;) [Target = WebCore::CSSFunctionValue, Source = const WebCore::CSSValue]
<a href="https://rdar.apple.com/115107618">rdar://115107618</a>

Reviewed by Chris Dumez.

Downcast was attempted before ensuring type is correct, so added a typecheck before downcast

* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::createGridTrackSize): added typecheck before downcast

Originally-landed-as: 267815.304@safari-7617-branch (395cb173896a). rdar://119564042
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52e69289eef53f0f8b4dfb78d14fcef441eb41c8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30518 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9212 "Hash 52e69289 for PR 21815 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32172 "Hash 52e69289 for PR 21815 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33028 "Hash 52e69289 for PR 21815 does not build (failure)") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27604 "Hash 52e69289 for PR 21815 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31221 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11493 "Hash 52e69289 for PR 21815 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6465 "Hash 52e69289 for PR 21815 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/33028 "Hash 52e69289 for PR 21815 does not build (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30826 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/11493 "Hash 52e69289 for PR 21815 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/32172 "Hash 52e69289 for PR 21815 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/33028 "Hash 52e69289 for PR 21815 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/11493 "Hash 52e69289 for PR 21815 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/32172 "Hash 52e69289 for PR 21815 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34363 "Hash 52e69289 for PR 21815 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/11493 "Hash 52e69289 for PR 21815 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/32172 "Hash 52e69289 for PR 21815 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/34363 "Hash 52e69289 for PR 21815 does not build (failure)") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6776 "Hash 52e69289 for PR 21815 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/51/builds/6465 "Hash 52e69289 for PR 21815 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/34363 "Hash 52e69289 for PR 21815 does not build (failure)") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8513 "Hash 52e69289 for PR 21815 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/32172 "Hash 52e69289 for PR 21815 does not build (failure)") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7508 "Hash 52e69289 for PR 21815 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7328 "Hash 52e69289 for PR 21815 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->