### PR TITLE
[TextureMapper] right side of for-loop condition must be constant for ES SL 1.0

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
@@ -870,8 +870,9 @@ void TextureMapper::drawBlurred(const BitmapTexture& sourceTexture, const FloatR
     auto directionVector = direction == Direction::X ? FloatPoint(1, 0) : FloatPoint(0, 1);
     glUniform2f(program->blurDirectionLocation(), directionVector.x(), directionVector.y());
 
-    std::array<float, SimplifiedGaussianKernelMaxHalfSize> kernel;
-    std::array<float, SimplifiedGaussianKernelMaxHalfSize> offset;
+    // Zero-filled arrays for GLES<300
+    std::array<float, SimplifiedGaussianKernelMaxHalfSize> kernel = { };
+    std::array<float, SimplifiedGaussianKernelMaxHalfSize> offset = { };
     int simplifiedKernelHalfSize = computeGaussianKernel(radius, kernel, offset);
     glUniform1fv(program->gaussianKernelLocation(), SimplifiedGaussianKernelMaxHalfSize, kernel.data());
     glUniform1fv(program->gaussianKernelOffsetLocation(), SimplifiedGaussianKernelMaxHalfSize, offset.data());

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.cpp
@@ -362,7 +362,7 @@ static const char* fragmentTemplateCommon =
 
             vec4 total = texture2D(s_sampler, texCoord) * u_gaussianKernel[0];
 
-            for (int i = 1; i < u_gaussianKernelHalfSize; i++) {
+            for (int i = 1; i < GaussianKernelHalfSize; i++) {
                 vec2 offset = step * u_gaussianKernelOffset[i];
                 total += texture2D(s_sampler, clamp(texCoord + offset, min, max)) * u_gaussianKernel[i];
                 total += texture2D(s_sampler, clamp(texCoord - offset, min, max)) * u_gaussianKernel[i];
@@ -379,7 +379,7 @@ static const char* fragmentTemplateCommon =
 
             float total = texture2D(s_sampler, texCoord).a * u_gaussianKernel[0];
 
-            for (int i = 1; i < u_gaussianKernelHalfSize; i++) {
+            for (int i = 1; i < GaussianKernelHalfSize; i++) {
                 vec2 offset = step * u_gaussianKernelOffset[i];
                 total += texture2D(s_sampler, clamp(texCoord + offset, min, max)).a * u_gaussianKernel[i];
                 total += texture2D(s_sampler, clamp(texCoord - offset, min, max)).a * u_gaussianKernel[i];
@@ -519,6 +519,8 @@ Ref<TextureMapperShaderProgram> TextureMapperShaderProgram::create(TextureMapper
     optionsApplierBuilder.append(\
         (options & TextureMapperShaderProgram::Applier) ? ENABLE_APPLIER(Applier) : DISABLE_APPLIER(Applier))
 
+    unsigned glVersion = GLContext::current()->version();
+
     StringBuilder optionsApplierBuilder;
     SET_APPLIER_FROM_OPTIONS(TextureRGB);
     SET_APPLIER_FROM_OPTIONS(TextureYUV);
@@ -562,6 +564,11 @@ Ref<TextureMapperShaderProgram> TextureMapperShaderProgram::create(TextureMapper
 
     // Append the options.
     fragmentShaderBuilder.append(optionsApplierBuilder.toString());
+
+    if (glVersion >= 300)
+        fragmentShaderBuilder.append(GLSL_DIRECTIVE(define GaussianKernelHalfSize u_gaussianKernelHalfSize));
+    else
+        fragmentShaderBuilder.append(GLSL_DIRECTIVE(define GaussianKernelHalfSize GAUSSIAN_KERNEL_MAX_HALF_SIZE));
 
     // Append the common header.
     fragmentShaderBuilder.append(fragmentTemplateHeaderCommon);


### PR DESCRIPTION
#### 767a3b1ebacc83fda69adabd2cd05dcb44eaa087
<pre>
[TextureMapper] right side of for-loop condition must be constant for ES SL 1.0
<a href="https://bugs.webkit.org/show_bug.cgi?id=261870">https://bugs.webkit.org/show_bug.cgi?id=261870</a>

Reviewed by Miguel Gomez.

After 267646@main improved gaussian blur filter, nothing drawn on
Raspberry Pi 3 which supports only GLES 2.0. The shader compiler
reports the following errors.

&gt; Program log: ERROR:OPTIMIZER-3 (fragment shader, line 48) Support for for loops is restricted : right side of condition expression must be constant
&gt; Program log: ERROR:OPTIMIZER-3 (fragment shader, line 49) Support for for loops is restricted : right side of condition expression must be constant

* Source/WebCore/platform/graphics/texmap/TextureMapper.cpp: Zero-fills the kernel.
* Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.cpp:
Use a constant GAUSSIAN_KERNEL_MAX_HALF_SIZE for the for-loop of
applyBlurFilter and applyAlphaBlur for GLES&lt;3.0 (ESSL 1.0)

Canonical link: <a href="https://commits.webkit.org/272287@main">https://commits.webkit.org/272287@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/639ad0192d2e30312bd09bd781bc634d8d2c6a02

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30604 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9287 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32259 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33099 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27666 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31308 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11574 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6537 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27576 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30912 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27399 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6667 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27258 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34435 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27853 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27750 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32986 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6845 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4948 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30812 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8575 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7571 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4058 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7401 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->