### PR TITLE
Load compact ClassInfo from structure correctly in FTL

### DIFF
--- a/JSTests/stress/ClassInfo-across-structure-transition.js
+++ b/JSTests/stress/ClassInfo-across-structure-transition.js
@@ -1,0 +1,11 @@
+//@ runDefault("--useDollarVM=1", "--jitPolicyScale=0.01")
+var createDOMJITCheckJSCastObject = $vm.createDOMJITCheckJSCastObject;
+
+function calling(obj)
+{
+    return obj.func();
+}
+noInline(calling);
+
+for (var i = 0; i < 1e5; ++i)
+    calling(createDOMJITCheckJSCastObject());

--- a/JSTests/stress/array-iterator-to-this.js
+++ b/JSTests/stress/array-iterator-to-this.js
@@ -1,0 +1,27 @@
+function opt(f, length = 5) {
+    (function () {
+        f;
+        length;
+    })();
+
+    return f();
+}
+
+function main() {
+    opt(function () {});
+
+    for (let i = 0; i < 10000; i++) {
+        let threw = false;
+        try {
+            const iterator = opt(Array.prototype.keys);
+            print([...iterator]);
+        } catch {
+            threw = true;
+        }
+
+        if (!threw)
+            throw new Error();
+    }
+}
+
+main();

--- a/LayoutTests/fast/dom/HTMLObjectElement/updateWidget-crash-expected.txt
+++ b/LayoutTests/fast/dom/HTMLObjectElement/updateWidget-crash-expected.txt
@@ -1,0 +1,3 @@
+This test passes if it doesn't crash
+
+

--- a/LayoutTests/fast/dom/HTMLObjectElement/updateWidget-crash.html
+++ b/LayoutTests/fast/dom/HTMLObjectElement/updateWidget-crash.html
@@ -1,0 +1,17 @@
+<body>
+<p>This test passes if it doesn't crash</p>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+onload = () => {
+    let firstObject = document.getElementById("firstObject");
+    let secondObject = document.getElementById("secondObject");
+    secondObject.data = "x";
+    let secondObjectDocument = secondObject.contentDocument;
+    secondObject.align = "left";
+    secondObjectDocument.adoptNode(firstObject);
+    firstObject.reportValidity();
+}
+</script>
+<object id="firstObject"></object>
+<object id="secondObject"></object>

--- a/LayoutTests/streams/writable-stream-create-within-multiple-workers-crash-expected.txt
+++ b/LayoutTests/streams/writable-stream-create-within-multiple-workers-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it doesn't crash.

--- a/LayoutTests/streams/writable-stream-create-within-multiple-workers-crash.html
+++ b/LayoutTests/streams/writable-stream-create-within-multiple-workers-crash.html
@@ -1,0 +1,19 @@
+<!-- webkit-test-runner [ jscOptions=--slowPathAllocsBetweenGCs=50 ] -->
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    internals.settings.setWebRTCSFrameTransformEnabled(true);
+    testRunner.waitUntilDone();
+}
+    
+onload = () => {
+    for (let i = 0; i < 100; i++) {
+        new Worker(`data:text/javascript,for (let i = 0; i < 100; i++) new SFrameTransform().readable;`);
+    }
+    setTimeout(() => {
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }, 100);
+};
+</script>
+<p>This test passes if it doesn't crash.</p>

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -2586,9 +2586,10 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
             // Add the constant before exit becomes invalid because we may want to insert (redundant) checks on it in Fixup.
             Node* kindNode = jsConstant(jsNumber(static_cast<uint32_t>(*kind)));
 
+            Node* thisValue = addToGraph(ToThis, OpInfo(ECMAMode::strict()), OpInfo(getPrediction()), get(virtualRegisterForArgumentIncludingThis(0, registerOffset)));
             // We don't have an existing error string.
             unsigned errorStringIndex = UINT32_MAX;
-            Node* object = addToGraph(ToObject, OpInfo(errorStringIndex), OpInfo(SpecNone), get(virtualRegisterForArgumentIncludingThis(0, registerOffset)));
+            Node* object = addToGraph(ToObject, OpInfo(errorStringIndex), OpInfo(SpecNone), thisValue);
 
             Node* iterator = addToGraph(NewInternalFieldObject, OpInfo(m_graph.registerStructure(globalObject->arrayIteratorStructure())));
 

--- a/Source/JavaScriptCore/dfg/DFGClobbersExitState.cpp
+++ b/Source/JavaScriptCore/dfg/DFGClobbersExitState.cpp
@@ -112,11 +112,11 @@ bool clobbersExitState(Graph& graph, Node* node)
         clobberize(
             graph, node, NoOpClobberize(),
             [&] (const AbstractHeap& heap) {
-                // There shouldn't be such a thing as a strict subtype of SideState. That's what allows
-                // us to use a fast != check, below.
-                ASSERT(!heap.isStrictSubtypeOf(SideState));
+                // There shouldn't be such a thing as a strict subtype of SideState or HeapObjectCount.
+                // That's what allows us to use a fast != check, below.
+                ASSERT(!heap.isStrictSubtypeOf(SideState) && !heap.isStrictSubtypeOf(HeapObjectCount));
 
-                if (heap != SideState)
+                if (heap != SideState && heap != HeapObjectCount)
                     result = true;
             },
             NoOpClobberize());

--- a/Source/ThirdParty/ANGLE/src/libANGLE/Context.cpp
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/Context.cpp
@@ -892,6 +892,7 @@ egl::Error Context::onDestroy(const egl::Display *display)
 
     releaseShaderCompiler();
 
+    mState.ensureNoPendingLink(this);
     mState.reset(this);
 
     releaseSharedObjects();

--- a/Source/WebCore/bindings/js/InternalWritableStream.cpp
+++ b/Source/WebCore/bindings/js/InternalWritableStream.cpp
@@ -41,8 +41,8 @@ static ExceptionOr<JSC::JSValue> invokeWritableStreamFunction(JSC::JSGlobalObjec
     auto scope = DECLARE_CATCH_SCOPE(vm);
 
     auto function = globalObject.get(&globalObject, identifier);
+    RETURN_IF_EXCEPTION(scope, Exception { ExistingExceptionError });
     ASSERT(function.isCallable());
-    scope.assertNoExceptionExceptTermination();
 
     auto callData = JSC::getCallData(function);
 

--- a/Tools/DumpRenderTree/mac/DumpRenderTree.mm
+++ b/Tools/DumpRenderTree/mac/DumpRenderTree.mm
@@ -1892,6 +1892,8 @@ static NSURL *computeTestURL(NSString *pathOrURLString, NSString **relativeTestP
 
 static WTR::TestOptions testOptionsForTest(const WTR::TestCommand& command)
 {
+    // hack for cases when useDollarVM will be reset before injectInternalsObject is called in DRT
+    JSC::Options::useDollarVM() = true;
     WTR::TestFeatures features = WTR::TestOptions::defaults();
     WTR::merge(features, WTR::hardcodedFeaturesBasedOnPathForTest(command));
     WTR::merge(features, WTR::featureDefaultsFromTestHeaderForTest(command, WTR::TestOptions::keyTypeMapping()));


### PR DESCRIPTION
#### 6f9587b87d0fef7663cce94025358577abe2a66d
<pre>
Load compact ClassInfo from structure correctly in FTL
<a href="https://bugs.webkit.org/show_bug.cgi?id=263356">https://bugs.webkit.org/show_bug.cgi?id=263356</a>
<a href="https://rdar.apple.com/115494572">rdar://115494572</a>

Reviewed by Mark Lam.

Currently, FTL assumes loading the m_classInfo from a structure is a
loadPtr on all platforms - this is not the case, since ClassInfo is
represented as a 32-bit CompactPtr&lt;ClassInfo&gt; on platforms with 36-bit
addresses. As a result, when loading the ClassInfo in some FTL nodes, it
results in a junk value with the lower bits being the unshifted ClassInfo
address, and the upper bits being taken erroneously from
m_transitionPropertyName. This patch introduces a new loadCompactPtr()
helper to FTLLowerDFGToB3 that correctly loads and shifts compact pointer
fields, which in current FTL is just Structure.m_classInfo.

* JSTests/stress/ClassInfo-across-structure-transition.js: Added.
(calling):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCreatePromise):
(JSC::FTL::DFG::LowerDFGToB3::compileCreateInternalFieldObject):
(JSC::FTL::DFG::LowerDFGToB3::compileFunctionToString):
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):

Originally-landed-as: 267815.353@safari-7617-branch (20234c667f25). rdar://119597685
</pre>
----------------------------------------------------------------------
#### bd4a4b8630ce2fe936a9c7f72118daa95324db02
<pre>
Assertion hit under Document::dispatchPagehideEvent()
<a href="https://bugs.webkit.org/show_bug.cgi?id=263204">https://bugs.webkit.org/show_bug.cgi?id=263204</a>
<a href="https://rdar.apple.com/116715579">rdar://116715579</a>

Reviewed by Ryosuke Niwa.

Delay the load if we&apos;re not allowed to run script right now. Scheduling a load will
cancel / stop any pending load, which may cause events to be fired and script to run.

The synchronous code path is kept when we&apos;re allowed to run script to avoid breaking
tests such as:
- imported/w3c/web-platform-tests/css/css-writing-modes/abs-pos-non-replaced-icb-vlr-*.xht
- imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/sandbox_004.htm
- imported/blink/svg/dom/viewspec-*.html
- fast/css/acid2.html

* LayoutTests/fast/dom/HTMLObjectElement/updateWidget-crash-expected.txt: Added.
* LayoutTests/fast/dom/HTMLObjectElement/updateWidget-crash.html: Added.
* Source/WebCore/html/HTMLPlugInImageElement.cpp:
(WebCore::HTMLPlugInImageElement::requestObject):

Originally-landed-as: 267815.354@safari-7617-branch (c34793cc5793). rdar://119597568
</pre>
----------------------------------------------------------------------
#### a8f111fb34755398c2e3ec3d18d1642d9994829c
<pre>
[ANGLE] Clear pending program linking in Context::onDestroy
<a href="https://rdar.apple.com/116661298">rdar://116661298</a>

Reviewed by Kimmo Kinnunen.

When destroying Context, ANGLE resets any internal state before releasing
allocated objects, such as Programs and Shaders. When destroying a program, any
pending program linking is resolved via Program::resolveLink. This results in
trying to access the Context state that’s just been reset, leading to a nullptr
access.

To work around this, we ensure there are no pending links before resetting the
Context state.

* Source/ThirdParty/ANGLE/src/libANGLE/Context.cpp:
(gl::Context::onDestroy):
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/TestGraphicsContextGLCocoa.mm:
(TestWebKitAPI::TEST_F):

Originally-landed-as: 267815.356@safari-7617-branch (d32cd290f021). rdar://119597554
</pre>
----------------------------------------------------------------------
#### ec572c2050fb256bf90c337802e86176a4cac53b
<pre>
Array iterator creation intrinsics need ToThis
<a href="https://bugs.webkit.org/show_bug.cgi?id=263408">https://bugs.webkit.org/show_bug.cgi?id=263408</a>
<a href="https://rdar.apple.com/113898245">rdar://113898245</a>

Reviewed by Yusuke Suzuki.

Currently, we don&apos;t ToThis the &apos;this&apos; value when we intrinsicify
the various Array iterator creation functions, which we should.
This patch also changes `clobbersExitState` to say exit state
is not clobbered if a node only writes to `HeapObjectCount`.
Our previous behavior was overly conservative, which caused
assertion failures as the `ToObject` following the `ToThis`
would get converted to a `Check(Object)` when exit was invalid.

* JSTests/stress/array-iterator-to-this.js: Added.
(opt):
(main):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
* Source/JavaScriptCore/dfg/DFGClobbersExitState.cpp:
(JSC::DFG::clobbersExitState):

Originally-landed-as: 267815.357@safari-7617-branch (ae764a813e03). rdar://119597428
</pre>
----------------------------------------------------------------------
#### 595ee7d30517503030f1ee9746b44b12cd927974
<pre>
jsc_fuz/wktr: null ptr deref in WebCore::invokeWritableStreamFunction(...) (InternalWritableStream.cpp:49)
<a href="https://bugs.webkit.org/show_bug.cgi\?id\=262865">https://bugs.webkit.org/show_bug.cgi\?id\=262865</a>
<a href="https://rdar.apple.com/116465595">rdar://116465595</a>

Reviewed by Mark Lam.

Return early when worker is terminated while trying to get function from globalObject.
Set useDollarVM in test option initialization for cases when useDollarVM will be reset before injectInternalsObject is called in DRT.

* LayoutTests/streams/writable-stream-create-within-multiple-workers-crash-expected.txt: Added.
* LayoutTests/streams/writable-stream-create-within-multiple-workers-crash.html: Added.
* Source/WebCore/bindings/js/InternalWritableStream.cpp:
(WebCore::invokeWritableStreamFunction):
* Tools/DumpRenderTree/mac/DumpRenderTree.mm:
(testOptionsForTest):

Originally-landed-as: 267815.398@safari-7617-branch (f11c81a103a8). rdar://119596601
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/apple/WebKit/commit/a8f111fb34755398c2e3ec3d18d1642d9994829c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [⏳ 🧪 style ](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-17-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wincairo ](https://ews-build.webkit.org/#/builders/WinCairo-EWS "Waiting in queue, processing has not started yet") 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Sonoma-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitperl ](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2 ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-17-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Sonoma-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-10-Build-EWS "Waiting in queue, processing has not started yet") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-10-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | 
<!--EWS-Status-Bubble-End-->