### PR TITLE
Unable to log into gizmodo.com with tracking prevention enabled

### DIFF
--- a/Source/WebCore/platform/network/NetworkStorageSession.cpp
+++ b/Source/WebCore/platform/network/NetworkStorageSession.cpp
@@ -432,6 +432,8 @@ const HashMap<RegistrableDomain, HashSet<RegistrableDomain>>& NetworkStorageSess
             RegistrableDomain::uncheckedCreateFromRegistrableDomainString("sony.com"_s) });
         map.add(RegistrableDomain::uncheckedCreateFromRegistrableDomainString("bbc.co.uk"_s), HashSet {
             RegistrableDomain::uncheckedCreateFromRegistrableDomainString("radioplayer.co.uk"_s) });
+        map.add(RegistrableDomain::uncheckedCreateFromRegistrableDomainString("gizmodo.com"_s), HashSet {
+            RegistrableDomain::uncheckedCreateFromRegistrableDomainString("kinja.com"_s) });
         return map;
     }();
     return map.get();


### PR DESCRIPTION
#### eb1f7a4e8a5e59ed10780be8869e34b5b6289b90
<pre>
Unable to log into gizmodo.com with tracking prevention enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=266442">https://bugs.webkit.org/show_bug.cgi?id=266442</a>
<a href="https://rdar.apple.com/106782128">rdar://106782128</a>

Reviewed by John Wilander.

Update the quirk to make authentication flow of gizmodo.com work by:
1. Invoking requestStorageAccess on behalf of kinja.com when user starts authentication flow by clicking user profile
button (console log is added to make user and developer aware of the quirk).
2. Adjusting heuristics of detecting user profile button by finding target class on its ancestors, instead of only on
the element itself.
3. Skip checking user interaction on kinja.com in requestStorageAccess.

* Source/WebCore/page/Quirks.cpp:
(WebCore::elementHasClassInClosestAncestors):
(WebCore::isStorageAccessQuirkDomainAndElement):
(WebCore::Quirks::requestStorageAccessAndHandleClick const):
(WebCore::Quirks::triggerOptionalStorageAccessQuirk const):
* Source/WebCore/platform/network/NetworkStorageSession.cpp:
(WebCore::NetworkStorageSession::storageAccessQuirks):

Canonical link: <a href="https://commits.webkit.org/272146@main">https://commits.webkit.org/272146@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df36a63520af6dd8eacfd5c269e206725286e265

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30564 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9246 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32217 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33061 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27635 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31268 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11570 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6498 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27551 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30872 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7777 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27367 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6636 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6817 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27222 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34397 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27848 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27717 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32966 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6808 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4922 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30792 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8544 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7269 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7539 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7363 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->