### PR TITLE
Stop using CheckedRef with DictationCommand

### DIFF
--- a/Source/WebCore/editing/DictationCommand.cpp
+++ b/Source/WebCore/editing/DictationCommand.cpp
@@ -53,7 +53,7 @@ public:
             Ref { m_dictationCommand.get() }->insertParagraphSeparator();
     }
 private:
-    CheckedRef<DictationCommand> m_dictationCommand;
+    WeakRef<DictationCommand> m_dictationCommand;
 };
 
 class DictationMarkerSupplier : public TextInsertionMarkerSupplier {

--- a/Source/WebCore/editing/DictationCommand.h
+++ b/Source/WebCore/editing/DictationCommand.h
@@ -31,7 +31,7 @@
 
 namespace WebCore {
 
-class DictationCommand : public TextInsertionBaseCommand, public CanMakeCheckedPtr {
+class DictationCommand : public TextInsertionBaseCommand {
     friend class DictationCommandLineOperation;
 public:
     static void insertText(Ref<Document>&&, const String&, const Vector<DictationAlternative>& alternatives, const VisibleSelection&);


### PR DESCRIPTION
#### 9637d0d8d3c485347fcfeaebdd54f03ec871bcbe
<pre>
Stop using CheckedRef with DictationCommand
<a href="https://bugs.webkit.org/show_bug.cgi?id=266454">https://bugs.webkit.org/show_bug.cgi?id=266454</a>

Reviewed by Ryosuke Niwa.

Stop using CheckedRef with DictationCommand. Use WeakRef instead to generate
more actionable crashes.

* Source/WebCore/editing/DictationCommand.cpp:
* Source/WebCore/editing/DictationCommand.h:

Canonical link: <a href="https://commits.webkit.org/272116@main">https://commits.webkit.org/272116@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c21cb3ab99e64e2d69443aa0ba243ac0024ae67e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30601 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9284 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32256 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33096 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27664 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31305 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11571 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6534 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27574 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30909 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7781 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27395 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6663 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6821 "Too many flaky failures: imported/w3c/web-platform-tests/css/css-cascade/scope-hover.html, imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-below-viewport-partially-onscreen-new.html, imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-below-viewport-partially-onscreen-old.html, imported/w3c/web-platform-tests/css/selectors/invalidation/user-valid-user-invalid.html, imported/w3c/web-platform-tests/css/selectors/user-invalid.html, imported/w3c/web-platform-tests/css/selectors/valid-invalid-form-fieldset.html, imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-allowed-for-all.https.sub.html, imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch.tentative.html, imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative.html, imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/readwrite-readonly.html, imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.html?h264_annexb, imported/w3c/web-platform-tests/webrtc-extensions/RTCRtpSynchronizationSource-captureTimestamp.html, imported/w3c/web-platform-tests/webrtc-extensions/RTCRtpSynchronizationSource-senderCaptureTimeOffset.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27253 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34432 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27852 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27747 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32984 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6842 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4947 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30810 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8573 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7568 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3976 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7399 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->