### PR TITLE
jsc_fuz/wktr: heap-use-after-free in WebCore::IDBServer::MemoryObjectStore::takeIndexByIdentifier(unsigned long long) MemoryObjectStore.cpp:128.

### DIFF
--- a/LayoutTests/storage/indexeddb/abort-index-rename-crash-expected.txt
+++ b/LayoutTests/storage/indexeddb/abort-index-rename-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it doesn't crash.

--- a/LayoutTests/storage/indexeddb/abort-index-rename-crash.html
+++ b/LayoutTests/storage/indexeddb/abort-index-rename-crash.html
@@ -1,0 +1,27 @@
+<!-- webkit-test-runner [ useEphemeralSession=true ] -->
+<body>
+<script>
+if (window.testRunner) {
+  testRunner.dumpAsText();
+  testRunner.waitUntilDone();
+}
+indexedDB.open('abort-index-rename').onupgradeneeded = (event) => {
+    request = event.target;
+    transaction = request.transaction;
+    transaction.onabort = () => {
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }
+    database = request.result;
+    objectStore = database.createObjectStore('os');
+    index = objectStore.createIndex('foo', 'foo');
+    index.name = 'bar';
+    database.deleteObjectStore('os');
+    objectStore2 = database.createObjectStore('os2');
+    objectStore2.add('value', 'key').onsuccess = () => {
+        transaction.abort();
+    }
+};
+</script>
+<p>This test passes if it doesn't crash.</p>
+</body>

--- a/Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.cpp
@@ -124,7 +124,7 @@ void MemoryBackingStoreTransaction::objectStoreDeleted(Ref<MemoryObjectStore>&& 
     if (auto addedObjectStore = m_versionChangeAddedObjectStores.take(&objectStore.get())) {
         // We don't need to track its indexes either.
         m_deletedIndexes.removeIf([identifier = objectStore->info().identifier()](auto& entry) {
-            return entry.value->objectStore().info().identifier() == identifier;
+            return entry.value->objectStore()->info().identifier() == identifier;
         });
         return;
     }
@@ -162,7 +162,7 @@ void MemoryBackingStoreTransaction::objectStoreRenamed(MemoryObjectStore& object
 
 void MemoryBackingStoreTransaction::indexRenamed(MemoryIndex& index, const String& oldName)
 {
-    ASSERT(m_objectStores.contains(&index.objectStore()));
+    ASSERT(!index.objectStore() || m_objectStores.contains(index.objectStore().get()));
     ASSERT(m_info.mode() == IDBTransactionMode::Versionchange);
 
     // We only care about the first rename in a given transaction, because if the transaction is aborted we want
@@ -225,15 +225,16 @@ void MemoryBackingStoreTransaction::abort()
                 break;
             }
         }
-        if (indexToDelete)
-            indexToDelete->objectStore().deleteIndex(*this, indexToDelete->info().identifier());
+        if (indexToDelete && indexToDelete->objectStore())
+            indexToDelete->objectStore()->deleteIndex(*this, indexToDelete->info().identifier());
 
-        auto& objectStore = index->objectStore();
-        auto indexToReRegister = objectStore.takeIndexByIdentifier(identifier).releaseNonNull();
-        objectStore.info().deleteIndex(identifier);
-        index->rename(originalName);
-        objectStore.info().addExistingIndex(index->info());
-        objectStore.registerIndex(WTFMove(indexToReRegister));
+        if (auto objectStore = index->objectStore()) {
+            auto indexToReRegister = objectStore->takeIndexByIdentifier(identifier).releaseNonNull();
+            objectStore->info().deleteIndex(identifier);
+            index->rename(originalName);
+            objectStore->info().addExistingIndex(index->info());
+            objectStore->registerIndex(WTFMove(indexToReRegister));
+        }
     }
     m_originalIndexNames.clear();
 
@@ -244,7 +245,7 @@ void MemoryBackingStoreTransaction::abort()
     for (const auto& objectStore : m_versionChangeAddedObjectStores)
         m_backingStore.removeObjectStoreForVersionChangeAbort(*objectStore);
     m_deletedIndexes.removeIf([&](auto& entry) {
-        return m_versionChangeAddedObjectStores.contains(&entry.value->objectStore());
+        return m_versionChangeAddedObjectStores.contains(entry.value->objectStore().get());
     });
     m_versionChangeAddedObjectStores.clear();
 
@@ -288,7 +289,7 @@ void MemoryBackingStoreTransaction::abort()
 
     for (auto& index : m_deletedIndexes.values()) {
         RELEASE_ASSERT(m_backingStore.hasObjectStore(index->info().objectStoreIdentifier()));
-        index->objectStore().maybeRestoreDeletedIndex(*index);
+        index->objectStore()->maybeRestoreDeletedIndex(*index);
     }
     m_deletedIndexes.clear();
 

--- a/Source/WebCore/Modules/indexeddb/server/MemoryIndex.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryIndex.cpp
@@ -65,7 +65,7 @@ void MemoryIndex::cursorDidBecomeDirty(MemoryIndexCursor& cursor)
 
 void MemoryIndex::objectStoreCleared()
 {
-    auto transaction = m_objectStore.writeTransaction();
+    auto transaction = m_objectStore->writeTransaction();
     ASSERT(transaction);
 
     transaction->indexCleared(*this, WTFMove(m_records));
@@ -89,16 +89,16 @@ void MemoryIndex::notifyCursorsOfAllRecordsChanged()
 
 void MemoryIndex::clearIndexValueStore()
 {
-    ASSERT(m_objectStore.writeTransaction());
-    ASSERT(m_objectStore.writeTransaction()->isAborting());
+    ASSERT(m_objectStore->writeTransaction());
+    ASSERT(m_objectStore->writeTransaction()->isAborting());
 
     m_records = nullptr;
 }
 
 void MemoryIndex::replaceIndexValueStore(std::unique_ptr<IndexValueStore>&& valueStore)
 {
-    ASSERT(m_objectStore.writeTransaction());
-    ASSERT(m_objectStore.writeTransaction()->isAborting());
+    ASSERT(m_objectStore->writeTransaction());
+    ASSERT(m_objectStore->writeTransaction()->isAborting());
 
     m_records = WTFMove(valueStore);
 }
@@ -124,7 +124,7 @@ IDBGetResult MemoryIndex::getResultForKeyRange(IndexedDB::IndexRecordType type, 
     if (!keyValue)
         return { };
 
-    return type == IndexedDB::IndexRecordType::Key ? IDBGetResult(*keyValue) : IDBGetResult(*keyValue, m_objectStore.valueForKeyRange(*keyValue), m_objectStore.info().keyPath());
+    return type == IndexedDB::IndexRecordType::Key ? IDBGetResult(*keyValue) : IDBGetResult(*keyValue, m_objectStore->valueForKeyRange(*keyValue), m_objectStore->info().keyPath());
 }
 
 uint64_t MemoryIndex::countForKeyRange(const IDBKeyRangeData& inRange)
@@ -154,7 +154,7 @@ void MemoryIndex::getAllRecords(const IDBKeyRangeData& keyRangeData, std::option
 {
     LOG(IndexedDB, "MemoryIndex::getAllRecords");
 
-    result = { type, m_objectStore.info().keyPath() };
+    result = { type, m_objectStore->info().keyPath() };
 
     if (!m_records)
         return;
@@ -179,7 +179,7 @@ void MemoryIndex::getAllRecords(const IDBKeyRangeData& keyRangeData, std::option
         for (auto& keyValue : allValues) {
             result.addKey(IDBKeyData(keyValue));
             if (type == IndexedDB::GetAllType::Values)
-                result.addValue(m_objectStore.valueForKeyRange(keyValue));
+                result.addValue(m_objectStore->valueForKeyRange(keyValue));
         }
 
         currentCount += allValues.size();

--- a/Source/WebCore/Modules/indexeddb/server/MemoryIndex.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryIndex.h
@@ -81,7 +81,7 @@ public:
 
     IndexValueStore* valueStore() { return m_records.get(); }
 
-    MemoryObjectStore& objectStore() { return m_objectStore; }
+    WeakPtr<MemoryObjectStore> objectStore() { return m_objectStore; }
 
     void cursorDidBecomeClean(MemoryIndexCursor&);
     void cursorDidBecomeDirty(MemoryIndexCursor&);
@@ -96,7 +96,7 @@ private:
     void notifyCursorsOfAllRecordsChanged();
 
     IDBIndexInfo m_info;
-    MemoryObjectStore& m_objectStore;
+    WeakPtr<MemoryObjectStore> m_objectStore;
 
     std::unique_ptr<IndexValueStore> m_records;
 

--- a/Source/WebCore/Modules/indexeddb/server/MemoryIndexCursor.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryIndexCursor.cpp
@@ -72,8 +72,8 @@ void MemoryIndexCursor::currentData(IDBGetResult& getResult)
     if (m_info.cursorType() == IndexedDB::CursorType::KeyOnly)
         getResult = { m_currentKey, m_currentPrimaryKey };
     else {
-        IDBValue value = { m_index.objectStore().valueForKey(m_currentPrimaryKey), { }, { } };
-        getResult = { m_currentKey, m_currentPrimaryKey, WTFMove(value), m_index.objectStore().info().keyPath() };
+        IDBValue value = { m_index.objectStore()->valueForKey(m_currentPrimaryKey), { }, { } };
+        getResult = { m_currentKey, m_currentPrimaryKey, WTFMove(value), m_index.objectStore()->info().keyPath() };
     }
 }
 

--- a/Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.h
@@ -55,7 +55,7 @@ class MemoryBackingStoreTransaction;
 
 typedef HashMap<IDBKeyData, ThreadSafeDataBuffer, IDBKeyDataHash, IDBKeyDataHashTraits> KeyValueMap;
 
-class MemoryObjectStore : public RefCounted<MemoryObjectStore> {
+class MemoryObjectStore : public RefCounted<MemoryObjectStore>, public CanMakeWeakPtr<MemoryObjectStore> {
 public:
     static Ref<MemoryObjectStore> create(const IDBObjectStoreInfo&);
 


### PR DESCRIPTION
#### 5e2fbff61ae90daff246d581be165947505b2d10
<pre>
jsc_fuz/wktr: heap-use-after-free in WebCore::IDBServer::MemoryObjectStore::takeIndexByIdentifier(unsigned long long) MemoryObjectStore.cpp:128.
<a href="https://bugs.webkit.org/show_bug.cgi?id=264180.">https://bugs.webkit.org/show_bug.cgi?id=264180.</a>
<a href="https://rdar.apple.com/117463447">rdar://117463447</a>.

Reviewed by Sihui Liu.

MemoryIndex now keeps WeakPtr to MemoryObjectStore &apos;m_objectStore&apos; and checks it&apos;s validity before using it. Also RefPtr conversion from WekPtr using get() API as applicable.

* LayoutTests/storage/indexeddb/abort-index-rename-crash-expected.txt: Added the test expected file.
* LayoutTests/storage/indexeddb/abort-index-rename-crash.html: Added the test case.
* Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.cpp: Checks the validity of MemoryObjectStore pointer before using.
(WebCore::IDBServer::MemoryBackingStoreTransaction::objectStoreDeleted):
(WebCore::IDBServer::MemoryBackingStoreTransaction::indexRenamed):
(WebCore::IDBServer::MemoryBackingStoreTransaction::abort):
* Source/WebCore/Modules/indexeddb/server/MemoryIndex.cpp: Changed direct reference to WeakPtr. Also used RefPtr conversion using get() API as applicable.
(WebCore::IDBServer::MemoryIndex::objectStoreCleared):
(WebCore::IDBServer::MemoryIndex::clearIndexValueStore):
(WebCore::IDBServer::MemoryIndex::replaceIndexValueStore):
(WebCore::IDBServer::MemoryIndex::getResultForKeyRange const):
(WebCore::IDBServer::MemoryIndex::getAllRecords const):
* Source/WebCore/Modules/indexeddb/server/MemoryIndex.h: Changed direct reference to WeakPtr.
(WebCore::IDBServer::MemoryIndex::objectStore):
* Source/WebCore/Modules/indexeddb/server/MemoryIndexCursor.cpp: Used RefPtr conversion using get() API for MemoryIndex based MemoryObjectStore object.
(WebCore::IDBServer::MemoryIndexCursor::currentData):
* Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.h:

Originally-landed-as: 267815.545@safari-7617-branch (64bcd93cbc55). <a href="https://rdar.apple.com/119599034">rdar://119599034</a>
Canonical link: <a href="https://commits.webkit.org/272317@main">https://commits.webkit.org/272317@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af863fa65f0f59138f43e6ddcd1b44d7c32367c1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31246 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9918 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32940 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33751 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28351 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32013 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12263 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7174 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28002 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31582 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8360 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27919 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7177 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7353 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27815 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35093 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28427 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28271 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33484 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7403 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5455 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31322 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9082 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/27610 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7352 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8103 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7929 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->