### PR TITLE
Some animations can cause InteractionRegion layers to disappear

### DIFF
--- a/LayoutTests/interaction-region/interaction-layers-culling-layer-type-change-expected.txt
+++ b/LayoutTests/interaction-region/interaction-layers-culling-layer-type-change-expected.txt
@@ -1,0 +1,324 @@
+
+(CALayer tree root
+  (layer bounds [x: 0 y: 0 width: 800 height: 600])
+  (layer position [x: 400 y: 400])
+  (sublayers
+    (
+      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+      (layer position [x: 400 y: 400])
+      (sublayers
+        (
+          (layer bounds [x: 0 y: 0 width: 800 height: 713])
+          (layer anchorPoint [x: 0 y: 0])
+          (sublayers
+            (
+              (layer bounds [x: 0 y: 0 width: 800 height: 713])
+              (layer anchorPoint [x: 0 y: 0])
+              (sublayers
+                (
+                  (layer bounds [x: 0 y: 0 width: 800 height: 713])
+                  (layer position [x: 400 y: 400])
+                  (sublayers
+                    (
+                      (layer bounds [x: 0 y: 0 width: 800 height: 713])
+                      (layer position [x: 400 y: 400])
+                      (sublayers
+                        (
+                          (layer bounds [x: 0 y: 0 width: 800 height: 713])
+                          (layer anchorPoint [x: 0 y: 0])
+                          (sublayers
+                            (
+                              (layer bounds [x: 0 y: 0 width: 800 height: 713])
+                              (layer anchorPoint [x: 0 y: 0])
+                              (sublayers
+                                (
+                                  (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                  (sublayers
+                                    (
+                                      (layer bounds [x: 0 y: 0 width: 800 height: 512])
+                                      (layer anchorPoint [x: 0 y: 0]))
+                                    (
+                                      (layer bounds [x: 0 y: 0 width: 800 height: 201])
+                                      (layer position [x: 0 y: 0])
+                                      (layer anchorPoint [x: 0 y: 0]))))
+                                (
+                                  (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                  (layer anchorPoint [x: 0 y: 0])
+                                  (sublayers
+                                    (
+                                      (layer bounds [x: 0 y: 0 width: 800 height: 700])
+                                      (layer position [x: 400 y: 400])
+                                      (sublayers
+                                        (
+                                          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                          (sublayers
+                                            (
+                                              (type 0)
+                                              (layer bounds [x: 0 y: 0 width: 700 height: 36])
+                                              (layer position [x: 400 y: 400])
+                                              (layer cornerRadius 8))
+                                            (
+                                              (type 0)
+                                              (layer bounds [x: 0 y: 0 width: 700 height: 36])
+                                              (layer position [x: 400 y: 400])
+                                              (layer cornerRadius 8))
+                                            (
+                                              (type 0)
+                                              (layer bounds [x: 0 y: 0 width: 700 height: 36])
+                                              (layer position [x: 400 y: 400])
+                                              (layer cornerRadius 8))))))))))))))))))
+            (
+              (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
+        (
+          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+          (layer anchorPoint [x: 0 y: 0]))
+        (
+          (layer bounds [x: 0 y: 0 width: 800 height: 12])
+          (layer position [x: 400 y: 400])
+          (layer zPosition 1000)
+          (layer opacity 0)
+          (sublayers
+            (
+              (layer bounds [x: 0 y: 0 width: 116 height: 32])
+              (layer position [x: 400 y: 400]))
+            (
+              (layer bounds [x: 0 y: 0 width: 800 height: 12])
+              (layer position [x: 400 y: 400])
+              (sublayers
+                (
+                  (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                  (layer position [x: 400 y: 400])
+                  (layer cornerRadius 6)
+                  (sublayers
+                    (
+                      (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                      (layer position [x: 48 y: 48])
+                      (layer cornerRadius 6))
+                    (
+                      (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                      (layer position [x: 48 y: 48])
+                      (layer cornerRadius 6))
+                    (
+                      (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                      (layer position [x: 48 y: 48])
+                      (layer cornerRadius 6))
+                    (
+                      (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                      (layer position [x: 48 y: 48])
+                      (layer cornerRadius 6))
+                    (
+                      (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                      (layer position [x: 48 y: 48])
+                      (layer cornerRadius 6))
+                    (
+                      (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                      (layer position [x: 48 y: 48])
+                      (layer cornerRadius 6))
+                    (
+                      (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
+                      (layer position [x: 48 y: 48])
+                      (layer opacity 0)
+                      (sublayers
+                        (
+                          (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
+                          (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                          (layer opacity 0.15)
+                          (sublayers
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))))))
+                    (
+                      (layer bounds [x: 0 y: 0 width: 90 height: 6])
+                      (layer position [x: 48 y: 48])
+                      (layer opacity 0.15)
+                      (layer cornerRadius 3))))))))
+        (
+          (layer bounds [x: 0 y: 0 width: 12 height: 600])
+          (layer position [x: 791 y: 791])
+          (layer zPosition 1000)
+          (layer opacity 0)
+          (sublayers
+            (
+              (layer bounds [x: 0 y: 0 width: 32 height: 116])
+              (layer position [x: 6 y: 6]))
+            (
+              (layer bounds [x: 0 y: 0 width: 12 height: 600])
+              (layer position [x: 6 y: 6])
+              (sublayers
+                (
+                  (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                  (layer position [x: 6 y: 6])
+                  (layer cornerRadius 6)
+                  (sublayers
+                    (
+                      (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                      (layer position [x: 6 y: 6])
+                      (layer cornerRadius 6))
+                    (
+                      (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                      (layer position [x: 6 y: 6])
+                      (layer cornerRadius 6))
+                    (
+                      (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                      (layer position [x: 6 y: 6])
+                      (layer cornerRadius 6))
+                    (
+                      (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                      (layer position [x: 6 y: 6])
+                      (layer cornerRadius 6))
+                    (
+                      (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                      (layer position [x: 6 y: 6])
+                      (layer cornerRadius 6))
+                    (
+                      (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                      (layer position [x: 6 y: 6])
+                      (layer cornerRadius 6))
+                    (
+                      (layer bounds [x: 0 y: 0 width: 6 height: 90])
+                      (layer position [x: 6 y: 6])
+                      (layer opacity 0)
+                      (sublayers
+                        (
+                          (layer bounds [x: 0 y: 0 width: 6 height: 90])
+                          (layer position [x: 3 y: 3])
+                          (layer opacity 0.15)
+                          (sublayers
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))))))
+                    (
+                      (layer bounds [x: 0 y: 0 width: 6 height: 75.5])
+                      (layer position [x: 6 y: 6])
+                      (layer opacity 0.15)
+                      (layer cornerRadius 3))))))))))))

--- a/LayoutTests/interaction-region/interaction-layers-culling-layer-type-change.html
+++ b/LayoutTests/interaction-region/interaction-layers-culling-layer-type-change.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html>
+<style>
+    body {
+        margin: 0;
+    }
+
+    #test {
+        position: absolute;
+        width: 100%;
+        height: 600px;
+        background: #efefef;
+        will-change: opacity;
+    }
+
+    #test a {
+        display: block;
+        margin: 50px;
+        font-size: 30px;
+    }
+
+    #moving {
+        position: absolute;
+        top: 500px;
+        left: 400px;
+        width: 200px;
+        height: 200px;
+        background: blue;
+    }
+
+    .animate {
+        animation-duration: 0.25s;
+        animation-name: grow-shrink;
+        animation-fill-mode: forwards;
+    }
+
+    @keyframes grow-shrink {
+      0% { height: 200px;}
+      50% { height: 2000px;}
+      100% { height: 200px;}
+    }
+
+</style>
+<script src="../resources/ui-helper.js"></script>
+<body>
+
+<section id="test" >
+    <div id="moving">
+    </div>
+    <a href="#">Link 1</a>
+    <a href="#">Link 2</a>
+    <a href="#">Link 3</a>
+</section>
+
+<pre id="results"></pre>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+let testEl = document.getElementById("test");
+let movingEl = document.getElementById("moving");
+
+window.onload = async function () {
+    if (!window.internals)
+        return;
+
+    await UIHelper.animationFrame();
+
+    movingEl.classList.add("animate");
+    await new Promise(r => {
+        movingEl.addEventListener("animationend", r);
+    });
+
+    await UIHelper.ensureStablePresentationUpdate();
+
+    results.textContent = await UIHelper.getCALayerTree();
+    testEl.remove();
+
+    testRunner.notifyDone();
+};
+</script>
+</body>
+</html>
+

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -4555,10 +4555,15 @@ void GraphicsLayerCA::changeLayerTypeTo(PlatformCALayer::LayerType newLayerType)
         | OpacityChanged
         | EventRegionChanged
         | NameChanged
-        | DebugIndicatorsChanged);
-    
-    if (isTiledLayer)
-        addUncommittedChanges(CoverageRectChanged);
+        | DebugIndicatorsChanged
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+        | CoverageRectChanged);
+#else
+        );
+
+        if (isTiledLayer)
+            addUncommittedChanges(CoverageRectChanged);
+#endif
 
     adjustContentsScaleLimitingFactor();
 


### PR DESCRIPTION
#### 694cea7f71185b8a8b423367911fd79612e62b47
<pre>
Some animations can cause InteractionRegion layers to disappear
<a href="https://bugs.webkit.org/show_bug.cgi?id=266436">https://bugs.webkit.org/show_bug.cgi?id=266436</a>
&lt;<a href="https://rdar.apple.com/119496239">rdar://119496239</a>&gt;

Reviewed by Mike Wyrzykowski.

When a GraphicsLayer stops requiring a tiled layer, we change its layer
type but skip updating its coverage.
This results in a freshly created PlatformCALayer without any visibleRect
set. Which in turn causes all descendent InteractionRegion layers to get
culled.

Always update the coverage when changing layer type if Interaction
Regions are enabled.

* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::changeLayerTypeTo):
Always add CoverageRectChanged to the uncommitted changes list when
Interaction Regions are enabled.

* LayoutTests/interaction-region/interaction-layers-culling-layer-type-change-expected.txt: Added.
* LayoutTests/interaction-region/interaction-layers-culling-layer-type-change.html: Added.
Add a new LayerTree-based test covering the specific scenario where an element temporarily
requires a tiled layer during an animation.

Canonical link: <a href="https://commits.webkit.org/272101@main">https://commits.webkit.org/272101@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b367678ef2b444114afe08da6c025b1542eaa59

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30547 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9231 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32201 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33047 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27623 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31251 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11516 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6484 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27545 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30855 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7742 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27357 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6629 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6790 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27210 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34384 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27812 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27706 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32960 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6795 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4911 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30786 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/proxy (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8532 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/26983 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7244 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7527 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7349 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->