### PR TITLE
[update-test-expectations-from-bugzilla] Use the metadata from JSON

### DIFF
--- a/Tools/Scripts/webkitpy/common/net/bugzilla/results_fetcher.py
+++ b/Tools/Scripts/webkitpy/common/net/bugzilla/results_fetcher.py
@@ -57,25 +57,6 @@ EWS_STATECODES = {
 _log = logging.getLogger(__name__)
 
 
-def _platform_name_for_bot(bot_name):
-    name = bot_name
-    if "mac" in name and name.endswith("-wk2"):
-        return "mac-wk2"
-    if "mac" in name and not name.endswith("-wk2"):
-        return "mac-wk1"
-    if "simulator" in name:
-        return "ios-wk2"
-    if "win-future" in name:
-        return "win"
-    if "gtk" in name:
-        return "gtk"
-    if "wpe" in name:
-        return "wpe"
-    if "-debug" in name:
-        name = name.replace("-debug", "")
-    return name
-
-
 def _get_first_layout_test_step(steps):
     # pick the first run as the one for updating the layout tests.
     layout_tests_steps = [step for step in steps if step["name"] == "layout-tests"]
@@ -132,7 +113,6 @@ def lookup_ews_results(ews_build_urls, bot_filter_name=None):
         steps = ews.steps_from_build_number(builder_id, build_number)
 
         bot_name = builder["description"]
-        platform = _platform_name_for_bot(bot_name)
 
         layout_tests_step = _get_first_layout_test_step(steps)
         if layout_tests_step is None:
@@ -146,7 +126,7 @@ def lookup_ews_results(ews_build_urls, bot_filter_name=None):
             if not urlsplit(tests_url).path.endswith(".zip"):
                 continue
 
-            ews_results.setdefault(platform, []).append(tests_url)
+            ews_results.setdefault(bot_name, []).append(tests_url)
             break
 
     return ews_results

--- a/Tools/Scripts/webkitpy/common/net/bugzilla/results_fetcher_unittest.py
+++ b/Tools/Scripts/webkitpy/common/net/bugzilla/results_fetcher_unittest.py
@@ -226,11 +226,15 @@ class ResultsFetcherTest(unittest.TestCase):
         )
 
     def test_lookup_ews_results_from_bugzilla(self):
-        with mock.patch("requests.Session.get", MockRequestsGet), mock.patch("requests.get", MockRequestsGet):
+        with mock.patch("requests.Session.get", MockRequestsGet), mock.patch(
+            "requests.get", MockRequestsGet
+        ):
             actual = lookup_ews_results_from_bugzilla("123456", True, MockBugzilla())
             expected = {
                 "mac-wk1": [
                     "https://ews-build.webkit.org/results/mac-wk1/r12345.zip",
+                ],
+                "mac-debug-wk1": [
                     "https://ews-build.webkit.org/results/mac-debug-wk1/r12345.zip",
                 ],
                 "mac-wk2": ["https://ews-build.webkit.org/results/mac-wk2/r12345.zip"],

--- a/Tools/Scripts/webkitpy/common/net/layouttestresults.py
+++ b/Tools/Scripts/webkitpy/common/net/layouttestresults.py
@@ -49,12 +49,23 @@ class LayoutTestResults(object):
         if not string:
             return None
         parsed_results = ParsedJSONResults(string)
-        return cls(parsed_results.test_results(), parsed_results.did_exceed_test_failure_limit())
+        return cls(
+            parsed_results.test_results(),
+            parsed_results.did_exceed_test_failure_limit(),
+            parsed_results.metadata(),
+        )
 
-    def __init__(self, test_results, did_exceed_test_failure_limit):
+    def __init__(self, test_results, did_exceed_test_failure_limit, metadata):
         self._unit_test_failures = []
         self._test_results = test_results
         self._did_exceed_test_failure_limit = did_exceed_test_failure_limit
+        self._metadata = metadata
+
+    def port_name(self):
+        return self._metadata.get("port_name")
+
+    def test_configuration(self):
+        return self._metadata.get("test_configuration")
 
     def did_exceed_test_failure_limit(self):
         return self._did_exceed_test_failure_limit

--- a/Tools/Scripts/webkitpy/common/net/resultsjsonparser.py
+++ b/Tools/Scripts/webkitpy/common/net/resultsjsonparser.py
@@ -27,13 +27,13 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import json
 import logging
 
 from webkitpy.common.memoized import memoized
+
 # FIXME: common should never import from new-run-webkit-tests, one of these files needs to move.
 from webkitpy.layout_tests.layout_package import json_results_generator
-from webkitpy.layout_tests.models import test_expectations, test_results, test_failures
+from webkitpy.layout_tests.models import test_expectations, test_failures, test_results
 from webkitpy.layout_tests.models.test_expectations import TestExpectations
 
 _log = logging.getLogger(__name__)
@@ -162,8 +162,14 @@ class ParsedJSONResults(object):
         self._test_results.sort(key=lambda result: result.test_name)
         self._did_exceed_test_failure_limit = json_dict["interrupted"]
 
+        del json_dict["tests"]
+        self._metadata = json_dict
+
     def did_exceed_test_failure_limit(self):
         return self._did_exceed_test_failure_limit
 
     def test_results(self):
         return self._test_results
+
+    def metadata(self):
+        return self._metadata

--- a/Tools/Scripts/webkitpy/common/net/resultsjsonparser_unittest.py
+++ b/Tools/Scripts/webkitpy/common/net/resultsjsonparser_unittest.py
@@ -30,8 +30,7 @@
 import unittest
 
 from webkitpy.common.net.resultsjsonparser import ParsedJSONResults
-from webkitpy.layout_tests.models import test_results
-from webkitpy.layout_tests.models import test_failures
+from webkitpy.layout_tests.models import test_failures, test_results
 
 
 class ParsedJSONResultsTest(unittest.TestCase):

--- a/Tools/Scripts/webkitpy/common/system/filesystem_mock.py
+++ b/Tools/Scripts/webkitpy/common/system/filesystem_mock.py
@@ -488,8 +488,21 @@ class ReadableBinaryFileObject(object):
         self.offset += bytes
         return self.data[start:self.offset]
 
-    def seek(self, offset):
-        self.offset = offset
+    def seek(self, offset, whence=0):
+        if whence == 0:
+            self.offset = offset
+        elif whence == 1:
+            self.offset += offset
+        elif whence == 2:
+            self.offset = len(self.data) + offset
+        else:
+            raise OSError("unsupported whence")
+
+    def tell(self):
+        return self.offset
+
+    def seekable(self):
+        return True
 
 
 class ReadableTextFileObject(ReadableBinaryFileObject):


### PR DESCRIPTION
#### 0e67a6485be5
<pre>
[update-test-expectations-from-bugzilla] Use the metadata from JSON
<a href="https://bugs.webkit.org/show_bug.cgi?id=266446">https://bugs.webkit.org/show_bug.cgi?id=266446</a>

Reviewed by NOBODY (OOPS!).

This stops us from having to infer a lot of this metadata from the bot
name, which is good.

Explanation of why this fixes the bug (OOPS!).

* Tools/Scripts/webkitpy/common/net/bugzilla/results_fetcher.py:
(lookup_ews_results):
(_platform_name_for_bot): Deleted.
* Tools/Scripts/webkitpy/common/net/bugzilla/results_fetcher_unittest.py:
(ResultsFetcherTest.test_lookup_ews_results_from_bugzilla):
* Tools/Scripts/webkitpy/common/net/bugzilla/test_expectation_updater.py:
(TestExpectationUpdater._update_for_bot_results):
(TestExpectationUpdater):
(TestExpectationUpdater._config_for_bot):
(TestExpectationUpdater.do_update):
(TestExpectationUpdater._tests_to_update): Deleted.
(TestExpectationUpdater._file_content_if_exists): Deleted.
(TestExpectationUpdater._update_for_generic_bot): Deleted.
(TestExpectationUpdater._update_for_platform_specific_bot): Deleted.
* Tools/Scripts/webkitpy/common/net/bugzilla/test_expectation_updater_unittest.py:
(MockRequestsGet.__init__):
(MockRequestsGet.iter_content):
(TestExpectationUpdaterTest.test_update_test_expectations):
* Tools/Scripts/webkitpy/common/net/layouttestresults.py:
(LayoutTestResults.results_from_string):
(LayoutTestResults.__init__):
(LayoutTestResults):
(LayoutTestResults.port_name):
(LayoutTestResults.test_configuration):
* Tools/Scripts/webkitpy/common/net/resultsjsonparser.py:
(ParsedJSONResults.__init__):
(ParsedJSONResults.test_results):
(ParsedJSONResults):
(ParsedJSONResults.metadata):
* Tools/Scripts/webkitpy/common/net/resultsjsonparser_unittest.py:
* Tools/Scripts/webkitpy/common/system/filesystem_mock.py:
(ReadableBinaryFileObject.seek):
(ReadableBinaryFileObject):
(ReadableBinaryFileObject.tell):
(ReadableBinaryFileObject.seekable):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e67a6485be5850bbf3545dc4af4b709da1a9687

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30579 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9261 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32232 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33074 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27647 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31283 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11579 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6511 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27564 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30887 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7787 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27379 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6653 "Passed tests") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/30731 "Found 9 webkitpy python3 test failures: webkitpy.common.net.bugzilla.test_expectation_updater_unittest.TestExpectationUpdaterTest.test_update_test_expectations, webkitpy.common.net.buildbot.buildbot_unittest.BuilderTest.test_build_caching, webkitpy.common.net.buildbot.buildbot_unittest.BuilderTest.test_failure_after_flaky, webkitpy.common.net.buildbot.buildbot_unittest.BuilderTest.test_failure_and_flaky, webkitpy.common.net.buildbot.buildbot_unittest.BuilderTest.test_find_blameworthy_regression_window, webkitpy.common.net.buildbot.buildbot_unittest.BuilderTest.test_find_regression_window, webkitpy.common.net.buildbot.buildbot_unittest.BuilderTest.test_flaky_tests, webkitpy.common.net.buildbot.buildbot_unittest.BuilderTest.test_latest_layout_test_results, webkitpy.common.net.buildbot.buildbot_unittest.BuilderTest.test_no_results") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6826 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27235 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34410 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27858 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27730 "Found 1 new test failure: tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-mainframe-vertical-then-horizontal.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32972 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6821 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4930 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30798 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8556 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7551 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7377 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->