### PR TITLE
[scroll-anchoring] Reenable scroll anchoring on more LayoutTests

### DIFF
--- a/LayoutTests/accessibility/scroll-to-global-point-iframe-nested.html
+++ b/LayoutTests/accessibility/scroll-to-global-point-iframe-nested.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
 <script src="../resources/accessibility-helper.js"></script>

--- a/LayoutTests/accessibility/scroll-to-global-point-nested.html
+++ b/LayoutTests/accessibility/scroll-to-global-point-nested.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
 <script src="../resources/accessibility-helper.js"></script>

--- a/LayoutTests/accessibility/visible-character-range-width-changes.html
+++ b/LayoutTests/accessibility/visible-character-range-width-changes.html
@@ -1,4 +1,3 @@
-<!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>

--- a/LayoutTests/css3/scroll-snap/ios/scroll-snap-mainframe-pinch-out.html
+++ b/LayoutTests/css3/scroll-snap/ios/scroll-snap-mainframe-pinch-out.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true CSSScrollAnchoringEnabled=false ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
 <html>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <head>

--- a/LayoutTests/editing/execCommand/insert-line-break-no-scroll.html
+++ b/LayoutTests/editing/execCommand/insert-line-break-no-scroll.html
@@ -1,4 +1,3 @@
-<!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 <p>Matching other execCommand identifiers, execCommand("InsertLineBreak") should not scroll the page to make selection visible.</p>
 <p>This test only works in WebKit, as other engines do not implement this command.</p>
 <div contenteditable>a</div>

--- a/LayoutTests/editing/selection/ios/autoscroll-with-top-content-inset.html
+++ b/LayoutTests/editing/selection/ios/autoscroll-with-top-content-inset.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true CSSScrollAnchoringEnabled=false contentInset.top=100 ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true contentInset.top=100 ] -->
 <html>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <head>

--- a/LayoutTests/fast/dom/vertical-scrollbar-in-rtl-doesnt-fire-onscroll.html
+++ b/LayoutTests/fast/dom/vertical-scrollbar-in-rtl-doesnt-fire-onscroll.html
@@ -1,4 +1,3 @@
-<!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 <!DOCTYPE html>
 <html dir=rtl style="-webkit-writing-mode:vertical-lr">
     <head>

--- a/LayoutTests/fast/events/no-scroll-on-input-text-selection.html
+++ b/LayoutTests/fast/events/no-scroll-on-input-text-selection.html
@@ -1,4 +1,3 @@
-<!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 <html>
     <head>
         <script src="../../resources/js-test-pre.js"></script>

--- a/LayoutTests/fast/scrolling/latching/latching-and-wheel-events.html
+++ b/LayoutTests/fast/scrolling/latching/latching-and-wheel-events.html
@@ -1,4 +1,3 @@
-<!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 <!DOCTYPE html>
 <html>
 <head>

--- a/LayoutTests/fast/scrolling/latching/overflow-in-iframe-latching.html
+++ b/LayoutTests/fast/scrolling/latching/overflow-in-iframe-latching.html
@@ -1,4 +1,3 @@
-<!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 <!DOCTYPE html>
 <html>
 <head>

--- a/LayoutTests/fast/scrolling/mac/adjust-scroll-snap-during-gesture.html
+++ b/LayoutTests/fast/scrolling/mac/adjust-scroll-snap-during-gesture.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true CSSScrollAnchoringEnabled=false ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
 <html>
 <head>
     <style>

--- a/LayoutTests/fast/scrolling/mac/programmatic-scroll-overrides-rubberband.html
+++ b/LayoutTests/fast/scrolling/mac/programmatic-scroll-overrides-rubberband.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true CSSScrollAnchoringEnabled=false ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
 <html>
 <head>
     <style>

--- a/LayoutTests/fast/visual-viewport/client-coordinates-relative-to-layout-viewport.html
+++ b/LayoutTests/fast/visual-viewport/client-coordinates-relative-to-layout-viewport.html
@@ -1,4 +1,3 @@
-<!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 <!DOCTYPE html>
 
 <html>

--- a/LayoutTests/fast/visual-viewport/rtl-zoomed-rects.html
+++ b/LayoutTests/fast/visual-viewport/rtl-zoomed-rects.html
@@ -1,4 +1,3 @@
-<!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 <!DOCTYPE html>
 
 <html dir="rtl">

--- a/LayoutTests/fullscreen/fullscreen-restore-scroll-position.html
+++ b/LayoutTests/fullscreen/fullscreen-restore-scroll-position.html
@@ -1,4 +1,3 @@
-<!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 <!DOCTYPE html>
 <html>
     <head>

--- a/LayoutTests/scrollingcoordinator/mac/latching/scrolling-select-should-not-latch-mainframe.html
+++ b/LayoutTests/scrollingcoordinator/mac/latching/scrolling-select-should-not-latch-mainframe.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true CSSScrollAnchoringEnabled=false ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
 <html>
 <head>
     <style>


### PR DESCRIPTION
#### 17faf7b3085ae41935c20671d774a69f088b8262
<pre>
[scroll-anchoring] Reenable scroll anchoring on more LayoutTests
<a href="https://bugs.webkit.org/show_bug.cgi?id=266439">https://bugs.webkit.org/show_bug.cgi?id=266439</a>
<a href="https://rdar.apple.com/119688035">rdar://119688035</a>

Reviewed by Tim Nguyen.

Reenable scroll anchoring on more LayoutTests.

* LayoutTests/fast/dom/vertical-scrollbar-in-rtl-doesnt-fire-onscroll.html:
* LayoutTests/fast/events/no-scroll-on-input-text-selection.html:
* LayoutTests/fast/scrolling/latching/latching-and-wheel-events.html:
* LayoutTests/fast/scrolling/latching/overflow-in-iframe-latching.html:
* LayoutTests/fast/scrolling/mac/adjust-scroll-snap-during-gesture.html:
* LayoutTests/fast/scrolling/mac/programmatic-scroll-overrides-rubberband.html:
* LayoutTests/fast/scrolling/programmatic-document-rtl-scroll.html:
* LayoutTests/fast/visual-viewport/client-coordinates-relative-to-layout-viewport.html:
* LayoutTests/fast/visual-viewport/rtl-zoomed-rects.html:

Canonical link: <a href="https://commits.webkit.org/272381@main">https://commits.webkit.org/272381@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a459d3823d57eabc3279f4a702c9ad5fbcb6d9e7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30739 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9418 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32406 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33234 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27783 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11787 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6673 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27664 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31052 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7950 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27505 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6778 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6968 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27381 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34571 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28024 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27863 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33089 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6968 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5060 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30921 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8685 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/27163 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7389 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7686 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7523 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->