### PR TITLE
[MSE] MediaSourcePrivateRemote hiding base m_sourceBuffers member

### DIFF
--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
@@ -191,7 +191,7 @@ void MediaSourcePrivateRemote::mediaSourcePrivateShuttingDown(CompletionHandler<
     m_readyState = MediaPlayer::ReadyState::HaveNothing;
 
     for (auto& sourceBuffer : m_sourceBuffers)
-        sourceBuffer->disconnect();
+        downcast<SourceBufferPrivateRemote>(sourceBuffer)->disconnect();
     completionHandler();
 }
 

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h
@@ -100,7 +100,6 @@ private:
     RemoteMediaSourceIdentifier m_identifier;
     RemoteMediaPlayerMIMETypeCache& m_mimeTypeCache;
     WeakPtr<MediaPlayerPrivateRemote> m_mediaPlayerPrivate;
-    Vector<RefPtr<SourceBufferPrivateRemote>> m_sourceBuffers;
     bool m_shutdown { false };
     WebCore::MediaPlayer::ReadyState m_readyState { WebCore::MediaPlayer::ReadyState::HaveNothing };
 

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
@@ -145,4 +145,8 @@ private:
 
 } // namespace WebKit
 
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::SourceBufferPrivateRemote)
+static bool isType(const WebCore::SourceBufferPrivate& sourceBuffer) { return sourceBuffer.platformType() == WebCore::MediaPlatformType::Remote; }
+SPECIALIZE_TYPE_TRAITS_END()
+
 #endif // ENABLE(GPU_PROCESS) && ENABLE(MEDIA_SOURCE)


### PR DESCRIPTION
#### ab512fb562c34ab3f456c6af0ca4e69bde3d5b85
<pre>
[MSE] MediaSourcePrivateRemote hiding base m_sourceBuffers member
<a href="https://bugs.webkit.org/show_bug.cgi?id=266447">https://bugs.webkit.org/show_bug.cgi?id=266447</a>
<a href="https://rdar.apple.com/119694935">rdar://119694935</a>

Reviewed by Jer Noble.

Missed in 270354@main.

* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp:
(WebKit::MediaSourcePrivateRemote::mediaSourcePrivateShuttingDown):
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h:
(isType): Adding TypeTrait for downcast&lt;SourceBufferPrivateRemote&gt; to work.

Canonical link: <a href="https://commits.webkit.org/272098@main">https://commits.webkit.org/272098@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b001f9d8429f702305c7943dd66e63a85253c4c0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30583 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9265 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32236 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33078 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27650 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11551 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6515 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27565 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30891 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7765 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27382 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6654 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6810 "Too many flaky failures: imported/w3c/web-platform-tests/css/css-cascade/scope-hover.html, imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-below-viewport-partially-onscreen-new.html, imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-below-viewport-partially-onscreen-old.html, imported/w3c/web-platform-tests/css/selectors/invalidation/user-valid-user-invalid.html, imported/w3c/web-platform-tests/css/selectors/user-invalid.html, imported/w3c/web-platform-tests/css/selectors/valid-invalid-form-fieldset.html, imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch.tentative.html, imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative.html, imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/readwrite-readonly.html, imported/w3c/web-platform-tests/mixed-content/gen/worker-module-data.meta/unset/fetch.https.html, imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback-webrtc.https.html, imported/w3c/web-platform-tests/workers/SharedWorker_dataUrl.html (failure)") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34414 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27836 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27740 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32977 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6824 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4935 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30803 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8559 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7243 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7554 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7381 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->