### PR TITLE
Gamepad's getGamepads() should return an empty array when not fully active.

### DIFF
--- a/LayoutTests/gamepad/gamepad-non-fully-active-expected.txt
+++ b/LayoutTests/gamepad/gamepad-non-fully-active-expected.txt
@@ -1,0 +1,4 @@
+Connected 3 gamepads.
+Gamepads fully active: 3
+Gamepads not fully active: 0
+

--- a/LayoutTests/gamepad/gamepad-non-fully-active.html
+++ b/LayoutTests/gamepad/gamepad-non-fully-active.html
@@ -1,0 +1,41 @@
+<head>
+    <script>
+        testRunner?.dumpAsText();
+        testRunner?.waitUntilDone();
+
+        function log(msg) {
+            document.getElementById("logger").innerHTML += msg + "<br>";
+        }
+
+        async function runTest(iframe) {
+            const { contentWindow } = iframe;
+            for (let i = 0; i < 3; i++) {
+                testRunner?.setMockGamepadDetails(i, `g${i}`, "", 2, 2, false);
+                const { gamepad } = await new Promise((resolve) => {
+                    contentWindow.addEventListener(
+                        "gamepadconnected",
+                        resolve,
+                        {
+                            once: true,
+                        }
+                    );
+                    testRunner?.connectMockGamepad(i);
+                });
+            }
+            log(`Connected 3 gamepads.`);
+
+            const iframeNav = contentWindow.navigator;
+
+            log(`Gamepads fully active: ${iframeNav.getGamepads().length}`);
+
+            iframe.remove();
+            log(`Gamepads not fully active: ${iframeNav.getGamepads().length}`);
+
+            testRunner.notifyDone();
+        }
+    </script>
+</head>
+<body>
+    <div id="logger"></div>
+    <iframe srcdoc="test" onload="runTest(this);"></iframe>
+</body>

--- a/Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp
+++ b/Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp
@@ -78,7 +78,7 @@ Ref<Gamepad> NavigatorGamepad::gamepadFromPlatformGamepad(PlatformGamepad& platf
 ExceptionOr<const Vector<RefPtr<Gamepad>>&> NavigatorGamepad::getGamepads(Navigator& navigator)
 {
     RefPtr document = navigator.document() ? navigator.document() : nullptr;
-    if (!document) {
+    if (!document || !document->isFullyActive()) {
         static NeverDestroyed<Vector<RefPtr<Gamepad>>> emptyGamepads;
         return { emptyGamepads.get() };
     }


### PR DESCRIPTION
#### 9c9f8fb6a98d5c005105f19b3930b022b5fafaec
<pre>
Gamepad&apos;s getGamepads() should return an empty array when not fully active.
<a href="https://bugs.webkit.org/show_bug.cgi?id=266450">https://bugs.webkit.org/show_bug.cgi?id=266450</a>
<a href="https://rdar.apple.com/119702262">rdar://119702262</a>

Reviewed by Youenn Fablet.

Now checks if document is fully active.
Aligns with other browsers, specially Firefox, and the spec.

* LayoutTests/gamepad/gamepad-non-fully-active-expected.txt: Added.
* LayoutTests/gamepad/gamepad-non-fully-active.html: Added.
* Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp:
(WebCore::NavigatorGamepad::getGamepads):

Canonical link: <a href="https://commits.webkit.org/272245@main">https://commits.webkit.org/272245@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0f69558212881dd50a335cedc73f6d270e7816b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30928 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9601 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32607 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33435 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27939 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31683 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11963 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6861 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27810 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31252 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8101 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27672 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6941 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7118 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27551 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34773 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28176 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28025 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33248 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7141 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5216 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31080 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8847 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/27335 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7318 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7849 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7690 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->