### PR TITLE
[TextureMapper] shrinked blur radius of drop-shadow shouldn't exceed GaussianBlurMaxRadius

### DIFF
--- a/LayoutTests/compositing/filters/drop-shadow-large-blur-radius-expected.html
+++ b/LayoutTests/compositing/filters/drop-shadow-large-blur-radius-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<style>
+    :root {
+        background: rgba(0, 0, 0, 0.02);
+    }
+    div {
+        background: green;
+        width: 100px;
+        height: 100px;
+    }
+</style>
+<div></div>

--- a/LayoutTests/compositing/filters/drop-shadow-large-blur-radius.html
+++ b/LayoutTests/compositing/filters/drop-shadow-large-blur-radius.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta name="fuzzy" content="maxDifference=0-5; totalPixels=0-480000" />
+<style>
+    div {
+        background: green;
+        width: 100px;
+        height: 100px;
+        will-change: transform;
+        // A black drop-shadow with a very large blur radius looks like almost no drop-shadow with slightly dark background.
+        filter: drop-shadow(0 0 1000000px);
+    }
+</style>
+<div></div>

--- a/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
@@ -362,7 +362,7 @@ static inline float gauss(float x, float radius)
 static int computeGaussianKernel(float radius, std::array<float, SimplifiedGaussianKernelMaxHalfSize>& kernel, std::array<float, SimplifiedGaussianKernelMaxHalfSize>& offset)
 {
     unsigned kernelHalfSize = blurRadiusToKernelHalfSize(radius);
-    ASSERT(kernelHalfSize <= GaussianKernelMaxHalfSize);
+    RELEASE_ASSERT(kernelHalfSize <= GaussianKernelMaxHalfSize);
 
     float fullKernel[GaussianKernelMaxHalfSize];
 
@@ -999,7 +999,7 @@ RefPtr<BitmapTexture> TextureMapper::applyDropShadowFilter(RefPtr<BitmapTexture>
                 std::max(textureSize.height() * scale, 1.f)
             );
             scale = float(targetSize.width()) / textureSize.width();
-            radius *= scale;
+            radius = std::min(GaussianBlurMaxRadius, radius * scale);
         }
     }
 


### PR DESCRIPTION
#### 15dc72ca9521ce9b61a9d91e4e8749482c59bd4c
<pre>
[TextureMapper] shrinked blur radius of drop-shadow shouldn&apos;t exceed GaussianBlurMaxRadius
<a href="https://bugs.webkit.org/show_bug.cgi?id=265659">https://bugs.webkit.org/show_bug.cgi?id=265659</a>

Reviewed by Michael Catanzaro.

TextureMapper::applyDropShadowFilter shrinks a source texture and a
blur radius of drop-shadow before applying a blur filter. The
downscaling ratio is based on the blur radius so that the shrinked
blur radius doesn&apos;t exceed GaussianBlurMaxRadius. However, the
calculation wasn&apos;t correct. it could slightly exceed
GaussianBlurMaxRadius if a blur radius is very large.

* LayoutTests/compositing/filters/drop-shadow-large-blur-radius-expected.html: Added.
* LayoutTests/compositing/filters/drop-shadow-large-blur-radius.html: Added.
* Source/WebCore/platform/graphics/texmap/TextureMapper.cpp:
Use std::min to radius as well as TextureMapper::applyBlurFilter does.

Canonical link: <a href="https://commits.webkit.org/272081@main">https://commits.webkit.org/272081@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92b44300a41b81188ec370c4ad3115d2b0c92c03

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30532 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9222 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32186 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33038 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27614 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31236 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11503 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6475 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/27540 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30840 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7730 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27349 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6624 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6778 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27202 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34375 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27800 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27698 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/32957 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6786 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4913 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/30781 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8523 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/26973 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7229 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/7518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7338 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->