### PR TITLE
jsc_fuz/wktr: ASSERTION FAILED: is<Target>(source) downcast(Source &) [Target = WebCore::CSSFunctionValue, Source = const WebCore::CSSValue]

### DIFF
--- a/LayoutTests/fast/css/content-visibility-crash-expected.txt
+++ b/LayoutTests/fast/css/content-visibility-crash-expected.txt
@@ -1,0 +1,1 @@
+This test should not crash.

--- a/LayoutTests/fast/css/content-visibility-crash.html
+++ b/LayoutTests/fast/css/content-visibility-crash.html
@@ -1,0 +1,22 @@
+<style>
+html, body {
+    content-visibility: auto;
+}
+</style>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+onload = async () => {
+    let s0 = document.createElement('script');
+    s0.src = 'data:';
+    document.head.appendChild(s0);
+    if ('caches' in window) await caches.has('a');
+    document.styleSheets[0].disabled = true;
+    if ('caches' in window) await caches.has('b');
+    document.styleSheets[0].disabled = false;
+    document.body.offsetTop;
+    setTimeout(function() { document.write('This test should not crash.'); testRunner.notifyDone(); });
+};
+</script>

--- a/LayoutTests/fast/css/create-columns-onload-crash-expected.txt
+++ b/LayoutTests/fast/css/create-columns-onload-crash-expected.txt
@@ -1,0 +1,1 @@
+This test should not crash

--- a/LayoutTests/fast/css/create-columns-onload-crash.html
+++ b/LayoutTests/fast/css/create-columns-onload-crash.html
@@ -1,0 +1,9 @@
+<script>
+    if (window.testRunner)
+        testRunner.dumpAsText();
+  onload = () => {
+    let cssStyleValue = CSSMathValue.parseAll('columns', 'auto')[0];
+    document.body.attributeStyleMap.append('grid-auto-columns', cssStyleValue);
+  };
+</script>
+<div>This test should not crash</div>

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -4268,8 +4268,10 @@ private:
     JSValue readTerminal()
     {
         SerializationTag tag = readTag();
-        if (!isTypeExposedToGlobalObject(*m_globalObject, tag))
+        if (!isTypeExposedToGlobalObject(*m_globalObject, tag)) {
+            fail();
             return JSValue();
+        }
         switch (tag) {
         case UndefinedTag:
             return jsUndefined();

--- a/Source/WebCore/dom/ContentVisibilityDocumentState.cpp
+++ b/Source/WebCore/dom/ContentVisibilityDocumentState.cpp
@@ -115,7 +115,10 @@ bool ContentVisibilityDocumentState::checkRelevancyOfContentVisibilityElement(El
     };
     if (relevancyToCheck.contains(ContentRelevancy::OnScreen)) {
         auto viewportProximityIterator = m_elementViewportProximities.find(target);
-        setRelevancyValue(ContentRelevancy::OnScreen, viewportProximityIterator->value == ViewportProximity::Near);
+        auto viewportProximity = ViewportProximity::Far;
+        if (viewportProximityIterator != m_elementViewportProximities.end())
+            viewportProximity = viewportProximityIterator->value;
+        setRelevancyValue(ContentRelevancy::OnScreen, viewportProximity == ViewportProximity::Near);
     }
 
     if (relevancyToCheck.contains(ContentRelevancy::Focused))

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -1136,6 +1136,9 @@ inline GridTrackSize BuilderConverter::createGridTrackSize(const CSSValue& value
     if (is<CSSPrimitiveValue>(value))
         return GridTrackSize(createGridTrackBreadth(downcast<CSSPrimitiveValue>(value), builderState));
 
+    if (!is<CSSFunctionValue>(value))
+        return GridTrackSize(GridLength(0));
+
     const auto& function = downcast<CSSFunctionValue>(value);
 
     if (function.length() == 1)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -204,8 +204,13 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTree(IPC::Connection& connectio
         }
     }
 
-    for (auto& transaction : transactions)
+    WeakPtr weakThis { *this };
+
+    for (auto& transaction : transactions) {
         commitLayerTreeTransaction(connection, transaction.first, transaction.second);
+        if (!weakThis)
+            return;
+    }
 
     // Keep IOSurface send rights alive until the transaction is commited, otherwise we will
     // prematurely drop the only reference to them, and `inUse` will be wrong for a brief window.


### PR DESCRIPTION
#### d385faf9aa709767d45073b35f385a9566e236a8
<pre>
jsc_fuz/wktr: ASSERTION FAILED: is&lt;Target&gt;(source) downcast(Source &amp;) [Target = WebCore::CSSFunctionValue, Source = const WebCore::CSSValue]
<a href="https://rdar.apple.com/115107618">rdar://115107618</a>

Reviewed by Chris Dumez.

Downcast was attempted before ensuring type is correct, so added a typecheck before downcast

* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::createGridTrackSize): added typecheck before downcast

Originally-landed-as: 267815.304@safari-7617-branch (395cb173896a). <a href="https://rdar.apple.com/119564042">rdar://119564042</a>
Canonical link: <a href="https://commits.webkit.org/272139@main">https://commits.webkit.org/272139@main</a>
</pre>
----------------------------------------------------------------------
#### 637470b5995fdf7e04b974ad1935b8f7da312f75
<pre>
REGRESSION: OOB read in RemoteLayerTreeDrawingAreaProxy::commitLayerTree
<a href="https://bugs.webkit.org/show_bug.cgi?id=262977">https://bugs.webkit.org/show_bug.cgi?id=262977</a>
&lt;<a href="https://rdar.apple.com/116651090">rdar://116651090</a>&gt;

Reviewed by Tim Horton and Chris Dumez.

Post-commit callbacks can run arbitrary code, including code that results in the drawing
area being removed. It&apos;s not ref-counted, so we can&apos;t prevent its destruction if we recurse
into code that destroys it.

Instead, use a WeakPtr to |this| to check if destruction happens, and avoid doing
any futher work.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction):

Originally-landed-as: 267815.273@safari-7617-branch (5257e528b2d7). <a href="https://rdar.apple.com/119564982">rdar://119564982</a>
Canonical link: <a href="https://commits.webkit.org/272138@main">https://commits.webkit.org/272138@main</a>
</pre>
----------------------------------------------------------------------
#### 0fa1c15c77c2df1f269442704135c8f416d3ab64
<pre>
Check m_elementViewportProximities lookup
<a href="https://bugs.webkit.org/show_bug.cgi?id=262061">https://bugs.webkit.org/show_bug.cgi?id=262061</a>
<a href="https://rdar.apple.com/115978526">rdar://115978526</a>

Reviewed by Tim Nguyen.

It is possible a lookup in m_elementViewportProximities fails
to find an element, in that case do not use the iterator and
treat the viewport proximity as &quot;far&quot;.

* LayoutTests/fast/css/content-visibility-crash-expected.txt: Added.
* LayoutTests/fast/css/content-visibility-crash.html: Added.
* Source/WebCore/dom/ContentVisibilityDocumentState.cpp:
(WebCore::ContentVisibilityDocumentState::checkRelevancyOfContentVisibilityElement const):

Originally-landed-as: 268451.2@webkit-2023.9-embargoed (334d4db2351c). <a href="https://rdar.apple.com/119566027">rdar://119566027</a>
Canonical link: <a href="https://commits.webkit.org/272137@main">https://commits.webkit.org/272137@main</a>
</pre>
----------------------------------------------------------------------
#### 294263160d19f7909f691abbed510e6506a6d4ee
<pre>
CloneDeserializer::readTerminal() should fail decoding if tag is not exposed to current JS context
<a href="https://bugs.webkit.org/show_bug.cgi?id=262921">https://bugs.webkit.org/show_bug.cgi?id=262921</a>
<a href="https://rdar.apple.com/115756703">rdar://115756703</a>

Reviewed by Mark Lam.

In 265678@main, I added a check to make sure the type getting deserialized was exposed to the
current JS context (e.g. audio worklet contexts don&apos;t have access to many of the types that
Window context do). I added an early return when detecting this but failed to call `fail()`
to explicitly fail decoding.

* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneDeserializer::readTerminal):

Originally-landed-as: 267815.245@safari-7617-branch (bf21fed44b35). <a href="https://rdar.apple.com/119577123">rdar://119577123</a>
Canonical link: <a href="https://commits.webkit.org/272136@main">https://commits.webkit.org/272136@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0380e61d141c246e9e27a26a3513b08d7d030362

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30575 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9257 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32228 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33072 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27645 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31279 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11543 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6509 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27558 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30883 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7758 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27378 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6647 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6803 "Too many flaky failures: imported/w3c/web-platform-tests/css/css-cascade/scope-hover.html, imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-below-viewport-partially-onscreen-new.html, imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-below-viewport-partially-onscreen-old.html, imported/w3c/web-platform-tests/css/selectors/invalidation/user-valid-user-invalid.html, imported/w3c/web-platform-tests/css/selectors/user-invalid.html, imported/w3c/web-platform-tests/css/selectors/valid-invalid-form-fieldset.html, imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-negative-screenx-screeny.html, imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch.tentative.html, imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative.html, imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/readwrite-readonly.html, imported/w3c/web-platform-tests/webrtc-extensions/RTCRtpSynchronizationSource-captureTimestamp.html (failure)") | [💥 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27234 "An unexpected error occured. Recent messages:OS: Monterey (12.6.8), Xcode: 14.0; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34408 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27829 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27729 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32970 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6820 "Built successfully") | [💥 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4928 "An unexpected error occured. Recent messages:OS: Sonoma (14.1), Xcode: 15.0; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30795 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8554 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/27008 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7549 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3983 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7374 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->