### PR TITLE
[WebGPU] CTS validation/texture/bgra8unorm_storage is failing

### DIFF
--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -289,7 +289,9 @@ TypeChecker::TypeChecker(ShaderModule& shaderModule)
     introduceValue(AST::Identifier::make("write"_s), m_types.accessModeType());
     introduceValue(AST::Identifier::make("read_write"_s), m_types.accessModeType());
 
-    introduceValue(AST::Identifier::make("bgra8unorm"_s), m_types.texelFormatType());
+    if (m_shaderModule.hasFeature("bgra8unorm-storage"_s))
+        introduceValue(AST::Identifier::make("bgra8unorm"_s), m_types.texelFormatType());
+
     introduceValue(AST::Identifier::make("r32float"_s), m_types.texelFormatType());
     introduceValue(AST::Identifier::make("r32sint"_s), m_types.texelFormatType());
     introduceValue(AST::Identifier::make("r32uint"_s), m_types.texelFormatType());

--- a/Source/WebGPU/WGSL/WGSL.h
+++ b/Source/WebGPU/WGSL/WGSL.h
@@ -33,6 +33,7 @@
 #include <memory>
 #include <variant>
 #include <wtf/HashMap.h>
+#include <wtf/HashSet.h>
 #include <wtf/OptionSet.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/Vector.h>
@@ -73,6 +74,7 @@ struct Configuration {
     uint32_t maxBuffersPlusVertexBuffersForVertexStage = 8;
     uint32_t maxBuffersForFragmentStage = 8;
     uint32_t maxBuffersForComputeStage = 8;
+    const HashSet<String> supportedFeatures = { };
 };
 
 std::variant<SuccessfulCheck, FailedCheck> staticCheck(const String& wgsl, const std::optional<SourceMap>&, const Configuration&);

--- a/Source/WebGPU/WGSL/WGSLShaderModule.h
+++ b/Source/WebGPU/WGSL/WGSLShaderModule.h
@@ -235,6 +235,7 @@ public:
     {
         m_pipelineOverrideIds.add(idValue);
     }
+    bool hasFeature(const String& featureName) const { return m_configuration.supportedFeatures.contains(featureName); }
 
 private:
     String m_source;

--- a/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
+++ b/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
@@ -81,6 +81,9 @@ void PresentationContextIOSurface::configure(Device& device, const WGPUSwapChain
     if (descriptor.format != WGPUTextureFormat_BGRA8Unorm)
         return;
 
+    if ((descriptor.usage & WGPUTextureUsage_StorageBinding) && !device.hasFeature(WGPUFeatureName_BGRA8UnormStorage))
+        device.generateAValidationError("Requested storage format but BGRA8UnormStorage is not enabled"_s);
+
     m_device = &device;
 
     auto width = std::min<uint32_t>(device.limits().maxTextureDimension2D, descriptor.width);


### PR DESCRIPTION
#### d47bd56357ddde76498045faa41f6bac206b89cb
<pre>
[WebGPU] CTS validation/texture/bgra8unorm_storage is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=266438">https://bugs.webkit.org/show_bug.cgi?id=266438</a>
&lt;radar://119687642&gt;

Reviewed by Tadeu Zagallo.

Add validation for bgra8unorm-storage and add the now passing expectations.

* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::TypeChecker):
* Source/WebGPU/WGSL/WGSL.h:
* Source/WebGPU/WGSL/WGSLShaderModule.h:
(WGSL::ShaderModule::hasFeature const):
* Source/WebGPU/WebGPU/PresentationContextIOSurface.mm:
(WebGPU::PresentationContextIOSurface::configure):
* Source/WebGPU/WebGPU/ShaderModule.mm:
(WebGPU::buildFeatureSet):
(WebGPU::Device::createShaderModule):

Canonical link: <a href="https://commits.webkit.org/272525@main">https://commits.webkit.org/272525@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5be9ecae2d3823c49e229ce9f988f73e42e8f18a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31958 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10657 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33713 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34473 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28954 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13020 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7893 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28549 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32329 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9013 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28562 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7799 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7979 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35817 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29075 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28929 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34079 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8065 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6050 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31938 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9709 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7473 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8726 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8588 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->