### PR TITLE
Non-unified build fixes, mid January 2024 edition

### DIFF
--- a/Source/JavaScriptCore/bytecode/CallLinkInfoBase.cpp
+++ b/Source/JavaScriptCore/bytecode/CallLinkInfoBase.cpp
@@ -28,6 +28,7 @@
 
 #include "CachedCall.h"
 #include "CallLinkInfo.h"
+#include "JSCJSValueInlines.h"
 #include "PolymorphicCallStubRoutine.h"
 
 namespace JSC {

--- a/Source/JavaScriptCore/heap/JITStubRoutineSet.h
+++ b/Source/JavaScriptCore/heap/JITStubRoutineSet.h
@@ -36,6 +36,7 @@ using WTF::Range;
 namespace JSC {
 
 class GCAwareJITStubRoutine;
+class VM;
 
 #if ENABLE(JIT)
 

--- a/Source/JavaScriptCore/jit/JITOperations.cpp
+++ b/Source/JavaScriptCore/jit/JITOperations.cpp
@@ -44,6 +44,7 @@
 #include "Interpreter.h"
 #include "JIT.h"
 #include "JITExceptions.h"
+#include "JITThunks.h"
 #include "JITToDFGDeferredCompilationCallback.h"
 #include "JITWorklist.h"
 #include "JSAsyncFunction.h"

--- a/Source/JavaScriptCore/wasm/WasmCallsiteCollection.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCallsiteCollection.cpp
@@ -36,9 +36,12 @@
 #include <wtf/StdLibExtras.h>
 
 namespace JSC { namespace Wasm {
+
+#if ENABLE(WEBASSEMBLY_OMGJIT)
 namespace WasmCallsiteCollectionInternal {
 static constexpr bool verbose = false;
 }
+#endif
 
 void CallsiteCollection::addCallsites(const AbstractLocker& calleeGroupLocker, CalleeGroup& calleeGroup, const FixedVector<UnlinkedWasmToWasmCall>& callsites)
 {

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -65,9 +65,11 @@ IGNORE_WARNINGS_BEGIN("frame-address")
 
 namespace JSC { namespace Wasm {
 
+#if ENABLE(WEBASSEMBLY_OMGJIT)
 namespace WasmOperationsInternal {
     static constexpr bool verbose = false;
 }
+#endif
 
 #if ENABLE(WEBASSEMBLY_OMGJIT)
 static bool shouldTriggerOMGCompile(TierUpCount& tierUp, OMGCallee* replacement, uint32_t functionIndex)

--- a/Source/WebCore/Modules/gamepad/Gamepad.cpp
+++ b/Source/WebCore/Modules/gamepad/Gamepad.cpp
@@ -31,6 +31,7 @@
 #include "GamepadButton.h"
 #include "GamepadHapticActuator.h"
 #include "PlatformGamepad.h"
+#include "ScriptExecutionContext.h"
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/indexeddb/IDBDatabase.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBDatabase.cpp
@@ -37,6 +37,7 @@
 #include "IDBTransaction.h"
 #include "IDBVersionChangeEvent.h"
 #include "Logging.h"
+#include "Node.h"
 #include "ScriptExecutionContext.h"
 #include <JavaScriptCore/HeapInlines.h>
 #include <wtf/IsoMallocInlines.h>

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.cpp
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "WakeLockSentinel.h"
 
+#include "Document.h"
 #include "EventNames.h"
 #include "Exception.h"
 #include "JSDOMPromiseDeferred.h"

--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -27,6 +27,7 @@
 #include "CSSSelector.h"
 
 #include "CSSMarkup.h"
+#include "CSSParserTokenRange.h"
 #include "CSSSelectorInlines.h"
 #include "CSSSelectorList.h"
 #include "CSSSelectorParserContext.h"

--- a/Source/WebCore/css/StyleRule.cpp
+++ b/Source/WebCore/css/StyleRule.cpp
@@ -45,6 +45,7 @@
 #include "StyleProperties.h"
 #include "StylePropertiesInlines.h"
 #include "StyleRuleImport.h"
+#include "StyleSheetContents.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/dom/ConstantPropertyMap.h
+++ b/Source/WebCore/dom/ConstantPropertyMap.h
@@ -38,6 +38,7 @@ namespace WebCore {
 class CSSCustomPropertyValue;
 class CSSVariableData;
 class Document;
+class WeakPtrImplWithEventTargetData;
 
 enum class ConstantProperty {
     SafeAreaInsetTop,

--- a/Source/WebCore/dom/ExtensionStyleSheets.h
+++ b/Source/WebCore/dom/ExtensionStyleSheets.h
@@ -48,6 +48,7 @@ class Node;
 class StyleSheet;
 class StyleSheetContents;
 class StyleSheetList;
+class WeakPtrImplWithEventTargetData;
 
 class ExtensionStyleSheets {
     WTF_MAKE_FAST_ALLOCATED;

--- a/Source/WebCore/dom/RejectedPromiseTracker.cpp
+++ b/Source/WebCore/dom/RejectedPromiseTracker.cpp
@@ -31,6 +31,7 @@
 #include "EventTarget.h"
 #include "JSDOMGlobalObject.h"
 #include "JSDOMPromise.h"
+#include "Node.h"
 #include "PromiseRejectionEvent.h"
 #include "ScriptExecutionContext.h"
 #include <JavaScriptCore/Exception.h>

--- a/Source/WebCore/dom/ScriptRunner.h
+++ b/Source/WebCore/dom/ScriptRunner.h
@@ -37,6 +37,7 @@ namespace WebCore {
 class Document;
 class ScriptElement;
 class LoadableScript;
+class WeakPtrImplWithEventTargetData;
 
 class ScriptRunner : public PendingScriptClient {
     WTF_MAKE_NONCOPYABLE(ScriptRunner); WTF_MAKE_FAST_ALLOCATED;

--- a/Source/WebCore/dom/SimulatedClick.cpp
+++ b/Source/WebCore/dom/SimulatedClick.cpp
@@ -28,6 +28,7 @@
 
 #include "DOMRect.h"
 #include "DataTransfer.h"
+#include "Document.h"
 #include "Element.h"
 #include "EventNames.h"
 #include "MouseEvent.h"

--- a/Source/WebCore/dom/WheelEvent.cpp
+++ b/Source/WebCore/dom/WheelEvent.cpp
@@ -26,6 +26,7 @@
 
 #include "DataTransfer.h"
 #include "EventNames.h"
+#include "Node.h"
 #include "PlatformMouseEvent.h"
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/MathExtras.h>

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -79,6 +79,7 @@
 #include "NodeTraversal.h"
 #include "PopoverData.h"
 #include "PseudoClassChangeInvalidation.h"
+#include "Quirks.h"
 #include "RenderElement.h"
 #include "ScriptController.h"
 #include "ScriptDisallowedScope.h"

--- a/Source/WebCore/html/track/TextTrackCueGeneric.cpp
+++ b/Source/WebCore/html/track/TextTrackCueGeneric.cpp
@@ -46,8 +46,6 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(TextTrackCueGeneric);
 
-static constexpr int DEFAULTCAPTIONFONTSIZE = 22; // Keep in sync with `font-size` in `video::-webkit-media-text-track-display`.
-
 class TextTrackCueGenericBoxElement final : public VTTCueBox {
     WTF_MAKE_ISO_ALLOCATED_INLINE(TextTrackCueGenericBoxElement);
 public:

--- a/Source/WebCore/layout/formattingContexts/table/TableGrid.h
+++ b/Source/WebCore/layout/formattingContexts/table/TableGrid.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "FormattingContext.h"
+#include "LayoutBoxGeometry.h"
 #include "LayoutUnits.h"
 #include <wtf/HashMap.h>
 #include <wtf/IsoMalloc.h>

--- a/Source/WebCore/platform/graphics/filters/software/FELightingSoftwareParallelApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FELightingSoftwareParallelApplier.cpp
@@ -29,7 +29,7 @@
 #include "FELightingSoftwareParallelApplier.h"
 
 #if !(CPU(ARM_NEON) && CPU(ARM_TRADITIONAL) && COMPILER(GCC_COMPATIBLE))
-
+#include "ImageBuffer.h"
 #include <wtf/ParallelJobs.h>
 
 namespace WebCore {

--- a/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
@@ -43,6 +43,7 @@
 #include "RenderSVGModelObjectInlines.h"
 #include "RenderView.h"
 #include "SVGElementInlines.h"
+#include "SVGElementTypeHelpers.h"
 #include "SVGGraphicsElement.h"
 #include "SVGLocatable.h"
 #include "SVGNames.h"

--- a/Source/WebCore/rendering/svg/RenderSVGResourceGradient.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceGradient.cpp
@@ -21,7 +21,10 @@
 #include "RenderSVGResourceGradient.h"
 
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
+#include "RenderSVGModelObjectInlines.h"
 #include "RenderSVGResourceGradientInlines.h"
+#include "RenderSVGShape.h"
+#include "SVGRenderStyle.h"
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/rendering/svg/RenderSVGResourceLinearGradient.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceLinearGradient.cpp
@@ -23,6 +23,7 @@
 #include "RenderSVGResourceLinearGradient.h"
 
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
+#include "RenderSVGModelObjectInlines.h"
 #include "RenderSVGResourceLinearGradientInlines.h"
 #include <wtf/IsoMallocInlines.h>
 

--- a/Source/WebCore/rendering/svg/RenderSVGResourceRadialGradient.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceRadialGradient.cpp
@@ -23,7 +23,9 @@
 #include "RenderSVGResourceRadialGradient.h"
 
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
+#include "RenderSVGModelObjectInlines.h"
 #include "RenderSVGResourceRadialGradientInlines.h"
+#include "RenderSVGShape.h"
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/rendering/svg/RenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGShape.cpp
@@ -41,6 +41,7 @@
 #include "PointerEventsHitRules.h"
 #include "RenderSVGShapeInlines.h"
 #include "RenderStyleInlines.h"
+#include "RenderView.h"
 #include "SVGPaintServerHandling.h"
 #include "SVGPathData.h"
 #include "SVGRenderingContext.h"

--- a/Source/WebCore/rendering/svg/SVGInlineTextBox.cpp
+++ b/Source/WebCore/rendering/svg/SVGInlineTextBox.cpp
@@ -34,6 +34,7 @@
 #include "PointerEventsHitRules.h"
 #include "RenderBlock.h"
 #include "RenderInline.h"
+#include "RenderSVGText.h"
 #include "RenderStyleInlines.h"
 #include "RenderView.h"
 #include "SVGInlineTextBoxInlines.h"

--- a/Source/WebCore/svg/SVGTextPathElement.cpp
+++ b/Source/WebCore/svg/SVGTextPathElement.cpp
@@ -27,6 +27,7 @@
 #include "RenderSVGTextPath.h"
 #include "SVGDocumentExtensions.h"
 #include "SVGElementInlines.h"
+#include "SVGElementTypeHelpers.h"
 #include "SVGNames.h"
 #include "SVGPathElement.h"
 #include <wtf/IsoMallocInlines.h>

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchRegistration.cpp
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchRegistration.cpp
@@ -34,6 +34,7 @@
 #include "FetchResponse.h"
 #include "FetchResponseBodyLoader.h"
 #include "JSBackgroundFetchRecord.h"
+#include "Node.h"
 #include "RetrieveRecordsOptions.h"
 #include "SWClientConnection.h"
 #include "ServiceWorkerContainer.h"

--- a/Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.cpp
+++ b/Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.cpp
@@ -30,6 +30,7 @@
 #include "EventLoop.h"
 #include "EventNames.h"
 #include "EventTarget.h"
+#include "ScriptExecutionContext.h"
 #include "XMLHttpRequest.h"
 #include "XMLHttpRequestProgressEvent.h"
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp
@@ -30,6 +30,7 @@
 #include "Logging.h"
 #include "RemoteImageBufferSetMessages.h"
 #include "RemoteRenderingBackend.h"
+#include <WebCore/GraphicsContext.h>
 
 #if PLATFORM(COCOA)
 #include <WebCore/PlatformCALayer.h>
@@ -46,14 +47,14 @@
 
 namespace WebKit {
 
-Ref<RemoteImageBufferSet> RemoteImageBufferSet::create(RemoteImageBufferSetIdentifier identifier, RenderingResourceIdentifier displayListIdentifier, RemoteRenderingBackend& backend)
+Ref<RemoteImageBufferSet> RemoteImageBufferSet::create(RemoteImageBufferSetIdentifier identifier, WebCore::RenderingResourceIdentifier displayListIdentifier, RemoteRenderingBackend& backend)
 {
     auto instance = adoptRef(*new RemoteImageBufferSet(identifier, displayListIdentifier, backend));
     instance->startListeningForIPC();
     return instance;
 }
 
-RemoteImageBufferSet::RemoteImageBufferSet(RemoteImageBufferSetIdentifier identifier, RenderingResourceIdentifier displayListIdentifier, RemoteRenderingBackend& backend)
+RemoteImageBufferSet::RemoteImageBufferSet(RemoteImageBufferSetIdentifier identifier, WebCore::RenderingResourceIdentifier displayListIdentifier, RemoteRenderingBackend& backend)
     : m_backend(&backend)
     , m_identifier(identifier)
     , m_displayListIdentifier(displayListIdentifier)
@@ -78,7 +79,7 @@ IPC::StreamConnectionWorkQueue& RemoteImageBufferSet::workQueue() const
     return m_backend->workQueue();
 }
 
-void RemoteImageBufferSet::updateConfiguration(const FloatSize& logicalSize, RenderingMode renderingMode, float resolutionScale, const DestinationColorSpace& colorSpace, PixelFormat pixelFormat)
+void RemoteImageBufferSet::updateConfiguration(const WebCore::FloatSize& logicalSize, WebCore::RenderingMode renderingMode, float resolutionScale, const WebCore::DestinationColorSpace& colorSpace, WebCore::PixelFormat pixelFormat)
 {
     m_logicalSize = logicalSize;
     m_renderingMode = renderingMode;
@@ -107,7 +108,7 @@ void RemoteImageBufferSet::flush()
 void RemoteImageBufferSet::ensureBufferForDisplay(ImageBufferSetPrepareBufferForDisplayInputData& inputData, ImageBufferSetPrepareBufferForDisplayOutputData& outputData)
 {
     assertIsCurrent(workQueue());
-    auto bufferIdentifier = [](RefPtr<WebCore::ImageBuffer> buffer) -> std::optional<RenderingResourceIdentifier> {
+    auto bufferIdentifier = [](RefPtr<WebCore::ImageBuffer> buffer) -> std::optional<WebCore::RenderingResourceIdentifier> {
         if (!buffer)
             return std::nullopt;
         return buffer->renderingResourceIdentifier();
@@ -123,9 +124,9 @@ void RemoteImageBufferSet::ensureBufferForDisplay(ImageBufferSetPrepareBufferFor
     bool needsFullDisplay = false;
     if (m_frontBuffer) {
         auto previousState = m_frontBuffer->setNonVolatile();
-        if (previousState == SetNonVolatileResult::Empty) {
+        if (previousState == WebCore::SetNonVolatileResult::Empty) {
             needsFullDisplay = true;
-            inputData.dirtyRegion = IntRect { { }, expandedIntSize(m_logicalSize) };
+            inputData.dirtyRegion = WebCore::IntRect { { }, expandedIntSize(m_logicalSize) };
         }
     }
 
@@ -154,13 +155,13 @@ void RemoteImageBufferSet::ensureBufferForDisplay(ImageBufferSetPrepareBufferFor
 
         if (m_frontBuffer) {
             auto previousState = m_frontBuffer->setNonVolatile();
-            if (previousState == SetNonVolatileResult::Empty)
+            if (previousState == WebCore::SetNonVolatileResult::Empty)
                 m_previouslyPaintedRect = std::nullopt;
         }
     }
 
     if (!m_frontBuffer) {
-        m_frontBuffer = m_backend->allocateImageBuffer(m_logicalSize, m_renderingMode, WebCore::RenderingPurpose::LayerBacking, m_resolutionScale, m_colorSpace, m_pixelFormat, RenderingResourceIdentifier::generate());
+        m_frontBuffer = m_backend->allocateImageBuffer(m_logicalSize, m_renderingMode, WebCore::RenderingPurpose::LayerBacking, m_resolutionScale, m_colorSpace, m_pixelFormat, WebCore::RenderingResourceIdentifier::generate());
         m_frontBufferIsCleared = true;
     }
 
@@ -185,35 +186,35 @@ void RemoteImageBufferSet::prepareBufferForDisplay(const WebCore::Region& dirtyR
         return;
     }
 
-    FloatRect bufferBounds { { }, m_logicalSize };
+    WebCore::FloatRect bufferBounds { { }, m_logicalSize };
 
-    GraphicsContext& context = m_frontBuffer->context();
+    WebCore::GraphicsContext& context = m_frontBuffer->context();
     context.resetClip();
 
-    FloatRect copyRect;
+    WebCore::FloatRect copyRect;
     if (m_previousFrontBuffer && m_frontBuffer != m_previousFrontBuffer) {
-        IntRect enclosingCopyRect { m_previouslyPaintedRect ? *m_previouslyPaintedRect : enclosingIntRect(bufferBounds) };
+        WebCore::IntRect enclosingCopyRect { m_previouslyPaintedRect ? *m_previouslyPaintedRect : enclosingIntRect(bufferBounds) };
         if (!dirtyRegion.contains(enclosingCopyRect)) {
-            Region copyRegion(enclosingCopyRect);
+            WebCore::Region copyRegion(enclosingCopyRect);
             copyRegion.subtract(dirtyRegion);
             copyRect = intersection(copyRegion.bounds(), bufferBounds);
             if (!copyRect.isEmpty())
-                m_frontBuffer->context().drawImageBuffer(*m_previousFrontBuffer, copyRect, copyRect, { CompositeOperator::Copy });
+                m_frontBuffer->context().drawImageBuffer(*m_previousFrontBuffer, copyRect, copyRect, { WebCore::CompositeOperator::Copy });
         }
     }
 
     auto dirtyRects = dirtyRegion.rects();
 #if PLATFORM(COCOA)
-    IntRect dirtyBounds = dirtyRegion.bounds();
+    WebCore::IntRect dirtyBounds = dirtyRegion.bounds();
     if (dirtyRects.size() > PlatformCALayer::webLayerMaxRectsToPaint || dirtyRegion.totalArea() > PlatformCALayer::webLayerWastedSpaceThreshold * dirtyBounds.width() * dirtyBounds.height()) {
         dirtyRects.clear();
         dirtyRects.append(dirtyBounds);
     }
 #endif
 
-    Vector<FloatRect, 5> paintingRects;
+    Vector<WebCore::FloatRect, 5> paintingRects;
     for (const auto& rect : dirtyRects) {
-        FloatRect scaledRect(rect);
+        WebCore::FloatRect scaledRect(rect);
         scaledRect.scale(m_resolutionScale);
         scaledRect = enclosingIntRect(scaledRect);
         scaledRect.scale(1 / m_resolutionScale);
@@ -228,7 +229,7 @@ void RemoteImageBufferSet::prepareBufferForDisplay(const WebCore::Region& dirtyR
     if (paintingRects.size() == 1)
         context.clip(paintingRects[0]);
     else {
-        Path clipPath;
+        WebCore::Path clipPath;
         for (auto rect : paintingRects)
             clipPath.addRect(rect);
         context.clipPath(clipPath);
@@ -246,12 +247,12 @@ bool RemoteImageBufferSet::makeBuffersVolatile(OptionSet<BufferInSetType> reques
 {
     bool allSucceeded = true;
 
-    auto makeVolatile = [](ImageBuffer& imageBuffer) {
+    auto makeVolatile = [](WebCore::ImageBuffer& imageBuffer) {
         imageBuffer.releaseGraphicsContext();
         return imageBuffer.setVolatile();
     };
 
-    auto makeBufferTypeVolatile = [&](BufferInSetType type, RefPtr<ImageBuffer> imageBuffer) {
+    auto makeBufferTypeVolatile = [&](BufferInSetType type, RefPtr<WebCore::ImageBuffer> imageBuffer) {
         if (requestedBuffers.contains(type) && imageBuffer) {
             if (makeVolatile(*imageBuffer))
                 volatileBuffers.add(type);

--- a/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(GPU_PROCESS)
 
+#include "ArgumentCoders.h"
 #include "RemoteImageBuffer.h"
 #include <WebCore/ImageBuffer.h>
 

--- a/Source/WebKit/UIProcess/RemotePageProxy.cpp
+++ b/Source/WebKit/UIProcess/RemotePageProxy.cpp
@@ -33,6 +33,7 @@
 #include "HandleMessage.h"
 #include "NativeWebMouseEvent.h"
 #include "NavigationActionData.h"
+#include "NavigationActionPolicyParameters.h"
 #include "RemotePageDrawingAreaProxy.h"
 #include "RemotePageVisitedLinkStoreRegistration.h"
 #include "WebFrameProxy.h"

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -111,6 +111,10 @@
 #include "HighPerformanceGPUManager.h"
 #endif
 
+#if ENABLE(GPU_PROCESS)
+#include "APIPageConfiguration.h"
+#endif
+
 #if ENABLE(SEC_ITEM_SHIM)
 #include "SecItemShimProxy.h"
 #endif


### PR DESCRIPTION
#### 1c19226f030bcafb4e0796354d3af7aed915f23d
<pre>
Non-unified build fixes, mid January 2024 edition
<a href="https://bugs.webkit.org/show_bug.cgi?id=266437">https://bugs.webkit.org/show_bug.cgi?id=266437</a>

Unreviewed non-unified build fix.

* Source/JavaScriptCore/bytecode/CallLinkInfoBase.cpp:
* Source/JavaScriptCore/heap/JITStubRoutineSet.h:
* Source/JavaScriptCore/jit/JITOperations.cpp:
* Source/JavaScriptCore/wasm/WasmCallsiteCollection.cpp:
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
* Source/WebCore/Modules/gamepad/Gamepad.cpp:
* Source/WebCore/Modules/indexeddb/IDBDatabase.cpp:
* Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.cpp:
* Source/WebCore/css/CSSSelector.cpp:
* Source/WebCore/css/StyleRule.cpp:
* Source/WebCore/dom/ConstantPropertyMap.h:
* Source/WebCore/dom/ExtensionStyleSheets.h:
* Source/WebCore/dom/RejectedPromiseTracker.cpp:
* Source/WebCore/dom/ScriptRunner.h:
* Source/WebCore/dom/SimulatedClick.cpp:
* Source/WebCore/dom/WheelEvent.cpp:
* Source/WebCore/html/HTMLElement.cpp:
* Source/WebCore/html/track/TextTrackCueGeneric.cpp:
* Source/WebCore/layout/formattingContexts/table/TableGrid.h:
* Source/WebCore/platform/graphics/filters/software/FELightingSoftwareParallelApplier.cpp:
* Source/WebCore/rendering/svg/RenderSVGModelObject.cpp:
* Source/WebCore/rendering/svg/RenderSVGResourceGradient.cpp:
* Source/WebCore/rendering/svg/RenderSVGResourceLinearGradient.cpp:
* Source/WebCore/rendering/svg/RenderSVGResourceRadialGradient.cpp:
* Source/WebCore/rendering/svg/RenderSVGShape.cpp:
* Source/WebCore/rendering/svg/SVGInlineTextBox.cpp:
* Source/WebCore/svg/SVGTextPathElement.cpp:
* Source/WebCore/workers/service/background-fetch/BackgroundFetchRegistration.cpp:
* Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.cpp:
* Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp:
* Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp:
* Source/WebKit/UIProcess/RemotePageProxy.cpp:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:

Canonical link: <a href="https://commits.webkit.org/273099@main">https://commits.webkit.org/273099@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e11fd8a76581c2b212a18e92eba2a1abefc9fd39

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34247 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13056 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36238 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36935 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/31024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35331 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15443 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10185 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30047 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34759 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11056 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30558 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9653 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/9756 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30599 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38226 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/29155 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31120 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30916 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35835 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/34169 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9880 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7746 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33756 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11671 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/40710 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7884 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10439 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8477 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10704 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->