### PR TITLE
REGRESSION (268616@main): No context menu preview appears for data detected links in Notes

### DIFF
--- a/LayoutTests/fast/events/touch/ios/long-press-on-link-in-ephemeral-session-expected.txt
+++ b/LayoutTests/fast/events/touch/ios/long-press-on-link-in-ephemeral-session-expected.txt
@@ -1,0 +1,12 @@
+Verifies that long pressing an app store URL in an ephemeral browsing session does not show a full link preview. Requires WebKitTestRunner (though you can test manually in Safari, using Private Browsing mode).
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS contextMenuPreviewRectForAppStoreLink.height is <= fullLinkPreviewHeightThreshold
+PASS contextMenuPreviewRectForRegularLink.height is >= fullLinkPreviewHeightThreshold
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Download Keynote
+WebKit Home Page

--- a/LayoutTests/fast/events/touch/ios/long-press-on-link-in-ephemeral-session.html
+++ b/LayoutTests/fast/events/touch/ios/long-press-on-link-in-ephemeral-session.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useEphemeralSession=true useFlexibleViewport=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="../../../../resources/ui-helper.js"></script>
+<script src="../../../../resources/js-test.js"></script>
+<style>
+body, html {
+    font-size: 16px;
+    font-family: system-ui;
+}
+
+.link-container {
+    margin-top: 1.5em;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("Verifies that long pressing an app store URL in an ephemeral browsing session does not show a full link preview. Requires WebKitTestRunner (though you can test manually in Safari, using Private Browsing mode).");
+    fullLinkPreviewHeightThreshold = 250;
+
+    await UIHelper.longPressElement(document.getElementById("appstore-link"));
+    await UIHelper.waitForContextMenuToShow();
+    contextMenuPreviewRectForAppStoreLink = await UIHelper.contextMenuPreviewRect();
+    shouldBeLessThanOrEqual("contextMenuPreviewRectForAppStoreLink.height", "fullLinkPreviewHeightThreshold");
+    await UIHelper.activateAt(0, 0);
+    await UIHelper.waitForContextMenuToHide();
+
+    await UIHelper.longPressElement(document.getElementById("regular-link"));
+    await UIHelper.waitForContextMenuToShow();
+    contextMenuPreviewRectForRegularLink = await UIHelper.contextMenuPreviewRect();
+    shouldBeGreaterThanOrEqual("contextMenuPreviewRectForRegularLink.height", "fullLinkPreviewHeightThreshold");
+    await UIHelper.activateAt(0, 0);
+    await UIHelper.waitForContextMenuToHide();
+
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <div class="link-container">
+        <a id="appstore-link" href="https://itunes.apple.com/us/app/keynote/id361285480">Download Keynote</a>
+    </div>
+    <div class="link-container">
+        <a id="regular-link" href="https://webkit.org">WebKit Home Page</a>
+    </div>
+</body>
+</html>

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -1544,6 +1544,13 @@ window.UIHelper = class UIHelper {
         });
     }
 
+    static contextMenuPreviewRect()
+    {
+        return new Promise(resolve => {
+            testRunner.runUIScript("JSON.stringify(uiController.contextMenuPreviewRect)", result => resolve(JSON.parse(result)));
+        });
+    }
+
     static setHardwareKeyboardAttached(attached)
     {
         return new Promise(resolve => testRunner.runUIScript(`uiController.setHardwareKeyboardAttached(${attached ? "true" : "false"})`, resolve));

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -268,6 +268,7 @@ interface UIScriptController {
     readonly attribute boolean isShowingMenu;
     readonly attribute object menuRect;
     readonly attribute object contextMenuRect;
+    readonly attribute object contextMenuPreviewRect;
     object rectForMenuAction(DOMString action);
     undefined chooseMenuAction(DOMString action, object callback);
     undefined dismissMenu();

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -309,6 +309,7 @@ public:
     virtual bool isShowingMenu() const { notImplemented(); return false; }
     virtual JSObjectRef rectForMenuAction(JSStringRef) const { notImplemented(); return nullptr; }
     virtual JSObjectRef menuRect() const { notImplemented(); return nullptr; }
+    virtual JSObjectRef contextMenuPreviewRect() const { notImplemented(); return nullptr; }
     virtual JSObjectRef contextMenuRect() const { notImplemented(); return nullptr; }
     virtual bool isShowingContextMenu() const { notImplemented(); return false; }
 

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -629,6 +629,9 @@ private:
 #if HAVE(UIKIT_RESIZABLE_WINDOWS)
     std::unique_ptr<InstanceMethodSwizzler> m_enhancedWindowingEnabledSwizzler;
 #endif
+#if ENABLE(DATA_DETECTION)
+    std::unique_ptr<InstanceMethodSwizzler> m_appStoreURLSwizzler;
+#endif
     bool m_verbose { false };
     bool m_printSeparators { false };
     bool m_usingServerMode { false };

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
@@ -132,6 +132,7 @@ private:
     bool isShowingFormValidationBubble() const override;
     JSObjectRef rectForMenuAction(JSStringRef) const override;
     JSObjectRef contextMenuRect() const override;
+    JSObjectRef contextMenuPreviewRect() const final;
     JSObjectRef menuRect() const override;
     bool isDismissingMenu() const override;
     void chooseMenuAction(JSStringRef, JSValueRef) override;

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
@@ -1274,6 +1274,15 @@ JSObjectRef UIScriptControllerIOS::menuRect() const
     return containerView ? toObject([containerView convertRect:containerView.bounds toView:platformContentView()]) : nullptr;
 }
 
+JSObjectRef UIScriptControllerIOS::contextMenuPreviewRect() const
+{
+    auto *container = findAllViewsInHierarchyOfType(webView().window, internalClassNamed(@"_UIMorphingPlatterView")).firstObject;
+    if (!container)
+        return nullptr;
+
+    return toObject([container convertRect:container.bounds toView:nil]);
+}
+
 JSObjectRef UIScriptControllerIOS::contextMenuRect() const
 {
     auto *window = webView().window;


### PR DESCRIPTION
#### 8c025b25b577af2f5489f1af12efa8da92eb5eb7
<pre>
REGRESSION (268616@main): No context menu preview appears for data detected links in Notes
<a href="https://bugs.webkit.org/show_bug.cgi?id=266431">https://bugs.webkit.org/show_bug.cgi?id=266431</a>
<a href="https://rdar.apple.com/119524150">rdar://119524150</a>

Reviewed by Megan Gardner.

Make a couple of minor adjustments to fix context menu previews for data detected links in HTML
Notes, after the changes in 268616@main. See below for more details.

Test: fast/events/touch/ios/long-press-on-link-in-ephemeral-session.html

* LayoutTests/fast/events/touch/ios/long-press-on-link-in-ephemeral-session-expected.txt: Added.
* LayoutTests/fast/events/touch/ios/long-press-on-link-in-ephemeral-session.html: Added.

Add a layout test to cover the changes in 264553@main, as well as the changes in this bug, by
verifying that in an ephemeral browsing session:

1. The context menu preview for an app store link is not full height (where &quot;full height&quot; is just
   represented by an arbitrary height cutoff of the preview platter view).
2. The context menu preview for a regular HTTP link is full height.

* LayoutTests/resources/ui-helper.js:
(window.UIHelper.contextMenuPreviewRect):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView dataDetectionContextForPositionInformation:]):

Limit the logic to avoid showing previews in ephemeral browsing (or when advanced privacy is
enabled) to iTunes Store links only. This data detectors codepath is the default way to preview
links for `WKWebView` clients that don&apos;t otherwise provide a custom menu configuration (e.g.
Safari). As such, the changes in 268616@main actually caused links in ephemeral browsing sessions
outside of Safari to lose their previews. This patch restores the iTunes Store check to bring back
shipping behavior.

(-[WKContentView _createTargetedContextMenuHintPreviewIfPossible]):

After we stopped using `UIContextMenuStyle` to show a compact menu for data-detected links, the
preview is now shown with a transparent background in Notes, since Notes makes their web view
transparent, such that the estimated background color is transparent black. This looks really ugly
on iOS in the context of the preview platter&apos;s background, since the text in the text indicator is
barely legible in light mode, on top of the backdrop filter.

To mitigate this, fall back to `+[UIColor systemBackgroundColor]` instead of transparent black for
text indicator previews, in the case where the estimated background color for the text indicator is
transparent black.

* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
(WTR::UIScriptController::contextMenuPreviewRect const):
* Tools/WebKitTestRunner/TestController.h:
* Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm:
(swizzledAppStoreURL):
(WTR::TestController::cocoaPlatformInitialize):

Swizzle out `-[NSURL iTunesStoreURL]` to:
1. Make it work on iOS simulator, in the same way as it does on device (for the link in the new test).
2. Make it work in a consistent manner, to ensure stability when testing.

* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h:
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm:
(WTR::UIScriptControllerIOS::contextMenuPreviewRect const):

Add a new testing helper to retrieve the bounds of the context menu preview platter.

Canonical link: <a href="https://commits.webkit.org/272084@main">https://commits.webkit.org/272084@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89e2a3145cb29430e34a384a60b3fd193cd7f8f5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30537 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9225 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32191 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33041 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27617 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31241 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11508 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6478 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27541 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30845 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7734 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27348 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6625 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6782 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27201 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34378 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27804 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27697 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32954 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6789 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4906 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/30778 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8526 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/26972 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7231 "Built successfully and passed tests") | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7521 "Failed to checkout and rebase branch from PR 21823") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7341 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->