### PR TITLE
Table rules="rows" draws the rule on the cells instead of the rows

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7460,3 +7460,6 @@ http/wpt/opener/iframe-access-top-via-windowproxy.html [ Skip ]
 http/wpt/opener/parent-access-child-via-windowproxy.html [ Skip ]
 
 webkit.org/b/266477 compositing/layer-creation/scale-rotation-transition-overlap.html [ Failure Timeout ]
+
+# webkit.org/b/257254 table rules presentation attributes
+fast/css/table-rules-attribute.html [ ImageOnlyFailure ]

--- a/LayoutTests/fast/table/border-changes-expected.txt
+++ b/LayoutTests/fast/table/border-changes-expected.txt
@@ -113,12 +113,12 @@ PASS getComputedStyle(table, '').borderTopColor is yellow
 PASS getComputedStyle(table, '').borderBottomColor is yellow
 PASS getComputedStyle(cell, '').borderLeftWidth is '0px'
 PASS getComputedStyle(cell, '').borderRightWidth is '0px'
-FAIL getComputedStyle(cell, '').borderTopWidth should be 0px. Was 1px.
-FAIL getComputedStyle(cell, '').borderBottomWidth should be 0px. Was 1px.
+PASS getComputedStyle(cell, '').borderTopWidth is '0px'
+PASS getComputedStyle(cell, '').borderBottomWidth is '0px'
 PASS getComputedStyle(cell, '').borderLeftStyle is 'none'
 PASS getComputedStyle(cell, '').borderRightStyle is 'none'
-FAIL getComputedStyle(cell, '').borderTopStyle should be none. Was solid.
-FAIL getComputedStyle(cell, '').borderBottomStyle should be none. Was solid.
+PASS getComputedStyle(cell, '').borderTopStyle is 'none'
+PASS getComputedStyle(cell, '').borderBottomStyle is 'none'
 PASS getComputedStyle(cell, '').borderLeftColor is red
 PASS getComputedStyle(cell, '').borderRightColor is red
 PASS getComputedStyle(cell, '').borderTopColor is red
@@ -136,7 +136,6 @@ PASS getComputedStyle(table, '').borderRightColor is yellow
 PASS getComputedStyle(table, '').borderTopColor is yellow
 PASS getComputedStyle(table, '').borderBottomColor is yellow
 PASS successfullyParsed is true
-Some tests failed.
 
 TEST COMPLETE
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-border-attributes-computed-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-border-attributes-computed-style-expected.txt
@@ -1,0 +1,11 @@
+
+PASS border-color on its own gives the table no border
+PASS border-color on its own gives the cell no border
+PASS the border attribute gives the table an outset border
+PASS the border attribute gives the cells an inset border
+PASS adding bordercolor does not change which borders exist
+PASS setting rules=cols replaces the cells' inset border with a rule on their inline edges
+PASS setting rules=rows leaves the cells with no border
+PASS setting rules=rows puts the rule on the row
+PASS removing the border attribute while rules is set hides the table's own border
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-border-attributes-computed-style.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-border-attributes-computed-style.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Table border and bordercolor attributes: computed borders, including when they change</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#tables-2">
+<link rel="author" title="Karl Dubost" href="mailto:karlcow@apple.com">
+<link rel="author" title="Apple" href="https://www.apple.com/">
+<meta name="assert" content="A border colour on its own never creates a visible border; the border attribute creates an outset border on the table and inset borders on the cells; adding bordercolor does not change which borders exist.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<!--
+  Two things are checked here, in one table that is mutated step by step so that
+  the effect of each attribute is isolated.
+
+  1. A colour alone must not produce a border. Neither the bordercolor content
+     attribute nor the border-color CSS property sets a border style or width, and
+     the initial border style is none, so there is nothing to paint. There is
+     already a reftest for the rendering of this (table-bordercolor-001.html);
+     this test pins the computed values, and pins that adding bordercolor to a
+     table that already has borders does not alter which borders exist.
+
+  2. The border attribute:
+
+       table[border] { border-style: outset; }        /* only if not zero */
+       table[border] > tbody > tr > td, ... {
+         border-width: 1px;
+         border-style: inset;
+       }
+
+     and then what happens when rules is added on top of it, which replaces the
+     cells' inset border.
+
+  border="1" is used rather than border="" throughout: the UA stylesheet entry is
+  annotated "only if border is not equivalent to zero", and whether the empty
+  string counts as zero is not something this test takes a position on.
+
+  The table and the cell each carry their own inline border-color so that the
+  colour assertions test the presentational hints rather than inheritance.
+-->
+
+<div id="log"></div>
+<div id="container"></div>
+
+<script>
+const YELLOW = "rgb(255, 255, 0)";
+const RED = "rgb(255, 0, 0)";
+
+const table = document.createElement("table");
+table.setAttribute("style", "border-color: yellow");
+const row = table.insertRow(-1);
+const cell = row.insertCell(-1);
+cell.setAttribute("style", "border-color: red");
+document.getElementById("container").append(table);
+
+const SIDES = ["top", "right", "bottom", "left"];
+
+function assertUniformBorder(element, width, style, label) {
+  const computed = getComputedStyle(element);
+  for (const side of SIDES) {
+    assert_equals(computed.getPropertyValue(`border-${side}-width`), width,
+                  `${label}: border-${side}-width`);
+    assert_equals(computed.getPropertyValue(`border-${side}-style`), style,
+                  `${label}: border-${side}-style`);
+  }
+}
+
+function assertBorderColor(element, color, label) {
+  const computed = getComputedStyle(element);
+  for (const side of SIDES) {
+    assert_equals(computed.getPropertyValue(`border-${side}-color`), color,
+                  `${label}: border-${side}-color`);
+  }
+}
+
+// A colour with no style and no width paints nothing.
+test(() => {
+  assertUniformBorder(table, "0px", "none", "table with only border-color");
+  assertBorderColor(table, YELLOW, "table");
+}, "border-color on its own gives the table no border");
+
+test(() => {
+  assertUniformBorder(cell, "0px", "none", "cell with only border-color");
+  assertBorderColor(cell, RED, "cell");
+}, "border-color on its own gives the cell no border");
+
+// The border attribute is what actually creates the borders.
+test(() => {
+  table.setAttribute("border", "1");
+  assertUniformBorder(table, "1px", "outset", "table with border=1");
+  assertBorderColor(table, YELLOW, "table");
+}, "the border attribute gives the table an outset border");
+
+test(() => {
+  assertUniformBorder(cell, "1px", "inset", "cell of a table with border=1");
+  assertBorderColor(cell, RED, "cell");
+}, "the border attribute gives the cells an inset border");
+
+// Adding a colour must not change which borders exist.
+test(() => {
+  table.setAttribute("bordercolor", "green");
+  assertUniformBorder(table, "1px", "outset", "table with border=1 and bordercolor");
+  assertUniformBorder(cell, "1px", "inset", "cell with border=1 and bordercolor");
+}, "adding bordercolor does not change which borders exist");
+
+// rules replaces the cells' inset border. Under rules=cols the rule belongs to
+// the cells' inline edges; the block edges get nothing.
+test(() => {
+  table.rules = "cols";
+  const computed = getComputedStyle(cell);
+  assert_equals(computed.borderInlineStartStyle, "solid", "cell border-inline-start-style");
+  assert_equals(computed.borderInlineEndStyle, "solid", "cell border-inline-end-style");
+  assert_equals(computed.borderInlineStartWidth, "1px", "cell border-inline-start-width");
+  assert_equals(computed.borderInlineEndWidth, "1px", "cell border-inline-end-width");
+  assert_equals(computed.borderBlockStartStyle, "none", "cell border-block-start-style");
+  assert_equals(computed.borderBlockEndStyle, "none", "cell border-block-end-style");
+  assert_equals(computed.borderBlockStartWidth, "0px", "cell border-block-start-width");
+  assert_equals(computed.borderBlockEndWidth, "0px", "cell border-block-end-width");
+}, "setting rules=cols replaces the cells' inset border with a rule on their inline edges");
+
+// Under rules=rows the rule moves off the cells entirely and onto the row, even
+// though the border attribute is still present.
+test(() => {
+  table.rules = "rows";
+  assertUniformBorder(cell, "0px", "none", "cell of a table with rules=rows");
+  assertBorderColor(cell, RED, "cell");
+}, "setting rules=rows leaves the cells with no border");
+
+test(() => {
+  const computed = getComputedStyle(row);
+  assert_equals(computed.borderBlockStartStyle, "solid", "row border-block-start-style");
+  assert_equals(computed.borderBlockEndStyle, "solid", "row border-block-end-style");
+  assert_equals(computed.borderBlockStartWidth, "1px", "row border-block-start-width");
+  assert_equals(computed.borderBlockEndWidth, "1px", "row border-block-end-width");
+  assert_equals(computed.borderInlineStartStyle, "none", "row border-inline-start-style");
+  assert_equals(computed.borderInlineEndStyle, "none", "row border-inline-end-style");
+}, "setting rules=rows puts the rule on the row");
+
+// With rules still set and the border attribute gone, the table's own border
+// becomes hidden so that it wins over any border set on the cells.
+test(() => {
+  table.removeAttribute("border");
+  assertUniformBorder(table, "0px", "hidden", "table with rules=rows and no border attribute");
+  assertBorderColor(table, YELLOW, "table");
+}, "removing the border attribute while rules is set hides the table's own border");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-rules-computed-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-rules-computed-style-expected.txt
@@ -1,0 +1,37 @@
+
+PASS rules=none collapses the table's borders and hides its own border
+PASS rules=none gives the cells the expected border
+PASS rules=none gives the rows the expected border
+PASS rules=none gives the row groups the expected border
+PASS rules=none gives the column group the expected border
+PASS rules=groups collapses the table's borders and hides its own border
+PASS rules=groups gives the cells the expected border
+PASS rules=groups gives the rows the expected border
+PASS rules=groups gives the row groups the expected border
+PASS rules=groups gives the column group the expected border
+PASS rules=rows collapses the table's borders and hides its own border
+PASS rules=rows gives the cells the expected border
+PASS rules=rows gives the rows the expected border
+PASS rules=rows gives the row groups the expected border
+PASS rules=rows gives the column group the expected border
+PASS rules=cols collapses the table's borders and hides its own border
+PASS rules=cols gives the cells the expected border
+PASS rules=cols gives the rows the expected border
+PASS rules=cols gives the row groups the expected border
+PASS rules=cols gives the column group the expected border
+PASS rules=all collapses the table's borders and hides its own border
+PASS rules=all gives the cells the expected border
+PASS rules=all gives the rows the expected border
+PASS rules=all gives the row groups the expected border
+PASS rules=all gives the column group the expected border
+PASS rules=rows applies to a row that is a direct child of the table
+PASS rules=ROWS is matched ASCII case-insensitively
+PASS rules with an unrecognised value sets no rule
+PASS rules with U+017F, which is not an ASCII case match for s sets no rule
+PASS rules with the empty string sets no rule
+PASS rules with no value sets no rule
+PASS rules with no attribute at all sets no rule
+PASS rules=rows follows the writing mode: the rule is on the row's block edges
+FAIL rules=cols follows the writing mode: the rule is on the cells' inline edges assert_equals: td in vertical-rl: border-block-start-style expected "none" but got "solid"
+FAIL rules=groups follows the writing mode: the rules are on the groups' block and inline edges assert_equals: tbody in vertical-rl: border-block-start-style expected "solid" but got "none"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-rules-computed-style.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-rules-computed-style.html
@@ -1,0 +1,262 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Table rules attribute: computed borders on the table, row groups, rows, cells and column groups</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#tables-2">
+<link rel="author" title="Karl Dubost" href="mailto:karlcow@apple.com">
+<link rel="author" title="Apple" href="https://www.apple.com/">
+<meta name="assert" content="The rules attribute puts the rule between rows on the row itself and the rule between columns on the cells, and gives the cells no border where the rule is not theirs.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<!--
+  The rendering section gives the rules attribute five presentational hints. The
+  part that is easy to get wrong, and that no test covered before this one, is
+  WHICH ELEMENT owns each rule:
+
+    table[rules=rows i] > tr, table[rules=rows i] > thead > tr,
+    table[rules=rows i] > tbody > tr, table[rules=rows i] > tfoot > tr {
+      border-block-width: 1px;
+      border-block-style: solid;
+    }
+
+  while the cells of rules=none, rules=groups and rules=rows are explicitly
+  given no border:
+
+    ... table[rules=rows i] > tbody > tr > td, ... {
+      border-width: 1px;
+      border-style: none;
+    }
+
+  so under rules=rows the horizontal rule belongs to the ROW and the cells have
+  no border, whereas under rules=cols the vertical rule belongs to the CELLS.
+
+  Two things worth knowing before reading the expectations below:
+
+  * The spec says border-width: 1px even on sides whose style is none. A computed
+    border width is 0px whenever the style is none, so those sides are asserted
+    as 0px. That is not a contradiction with the spec text.
+  * The rules are written with the flow-relative border properties
+    (border-block-*, border-inline-*), so they follow the writing mode. These
+    tests read the same flow-relative properties, and the vertical-rl section at
+    the end pins the mapping explicitly.
+-->
+
+<div id="log"></div>
+<div id="container"></div>
+
+<script>
+const SOLID = { style: "solid", width: "1px" };
+const NONE = { style: "none", width: "0px" };
+
+// Build an expectation for all four flow-relative sides.
+function borders(block, inline) {
+  return {
+    "block-start": block, "block-end": block,
+    "inline-start": inline, "inline-end": inline,
+  };
+}
+const NO_BORDER = borders(NONE, NONE);
+const BLOCK_ONLY = borders(SOLID, NONE);
+const INLINE_ONLY = borders(NONE, SOLID);
+const ALL_SIDES = borders(SOLID, SOLID);
+
+function assertBorders(element, expected, label) {
+  const style = getComputedStyle(element);
+  for (const side of ["block-start", "block-end", "inline-start", "inline-end"]) {
+    assert_equals(style.getPropertyValue(`border-${side}-style`), expected[side].style,
+                  `${label}: border-${side}-style`);
+    assert_equals(style.getPropertyValue(`border-${side}-width`), expected[side].width,
+                  `${label}: border-${side}-width`);
+  }
+}
+
+const container = document.getElementById("container");
+
+// One table per case, with a column group, all three row groups, and both cell
+// element types. Nothing here styles the elements under test, and the cells are
+// deliberately empty: these tests only read computed values, and text in the
+// cells would otherwise be dumped into implementations' text baselines.
+function buildTable(rulesAttribute) {
+  const html = `
+    <table${rulesAttribute}>
+      <colgroup><col><col></colgroup>
+      <thead><tr><th></th><th></th></tr></thead>
+      <tbody><tr><td></td><td></td></tr></tbody>
+      <tfoot><tr><td></td><td></td></tr></tfoot>
+    </table>`;
+  const host = document.createElement("div");
+  host.innerHTML = html;
+  container.append(host);
+  const table = host.querySelector("table");
+  return {
+    table,
+    colgroup: host.querySelector("colgroup"),
+    thead: host.querySelector("thead"),
+    tbody: host.querySelector("tbody"),
+    tfoot: host.querySelector("tfoot"),
+    headerRow: host.querySelector("thead > tr"),
+    bodyRow: host.querySelector("tbody > tr"),
+    footerRow: host.querySelector("tfoot > tr"),
+    th: host.querySelector("th"),
+    td: host.querySelector("tbody td"),
+  };
+}
+
+// The rule between rows lives on the row; the rule between columns lives on the
+// cells; the rule between groups lives on the row groups and column groups.
+const CASES = [
+  {
+    value: "none",
+    cells: NO_BORDER, rows: NO_BORDER, rowGroups: NO_BORDER, columnGroups: NO_BORDER,
+  },
+  {
+    value: "groups",
+    cells: NO_BORDER, rows: NO_BORDER, rowGroups: BLOCK_ONLY, columnGroups: INLINE_ONLY,
+  },
+  {
+    value: "rows",
+    cells: NO_BORDER, rows: BLOCK_ONLY, rowGroups: NO_BORDER, columnGroups: NO_BORDER,
+  },
+  {
+    value: "cols",
+    cells: INLINE_ONLY, rows: NO_BORDER, rowGroups: NO_BORDER, columnGroups: NO_BORDER,
+  },
+  {
+    value: "all",
+    cells: ALL_SIDES, rows: NO_BORDER, rowGroups: NO_BORDER, columnGroups: NO_BORDER,
+  },
+];
+
+for (const testCase of CASES) {
+  const value = testCase.value;
+
+  test(() => {
+    const parts = buildTable(` rules="${value}"`);
+    // table[rules=...] { border-style: hidden; border-collapse: collapse; }
+    assert_equals(getComputedStyle(parts.table).borderCollapse, "collapse",
+                  "border-collapse on the table");
+    for (const side of ["top", "right", "bottom", "left"]) {
+      assert_equals(getComputedStyle(parts.table).getPropertyValue(`border-${side}-style`),
+                    "hidden", `border-${side}-style on the table`);
+    }
+  }, `rules=${value} collapses the table's borders and hides its own border`);
+
+  test(() => {
+    const parts = buildTable(` rules="${value}"`);
+    assertBorders(parts.td, testCase.cells, "td");
+    assertBorders(parts.th, testCase.cells, "th");
+  }, `rules=${value} gives the cells the expected border`);
+
+  test(() => {
+    const parts = buildTable(` rules="${value}"`);
+    assertBorders(parts.bodyRow, testCase.rows, "tbody > tr");
+    assertBorders(parts.headerRow, testCase.rows, "thead > tr");
+    assertBorders(parts.footerRow, testCase.rows, "tfoot > tr");
+  }, `rules=${value} gives the rows the expected border`);
+
+  test(() => {
+    const parts = buildTable(` rules="${value}"`);
+    assertBorders(parts.thead, testCase.rowGroups, "thead");
+    assertBorders(parts.tbody, testCase.rowGroups, "tbody");
+    assertBorders(parts.tfoot, testCase.rowGroups, "tfoot");
+  }, `rules=${value} gives the row groups the expected border`);
+
+  test(() => {
+    const parts = buildTable(` rules="${value}"`);
+    assertBorders(parts.colgroup, testCase.columnGroups, "colgroup");
+  }, `rules=${value} gives the column group the expected border`);
+}
+
+// table[rules=rows i] > tr is its own selector in the spec. The parser always
+// inserts a tbody, so this shape has to be built with DOM calls.
+test(() => {
+  const table = document.createElement("table");
+  table.setAttribute("rules", "rows");
+  const row = document.createElement("tr");
+  const cell = document.createElement("td");
+  row.append(cell);
+  table.append(row);
+  container.append(table);
+
+  assertBorders(row, BLOCK_ONLY, "table > tr");
+  assertBorders(cell, NO_BORDER, "table > tr > td");
+}, "rules=rows applies to a row that is a direct child of the table");
+
+// The attribute value is matched ASCII case-insensitively.
+test(() => {
+  const parts = buildTable(` rules="ROWS"`);
+  assert_equals(getComputedStyle(parts.table).borderCollapse, "collapse");
+  assertBorders(parts.bodyRow, BLOCK_ONLY, "tbody > tr");
+  assertBorders(parts.td, NO_BORDER, "td");
+}, "rules=ROWS is matched ASCII case-insensitively");
+
+// Case-insensitive matching is ASCII-only, so U+017F LATIN SMALL LETTER LONG S
+// must not match the "s" of "rows".
+for (const { label, attribute } of [
+  { label: "an unrecognised value", attribute: ` rules="rowz"` },
+  { label: "U+017F, which is not an ASCII case match for s", attribute: ` rules="rowſ"` },
+  { label: "the empty string", attribute: ` rules=""` },
+  { label: "no value", attribute: ` rules` },
+  { label: "no attribute at all", attribute: `` },
+]) {
+  test(() => {
+    const parts = buildTable(attribute);
+    assert_equals(getComputedStyle(parts.table).borderCollapse, "separate",
+                  "border-collapse on the table");
+    for (const side of ["top", "right", "bottom", "left"]) {
+      assert_equals(getComputedStyle(parts.table).getPropertyValue(`border-${side}-style`),
+                    "none", `border-${side}-style on the table`);
+    }
+    assertBorders(parts.bodyRow, NO_BORDER, "tbody > tr");
+    assertBorders(parts.td, NO_BORDER, "td");
+    assertBorders(parts.tbody, NO_BORDER, "tbody");
+    assertBorders(parts.colgroup, NO_BORDER, "colgroup");
+  }, `rules with ${label} sets no rule`);
+}
+
+// The hints use the flow-relative properties, so in a vertical writing mode the
+// rule between rows runs down the page rather than across it. Reading the
+// physical properties as well pins which way round the mapping goes: in
+// vertical-rl the block axis is horizontal, so block-start is the right edge.
+test(() => {
+  const parts = buildTable(` rules="rows"`);
+  parts.table.style.writingMode = "vertical-rl";
+
+  assertBorders(parts.bodyRow, BLOCK_ONLY, "tbody > tr in vertical-rl");
+
+  const rowStyle = getComputedStyle(parts.bodyRow);
+  assert_equals(rowStyle.borderRightStyle, "solid", "physical right edge is the block-start edge");
+  assert_equals(rowStyle.borderLeftStyle, "solid", "physical left edge is the block-end edge");
+  assert_equals(rowStyle.borderTopStyle, "none", "physical top edge is an inline edge");
+  assert_equals(rowStyle.borderBottomStyle, "none", "physical bottom edge is an inline edge");
+}, "rules=rows follows the writing mode: the rule is on the row's block edges");
+
+test(() => {
+  const parts = buildTable(` rules="cols"`);
+  parts.table.style.writingMode = "vertical-rl";
+
+  assertBorders(parts.td, INLINE_ONLY, "td in vertical-rl");
+
+  const cellStyle = getComputedStyle(parts.td);
+  assert_equals(cellStyle.borderTopStyle, "solid", "physical top edge is the inline-start edge");
+  assert_equals(cellStyle.borderBottomStyle, "solid", "physical bottom edge is the inline-end edge");
+  assert_equals(cellStyle.borderRightStyle, "none", "physical right edge is a block edge");
+  assert_equals(cellStyle.borderLeftStyle, "none", "physical left edge is a block edge");
+}, "rules=cols follows the writing mode: the rule is on the cells' inline edges");
+
+test(() => {
+  const parts = buildTable(` rules="groups"`);
+  parts.table.style.writingMode = "vertical-rl";
+
+  assertBorders(parts.tbody, BLOCK_ONLY, "tbody in vertical-rl");
+  assertBorders(parts.colgroup, INLINE_ONLY, "colgroup in vertical-rl");
+
+  const groupStyle = getComputedStyle(parts.tbody);
+  assert_equals(groupStyle.borderRightStyle, "solid", "row group: physical right edge is the block-start edge");
+  assert_equals(groupStyle.borderTopStyle, "none", "row group: physical top edge is an inline edge");
+
+  const columnGroupStyle = getComputedStyle(parts.colgroup);
+  assert_equals(columnGroupStyle.borderTopStyle, "solid", "column group: physical top edge is the inline-start edge");
+  assert_equals(columnGroupStyle.borderRightStyle, "none", "column group: physical right edge is a block edge");
+}, "rules=groups follows the writing mode: the rules are on the groups' block and inline edges");
+</script>

--- a/LayoutTests/platform/glib/fast/table/frame-and-rules-expected.txt
+++ b/LayoutTests/platform/glib/fast/table/frame-and-rules-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 785x7608
+layer at (0,0) size 785x7572
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x7608
-  RenderBlock {HTML} at (0,0) size 785x7608
-    RenderBody {BODY} at (8,8) size 769x7552
+layer at (0,0) size 785x7572
+  RenderBlock {HTML} at (0,0) size 785x7572
+    RenderBody {BODY} at (8,8) size 769x7516
       RenderTable {TABLE} at (0,0) size 273x118
         RenderBlock {CAPTION} at (0,0) size 273x18
           RenderInline {A} at (0,0) size 224x17
@@ -885,7 +885,7 @@ layer at (0,0) size 785x7608
             RenderTableCell {TD} at (183,0) size 91x21 [border: (1px none #000000)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x17
                 text run at (1,2) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,3022) size 273x122
+      RenderTable {TABLE} at (0,3022) size 273x118
         RenderBlock {CAPTION} at (0,0) size 273x18
           RenderInline {A} at (0,0) size 222x17
             RenderText {#text} at (23,0) size 222x17
@@ -904,37 +904,37 @@ layer at (0,0) size 785x7608
             RenderTableCell {TD} at (182,0) size 91x20 [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x17
                 text run at (1,1) width 89: "Row 1, Cell 3"
-        RenderTableSection {TBODY} at (0,38) size 273x63
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,10) size 91x22 [border: (1px solid #808080) none none none] [r=0 c=0 rs=2 cs=1]
-              RenderText {#text} at (1,1) size 89x19
-                text run at (1,2) width 89: "Row 2, Cell 1"
-            RenderTableCell {TD} at (91,0) size 182x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=2]
-              RenderText {#text} at (1,2) size 89x17
-                text run at (1,2) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,21) size 273x21
-            RenderTableCell {TD} at (91,21) size 91x21 [border: (1px solid #808080) none none none] [r=1 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x17
-                text run at (1,2) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (182,31) size 91x22 [border: (1px solid #808080) none none none] [r=1 c=2 rs=2 cs=1]
-              RenderText {#text} at (1,1) size 89x19
-                text run at (1,2) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,42) size 273x21
-            RenderTableCell {TD} at (0,42) size 182x21 [border: (1px solid #808080) none none none] [r=2 c=0 rs=1 cs=2]
-              RenderText {#text} at (1,2) size 89x17
-                text run at (1,2) width 89: "Row 4, Cell 1"
-        RenderTableSection {TFOOT} at (0,101) size 273x21
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,0) size 91x21 [border: (1px solid #808080) none none none] [r=0 c=0 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x17
-                text run at (1,2) width 89: "Row 5, Cell 1"
-            RenderTableCell {TD} at (91,0) size 91x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x17
-                text run at (1,2) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (182,0) size 91x21 [border: (1px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x17
-                text run at (1,2) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,3192) size 273x123
+        RenderTableSection {TBODY} at (0,38) size 273x60
+          RenderTableRow {TR} at (0,0) size 273x20
+            RenderTableCell {TD} at (0,10) size 91x20 [r=0 c=0 rs=2 cs=1]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 2, Cell 1"
+            RenderTableCell {TD} at (91,0) size 182x20 [r=0 c=1 rs=1 cs=2]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 2, Cell 2"
+          RenderTableRow {TR} at (0,20) size 273x20
+            RenderTableCell {TD} at (91,20) size 91x20 [r=1 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 3, Cell 2"
+            RenderTableCell {TD} at (182,30) size 91x20 [r=1 c=2 rs=2 cs=1]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 3, Cell 3"
+          RenderTableRow {TR} at (0,40) size 273x20
+            RenderTableCell {TD} at (0,40) size 182x20 [r=2 c=0 rs=1 cs=2]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 4, Cell 1"
+        RenderTableSection {TFOOT} at (0,98) size 273x20
+          RenderTableRow {TR} at (0,0) size 273x20
+            RenderTableCell {TD} at (0,0) size 91x20 [r=0 c=0 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 5, Cell 1"
+            RenderTableCell {TD} at (91,0) size 91x20 [r=0 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 5, Cell 2"
+            RenderTableCell {TD} at (182,0) size 91x20 [r=0 c=2 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 5, Cell 3"
+      RenderTable {TABLE} at (0,3188) size 273x119
         RenderBlock {CAPTION} at (0,0) size 273x18
           RenderInline {A} at (0,0) size 234x17
             RenderText {#text} at (17,0) size 234x17
@@ -944,46 +944,46 @@ layer at (0,0) size 785x7608
               text run at (250,0) width 6: ":"
         RenderTableSection {THEAD} at (0,18) size 273x21
           RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,0) size 91x21 [border: (1px solid #808080) none none none] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (0,0) size 91x21 [border: (1px none #808080) none none none] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x17
                 text run at (1,2) width 89: "Row 1, Cell 1"
-            RenderTableCell {TD} at (91,0) size 91x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (91,0) size 91x21 [border: (1px none #808080) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x17
                 text run at (1,2) width 89: "Row 1, Cell 2"
-            RenderTableCell {TD} at (182,0) size 91x21 [border: (1px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (182,0) size 91x21 [border: (1px none #808080) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x17
                 text run at (1,2) width 89: "Row 1, Cell 3"
-        RenderTableSection {TBODY} at (0,39) size 273x63
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,10) size 91x22 [border: (1px solid #808080) none none none] [r=0 c=0 rs=2 cs=1]
-              RenderText {#text} at (1,1) size 89x19
-                text run at (1,2) width 89: "Row 2, Cell 1"
-            RenderTableCell {TD} at (91,0) size 182x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=2]
-              RenderText {#text} at (1,2) size 89x17
-                text run at (1,2) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,21) size 273x21
-            RenderTableCell {TD} at (91,21) size 91x21 [border: (1px solid #808080) none none none] [r=1 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x17
-                text run at (1,2) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (182,31) size 91x22 [border: (1px solid #808080) none none none] [r=1 c=2 rs=2 cs=1]
-              RenderText {#text} at (1,1) size 89x19
-                text run at (1,2) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,42) size 273x21
-            RenderTableCell {TD} at (0,42) size 182x21 [border: (1px solid #808080) none none none] [r=2 c=0 rs=1 cs=2]
-              RenderText {#text} at (1,2) size 89x17
-                text run at (1,2) width 89: "Row 4, Cell 1"
-        RenderTableSection {TFOOT} at (0,102) size 273x21
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,0) size 91x21 [border: (1px solid #808080) none none none] [r=0 c=0 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x17
-                text run at (1,2) width 89: "Row 5, Cell 1"
-            RenderTableCell {TD} at (91,0) size 91x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x17
-                text run at (1,2) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (182,0) size 91x21 [border: (1px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x17
-                text run at (1,2) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,3363) size 273x123 [border: none (1px solid #808080) none]
+        RenderTableSection {TBODY} at (0,39) size 273x60
+          RenderTableRow {TR} at (0,0) size 273x20
+            RenderTableCell {TD} at (0,10) size 91x20 [r=0 c=0 rs=2 cs=1]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 2, Cell 1"
+            RenderTableCell {TD} at (91,0) size 182x20 [r=0 c=1 rs=1 cs=2]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 2, Cell 2"
+          RenderTableRow {TR} at (0,20) size 273x20
+            RenderTableCell {TD} at (91,20) size 91x20 [r=1 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 3, Cell 2"
+            RenderTableCell {TD} at (182,30) size 91x20 [r=1 c=2 rs=2 cs=1]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 3, Cell 3"
+          RenderTableRow {TR} at (0,40) size 273x20
+            RenderTableCell {TD} at (0,40) size 182x20 [r=2 c=0 rs=1 cs=2]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 4, Cell 1"
+        RenderTableSection {TFOOT} at (0,99) size 273x20
+          RenderTableRow {TR} at (0,0) size 273x20
+            RenderTableCell {TD} at (0,0) size 91x20 [r=0 c=0 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 5, Cell 1"
+            RenderTableCell {TD} at (91,0) size 91x20 [r=0 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 5, Cell 2"
+            RenderTableCell {TD} at (182,0) size 91x20 [r=0 c=2 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 5, Cell 3"
+      RenderTable {TABLE} at (0,3355) size 273x119 [border: none (1px solid #808080) none]
         RenderBlock {CAPTION} at (0,0) size 273x18
           RenderInline {A} at (0,0) size 234x17
             RenderText {#text} at (17,0) size 234x17
@@ -1002,37 +1002,37 @@ layer at (0,0) size 785x7608
             RenderTableCell {TD} at (182,0) size 91x20 [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x17
                 text run at (1,1) width 89: "Row 1, Cell 3"
-        RenderTableSection {TBODY} at (0,38) size 273x63
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,10) size 91x22 [border: (1px solid #808080) none none none] [r=0 c=0 rs=2 cs=1]
-              RenderText {#text} at (1,1) size 89x19
-                text run at (1,2) width 89: "Row 2, Cell 1"
-            RenderTableCell {TD} at (91,0) size 182x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=2]
-              RenderText {#text} at (1,2) size 89x17
-                text run at (1,2) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,21) size 273x21
-            RenderTableCell {TD} at (91,21) size 91x21 [border: (1px solid #808080) none none none] [r=1 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x17
-                text run at (1,2) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (182,31) size 91x22 [border: (1px solid #808080) none none none] [r=1 c=2 rs=2 cs=1]
-              RenderText {#text} at (1,1) size 89x19
-                text run at (1,2) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,42) size 273x21
-            RenderTableCell {TD} at (0,42) size 182x21 [border: (1px solid #808080) none none none] [r=2 c=0 rs=1 cs=2]
-              RenderText {#text} at (1,2) size 89x17
-                text run at (1,2) width 89: "Row 4, Cell 1"
-        RenderTableSection {TFOOT} at (0,101) size 273x21
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,0) size 91x21 [border: (1px solid #808080) none none none] [r=0 c=0 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x17
-                text run at (1,2) width 89: "Row 5, Cell 1"
-            RenderTableCell {TD} at (91,0) size 91x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x17
-                text run at (1,2) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (182,0) size 91x21 [border: (1px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x17
-                text run at (1,2) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,3534) size 273x124 [border: none none (1px solid #808080) none]
+        RenderTableSection {TBODY} at (0,38) size 273x60
+          RenderTableRow {TR} at (0,0) size 273x20
+            RenderTableCell {TD} at (0,10) size 91x20 [r=0 c=0 rs=2 cs=1]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 2, Cell 1"
+            RenderTableCell {TD} at (91,0) size 182x20 [r=0 c=1 rs=1 cs=2]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 2, Cell 2"
+          RenderTableRow {TR} at (0,20) size 273x20
+            RenderTableCell {TD} at (91,20) size 91x20 [r=1 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 3, Cell 2"
+            RenderTableCell {TD} at (182,30) size 91x20 [r=1 c=2 rs=2 cs=1]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 3, Cell 3"
+          RenderTableRow {TR} at (0,40) size 273x20
+            RenderTableCell {TD} at (0,40) size 182x20 [r=2 c=0 rs=1 cs=2]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 4, Cell 1"
+        RenderTableSection {TFOOT} at (0,98) size 273x20
+          RenderTableRow {TR} at (0,0) size 273x20
+            RenderTableCell {TD} at (0,0) size 91x20 [r=0 c=0 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 5, Cell 1"
+            RenderTableCell {TD} at (91,0) size 91x20 [r=0 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 5, Cell 2"
+            RenderTableCell {TD} at (182,0) size 91x20 [r=0 c=2 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 5, Cell 3"
+      RenderTable {TABLE} at (0,3522) size 273x120 [border: none none (1px solid #808080) none]
         RenderBlock {CAPTION} at (0,0) size 273x18
           RenderInline {A} at (0,0) size 236x17
             RenderText {#text} at (16,0) size 236x17
@@ -1042,46 +1042,46 @@ layer at (0,0) size 785x7608
               text run at (251,0) width 6: ":"
         RenderTableSection {THEAD} at (0,18) size 273x21
           RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,0) size 91x21 [border: (1px solid #808080) none none none] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (0,0) size 91x21 [border: (1px none #808080) none none none] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x17
                 text run at (1,2) width 89: "Row 1, Cell 1"
-            RenderTableCell {TD} at (91,0) size 91x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (91,0) size 91x21 [border: (1px none #808080) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x17
                 text run at (1,2) width 89: "Row 1, Cell 2"
-            RenderTableCell {TD} at (182,0) size 91x21 [border: (1px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (182,0) size 91x21 [border: (1px none #808080) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x17
                 text run at (1,2) width 89: "Row 1, Cell 3"
-        RenderTableSection {TBODY} at (0,39) size 273x63
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,10) size 91x22 [border: (1px solid #808080) none none none] [r=0 c=0 rs=2 cs=1]
-              RenderText {#text} at (1,1) size 89x19
-                text run at (1,2) width 89: "Row 2, Cell 1"
-            RenderTableCell {TD} at (91,0) size 182x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=2]
-              RenderText {#text} at (1,2) size 89x17
-                text run at (1,2) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,21) size 273x21
-            RenderTableCell {TD} at (91,21) size 91x21 [border: (1px solid #808080) none none none] [r=1 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x17
-                text run at (1,2) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (182,31) size 91x22 [border: (1px solid #808080) none none none] [r=1 c=2 rs=2 cs=1]
-              RenderText {#text} at (1,1) size 89x19
-                text run at (1,2) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,42) size 273x21
-            RenderTableCell {TD} at (0,42) size 182x21 [border: (1px solid #808080) none none none] [r=2 c=0 rs=1 cs=2]
-              RenderText {#text} at (1,2) size 89x17
-                text run at (1,2) width 89: "Row 4, Cell 1"
-        RenderTableSection {TFOOT} at (0,102) size 273x21
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,0) size 91x21 [border: (1px solid #808080) none none none] [r=0 c=0 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x17
-                text run at (1,2) width 89: "Row 5, Cell 1"
-            RenderTableCell {TD} at (91,0) size 91x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x17
-                text run at (1,2) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (182,0) size 91x21 [border: (1px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x17
-                text run at (1,2) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,3706) size 275x122 [border: none (1px solid #808080) none none]
+        RenderTableSection {TBODY} at (0,39) size 273x60
+          RenderTableRow {TR} at (0,0) size 273x20
+            RenderTableCell {TD} at (0,10) size 91x20 [r=0 c=0 rs=2 cs=1]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 2, Cell 1"
+            RenderTableCell {TD} at (91,0) size 182x20 [r=0 c=1 rs=1 cs=2]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 2, Cell 2"
+          RenderTableRow {TR} at (0,20) size 273x20
+            RenderTableCell {TD} at (91,20) size 91x20 [r=1 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 3, Cell 2"
+            RenderTableCell {TD} at (182,30) size 91x20 [r=1 c=2 rs=2 cs=1]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 3, Cell 3"
+          RenderTableRow {TR} at (0,40) size 273x20
+            RenderTableCell {TD} at (0,40) size 182x20 [r=2 c=0 rs=1 cs=2]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 4, Cell 1"
+        RenderTableSection {TFOOT} at (0,99) size 273x20
+          RenderTableRow {TR} at (0,0) size 273x20
+            RenderTableCell {TD} at (0,0) size 91x20 [r=0 c=0 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 5, Cell 1"
+            RenderTableCell {TD} at (91,0) size 91x20 [r=0 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 5, Cell 2"
+            RenderTableCell {TD} at (182,0) size 91x20 [r=0 c=2 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 5, Cell 3"
+      RenderTable {TABLE} at (0,3690) size 275x118 [border: none (1px solid #808080) none none]
         RenderBlock {CAPTION} at (0,0) size 275x18
           RenderInline {A} at (0,0) size 234x17
             RenderText {#text} at (18,0) size 234x17
@@ -1100,37 +1100,37 @@ layer at (0,0) size 785x7608
             RenderTableCell {TD} at (183,0) size 91x20 [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x17
                 text run at (1,1) width 89: "Row 1, Cell 3"
-        RenderTableSection {TBODY} at (0,38) size 274x63
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,10) size 92x22 [border: (1px solid #808080) none none (1px none #808080)] [r=0 c=0 rs=2 cs=1]
-              RenderText {#text} at (2,1) size 89x19
-                text run at (2,2) width 89: "Row 2, Cell 1"
-            RenderTableCell {TD} at (92,0) size 182x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=2]
-              RenderText {#text} at (1,2) size 89x17
-                text run at (1,2) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,21) size 274x21
-            RenderTableCell {TD} at (92,21) size 91x21 [border: (1px solid #808080) none none none] [r=1 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x17
-                text run at (1,2) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (183,31) size 91x22 [border: (1px solid #808080) none none none] [r=1 c=2 rs=2 cs=1]
-              RenderText {#text} at (1,1) size 89x19
-                text run at (1,2) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,42) size 274x21
-            RenderTableCell {TD} at (0,42) size 183x21 [border: (1px solid #808080) none none (1px none #808080)] [r=2 c=0 rs=1 cs=2]
-              RenderText {#text} at (2,2) size 89x17
-                text run at (2,2) width 89: "Row 4, Cell 1"
-        RenderTableSection {TFOOT} at (0,101) size 274x21
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,0) size 92x21 [border: (1px solid #808080) none none (1px none #808080)] [r=0 c=0 rs=1 cs=1]
-              RenderText {#text} at (2,2) size 89x17
-                text run at (2,2) width 89: "Row 5, Cell 1"
-            RenderTableCell {TD} at (92,0) size 91x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x17
-                text run at (1,2) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (183,0) size 91x21 [border: (1px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x17
-                text run at (1,2) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,3876) size 274x122
+        RenderTableSection {TBODY} at (0,38) size 274x60
+          RenderTableRow {TR} at (0,0) size 274x20
+            RenderTableCell {TD} at (0,10) size 92x20 [border: none none none (1px none #808080)] [r=0 c=0 rs=2 cs=1]
+              RenderText {#text} at (2,1) size 89x17
+                text run at (2,1) width 89: "Row 2, Cell 1"
+            RenderTableCell {TD} at (92,0) size 182x20 [r=0 c=1 rs=1 cs=2]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 2, Cell 2"
+          RenderTableRow {TR} at (0,20) size 274x20
+            RenderTableCell {TD} at (92,20) size 91x20 [r=1 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 3, Cell 2"
+            RenderTableCell {TD} at (183,30) size 91x20 [r=1 c=2 rs=2 cs=1]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 3, Cell 3"
+          RenderTableRow {TR} at (0,40) size 274x20
+            RenderTableCell {TD} at (0,40) size 183x20 [border: none none none (1px none #808080)] [r=2 c=0 rs=1 cs=2]
+              RenderText {#text} at (2,1) size 89x17
+                text run at (2,1) width 89: "Row 4, Cell 1"
+        RenderTableSection {TFOOT} at (0,98) size 274x20
+          RenderTableRow {TR} at (0,0) size 274x20
+            RenderTableCell {TD} at (0,0) size 92x20 [border: none none none (1px none #808080)] [r=0 c=0 rs=1 cs=1]
+              RenderText {#text} at (2,1) size 89x17
+                text run at (2,1) width 89: "Row 5, Cell 1"
+            RenderTableCell {TD} at (92,0) size 91x20 [r=0 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 5, Cell 2"
+            RenderTableCell {TD} at (183,0) size 91x20 [r=0 c=2 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 5, Cell 3"
+      RenderTable {TABLE} at (0,3856) size 274x118
         RenderBlock {CAPTION} at (0,0) size 274x18
           RenderInline {A} at (0,0) size 215x17
             RenderText {#text} at (27,0) size 215x17
@@ -1149,37 +1149,37 @@ layer at (0,0) size 785x7608
             RenderTableCell {TD} at (183,0) size 91x20 [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x17
                 text run at (1,1) width 89: "Row 1, Cell 3"
-        RenderTableSection {TBODY} at (0,38) size 274x63
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,10) size 92x22 [border: (1px solid #808080) none none (1px none #808080)] [r=0 c=0 rs=2 cs=1]
-              RenderText {#text} at (2,1) size 89x19
-                text run at (2,2) width 89: "Row 2, Cell 1"
-            RenderTableCell {TD} at (92,0) size 182x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=2]
-              RenderText {#text} at (1,2) size 89x17
-                text run at (1,2) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,21) size 274x21
-            RenderTableCell {TD} at (92,21) size 91x21 [border: (1px solid #808080) none none none] [r=1 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x17
-                text run at (1,2) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (183,31) size 91x22 [border: (1px solid #808080) none none none] [r=1 c=2 rs=2 cs=1]
-              RenderText {#text} at (1,1) size 89x19
-                text run at (1,2) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,42) size 274x21
-            RenderTableCell {TD} at (0,42) size 183x21 [border: (1px solid #808080) none none (1px none #808080)] [r=2 c=0 rs=1 cs=2]
-              RenderText {#text} at (2,2) size 89x17
-                text run at (2,2) width 89: "Row 4, Cell 1"
-        RenderTableSection {TFOOT} at (0,101) size 274x21
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,0) size 92x21 [border: (1px solid #808080) none none (1px none #808080)] [r=0 c=0 rs=1 cs=1]
-              RenderText {#text} at (2,2) size 89x17
-                text run at (2,2) width 89: "Row 5, Cell 1"
-            RenderTableCell {TD} at (92,0) size 91x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x17
-                text run at (1,2) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (183,0) size 91x21 [border: (1px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x17
-                text run at (1,2) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,4046) size 274x122 [border: none (1px solid #808080) none]
+        RenderTableSection {TBODY} at (0,38) size 274x60
+          RenderTableRow {TR} at (0,0) size 274x20
+            RenderTableCell {TD} at (0,10) size 92x20 [border: none none none (1px none #808080)] [r=0 c=0 rs=2 cs=1]
+              RenderText {#text} at (2,1) size 89x17
+                text run at (2,1) width 89: "Row 2, Cell 1"
+            RenderTableCell {TD} at (92,0) size 182x20 [r=0 c=1 rs=1 cs=2]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 2, Cell 2"
+          RenderTableRow {TR} at (0,20) size 274x20
+            RenderTableCell {TD} at (92,20) size 91x20 [r=1 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 3, Cell 2"
+            RenderTableCell {TD} at (183,30) size 91x20 [r=1 c=2 rs=2 cs=1]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 3, Cell 3"
+          RenderTableRow {TR} at (0,40) size 274x20
+            RenderTableCell {TD} at (0,40) size 183x20 [border: none none none (1px none #808080)] [r=2 c=0 rs=1 cs=2]
+              RenderText {#text} at (2,1) size 89x17
+                text run at (2,1) width 89: "Row 4, Cell 1"
+        RenderTableSection {TFOOT} at (0,98) size 274x20
+          RenderTableRow {TR} at (0,0) size 274x20
+            RenderTableCell {TD} at (0,0) size 92x20 [border: none none none (1px none #808080)] [r=0 c=0 rs=1 cs=1]
+              RenderText {#text} at (2,1) size 89x17
+                text run at (2,1) width 89: "Row 5, Cell 1"
+            RenderTableCell {TD} at (92,0) size 91x20 [r=0 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 5, Cell 2"
+            RenderTableCell {TD} at (183,0) size 91x20 [r=0 c=2 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 5, Cell 3"
+      RenderTable {TABLE} at (0,4022) size 274x118 [border: none (1px solid #808080) none]
         RenderBlock {CAPTION} at (0,0) size 274x18
           RenderInline {A} at (0,0) size 217x17
             RenderText {#text} at (26,0) size 217x17
@@ -1198,37 +1198,37 @@ layer at (0,0) size 785x7608
             RenderTableCell {TD} at (182,0) size 91x20 [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x17
                 text run at (1,1) width 89: "Row 1, Cell 3"
-        RenderTableSection {TBODY} at (0,38) size 273x63
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,10) size 91x22 [border: (1px solid #808080) none none none] [r=0 c=0 rs=2 cs=1]
-              RenderText {#text} at (1,1) size 89x19
-                text run at (1,2) width 89: "Row 2, Cell 1"
-            RenderTableCell {TD} at (91,0) size 182x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=2]
-              RenderText {#text} at (1,2) size 89x17
-                text run at (1,2) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,21) size 273x21
-            RenderTableCell {TD} at (91,21) size 91x21 [border: (1px solid #808080) none none none] [r=1 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x17
-                text run at (1,2) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (182,31) size 91x22 [border: (1px solid #808080) none none none] [r=1 c=2 rs=2 cs=1]
-              RenderText {#text} at (1,1) size 89x19
-                text run at (1,2) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,42) size 273x21
-            RenderTableCell {TD} at (0,42) size 182x21 [border: (1px solid #808080) none none none] [r=2 c=0 rs=1 cs=2]
-              RenderText {#text} at (1,2) size 89x17
-                text run at (1,2) width 89: "Row 4, Cell 1"
-        RenderTableSection {TFOOT} at (0,101) size 273x21
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,0) size 91x21 [border: (1px solid #808080) none none none] [r=0 c=0 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x17
-                text run at (1,2) width 89: "Row 5, Cell 1"
-            RenderTableCell {TD} at (91,0) size 91x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x17
-                text run at (1,2) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (182,0) size 91x21 [border: (1px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x17
-                text run at (1,2) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,4216) size 275x124 [border: none]
+        RenderTableSection {TBODY} at (0,38) size 273x60
+          RenderTableRow {TR} at (0,0) size 273x20
+            RenderTableCell {TD} at (0,10) size 91x20 [r=0 c=0 rs=2 cs=1]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 2, Cell 1"
+            RenderTableCell {TD} at (91,0) size 182x20 [r=0 c=1 rs=1 cs=2]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 2, Cell 2"
+          RenderTableRow {TR} at (0,20) size 273x20
+            RenderTableCell {TD} at (91,20) size 91x20 [r=1 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 3, Cell 2"
+            RenderTableCell {TD} at (182,30) size 91x20 [r=1 c=2 rs=2 cs=1]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 3, Cell 3"
+          RenderTableRow {TR} at (0,40) size 273x20
+            RenderTableCell {TD} at (0,40) size 182x20 [r=2 c=0 rs=1 cs=2]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 4, Cell 1"
+        RenderTableSection {TFOOT} at (0,98) size 273x20
+          RenderTableRow {TR} at (0,0) size 273x20
+            RenderTableCell {TD} at (0,0) size 91x20 [r=0 c=0 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 5, Cell 1"
+            RenderTableCell {TD} at (91,0) size 91x20 [r=0 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 5, Cell 2"
+            RenderTableCell {TD} at (182,0) size 91x20 [r=0 c=2 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 5, Cell 3"
+      RenderTable {TABLE} at (0,4188) size 275x120 [border: none]
         RenderBlock {CAPTION} at (0,0) size 275x18
           RenderInline {A} at (0,0) size 220x17
             RenderText {#text} at (25,0) size 220x17
@@ -1238,46 +1238,46 @@ layer at (0,0) size 785x7608
               text run at (244,0) width 6: ":"
         RenderTableSection {THEAD} at (0,18) size 274x21
           RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,0) size 92x21 [border: (1px solid #808080) none none (1px none #808080)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (0,0) size 92x21 [border: (1px none #808080) none none (1px none #808080)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 89x17
                 text run at (2,2) width 89: "Row 1, Cell 1"
-            RenderTableCell {TD} at (92,0) size 91x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (92,0) size 91x21 [border: (1px none #808080) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x17
                 text run at (1,2) width 89: "Row 1, Cell 2"
-            RenderTableCell {TD} at (183,0) size 91x21 [border: (1px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (183,0) size 91x21 [border: (1px none #808080) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x17
                 text run at (1,2) width 89: "Row 1, Cell 3"
-        RenderTableSection {TBODY} at (0,39) size 274x63
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,10) size 92x22 [border: (1px solid #808080) none none (1px none #808080)] [r=0 c=0 rs=2 cs=1]
-              RenderText {#text} at (2,1) size 89x19
-                text run at (2,2) width 89: "Row 2, Cell 1"
-            RenderTableCell {TD} at (92,0) size 182x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=2]
-              RenderText {#text} at (1,2) size 89x17
-                text run at (1,2) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,21) size 274x21
-            RenderTableCell {TD} at (92,21) size 91x21 [border: (1px solid #808080) none none none] [r=1 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x17
-                text run at (1,2) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (183,31) size 91x22 [border: (1px solid #808080) none none none] [r=1 c=2 rs=2 cs=1]
-              RenderText {#text} at (1,1) size 89x19
-                text run at (1,2) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,42) size 274x21
-            RenderTableCell {TD} at (0,42) size 183x21 [border: (1px solid #808080) none none (1px none #808080)] [r=2 c=0 rs=1 cs=2]
-              RenderText {#text} at (2,2) size 89x17
-                text run at (2,2) width 89: "Row 4, Cell 1"
-        RenderTableSection {TFOOT} at (0,102) size 274x21
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,0) size 92x21 [border: (1px solid #808080) none none (1px none #808080)] [r=0 c=0 rs=1 cs=1]
-              RenderText {#text} at (2,2) size 89x17
-                text run at (2,2) width 89: "Row 5, Cell 1"
-            RenderTableCell {TD} at (92,0) size 91x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x17
-                text run at (1,2) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (183,0) size 91x21 [border: (1px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x17
-                text run at (1,2) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,4388) size 275x124 [border: none]
+        RenderTableSection {TBODY} at (0,39) size 274x60
+          RenderTableRow {TR} at (0,0) size 274x20
+            RenderTableCell {TD} at (0,10) size 92x20 [border: none none none (1px none #808080)] [r=0 c=0 rs=2 cs=1]
+              RenderText {#text} at (2,1) size 89x17
+                text run at (2,1) width 89: "Row 2, Cell 1"
+            RenderTableCell {TD} at (92,0) size 182x20 [r=0 c=1 rs=1 cs=2]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 2, Cell 2"
+          RenderTableRow {TR} at (0,20) size 274x20
+            RenderTableCell {TD} at (92,20) size 91x20 [r=1 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 3, Cell 2"
+            RenderTableCell {TD} at (183,30) size 91x20 [r=1 c=2 rs=2 cs=1]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 3, Cell 3"
+          RenderTableRow {TR} at (0,40) size 274x20
+            RenderTableCell {TD} at (0,40) size 183x20 [border: none none none (1px none #808080)] [r=2 c=0 rs=1 cs=2]
+              RenderText {#text} at (2,1) size 89x17
+                text run at (2,1) width 89: "Row 4, Cell 1"
+        RenderTableSection {TFOOT} at (0,99) size 274x20
+          RenderTableRow {TR} at (0,0) size 274x20
+            RenderTableCell {TD} at (0,0) size 92x20 [border: none none none (1px none #808080)] [r=0 c=0 rs=1 cs=1]
+              RenderText {#text} at (2,1) size 89x17
+                text run at (2,1) width 89: "Row 5, Cell 1"
+            RenderTableCell {TD} at (92,0) size 91x20 [r=0 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 5, Cell 2"
+            RenderTableCell {TD} at (183,0) size 91x20 [r=0 c=2 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 5, Cell 3"
+      RenderTable {TABLE} at (0,4356) size 275x120 [border: none]
         RenderBlock {CAPTION} at (0,0) size 275x18
           RenderInline {A} at (0,0) size 238x17
             RenderText {#text} at (16,0) size 238x17
@@ -1287,46 +1287,46 @@ layer at (0,0) size 785x7608
               text run at (254,0) width 5: ":"
         RenderTableSection {THEAD} at (0,18) size 274x21
           RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,0) size 92x21 [border: (1px solid #808080) none none (1px none #808080)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (0,0) size 92x21 [border: (1px none #808080) none none (1px none #808080)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 89x17
                 text run at (2,2) width 89: "Row 1, Cell 1"
-            RenderTableCell {TD} at (92,0) size 91x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (92,0) size 91x21 [border: (1px none #808080) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x17
                 text run at (1,2) width 89: "Row 1, Cell 2"
-            RenderTableCell {TD} at (183,0) size 91x21 [border: (1px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (183,0) size 91x21 [border: (1px none #808080) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x17
                 text run at (1,2) width 89: "Row 1, Cell 3"
-        RenderTableSection {TBODY} at (0,39) size 274x63
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,10) size 92x22 [border: (1px solid #808080) none none (1px none #808080)] [r=0 c=0 rs=2 cs=1]
-              RenderText {#text} at (2,1) size 89x19
-                text run at (2,2) width 89: "Row 2, Cell 1"
-            RenderTableCell {TD} at (92,0) size 182x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=2]
-              RenderText {#text} at (1,2) size 89x17
-                text run at (1,2) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,21) size 274x21
-            RenderTableCell {TD} at (92,21) size 91x21 [border: (1px solid #808080) none none none] [r=1 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x17
-                text run at (1,2) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (183,31) size 91x22 [border: (1px solid #808080) none none none] [r=1 c=2 rs=2 cs=1]
-              RenderText {#text} at (1,1) size 89x19
-                text run at (1,2) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,42) size 274x21
-            RenderTableCell {TD} at (0,42) size 183x21 [border: (1px solid #808080) none none (1px none #808080)] [r=2 c=0 rs=1 cs=2]
-              RenderText {#text} at (2,2) size 89x17
-                text run at (2,2) width 89: "Row 4, Cell 1"
-        RenderTableSection {TFOOT} at (0,102) size 274x21
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,0) size 92x21 [border: (1px solid #808080) none none (1px none #808080)] [r=0 c=0 rs=1 cs=1]
-              RenderText {#text} at (2,2) size 89x17
-                text run at (2,2) width 89: "Row 5, Cell 1"
-            RenderTableCell {TD} at (92,0) size 91x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x17
-                text run at (1,2) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (183,0) size 91x21 [border: (1px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x17
-                text run at (1,2) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,4560) size 275x118
+        RenderTableSection {TBODY} at (0,39) size 274x60
+          RenderTableRow {TR} at (0,0) size 274x20
+            RenderTableCell {TD} at (0,10) size 92x20 [border: none none none (1px none #808080)] [r=0 c=0 rs=2 cs=1]
+              RenderText {#text} at (2,1) size 89x17
+                text run at (2,1) width 89: "Row 2, Cell 1"
+            RenderTableCell {TD} at (92,0) size 182x20 [r=0 c=1 rs=1 cs=2]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 2, Cell 2"
+          RenderTableRow {TR} at (0,20) size 274x20
+            RenderTableCell {TD} at (92,20) size 91x20 [r=1 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 3, Cell 2"
+            RenderTableCell {TD} at (183,30) size 91x20 [r=1 c=2 rs=2 cs=1]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 3, Cell 3"
+          RenderTableRow {TR} at (0,40) size 274x20
+            RenderTableCell {TD} at (0,40) size 183x20 [border: none none none (1px none #808080)] [r=2 c=0 rs=1 cs=2]
+              RenderText {#text} at (2,1) size 89x17
+                text run at (2,1) width 89: "Row 4, Cell 1"
+        RenderTableSection {TFOOT} at (0,99) size 274x20
+          RenderTableRow {TR} at (0,0) size 274x20
+            RenderTableCell {TD} at (0,0) size 92x20 [border: none none none (1px none #808080)] [r=0 c=0 rs=1 cs=1]
+              RenderText {#text} at (2,1) size 89x17
+                text run at (2,1) width 89: "Row 5, Cell 1"
+            RenderTableCell {TD} at (92,0) size 91x20 [r=0 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 5, Cell 2"
+            RenderTableCell {TD} at (183,0) size 91x20 [r=0 c=2 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x17
+                text run at (1,1) width 89: "Row 5, Cell 3"
+      RenderTable {TABLE} at (0,4524) size 275x118
         RenderBlock {CAPTION} at (0,0) size 275x18
           RenderInline {A} at (0,0) size 216x17
             RenderText {#text} at (27,0) size 216x17
@@ -1375,7 +1375,7 @@ layer at (0,0) size 785x7608
             RenderTableCell {TD} at (183,0) size 92x20 [border: none none none (1px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (2,1) size 89x17
                 text run at (2,1) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,4726) size 275x119
+      RenderTable {TABLE} at (0,4690) size 275x119
         RenderBlock {CAPTION} at (0,0) size 275x18
           RenderInline {A} at (0,0) size 228x17
             RenderText {#text} at (21,0) size 228x17
@@ -1424,7 +1424,7 @@ layer at (0,0) size 785x7608
             RenderTableCell {TD} at (183,0) size 92x20 [border: none none none (1px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (2,1) size 89x17
                 text run at (2,1) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,4893) size 275x119 [border: none (1px solid #808080) none]
+      RenderTable {TABLE} at (0,4857) size 275x119 [border: none (1px solid #808080) none]
         RenderBlock {CAPTION} at (0,0) size 275x18
           RenderInline {A} at (0,0) size 228x17
             RenderText {#text} at (21,0) size 228x17
@@ -1473,7 +1473,7 @@ layer at (0,0) size 785x7608
             RenderTableCell {TD} at (183,0) size 92x20 [border: none none none (1px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (2,1) size 89x17
                 text run at (2,1) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,5060) size 275x120 [border: none none (1px solid #808080) none]
+      RenderTable {TABLE} at (0,5024) size 275x120 [border: none none (1px solid #808080) none]
         RenderBlock {CAPTION} at (0,0) size 275x18
           RenderInline {A} at (0,0) size 230x17
             RenderText {#text} at (20,0) size 230x17
@@ -1522,7 +1522,7 @@ layer at (0,0) size 785x7608
             RenderTableCell {TD} at (183,0) size 92x20 [border: none none none (1px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (2,1) size 89x17
                 text run at (2,1) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,5228) size 277x118 [border: none (1px solid #808080) none none]
+      RenderTable {TABLE} at (0,5192) size 277x118 [border: none (1px solid #808080) none none]
         RenderBlock {CAPTION} at (0,0) size 277x18
           RenderInline {A} at (0,0) size 228x17
             RenderText {#text} at (22,0) size 228x17
@@ -1571,7 +1571,7 @@ layer at (0,0) size 785x7608
             RenderTableCell {TD} at (184,0) size 92x20 [border: none none none (1px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (2,1) size 89x17
                 text run at (2,1) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,5394) size 276x118
+      RenderTable {TABLE} at (0,5358) size 276x118
         RenderBlock {CAPTION} at (0,0) size 276x18
           RenderInline {A} at (0,0) size 209x17
             RenderText {#text} at (31,0) size 209x17
@@ -1620,7 +1620,7 @@ layer at (0,0) size 785x7608
             RenderTableCell {TD} at (184,0) size 92x20 [border: none none none (1px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (2,1) size 89x17
                 text run at (2,1) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,5560) size 276x118 [border: none (1px solid #808080) none]
+      RenderTable {TABLE} at (0,5524) size 276x118 [border: none (1px solid #808080) none]
         RenderBlock {CAPTION} at (0,0) size 276x18
           RenderInline {A} at (0,0) size 211x17
             RenderText {#text} at (30,0) size 211x17
@@ -1669,7 +1669,7 @@ layer at (0,0) size 785x7608
             RenderTableCell {TD} at (183,0) size 92x20 [border: none none none (1px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (2,1) size 89x17
                 text run at (2,1) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,5726) size 277x120 [border: none]
+      RenderTable {TABLE} at (0,5690) size 277x120 [border: none]
         RenderBlock {CAPTION} at (0,0) size 277x18
           RenderInline {A} at (0,0) size 214x17
             RenderText {#text} at (29,0) size 214x17
@@ -1718,7 +1718,7 @@ layer at (0,0) size 785x7608
             RenderTableCell {TD} at (184,0) size 92x20 [border: none none none (1px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (2,1) size 89x17
                 text run at (2,1) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,5894) size 277x120 [border: none]
+      RenderTable {TABLE} at (0,5858) size 277x120 [border: none]
         RenderBlock {CAPTION} at (0,0) size 277x18
           RenderInline {A} at (0,0) size 232x17
             RenderText {#text} at (20,0) size 232x17
@@ -1767,7 +1767,7 @@ layer at (0,0) size 785x7608
             RenderTableCell {TD} at (184,0) size 92x20 [border: none none none (1px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (2,1) size 89x17
                 text run at (2,1) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,6062) size 275x122
+      RenderTable {TABLE} at (0,6026) size 275x122
         RenderBlock {CAPTION} at (0,0) size 275x18
           RenderInline {A} at (0,0) size 208x17
             RenderText {#text} at (31,0) size 208x17
@@ -1816,7 +1816,7 @@ layer at (0,0) size 785x7608
             RenderTableCell {TD} at (183,0) size 92x21 [border: (1px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (2,2) size 89x17
                 text run at (2,2) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,6232) size 275x123
+      RenderTable {TABLE} at (0,6196) size 275x123
         RenderBlock {CAPTION} at (0,0) size 275x18
           RenderInline {A} at (0,0) size 218x17
             RenderText {#text} at (26,0) size 218x17
@@ -1865,7 +1865,7 @@ layer at (0,0) size 785x7608
             RenderTableCell {TD} at (183,0) size 92x21 [border: (1px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (2,2) size 89x17
                 text run at (2,2) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,6403) size 275x123 [border: none (1px solid #808080) none]
+      RenderTable {TABLE} at (0,6367) size 275x123 [border: none (1px solid #808080) none]
         RenderBlock {CAPTION} at (0,0) size 275x18
           RenderInline {A} at (0,0) size 218x17
             RenderText {#text} at (26,0) size 218x17
@@ -1914,7 +1914,7 @@ layer at (0,0) size 785x7608
             RenderTableCell {TD} at (183,0) size 92x21 [border: (1px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (2,2) size 89x17
                 text run at (2,2) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,6574) size 275x124 [border: none none (1px solid #808080) none]
+      RenderTable {TABLE} at (0,6538) size 275x124 [border: none none (1px solid #808080) none]
         RenderBlock {CAPTION} at (0,0) size 275x18
           RenderInline {A} at (0,0) size 220x17
             RenderText {#text} at (25,0) size 220x17
@@ -1963,7 +1963,7 @@ layer at (0,0) size 785x7608
             RenderTableCell {TD} at (183,0) size 92x21 [border: (1px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (2,2) size 89x17
                 text run at (2,2) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,6746) size 277x122 [border: none (1px solid #808080) none none]
+      RenderTable {TABLE} at (0,6710) size 277x122 [border: none (1px solid #808080) none none]
         RenderBlock {CAPTION} at (0,0) size 277x18
           RenderInline {A} at (0,0) size 218x17
             RenderText {#text} at (27,0) size 218x17
@@ -2012,7 +2012,7 @@ layer at (0,0) size 785x7608
             RenderTableCell {TD} at (184,0) size 92x21 [border: (1px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (2,2) size 89x17
                 text run at (2,2) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,6916) size 276x122
+      RenderTable {TABLE} at (0,6880) size 276x122
         RenderBlock {CAPTION} at (0,0) size 276x18
           RenderInline {A} at (0,0) size 199x17
             RenderText {#text} at (36,0) size 199x17
@@ -2061,7 +2061,7 @@ layer at (0,0) size 785x7608
             RenderTableCell {TD} at (184,0) size 92x21 [border: (1px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (2,2) size 89x17
                 text run at (2,2) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,7086) size 276x122 [border: none (1px solid #808080) none]
+      RenderTable {TABLE} at (0,7050) size 276x122 [border: none (1px solid #808080) none]
         RenderBlock {CAPTION} at (0,0) size 276x18
           RenderInline {A} at (0,0) size 201x17
             RenderText {#text} at (35,0) size 201x17
@@ -2110,7 +2110,7 @@ layer at (0,0) size 785x7608
             RenderTableCell {TD} at (183,0) size 92x21 [border: (1px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (2,2) size 89x17
                 text run at (2,2) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,7256) size 277x124 [border: none]
+      RenderTable {TABLE} at (0,7220) size 277x124 [border: none]
         RenderBlock {CAPTION} at (0,0) size 277x18
           RenderInline {A} at (0,0) size 204x17
             RenderText {#text} at (34,0) size 204x17
@@ -2159,7 +2159,7 @@ layer at (0,0) size 785x7608
             RenderTableCell {TD} at (184,0) size 92x21 [border: (1px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (2,2) size 89x17
                 text run at (2,2) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,7428) size 277x124 [border: none]
+      RenderTable {TABLE} at (0,7392) size 277x124 [border: none]
         RenderBlock {CAPTION} at (0,0) size 277x18
           RenderInline {A} at (0,0) size 224x17
             RenderText {#text} at (24,0) size 224x17

--- a/LayoutTests/platform/glib/fast/table/frame-and-rules-expected.txt
+++ b/LayoutTests/platform/glib/fast/table/frame-and-rules-expected.txt
@@ -894,7 +894,7 @@ layer at (0,0) size 785x7608
             RenderText at (245,0) size 5x18
               text run at (245,0) width 5: ":"
         RenderTableSection {THEAD} at (0,18) size 273x20
-          RenderTableRow {TR} at (0,0) size 273x20
+          RenderTableRow {TR} at (0,0) size 273x20 [border: (1px solid #000000) none (1px solid #000000) none]
             RenderTableCell {TD} at (0,0) size 91x20 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x18
                 text run at (1,1) width 89: "Row 1, Cell 1"
@@ -905,33 +905,33 @@ layer at (0,0) size 785x7608
               RenderText {#text} at (1,1) size 89x18
                 text run at (1,1) width 89: "Row 1, Cell 3"
         RenderTableSection {TBODY} at (0,38) size 273x63
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,10) size 91x22 [border: (1px solid #000000) none none none] [r=0 c=0 rs=2 cs=1]
+          RenderTableRow {TR} at (0,0) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,10) size 91x22 [border: (1px none #000000) none none none] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (1,13) size 89x17
                 text run at (1,3) width 89: "Row 2, Cell 1"
-            RenderTableCell {TD} at (91,0) size 182x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=2]
+            RenderTableCell {TD} at (91,0) size 182x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=2]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,21) size 273x21
-            RenderTableCell {TD} at (91,21) size 91x21 [border: (1px solid #000000) none none none] [r=1 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,21) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (91,21) size 91x21 [border: (1px none #000000) none none none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (182,31) size 91x22 [border: (1px solid #000000) none none none] [r=1 c=2 rs=2 cs=1]
+            RenderTableCell {TD} at (182,31) size 91x22 [border: (1px none #000000) none none none] [r=1 c=2 rs=2 cs=1]
               RenderText {#text} at (1,13) size 89x17
                 text run at (1,3) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,42) size 273x21
-            RenderTableCell {TD} at (0,42) size 182x21 [border: (1px solid #000000) none none none] [r=2 c=0 rs=1 cs=2]
+          RenderTableRow {TR} at (0,42) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,42) size 182x21 [border: (1px none #000000) none none none] [r=2 c=0 rs=1 cs=2]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 4, Cell 1"
         RenderTableSection {TFOOT} at (0,101) size 273x21
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,0) size 91x21 [border: (1px solid #000000) none none none] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,0) size 91x21 [border: (1px none #000000) none none none] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 5, Cell 1"
-            RenderTableCell {TD} at (91,0) size 91x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (91,0) size 91x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (182,0) size 91x21 [border: (1px solid #000000) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (182,0) size 91x21 [border: (1px none #000000) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 5, Cell 3"
       RenderTable {TABLE} at (0,3192) size 273x123
@@ -943,44 +943,44 @@ layer at (0,0) size 785x7608
             RenderText at (250,0) size 6x18
               text run at (250,0) width 6: ":"
         RenderTableSection {THEAD} at (0,18) size 273x21
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,0) size 91x21 [border: (1px solid #000000) none none none] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,0) size 91x21 [border: (1px none #000000) none none none] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 1, Cell 1"
-            RenderTableCell {TD} at (91,0) size 91x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (91,0) size 91x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 1, Cell 2"
-            RenderTableCell {TD} at (182,0) size 91x21 [border: (1px solid #000000) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (182,0) size 91x21 [border: (1px none #000000) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 1, Cell 3"
         RenderTableSection {TBODY} at (0,39) size 273x63
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,10) size 91x22 [border: (1px solid #000000) none none none] [r=0 c=0 rs=2 cs=1]
+          RenderTableRow {TR} at (0,0) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,10) size 91x22 [border: (1px none #000000) none none none] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (1,13) size 89x17
                 text run at (1,3) width 89: "Row 2, Cell 1"
-            RenderTableCell {TD} at (91,0) size 182x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=2]
+            RenderTableCell {TD} at (91,0) size 182x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=2]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,21) size 273x21
-            RenderTableCell {TD} at (91,21) size 91x21 [border: (1px solid #000000) none none none] [r=1 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,21) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (91,21) size 91x21 [border: (1px none #000000) none none none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (182,31) size 91x22 [border: (1px solid #000000) none none none] [r=1 c=2 rs=2 cs=1]
+            RenderTableCell {TD} at (182,31) size 91x22 [border: (1px none #000000) none none none] [r=1 c=2 rs=2 cs=1]
               RenderText {#text} at (1,13) size 89x17
                 text run at (1,3) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,42) size 273x21
-            RenderTableCell {TD} at (0,42) size 182x21 [border: (1px solid #000000) none none none] [r=2 c=0 rs=1 cs=2]
+          RenderTableRow {TR} at (0,42) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,42) size 182x21 [border: (1px none #000000) none none none] [r=2 c=0 rs=1 cs=2]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 4, Cell 1"
         RenderTableSection {TFOOT} at (0,102) size 273x21
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,0) size 91x21 [border: (1px solid #000000) none none none] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,0) size 91x21 [border: (1px none #000000) none none none] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 5, Cell 1"
-            RenderTableCell {TD} at (91,0) size 91x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (91,0) size 91x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (182,0) size 91x21 [border: (1px solid #000000) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (182,0) size 91x21 [border: (1px none #000000) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 5, Cell 3"
       RenderTable {TABLE} at (0,3363) size 273x123 [border: none (1px solid #000000) none]
@@ -992,7 +992,7 @@ layer at (0,0) size 785x7608
             RenderText at (250,0) size 6x18
               text run at (250,0) width 6: ":"
         RenderTableSection {THEAD} at (0,18) size 273x20
-          RenderTableRow {TR} at (0,0) size 273x20
+          RenderTableRow {TR} at (0,0) size 273x20 [border: (1px solid #000000) none (1px solid #000000) none]
             RenderTableCell {TD} at (0,0) size 91x20 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x18
                 text run at (1,1) width 89: "Row 1, Cell 1"
@@ -1003,33 +1003,33 @@ layer at (0,0) size 785x7608
               RenderText {#text} at (1,1) size 89x18
                 text run at (1,1) width 89: "Row 1, Cell 3"
         RenderTableSection {TBODY} at (0,38) size 273x63
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,10) size 91x22 [border: (1px solid #000000) none none none] [r=0 c=0 rs=2 cs=1]
+          RenderTableRow {TR} at (0,0) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,10) size 91x22 [border: (1px none #000000) none none none] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (1,13) size 89x17
                 text run at (1,3) width 89: "Row 2, Cell 1"
-            RenderTableCell {TD} at (91,0) size 182x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=2]
+            RenderTableCell {TD} at (91,0) size 182x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=2]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,21) size 273x21
-            RenderTableCell {TD} at (91,21) size 91x21 [border: (1px solid #000000) none none none] [r=1 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,21) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (91,21) size 91x21 [border: (1px none #000000) none none none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (182,31) size 91x22 [border: (1px solid #000000) none none none] [r=1 c=2 rs=2 cs=1]
+            RenderTableCell {TD} at (182,31) size 91x22 [border: (1px none #000000) none none none] [r=1 c=2 rs=2 cs=1]
               RenderText {#text} at (1,13) size 89x17
                 text run at (1,3) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,42) size 273x21
-            RenderTableCell {TD} at (0,42) size 182x21 [border: (1px solid #000000) none none none] [r=2 c=0 rs=1 cs=2]
+          RenderTableRow {TR} at (0,42) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,42) size 182x21 [border: (1px none #000000) none none none] [r=2 c=0 rs=1 cs=2]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 4, Cell 1"
         RenderTableSection {TFOOT} at (0,101) size 273x21
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,0) size 91x21 [border: (1px solid #000000) none none none] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,0) size 91x21 [border: (1px none #000000) none none none] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 5, Cell 1"
-            RenderTableCell {TD} at (91,0) size 91x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (91,0) size 91x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (182,0) size 91x21 [border: (1px solid #000000) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (182,0) size 91x21 [border: (1px none #000000) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 5, Cell 3"
       RenderTable {TABLE} at (0,3534) size 273x124 [border: none none (1px solid #000000) none]
@@ -1041,44 +1041,44 @@ layer at (0,0) size 785x7608
             RenderText at (251,0) size 6x18
               text run at (251,0) width 6: ":"
         RenderTableSection {THEAD} at (0,18) size 273x21
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,0) size 91x21 [border: (1px solid #000000) none none none] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,0) size 91x21 [border: (1px none #000000) none none none] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 1, Cell 1"
-            RenderTableCell {TD} at (91,0) size 91x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (91,0) size 91x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 1, Cell 2"
-            RenderTableCell {TD} at (182,0) size 91x21 [border: (1px solid #000000) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (182,0) size 91x21 [border: (1px none #000000) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 1, Cell 3"
         RenderTableSection {TBODY} at (0,39) size 273x63
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,10) size 91x22 [border: (1px solid #000000) none none none] [r=0 c=0 rs=2 cs=1]
+          RenderTableRow {TR} at (0,0) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,10) size 91x22 [border: (1px none #000000) none none none] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (1,13) size 89x17
                 text run at (1,3) width 89: "Row 2, Cell 1"
-            RenderTableCell {TD} at (91,0) size 182x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=2]
+            RenderTableCell {TD} at (91,0) size 182x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=2]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,21) size 273x21
-            RenderTableCell {TD} at (91,21) size 91x21 [border: (1px solid #000000) none none none] [r=1 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,21) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (91,21) size 91x21 [border: (1px none #000000) none none none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (182,31) size 91x22 [border: (1px solid #000000) none none none] [r=1 c=2 rs=2 cs=1]
+            RenderTableCell {TD} at (182,31) size 91x22 [border: (1px none #000000) none none none] [r=1 c=2 rs=2 cs=1]
               RenderText {#text} at (1,13) size 89x17
                 text run at (1,3) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,42) size 273x21
-            RenderTableCell {TD} at (0,42) size 182x21 [border: (1px solid #000000) none none none] [r=2 c=0 rs=1 cs=2]
+          RenderTableRow {TR} at (0,42) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,42) size 182x21 [border: (1px none #000000) none none none] [r=2 c=0 rs=1 cs=2]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 4, Cell 1"
         RenderTableSection {TFOOT} at (0,102) size 273x21
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,0) size 91x21 [border: (1px solid #000000) none none none] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,0) size 91x21 [border: (1px none #000000) none none none] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 5, Cell 1"
-            RenderTableCell {TD} at (91,0) size 91x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (91,0) size 91x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (182,0) size 91x21 [border: (1px solid #000000) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (182,0) size 91x21 [border: (1px none #000000) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 5, Cell 3"
       RenderTable {TABLE} at (0,3706) size 275x122 [border: none (1px solid #000000) none none]
@@ -1090,7 +1090,7 @@ layer at (0,0) size 785x7608
             RenderText at (251,0) size 6x18
               text run at (251,0) width 6: ":"
         RenderTableSection {THEAD} at (0,18) size 274x20
-          RenderTableRow {TR} at (0,0) size 274x20
+          RenderTableRow {TR} at (0,0) size 274x20 [border: (1px solid #000000) none (1px solid #000000) none]
             RenderTableCell {TD} at (0,0) size 92x20 [border: none none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,1) size 89x18
                 text run at (2,1) width 89: "Row 1, Cell 1"
@@ -1101,33 +1101,33 @@ layer at (0,0) size 785x7608
               RenderText {#text} at (1,1) size 89x18
                 text run at (1,1) width 89: "Row 1, Cell 3"
         RenderTableSection {TBODY} at (0,38) size 274x63
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,10) size 92x22 [border: (1px solid #000000) none none (1px none #000000)] [r=0 c=0 rs=2 cs=1]
+          RenderTableRow {TR} at (0,0) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,10) size 92x22 [border: (1px none #000000) none none (1px none #000000)] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (2,13) size 89x17
                 text run at (2,3) width 89: "Row 2, Cell 1"
-            RenderTableCell {TD} at (92,0) size 182x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=2]
+            RenderTableCell {TD} at (92,0) size 182x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=2]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,21) size 274x21
-            RenderTableCell {TD} at (92,21) size 91x21 [border: (1px solid #000000) none none none] [r=1 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,21) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (92,21) size 91x21 [border: (1px none #000000) none none none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (183,31) size 91x22 [border: (1px solid #000000) none none none] [r=1 c=2 rs=2 cs=1]
+            RenderTableCell {TD} at (183,31) size 91x22 [border: (1px none #000000) none none none] [r=1 c=2 rs=2 cs=1]
               RenderText {#text} at (1,13) size 89x17
                 text run at (1,3) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,42) size 274x21
-            RenderTableCell {TD} at (0,42) size 183x21 [border: (1px solid #000000) none none (1px none #000000)] [r=2 c=0 rs=1 cs=2]
+          RenderTableRow {TR} at (0,42) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,42) size 183x21 [border: (1px none #000000) none none (1px none #000000)] [r=2 c=0 rs=1 cs=2]
               RenderText {#text} at (2,2) size 89x18
                 text run at (2,2) width 89: "Row 4, Cell 1"
         RenderTableSection {TFOOT} at (0,101) size 274x21
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,0) size 92x21 [border: (1px solid #000000) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,0) size 92x21 [border: (1px none #000000) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 89x18
                 text run at (2,2) width 89: "Row 5, Cell 1"
-            RenderTableCell {TD} at (92,0) size 91x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (92,0) size 91x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (183,0) size 91x21 [border: (1px solid #000000) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (183,0) size 91x21 [border: (1px none #000000) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 5, Cell 3"
       RenderTable {TABLE} at (0,3876) size 274x122
@@ -1139,7 +1139,7 @@ layer at (0,0) size 785x7608
             RenderText at (241,0) size 6x18
               text run at (241,0) width 6: ":"
         RenderTableSection {THEAD} at (0,18) size 274x20
-          RenderTableRow {TR} at (0,0) size 274x20
+          RenderTableRow {TR} at (0,0) size 274x20 [border: (1px solid #000000) none (1px solid #000000) none]
             RenderTableCell {TD} at (0,0) size 92x20 [border: none none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,1) size 89x18
                 text run at (2,1) width 89: "Row 1, Cell 1"
@@ -1150,33 +1150,33 @@ layer at (0,0) size 785x7608
               RenderText {#text} at (1,1) size 89x18
                 text run at (1,1) width 89: "Row 1, Cell 3"
         RenderTableSection {TBODY} at (0,38) size 274x63
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,10) size 92x22 [border: (1px solid #000000) none none (1px none #000000)] [r=0 c=0 rs=2 cs=1]
+          RenderTableRow {TR} at (0,0) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,10) size 92x22 [border: (1px none #000000) none none (1px none #000000)] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (2,13) size 89x17
                 text run at (2,3) width 89: "Row 2, Cell 1"
-            RenderTableCell {TD} at (92,0) size 182x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=2]
+            RenderTableCell {TD} at (92,0) size 182x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=2]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,21) size 274x21
-            RenderTableCell {TD} at (92,21) size 91x21 [border: (1px solid #000000) none none none] [r=1 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,21) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (92,21) size 91x21 [border: (1px none #000000) none none none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (183,31) size 91x22 [border: (1px solid #000000) none none none] [r=1 c=2 rs=2 cs=1]
+            RenderTableCell {TD} at (183,31) size 91x22 [border: (1px none #000000) none none none] [r=1 c=2 rs=2 cs=1]
               RenderText {#text} at (1,13) size 89x17
                 text run at (1,3) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,42) size 274x21
-            RenderTableCell {TD} at (0,42) size 183x21 [border: (1px solid #000000) none none (1px none #000000)] [r=2 c=0 rs=1 cs=2]
+          RenderTableRow {TR} at (0,42) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,42) size 183x21 [border: (1px none #000000) none none (1px none #000000)] [r=2 c=0 rs=1 cs=2]
               RenderText {#text} at (2,2) size 89x18
                 text run at (2,2) width 89: "Row 4, Cell 1"
         RenderTableSection {TFOOT} at (0,101) size 274x21
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,0) size 92x21 [border: (1px solid #000000) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,0) size 92x21 [border: (1px none #000000) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 89x18
                 text run at (2,2) width 89: "Row 5, Cell 1"
-            RenderTableCell {TD} at (92,0) size 91x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (92,0) size 91x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (183,0) size 91x21 [border: (1px solid #000000) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (183,0) size 91x21 [border: (1px none #000000) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 5, Cell 3"
       RenderTable {TABLE} at (0,4046) size 274x122 [border: none (1px solid #000000) none]
@@ -1188,7 +1188,7 @@ layer at (0,0) size 785x7608
             RenderText at (242,0) size 6x18
               text run at (242,0) width 6: ":"
         RenderTableSection {THEAD} at (0,18) size 273x20
-          RenderTableRow {TR} at (0,0) size 273x20
+          RenderTableRow {TR} at (0,0) size 273x20 [border: (1px solid #000000) none (1px solid #000000) none]
             RenderTableCell {TD} at (0,0) size 91x20 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x18
                 text run at (1,1) width 89: "Row 1, Cell 1"
@@ -1199,33 +1199,33 @@ layer at (0,0) size 785x7608
               RenderText {#text} at (1,1) size 89x18
                 text run at (1,1) width 89: "Row 1, Cell 3"
         RenderTableSection {TBODY} at (0,38) size 273x63
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,10) size 91x22 [border: (1px solid #000000) none none none] [r=0 c=0 rs=2 cs=1]
+          RenderTableRow {TR} at (0,0) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,10) size 91x22 [border: (1px none #000000) none none none] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (1,13) size 89x17
                 text run at (1,3) width 89: "Row 2, Cell 1"
-            RenderTableCell {TD} at (91,0) size 182x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=2]
+            RenderTableCell {TD} at (91,0) size 182x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=2]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,21) size 273x21
-            RenderTableCell {TD} at (91,21) size 91x21 [border: (1px solid #000000) none none none] [r=1 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,21) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (91,21) size 91x21 [border: (1px none #000000) none none none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (182,31) size 91x22 [border: (1px solid #000000) none none none] [r=1 c=2 rs=2 cs=1]
+            RenderTableCell {TD} at (182,31) size 91x22 [border: (1px none #000000) none none none] [r=1 c=2 rs=2 cs=1]
               RenderText {#text} at (1,13) size 89x17
                 text run at (1,3) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,42) size 273x21
-            RenderTableCell {TD} at (0,42) size 182x21 [border: (1px solid #000000) none none none] [r=2 c=0 rs=1 cs=2]
+          RenderTableRow {TR} at (0,42) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,42) size 182x21 [border: (1px none #000000) none none none] [r=2 c=0 rs=1 cs=2]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 4, Cell 1"
         RenderTableSection {TFOOT} at (0,101) size 273x21
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,0) size 91x21 [border: (1px solid #000000) none none none] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,0) size 91x21 [border: (1px none #000000) none none none] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 5, Cell 1"
-            RenderTableCell {TD} at (91,0) size 91x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (91,0) size 91x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (182,0) size 91x21 [border: (1px solid #000000) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (182,0) size 91x21 [border: (1px none #000000) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 5, Cell 3"
       RenderTable {TABLE} at (0,4216) size 275x124 [border: none]
@@ -1237,44 +1237,44 @@ layer at (0,0) size 785x7608
             RenderText at (244,0) size 6x18
               text run at (244,0) width 6: ":"
         RenderTableSection {THEAD} at (0,18) size 274x21
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,0) size 92x21 [border: (1px solid #000000) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,0) size 92x21 [border: (1px none #000000) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 89x18
                 text run at (2,2) width 89: "Row 1, Cell 1"
-            RenderTableCell {TD} at (92,0) size 91x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (92,0) size 91x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 1, Cell 2"
-            RenderTableCell {TD} at (183,0) size 91x21 [border: (1px solid #000000) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (183,0) size 91x21 [border: (1px none #000000) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 1, Cell 3"
         RenderTableSection {TBODY} at (0,39) size 274x63
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,10) size 92x22 [border: (1px solid #000000) none none (1px none #000000)] [r=0 c=0 rs=2 cs=1]
+          RenderTableRow {TR} at (0,0) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,10) size 92x22 [border: (1px none #000000) none none (1px none #000000)] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (2,13) size 89x17
                 text run at (2,3) width 89: "Row 2, Cell 1"
-            RenderTableCell {TD} at (92,0) size 182x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=2]
+            RenderTableCell {TD} at (92,0) size 182x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=2]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,21) size 274x21
-            RenderTableCell {TD} at (92,21) size 91x21 [border: (1px solid #000000) none none none] [r=1 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,21) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (92,21) size 91x21 [border: (1px none #000000) none none none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (183,31) size 91x22 [border: (1px solid #000000) none none none] [r=1 c=2 rs=2 cs=1]
+            RenderTableCell {TD} at (183,31) size 91x22 [border: (1px none #000000) none none none] [r=1 c=2 rs=2 cs=1]
               RenderText {#text} at (1,13) size 89x17
                 text run at (1,3) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,42) size 274x21
-            RenderTableCell {TD} at (0,42) size 183x21 [border: (1px solid #000000) none none (1px none #000000)] [r=2 c=0 rs=1 cs=2]
+          RenderTableRow {TR} at (0,42) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,42) size 183x21 [border: (1px none #000000) none none (1px none #000000)] [r=2 c=0 rs=1 cs=2]
               RenderText {#text} at (2,2) size 89x18
                 text run at (2,2) width 89: "Row 4, Cell 1"
         RenderTableSection {TFOOT} at (0,102) size 274x21
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,0) size 92x21 [border: (1px solid #000000) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,0) size 92x21 [border: (1px none #000000) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 89x18
                 text run at (2,2) width 89: "Row 5, Cell 1"
-            RenderTableCell {TD} at (92,0) size 91x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (92,0) size 91x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (183,0) size 91x21 [border: (1px solid #000000) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (183,0) size 91x21 [border: (1px none #000000) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 5, Cell 3"
       RenderTable {TABLE} at (0,4388) size 275x124 [border: none]
@@ -1286,44 +1286,44 @@ layer at (0,0) size 785x7608
             RenderText at (254,0) size 5x18
               text run at (254,0) width 5: ":"
         RenderTableSection {THEAD} at (0,18) size 274x21
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,0) size 92x21 [border: (1px solid #000000) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,0) size 92x21 [border: (1px none #000000) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 89x18
                 text run at (2,2) width 89: "Row 1, Cell 1"
-            RenderTableCell {TD} at (92,0) size 91x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (92,0) size 91x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 1, Cell 2"
-            RenderTableCell {TD} at (183,0) size 91x21 [border: (1px solid #000000) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (183,0) size 91x21 [border: (1px none #000000) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 1, Cell 3"
         RenderTableSection {TBODY} at (0,39) size 274x63
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,10) size 92x22 [border: (1px solid #000000) none none (1px none #000000)] [r=0 c=0 rs=2 cs=1]
+          RenderTableRow {TR} at (0,0) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,10) size 92x22 [border: (1px none #000000) none none (1px none #000000)] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (2,13) size 89x17
                 text run at (2,3) width 89: "Row 2, Cell 1"
-            RenderTableCell {TD} at (92,0) size 182x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=2]
+            RenderTableCell {TD} at (92,0) size 182x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=2]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,21) size 274x21
-            RenderTableCell {TD} at (92,21) size 91x21 [border: (1px solid #000000) none none none] [r=1 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,21) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (92,21) size 91x21 [border: (1px none #000000) none none none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (183,31) size 91x22 [border: (1px solid #000000) none none none] [r=1 c=2 rs=2 cs=1]
+            RenderTableCell {TD} at (183,31) size 91x22 [border: (1px none #000000) none none none] [r=1 c=2 rs=2 cs=1]
               RenderText {#text} at (1,13) size 89x17
                 text run at (1,3) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,42) size 274x21
-            RenderTableCell {TD} at (0,42) size 183x21 [border: (1px solid #000000) none none (1px none #000000)] [r=2 c=0 rs=1 cs=2]
+          RenderTableRow {TR} at (0,42) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,42) size 183x21 [border: (1px none #000000) none none (1px none #000000)] [r=2 c=0 rs=1 cs=2]
               RenderText {#text} at (2,2) size 89x18
                 text run at (2,2) width 89: "Row 4, Cell 1"
         RenderTableSection {TFOOT} at (0,102) size 274x21
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,0) size 92x21 [border: (1px solid #000000) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,0) size 92x21 [border: (1px none #000000) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 89x18
                 text run at (2,2) width 89: "Row 5, Cell 1"
-            RenderTableCell {TD} at (92,0) size 91x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (92,0) size 91x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (183,0) size 91x21 [border: (1px solid #000000) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (183,0) size 91x21 [border: (1px none #000000) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 5, Cell 3"
       RenderTable {TABLE} at (0,4560) size 275x118

--- a/LayoutTests/platform/glib/fast/table/rules-attr-dynchange2-expected.txt
+++ b/LayoutTests/platform/glib/fast/table/rules-attr-dynchange2-expected.txt
@@ -3,29 +3,29 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576
-      RenderTable {TABLE} at (0,0) size 152x64 [border: none]
-        RenderTableSection {TBODY} at (0,0) size 151x63
+      RenderTable {TABLE} at (0,0) size 152x62 [border: none]
+        RenderTableSection {TBODY} at (0,0) size 151x61
           RenderTableRow {TR} at (0,0) size 151x21
-            RenderTableCell {TD} at (0,0) size 76x21 [border: (1px solid #808080) none none (1px none #808080)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (0,0) size 76x21 [border: (1px none #808080) none none (1px none #808080)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 73x17
                 text run at (2,2) width 73: "Row1 cell1"
-            RenderTableCell {TD} at (76,0) size 75x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (76,0) size 75x21 [border: (1px none #808080) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 73x17
                 text run at (1,2) width 73: "Row1 cell2"
-          RenderTableRow {TR} at (0,21) size 151x21
-            RenderTableCell {TD} at (0,21) size 76x21 [border: (1px solid #808080) none none (1px none #808080)] [r=1 c=0 rs=1 cs=1]
-              RenderText {#text} at (2,2) size 73x17
-                text run at (2,2) width 73: "Row2 cell1"
-            RenderTableCell {TD} at (76,21) size 75x21 [border: (1px solid #808080) none none none] [r=1 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 73x17
-                text run at (1,2) width 73: "Row2 cell2"
-          RenderTableRow {TR} at (0,42) size 151x21
-            RenderTableCell {TD} at (0,42) size 76x21 [border: (1px solid #808080) none none (1px none #808080)] [r=2 c=0 rs=1 cs=1]
-              RenderText {#text} at (2,2) size 73x17
-                text run at (2,2) width 73: "Row3 cell1"
-            RenderTableCell {TD} at (76,42) size 75x21 [border: (1px solid #808080) none none none] [r=2 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 73x17
-                text run at (1,2) width 73: "Row3 cell2"
-      RenderBlock {P} at (0,80) size 784x18
+          RenderTableRow {TR} at (0,21) size 151x20
+            RenderTableCell {TD} at (0,21) size 76x20 [border: none none none (1px none #808080)] [r=1 c=0 rs=1 cs=1]
+              RenderText {#text} at (2,1) size 73x17
+                text run at (2,1) width 73: "Row2 cell1"
+            RenderTableCell {TD} at (76,21) size 75x20 [r=1 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 73x17
+                text run at (1,1) width 73: "Row2 cell2"
+          RenderTableRow {TR} at (0,41) size 151x20
+            RenderTableCell {TD} at (0,41) size 76x20 [border: none none none (1px none #808080)] [r=2 c=0 rs=1 cs=1]
+              RenderText {#text} at (2,1) size 73x17
+                text run at (2,1) width 73: "Row3 cell1"
+            RenderTableCell {TD} at (76,41) size 75x20 [r=2 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 73x17
+                text run at (1,1) width 73: "Row3 cell2"
+      RenderBlock {P} at (0,78) size 784x18
         RenderText {#text} at (0,0) size 747x17
           text run at (0,0) width 747: "The rules attribute is first set dynamically to cols, then to rows, so the table should show only row borders. Bug 14848."

--- a/LayoutTests/platform/glib/fast/table/rules-attr-dynchange2-expected.txt
+++ b/LayoutTests/platform/glib/fast/table/rules-attr-dynchange2-expected.txt
@@ -5,25 +5,25 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576
       RenderTable {TABLE} at (0,0) size 152x64 [border: none]
         RenderTableSection {TBODY} at (0,0) size 151x63
-          RenderTableRow {TR} at (0,0) size 151x21
-            RenderTableCell {TD} at (0,0) size 76x21 [border: (1px solid #000000) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 151x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,0) size 76x21 [border: (1px none #000000) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 73x18
                 text run at (2,2) width 73: "Row1 cell1"
-            RenderTableCell {TD} at (76,0) size 75x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (76,0) size 75x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 73x18
                 text run at (1,2) width 73: "Row1 cell2"
-          RenderTableRow {TR} at (0,21) size 151x21
-            RenderTableCell {TD} at (0,21) size 76x21 [border: (1px solid #000000) none none (1px none #000000)] [r=1 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,21) size 151x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,21) size 76x21 [border: (1px none #000000) none none (1px none #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 73x18
                 text run at (2,2) width 73: "Row2 cell1"
-            RenderTableCell {TD} at (76,21) size 75x21 [border: (1px solid #000000) none none none] [r=1 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (76,21) size 75x21 [border: (1px none #000000) none none none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 73x18
                 text run at (1,2) width 73: "Row2 cell2"
-          RenderTableRow {TR} at (0,42) size 151x21
-            RenderTableCell {TD} at (0,42) size 76x21 [border: (1px solid #000000) none none (1px none #000000)] [r=2 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,42) size 151x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,42) size 76x21 [border: (1px none #000000) none none (1px none #000000)] [r=2 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 73x18
                 text run at (2,2) width 73: "Row3 cell1"
-            RenderTableCell {TD} at (76,42) size 75x21 [border: (1px solid #000000) none none none] [r=2 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (76,42) size 75x21 [border: (1px none #000000) none none none] [r=2 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 73x18
                 text run at (1,2) width 73: "Row3 cell2"
       RenderBlock {P} at (0,80) size 784x18

--- a/LayoutTests/platform/glib/tables/mozilla/core/table_rules-expected.txt
+++ b/LayoutTests/platform/glib/tables/mozilla/core/table_rules-expected.txt
@@ -90,25 +90,25 @@ layer at (0,0) size 800x600
                 text run at (1,1) width 72: "col group 2"
       RenderBlock (anonymous) at (0,203) size 784x18
         RenderBR {BR} at (0,0) size 0x17
-      RenderTable {TABLE} at (0,221) size 67x43 [border: none]
-        RenderTableSection {TBODY} at (0,0) size 66x42
+      RenderTable {TABLE} at (0,221) size 67x42 [border: none]
+        RenderTableSection {TBODY} at (0,0) size 66x41
           RenderTableRow {TR} at (0,0) size 66x21
-            RenderTableCell {TD} at (0,0) size 33x21 [border: (1px solid #808080) none none (1px none #808080)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (0,0) size 33x21 [border: (1px none #808080) none none (1px none #808080)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 30x17
                 text run at (2,2) width 30: "rules"
-            RenderTableCell {TD} at (33,0) size 33x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (33,0) size 33x21 [border: (1px none #808080) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 31x17
                 text run at (1,2) width 31: "rows"
-          RenderTableRow {TR} at (0,21) size 66x21
-            RenderTableCell {TD} at (0,21) size 33x21 [border: (1px solid #808080) none none (1px none #808080)] [r=1 c=0 rs=1 cs=1]
-              RenderText {#text} at (2,2) size 30x17
-                text run at (2,2) width 30: "rules"
-            RenderTableCell {TD} at (33,21) size 33x21 [border: (1px solid #808080) none none none] [r=1 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 31x17
-                text run at (1,2) width 31: "rows"
-      RenderBlock (anonymous) at (0,264) size 784x18
+          RenderTableRow {TR} at (0,21) size 66x20
+            RenderTableCell {TD} at (0,21) size 33x20 [border: none none none (1px none #808080)] [r=1 c=0 rs=1 cs=1]
+              RenderText {#text} at (2,1) size 30x17
+                text run at (2,1) width 30: "rules"
+            RenderTableCell {TD} at (33,21) size 33x20 [r=1 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 31x17
+                text run at (1,1) width 31: "rows"
+      RenderBlock (anonymous) at (0,263) size 784x18
         RenderBR {BR} at (0,0) size 0x17
-      RenderTable {TABLE} at (0,282) size 62x42 [border: none]
+      RenderTable {TABLE} at (0,281) size 62x42 [border: none]
         RenderTableSection {TBODY} at (0,0) size 61x41
           RenderTableRow {TR} at (0,0) size 61x21
             RenderTableCell {TD} at (0,0) size 33x21 [border: (1px none #808080) none none (1px solid #808080)] [r=0 c=0 rs=1 cs=1]
@@ -124,9 +124,9 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (33,21) size 28x20 [border: none none none (1px solid #808080)] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (2,1) size 25x17
                 text run at (2,1) width 25: "cols"
-      RenderBlock (anonymous) at (0,324) size 784x18
+      RenderBlock (anonymous) at (0,323) size 784x18
         RenderBR {BR} at (0,0) size 0x17
-      RenderTable {TABLE} at (0,342) size 52x43 [border: none]
+      RenderTable {TABLE} at (0,341) size 52x43 [border: none]
         RenderTableSection {TBODY} at (0,0) size 51x42
           RenderTableRow {TR} at (0,0) size 51x21
             RenderTableCell {TD} at (0,0) size 33x21 [border: (1px solid #808080)] [r=0 c=0 rs=1 cs=1]
@@ -142,5 +142,5 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (33,21) size 18x21 [border: (1px solid #808080)] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 15x17
                 text run at (2,2) width 15: "all"
-      RenderBlock (anonymous) at (0,385) size 784x18
+      RenderBlock (anonymous) at (0,384) size 784x18
         RenderBR {BR} at (0,0) size 0x17

--- a/LayoutTests/platform/glib/tables/mozilla/core/table_rules-expected.txt
+++ b/LayoutTests/platform/glib/tables/mozilla/core/table_rules-expected.txt
@@ -92,18 +92,18 @@ layer at (0,0) size 800x600
         RenderBR {BR} at (0,0) size 0x18
       RenderTable {TABLE} at (0,221) size 67x43 [border: none]
         RenderTableSection {TBODY} at (0,0) size 66x42
-          RenderTableRow {TR} at (0,0) size 66x21
-            RenderTableCell {TD} at (0,0) size 33x21 [border: (1px solid #000000) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 66x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,0) size 33x21 [border: (1px none #000000) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 30x18
                 text run at (2,2) width 30: "rules"
-            RenderTableCell {TD} at (33,0) size 33x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (33,0) size 33x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 31x18
                 text run at (1,2) width 31: "rows"
-          RenderTableRow {TR} at (0,21) size 66x21
-            RenderTableCell {TD} at (0,21) size 33x21 [border: (1px solid #000000) none none (1px none #000000)] [r=1 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,21) size 66x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,21) size 33x21 [border: (1px none #000000) none none (1px none #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 30x18
                 text run at (2,2) width 30: "rules"
-            RenderTableCell {TD} at (33,21) size 33x21 [border: (1px solid #000000) none none none] [r=1 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (33,21) size 33x21 [border: (1px none #000000) none none none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 31x18
                 text run at (1,2) width 31: "rows"
       RenderBlock (anonymous) at (0,264) size 784x18

--- a/LayoutTests/platform/glib/tables/mozilla_expected_failures/marvin/table_rules_rows-expected.txt
+++ b/LayoutTests/platform/glib/tables/mozilla_expected_failures/marvin/table_rules_rows-expected.txt
@@ -3,58 +3,58 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderTable {TABLE} at (0,0) size 414x111 [border: (2px outset #808080)]
+      RenderTable {TABLE} at (0,0) size 414x108 [border: (2px outset #808080)]
         RenderBlock {CAPTION} at (0,0) size 414x18
           RenderText {#text} at (13,0) size 388x17
             text run at (13,0) width 388: "Communicator 4.5 Installers for Mac and Windows Platforms"
-        RenderTableSection {TBODY} at (2,20) size 409x88
+        RenderTableSection {TBODY} at (2,20) size 409x85
           RenderTableRow {TR} at (0,0) size 409x23
-            RenderTableCell {TH} at (0,9) size 119x5 [border: (3px solid #808080) none none (3px none #808080)] [r=0 c=0 rs=1 cs=1]
-            RenderTableCell {TH} at (119,0) size 109x23 [border: (3px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TH} at (0,9) size 119x5 [border: (3px none #808080) none none (3px none #808080)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TH} at (119,0) size 109x23 [border: (3px none #808080) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,4) size 107x17
                 text run at (1,4) width 107: "Macintosh PPC"
-            RenderTableCell {TH} at (228,0) size 86x23 [border: (3px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TH} at (228,0) size 86x23 [border: (3px none #808080) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,4) size 84x17
                 text run at (1,4) width 84: "Windows 95"
-            RenderTableCell {TH} at (313,0) size 96x23 [border: (3px solid #808080) (2px none #808080) none none] [r=0 c=3 rs=1 cs=1]
+            RenderTableCell {TH} at (313,0) size 96x23 [border: (3px none #808080) (2px none #808080) none none] [r=0 c=3 rs=1 cs=1]
               RenderText {#text} at (1,4) size 91x17
                 text run at (1,4) width 91: "Windows NT"
-          RenderTableRow {TR} at (0,23) size 409x21
-            RenderTableCell {TD} at (0,23) size 119x21 [border: (1px solid #808080) none none (3px none #808080)] [r=1 c=0 rs=1 cs=1]
-              RenderText {#text} at (4,2) size 73x17
-                text run at (4,2) width 73: "Base Install"
-            RenderTableCell {TD} at (119,23) size 109x21 [border: (1px solid #808080) none none none] [r=1 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 21x17
-                text run at (1,2) width 21: "yes"
-            RenderTableCell {TD} at (228,23) size 86x21 [border: (1px solid #808080) none none none] [r=1 c=2 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 21x17
-                text run at (1,2) width 21: "yes"
-            RenderTableCell {TD} at (313,23) size 96x21 [border: (1px solid #808080) (2px none #808080) none none] [r=1 c=3 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 21x17
-                text run at (1,2) width 21: "yes"
-          RenderTableRow {TR} at (0,44) size 409x21
-            RenderTableCell {TD} at (0,44) size 119x21 [border: (1px solid #808080) none none (3px none #808080)] [r=2 c=0 rs=1 cs=1]
-              RenderText {#text} at (4,2) size 103x17
-                text run at (4,2) width 103: "Complete Install"
-            RenderTableCell {TD} at (119,44) size 109x21 [border: (1px solid #808080) none none none] [r=2 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 21x17
-                text run at (1,2) width 21: "yes"
-            RenderTableCell {TD} at (228,44) size 86x21 [border: (1px solid #808080) none none none] [r=2 c=2 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 21x17
-                text run at (1,2) width 21: "yes"
-            RenderTableCell {TD} at (313,44) size 96x21 [border: (1px solid #808080) (2px none #808080) none none] [r=2 c=3 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 21x17
-                text run at (1,2) width 21: "yes"
-          RenderTableRow {TR} at (0,65) size 409x23
-            RenderTableCell {TD} at (0,65) size 119x23 [border: (1px solid #808080) none (2px solid #808080) (3px none #808080)] [r=3 c=0 rs=1 cs=1]
-              RenderText {#text} at (4,2) size 114x17
-                text run at (4,2) width 114: "Pro Edition Install"
-            RenderTableCell {TD} at (119,65) size 109x23 [border: (1px solid #808080) none (2px solid #808080) none] [r=3 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 21x17
-                text run at (1,2) width 21: "yes"
-            RenderTableCell {TD} at (228,65) size 86x23 [border: (1px solid #808080) none (2px solid #808080) none] [r=3 c=2 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 21x17
-                text run at (1,2) width 21: "yes"
-            RenderTableCell {TD} at (313,65) size 96x23 [border: (1px solid #808080) (2px none #808080) (2px solid #808080) none] [r=3 c=3 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 21x17
-                text run at (1,2) width 21: "yes"
+          RenderTableRow {TR} at (0,23) size 409x20
+            RenderTableCell {TD} at (0,23) size 119x20 [border: none none none (3px none #808080)] [r=1 c=0 rs=1 cs=1]
+              RenderText {#text} at (4,1) size 73x17
+                text run at (4,1) width 73: "Base Install"
+            RenderTableCell {TD} at (119,23) size 109x20 [r=1 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 21x17
+                text run at (1,1) width 21: "yes"
+            RenderTableCell {TD} at (228,23) size 86x20 [r=1 c=2 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 21x17
+                text run at (1,1) width 21: "yes"
+            RenderTableCell {TD} at (313,23) size 96x20 [border: none (2px none #808080) none none] [r=1 c=3 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 21x17
+                text run at (1,1) width 21: "yes"
+          RenderTableRow {TR} at (0,43) size 409x20
+            RenderTableCell {TD} at (0,43) size 119x20 [border: none none none (3px none #808080)] [r=2 c=0 rs=1 cs=1]
+              RenderText {#text} at (4,1) size 103x17
+                text run at (4,1) width 103: "Complete Install"
+            RenderTableCell {TD} at (119,43) size 109x20 [r=2 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 21x17
+                text run at (1,1) width 21: "yes"
+            RenderTableCell {TD} at (228,43) size 86x20 [r=2 c=2 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 21x17
+                text run at (1,1) width 21: "yes"
+            RenderTableCell {TD} at (313,43) size 96x20 [border: none (2px none #808080) none none] [r=2 c=3 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 21x17
+                text run at (1,1) width 21: "yes"
+          RenderTableRow {TR} at (0,63) size 409x22
+            RenderTableCell {TD} at (0,63) size 119x22 [border: none none (2px none #808080) (3px none #808080)] [r=3 c=0 rs=1 cs=1]
+              RenderText {#text} at (4,1) size 114x17
+                text run at (4,1) width 114: "Pro Edition Install"
+            RenderTableCell {TD} at (119,63) size 109x22 [border: none none (2px none #808080) none] [r=3 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 21x17
+                text run at (1,1) width 21: "yes"
+            RenderTableCell {TD} at (228,63) size 86x22 [border: none none (2px none #808080) none] [r=3 c=2 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 21x17
+                text run at (1,1) width 21: "yes"
+            RenderTableCell {TD} at (313,63) size 96x22 [border: none (2px none #808080) (2px none #808080) none] [r=3 c=3 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 21x17
+                text run at (1,1) width 21: "yes"

--- a/LayoutTests/platform/glib/tables/mozilla_expected_failures/marvin/table_rules_rows-expected.txt
+++ b/LayoutTests/platform/glib/tables/mozilla_expected_failures/marvin/table_rules_rows-expected.txt
@@ -8,53 +8,53 @@ layer at (0,0) size 800x600
           RenderText {#text} at (13,0) size 388x18
             text run at (13,0) width 388: "Communicator 4.5 Installers for Mac and Windows Platforms"
         RenderTableSection {TBODY} at (2,20) size 409x88
-          RenderTableRow {TR} at (0,0) size 409x23
-            RenderTableCell {TH} at (0,9) size 119x5 [border: (3px solid #000000) none none (3px none #000000)] [r=0 c=0 rs=1 cs=1]
-            RenderTableCell {TH} at (119,0) size 109x23 [border: (3px solid #000000) none none none] [r=0 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 409x23 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TH} at (0,9) size 119x5 [border: (3px none #000000) none none (3px none #000000)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TH} at (119,0) size 109x23 [border: (3px none #000000) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,4) size 107x18
                 text run at (1,4) width 107: "Macintosh PPC"
-            RenderTableCell {TH} at (228,0) size 86x23 [border: (3px solid #000000) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TH} at (228,0) size 86x23 [border: (3px none #000000) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,4) size 84x18
                 text run at (1,4) width 84: "Windows 95"
-            RenderTableCell {TH} at (313,0) size 96x23 [border: (3px solid #000000) (2px none #000000) none none] [r=0 c=3 rs=1 cs=1]
+            RenderTableCell {TH} at (313,0) size 96x23 [border: (3px none #000000) (2px none #000000) none none] [r=0 c=3 rs=1 cs=1]
               RenderText {#text} at (1,4) size 91x18
                 text run at (1,4) width 91: "Windows NT"
-          RenderTableRow {TR} at (0,23) size 409x21
-            RenderTableCell {TD} at (0,23) size 119x21 [border: (1px solid #000000) none none (3px none #000000)] [r=1 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,23) size 409x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,23) size 119x21 [border: (1px none #000000) none none (3px none #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (4,2) size 73x18
                 text run at (4,2) width 73: "Base Install"
-            RenderTableCell {TD} at (119,23) size 109x21 [border: (1px solid #000000) none none none] [r=1 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (119,23) size 109x21 [border: (1px none #000000) none none none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 21x18
                 text run at (1,2) width 21: "yes"
-            RenderTableCell {TD} at (228,23) size 86x21 [border: (1px solid #000000) none none none] [r=1 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (228,23) size 86x21 [border: (1px none #000000) none none none] [r=1 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 21x18
                 text run at (1,2) width 21: "yes"
-            RenderTableCell {TD} at (313,23) size 96x21 [border: (1px solid #000000) (2px none #000000) none none] [r=1 c=3 rs=1 cs=1]
+            RenderTableCell {TD} at (313,23) size 96x21 [border: (1px none #000000) (2px none #000000) none none] [r=1 c=3 rs=1 cs=1]
               RenderText {#text} at (1,2) size 21x18
                 text run at (1,2) width 21: "yes"
-          RenderTableRow {TR} at (0,44) size 409x21
-            RenderTableCell {TD} at (0,44) size 119x21 [border: (1px solid #000000) none none (3px none #000000)] [r=2 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,44) size 409x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,44) size 119x21 [border: (1px none #000000) none none (3px none #000000)] [r=2 c=0 rs=1 cs=1]
               RenderText {#text} at (4,2) size 103x18
                 text run at (4,2) width 103: "Complete Install"
-            RenderTableCell {TD} at (119,44) size 109x21 [border: (1px solid #000000) none none none] [r=2 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (119,44) size 109x21 [border: (1px none #000000) none none none] [r=2 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 21x18
                 text run at (1,2) width 21: "yes"
-            RenderTableCell {TD} at (228,44) size 86x21 [border: (1px solid #000000) none none none] [r=2 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (228,44) size 86x21 [border: (1px none #000000) none none none] [r=2 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 21x18
                 text run at (1,2) width 21: "yes"
-            RenderTableCell {TD} at (313,44) size 96x21 [border: (1px solid #000000) (2px none #000000) none none] [r=2 c=3 rs=1 cs=1]
+            RenderTableCell {TD} at (313,44) size 96x21 [border: (1px none #000000) (2px none #000000) none none] [r=2 c=3 rs=1 cs=1]
               RenderText {#text} at (1,2) size 21x18
                 text run at (1,2) width 21: "yes"
-          RenderTableRow {TR} at (0,65) size 409x23
-            RenderTableCell {TD} at (0,65) size 119x23 [border: (1px solid #000000) none (2px solid #000000) (3px none #000000)] [r=3 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,65) size 409x23 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,65) size 119x23 [border: (1px none #000000) none (2px none #000000) (3px none #000000)] [r=3 c=0 rs=1 cs=1]
               RenderText {#text} at (4,2) size 114x18
                 text run at (4,2) width 114: "Pro Edition Install"
-            RenderTableCell {TD} at (119,65) size 109x23 [border: (1px solid #000000) none (2px solid #000000) none] [r=3 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (119,65) size 109x23 [border: (1px none #000000) none (2px none #000000) none] [r=3 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 21x18
                 text run at (1,2) width 21: "yes"
-            RenderTableCell {TD} at (228,65) size 86x23 [border: (1px solid #000000) none (2px solid #000000) none] [r=3 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (228,65) size 86x23 [border: (1px none #000000) none (2px none #000000) none] [r=3 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 21x18
                 text run at (1,2) width 21: "yes"
-            RenderTableCell {TD} at (313,65) size 96x23 [border: (1px solid #000000) (2px none #000000) (2px solid #000000) none] [r=3 c=3 rs=1 cs=1]
+            RenderTableCell {TD} at (313,65) size 96x23 [border: (1px none #000000) (2px none #000000) (2px none #000000) none] [r=3 c=3 rs=1 cs=1]
               RenderText {#text} at (1,2) size 21x18
                 text run at (1,2) width 21: "yes"

--- a/LayoutTests/platform/glib/tables/mozilla_expected_failures/marvin/x_table_rules_rows-expected.txt
+++ b/LayoutTests/platform/glib/tables/mozilla_expected_failures/marvin/x_table_rules_rows-expected.txt
@@ -1,13 +1,13 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x143
-  RenderBlock {html} at (0,0) size 800x143
-    RenderBody {body} at (8,16) size 784x119
+layer at (0,0) size 800x140
+  RenderBlock {html} at (0,0) size 800x140
+    RenderBody {body} at (8,16) size 784x116
       RenderBlock {p} at (0,0) size 784x18
         RenderText {#text} at (0,0) size 470x17
           text run at (0,0) width 394: "There should be rules between all rows (and only rows) in the "
           text run at (394,0) width 76: "table below."
-      RenderTable {table} at (0,34) size 182x85 [border: none]
+      RenderTable {table} at (0,34) size 182x82 [border: none]
         RenderTableCol {colgroup} at (0,0) size 0x0
           RenderTableCol {col} at (0,0) size 0x0
         RenderTableCol {colgroup} at (0,0) size 0x0
@@ -16,44 +16,44 @@ layer at (0,0) size 800x143
           RenderTableCol {col} at (0,0) size 0x0
         RenderTableSection {thead} at (0,0) size 181x21
           RenderTableRow {tr} at (0,0) size 181x21
-            RenderTableCell {th} at (0,0) size 61x21 [border: (1px solid #808080) none none (1px none #808080)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {th} at (0,0) size 61x21 [border: (1px none #808080) none none (1px none #808080)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 58x17
                 text run at (2,2) width 58: "THEAD"
-            RenderTableCell {th} at (61,0) size 60x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {th} at (61,0) size 60x21 [border: (1px none #808080) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 58x17
                 text run at (1,2) width 58: "THEAD"
-            RenderTableCell {th} at (121,0) size 60x21 [border: (1px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {th} at (121,0) size 60x21 [border: (1px none #808080) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 58x17
                 text run at (1,2) width 58: "THEAD"
-        RenderTableSection {tfoot} at (0,63) size 181x21
-          RenderTableRow {tr} at (0,0) size 181x21
-            RenderTableCell {td} at (0,0) size 61x21 [border: (1px solid #808080) none none (1px none #808080)] [r=0 c=0 rs=1 cs=1]
-              RenderText {#text} at (2,2) size 53x17
-                text run at (2,2) width 53: "TFOOT"
-            RenderTableCell {td} at (61,0) size 60x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 53x17
-                text run at (1,2) width 53: "TFOOT"
-            RenderTableCell {td} at (121,0) size 60x21 [border: (1px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 53x17
-                text run at (1,2) width 53: "TFOOT"
-        RenderTableSection {tbody} at (0,21) size 181x42
-          RenderTableRow {tr} at (0,0) size 181x21
-            RenderTableCell {td} at (0,0) size 61x21 [border: (1px solid #808080) none none (1px none #808080)] [r=0 c=0 rs=1 cs=1]
-              RenderText {#text} at (2,2) size 57x17
-                text run at (2,2) width 57: "TBODY"
-            RenderTableCell {td} at (61,0) size 60x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 57x17
-                text run at (1,2) width 57: "TBODY"
-            RenderTableCell {td} at (121,0) size 60x21 [border: (1px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 57x17
-                text run at (1,2) width 57: "TBODY"
-          RenderTableRow {tr} at (0,21) size 181x21
-            RenderTableCell {td} at (0,21) size 61x21 [border: (1px solid #808080) none none (1px none #808080)] [r=1 c=0 rs=1 cs=1]
-              RenderText {#text} at (2,2) size 57x17
-                text run at (2,2) width 57: "TBODY"
-            RenderTableCell {td} at (61,21) size 60x21 [border: (1px solid #808080) none none none] [r=1 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 57x17
-                text run at (1,2) width 57: "TBODY"
-            RenderTableCell {td} at (121,21) size 60x21 [border: (1px solid #808080) none none none] [r=1 c=2 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 57x17
-                text run at (1,2) width 57: "TBODY"
+        RenderTableSection {tfoot} at (0,61) size 181x20
+          RenderTableRow {tr} at (0,0) size 181x20
+            RenderTableCell {td} at (0,0) size 61x20 [border: none none none (1px none #808080)] [r=0 c=0 rs=1 cs=1]
+              RenderText {#text} at (2,1) size 53x17
+                text run at (2,1) width 53: "TFOOT"
+            RenderTableCell {td} at (61,0) size 60x20 [r=0 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 53x17
+                text run at (1,1) width 53: "TFOOT"
+            RenderTableCell {td} at (121,0) size 60x20 [r=0 c=2 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 53x17
+                text run at (1,1) width 53: "TFOOT"
+        RenderTableSection {tbody} at (0,21) size 181x40
+          RenderTableRow {tr} at (0,0) size 181x20
+            RenderTableCell {td} at (0,0) size 61x20 [border: none none none (1px none #808080)] [r=0 c=0 rs=1 cs=1]
+              RenderText {#text} at (2,1) size 57x17
+                text run at (2,1) width 57: "TBODY"
+            RenderTableCell {td} at (61,0) size 60x20 [r=0 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 57x17
+                text run at (1,1) width 57: "TBODY"
+            RenderTableCell {td} at (121,0) size 60x20 [r=0 c=2 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 57x17
+                text run at (1,1) width 57: "TBODY"
+          RenderTableRow {tr} at (0,20) size 181x20
+            RenderTableCell {td} at (0,20) size 61x20 [border: none none none (1px none #808080)] [r=1 c=0 rs=1 cs=1]
+              RenderText {#text} at (2,1) size 57x17
+                text run at (2,1) width 57: "TBODY"
+            RenderTableCell {td} at (61,20) size 60x20 [r=1 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 57x17
+                text run at (1,1) width 57: "TBODY"
+            RenderTableCell {td} at (121,20) size 60x20 [r=1 c=2 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 57x17
+                text run at (1,1) width 57: "TBODY"

--- a/LayoutTests/platform/glib/tables/mozilla_expected_failures/marvin/x_table_rules_rows-expected.txt
+++ b/LayoutTests/platform/glib/tables/mozilla_expected_failures/marvin/x_table_rules_rows-expected.txt
@@ -15,45 +15,45 @@ layer at (0,0) size 800x143
         RenderTableCol {colgroup} at (0,0) size 0x0
           RenderTableCol {col} at (0,0) size 0x0
         RenderTableSection {thead} at (0,0) size 181x21
-          RenderTableRow {tr} at (0,0) size 181x21
-            RenderTableCell {th} at (0,0) size 61x21 [border: (1px solid #000000) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {tr} at (0,0) size 181x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {th} at (0,0) size 61x21 [border: (1px none #000000) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 58x18
                 text run at (2,2) width 58: "THEAD"
-            RenderTableCell {th} at (61,0) size 60x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {th} at (61,0) size 60x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 58x18
                 text run at (1,2) width 58: "THEAD"
-            RenderTableCell {th} at (121,0) size 60x21 [border: (1px solid #000000) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {th} at (121,0) size 60x21 [border: (1px none #000000) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 58x18
                 text run at (1,2) width 58: "THEAD"
         RenderTableSection {tfoot} at (0,63) size 181x21
-          RenderTableRow {tr} at (0,0) size 181x21
-            RenderTableCell {td} at (0,0) size 61x21 [border: (1px solid #000000) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {tr} at (0,0) size 181x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {td} at (0,0) size 61x21 [border: (1px none #000000) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 53x18
                 text run at (2,2) width 53: "TFOOT"
-            RenderTableCell {td} at (61,0) size 60x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {td} at (61,0) size 60x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 53x18
                 text run at (1,2) width 53: "TFOOT"
-            RenderTableCell {td} at (121,0) size 60x21 [border: (1px solid #000000) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {td} at (121,0) size 60x21 [border: (1px none #000000) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 53x18
                 text run at (1,2) width 53: "TFOOT"
         RenderTableSection {tbody} at (0,21) size 181x42
-          RenderTableRow {tr} at (0,0) size 181x21
-            RenderTableCell {td} at (0,0) size 61x21 [border: (1px solid #000000) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {tr} at (0,0) size 181x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {td} at (0,0) size 61x21 [border: (1px none #000000) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 57x18
                 text run at (2,2) width 57: "TBODY"
-            RenderTableCell {td} at (61,0) size 60x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {td} at (61,0) size 60x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 57x18
                 text run at (1,2) width 57: "TBODY"
-            RenderTableCell {td} at (121,0) size 60x21 [border: (1px solid #000000) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {td} at (121,0) size 60x21 [border: (1px none #000000) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 57x18
                 text run at (1,2) width 57: "TBODY"
-          RenderTableRow {tr} at (0,21) size 181x21
-            RenderTableCell {td} at (0,21) size 61x21 [border: (1px solid #000000) none none (1px none #000000)] [r=1 c=0 rs=1 cs=1]
+          RenderTableRow {tr} at (0,21) size 181x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {td} at (0,21) size 61x21 [border: (1px none #000000) none none (1px none #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 57x18
                 text run at (2,2) width 57: "TBODY"
-            RenderTableCell {td} at (61,21) size 60x21 [border: (1px solid #000000) none none none] [r=1 c=1 rs=1 cs=1]
+            RenderTableCell {td} at (61,21) size 60x21 [border: (1px none #000000) none none none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 57x18
                 text run at (1,2) width 57: "TBODY"
-            RenderTableCell {td} at (121,21) size 60x21 [border: (1px solid #000000) none none none] [r=1 c=2 rs=1 cs=1]
+            RenderTableCell {td} at (121,21) size 60x21 [border: (1px none #000000) none none none] [r=1 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 57x18
                 text run at (1,2) width 57: "TBODY"

--- a/LayoutTests/platform/ios/fast/table/frame-and-rules-expected.txt
+++ b/LayoutTests/platform/ios/fast/table/frame-and-rules-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 800x8148
+layer at (0,0) size 800x8112
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x8148
-  RenderBlock {HTML} at (0,0) size 800x8148
-    RenderBody {BODY} at (8,8) size 784x8092
+layer at (0,0) size 800x8112
+  RenderBlock {HTML} at (0,0) size 800x8112
+    RenderBody {BODY} at (8,8) size 784x8056
       RenderTable {TABLE} at (0,0) size 273x130
         RenderBlock {CAPTION} at (0,0) size 273x20
           RenderInline {A} at (0,0) size 227x19
@@ -885,7 +885,7 @@ layer at (0,0) size 800x8148
             RenderTableCell {TD} at (182,0) size 92x23 [border: (0.50px none #000000)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x20
                 text run at (1,1) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,3238) size 273x134
+      RenderTable {TABLE} at (0,3238) size 273x130
         RenderBlock {CAPTION} at (0,0) size 273x20
           RenderInline {A} at (0,0) size 225x19
             RenderText {#text} at (21,0) size 225x19
@@ -893,48 +893,48 @@ layer at (0,0) size 800x8148
           RenderInline (generated) at (0,0) size 6x19
             RenderText at (245,0) size 6x19
               text run at (245,0) width 6: ":"
-        RenderTableSection {THEAD} at (0,20) size 273x23
-          RenderTableRow {TR} at (0,0) size 273x23
-            RenderTableCell {TD} at (0,0) size 91x23 [border: none none (0.50px solid #808080) none] [r=0 c=0 rs=1 cs=1]
+        RenderTableSection {THEAD} at (0,20) size 273x22
+          RenderTableRow {TR} at (0,0) size 273x22
+            RenderTableCell {TD} at (0,0) size 91x22 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 1, Cell 1"
-            RenderTableCell {TD} at (90,0) size 92x23 [border: none none (0.50px solid #808080) none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (90,0) size 92x22 [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 1, Cell 2"
-            RenderTableCell {TD} at (181,0) size 92x23 [border: none none (0.50px solid #808080) none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (181,0) size 92x22 [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 1, Cell 3"
-        RenderTableSection {TBODY} at (0,42) size 273x70
-          RenderTableRow {TR} at (0,0) size 273x23
-            RenderTableCell {TD} at (0,11) size 91x24 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=0 c=0 rs=2 cs=1]
-              RenderText {#text} at (1,1) size 89x20
-                text run at (1,2) width 89: "Row 2, Cell 1"
-            RenderTableCell {TD} at (90,0) size 183x23 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=0 c=1 rs=1 cs=2]
-              RenderText {#text} at (1,1) size 89x20
+        RenderTableSection {TBODY} at (0,42) size 273x66
+          RenderTableRow {TR} at (0,0) size 273x22
+            RenderTableCell {TD} at (0,11) size 91x22 [r=0 c=0 rs=2 cs=1]
+              RenderText {#text} at (1,1) size 89x19
+                text run at (1,1) width 89: "Row 2, Cell 1"
+            RenderTableCell {TD} at (90,0) size 183x22 [r=0 c=1 rs=1 cs=2]
+              RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,23) size 273x23
-            RenderTableCell {TD} at (90,23) size 92x23 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=1 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 89x20
+          RenderTableRow {TR} at (0,22) size 273x22
+            RenderTableCell {TD} at (90,22) size 92x22 [r=1 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (181,34) size 92x24 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=1 c=2 rs=2 cs=1]
-              RenderText {#text} at (1,1) size 89x20
-                text run at (1,2) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,46) size 273x23
-            RenderTableCell {TD} at (0,46) size 182x23 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=2 c=0 rs=1 cs=2]
-              RenderText {#text} at (1,1) size 89x20
+            RenderTableCell {TD} at (181,33) size 92x22 [r=1 c=2 rs=2 cs=1]
+              RenderText {#text} at (1,1) size 89x19
+                text run at (1,1) width 89: "Row 3, Cell 3"
+          RenderTableRow {TR} at (0,44) size 273x22
+            RenderTableCell {TD} at (0,44) size 182x22 [r=2 c=0 rs=1 cs=2]
+              RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 4, Cell 1"
-        RenderTableSection {TFOOT} at (0,111) size 273x23
-          RenderTableRow {TR} at (0,0) size 273x23
-            RenderTableCell {TD} at (0,0) size 91x23 [border: (0.50px solid #808080) none none none] [r=0 c=0 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 89x20
+        RenderTableSection {TFOOT} at (0,108) size 273x22
+          RenderTableRow {TR} at (0,0) size 273x22
+            RenderTableCell {TD} at (0,0) size 91x22 [r=0 c=0 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 5, Cell 1"
-            RenderTableCell {TD} at (90,0) size 92x23 [border: (0.50px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 89x20
+            RenderTableCell {TD} at (90,0) size 92x22 [r=0 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (181,0) size 92x23 [border: (0.50px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 89x20
+            RenderTableCell {TD} at (181,0) size 92x22 [r=0 c=2 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,3420) size 273x135 [border: (0.50px solid #808080) none]
+      RenderTable {TABLE} at (0,3416) size 273x131 [border: (0.50px solid #808080) none]
         RenderBlock {CAPTION} at (0,0) size 273x20
           RenderInline {A} at (0,0) size 235x19
             RenderText {#text} at (16,0) size 235x19
@@ -942,48 +942,48 @@ layer at (0,0) size 800x8148
           RenderInline (generated) at (0,0) size 7x19
             RenderText at (250,0) size 7x19
               text run at (250,0) width 7: ":"
-        RenderTableSection {THEAD} at (0,20) size 273x24
+        RenderTableSection {THEAD} at (0,20) size 273x23
           RenderTableRow {TR} at (0,0) size 273x23
-            RenderTableCell {TD} at (0,0) size 91x23 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (0,0) size 91x23 [border: (0.50px none #808080) none none none] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x20
                 text run at (1,1) width 89: "Row 1, Cell 1"
-            RenderTableCell {TD} at (90,0) size 92x23 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (90,0) size 92x23 [border: (0.50px none #808080) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x20
                 text run at (1,1) width 89: "Row 1, Cell 2"
-            RenderTableCell {TD} at (181,0) size 92x23 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (181,0) size 92x23 [border: (0.50px none #808080) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x20
                 text run at (1,1) width 89: "Row 1, Cell 3"
-        RenderTableSection {TBODY} at (0,43) size 273x70
-          RenderTableRow {TR} at (0,0) size 273x23
-            RenderTableCell {TD} at (0,11) size 91x24 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=0 c=0 rs=2 cs=1]
-              RenderText {#text} at (1,1) size 89x20
-                text run at (1,2) width 89: "Row 2, Cell 1"
-            RenderTableCell {TD} at (90,0) size 183x23 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=0 c=1 rs=1 cs=2]
-              RenderText {#text} at (1,1) size 89x20
+        RenderTableSection {TBODY} at (0,43) size 273x66
+          RenderTableRow {TR} at (0,0) size 273x22
+            RenderTableCell {TD} at (0,11) size 91x22 [r=0 c=0 rs=2 cs=1]
+              RenderText {#text} at (1,1) size 89x19
+                text run at (1,1) width 89: "Row 2, Cell 1"
+            RenderTableCell {TD} at (90,0) size 183x22 [r=0 c=1 rs=1 cs=2]
+              RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,23) size 273x23
-            RenderTableCell {TD} at (90,23) size 92x23 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=1 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 89x20
+          RenderTableRow {TR} at (0,22) size 273x22
+            RenderTableCell {TD} at (90,22) size 92x22 [r=1 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (181,34) size 92x24 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=1 c=2 rs=2 cs=1]
-              RenderText {#text} at (1,1) size 89x20
-                text run at (1,2) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,46) size 273x23
-            RenderTableCell {TD} at (0,46) size 182x23 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=2 c=0 rs=1 cs=2]
-              RenderText {#text} at (1,1) size 89x20
+            RenderTableCell {TD} at (181,33) size 92x22 [r=1 c=2 rs=2 cs=1]
+              RenderText {#text} at (1,1) size 89x19
+                text run at (1,1) width 89: "Row 3, Cell 3"
+          RenderTableRow {TR} at (0,44) size 273x22
+            RenderTableCell {TD} at (0,44) size 182x22 [r=2 c=0 rs=1 cs=2]
+              RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 4, Cell 1"
-        RenderTableSection {TFOOT} at (0,112) size 273x23
-          RenderTableRow {TR} at (0,0) size 273x23
-            RenderTableCell {TD} at (0,0) size 91x23 [border: (0.50px solid #808080) none none none] [r=0 c=0 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 89x20
+        RenderTableSection {TFOOT} at (0,109) size 273x22
+          RenderTableRow {TR} at (0,0) size 273x22
+            RenderTableCell {TD} at (0,0) size 91x22 [r=0 c=0 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 5, Cell 1"
-            RenderTableCell {TD} at (90,0) size 92x23 [border: (0.50px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 89x20
+            RenderTableCell {TD} at (90,0) size 92x22 [r=0 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (181,0) size 92x23 [border: (0.50px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 89x20
+            RenderTableCell {TD} at (181,0) size 92x22 [r=0 c=2 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,3603) size 273x135 [border: none (0.50px solid #808080) none]
+      RenderTable {TABLE} at (0,3595) size 273x131 [border: none (0.50px solid #808080) none]
         RenderBlock {CAPTION} at (0,0) size 273x20
           RenderInline {A} at (0,0) size 235x19
             RenderText {#text} at (16,0) size 235x19
@@ -991,48 +991,48 @@ layer at (0,0) size 800x8148
           RenderInline (generated) at (0,0) size 7x19
             RenderText at (250,0) size 7x19
               text run at (250,0) width 7: ":"
-        RenderTableSection {THEAD} at (0,20) size 273x23
-          RenderTableRow {TR} at (0,0) size 273x23
-            RenderTableCell {TD} at (0,0) size 91x23 [border: none none (0.50px solid #808080) none] [r=0 c=0 rs=1 cs=1]
+        RenderTableSection {THEAD} at (0,20) size 273x22
+          RenderTableRow {TR} at (0,0) size 273x22
+            RenderTableCell {TD} at (0,0) size 91x22 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 1, Cell 1"
-            RenderTableCell {TD} at (90,0) size 92x23 [border: none none (0.50px solid #808080) none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (90,0) size 92x22 [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 1, Cell 2"
-            RenderTableCell {TD} at (181,0) size 92x23 [border: none none (0.50px solid #808080) none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (181,0) size 92x22 [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 1, Cell 3"
-        RenderTableSection {TBODY} at (0,42) size 273x70
-          RenderTableRow {TR} at (0,0) size 273x23
-            RenderTableCell {TD} at (0,11) size 91x24 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=0 c=0 rs=2 cs=1]
-              RenderText {#text} at (1,1) size 89x20
-                text run at (1,2) width 89: "Row 2, Cell 1"
-            RenderTableCell {TD} at (90,0) size 183x23 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=0 c=1 rs=1 cs=2]
-              RenderText {#text} at (1,1) size 89x20
+        RenderTableSection {TBODY} at (0,42) size 273x66
+          RenderTableRow {TR} at (0,0) size 273x22
+            RenderTableCell {TD} at (0,11) size 91x22 [r=0 c=0 rs=2 cs=1]
+              RenderText {#text} at (1,1) size 89x19
+                text run at (1,1) width 89: "Row 2, Cell 1"
+            RenderTableCell {TD} at (90,0) size 183x22 [r=0 c=1 rs=1 cs=2]
+              RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,23) size 273x23
-            RenderTableCell {TD} at (90,23) size 92x23 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=1 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 89x20
+          RenderTableRow {TR} at (0,22) size 273x22
+            RenderTableCell {TD} at (90,22) size 92x22 [r=1 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (181,34) size 92x24 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=1 c=2 rs=2 cs=1]
-              RenderText {#text} at (1,1) size 89x20
-                text run at (1,2) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,46) size 273x23
-            RenderTableCell {TD} at (0,46) size 182x23 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=2 c=0 rs=1 cs=2]
-              RenderText {#text} at (1,1) size 89x20
+            RenderTableCell {TD} at (181,33) size 92x22 [r=1 c=2 rs=2 cs=1]
+              RenderText {#text} at (1,1) size 89x19
+                text run at (1,1) width 89: "Row 3, Cell 3"
+          RenderTableRow {TR} at (0,44) size 273x22
+            RenderTableCell {TD} at (0,44) size 182x22 [r=2 c=0 rs=1 cs=2]
+              RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 4, Cell 1"
-        RenderTableSection {TFOOT} at (0,111) size 273x24
+        RenderTableSection {TFOOT} at (0,108) size 273x23
           RenderTableRow {TR} at (0,0) size 273x23
-            RenderTableCell {TD} at (0,0) size 91x23 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=0 c=0 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 89x20
+            RenderTableCell {TD} at (0,0) size 91x23 [border: none none (0.50px none #808080) none] [r=0 c=0 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 5, Cell 1"
-            RenderTableCell {TD} at (90,0) size 92x23 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=0 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 89x20
+            RenderTableCell {TD} at (90,0) size 92x23 [border: none none (0.50px none #808080) none] [r=0 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (181,0) size 92x23 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=0 c=2 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 89x20
+            RenderTableCell {TD} at (181,0) size 92x23 [border: none none (0.50px none #808080) none] [r=0 c=2 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,3786) size 273x136 [border: (0.50px solid #808080) none (0.50px solid #808080) none]
+      RenderTable {TABLE} at (0,3774) size 273x132 [border: (0.50px solid #808080) none (0.50px solid #808080) none]
         RenderBlock {CAPTION} at (0,0) size 273x20
           RenderInline {A} at (0,0) size 238x19
             RenderText {#text} at (15,0) size 238x19
@@ -1040,48 +1040,48 @@ layer at (0,0) size 800x8148
           RenderInline (generated) at (0,0) size 6x19
             RenderText at (252,0) size 6x19
               text run at (252,0) width 6: ":"
-        RenderTableSection {THEAD} at (0,20) size 273x24
+        RenderTableSection {THEAD} at (0,20) size 273x23
           RenderTableRow {TR} at (0,0) size 273x23
-            RenderTableCell {TD} at (0,0) size 91x23 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (0,0) size 91x23 [border: (0.50px none #808080) none none none] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x20
                 text run at (1,1) width 89: "Row 1, Cell 1"
-            RenderTableCell {TD} at (90,0) size 92x23 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (90,0) size 92x23 [border: (0.50px none #808080) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x20
                 text run at (1,1) width 89: "Row 1, Cell 2"
-            RenderTableCell {TD} at (181,0) size 92x23 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (181,0) size 92x23 [border: (0.50px none #808080) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x20
                 text run at (1,1) width 89: "Row 1, Cell 3"
-        RenderTableSection {TBODY} at (0,43) size 273x70
-          RenderTableRow {TR} at (0,0) size 273x23
-            RenderTableCell {TD} at (0,11) size 91x24 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=0 c=0 rs=2 cs=1]
-              RenderText {#text} at (1,1) size 89x20
-                text run at (1,2) width 89: "Row 2, Cell 1"
-            RenderTableCell {TD} at (90,0) size 183x23 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=0 c=1 rs=1 cs=2]
-              RenderText {#text} at (1,1) size 89x20
+        RenderTableSection {TBODY} at (0,43) size 273x66
+          RenderTableRow {TR} at (0,0) size 273x22
+            RenderTableCell {TD} at (0,11) size 91x22 [r=0 c=0 rs=2 cs=1]
+              RenderText {#text} at (1,1) size 89x19
+                text run at (1,1) width 89: "Row 2, Cell 1"
+            RenderTableCell {TD} at (90,0) size 183x22 [r=0 c=1 rs=1 cs=2]
+              RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,23) size 273x23
-            RenderTableCell {TD} at (90,23) size 92x23 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=1 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 89x20
+          RenderTableRow {TR} at (0,22) size 273x22
+            RenderTableCell {TD} at (90,22) size 92x22 [r=1 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (181,34) size 92x24 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=1 c=2 rs=2 cs=1]
-              RenderText {#text} at (1,1) size 89x20
-                text run at (1,2) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,46) size 273x23
-            RenderTableCell {TD} at (0,46) size 182x23 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=2 c=0 rs=1 cs=2]
-              RenderText {#text} at (1,1) size 89x20
+            RenderTableCell {TD} at (181,33) size 92x22 [r=1 c=2 rs=2 cs=1]
+              RenderText {#text} at (1,1) size 89x19
+                text run at (1,1) width 89: "Row 3, Cell 3"
+          RenderTableRow {TR} at (0,44) size 273x22
+            RenderTableCell {TD} at (0,44) size 182x22 [r=2 c=0 rs=1 cs=2]
+              RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 4, Cell 1"
-        RenderTableSection {TFOOT} at (0,112) size 273x24
+        RenderTableSection {TFOOT} at (0,109) size 273x23
           RenderTableRow {TR} at (0,0) size 273x23
-            RenderTableCell {TD} at (0,0) size 91x23 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=0 c=0 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 89x20
+            RenderTableCell {TD} at (0,0) size 91x23 [border: none none (0.50px none #808080) none] [r=0 c=0 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 5, Cell 1"
-            RenderTableCell {TD} at (90,0) size 92x23 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=0 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 89x20
+            RenderTableCell {TD} at (90,0) size 92x23 [border: none none (0.50px none #808080) none] [r=0 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (181,0) size 92x23 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=0 c=2 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 89x20
+            RenderTableCell {TD} at (181,0) size 92x23 [border: none none (0.50px none #808080) none] [r=0 c=2 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,3970) size 275x134 [border: none (0.50px solid #808080) none (0.50px solid #808080)]
+      RenderTable {TABLE} at (0,3954) size 275x130 [border: none (0.50px solid #808080) none (0.50px solid #808080)]
         RenderBlock {CAPTION} at (0,0) size 275x20
           RenderInline {A} at (0,0) size 236x19
             RenderText {#text} at (17,0) size 236x19
@@ -1089,48 +1089,48 @@ layer at (0,0) size 800x8148
           RenderInline (generated) at (0,0) size 6x19
             RenderText at (252,0) size 6x19
               text run at (252,0) width 6: ":"
-        RenderTableSection {THEAD} at (0,20) size 275x23
-          RenderTableRow {TR} at (0,0) size 274x23
-            RenderTableCell {TD} at (0,0) size 92x23 [border: none none (0.50px solid #808080) (0.50px none #808080)] [r=0 c=0 rs=1 cs=1]
+        RenderTableSection {THEAD} at (0,20) size 275x22
+          RenderTableRow {TR} at (0,0) size 274x22
+            RenderTableCell {TD} at (0,0) size 92x22 [border: none none none (0.50px none #808080)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 90x19
                 text run at (1,1) width 90: "Row 1, Cell 1"
-            RenderTableCell {TD} at (91,0) size 92x23 [border: none none (0.50px solid #808080) none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (91,0) size 92x22 [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 1, Cell 2"
-            RenderTableCell {TD} at (182,0) size 92x23 [border: none (0.50px none #808080) (0.50px solid #808080) none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (182,0) size 92x22 [border: none (0.50px none #808080) none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 1, Cell 3"
-        RenderTableSection {TBODY} at (0,42) size 275x70
-          RenderTableRow {TR} at (0,0) size 274x23
-            RenderTableCell {TD} at (0,11) size 92x24 [border: (0.50px solid #808080) none (0.50px solid #808080) (0.50px none #808080)] [r=0 c=0 rs=2 cs=1]
-              RenderText {#text} at (1,1) size 90x20
-                text run at (1,2) width 90: "Row 2, Cell 1"
-            RenderTableCell {TD} at (91,0) size 183x23 [border: (0.50px solid #808080) (0.50px none #808080) (0.50px solid #808080) none] [r=0 c=1 rs=1 cs=2]
-              RenderText {#text} at (1,1) size 89x20
+        RenderTableSection {TBODY} at (0,42) size 275x66
+          RenderTableRow {TR} at (0,0) size 274x22
+            RenderTableCell {TD} at (0,11) size 92x22 [border: none none none (0.50px none #808080)] [r=0 c=0 rs=2 cs=1]
+              RenderText {#text} at (1,1) size 90x19
+                text run at (1,1) width 90: "Row 2, Cell 1"
+            RenderTableCell {TD} at (91,0) size 183x22 [border: none (0.50px none #808080) none none] [r=0 c=1 rs=1 cs=2]
+              RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,23) size 274x23
-            RenderTableCell {TD} at (91,23) size 92x23 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=1 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 89x20
+          RenderTableRow {TR} at (0,22) size 274x22
+            RenderTableCell {TD} at (91,22) size 92x22 [r=1 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (182,34) size 92x24 [border: (0.50px solid #808080) (0.50px none #808080) (0.50px solid #808080) none] [r=1 c=2 rs=2 cs=1]
-              RenderText {#text} at (1,1) size 89x20
-                text run at (1,2) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,46) size 274x23
-            RenderTableCell {TD} at (0,46) size 183x23 [border: (0.50px solid #808080) none (0.50px solid #808080) (0.50px none #808080)] [r=2 c=0 rs=1 cs=2]
-              RenderText {#text} at (1,1) size 90x20
+            RenderTableCell {TD} at (182,33) size 92x22 [border: none (0.50px none #808080) none none] [r=1 c=2 rs=2 cs=1]
+              RenderText {#text} at (1,1) size 89x19
+                text run at (1,1) width 89: "Row 3, Cell 3"
+          RenderTableRow {TR} at (0,44) size 274x22
+            RenderTableCell {TD} at (0,44) size 183x22 [border: none none none (0.50px none #808080)] [r=2 c=0 rs=1 cs=2]
+              RenderText {#text} at (1,1) size 90x19
                 text run at (1,1) width 90: "Row 4, Cell 1"
-        RenderTableSection {TFOOT} at (0,111) size 275x23
-          RenderTableRow {TR} at (0,0) size 274x23
-            RenderTableCell {TD} at (0,0) size 92x23 [border: (0.50px solid #808080) none none (0.50px none #808080)] [r=0 c=0 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 90x20
+        RenderTableSection {TFOOT} at (0,108) size 275x22
+          RenderTableRow {TR} at (0,0) size 274x22
+            RenderTableCell {TD} at (0,0) size 92x22 [border: none none none (0.50px none #808080)] [r=0 c=0 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 90x19
                 text run at (1,1) width 90: "Row 5, Cell 1"
-            RenderTableCell {TD} at (91,0) size 92x23 [border: (0.50px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 89x20
+            RenderTableCell {TD} at (91,0) size 92x22 [r=0 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (182,0) size 92x23 [border: (0.50px solid #808080) (0.50px none #808080) none none] [r=0 c=2 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 89x20
+            RenderTableCell {TD} at (182,0) size 92x22 [border: none (0.50px none #808080) none none] [r=0 c=2 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,4152) size 274x134 [border: none (0.50px solid #808080)]
+      RenderTable {TABLE} at (0,4132) size 274x130 [border: none (0.50px solid #808080)]
         RenderBlock {CAPTION} at (0,0) size 274x20
           RenderInline {A} at (0,0) size 216x19
             RenderText {#text} at (26,0) size 216x19
@@ -1138,48 +1138,48 @@ layer at (0,0) size 800x8148
           RenderInline (generated) at (0,0) size 7x19
             RenderText at (241,0) size 7x19
               text run at (241,0) width 7: ":"
-        RenderTableSection {THEAD} at (0,20) size 274x23
-          RenderTableRow {TR} at (0,0) size 274x23
-            RenderTableCell {TD} at (0,0) size 92x23 [border: none none (0.50px solid #808080) (0.50px none #808080)] [r=0 c=0 rs=1 cs=1]
+        RenderTableSection {THEAD} at (0,20) size 274x22
+          RenderTableRow {TR} at (0,0) size 274x22
+            RenderTableCell {TD} at (0,0) size 92x22 [border: none none none (0.50px none #808080)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 90x19
                 text run at (1,1) width 90: "Row 1, Cell 1"
-            RenderTableCell {TD} at (91,0) size 92x23 [border: none none (0.50px solid #808080) none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (91,0) size 92x22 [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 1, Cell 2"
-            RenderTableCell {TD} at (182,0) size 92x23 [border: none none (0.50px solid #808080) none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (182,0) size 92x22 [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 1, Cell 3"
-        RenderTableSection {TBODY} at (0,42) size 274x70
-          RenderTableRow {TR} at (0,0) size 274x23
-            RenderTableCell {TD} at (0,11) size 92x24 [border: (0.50px solid #808080) none (0.50px solid #808080) (0.50px none #808080)] [r=0 c=0 rs=2 cs=1]
-              RenderText {#text} at (1,1) size 90x20
-                text run at (1,2) width 90: "Row 2, Cell 1"
-            RenderTableCell {TD} at (91,0) size 183x23 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=0 c=1 rs=1 cs=2]
-              RenderText {#text} at (1,1) size 89x20
+        RenderTableSection {TBODY} at (0,42) size 274x66
+          RenderTableRow {TR} at (0,0) size 274x22
+            RenderTableCell {TD} at (0,11) size 92x22 [border: none none none (0.50px none #808080)] [r=0 c=0 rs=2 cs=1]
+              RenderText {#text} at (1,1) size 90x19
+                text run at (1,1) width 90: "Row 2, Cell 1"
+            RenderTableCell {TD} at (91,0) size 183x22 [r=0 c=1 rs=1 cs=2]
+              RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,23) size 274x23
-            RenderTableCell {TD} at (91,23) size 92x23 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=1 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 89x20
+          RenderTableRow {TR} at (0,22) size 274x22
+            RenderTableCell {TD} at (91,22) size 92x22 [r=1 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (182,34) size 92x24 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=1 c=2 rs=2 cs=1]
-              RenderText {#text} at (1,1) size 89x20
-                text run at (1,2) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,46) size 274x23
-            RenderTableCell {TD} at (0,46) size 183x23 [border: (0.50px solid #808080) none (0.50px solid #808080) (0.50px none #808080)] [r=2 c=0 rs=1 cs=2]
-              RenderText {#text} at (1,1) size 90x20
+            RenderTableCell {TD} at (182,33) size 92x22 [r=1 c=2 rs=2 cs=1]
+              RenderText {#text} at (1,1) size 89x19
+                text run at (1,1) width 89: "Row 3, Cell 3"
+          RenderTableRow {TR} at (0,44) size 274x22
+            RenderTableCell {TD} at (0,44) size 183x22 [border: none none none (0.50px none #808080)] [r=2 c=0 rs=1 cs=2]
+              RenderText {#text} at (1,1) size 90x19
                 text run at (1,1) width 90: "Row 4, Cell 1"
-        RenderTableSection {TFOOT} at (0,111) size 274x23
-          RenderTableRow {TR} at (0,0) size 274x23
-            RenderTableCell {TD} at (0,0) size 92x23 [border: (0.50px solid #808080) none none (0.50px none #808080)] [r=0 c=0 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 90x20
+        RenderTableSection {TFOOT} at (0,108) size 274x22
+          RenderTableRow {TR} at (0,0) size 274x22
+            RenderTableCell {TD} at (0,0) size 92x22 [border: none none none (0.50px none #808080)] [r=0 c=0 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 90x19
                 text run at (1,1) width 90: "Row 5, Cell 1"
-            RenderTableCell {TD} at (91,0) size 92x23 [border: (0.50px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 89x20
+            RenderTableCell {TD} at (91,0) size 92x22 [r=0 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (182,0) size 92x23 [border: (0.50px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 89x20
+            RenderTableCell {TD} at (182,0) size 92x22 [r=0 c=2 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,4334) size 274x134 [border: none (0.50px solid #808080) none]
+      RenderTable {TABLE} at (0,4310) size 274x130 [border: none (0.50px solid #808080) none]
         RenderBlock {CAPTION} at (0,0) size 274x20
           RenderInline {A} at (0,0) size 218x19
             RenderText {#text} at (25,0) size 218x19
@@ -1187,48 +1187,48 @@ layer at (0,0) size 800x8148
           RenderInline (generated) at (0,0) size 7x19
             RenderText at (242,0) size 7x19
               text run at (242,0) width 7: ":"
-        RenderTableSection {THEAD} at (0,20) size 274x23
-          RenderTableRow {TR} at (0,0) size 274x23
-            RenderTableCell {TD} at (0,0) size 91x23 [border: none none (0.50px solid #808080) none] [r=0 c=0 rs=1 cs=1]
+        RenderTableSection {THEAD} at (0,20) size 274x22
+          RenderTableRow {TR} at (0,0) size 274x22
+            RenderTableCell {TD} at (0,0) size 91x22 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 1, Cell 1"
-            RenderTableCell {TD} at (90,0) size 92x23 [border: none none (0.50px solid #808080) none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (90,0) size 92x22 [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 1, Cell 2"
-            RenderTableCell {TD} at (181,0) size 93x23 [border: none (0.50px none #808080) (0.50px solid #808080) none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (181,0) size 93x22 [border: none (0.50px none #808080) none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 1, Cell 3"
-        RenderTableSection {TBODY} at (0,42) size 274x70
-          RenderTableRow {TR} at (0,0) size 274x23
-            RenderTableCell {TD} at (0,11) size 91x24 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=0 c=0 rs=2 cs=1]
-              RenderText {#text} at (1,1) size 89x20
-                text run at (1,2) width 89: "Row 2, Cell 1"
-            RenderTableCell {TD} at (90,0) size 184x23 [border: (0.50px solid #808080) (0.50px none #808080) (0.50px solid #808080) none] [r=0 c=1 rs=1 cs=2]
-              RenderText {#text} at (1,1) size 89x20
+        RenderTableSection {TBODY} at (0,42) size 274x66
+          RenderTableRow {TR} at (0,0) size 274x22
+            RenderTableCell {TD} at (0,11) size 91x22 [r=0 c=0 rs=2 cs=1]
+              RenderText {#text} at (1,1) size 89x19
+                text run at (1,1) width 89: "Row 2, Cell 1"
+            RenderTableCell {TD} at (90,0) size 184x22 [border: none (0.50px none #808080) none none] [r=0 c=1 rs=1 cs=2]
+              RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,23) size 274x23
-            RenderTableCell {TD} at (90,23) size 92x23 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=1 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 89x20
+          RenderTableRow {TR} at (0,22) size 274x22
+            RenderTableCell {TD} at (90,22) size 92x22 [r=1 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (181,34) size 93x24 [border: (0.50px solid #808080) (0.50px none #808080) (0.50px solid #808080) none] [r=1 c=2 rs=2 cs=1]
-              RenderText {#text} at (1,1) size 89x20
-                text run at (1,2) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,46) size 274x23
-            RenderTableCell {TD} at (0,46) size 182x23 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=2 c=0 rs=1 cs=2]
-              RenderText {#text} at (1,1) size 89x20
+            RenderTableCell {TD} at (181,33) size 93x22 [border: none (0.50px none #808080) none none] [r=1 c=2 rs=2 cs=1]
+              RenderText {#text} at (1,1) size 89x19
+                text run at (1,1) width 89: "Row 3, Cell 3"
+          RenderTableRow {TR} at (0,44) size 274x22
+            RenderTableCell {TD} at (0,44) size 182x22 [r=2 c=0 rs=1 cs=2]
+              RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 4, Cell 1"
-        RenderTableSection {TFOOT} at (0,111) size 274x23
-          RenderTableRow {TR} at (0,0) size 274x23
-            RenderTableCell {TD} at (0,0) size 91x23 [border: (0.50px solid #808080) none none none] [r=0 c=0 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 89x20
+        RenderTableSection {TFOOT} at (0,108) size 274x22
+          RenderTableRow {TR} at (0,0) size 274x22
+            RenderTableCell {TD} at (0,0) size 91x22 [r=0 c=0 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 5, Cell 1"
-            RenderTableCell {TD} at (90,0) size 92x23 [border: (0.50px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 89x20
+            RenderTableCell {TD} at (90,0) size 92x22 [r=0 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (181,0) size 93x23 [border: (0.50px solid #808080) (0.50px none #808080) none none] [r=0 c=2 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 89x20
+            RenderTableCell {TD} at (181,0) size 93x22 [border: none (0.50px none #808080) none none] [r=0 c=2 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,4516) size 275x136 [border: (0.50px solid #808080)]
+      RenderTable {TABLE} at (0,4488) size 275x132 [border: (0.50px solid #808080)]
         RenderBlock {CAPTION} at (0,0) size 275x20
           RenderInline {A} at (0,0) size 221x19
             RenderText {#text} at (24,0) size 221x19
@@ -1236,48 +1236,48 @@ layer at (0,0) size 800x8148
           RenderInline (generated) at (0,0) size 7x19
             RenderText at (244,0) size 7x19
               text run at (244,0) width 7: ":"
-        RenderTableSection {THEAD} at (0,20) size 275x24
+        RenderTableSection {THEAD} at (0,20) size 275x23
           RenderTableRow {TR} at (0,0) size 274x23
-            RenderTableCell {TD} at (0,0) size 92x23 [border: (0.50px solid #808080) none (0.50px solid #808080) (0.50px none #808080)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (0,0) size 92x23 [border: (0.50px none #808080) none none (0.50px none #808080)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 90x20
                 text run at (1,1) width 90: "Row 1, Cell 1"
-            RenderTableCell {TD} at (91,0) size 92x23 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (91,0) size 92x23 [border: (0.50px none #808080) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x20
                 text run at (1,1) width 89: "Row 1, Cell 2"
-            RenderTableCell {TD} at (182,0) size 92x23 [border: (0.50px solid #808080) (0.50px none #808080) (0.50px solid #808080) none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (182,0) size 92x23 [border: (0.50px none #808080) (0.50px none #808080) none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x20
                 text run at (1,1) width 89: "Row 1, Cell 3"
-        RenderTableSection {TBODY} at (0,43) size 275x70
-          RenderTableRow {TR} at (0,0) size 274x23
-            RenderTableCell {TD} at (0,11) size 92x24 [border: (0.50px solid #808080) none (0.50px solid #808080) (0.50px none #808080)] [r=0 c=0 rs=2 cs=1]
-              RenderText {#text} at (1,1) size 90x20
-                text run at (1,2) width 90: "Row 2, Cell 1"
-            RenderTableCell {TD} at (91,0) size 183x23 [border: (0.50px solid #808080) (0.50px none #808080) (0.50px solid #808080) none] [r=0 c=1 rs=1 cs=2]
-              RenderText {#text} at (1,1) size 89x20
+        RenderTableSection {TBODY} at (0,43) size 275x66
+          RenderTableRow {TR} at (0,0) size 274x22
+            RenderTableCell {TD} at (0,11) size 92x22 [border: none none none (0.50px none #808080)] [r=0 c=0 rs=2 cs=1]
+              RenderText {#text} at (1,1) size 90x19
+                text run at (1,1) width 90: "Row 2, Cell 1"
+            RenderTableCell {TD} at (91,0) size 183x22 [border: none (0.50px none #808080) none none] [r=0 c=1 rs=1 cs=2]
+              RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,23) size 274x23
-            RenderTableCell {TD} at (91,23) size 92x23 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=1 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 89x20
+          RenderTableRow {TR} at (0,22) size 274x22
+            RenderTableCell {TD} at (91,22) size 92x22 [r=1 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (182,34) size 92x24 [border: (0.50px solid #808080) (0.50px none #808080) (0.50px solid #808080) none] [r=1 c=2 rs=2 cs=1]
-              RenderText {#text} at (1,1) size 89x20
-                text run at (1,2) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,46) size 274x23
-            RenderTableCell {TD} at (0,46) size 183x23 [border: (0.50px solid #808080) none (0.50px solid #808080) (0.50px none #808080)] [r=2 c=0 rs=1 cs=2]
-              RenderText {#text} at (1,1) size 90x20
+            RenderTableCell {TD} at (182,33) size 92x22 [border: none (0.50px none #808080) none none] [r=1 c=2 rs=2 cs=1]
+              RenderText {#text} at (1,1) size 89x19
+                text run at (1,1) width 89: "Row 3, Cell 3"
+          RenderTableRow {TR} at (0,44) size 274x22
+            RenderTableCell {TD} at (0,44) size 183x22 [border: none none none (0.50px none #808080)] [r=2 c=0 rs=1 cs=2]
+              RenderText {#text} at (1,1) size 90x19
                 text run at (1,1) width 90: "Row 4, Cell 1"
-        RenderTableSection {TFOOT} at (0,112) size 275x24
+        RenderTableSection {TFOOT} at (0,109) size 275x23
           RenderTableRow {TR} at (0,0) size 274x23
-            RenderTableCell {TD} at (0,0) size 92x23 [border: (0.50px solid #808080) none (0.50px solid #808080) (0.50px none #808080)] [r=0 c=0 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 90x20
+            RenderTableCell {TD} at (0,0) size 92x23 [border: none none (0.50px none #808080) (0.50px none #808080)] [r=0 c=0 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 90x19
                 text run at (1,1) width 90: "Row 5, Cell 1"
-            RenderTableCell {TD} at (91,0) size 92x23 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=0 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 89x20
+            RenderTableCell {TD} at (91,0) size 92x23 [border: none none (0.50px none #808080) none] [r=0 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (182,0) size 92x23 [border: (0.50px solid #808080) (0.50px none #808080) (0.50px solid #808080) none] [r=0 c=2 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 89x20
+            RenderTableCell {TD} at (182,0) size 92x23 [border: none (0.50px none #808080) (0.50px none #808080) none] [r=0 c=2 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,4700) size 275x136 [border: (0.50px solid #808080)]
+      RenderTable {TABLE} at (0,4668) size 275x132 [border: (0.50px solid #808080)]
         RenderBlock {CAPTION} at (0,0) size 275x20
           RenderInline {A} at (0,0) size 241x19
             RenderText {#text} at (14,0) size 241x19
@@ -1285,48 +1285,48 @@ layer at (0,0) size 800x8148
           RenderInline (generated) at (0,0) size 6x19
             RenderText at (254,0) size 6x19
               text run at (254,0) width 6: ":"
-        RenderTableSection {THEAD} at (0,20) size 275x24
+        RenderTableSection {THEAD} at (0,20) size 275x23
           RenderTableRow {TR} at (0,0) size 274x23
-            RenderTableCell {TD} at (0,0) size 92x23 [border: (0.50px solid #808080) none (0.50px solid #808080) (0.50px none #808080)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (0,0) size 92x23 [border: (0.50px none #808080) none none (0.50px none #808080)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 90x20
                 text run at (1,1) width 90: "Row 1, Cell 1"
-            RenderTableCell {TD} at (91,0) size 92x23 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (91,0) size 92x23 [border: (0.50px none #808080) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x20
                 text run at (1,1) width 89: "Row 1, Cell 2"
-            RenderTableCell {TD} at (182,0) size 92x23 [border: (0.50px solid #808080) (0.50px none #808080) (0.50px solid #808080) none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (182,0) size 92x23 [border: (0.50px none #808080) (0.50px none #808080) none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x20
                 text run at (1,1) width 89: "Row 1, Cell 3"
-        RenderTableSection {TBODY} at (0,43) size 275x70
-          RenderTableRow {TR} at (0,0) size 274x23
-            RenderTableCell {TD} at (0,11) size 92x24 [border: (0.50px solid #808080) none (0.50px solid #808080) (0.50px none #808080)] [r=0 c=0 rs=2 cs=1]
-              RenderText {#text} at (1,1) size 90x20
-                text run at (1,2) width 90: "Row 2, Cell 1"
-            RenderTableCell {TD} at (91,0) size 183x23 [border: (0.50px solid #808080) (0.50px none #808080) (0.50px solid #808080) none] [r=0 c=1 rs=1 cs=2]
-              RenderText {#text} at (1,1) size 89x20
+        RenderTableSection {TBODY} at (0,43) size 275x66
+          RenderTableRow {TR} at (0,0) size 274x22
+            RenderTableCell {TD} at (0,11) size 92x22 [border: none none none (0.50px none #808080)] [r=0 c=0 rs=2 cs=1]
+              RenderText {#text} at (1,1) size 90x19
+                text run at (1,1) width 90: "Row 2, Cell 1"
+            RenderTableCell {TD} at (91,0) size 183x22 [border: none (0.50px none #808080) none none] [r=0 c=1 rs=1 cs=2]
+              RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,23) size 274x23
-            RenderTableCell {TD} at (91,23) size 92x23 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=1 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 89x20
+          RenderTableRow {TR} at (0,22) size 274x22
+            RenderTableCell {TD} at (91,22) size 92x22 [r=1 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (182,34) size 92x24 [border: (0.50px solid #808080) (0.50px none #808080) (0.50px solid #808080) none] [r=1 c=2 rs=2 cs=1]
-              RenderText {#text} at (1,1) size 89x20
-                text run at (1,2) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,46) size 274x23
-            RenderTableCell {TD} at (0,46) size 183x23 [border: (0.50px solid #808080) none (0.50px solid #808080) (0.50px none #808080)] [r=2 c=0 rs=1 cs=2]
-              RenderText {#text} at (1,1) size 90x20
+            RenderTableCell {TD} at (182,33) size 92x22 [border: none (0.50px none #808080) none none] [r=1 c=2 rs=2 cs=1]
+              RenderText {#text} at (1,1) size 89x19
+                text run at (1,1) width 89: "Row 3, Cell 3"
+          RenderTableRow {TR} at (0,44) size 274x22
+            RenderTableCell {TD} at (0,44) size 183x22 [border: none none none (0.50px none #808080)] [r=2 c=0 rs=1 cs=2]
+              RenderText {#text} at (1,1) size 90x19
                 text run at (1,1) width 90: "Row 4, Cell 1"
-        RenderTableSection {TFOOT} at (0,112) size 275x24
+        RenderTableSection {TFOOT} at (0,109) size 275x23
           RenderTableRow {TR} at (0,0) size 274x23
-            RenderTableCell {TD} at (0,0) size 92x23 [border: (0.50px solid #808080) none (0.50px solid #808080) (0.50px none #808080)] [r=0 c=0 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 90x20
+            RenderTableCell {TD} at (0,0) size 92x23 [border: none none (0.50px none #808080) (0.50px none #808080)] [r=0 c=0 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 90x19
                 text run at (1,1) width 90: "Row 5, Cell 1"
-            RenderTableCell {TD} at (91,0) size 92x23 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=0 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 89x20
+            RenderTableCell {TD} at (91,0) size 92x23 [border: none none (0.50px none #808080) none] [r=0 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (182,0) size 92x23 [border: (0.50px solid #808080) (0.50px none #808080) (0.50px solid #808080) none] [r=0 c=2 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 89x20
+            RenderTableCell {TD} at (182,0) size 92x23 [border: none (0.50px none #808080) (0.50px none #808080) none] [r=0 c=2 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,4884) size 275x130
+      RenderTable {TABLE} at (0,4848) size 275x130
         RenderBlock {CAPTION} at (0,0) size 275x20
           RenderInline {A} at (0,0) size 219x19
             RenderText {#text} at (25,0) size 219x19
@@ -1375,7 +1375,7 @@ layer at (0,0) size 800x8148
             RenderTableCell {TD} at (183,0) size 92x22 [border: none none none (0.50px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 90x19
                 text run at (1,1) width 90: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,5062) size 275x131 [border: (0.50px solid #808080) none]
+      RenderTable {TABLE} at (0,5026) size 275x131 [border: (0.50px solid #808080) none]
         RenderBlock {CAPTION} at (0,0) size 275x20
           RenderInline {A} at (0,0) size 230x19
             RenderText {#text} at (20,0) size 230x19
@@ -1424,7 +1424,7 @@ layer at (0,0) size 800x8148
             RenderTableCell {TD} at (183,0) size 92x22 [border: none none none (0.50px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 90x19
                 text run at (1,1) width 90: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,5241) size 275x131 [border: none (0.50px solid #808080) none]
+      RenderTable {TABLE} at (0,5205) size 275x131 [border: none (0.50px solid #808080) none]
         RenderBlock {CAPTION} at (0,0) size 275x20
           RenderInline {A} at (0,0) size 230x19
             RenderText {#text} at (20,0) size 230x19
@@ -1473,7 +1473,7 @@ layer at (0,0) size 800x8148
             RenderTableCell {TD} at (183,0) size 92x23 [border: none none (0.50px none #808080) (0.50px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 90x19
                 text run at (1,1) width 90: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,5420) size 275x132 [border: (0.50px solid #808080) none (0.50px solid #808080) none]
+      RenderTable {TABLE} at (0,5384) size 275x132 [border: (0.50px solid #808080) none (0.50px solid #808080) none]
         RenderBlock {CAPTION} at (0,0) size 275x20
           RenderInline {A} at (0,0) size 233x19
             RenderText {#text} at (18,0) size 233x19
@@ -1522,7 +1522,7 @@ layer at (0,0) size 800x8148
             RenderTableCell {TD} at (183,0) size 92x23 [border: none none (0.50px none #808080) (0.50px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 90x19
                 text run at (1,1) width 90: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,5600) size 277x130 [border: none (0.50px solid #808080) none (0.50px solid #808080)]
+      RenderTable {TABLE} at (0,5564) size 277x130 [border: none (0.50px solid #808080) none (0.50px solid #808080)]
         RenderBlock {CAPTION} at (0,0) size 277x20
           RenderInline {A} at (0,0) size 231x19
             RenderText {#text} at (20,0) size 231x19
@@ -1571,7 +1571,7 @@ layer at (0,0) size 800x8148
             RenderTableCell {TD} at (183,0) size 93x22 [border: none (0.50px solid #808080) none (0.50px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 90x19
                 text run at (1,1) width 90: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,5778) size 276x130 [border: none (0.50px solid #808080)]
+      RenderTable {TABLE} at (0,5742) size 276x130 [border: none (0.50px solid #808080)]
         RenderBlock {CAPTION} at (0,0) size 276x20
           RenderInline {A} at (0,0) size 211x19
             RenderText {#text} at (30,0) size 211x19
@@ -1620,7 +1620,7 @@ layer at (0,0) size 800x8148
             RenderTableCell {TD} at (183,0) size 93x22 [border: none none none (0.50px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 90x19
                 text run at (1,1) width 90: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,5956) size 276x130 [border: none (0.50px solid #808080) none]
+      RenderTable {TABLE} at (0,5920) size 276x130 [border: none (0.50px solid #808080) none]
         RenderBlock {CAPTION} at (0,0) size 276x20
           RenderInline {A} at (0,0) size 213x19
             RenderText {#text} at (29,0) size 213x19
@@ -1669,7 +1669,7 @@ layer at (0,0) size 800x8148
             RenderTableCell {TD} at (183,0) size 93x22 [border: none (0.50px solid #808080) none (0.50px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 90x19
                 text run at (1,1) width 90: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,6134) size 277x132 [border: (0.50px solid #808080)]
+      RenderTable {TABLE} at (0,6098) size 277x132 [border: (0.50px solid #808080)]
         RenderBlock {CAPTION} at (0,0) size 277x20
           RenderInline {A} at (0,0) size 216x19
             RenderText {#text} at (28,0) size 216x19
@@ -1718,7 +1718,7 @@ layer at (0,0) size 800x8148
             RenderTableCell {TD} at (183,0) size 93x23 [border: none (0.50px solid #808080) (0.50px none #808080) (0.50px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 90x19
                 text run at (1,1) width 90: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,6314) size 277x132 [border: (0.50px solid #808080)]
+      RenderTable {TABLE} at (0,6278) size 277x132 [border: (0.50px solid #808080)]
         RenderBlock {CAPTION} at (0,0) size 277x20
           RenderInline {A} at (0,0) size 235x19
             RenderText {#text} at (18,0) size 235x19
@@ -1767,7 +1767,7 @@ layer at (0,0) size 800x8148
             RenderTableCell {TD} at (183,0) size 93x23 [border: none (0.50px solid #808080) (0.50px none #808080) (0.50px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 90x19
                 text run at (1,1) width 90: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,6494) size 275x134
+      RenderTable {TABLE} at (0,6458) size 275x134
         RenderBlock {CAPTION} at (0,0) size 275x20
           RenderInline {A} at (0,0) size 211x19
             RenderText {#text} at (29,0) size 211x19
@@ -1816,7 +1816,7 @@ layer at (0,0) size 800x8148
             RenderTableCell {TD} at (183,0) size 92x23 [border: (0.50px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 90x20
                 text run at (1,1) width 90: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,6676) size 275x135 [border: (0.50px solid #808080) none]
+      RenderTable {TABLE} at (0,6640) size 275x135 [border: (0.50px solid #808080) none]
         RenderBlock {CAPTION} at (0,0) size 275x20
           RenderInline {A} at (0,0) size 221x19
             RenderText {#text} at (24,0) size 221x19
@@ -1865,7 +1865,7 @@ layer at (0,0) size 800x8148
             RenderTableCell {TD} at (183,0) size 92x23 [border: (0.50px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 90x20
                 text run at (1,1) width 90: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,6859) size 275x135 [border: none (0.50px solid #808080) none]
+      RenderTable {TABLE} at (0,6823) size 275x135 [border: none (0.50px solid #808080) none]
         RenderBlock {CAPTION} at (0,0) size 275x20
           RenderInline {A} at (0,0) size 221x19
             RenderText {#text} at (24,0) size 221x19
@@ -1914,7 +1914,7 @@ layer at (0,0) size 800x8148
             RenderTableCell {TD} at (183,0) size 92x23 [border: (0.50px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 90x20
                 text run at (1,1) width 90: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,7042) size 275x136 [border: (0.50px solid #808080) none (0.50px solid #808080) none]
+      RenderTable {TABLE} at (0,7006) size 275x136 [border: (0.50px solid #808080) none (0.50px solid #808080) none]
         RenderBlock {CAPTION} at (0,0) size 275x20
           RenderInline {A} at (0,0) size 224x19
             RenderText {#text} at (23,0) size 224x19
@@ -1963,7 +1963,7 @@ layer at (0,0) size 800x8148
             RenderTableCell {TD} at (183,0) size 92x23 [border: (0.50px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 90x20
                 text run at (1,1) width 90: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,7226) size 277x134 [border: none (0.50px solid #808080) none (0.50px solid #808080)]
+      RenderTable {TABLE} at (0,7190) size 277x134 [border: none (0.50px solid #808080) none (0.50px solid #808080)]
         RenderBlock {CAPTION} at (0,0) size 277x20
           RenderInline {A} at (0,0) size 222x19
             RenderText {#text} at (25,0) size 222x19
@@ -2012,7 +2012,7 @@ layer at (0,0) size 800x8148
             RenderTableCell {TD} at (183,0) size 93x23 [border: (0.50px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 90x20
                 text run at (1,1) width 90: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,7408) size 276x134 [border: none (0.50px solid #808080)]
+      RenderTable {TABLE} at (0,7372) size 276x134 [border: none (0.50px solid #808080)]
         RenderBlock {CAPTION} at (0,0) size 276x20
           RenderInline {A} at (0,0) size 202x19
             RenderText {#text} at (34,0) size 202x19
@@ -2061,7 +2061,7 @@ layer at (0,0) size 800x8148
             RenderTableCell {TD} at (183,0) size 93x23 [border: (0.50px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 90x20
                 text run at (1,1) width 90: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,7590) size 276x134 [border: none (0.50px solid #808080) none]
+      RenderTable {TABLE} at (0,7554) size 276x134 [border: none (0.50px solid #808080) none]
         RenderBlock {CAPTION} at (0,0) size 276x20
           RenderInline {A} at (0,0) size 204x19
             RenderText {#text} at (33,0) size 204x19
@@ -2110,7 +2110,7 @@ layer at (0,0) size 800x8148
             RenderTableCell {TD} at (183,0) size 93x23 [border: (0.50px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 90x20
                 text run at (1,1) width 90: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,7772) size 277x136 [border: (0.50px solid #808080)]
+      RenderTable {TABLE} at (0,7736) size 277x136 [border: (0.50px solid #808080)]
         RenderBlock {CAPTION} at (0,0) size 277x20
           RenderInline {A} at (0,0) size 207x19
             RenderText {#text} at (32,0) size 207x19
@@ -2159,7 +2159,7 @@ layer at (0,0) size 800x8148
             RenderTableCell {TD} at (183,0) size 93x23 [border: (0.50px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 90x20
                 text run at (1,1) width 90: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,7956) size 277x136 [border: (0.50px solid #808080)]
+      RenderTable {TABLE} at (0,7920) size 277x136 [border: (0.50px solid #808080)]
         RenderBlock {CAPTION} at (0,0) size 277x20
           RenderInline {A} at (0,0) size 227x19
             RenderText {#text} at (22,0) size 227x19

--- a/LayoutTests/platform/ios/fast/table/frame-and-rules-expected.txt
+++ b/LayoutTests/platform/ios/fast/table/frame-and-rules-expected.txt
@@ -894,44 +894,44 @@ layer at (0,0) size 800x7608
             RenderText at (245,0) size 6x18
               text run at (245,0) width 6: ":"
         RenderTableSection {THEAD} at (0,18) size 273x21
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,0) size 91x21 [border: none none (0.50px solid #000000) none] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,0) size 91x21 [border: none none (0.50px none #000000) none] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x18
                 text run at (1,1) width 89: "Row 1, Cell 1"
-            RenderTableCell {TD} at (90,0) size 92x21 [border: none none (0.50px solid #000000) none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (90,0) size 92x21 [border: none none (0.50px none #000000) none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x18
                 text run at (1,1) width 89: "Row 1, Cell 2"
-            RenderTableCell {TD} at (181,0) size 92x21 [border: none none (0.50px solid #000000) none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (181,0) size 92x21 [border: none none (0.50px none #000000) none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x18
                 text run at (1,1) width 89: "Row 1, Cell 3"
         RenderTableSection {TBODY} at (0,38) size 273x64
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,10) size 91x22 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=0 c=0 rs=2 cs=1]
+          RenderTableRow {TR} at (0,0) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,10) size 91x22 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (1,12) size 89x18
                 text run at (1,2) width 89: "Row 2, Cell 1"
-            RenderTableCell {TD} at (90,0) size 183x21 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=0 c=1 rs=1 cs=2]
+            RenderTableCell {TD} at (90,0) size 183x21 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=0 c=1 rs=1 cs=2]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,21) size 273x21
-            RenderTableCell {TD} at (90,21) size 92x21 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=1 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,21) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (90,21) size 92x21 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (181,31) size 92x22 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=1 c=2 rs=2 cs=1]
+            RenderTableCell {TD} at (181,31) size 92x22 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=1 c=2 rs=2 cs=1]
               RenderText {#text} at (1,12) size 89x18
                 text run at (1,2) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,42) size 273x21
-            RenderTableCell {TD} at (0,42) size 182x21 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=2 c=0 rs=1 cs=2]
+          RenderTableRow {TR} at (0,42) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,42) size 182x21 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=2 c=0 rs=1 cs=2]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 4, Cell 1"
         RenderTableSection {TFOOT} at (0,101) size 273x21
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,0) size 91x21 [border: (0.50px solid #000000) none none none] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,0) size 91x21 [border: (0.50px none #000000) none none none] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 5, Cell 1"
-            RenderTableCell {TD} at (90,0) size 92x21 [border: (0.50px solid #000000) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (90,0) size 92x21 [border: (0.50px none #000000) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (181,0) size 92x21 [border: (0.50px solid #000000) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (181,0) size 92x21 [border: (0.50px none #000000) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 5, Cell 3"
       RenderTable {TABLE} at (0,3192) size 273x123 [border: (0.50px solid #000000) none]
@@ -943,44 +943,44 @@ layer at (0,0) size 800x7608
             RenderText at (250,0) size 7x18
               text run at (250,0) width 7: ":"
         RenderTableSection {THEAD} at (0,18) size 273x22
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,0) size 91x21 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,0) size 91x21 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 1, Cell 1"
-            RenderTableCell {TD} at (90,0) size 92x21 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (90,0) size 92x21 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 1, Cell 2"
-            RenderTableCell {TD} at (181,0) size 92x21 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (181,0) size 92x21 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 1, Cell 3"
         RenderTableSection {TBODY} at (0,39) size 273x64
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,10) size 91x22 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=0 c=0 rs=2 cs=1]
+          RenderTableRow {TR} at (0,0) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,10) size 91x22 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (1,12) size 89x18
                 text run at (1,2) width 89: "Row 2, Cell 1"
-            RenderTableCell {TD} at (90,0) size 183x21 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=0 c=1 rs=1 cs=2]
+            RenderTableCell {TD} at (90,0) size 183x21 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=0 c=1 rs=1 cs=2]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,21) size 273x21
-            RenderTableCell {TD} at (90,21) size 92x21 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=1 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,21) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (90,21) size 92x21 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (181,31) size 92x22 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=1 c=2 rs=2 cs=1]
+            RenderTableCell {TD} at (181,31) size 92x22 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=1 c=2 rs=2 cs=1]
               RenderText {#text} at (1,12) size 89x18
                 text run at (1,2) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,42) size 273x21
-            RenderTableCell {TD} at (0,42) size 182x21 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=2 c=0 rs=1 cs=2]
+          RenderTableRow {TR} at (0,42) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,42) size 182x21 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=2 c=0 rs=1 cs=2]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 4, Cell 1"
         RenderTableSection {TFOOT} at (0,102) size 273x21
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,0) size 91x21 [border: (0.50px solid #000000) none none none] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,0) size 91x21 [border: (0.50px none #000000) none none none] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 5, Cell 1"
-            RenderTableCell {TD} at (90,0) size 92x21 [border: (0.50px solid #000000) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (90,0) size 92x21 [border: (0.50px none #000000) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (181,0) size 92x21 [border: (0.50px solid #000000) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (181,0) size 92x21 [border: (0.50px none #000000) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 5, Cell 3"
       RenderTable {TABLE} at (0,3363) size 273x123 [border: none (0.50px solid #000000) none]
@@ -992,44 +992,44 @@ layer at (0,0) size 800x7608
             RenderText at (250,0) size 7x18
               text run at (250,0) width 7: ":"
         RenderTableSection {THEAD} at (0,18) size 273x21
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,0) size 91x21 [border: none none (0.50px solid #000000) none] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,0) size 91x21 [border: none none (0.50px none #000000) none] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x18
                 text run at (1,1) width 89: "Row 1, Cell 1"
-            RenderTableCell {TD} at (90,0) size 92x21 [border: none none (0.50px solid #000000) none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (90,0) size 92x21 [border: none none (0.50px none #000000) none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x18
                 text run at (1,1) width 89: "Row 1, Cell 2"
-            RenderTableCell {TD} at (181,0) size 92x21 [border: none none (0.50px solid #000000) none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (181,0) size 92x21 [border: none none (0.50px none #000000) none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x18
                 text run at (1,1) width 89: "Row 1, Cell 3"
         RenderTableSection {TBODY} at (0,38) size 273x64
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,10) size 91x22 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=0 c=0 rs=2 cs=1]
+          RenderTableRow {TR} at (0,0) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,10) size 91x22 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (1,12) size 89x18
                 text run at (1,2) width 89: "Row 2, Cell 1"
-            RenderTableCell {TD} at (90,0) size 183x21 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=0 c=1 rs=1 cs=2]
+            RenderTableCell {TD} at (90,0) size 183x21 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=0 c=1 rs=1 cs=2]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,21) size 273x21
-            RenderTableCell {TD} at (90,21) size 92x21 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=1 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,21) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (90,21) size 92x21 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (181,31) size 92x22 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=1 c=2 rs=2 cs=1]
+            RenderTableCell {TD} at (181,31) size 92x22 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=1 c=2 rs=2 cs=1]
               RenderText {#text} at (1,12) size 89x18
                 text run at (1,2) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,42) size 273x21
-            RenderTableCell {TD} at (0,42) size 182x21 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=2 c=0 rs=1 cs=2]
+          RenderTableRow {TR} at (0,42) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,42) size 182x21 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=2 c=0 rs=1 cs=2]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 4, Cell 1"
         RenderTableSection {TFOOT} at (0,101) size 273x22
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,0) size 91x21 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,0) size 91x21 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 5, Cell 1"
-            RenderTableCell {TD} at (90,0) size 92x21 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (90,0) size 92x21 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (181,0) size 92x21 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (181,0) size 92x21 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 5, Cell 3"
       RenderTable {TABLE} at (0,3534) size 273x124 [border: (0.50px solid #000000) none (0.50px solid #000000) none]
@@ -1041,44 +1041,44 @@ layer at (0,0) size 800x7608
             RenderText at (252,0) size 6x18
               text run at (252,0) width 6: ":"
         RenderTableSection {THEAD} at (0,18) size 273x22
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,0) size 91x21 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,0) size 91x21 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 1, Cell 1"
-            RenderTableCell {TD} at (90,0) size 92x21 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (90,0) size 92x21 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 1, Cell 2"
-            RenderTableCell {TD} at (181,0) size 92x21 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (181,0) size 92x21 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 1, Cell 3"
         RenderTableSection {TBODY} at (0,39) size 273x64
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,10) size 91x22 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=0 c=0 rs=2 cs=1]
+          RenderTableRow {TR} at (0,0) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,10) size 91x22 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (1,12) size 89x18
                 text run at (1,2) width 89: "Row 2, Cell 1"
-            RenderTableCell {TD} at (90,0) size 183x21 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=0 c=1 rs=1 cs=2]
+            RenderTableCell {TD} at (90,0) size 183x21 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=0 c=1 rs=1 cs=2]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,21) size 273x21
-            RenderTableCell {TD} at (90,21) size 92x21 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=1 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,21) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (90,21) size 92x21 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (181,31) size 92x22 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=1 c=2 rs=2 cs=1]
+            RenderTableCell {TD} at (181,31) size 92x22 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=1 c=2 rs=2 cs=1]
               RenderText {#text} at (1,12) size 89x18
                 text run at (1,2) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,42) size 273x21
-            RenderTableCell {TD} at (0,42) size 182x21 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=2 c=0 rs=1 cs=2]
+          RenderTableRow {TR} at (0,42) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,42) size 182x21 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=2 c=0 rs=1 cs=2]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 4, Cell 1"
         RenderTableSection {TFOOT} at (0,102) size 273x22
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,0) size 91x21 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,0) size 91x21 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 5, Cell 1"
-            RenderTableCell {TD} at (90,0) size 92x21 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (90,0) size 92x21 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (181,0) size 92x21 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (181,0) size 92x21 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 5, Cell 3"
       RenderTable {TABLE} at (0,3706) size 275x122 [border: none (0.50px solid #000000) none (0.50px solid #000000)]
@@ -1090,44 +1090,44 @@ layer at (0,0) size 800x7608
             RenderText at (252,0) size 6x18
               text run at (252,0) width 6: ":"
         RenderTableSection {THEAD} at (0,18) size 275x21
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,0) size 92x21 [border: none none (0.50px solid #000000) (0.50px none #000000)] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,0) size 92x21 [border: none none (0.50px none #000000) (0.50px none #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 90x18
                 text run at (1,1) width 90: "Row 1, Cell 1"
-            RenderTableCell {TD} at (91,0) size 92x21 [border: none none (0.50px solid #000000) none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (91,0) size 92x21 [border: none none (0.50px none #000000) none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x18
                 text run at (1,1) width 89: "Row 1, Cell 2"
-            RenderTableCell {TD} at (182,0) size 92x21 [border: none (0.50px none #000000) (0.50px solid #000000) none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (182,0) size 92x21 [border: none (0.50px none #000000) (0.50px none #000000) none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x18
                 text run at (1,1) width 89: "Row 1, Cell 3"
         RenderTableSection {TBODY} at (0,38) size 275x64
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,10) size 92x22 [border: (0.50px solid #000000) none (0.50px solid #000000) (0.50px none #000000)] [r=0 c=0 rs=2 cs=1]
+          RenderTableRow {TR} at (0,0) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,10) size 92x22 [border: (0.50px none #000000) none (0.50px none #000000) (0.50px none #000000)] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (1,12) size 90x18
                 text run at (1,2) width 90: "Row 2, Cell 1"
-            RenderTableCell {TD} at (91,0) size 183x21 [border: (0.50px solid #000000) (0.50px none #000000) (0.50px solid #000000) none] [r=0 c=1 rs=1 cs=2]
+            RenderTableCell {TD} at (91,0) size 183x21 [border: (0.50px none #000000) (0.50px none #000000) (0.50px none #000000) none] [r=0 c=1 rs=1 cs=2]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,21) size 274x21
-            RenderTableCell {TD} at (91,21) size 92x21 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=1 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,21) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (91,21) size 92x21 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (182,31) size 92x22 [border: (0.50px solid #000000) (0.50px none #000000) (0.50px solid #000000) none] [r=1 c=2 rs=2 cs=1]
+            RenderTableCell {TD} at (182,31) size 92x22 [border: (0.50px none #000000) (0.50px none #000000) (0.50px none #000000) none] [r=1 c=2 rs=2 cs=1]
               RenderText {#text} at (1,12) size 89x18
                 text run at (1,2) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,42) size 274x21
-            RenderTableCell {TD} at (0,42) size 183x21 [border: (0.50px solid #000000) none (0.50px solid #000000) (0.50px none #000000)] [r=2 c=0 rs=1 cs=2]
+          RenderTableRow {TR} at (0,42) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,42) size 183x21 [border: (0.50px none #000000) none (0.50px none #000000) (0.50px none #000000)] [r=2 c=0 rs=1 cs=2]
               RenderText {#text} at (1,1) size 90x19
                 text run at (1,1) width 90: "Row 4, Cell 1"
         RenderTableSection {TFOOT} at (0,101) size 275x21
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,0) size 92x21 [border: (0.50px solid #000000) none none (0.50px none #000000)] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,0) size 92x21 [border: (0.50px none #000000) none none (0.50px none #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 90x19
                 text run at (1,1) width 90: "Row 5, Cell 1"
-            RenderTableCell {TD} at (91,0) size 92x21 [border: (0.50px solid #000000) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (91,0) size 92x21 [border: (0.50px none #000000) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (182,0) size 92x21 [border: (0.50px solid #000000) (0.50px none #000000) none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (182,0) size 92x21 [border: (0.50px none #000000) (0.50px none #000000) none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 5, Cell 3"
       RenderTable {TABLE} at (0,3876) size 274x122 [border: none (0.50px solid #000000)]
@@ -1139,44 +1139,44 @@ layer at (0,0) size 800x7608
             RenderText at (241,0) size 7x18
               text run at (241,0) width 7: ":"
         RenderTableSection {THEAD} at (0,18) size 274x21
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,0) size 92x21 [border: none none (0.50px solid #000000) (0.50px none #000000)] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,0) size 92x21 [border: none none (0.50px none #000000) (0.50px none #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 90x18
                 text run at (1,1) width 90: "Row 1, Cell 1"
-            RenderTableCell {TD} at (91,0) size 92x21 [border: none none (0.50px solid #000000) none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (91,0) size 92x21 [border: none none (0.50px none #000000) none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x18
                 text run at (1,1) width 89: "Row 1, Cell 2"
-            RenderTableCell {TD} at (182,0) size 92x21 [border: none none (0.50px solid #000000) none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (182,0) size 92x21 [border: none none (0.50px none #000000) none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x18
                 text run at (1,1) width 89: "Row 1, Cell 3"
         RenderTableSection {TBODY} at (0,38) size 274x64
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,10) size 92x22 [border: (0.50px solid #000000) none (0.50px solid #000000) (0.50px none #000000)] [r=0 c=0 rs=2 cs=1]
+          RenderTableRow {TR} at (0,0) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,10) size 92x22 [border: (0.50px none #000000) none (0.50px none #000000) (0.50px none #000000)] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (1,12) size 90x18
                 text run at (1,2) width 90: "Row 2, Cell 1"
-            RenderTableCell {TD} at (91,0) size 183x21 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=0 c=1 rs=1 cs=2]
+            RenderTableCell {TD} at (91,0) size 183x21 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=0 c=1 rs=1 cs=2]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,21) size 274x21
-            RenderTableCell {TD} at (91,21) size 92x21 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=1 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,21) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (91,21) size 92x21 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (182,31) size 92x22 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=1 c=2 rs=2 cs=1]
+            RenderTableCell {TD} at (182,31) size 92x22 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=1 c=2 rs=2 cs=1]
               RenderText {#text} at (1,12) size 89x18
                 text run at (1,2) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,42) size 274x21
-            RenderTableCell {TD} at (0,42) size 183x21 [border: (0.50px solid #000000) none (0.50px solid #000000) (0.50px none #000000)] [r=2 c=0 rs=1 cs=2]
+          RenderTableRow {TR} at (0,42) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,42) size 183x21 [border: (0.50px none #000000) none (0.50px none #000000) (0.50px none #000000)] [r=2 c=0 rs=1 cs=2]
               RenderText {#text} at (1,1) size 90x19
                 text run at (1,1) width 90: "Row 4, Cell 1"
         RenderTableSection {TFOOT} at (0,101) size 274x21
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,0) size 92x21 [border: (0.50px solid #000000) none none (0.50px none #000000)] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,0) size 92x21 [border: (0.50px none #000000) none none (0.50px none #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 90x19
                 text run at (1,1) width 90: "Row 5, Cell 1"
-            RenderTableCell {TD} at (91,0) size 92x21 [border: (0.50px solid #000000) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (91,0) size 92x21 [border: (0.50px none #000000) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (182,0) size 92x21 [border: (0.50px solid #000000) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (182,0) size 92x21 [border: (0.50px none #000000) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 5, Cell 3"
       RenderTable {TABLE} at (0,4046) size 274x122 [border: none (0.50px solid #000000) none]
@@ -1188,44 +1188,44 @@ layer at (0,0) size 800x7608
             RenderText at (242,0) size 7x18
               text run at (242,0) width 7: ":"
         RenderTableSection {THEAD} at (0,18) size 274x21
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,0) size 91x21 [border: none none (0.50px solid #000000) none] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,0) size 91x21 [border: none none (0.50px none #000000) none] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x18
                 text run at (1,1) width 89: "Row 1, Cell 1"
-            RenderTableCell {TD} at (90,0) size 92x21 [border: none none (0.50px solid #000000) none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (90,0) size 92x21 [border: none none (0.50px none #000000) none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x18
                 text run at (1,1) width 89: "Row 1, Cell 2"
-            RenderTableCell {TD} at (181,0) size 93x21 [border: none (0.50px none #000000) (0.50px solid #000000) none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (181,0) size 93x21 [border: none (0.50px none #000000) (0.50px none #000000) none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x18
                 text run at (1,1) width 89: "Row 1, Cell 3"
         RenderTableSection {TBODY} at (0,38) size 274x64
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,10) size 91x22 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=0 c=0 rs=2 cs=1]
+          RenderTableRow {TR} at (0,0) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,10) size 91x22 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (1,12) size 89x18
                 text run at (1,2) width 89: "Row 2, Cell 1"
-            RenderTableCell {TD} at (90,0) size 184x21 [border: (0.50px solid #000000) (0.50px none #000000) (0.50px solid #000000) none] [r=0 c=1 rs=1 cs=2]
+            RenderTableCell {TD} at (90,0) size 184x21 [border: (0.50px none #000000) (0.50px none #000000) (0.50px none #000000) none] [r=0 c=1 rs=1 cs=2]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,21) size 274x21
-            RenderTableCell {TD} at (90,21) size 92x21 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=1 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,21) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (90,21) size 92x21 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (181,31) size 93x22 [border: (0.50px solid #000000) (0.50px none #000000) (0.50px solid #000000) none] [r=1 c=2 rs=2 cs=1]
+            RenderTableCell {TD} at (181,31) size 93x22 [border: (0.50px none #000000) (0.50px none #000000) (0.50px none #000000) none] [r=1 c=2 rs=2 cs=1]
               RenderText {#text} at (1,12) size 89x18
                 text run at (1,2) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,42) size 274x21
-            RenderTableCell {TD} at (0,42) size 182x21 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=2 c=0 rs=1 cs=2]
+          RenderTableRow {TR} at (0,42) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,42) size 182x21 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=2 c=0 rs=1 cs=2]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 4, Cell 1"
         RenderTableSection {TFOOT} at (0,101) size 274x21
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,0) size 91x21 [border: (0.50px solid #000000) none none none] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,0) size 91x21 [border: (0.50px none #000000) none none none] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 5, Cell 1"
-            RenderTableCell {TD} at (90,0) size 92x21 [border: (0.50px solid #000000) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (90,0) size 92x21 [border: (0.50px none #000000) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (181,0) size 93x21 [border: (0.50px solid #000000) (0.50px none #000000) none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (181,0) size 93x21 [border: (0.50px none #000000) (0.50px none #000000) none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 5, Cell 3"
       RenderTable {TABLE} at (0,4216) size 275x124 [border: (0.50px solid #000000)]
@@ -1237,44 +1237,44 @@ layer at (0,0) size 800x7608
             RenderText at (244,0) size 7x18
               text run at (244,0) width 7: ":"
         RenderTableSection {THEAD} at (0,18) size 275x22
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,0) size 92x21 [border: (0.50px solid #000000) none (0.50px solid #000000) (0.50px none #000000)] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,0) size 92x21 [border: (0.50px none #000000) none (0.50px none #000000) (0.50px none #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 90x19
                 text run at (1,1) width 90: "Row 1, Cell 1"
-            RenderTableCell {TD} at (91,0) size 92x21 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (91,0) size 92x21 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 1, Cell 2"
-            RenderTableCell {TD} at (182,0) size 92x21 [border: (0.50px solid #000000) (0.50px none #000000) (0.50px solid #000000) none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (182,0) size 92x21 [border: (0.50px none #000000) (0.50px none #000000) (0.50px none #000000) none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 1, Cell 3"
         RenderTableSection {TBODY} at (0,39) size 275x64
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,10) size 92x22 [border: (0.50px solid #000000) none (0.50px solid #000000) (0.50px none #000000)] [r=0 c=0 rs=2 cs=1]
+          RenderTableRow {TR} at (0,0) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,10) size 92x22 [border: (0.50px none #000000) none (0.50px none #000000) (0.50px none #000000)] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (1,12) size 90x18
                 text run at (1,2) width 90: "Row 2, Cell 1"
-            RenderTableCell {TD} at (91,0) size 183x21 [border: (0.50px solid #000000) (0.50px none #000000) (0.50px solid #000000) none] [r=0 c=1 rs=1 cs=2]
+            RenderTableCell {TD} at (91,0) size 183x21 [border: (0.50px none #000000) (0.50px none #000000) (0.50px none #000000) none] [r=0 c=1 rs=1 cs=2]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,21) size 274x21
-            RenderTableCell {TD} at (91,21) size 92x21 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=1 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,21) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (91,21) size 92x21 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (182,31) size 92x22 [border: (0.50px solid #000000) (0.50px none #000000) (0.50px solid #000000) none] [r=1 c=2 rs=2 cs=1]
+            RenderTableCell {TD} at (182,31) size 92x22 [border: (0.50px none #000000) (0.50px none #000000) (0.50px none #000000) none] [r=1 c=2 rs=2 cs=1]
               RenderText {#text} at (1,12) size 89x18
                 text run at (1,2) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,42) size 274x21
-            RenderTableCell {TD} at (0,42) size 183x21 [border: (0.50px solid #000000) none (0.50px solid #000000) (0.50px none #000000)] [r=2 c=0 rs=1 cs=2]
+          RenderTableRow {TR} at (0,42) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,42) size 183x21 [border: (0.50px none #000000) none (0.50px none #000000) (0.50px none #000000)] [r=2 c=0 rs=1 cs=2]
               RenderText {#text} at (1,1) size 90x19
                 text run at (1,1) width 90: "Row 4, Cell 1"
         RenderTableSection {TFOOT} at (0,102) size 275x22
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,0) size 92x21 [border: (0.50px solid #000000) none (0.50px solid #000000) (0.50px none #000000)] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,0) size 92x21 [border: (0.50px none #000000) none (0.50px none #000000) (0.50px none #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 90x19
                 text run at (1,1) width 90: "Row 5, Cell 1"
-            RenderTableCell {TD} at (91,0) size 92x21 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (91,0) size 92x21 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (182,0) size 92x21 [border: (0.50px solid #000000) (0.50px none #000000) (0.50px solid #000000) none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (182,0) size 92x21 [border: (0.50px none #000000) (0.50px none #000000) (0.50px none #000000) none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 5, Cell 3"
       RenderTable {TABLE} at (0,4388) size 275x124 [border: (0.50px solid #000000)]
@@ -1286,44 +1286,44 @@ layer at (0,0) size 800x7608
             RenderText at (254,0) size 6x18
               text run at (254,0) width 6: ":"
         RenderTableSection {THEAD} at (0,18) size 275x22
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,0) size 92x21 [border: (0.50px solid #000000) none (0.50px solid #000000) (0.50px none #000000)] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,0) size 92x21 [border: (0.50px none #000000) none (0.50px none #000000) (0.50px none #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 90x19
                 text run at (1,1) width 90: "Row 1, Cell 1"
-            RenderTableCell {TD} at (91,0) size 92x21 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (91,0) size 92x21 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 1, Cell 2"
-            RenderTableCell {TD} at (182,0) size 92x21 [border: (0.50px solid #000000) (0.50px none #000000) (0.50px solid #000000) none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (182,0) size 92x21 [border: (0.50px none #000000) (0.50px none #000000) (0.50px none #000000) none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 1, Cell 3"
         RenderTableSection {TBODY} at (0,39) size 275x64
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,10) size 92x22 [border: (0.50px solid #000000) none (0.50px solid #000000) (0.50px none #000000)] [r=0 c=0 rs=2 cs=1]
+          RenderTableRow {TR} at (0,0) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,10) size 92x22 [border: (0.50px none #000000) none (0.50px none #000000) (0.50px none #000000)] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (1,12) size 90x18
                 text run at (1,2) width 90: "Row 2, Cell 1"
-            RenderTableCell {TD} at (91,0) size 183x21 [border: (0.50px solid #000000) (0.50px none #000000) (0.50px solid #000000) none] [r=0 c=1 rs=1 cs=2]
+            RenderTableCell {TD} at (91,0) size 183x21 [border: (0.50px none #000000) (0.50px none #000000) (0.50px none #000000) none] [r=0 c=1 rs=1 cs=2]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,21) size 274x21
-            RenderTableCell {TD} at (91,21) size 92x21 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=1 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,21) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (91,21) size 92x21 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (182,31) size 92x22 [border: (0.50px solid #000000) (0.50px none #000000) (0.50px solid #000000) none] [r=1 c=2 rs=2 cs=1]
+            RenderTableCell {TD} at (182,31) size 92x22 [border: (0.50px none #000000) (0.50px none #000000) (0.50px none #000000) none] [r=1 c=2 rs=2 cs=1]
               RenderText {#text} at (1,12) size 89x18
                 text run at (1,2) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,42) size 274x21
-            RenderTableCell {TD} at (0,42) size 183x21 [border: (0.50px solid #000000) none (0.50px solid #000000) (0.50px none #000000)] [r=2 c=0 rs=1 cs=2]
+          RenderTableRow {TR} at (0,42) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,42) size 183x21 [border: (0.50px none #000000) none (0.50px none #000000) (0.50px none #000000)] [r=2 c=0 rs=1 cs=2]
               RenderText {#text} at (1,1) size 90x19
                 text run at (1,1) width 90: "Row 4, Cell 1"
         RenderTableSection {TFOOT} at (0,102) size 275x22
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,0) size 92x21 [border: (0.50px solid #000000) none (0.50px solid #000000) (0.50px none #000000)] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,0) size 92x21 [border: (0.50px none #000000) none (0.50px none #000000) (0.50px none #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 90x19
                 text run at (1,1) width 90: "Row 5, Cell 1"
-            RenderTableCell {TD} at (91,0) size 92x21 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (91,0) size 92x21 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (182,0) size 92x21 [border: (0.50px solid #000000) (0.50px none #000000) (0.50px solid #000000) none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (182,0) size 92x21 [border: (0.50px none #000000) (0.50px none #000000) (0.50px none #000000) none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x19
                 text run at (1,1) width 89: "Row 5, Cell 3"
       RenderTable {TABLE} at (0,4560) size 275x118

--- a/LayoutTests/platform/ios/fast/table/rules-attr-dynchange2-expected.txt
+++ b/LayoutTests/platform/ios/fast/table/rules-attr-dynchange2-expected.txt
@@ -3,29 +3,29 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576
-      RenderTable {TABLE} at (0,0) size 153x70 [border: (0.50px outset #808080)]
-        RenderTableSection {TBODY} at (0,0) size 153x70
+      RenderTable {TABLE} at (0,0) size 153x68 [border: (0.50px outset #808080)]
+        RenderTableSection {TBODY} at (0,0) size 153x68
           RenderTableRow {TR} at (0,0) size 152x23
-            RenderTableCell {TD} at (0,0) size 76x23 [border: (0.50px solid #808080) none (0.50px solid #808080) (0.50px none #808080)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (0,0) size 76x23 [border: (0.50px none #808080) none none (0.50px none #808080)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 74x20
                 text run at (1,1) width 74: "Row1 cell1"
-            RenderTableCell {TD} at (75,0) size 77x23 [border: (0.50px solid #808080) (0.50px none #808080) (0.50px solid #808080) none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (75,0) size 77x23 [border: (0.50px none #808080) (0.50px none #808080) none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 74x20
                 text run at (1,1) width 74: "Row1 cell2"
-          RenderTableRow {TR} at (0,23) size 152x23
-            RenderTableCell {TD} at (0,23) size 76x23 [border: (0.50px solid #808080) none (0.50px solid #808080) (0.50px none #808080)] [r=1 c=0 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 74x20
+          RenderTableRow {TR} at (0,22) size 152x23
+            RenderTableCell {TD} at (0,22) size 76x23 [border: none none none (0.50px none #808080)] [r=1 c=0 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 74x19
                 text run at (1,1) width 74: "Row2 cell1"
-            RenderTableCell {TD} at (75,23) size 77x23 [border: (0.50px solid #808080) (0.50px none #808080) (0.50px solid #808080) none] [r=1 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 74x20
+            RenderTableCell {TD} at (75,22) size 77x23 [border: none (0.50px none #808080) none none] [r=1 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 74x19
                 text run at (1,1) width 74: "Row2 cell2"
-          RenderTableRow {TR} at (0,46) size 152x23
-            RenderTableCell {TD} at (0,46) size 76x23 [border: (0.50px solid #808080) none (0.50px solid #808080) (0.50px none #808080)] [r=2 c=0 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 74x20
+          RenderTableRow {TR} at (0,44) size 152x23
+            RenderTableCell {TD} at (0,44) size 76x23 [border: none none (0.50px none #808080) (0.50px none #808080)] [r=2 c=0 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 74x19
                 text run at (1,1) width 74: "Row3 cell1"
-            RenderTableCell {TD} at (75,46) size 77x23 [border: (0.50px solid #808080) (0.50px none #808080) (0.50px solid #808080) none] [r=2 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 74x20
+            RenderTableCell {TD} at (75,44) size 77x23 [border: none (0.50px none #808080) (0.50px none #808080) none] [r=2 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 74x19
                 text run at (1,1) width 74: "Row3 cell2"
-      RenderBlock {P} at (0,86) size 784x20
+      RenderBlock {P} at (0,84) size 784x20
         RenderText {#text} at (0,0) size 762x19
           text run at (0,0) width 762: "The rules attribute is first set dynamically to cols, then to rows, so the table should show only row borders. Bug 14848."

--- a/LayoutTests/platform/ios/fast/table/rules-attr-dynchange2-expected.txt
+++ b/LayoutTests/platform/ios/fast/table/rules-attr-dynchange2-expected.txt
@@ -5,25 +5,25 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576
       RenderTable {TABLE} at (0,0) size 153x64 [border: (0.50px outset #000000)]
         RenderTableSection {TBODY} at (0,0) size 153x64
-          RenderTableRow {TR} at (0,0) size 152x21
-            RenderTableCell {TD} at (0,0) size 76x21 [border: (0.50px solid #000000) none (0.50px solid #000000) (0.50px none #000000)] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 152x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,0) size 76x21 [border: (0.50px none #000000) none (0.50px none #000000) (0.50px none #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 74x19
                 text run at (1,1) width 74: "Row1 cell1"
-            RenderTableCell {TD} at (75,0) size 77x21 [border: (0.50px solid #000000) (0.50px none #000000) (0.50px solid #000000) none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (75,0) size 77x21 [border: (0.50px none #000000) (0.50px none #000000) (0.50px none #000000) none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 74x19
                 text run at (1,1) width 74: "Row1 cell2"
-          RenderTableRow {TR} at (0,21) size 152x21
-            RenderTableCell {TD} at (0,21) size 76x21 [border: (0.50px solid #000000) none (0.50px solid #000000) (0.50px none #000000)] [r=1 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,21) size 152x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,21) size 76x21 [border: (0.50px none #000000) none (0.50px none #000000) (0.50px none #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 74x19
                 text run at (1,1) width 74: "Row2 cell1"
-            RenderTableCell {TD} at (75,21) size 77x21 [border: (0.50px solid #000000) (0.50px none #000000) (0.50px solid #000000) none] [r=1 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (75,21) size 77x21 [border: (0.50px none #000000) (0.50px none #000000) (0.50px none #000000) none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 74x19
                 text run at (1,1) width 74: "Row2 cell2"
-          RenderTableRow {TR} at (0,42) size 152x21
-            RenderTableCell {TD} at (0,42) size 76x21 [border: (0.50px solid #000000) none (0.50px solid #000000) (0.50px none #000000)] [r=2 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,42) size 152x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,42) size 76x21 [border: (0.50px none #000000) none (0.50px none #000000) (0.50px none #000000)] [r=2 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 74x19
                 text run at (1,1) width 74: "Row3 cell1"
-            RenderTableCell {TD} at (75,42) size 77x21 [border: (0.50px solid #000000) (0.50px none #000000) (0.50px solid #000000) none] [r=2 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (75,42) size 77x21 [border: (0.50px none #000000) (0.50px none #000000) (0.50px none #000000) none] [r=2 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 74x19
                 text run at (1,1) width 74: "Row3 cell2"
       RenderBlock {P} at (0,80) size 784x18

--- a/LayoutTests/platform/ios/tables/mozilla/core/table_rules-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla/core/table_rules-expected.txt
@@ -90,25 +90,25 @@ layer at (0,0) size 800x600
                 text run at (1,1) width 73: "col group 2"
       RenderBlock (anonymous) at (0,223) size 784x20
         RenderBR {BR} at (0,0) size 0x19
-      RenderTable {TABLE} at (0,243) size 69x47 [border: (0.50px outset #808080)]
-        RenderTableSection {TBODY} at (0,0) size 68x47
+      RenderTable {TABLE} at (0,243) size 69x46 [border: (0.50px outset #808080)]
+        RenderTableSection {TBODY} at (0,0) size 68x46
           RenderTableRow {TR} at (0,0) size 68x23
-            RenderTableCell {TD} at (0,0) size 34x23 [border: (0.50px solid #808080) none (0.50px solid #808080) (0.50px none #808080)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (0,0) size 34x23 [border: (0.50px none #808080) none none (0.50px none #808080)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 32x20
                 text run at (1,1) width 32: "rules"
-            RenderTableCell {TD} at (33,0) size 35x23 [border: (0.50px solid #808080) (0.50px none #808080) (0.50px solid #808080) none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (33,0) size 35x23 [border: (0.50px none #808080) (0.50px none #808080) none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 32x20
                 text run at (1,1) width 32: "rows"
-          RenderTableRow {TR} at (0,23) size 68x23
-            RenderTableCell {TD} at (0,23) size 34x23 [border: (0.50px solid #808080) none (0.50px solid #808080) (0.50px none #808080)] [r=1 c=0 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 32x20
+          RenderTableRow {TR} at (0,22) size 68x23
+            RenderTableCell {TD} at (0,22) size 34x23 [border: none none (0.50px none #808080) (0.50px none #808080)] [r=1 c=0 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 32x19
                 text run at (1,1) width 32: "rules"
-            RenderTableCell {TD} at (33,23) size 35x23 [border: (0.50px solid #808080) (0.50px none #808080) (0.50px solid #808080) none] [r=1 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 32x20
+            RenderTableCell {TD} at (33,22) size 35x23 [border: none (0.50px none #808080) (0.50px none #808080) none] [r=1 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 32x19
                 text run at (1,1) width 32: "rows"
-      RenderBlock (anonymous) at (0,290) size 784x20
+      RenderBlock (anonymous) at (0,289) size 784x20
         RenderBR {BR} at (0,0) size 0x19
-      RenderTable {TABLE} at (0,310) size 64x46 [border: (0.50px outset #808080)]
+      RenderTable {TABLE} at (0,309) size 64x46 [border: (0.50px outset #808080)]
         RenderTableSection {TBODY} at (0,0) size 64x46
           RenderTableRow {TR} at (0,0) size 63x23
             RenderTableCell {TD} at (0,0) size 35x23 [border: (0.50px none #808080) (0.50px solid #808080) none (0.50px solid #808080)] [r=0 c=0 rs=1 cs=1]
@@ -124,9 +124,9 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (34,22) size 29x23 [border: none (0.50px solid #808080) (0.50px none #808080) (0.50px solid #808080)] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 27x19
                 text run at (1,1) width 27: "cols"
-      RenderBlock (anonymous) at (0,356) size 784x20
+      RenderBlock (anonymous) at (0,355) size 784x20
         RenderBR {BR} at (0,0) size 0x19
-      RenderTable {TABLE} at (0,376) size 55x47 [border: (0.50px outset #808080)]
+      RenderTable {TABLE} at (0,375) size 55x47 [border: (0.50px outset #808080)]
         RenderTableSection {TBODY} at (0,0) size 54x47
           RenderTableRow {TR} at (0,0) size 54x23
             RenderTableCell {TD} at (0,0) size 35x23 [border: (0.50px solid #808080)] [r=0 c=0 rs=1 cs=1]
@@ -142,5 +142,5 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (34,23) size 20x23 [border: (0.50px solid #808080)] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 17x20
                 text run at (1,1) width 17: "all"
-      RenderBlock (anonymous) at (0,423) size 784x20
+      RenderBlock (anonymous) at (0,422) size 784x20
         RenderBR {BR} at (0,0) size 0x19

--- a/LayoutTests/platform/ios/tables/mozilla/core/table_rules-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla/core/table_rules-expected.txt
@@ -92,18 +92,18 @@ layer at (0,0) size 800x600
         RenderBR {BR} at (0,0) size 0x18
       RenderTable {TABLE} at (0,221) size 69x43 [border: (0.50px outset #000000)]
         RenderTableSection {TBODY} at (0,0) size 68x43
-          RenderTableRow {TR} at (0,0) size 68x21
-            RenderTableCell {TD} at (0,0) size 34x21 [border: (0.50px solid #000000) none (0.50px solid #000000) (0.50px none #000000)] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 68x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,0) size 34x21 [border: (0.50px none #000000) none (0.50px none #000000) (0.50px none #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 32x19
                 text run at (1,1) width 32: "rules"
-            RenderTableCell {TD} at (33,0) size 35x21 [border: (0.50px solid #000000) (0.50px none #000000) (0.50px solid #000000) none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (33,0) size 35x21 [border: (0.50px none #000000) (0.50px none #000000) (0.50px none #000000) none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 32x19
                 text run at (1,1) width 32: "rows"
-          RenderTableRow {TR} at (0,21) size 68x21
-            RenderTableCell {TD} at (0,21) size 34x21 [border: (0.50px solid #000000) none (0.50px solid #000000) (0.50px none #000000)] [r=1 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,21) size 68x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,21) size 34x21 [border: (0.50px none #000000) none (0.50px none #000000) (0.50px none #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 32x19
                 text run at (1,1) width 32: "rules"
-            RenderTableCell {TD} at (33,21) size 35x21 [border: (0.50px solid #000000) (0.50px none #000000) (0.50px solid #000000) none] [r=1 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (33,21) size 35x21 [border: (0.50px none #000000) (0.50px none #000000) (0.50px none #000000) none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 32x19
                 text run at (1,1) width 32: "rows"
       RenderBlock (anonymous) at (0,264) size 784x18

--- a/LayoutTests/platform/ios/tables/mozilla_expected_failures/marvin/table_rules_rows-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla_expected_failures/marvin/table_rules_rows-expected.txt
@@ -3,58 +3,58 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderTable {TABLE} at (0,0) size 417x121 [border: (2.50px outset #808080)]
+      RenderTable {TABLE} at (0,0) size 417x118 [border: (2.50px outset #808080)]
         RenderBlock {CAPTION} at (0,0) size 417x20
           RenderText {#text} at (10,0) size 396x19
             text run at (10,0) width 396: "Communicator 4.5 Installers for Mac and Windows Platforms"
-        RenderTableSection {TBODY} at (2,22) size 412x97
+        RenderTableSection {TBODY} at (2,22) size 412x94
           RenderTableRow {TR} at (0,0) size 412x25
-            RenderTableCell {TH} at (0,10) size 122x5 [border: (2.50px solid #808080) none (0.50px solid #808080) (2.50px none #808080)] [r=0 c=0 rs=1 cs=1]
-            RenderTableCell {TH} at (121,0) size 110x25 [border: (2.50px solid #808080) none (0.50px solid #808080) none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TH} at (0,10) size 122x5 [border: (2.50px none #808080) none none (2.50px none #808080)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TH} at (121,0) size 110x25 [border: (2.50px none #808080) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,3) size 108x20
                 text run at (1,3) width 108: "Macintosh PPC"
-            RenderTableCell {TH} at (230,0) size 87x25 [border: (2.50px solid #808080) none (0.50px solid #808080) none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TH} at (230,0) size 87x25 [border: (2.50px none #808080) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,3) size 84x20
                 text run at (1,3) width 84: "Windows 95"
-            RenderTableCell {TH} at (316,0) size 96x25 [border: (2.50px solid #808080) (2.50px none #808080) (0.50px solid #808080) none] [r=0 c=3 rs=1 cs=1]
+            RenderTableCell {TH} at (316,0) size 96x25 [border: (2.50px none #808080) (2.50px none #808080) none none] [r=0 c=3 rs=1 cs=1]
               RenderText {#text} at (1,3) size 90x20
                 text run at (1,3) width 90: "Windows NT"
-          RenderTableRow {TR} at (0,25) size 412x23
-            RenderTableCell {TD} at (0,25) size 122x23 [border: (0.50px solid #808080) none (0.50px solid #808080) (2.50px none #808080)] [r=1 c=0 rs=1 cs=1]
-              RenderText {#text} at (3,1) size 76x20
+          RenderTableRow {TR} at (0,24) size 412x23
+            RenderTableCell {TD} at (0,24) size 122x23 [border: none none none (2.50px none #808080)] [r=1 c=0 rs=1 cs=1]
+              RenderText {#text} at (3,1) size 76x19
                 text run at (3,1) width 76: "Base Install"
-            RenderTableCell {TD} at (121,25) size 110x23 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=1 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 22x20
+            RenderTableCell {TD} at (121,24) size 110x23 [r=1 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 22x19
                 text run at (1,1) width 22: "yes"
-            RenderTableCell {TD} at (230,25) size 87x23 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=1 c=2 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 22x20
+            RenderTableCell {TD} at (230,24) size 87x23 [r=1 c=2 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 22x19
                 text run at (1,1) width 22: "yes"
-            RenderTableCell {TD} at (316,25) size 96x23 [border: (0.50px solid #808080) (2.50px none #808080) (0.50px solid #808080) none] [r=1 c=3 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 22x20
+            RenderTableCell {TD} at (316,24) size 96x23 [border: none (2.50px none #808080) none none] [r=1 c=3 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 22x19
                 text run at (1,1) width 22: "yes"
-          RenderTableRow {TR} at (0,48) size 412x23
-            RenderTableCell {TD} at (0,48) size 122x23 [border: (0.50px solid #808080) none (0.50px solid #808080) (2.50px none #808080)] [r=2 c=0 rs=1 cs=1]
-              RenderText {#text} at (3,1) size 107x20
+          RenderTableRow {TR} at (0,46) size 412x23
+            RenderTableCell {TD} at (0,46) size 122x23 [border: none none none (2.50px none #808080)] [r=2 c=0 rs=1 cs=1]
+              RenderText {#text} at (3,1) size 107x19
                 text run at (3,1) width 107: "Complete Install"
-            RenderTableCell {TD} at (121,48) size 110x23 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=2 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 22x20
+            RenderTableCell {TD} at (121,46) size 110x23 [r=2 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 22x19
                 text run at (1,1) width 22: "yes"
-            RenderTableCell {TD} at (230,48) size 87x23 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=2 c=2 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 22x20
+            RenderTableCell {TD} at (230,46) size 87x23 [r=2 c=2 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 22x19
                 text run at (1,1) width 22: "yes"
-            RenderTableCell {TD} at (316,48) size 96x23 [border: (0.50px solid #808080) (2.50px none #808080) (0.50px solid #808080) none] [r=2 c=3 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 22x20
+            RenderTableCell {TD} at (316,46) size 96x23 [border: none (2.50px none #808080) none none] [r=2 c=3 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 22x19
                 text run at (1,1) width 22: "yes"
-          RenderTableRow {TR} at (0,71) size 412x25
-            RenderTableCell {TD} at (0,71) size 122x25 [border: (0.50px solid #808080) none (2.50px solid #808080) (2.50px none #808080)] [r=3 c=0 rs=1 cs=1]
-              RenderText {#text} at (3,1) size 118x20
+          RenderTableRow {TR} at (0,68) size 412x25
+            RenderTableCell {TD} at (0,68) size 122x25 [border: none none (2.50px none #808080) (2.50px none #808080)] [r=3 c=0 rs=1 cs=1]
+              RenderText {#text} at (3,1) size 118x19
                 text run at (3,1) width 118: "Pro Edition Install"
-            RenderTableCell {TD} at (121,71) size 110x25 [border: (0.50px solid #808080) none (2.50px solid #808080) none] [r=3 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 22x20
+            RenderTableCell {TD} at (121,68) size 110x25 [border: none none (2.50px none #808080) none] [r=3 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 22x19
                 text run at (1,1) width 22: "yes"
-            RenderTableCell {TD} at (230,71) size 87x25 [border: (0.50px solid #808080) none (2.50px solid #808080) none] [r=3 c=2 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 22x20
+            RenderTableCell {TD} at (230,68) size 87x25 [border: none none (2.50px none #808080) none] [r=3 c=2 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 22x19
                 text run at (1,1) width 22: "yes"
-            RenderTableCell {TD} at (316,71) size 96x25 [border: (0.50px solid #808080) (2.50px none #808080) (2.50px solid #808080) none] [r=3 c=3 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 22x20
+            RenderTableCell {TD} at (316,68) size 96x25 [border: none (2.50px none #808080) (2.50px none #808080) none] [r=3 c=3 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 22x19
                 text run at (1,1) width 22: "yes"

--- a/LayoutTests/platform/ios/tables/mozilla_expected_failures/marvin/table_rules_rows-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla_expected_failures/marvin/table_rules_rows-expected.txt
@@ -8,53 +8,53 @@ layer at (0,0) size 800x600
           RenderText {#text} at (10,0) size 396x18
             text run at (10,0) width 396: "Communicator 4.5 Installers for Mac and Windows Platforms"
         RenderTableSection {TBODY} at (2,20) size 412x89
-          RenderTableRow {TR} at (0,0) size 412x23
-            RenderTableCell {TH} at (0,9) size 122x5 [border: (2.50px solid #000000) none (0.50px solid #000000) (2.50px none #000000)] [r=0 c=0 rs=1 cs=1]
-            RenderTableCell {TH} at (121,0) size 110x23 [border: (2.50px solid #000000) none (0.50px solid #000000) none] [r=0 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 412x23 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TH} at (0,9) size 122x5 [border: (2.50px none #000000) none (0.50px none #000000) (2.50px none #000000)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TH} at (121,0) size 110x23 [border: (2.50px none #000000) none (0.50px none #000000) none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,3) size 108x19
                 text run at (1,3) width 108: "Macintosh PPC"
-            RenderTableCell {TH} at (230,0) size 87x23 [border: (2.50px solid #000000) none (0.50px solid #000000) none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TH} at (230,0) size 87x23 [border: (2.50px none #000000) none (0.50px none #000000) none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,3) size 84x19
                 text run at (1,3) width 84: "Windows 95"
-            RenderTableCell {TH} at (316,0) size 96x23 [border: (2.50px solid #000000) (2.50px none #000000) (0.50px solid #000000) none] [r=0 c=3 rs=1 cs=1]
+            RenderTableCell {TH} at (316,0) size 96x23 [border: (2.50px none #000000) (2.50px none #000000) (0.50px none #000000) none] [r=0 c=3 rs=1 cs=1]
               RenderText {#text} at (1,3) size 90x19
                 text run at (1,3) width 90: "Windows NT"
-          RenderTableRow {TR} at (0,23) size 412x21
-            RenderTableCell {TD} at (0,23) size 122x21 [border: (0.50px solid #000000) none (0.50px solid #000000) (2.50px none #000000)] [r=1 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,23) size 412x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,23) size 122x21 [border: (0.50px none #000000) none (0.50px none #000000) (2.50px none #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (3,1) size 76x19
                 text run at (3,1) width 76: "Base Install"
-            RenderTableCell {TD} at (121,23) size 110x21 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=1 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (121,23) size 110x21 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 22x19
                 text run at (1,1) width 22: "yes"
-            RenderTableCell {TD} at (230,23) size 87x21 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=1 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (230,23) size 87x21 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=1 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 22x19
                 text run at (1,1) width 22: "yes"
-            RenderTableCell {TD} at (316,23) size 96x21 [border: (0.50px solid #000000) (2.50px none #000000) (0.50px solid #000000) none] [r=1 c=3 rs=1 cs=1]
+            RenderTableCell {TD} at (316,23) size 96x21 [border: (0.50px none #000000) (2.50px none #000000) (0.50px none #000000) none] [r=1 c=3 rs=1 cs=1]
               RenderText {#text} at (1,1) size 22x19
                 text run at (1,1) width 22: "yes"
-          RenderTableRow {TR} at (0,44) size 412x21
-            RenderTableCell {TD} at (0,44) size 122x21 [border: (0.50px solid #000000) none (0.50px solid #000000) (2.50px none #000000)] [r=2 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,44) size 412x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,44) size 122x21 [border: (0.50px none #000000) none (0.50px none #000000) (2.50px none #000000)] [r=2 c=0 rs=1 cs=1]
               RenderText {#text} at (3,1) size 107x19
                 text run at (3,1) width 107: "Complete Install"
-            RenderTableCell {TD} at (121,44) size 110x21 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=2 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (121,44) size 110x21 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=2 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 22x19
                 text run at (1,1) width 22: "yes"
-            RenderTableCell {TD} at (230,44) size 87x21 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=2 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (230,44) size 87x21 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=2 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 22x19
                 text run at (1,1) width 22: "yes"
-            RenderTableCell {TD} at (316,44) size 96x21 [border: (0.50px solid #000000) (2.50px none #000000) (0.50px solid #000000) none] [r=2 c=3 rs=1 cs=1]
+            RenderTableCell {TD} at (316,44) size 96x21 [border: (0.50px none #000000) (2.50px none #000000) (0.50px none #000000) none] [r=2 c=3 rs=1 cs=1]
               RenderText {#text} at (1,1) size 22x19
                 text run at (1,1) width 22: "yes"
-          RenderTableRow {TR} at (0,65) size 412x23
-            RenderTableCell {TD} at (0,65) size 122x23 [border: (0.50px solid #000000) none (2.50px solid #000000) (2.50px none #000000)] [r=3 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,65) size 412x23 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,65) size 122x23 [border: (0.50px none #000000) none (2.50px none #000000) (2.50px none #000000)] [r=3 c=0 rs=1 cs=1]
               RenderText {#text} at (3,1) size 118x19
                 text run at (3,1) width 118: "Pro Edition Install"
-            RenderTableCell {TD} at (121,65) size 110x23 [border: (0.50px solid #000000) none (2.50px solid #000000) none] [r=3 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (121,65) size 110x23 [border: (0.50px none #000000) none (2.50px none #000000) none] [r=3 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 22x19
                 text run at (1,1) width 22: "yes"
-            RenderTableCell {TD} at (230,65) size 87x23 [border: (0.50px solid #000000) none (2.50px solid #000000) none] [r=3 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (230,65) size 87x23 [border: (0.50px none #000000) none (2.50px none #000000) none] [r=3 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 22x19
                 text run at (1,1) width 22: "yes"
-            RenderTableCell {TD} at (316,65) size 96x23 [border: (0.50px solid #000000) (2.50px none #000000) (2.50px solid #000000) none] [r=3 c=3 rs=1 cs=1]
+            RenderTableCell {TD} at (316,65) size 96x23 [border: (0.50px none #000000) (2.50px none #000000) (2.50px none #000000) none] [r=3 c=3 rs=1 cs=1]
               RenderText {#text} at (1,1) size 22x19
                 text run at (1,1) width 22: "yes"

--- a/LayoutTests/platform/ios/tables/mozilla_expected_failures/marvin/x_table_rules_rows-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla_expected_failures/marvin/x_table_rules_rows-expected.txt
@@ -1,59 +1,59 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x153
-  RenderBlock {html} at (0,0) size 800x153
-    RenderBody {body} at (8,16) size 784x129
+layer at (0,0) size 800x150
+  RenderBlock {html} at (0,0) size 800x150
+    RenderBody {body} at (8,16) size 784x126
       RenderBlock {p} at (0,0) size 784x20
         RenderText {#text} at (0,0) size 478x19
           text run at (0,0) width 400: "There should be rules between all rows (and only rows) in the "
           text run at (399,0) width 79: "table below."
-      RenderTable {table} at (0,36) size 179x93 [border: (0.50px outset #808080)]
+      RenderTable {table} at (0,36) size 179x90 [border: (0.50px outset #808080)]
         RenderTableCol {colgroup} at (0,0) size 0x0
           RenderTableCol {col} at (0,0) size 0x0
         RenderTableCol {colgroup} at (0,0) size 0x0
           RenderTableCol {col} at (0,0) size 0x0
         RenderTableCol {colgroup} at (0,0) size 0x0
           RenderTableCol {col} at (0,0) size 0x0
-        RenderTableSection {thead} at (0,0) size 179x24
+        RenderTableSection {thead} at (0,0) size 179x23
           RenderTableRow {tr} at (0,0) size 178x23
-            RenderTableCell {th} at (0,0) size 60x23 [border: (0.50px solid #808080) none (0.50px solid #808080) (0.50px none #808080)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {th} at (0,0) size 60x23 [border: (0.50px none #808080) none none (0.50px none #808080)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 58x20
                 text run at (1,1) width 58: "THEAD"
-            RenderTableCell {th} at (59,0) size 60x23 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {th} at (59,0) size 60x23 [border: (0.50px none #808080) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 57x20
                 text run at (1,1) width 57: "THEAD"
-            RenderTableCell {th} at (118,0) size 60x23 [border: (0.50px solid #808080) (0.50px none #808080) (0.50px solid #808080) none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {th} at (118,0) size 60x23 [border: (0.50px none #808080) (0.50px none #808080) none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 57x20
                 text run at (1,1) width 57: "THEAD"
-        RenderTableSection {tfoot} at (0,69) size 179x24
+        RenderTableSection {tfoot} at (0,67) size 179x23
           RenderTableRow {tr} at (0,0) size 178x23
-            RenderTableCell {td} at (0,0) size 60x23 [border: (0.50px solid #808080) none (0.50px solid #808080) (0.50px none #808080)] [r=0 c=0 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 53x20
+            RenderTableCell {td} at (0,0) size 60x23 [border: none none (0.50px none #808080) (0.50px none #808080)] [r=0 c=0 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 53x19
                 text run at (1,1) width 53: "TFOOT"
-            RenderTableCell {td} at (59,0) size 60x23 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=0 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 52x20
+            RenderTableCell {td} at (59,0) size 60x23 [border: none none (0.50px none #808080) none] [r=0 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 52x19
                 text run at (1,1) width 52: "TFOOT"
-            RenderTableCell {td} at (118,0) size 60x23 [border: (0.50px solid #808080) (0.50px none #808080) (0.50px solid #808080) none] [r=0 c=2 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 52x20
+            RenderTableCell {td} at (118,0) size 60x23 [border: none (0.50px none #808080) (0.50px none #808080) none] [r=0 c=2 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 52x19
                 text run at (1,1) width 52: "TFOOT"
-        RenderTableSection {tbody} at (0,23) size 179x47
-          RenderTableRow {tr} at (0,0) size 178x23
-            RenderTableCell {td} at (0,0) size 60x23 [border: (0.50px solid #808080) none (0.50px solid #808080) (0.50px none #808080)] [r=0 c=0 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 56x20
+        RenderTableSection {tbody} at (0,23) size 179x44
+          RenderTableRow {tr} at (0,0) size 178x22
+            RenderTableCell {td} at (0,0) size 60x22 [border: none none none (0.50px none #808080)] [r=0 c=0 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 56x19
                 text run at (1,1) width 56: "TBODY"
-            RenderTableCell {td} at (59,0) size 60x23 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=0 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 56x20
+            RenderTableCell {td} at (59,0) size 60x22 [r=0 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 56x19
                 text run at (1,1) width 56: "TBODY"
-            RenderTableCell {td} at (118,0) size 60x23 [border: (0.50px solid #808080) (0.50px none #808080) (0.50px solid #808080) none] [r=0 c=2 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 56x20
+            RenderTableCell {td} at (118,0) size 60x22 [border: none (0.50px none #808080) none none] [r=0 c=2 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 56x19
                 text run at (1,1) width 56: "TBODY"
-          RenderTableRow {tr} at (0,23) size 178x23
-            RenderTableCell {td} at (0,23) size 60x23 [border: (0.50px solid #808080) none (0.50px solid #808080) (0.50px none #808080)] [r=1 c=0 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 56x20
+          RenderTableRow {tr} at (0,22) size 178x22
+            RenderTableCell {td} at (0,22) size 60x22 [border: none none none (0.50px none #808080)] [r=1 c=0 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 56x19
                 text run at (1,1) width 56: "TBODY"
-            RenderTableCell {td} at (59,23) size 60x23 [border: (0.50px solid #808080) none (0.50px solid #808080) none] [r=1 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 56x20
+            RenderTableCell {td} at (59,22) size 60x22 [r=1 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 56x19
                 text run at (1,1) width 56: "TBODY"
-            RenderTableCell {td} at (118,23) size 60x23 [border: (0.50px solid #808080) (0.50px none #808080) (0.50px solid #808080) none] [r=1 c=2 rs=1 cs=1]
-              RenderText {#text} at (1,1) size 56x20
+            RenderTableCell {td} at (118,22) size 60x22 [border: none (0.50px none #808080) none none] [r=1 c=2 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 56x19
                 text run at (1,1) width 56: "TBODY"

--- a/LayoutTests/platform/ios/tables/mozilla_expected_failures/marvin/x_table_rules_rows-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla_expected_failures/marvin/x_table_rules_rows-expected.txt
@@ -15,45 +15,45 @@ layer at (0,0) size 800x143
         RenderTableCol {colgroup} at (0,0) size 0x0
           RenderTableCol {col} at (0,0) size 0x0
         RenderTableSection {thead} at (0,0) size 179x22
-          RenderTableRow {tr} at (0,0) size 178x21
-            RenderTableCell {th} at (0,0) size 60x21 [border: (0.50px solid #000000) none (0.50px solid #000000) (0.50px none #000000)] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {tr} at (0,0) size 178x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {th} at (0,0) size 60x21 [border: (0.50px none #000000) none (0.50px none #000000) (0.50px none #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 58x19
                 text run at (1,1) width 58: "THEAD"
-            RenderTableCell {th} at (59,0) size 60x21 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {th} at (59,0) size 60x21 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 57x19
                 text run at (1,1) width 57: "THEAD"
-            RenderTableCell {th} at (118,0) size 60x21 [border: (0.50px solid #000000) (0.50px none #000000) (0.50px solid #000000) none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {th} at (118,0) size 60x21 [border: (0.50px none #000000) (0.50px none #000000) (0.50px none #000000) none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 57x19
                 text run at (1,1) width 57: "THEAD"
         RenderTableSection {tfoot} at (0,63) size 179x22
-          RenderTableRow {tr} at (0,0) size 178x21
-            RenderTableCell {td} at (0,0) size 60x21 [border: (0.50px solid #000000) none (0.50px solid #000000) (0.50px none #000000)] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {tr} at (0,0) size 178x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {td} at (0,0) size 60x21 [border: (0.50px none #000000) none (0.50px none #000000) (0.50px none #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 53x19
                 text run at (1,1) width 53: "TFOOT"
-            RenderTableCell {td} at (59,0) size 60x21 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {td} at (59,0) size 60x21 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 52x19
                 text run at (1,1) width 52: "TFOOT"
-            RenderTableCell {td} at (118,0) size 60x21 [border: (0.50px solid #000000) (0.50px none #000000) (0.50px solid #000000) none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {td} at (118,0) size 60x21 [border: (0.50px none #000000) (0.50px none #000000) (0.50px none #000000) none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 52x19
                 text run at (1,1) width 52: "TFOOT"
         RenderTableSection {tbody} at (0,21) size 179x43
-          RenderTableRow {tr} at (0,0) size 178x21
-            RenderTableCell {td} at (0,0) size 60x21 [border: (0.50px solid #000000) none (0.50px solid #000000) (0.50px none #000000)] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {tr} at (0,0) size 178x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {td} at (0,0) size 60x21 [border: (0.50px none #000000) none (0.50px none #000000) (0.50px none #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 56x19
                 text run at (1,1) width 56: "TBODY"
-            RenderTableCell {td} at (59,0) size 60x21 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {td} at (59,0) size 60x21 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 56x19
                 text run at (1,1) width 56: "TBODY"
-            RenderTableCell {td} at (118,0) size 60x21 [border: (0.50px solid #000000) (0.50px none #000000) (0.50px solid #000000) none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {td} at (118,0) size 60x21 [border: (0.50px none #000000) (0.50px none #000000) (0.50px none #000000) none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 56x19
                 text run at (1,1) width 56: "TBODY"
-          RenderTableRow {tr} at (0,21) size 178x21
-            RenderTableCell {td} at (0,21) size 60x21 [border: (0.50px solid #000000) none (0.50px solid #000000) (0.50px none #000000)] [r=1 c=0 rs=1 cs=1]
+          RenderTableRow {tr} at (0,21) size 178x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {td} at (0,21) size 60x21 [border: (0.50px none #000000) none (0.50px none #000000) (0.50px none #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 56x19
                 text run at (1,1) width 56: "TBODY"
-            RenderTableCell {td} at (59,21) size 60x21 [border: (0.50px solid #000000) none (0.50px solid #000000) none] [r=1 c=1 rs=1 cs=1]
+            RenderTableCell {td} at (59,21) size 60x21 [border: (0.50px none #000000) none (0.50px none #000000) none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 56x19
                 text run at (1,1) width 56: "TBODY"
-            RenderTableCell {td} at (118,21) size 60x21 [border: (0.50px solid #000000) (0.50px none #000000) (0.50px solid #000000) none] [r=1 c=2 rs=1 cs=1]
+            RenderTableCell {td} at (118,21) size 60x21 [border: (0.50px none #000000) (0.50px none #000000) (0.50px none #000000) none] [r=1 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 56x19
                 text run at (1,1) width 56: "TBODY"

--- a/LayoutTests/platform/mac/fast/table/frame-and-rules-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/frame-and-rules-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 785x7608
+layer at (0,0) size 785x7572
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x7608
-  RenderBlock {HTML} at (0,0) size 785x7608
-    RenderBody {BODY} at (8,8) size 769x7552
+layer at (0,0) size 785x7572
+  RenderBlock {HTML} at (0,0) size 785x7572
+    RenderBody {BODY} at (8,8) size 769x7516
       RenderTable {TABLE} at (0,0) size 273x118
         RenderBlock {CAPTION} at (0,0) size 273x18
           RenderInline {A} at (0,0) size 227x18
@@ -885,7 +885,7 @@ layer at (0,0) size 785x7608
             RenderTableCell {TD} at (182,0) size 92x21 [border: (1px none #000000)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,3022) size 273x122
+      RenderTable {TABLE} at (0,3022) size 273x118
         RenderBlock {CAPTION} at (0,0) size 273x18
           RenderInline {A} at (0,0) size 225x18
             RenderText {#text} at (21,0) size 225x18
@@ -904,37 +904,37 @@ layer at (0,0) size 785x7608
             RenderTableCell {TD} at (181,0) size 92x20 [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x18
                 text run at (1,1) width 89: "Row 1, Cell 3"
-        RenderTableSection {TBODY} at (0,38) size 273x63
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,10) size 91x22 [border: (1px solid #808080) none none none] [r=0 c=0 rs=2 cs=1]
-              RenderText {#text} at (1,1) size 89x20
-                text run at (1,2) width 89: "Row 2, Cell 1"
-            RenderTableCell {TD} at (90,0) size 183x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=2]
-              RenderText {#text} at (1,2) size 89x18
-                text run at (1,2) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,21) size 273x21
-            RenderTableCell {TD} at (90,21) size 92x21 [border: (1px solid #808080) none none none] [r=1 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x18
-                text run at (1,2) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (181,31) size 92x22 [border: (1px solid #808080) none none none] [r=1 c=2 rs=2 cs=1]
-              RenderText {#text} at (1,1) size 89x20
-                text run at (1,2) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,42) size 273x21
-            RenderTableCell {TD} at (0,42) size 182x21 [border: (1px solid #808080) none none none] [r=2 c=0 rs=1 cs=2]
-              RenderText {#text} at (1,2) size 89x18
-                text run at (1,2) width 89: "Row 4, Cell 1"
-        RenderTableSection {TFOOT} at (0,101) size 273x21
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,0) size 91x21 [border: (1px solid #808080) none none none] [r=0 c=0 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x18
-                text run at (1,2) width 89: "Row 5, Cell 1"
-            RenderTableCell {TD} at (90,0) size 92x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x18
-                text run at (1,2) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (181,0) size 92x21 [border: (1px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x18
-                text run at (1,2) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,3192) size 273x123
+        RenderTableSection {TBODY} at (0,38) size 273x60
+          RenderTableRow {TR} at (0,0) size 273x20
+            RenderTableCell {TD} at (0,10) size 91x20 [r=0 c=0 rs=2 cs=1]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 2, Cell 1"
+            RenderTableCell {TD} at (90,0) size 183x20 [r=0 c=1 rs=1 cs=2]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 2, Cell 2"
+          RenderTableRow {TR} at (0,20) size 273x20
+            RenderTableCell {TD} at (90,20) size 92x20 [r=1 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 3, Cell 2"
+            RenderTableCell {TD} at (181,30) size 92x20 [r=1 c=2 rs=2 cs=1]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 3, Cell 3"
+          RenderTableRow {TR} at (0,40) size 273x20
+            RenderTableCell {TD} at (0,40) size 182x20 [r=2 c=0 rs=1 cs=2]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 4, Cell 1"
+        RenderTableSection {TFOOT} at (0,98) size 273x20
+          RenderTableRow {TR} at (0,0) size 273x20
+            RenderTableCell {TD} at (0,0) size 91x20 [r=0 c=0 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 5, Cell 1"
+            RenderTableCell {TD} at (90,0) size 92x20 [r=0 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 5, Cell 2"
+            RenderTableCell {TD} at (181,0) size 92x20 [r=0 c=2 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 5, Cell 3"
+      RenderTable {TABLE} at (0,3188) size 273x119
         RenderBlock {CAPTION} at (0,0) size 273x18
           RenderInline {A} at (0,0) size 235x18
             RenderText {#text} at (16,0) size 235x18
@@ -944,46 +944,46 @@ layer at (0,0) size 785x7608
               text run at (250,0) width 7: ":"
         RenderTableSection {THEAD} at (0,18) size 273x21
           RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,0) size 91x21 [border: (1px solid #808080) none none none] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (0,0) size 91x21 [border: (1px none #808080) none none none] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 1, Cell 1"
-            RenderTableCell {TD} at (90,0) size 92x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (90,0) size 92x21 [border: (1px none #808080) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 1, Cell 2"
-            RenderTableCell {TD} at (181,0) size 92x21 [border: (1px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (181,0) size 92x21 [border: (1px none #808080) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 1, Cell 3"
-        RenderTableSection {TBODY} at (0,39) size 273x63
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,10) size 91x22 [border: (1px solid #808080) none none none] [r=0 c=0 rs=2 cs=1]
-              RenderText {#text} at (1,1) size 89x20
-                text run at (1,2) width 89: "Row 2, Cell 1"
-            RenderTableCell {TD} at (90,0) size 183x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=2]
-              RenderText {#text} at (1,2) size 89x18
-                text run at (1,2) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,21) size 273x21
-            RenderTableCell {TD} at (90,21) size 92x21 [border: (1px solid #808080) none none none] [r=1 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x18
-                text run at (1,2) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (181,31) size 92x22 [border: (1px solid #808080) none none none] [r=1 c=2 rs=2 cs=1]
-              RenderText {#text} at (1,1) size 89x20
-                text run at (1,2) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,42) size 273x21
-            RenderTableCell {TD} at (0,42) size 182x21 [border: (1px solid #808080) none none none] [r=2 c=0 rs=1 cs=2]
-              RenderText {#text} at (1,2) size 89x18
-                text run at (1,2) width 89: "Row 4, Cell 1"
-        RenderTableSection {TFOOT} at (0,102) size 273x21
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,0) size 91x21 [border: (1px solid #808080) none none none] [r=0 c=0 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x18
-                text run at (1,2) width 89: "Row 5, Cell 1"
-            RenderTableCell {TD} at (90,0) size 92x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x18
-                text run at (1,2) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (181,0) size 92x21 [border: (1px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x18
-                text run at (1,2) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,3363) size 273x123 [border: none (1px solid #808080) none]
+        RenderTableSection {TBODY} at (0,39) size 273x60
+          RenderTableRow {TR} at (0,0) size 273x20
+            RenderTableCell {TD} at (0,10) size 91x20 [r=0 c=0 rs=2 cs=1]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 2, Cell 1"
+            RenderTableCell {TD} at (90,0) size 183x20 [r=0 c=1 rs=1 cs=2]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 2, Cell 2"
+          RenderTableRow {TR} at (0,20) size 273x20
+            RenderTableCell {TD} at (90,20) size 92x20 [r=1 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 3, Cell 2"
+            RenderTableCell {TD} at (181,30) size 92x20 [r=1 c=2 rs=2 cs=1]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 3, Cell 3"
+          RenderTableRow {TR} at (0,40) size 273x20
+            RenderTableCell {TD} at (0,40) size 182x20 [r=2 c=0 rs=1 cs=2]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 4, Cell 1"
+        RenderTableSection {TFOOT} at (0,99) size 273x20
+          RenderTableRow {TR} at (0,0) size 273x20
+            RenderTableCell {TD} at (0,0) size 91x20 [r=0 c=0 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 5, Cell 1"
+            RenderTableCell {TD} at (90,0) size 92x20 [r=0 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 5, Cell 2"
+            RenderTableCell {TD} at (181,0) size 92x20 [r=0 c=2 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 5, Cell 3"
+      RenderTable {TABLE} at (0,3355) size 273x119 [border: none (1px solid #808080) none]
         RenderBlock {CAPTION} at (0,0) size 273x18
           RenderInline {A} at (0,0) size 235x18
             RenderText {#text} at (16,0) size 235x18
@@ -1002,37 +1002,37 @@ layer at (0,0) size 785x7608
             RenderTableCell {TD} at (181,0) size 92x20 [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x18
                 text run at (1,1) width 89: "Row 1, Cell 3"
-        RenderTableSection {TBODY} at (0,38) size 273x63
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,10) size 91x22 [border: (1px solid #808080) none none none] [r=0 c=0 rs=2 cs=1]
-              RenderText {#text} at (1,1) size 89x20
-                text run at (1,2) width 89: "Row 2, Cell 1"
-            RenderTableCell {TD} at (90,0) size 183x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=2]
-              RenderText {#text} at (1,2) size 89x18
-                text run at (1,2) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,21) size 273x21
-            RenderTableCell {TD} at (90,21) size 92x21 [border: (1px solid #808080) none none none] [r=1 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x18
-                text run at (1,2) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (181,31) size 92x22 [border: (1px solid #808080) none none none] [r=1 c=2 rs=2 cs=1]
-              RenderText {#text} at (1,1) size 89x20
-                text run at (1,2) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,42) size 273x21
-            RenderTableCell {TD} at (0,42) size 182x21 [border: (1px solid #808080) none none none] [r=2 c=0 rs=1 cs=2]
-              RenderText {#text} at (1,2) size 89x18
-                text run at (1,2) width 89: "Row 4, Cell 1"
-        RenderTableSection {TFOOT} at (0,101) size 273x21
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,0) size 91x21 [border: (1px solid #808080) none none none] [r=0 c=0 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x18
-                text run at (1,2) width 89: "Row 5, Cell 1"
-            RenderTableCell {TD} at (90,0) size 92x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x18
-                text run at (1,2) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (181,0) size 92x21 [border: (1px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x18
-                text run at (1,2) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,3534) size 273x124 [border: none none (1px solid #808080) none]
+        RenderTableSection {TBODY} at (0,38) size 273x60
+          RenderTableRow {TR} at (0,0) size 273x20
+            RenderTableCell {TD} at (0,10) size 91x20 [r=0 c=0 rs=2 cs=1]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 2, Cell 1"
+            RenderTableCell {TD} at (90,0) size 183x20 [r=0 c=1 rs=1 cs=2]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 2, Cell 2"
+          RenderTableRow {TR} at (0,20) size 273x20
+            RenderTableCell {TD} at (90,20) size 92x20 [r=1 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 3, Cell 2"
+            RenderTableCell {TD} at (181,30) size 92x20 [r=1 c=2 rs=2 cs=1]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 3, Cell 3"
+          RenderTableRow {TR} at (0,40) size 273x20
+            RenderTableCell {TD} at (0,40) size 182x20 [r=2 c=0 rs=1 cs=2]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 4, Cell 1"
+        RenderTableSection {TFOOT} at (0,98) size 273x20
+          RenderTableRow {TR} at (0,0) size 273x20
+            RenderTableCell {TD} at (0,0) size 91x20 [r=0 c=0 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 5, Cell 1"
+            RenderTableCell {TD} at (90,0) size 92x20 [r=0 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 5, Cell 2"
+            RenderTableCell {TD} at (181,0) size 92x20 [r=0 c=2 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 5, Cell 3"
+      RenderTable {TABLE} at (0,3522) size 273x120 [border: none none (1px solid #808080) none]
         RenderBlock {CAPTION} at (0,0) size 273x18
           RenderInline {A} at (0,0) size 238x18
             RenderText {#text} at (15,0) size 238x18
@@ -1042,46 +1042,46 @@ layer at (0,0) size 785x7608
               text run at (252,0) width 6: ":"
         RenderTableSection {THEAD} at (0,18) size 273x21
           RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,0) size 91x21 [border: (1px solid #808080) none none none] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (0,0) size 91x21 [border: (1px none #808080) none none none] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 1, Cell 1"
-            RenderTableCell {TD} at (90,0) size 92x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (90,0) size 92x21 [border: (1px none #808080) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 1, Cell 2"
-            RenderTableCell {TD} at (181,0) size 92x21 [border: (1px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (181,0) size 92x21 [border: (1px none #808080) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 1, Cell 3"
-        RenderTableSection {TBODY} at (0,39) size 273x63
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,10) size 91x22 [border: (1px solid #808080) none none none] [r=0 c=0 rs=2 cs=1]
-              RenderText {#text} at (1,1) size 89x20
-                text run at (1,2) width 89: "Row 2, Cell 1"
-            RenderTableCell {TD} at (90,0) size 183x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=2]
-              RenderText {#text} at (1,2) size 89x18
-                text run at (1,2) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,21) size 273x21
-            RenderTableCell {TD} at (90,21) size 92x21 [border: (1px solid #808080) none none none] [r=1 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x18
-                text run at (1,2) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (181,31) size 92x22 [border: (1px solid #808080) none none none] [r=1 c=2 rs=2 cs=1]
-              RenderText {#text} at (1,1) size 89x20
-                text run at (1,2) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,42) size 273x21
-            RenderTableCell {TD} at (0,42) size 182x21 [border: (1px solid #808080) none none none] [r=2 c=0 rs=1 cs=2]
-              RenderText {#text} at (1,2) size 89x18
-                text run at (1,2) width 89: "Row 4, Cell 1"
-        RenderTableSection {TFOOT} at (0,102) size 273x21
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,0) size 91x21 [border: (1px solid #808080) none none none] [r=0 c=0 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x18
-                text run at (1,2) width 89: "Row 5, Cell 1"
-            RenderTableCell {TD} at (90,0) size 92x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x18
-                text run at (1,2) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (181,0) size 92x21 [border: (1px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x18
-                text run at (1,2) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,3706) size 275x122 [border: none (1px solid #808080) none none]
+        RenderTableSection {TBODY} at (0,39) size 273x60
+          RenderTableRow {TR} at (0,0) size 273x20
+            RenderTableCell {TD} at (0,10) size 91x20 [r=0 c=0 rs=2 cs=1]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 2, Cell 1"
+            RenderTableCell {TD} at (90,0) size 183x20 [r=0 c=1 rs=1 cs=2]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 2, Cell 2"
+          RenderTableRow {TR} at (0,20) size 273x20
+            RenderTableCell {TD} at (90,20) size 92x20 [r=1 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 3, Cell 2"
+            RenderTableCell {TD} at (181,30) size 92x20 [r=1 c=2 rs=2 cs=1]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 3, Cell 3"
+          RenderTableRow {TR} at (0,40) size 273x20
+            RenderTableCell {TD} at (0,40) size 182x20 [r=2 c=0 rs=1 cs=2]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 4, Cell 1"
+        RenderTableSection {TFOOT} at (0,99) size 273x20
+          RenderTableRow {TR} at (0,0) size 273x20
+            RenderTableCell {TD} at (0,0) size 91x20 [r=0 c=0 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 5, Cell 1"
+            RenderTableCell {TD} at (90,0) size 92x20 [r=0 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 5, Cell 2"
+            RenderTableCell {TD} at (181,0) size 92x20 [r=0 c=2 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 5, Cell 3"
+      RenderTable {TABLE} at (0,3690) size 275x118 [border: none (1px solid #808080) none none]
         RenderBlock {CAPTION} at (0,0) size 275x18
           RenderInline {A} at (0,0) size 236x18
             RenderText {#text} at (17,0) size 236x18
@@ -1100,37 +1100,37 @@ layer at (0,0) size 785x7608
             RenderTableCell {TD} at (182,0) size 92x20 [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x18
                 text run at (1,1) width 89: "Row 1, Cell 3"
-        RenderTableSection {TBODY} at (0,38) size 274x63
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,10) size 92x22 [border: (1px solid #808080) none none (1px none #808080)] [r=0 c=0 rs=2 cs=1]
-              RenderText {#text} at (2,1) size 89x20
-                text run at (2,2) width 89: "Row 2, Cell 1"
-            RenderTableCell {TD} at (91,0) size 183x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=2]
-              RenderText {#text} at (1,2) size 89x18
-                text run at (1,2) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,21) size 274x21
-            RenderTableCell {TD} at (91,21) size 92x21 [border: (1px solid #808080) none none none] [r=1 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x18
-                text run at (1,2) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (182,31) size 92x22 [border: (1px solid #808080) none none none] [r=1 c=2 rs=2 cs=1]
-              RenderText {#text} at (1,1) size 89x20
-                text run at (1,2) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,42) size 274x21
-            RenderTableCell {TD} at (0,42) size 183x21 [border: (1px solid #808080) none none (1px none #808080)] [r=2 c=0 rs=1 cs=2]
-              RenderText {#text} at (2,2) size 89x18
-                text run at (2,2) width 89: "Row 4, Cell 1"
-        RenderTableSection {TFOOT} at (0,101) size 274x21
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,0) size 92x21 [border: (1px solid #808080) none none (1px none #808080)] [r=0 c=0 rs=1 cs=1]
-              RenderText {#text} at (2,2) size 89x18
-                text run at (2,2) width 89: "Row 5, Cell 1"
-            RenderTableCell {TD} at (91,0) size 92x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x18
-                text run at (1,2) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (182,0) size 92x21 [border: (1px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x18
-                text run at (1,2) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,3876) size 274x122
+        RenderTableSection {TBODY} at (0,38) size 274x60
+          RenderTableRow {TR} at (0,0) size 274x20
+            RenderTableCell {TD} at (0,10) size 92x20 [border: none none none (1px none #808080)] [r=0 c=0 rs=2 cs=1]
+              RenderText {#text} at (2,1) size 89x18
+                text run at (2,1) width 89: "Row 2, Cell 1"
+            RenderTableCell {TD} at (91,0) size 183x20 [r=0 c=1 rs=1 cs=2]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 2, Cell 2"
+          RenderTableRow {TR} at (0,20) size 274x20
+            RenderTableCell {TD} at (91,20) size 92x20 [r=1 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 3, Cell 2"
+            RenderTableCell {TD} at (182,30) size 92x20 [r=1 c=2 rs=2 cs=1]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 3, Cell 3"
+          RenderTableRow {TR} at (0,40) size 274x20
+            RenderTableCell {TD} at (0,40) size 183x20 [border: none none none (1px none #808080)] [r=2 c=0 rs=1 cs=2]
+              RenderText {#text} at (2,1) size 89x18
+                text run at (2,1) width 89: "Row 4, Cell 1"
+        RenderTableSection {TFOOT} at (0,98) size 274x20
+          RenderTableRow {TR} at (0,0) size 274x20
+            RenderTableCell {TD} at (0,0) size 92x20 [border: none none none (1px none #808080)] [r=0 c=0 rs=1 cs=1]
+              RenderText {#text} at (2,1) size 89x18
+                text run at (2,1) width 89: "Row 5, Cell 1"
+            RenderTableCell {TD} at (91,0) size 92x20 [r=0 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 5, Cell 2"
+            RenderTableCell {TD} at (182,0) size 92x20 [r=0 c=2 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 5, Cell 3"
+      RenderTable {TABLE} at (0,3856) size 274x118
         RenderBlock {CAPTION} at (0,0) size 274x18
           RenderInline {A} at (0,0) size 216x18
             RenderText {#text} at (26,0) size 216x18
@@ -1149,37 +1149,37 @@ layer at (0,0) size 785x7608
             RenderTableCell {TD} at (182,0) size 92x20 [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x18
                 text run at (1,1) width 89: "Row 1, Cell 3"
-        RenderTableSection {TBODY} at (0,38) size 274x63
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,10) size 92x22 [border: (1px solid #808080) none none (1px none #808080)] [r=0 c=0 rs=2 cs=1]
-              RenderText {#text} at (2,1) size 89x20
-                text run at (2,2) width 89: "Row 2, Cell 1"
-            RenderTableCell {TD} at (91,0) size 183x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=2]
-              RenderText {#text} at (1,2) size 89x18
-                text run at (1,2) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,21) size 274x21
-            RenderTableCell {TD} at (91,21) size 92x21 [border: (1px solid #808080) none none none] [r=1 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x18
-                text run at (1,2) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (182,31) size 92x22 [border: (1px solid #808080) none none none] [r=1 c=2 rs=2 cs=1]
-              RenderText {#text} at (1,1) size 89x20
-                text run at (1,2) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,42) size 274x21
-            RenderTableCell {TD} at (0,42) size 183x21 [border: (1px solid #808080) none none (1px none #808080)] [r=2 c=0 rs=1 cs=2]
-              RenderText {#text} at (2,2) size 89x18
-                text run at (2,2) width 89: "Row 4, Cell 1"
-        RenderTableSection {TFOOT} at (0,101) size 274x21
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,0) size 92x21 [border: (1px solid #808080) none none (1px none #808080)] [r=0 c=0 rs=1 cs=1]
-              RenderText {#text} at (2,2) size 89x18
-                text run at (2,2) width 89: "Row 5, Cell 1"
-            RenderTableCell {TD} at (91,0) size 92x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x18
-                text run at (1,2) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (182,0) size 92x21 [border: (1px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x18
-                text run at (1,2) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,4046) size 274x122 [border: none (1px solid #808080) none]
+        RenderTableSection {TBODY} at (0,38) size 274x60
+          RenderTableRow {TR} at (0,0) size 274x20
+            RenderTableCell {TD} at (0,10) size 92x20 [border: none none none (1px none #808080)] [r=0 c=0 rs=2 cs=1]
+              RenderText {#text} at (2,1) size 89x18
+                text run at (2,1) width 89: "Row 2, Cell 1"
+            RenderTableCell {TD} at (91,0) size 183x20 [r=0 c=1 rs=1 cs=2]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 2, Cell 2"
+          RenderTableRow {TR} at (0,20) size 274x20
+            RenderTableCell {TD} at (91,20) size 92x20 [r=1 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 3, Cell 2"
+            RenderTableCell {TD} at (182,30) size 92x20 [r=1 c=2 rs=2 cs=1]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 3, Cell 3"
+          RenderTableRow {TR} at (0,40) size 274x20
+            RenderTableCell {TD} at (0,40) size 183x20 [border: none none none (1px none #808080)] [r=2 c=0 rs=1 cs=2]
+              RenderText {#text} at (2,1) size 89x18
+                text run at (2,1) width 89: "Row 4, Cell 1"
+        RenderTableSection {TFOOT} at (0,98) size 274x20
+          RenderTableRow {TR} at (0,0) size 274x20
+            RenderTableCell {TD} at (0,0) size 92x20 [border: none none none (1px none #808080)] [r=0 c=0 rs=1 cs=1]
+              RenderText {#text} at (2,1) size 89x18
+                text run at (2,1) width 89: "Row 5, Cell 1"
+            RenderTableCell {TD} at (91,0) size 92x20 [r=0 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 5, Cell 2"
+            RenderTableCell {TD} at (182,0) size 92x20 [r=0 c=2 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 5, Cell 3"
+      RenderTable {TABLE} at (0,4022) size 274x118 [border: none (1px solid #808080) none]
         RenderBlock {CAPTION} at (0,0) size 274x18
           RenderInline {A} at (0,0) size 218x18
             RenderText {#text} at (25,0) size 218x18
@@ -1198,37 +1198,37 @@ layer at (0,0) size 785x7608
             RenderTableCell {TD} at (181,0) size 92x20 [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x18
                 text run at (1,1) width 89: "Row 1, Cell 3"
-        RenderTableSection {TBODY} at (0,38) size 273x63
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,10) size 91x22 [border: (1px solid #808080) none none none] [r=0 c=0 rs=2 cs=1]
-              RenderText {#text} at (1,1) size 89x20
-                text run at (1,2) width 89: "Row 2, Cell 1"
-            RenderTableCell {TD} at (90,0) size 183x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=2]
-              RenderText {#text} at (1,2) size 89x18
-                text run at (1,2) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,21) size 273x21
-            RenderTableCell {TD} at (90,21) size 92x21 [border: (1px solid #808080) none none none] [r=1 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x18
-                text run at (1,2) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (181,31) size 92x22 [border: (1px solid #808080) none none none] [r=1 c=2 rs=2 cs=1]
-              RenderText {#text} at (1,1) size 89x20
-                text run at (1,2) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,42) size 273x21
-            RenderTableCell {TD} at (0,42) size 182x21 [border: (1px solid #808080) none none none] [r=2 c=0 rs=1 cs=2]
-              RenderText {#text} at (1,2) size 89x18
-                text run at (1,2) width 89: "Row 4, Cell 1"
-        RenderTableSection {TFOOT} at (0,101) size 273x21
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,0) size 91x21 [border: (1px solid #808080) none none none] [r=0 c=0 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x18
-                text run at (1,2) width 89: "Row 5, Cell 1"
-            RenderTableCell {TD} at (90,0) size 92x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x18
-                text run at (1,2) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (181,0) size 92x21 [border: (1px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x18
-                text run at (1,2) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,4216) size 275x124 [border: none]
+        RenderTableSection {TBODY} at (0,38) size 273x60
+          RenderTableRow {TR} at (0,0) size 273x20
+            RenderTableCell {TD} at (0,10) size 91x20 [r=0 c=0 rs=2 cs=1]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 2, Cell 1"
+            RenderTableCell {TD} at (90,0) size 183x20 [r=0 c=1 rs=1 cs=2]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 2, Cell 2"
+          RenderTableRow {TR} at (0,20) size 273x20
+            RenderTableCell {TD} at (90,20) size 92x20 [r=1 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 3, Cell 2"
+            RenderTableCell {TD} at (181,30) size 92x20 [r=1 c=2 rs=2 cs=1]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 3, Cell 3"
+          RenderTableRow {TR} at (0,40) size 273x20
+            RenderTableCell {TD} at (0,40) size 182x20 [r=2 c=0 rs=1 cs=2]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 4, Cell 1"
+        RenderTableSection {TFOOT} at (0,98) size 273x20
+          RenderTableRow {TR} at (0,0) size 273x20
+            RenderTableCell {TD} at (0,0) size 91x20 [r=0 c=0 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 5, Cell 1"
+            RenderTableCell {TD} at (90,0) size 92x20 [r=0 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 5, Cell 2"
+            RenderTableCell {TD} at (181,0) size 92x20 [r=0 c=2 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 5, Cell 3"
+      RenderTable {TABLE} at (0,4188) size 275x120 [border: none]
         RenderBlock {CAPTION} at (0,0) size 275x18
           RenderInline {A} at (0,0) size 221x18
             RenderText {#text} at (24,0) size 221x18
@@ -1238,46 +1238,46 @@ layer at (0,0) size 785x7608
               text run at (244,0) width 7: ":"
         RenderTableSection {THEAD} at (0,18) size 274x21
           RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,0) size 92x21 [border: (1px solid #808080) none none (1px none #808080)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (0,0) size 92x21 [border: (1px none #808080) none none (1px none #808080)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 89x18
                 text run at (2,2) width 89: "Row 1, Cell 1"
-            RenderTableCell {TD} at (91,0) size 92x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (91,0) size 92x21 [border: (1px none #808080) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 1, Cell 2"
-            RenderTableCell {TD} at (182,0) size 92x21 [border: (1px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (182,0) size 92x21 [border: (1px none #808080) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 1, Cell 3"
-        RenderTableSection {TBODY} at (0,39) size 274x63
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,10) size 92x22 [border: (1px solid #808080) none none (1px none #808080)] [r=0 c=0 rs=2 cs=1]
-              RenderText {#text} at (2,1) size 89x20
-                text run at (2,2) width 89: "Row 2, Cell 1"
-            RenderTableCell {TD} at (91,0) size 183x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=2]
-              RenderText {#text} at (1,2) size 89x18
-                text run at (1,2) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,21) size 274x21
-            RenderTableCell {TD} at (91,21) size 92x21 [border: (1px solid #808080) none none none] [r=1 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x18
-                text run at (1,2) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (182,31) size 92x22 [border: (1px solid #808080) none none none] [r=1 c=2 rs=2 cs=1]
-              RenderText {#text} at (1,1) size 89x20
-                text run at (1,2) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,42) size 274x21
-            RenderTableCell {TD} at (0,42) size 183x21 [border: (1px solid #808080) none none (1px none #808080)] [r=2 c=0 rs=1 cs=2]
-              RenderText {#text} at (2,2) size 89x18
-                text run at (2,2) width 89: "Row 4, Cell 1"
-        RenderTableSection {TFOOT} at (0,102) size 274x21
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,0) size 92x21 [border: (1px solid #808080) none none (1px none #808080)] [r=0 c=0 rs=1 cs=1]
-              RenderText {#text} at (2,2) size 89x18
-                text run at (2,2) width 89: "Row 5, Cell 1"
-            RenderTableCell {TD} at (91,0) size 92x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x18
-                text run at (1,2) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (182,0) size 92x21 [border: (1px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x18
-                text run at (1,2) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,4388) size 275x124 [border: none]
+        RenderTableSection {TBODY} at (0,39) size 274x60
+          RenderTableRow {TR} at (0,0) size 274x20
+            RenderTableCell {TD} at (0,10) size 92x20 [border: none none none (1px none #808080)] [r=0 c=0 rs=2 cs=1]
+              RenderText {#text} at (2,1) size 89x18
+                text run at (2,1) width 89: "Row 2, Cell 1"
+            RenderTableCell {TD} at (91,0) size 183x20 [r=0 c=1 rs=1 cs=2]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 2, Cell 2"
+          RenderTableRow {TR} at (0,20) size 274x20
+            RenderTableCell {TD} at (91,20) size 92x20 [r=1 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 3, Cell 2"
+            RenderTableCell {TD} at (182,30) size 92x20 [r=1 c=2 rs=2 cs=1]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 3, Cell 3"
+          RenderTableRow {TR} at (0,40) size 274x20
+            RenderTableCell {TD} at (0,40) size 183x20 [border: none none none (1px none #808080)] [r=2 c=0 rs=1 cs=2]
+              RenderText {#text} at (2,1) size 89x18
+                text run at (2,1) width 89: "Row 4, Cell 1"
+        RenderTableSection {TFOOT} at (0,99) size 274x20
+          RenderTableRow {TR} at (0,0) size 274x20
+            RenderTableCell {TD} at (0,0) size 92x20 [border: none none none (1px none #808080)] [r=0 c=0 rs=1 cs=1]
+              RenderText {#text} at (2,1) size 89x18
+                text run at (2,1) width 89: "Row 5, Cell 1"
+            RenderTableCell {TD} at (91,0) size 92x20 [r=0 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 5, Cell 2"
+            RenderTableCell {TD} at (182,0) size 92x20 [r=0 c=2 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 5, Cell 3"
+      RenderTable {TABLE} at (0,4356) size 275x120 [border: none]
         RenderBlock {CAPTION} at (0,0) size 275x18
           RenderInline {A} at (0,0) size 241x18
             RenderText {#text} at (14,0) size 241x18
@@ -1287,46 +1287,46 @@ layer at (0,0) size 785x7608
               text run at (254,0) width 6: ":"
         RenderTableSection {THEAD} at (0,18) size 274x21
           RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,0) size 92x21 [border: (1px solid #808080) none none (1px none #808080)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (0,0) size 92x21 [border: (1px none #808080) none none (1px none #808080)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 89x18
                 text run at (2,2) width 89: "Row 1, Cell 1"
-            RenderTableCell {TD} at (91,0) size 92x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (91,0) size 92x21 [border: (1px none #808080) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 1, Cell 2"
-            RenderTableCell {TD} at (182,0) size 92x21 [border: (1px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (182,0) size 92x21 [border: (1px none #808080) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 1, Cell 3"
-        RenderTableSection {TBODY} at (0,39) size 274x63
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,10) size 92x22 [border: (1px solid #808080) none none (1px none #808080)] [r=0 c=0 rs=2 cs=1]
-              RenderText {#text} at (2,1) size 89x20
-                text run at (2,2) width 89: "Row 2, Cell 1"
-            RenderTableCell {TD} at (91,0) size 183x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=2]
-              RenderText {#text} at (1,2) size 89x18
-                text run at (1,2) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,21) size 274x21
-            RenderTableCell {TD} at (91,21) size 92x21 [border: (1px solid #808080) none none none] [r=1 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x18
-                text run at (1,2) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (182,31) size 92x22 [border: (1px solid #808080) none none none] [r=1 c=2 rs=2 cs=1]
-              RenderText {#text} at (1,1) size 89x20
-                text run at (1,2) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,42) size 274x21
-            RenderTableCell {TD} at (0,42) size 183x21 [border: (1px solid #808080) none none (1px none #808080)] [r=2 c=0 rs=1 cs=2]
-              RenderText {#text} at (2,2) size 89x18
-                text run at (2,2) width 89: "Row 4, Cell 1"
-        RenderTableSection {TFOOT} at (0,102) size 274x21
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,0) size 92x21 [border: (1px solid #808080) none none (1px none #808080)] [r=0 c=0 rs=1 cs=1]
-              RenderText {#text} at (2,2) size 89x18
-                text run at (2,2) width 89: "Row 5, Cell 1"
-            RenderTableCell {TD} at (91,0) size 92x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x18
-                text run at (1,2) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (182,0) size 92x21 [border: (1px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 89x18
-                text run at (1,2) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,4560) size 275x118
+        RenderTableSection {TBODY} at (0,39) size 274x60
+          RenderTableRow {TR} at (0,0) size 274x20
+            RenderTableCell {TD} at (0,10) size 92x20 [border: none none none (1px none #808080)] [r=0 c=0 rs=2 cs=1]
+              RenderText {#text} at (2,1) size 89x18
+                text run at (2,1) width 89: "Row 2, Cell 1"
+            RenderTableCell {TD} at (91,0) size 183x20 [r=0 c=1 rs=1 cs=2]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 2, Cell 2"
+          RenderTableRow {TR} at (0,20) size 274x20
+            RenderTableCell {TD} at (91,20) size 92x20 [r=1 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 3, Cell 2"
+            RenderTableCell {TD} at (182,30) size 92x20 [r=1 c=2 rs=2 cs=1]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 3, Cell 3"
+          RenderTableRow {TR} at (0,40) size 274x20
+            RenderTableCell {TD} at (0,40) size 183x20 [border: none none none (1px none #808080)] [r=2 c=0 rs=1 cs=2]
+              RenderText {#text} at (2,1) size 89x18
+                text run at (2,1) width 89: "Row 4, Cell 1"
+        RenderTableSection {TFOOT} at (0,99) size 274x20
+          RenderTableRow {TR} at (0,0) size 274x20
+            RenderTableCell {TD} at (0,0) size 92x20 [border: none none none (1px none #808080)] [r=0 c=0 rs=1 cs=1]
+              RenderText {#text} at (2,1) size 89x18
+                text run at (2,1) width 89: "Row 5, Cell 1"
+            RenderTableCell {TD} at (91,0) size 92x20 [r=0 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 5, Cell 2"
+            RenderTableCell {TD} at (182,0) size 92x20 [r=0 c=2 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 89x18
+                text run at (1,1) width 89: "Row 5, Cell 3"
+      RenderTable {TABLE} at (0,4524) size 275x118
         RenderBlock {CAPTION} at (0,0) size 275x18
           RenderInline {A} at (0,0) size 219x18
             RenderText {#text} at (25,0) size 219x18
@@ -1375,7 +1375,7 @@ layer at (0,0) size 785x7608
             RenderTableCell {TD} at (182,0) size 93x20 [border: none none none (1px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (2,1) size 89x18
                 text run at (2,1) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,4726) size 275x119
+      RenderTable {TABLE} at (0,4690) size 275x119
         RenderBlock {CAPTION} at (0,0) size 275x18
           RenderInline {A} at (0,0) size 230x18
             RenderText {#text} at (20,0) size 230x18
@@ -1424,7 +1424,7 @@ layer at (0,0) size 785x7608
             RenderTableCell {TD} at (182,0) size 93x20 [border: none none none (1px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (2,1) size 89x18
                 text run at (2,1) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,4893) size 275x119 [border: none (1px solid #808080) none]
+      RenderTable {TABLE} at (0,4857) size 275x119 [border: none (1px solid #808080) none]
         RenderBlock {CAPTION} at (0,0) size 275x18
           RenderInline {A} at (0,0) size 230x18
             RenderText {#text} at (20,0) size 230x18
@@ -1473,7 +1473,7 @@ layer at (0,0) size 785x7608
             RenderTableCell {TD} at (182,0) size 93x20 [border: none none none (1px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (2,1) size 89x18
                 text run at (2,1) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,5060) size 275x120 [border: none none (1px solid #808080) none]
+      RenderTable {TABLE} at (0,5024) size 275x120 [border: none none (1px solid #808080) none]
         RenderBlock {CAPTION} at (0,0) size 275x18
           RenderInline {A} at (0,0) size 233x18
             RenderText {#text} at (18,0) size 233x18
@@ -1522,7 +1522,7 @@ layer at (0,0) size 785x7608
             RenderTableCell {TD} at (182,0) size 93x20 [border: none none none (1px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (2,1) size 89x18
                 text run at (2,1) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,5228) size 277x118 [border: none (1px solid #808080) none none]
+      RenderTable {TABLE} at (0,5192) size 277x118 [border: none (1px solid #808080) none none]
         RenderBlock {CAPTION} at (0,0) size 277x18
           RenderInline {A} at (0,0) size 231x18
             RenderText {#text} at (20,0) size 231x18
@@ -1571,7 +1571,7 @@ layer at (0,0) size 785x7608
             RenderTableCell {TD} at (183,0) size 93x20 [border: none none none (1px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (2,1) size 89x18
                 text run at (2,1) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,5394) size 276x118
+      RenderTable {TABLE} at (0,5358) size 276x118
         RenderBlock {CAPTION} at (0,0) size 276x18
           RenderInline {A} at (0,0) size 211x18
             RenderText {#text} at (30,0) size 211x18
@@ -1620,7 +1620,7 @@ layer at (0,0) size 785x7608
             RenderTableCell {TD} at (183,0) size 93x20 [border: none none none (1px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (2,1) size 89x18
                 text run at (2,1) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,5560) size 276x118 [border: none (1px solid #808080) none]
+      RenderTable {TABLE} at (0,5524) size 276x118 [border: none (1px solid #808080) none]
         RenderBlock {CAPTION} at (0,0) size 276x18
           RenderInline {A} at (0,0) size 213x18
             RenderText {#text} at (29,0) size 213x18
@@ -1669,7 +1669,7 @@ layer at (0,0) size 785x7608
             RenderTableCell {TD} at (182,0) size 93x20 [border: none none none (1px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (2,1) size 89x18
                 text run at (2,1) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,5726) size 277x120 [border: none]
+      RenderTable {TABLE} at (0,5690) size 277x120 [border: none]
         RenderBlock {CAPTION} at (0,0) size 277x18
           RenderInline {A} at (0,0) size 216x18
             RenderText {#text} at (28,0) size 216x18
@@ -1718,7 +1718,7 @@ layer at (0,0) size 785x7608
             RenderTableCell {TD} at (183,0) size 93x20 [border: none none none (1px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (2,1) size 89x18
                 text run at (2,1) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,5894) size 277x120 [border: none]
+      RenderTable {TABLE} at (0,5858) size 277x120 [border: none]
         RenderBlock {CAPTION} at (0,0) size 277x18
           RenderInline {A} at (0,0) size 235x18
             RenderText {#text} at (18,0) size 235x18
@@ -1767,7 +1767,7 @@ layer at (0,0) size 785x7608
             RenderTableCell {TD} at (183,0) size 93x20 [border: none none none (1px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (2,1) size 89x18
                 text run at (2,1) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,6062) size 275x122
+      RenderTable {TABLE} at (0,6026) size 275x122
         RenderBlock {CAPTION} at (0,0) size 275x18
           RenderInline {A} at (0,0) size 211x18
             RenderText {#text} at (29,0) size 211x18
@@ -1816,7 +1816,7 @@ layer at (0,0) size 785x7608
             RenderTableCell {TD} at (182,0) size 93x21 [border: (1px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (2,2) size 89x18
                 text run at (2,2) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,6232) size 275x123
+      RenderTable {TABLE} at (0,6196) size 275x123
         RenderBlock {CAPTION} at (0,0) size 275x18
           RenderInline {A} at (0,0) size 221x18
             RenderText {#text} at (24,0) size 221x18
@@ -1865,7 +1865,7 @@ layer at (0,0) size 785x7608
             RenderTableCell {TD} at (182,0) size 93x21 [border: (1px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (2,2) size 89x18
                 text run at (2,2) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,6403) size 275x123 [border: none (1px solid #808080) none]
+      RenderTable {TABLE} at (0,6367) size 275x123 [border: none (1px solid #808080) none]
         RenderBlock {CAPTION} at (0,0) size 275x18
           RenderInline {A} at (0,0) size 221x18
             RenderText {#text} at (24,0) size 221x18
@@ -1914,7 +1914,7 @@ layer at (0,0) size 785x7608
             RenderTableCell {TD} at (182,0) size 93x21 [border: (1px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (2,2) size 89x18
                 text run at (2,2) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,6574) size 275x124 [border: none none (1px solid #808080) none]
+      RenderTable {TABLE} at (0,6538) size 275x124 [border: none none (1px solid #808080) none]
         RenderBlock {CAPTION} at (0,0) size 275x18
           RenderInline {A} at (0,0) size 224x18
             RenderText {#text} at (23,0) size 224x18
@@ -1963,7 +1963,7 @@ layer at (0,0) size 785x7608
             RenderTableCell {TD} at (182,0) size 93x21 [border: (1px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (2,2) size 89x18
                 text run at (2,2) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,6746) size 277x122 [border: none (1px solid #808080) none none]
+      RenderTable {TABLE} at (0,6710) size 277x122 [border: none (1px solid #808080) none none]
         RenderBlock {CAPTION} at (0,0) size 277x18
           RenderInline {A} at (0,0) size 222x18
             RenderText {#text} at (25,0) size 222x18
@@ -2012,7 +2012,7 @@ layer at (0,0) size 785x7608
             RenderTableCell {TD} at (183,0) size 93x21 [border: (1px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (2,2) size 89x18
                 text run at (2,2) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,6916) size 276x122
+      RenderTable {TABLE} at (0,6880) size 276x122
         RenderBlock {CAPTION} at (0,0) size 276x18
           RenderInline {A} at (0,0) size 202x18
             RenderText {#text} at (34,0) size 202x18
@@ -2061,7 +2061,7 @@ layer at (0,0) size 785x7608
             RenderTableCell {TD} at (183,0) size 93x21 [border: (1px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (2,2) size 89x18
                 text run at (2,2) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,7086) size 276x122 [border: none (1px solid #808080) none]
+      RenderTable {TABLE} at (0,7050) size 276x122 [border: none (1px solid #808080) none]
         RenderBlock {CAPTION} at (0,0) size 276x18
           RenderInline {A} at (0,0) size 204x18
             RenderText {#text} at (33,0) size 204x18
@@ -2110,7 +2110,7 @@ layer at (0,0) size 785x7608
             RenderTableCell {TD} at (182,0) size 93x21 [border: (1px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (2,2) size 89x18
                 text run at (2,2) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,7256) size 277x124 [border: none]
+      RenderTable {TABLE} at (0,7220) size 277x124 [border: none]
         RenderBlock {CAPTION} at (0,0) size 277x18
           RenderInline {A} at (0,0) size 207x18
             RenderText {#text} at (32,0) size 207x18
@@ -2159,7 +2159,7 @@ layer at (0,0) size 785x7608
             RenderTableCell {TD} at (183,0) size 93x21 [border: (1px solid #808080)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (2,2) size 89x18
                 text run at (2,2) width 89: "Row 5, Cell 3"
-      RenderTable {TABLE} at (0,7428) size 277x124 [border: none]
+      RenderTable {TABLE} at (0,7392) size 277x124 [border: none]
         RenderBlock {CAPTION} at (0,0) size 277x18
           RenderInline {A} at (0,0) size 227x18
             RenderText {#text} at (22,0) size 227x18

--- a/LayoutTests/platform/mac/fast/table/frame-and-rules-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/frame-and-rules-expected.txt
@@ -894,7 +894,7 @@ layer at (0,0) size 785x7608
             RenderText at (245,0) size 6x18
               text run at (245,0) width 6: ":"
         RenderTableSection {THEAD} at (0,18) size 273x20
-          RenderTableRow {TR} at (0,0) size 273x20
+          RenderTableRow {TR} at (0,0) size 273x20 [border: (1px solid #000000) none (1px solid #000000) none]
             RenderTableCell {TD} at (0,0) size 91x20 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x18
                 text run at (1,1) width 89: "Row 1, Cell 1"
@@ -905,33 +905,33 @@ layer at (0,0) size 785x7608
               RenderText {#text} at (1,1) size 89x18
                 text run at (1,1) width 89: "Row 1, Cell 3"
         RenderTableSection {TBODY} at (0,38) size 273x63
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,10) size 91x22 [border: (1px solid #000000) none none none] [r=0 c=0 rs=2 cs=1]
+          RenderTableRow {TR} at (0,0) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,10) size 91x22 [border: (1px none #000000) none none none] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (1,12) size 89x19
                 text run at (1,2) width 89: "Row 2, Cell 1"
-            RenderTableCell {TD} at (90,0) size 183x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=2]
+            RenderTableCell {TD} at (90,0) size 183x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=2]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,21) size 273x21
-            RenderTableCell {TD} at (90,21) size 92x21 [border: (1px solid #000000) none none none] [r=1 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,21) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (90,21) size 92x21 [border: (1px none #000000) none none none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (181,31) size 92x22 [border: (1px solid #000000) none none none] [r=1 c=2 rs=2 cs=1]
+            RenderTableCell {TD} at (181,31) size 92x22 [border: (1px none #000000) none none none] [r=1 c=2 rs=2 cs=1]
               RenderText {#text} at (1,12) size 89x19
                 text run at (1,2) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,42) size 273x21
-            RenderTableCell {TD} at (0,42) size 182x21 [border: (1px solid #000000) none none none] [r=2 c=0 rs=1 cs=2]
+          RenderTableRow {TR} at (0,42) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,42) size 182x21 [border: (1px none #000000) none none none] [r=2 c=0 rs=1 cs=2]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 4, Cell 1"
         RenderTableSection {TFOOT} at (0,101) size 273x21
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,0) size 91x21 [border: (1px solid #000000) none none none] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,0) size 91x21 [border: (1px none #000000) none none none] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 5, Cell 1"
-            RenderTableCell {TD} at (90,0) size 92x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (90,0) size 92x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (181,0) size 92x21 [border: (1px solid #000000) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (181,0) size 92x21 [border: (1px none #000000) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 5, Cell 3"
       RenderTable {TABLE} at (0,3192) size 273x123
@@ -943,44 +943,44 @@ layer at (0,0) size 785x7608
             RenderText at (250,0) size 7x18
               text run at (250,0) width 7: ":"
         RenderTableSection {THEAD} at (0,18) size 273x21
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,0) size 91x21 [border: (1px solid #000000) none none none] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,0) size 91x21 [border: (1px none #000000) none none none] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 1, Cell 1"
-            RenderTableCell {TD} at (90,0) size 92x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (90,0) size 92x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 1, Cell 2"
-            RenderTableCell {TD} at (181,0) size 92x21 [border: (1px solid #000000) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (181,0) size 92x21 [border: (1px none #000000) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 1, Cell 3"
         RenderTableSection {TBODY} at (0,39) size 273x63
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,10) size 91x22 [border: (1px solid #000000) none none none] [r=0 c=0 rs=2 cs=1]
+          RenderTableRow {TR} at (0,0) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,10) size 91x22 [border: (1px none #000000) none none none] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (1,12) size 89x19
                 text run at (1,2) width 89: "Row 2, Cell 1"
-            RenderTableCell {TD} at (90,0) size 183x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=2]
+            RenderTableCell {TD} at (90,0) size 183x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=2]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,21) size 273x21
-            RenderTableCell {TD} at (90,21) size 92x21 [border: (1px solid #000000) none none none] [r=1 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,21) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (90,21) size 92x21 [border: (1px none #000000) none none none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (181,31) size 92x22 [border: (1px solid #000000) none none none] [r=1 c=2 rs=2 cs=1]
+            RenderTableCell {TD} at (181,31) size 92x22 [border: (1px none #000000) none none none] [r=1 c=2 rs=2 cs=1]
               RenderText {#text} at (1,12) size 89x19
                 text run at (1,2) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,42) size 273x21
-            RenderTableCell {TD} at (0,42) size 182x21 [border: (1px solid #000000) none none none] [r=2 c=0 rs=1 cs=2]
+          RenderTableRow {TR} at (0,42) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,42) size 182x21 [border: (1px none #000000) none none none] [r=2 c=0 rs=1 cs=2]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 4, Cell 1"
         RenderTableSection {TFOOT} at (0,102) size 273x21
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,0) size 91x21 [border: (1px solid #000000) none none none] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,0) size 91x21 [border: (1px none #000000) none none none] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 5, Cell 1"
-            RenderTableCell {TD} at (90,0) size 92x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (90,0) size 92x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (181,0) size 92x21 [border: (1px solid #000000) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (181,0) size 92x21 [border: (1px none #000000) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 5, Cell 3"
       RenderTable {TABLE} at (0,3363) size 273x123 [border: none (1px solid #000000) none]
@@ -992,7 +992,7 @@ layer at (0,0) size 785x7608
             RenderText at (250,0) size 7x18
               text run at (250,0) width 7: ":"
         RenderTableSection {THEAD} at (0,18) size 273x20
-          RenderTableRow {TR} at (0,0) size 273x20
+          RenderTableRow {TR} at (0,0) size 273x20 [border: (1px solid #000000) none (1px solid #000000) none]
             RenderTableCell {TD} at (0,0) size 91x20 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x18
                 text run at (1,1) width 89: "Row 1, Cell 1"
@@ -1003,33 +1003,33 @@ layer at (0,0) size 785x7608
               RenderText {#text} at (1,1) size 89x18
                 text run at (1,1) width 89: "Row 1, Cell 3"
         RenderTableSection {TBODY} at (0,38) size 273x63
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,10) size 91x22 [border: (1px solid #000000) none none none] [r=0 c=0 rs=2 cs=1]
+          RenderTableRow {TR} at (0,0) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,10) size 91x22 [border: (1px none #000000) none none none] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (1,12) size 89x19
                 text run at (1,2) width 89: "Row 2, Cell 1"
-            RenderTableCell {TD} at (90,0) size 183x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=2]
+            RenderTableCell {TD} at (90,0) size 183x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=2]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,21) size 273x21
-            RenderTableCell {TD} at (90,21) size 92x21 [border: (1px solid #000000) none none none] [r=1 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,21) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (90,21) size 92x21 [border: (1px none #000000) none none none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (181,31) size 92x22 [border: (1px solid #000000) none none none] [r=1 c=2 rs=2 cs=1]
+            RenderTableCell {TD} at (181,31) size 92x22 [border: (1px none #000000) none none none] [r=1 c=2 rs=2 cs=1]
               RenderText {#text} at (1,12) size 89x19
                 text run at (1,2) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,42) size 273x21
-            RenderTableCell {TD} at (0,42) size 182x21 [border: (1px solid #000000) none none none] [r=2 c=0 rs=1 cs=2]
+          RenderTableRow {TR} at (0,42) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,42) size 182x21 [border: (1px none #000000) none none none] [r=2 c=0 rs=1 cs=2]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 4, Cell 1"
         RenderTableSection {TFOOT} at (0,101) size 273x21
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,0) size 91x21 [border: (1px solid #000000) none none none] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,0) size 91x21 [border: (1px none #000000) none none none] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 5, Cell 1"
-            RenderTableCell {TD} at (90,0) size 92x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (90,0) size 92x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (181,0) size 92x21 [border: (1px solid #000000) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (181,0) size 92x21 [border: (1px none #000000) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 5, Cell 3"
       RenderTable {TABLE} at (0,3534) size 273x124 [border: none none (1px solid #000000) none]
@@ -1041,44 +1041,44 @@ layer at (0,0) size 785x7608
             RenderText at (252,0) size 6x18
               text run at (252,0) width 6: ":"
         RenderTableSection {THEAD} at (0,18) size 273x21
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,0) size 91x21 [border: (1px solid #000000) none none none] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,0) size 91x21 [border: (1px none #000000) none none none] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 1, Cell 1"
-            RenderTableCell {TD} at (90,0) size 92x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (90,0) size 92x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 1, Cell 2"
-            RenderTableCell {TD} at (181,0) size 92x21 [border: (1px solid #000000) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (181,0) size 92x21 [border: (1px none #000000) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 1, Cell 3"
         RenderTableSection {TBODY} at (0,39) size 273x63
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,10) size 91x22 [border: (1px solid #000000) none none none] [r=0 c=0 rs=2 cs=1]
+          RenderTableRow {TR} at (0,0) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,10) size 91x22 [border: (1px none #000000) none none none] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (1,12) size 89x19
                 text run at (1,2) width 89: "Row 2, Cell 1"
-            RenderTableCell {TD} at (90,0) size 183x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=2]
+            RenderTableCell {TD} at (90,0) size 183x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=2]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,21) size 273x21
-            RenderTableCell {TD} at (90,21) size 92x21 [border: (1px solid #000000) none none none] [r=1 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,21) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (90,21) size 92x21 [border: (1px none #000000) none none none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (181,31) size 92x22 [border: (1px solid #000000) none none none] [r=1 c=2 rs=2 cs=1]
+            RenderTableCell {TD} at (181,31) size 92x22 [border: (1px none #000000) none none none] [r=1 c=2 rs=2 cs=1]
               RenderText {#text} at (1,12) size 89x19
                 text run at (1,2) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,42) size 273x21
-            RenderTableCell {TD} at (0,42) size 182x21 [border: (1px solid #000000) none none none] [r=2 c=0 rs=1 cs=2]
+          RenderTableRow {TR} at (0,42) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,42) size 182x21 [border: (1px none #000000) none none none] [r=2 c=0 rs=1 cs=2]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 4, Cell 1"
         RenderTableSection {TFOOT} at (0,102) size 273x21
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,0) size 91x21 [border: (1px solid #000000) none none none] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,0) size 91x21 [border: (1px none #000000) none none none] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 5, Cell 1"
-            RenderTableCell {TD} at (90,0) size 92x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (90,0) size 92x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (181,0) size 92x21 [border: (1px solid #000000) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (181,0) size 92x21 [border: (1px none #000000) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 5, Cell 3"
       RenderTable {TABLE} at (0,3706) size 275x122 [border: none (1px solid #000000) none none]
@@ -1090,7 +1090,7 @@ layer at (0,0) size 785x7608
             RenderText at (252,0) size 6x18
               text run at (252,0) width 6: ":"
         RenderTableSection {THEAD} at (0,18) size 274x20
-          RenderTableRow {TR} at (0,0) size 274x20
+          RenderTableRow {TR} at (0,0) size 274x20 [border: (1px solid #000000) none (1px solid #000000) none]
             RenderTableCell {TD} at (0,0) size 92x20 [border: none none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,1) size 89x18
                 text run at (2,1) width 89: "Row 1, Cell 1"
@@ -1101,33 +1101,33 @@ layer at (0,0) size 785x7608
               RenderText {#text} at (1,1) size 89x18
                 text run at (1,1) width 89: "Row 1, Cell 3"
         RenderTableSection {TBODY} at (0,38) size 274x63
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,10) size 92x22 [border: (1px solid #000000) none none (1px none #000000)] [r=0 c=0 rs=2 cs=1]
+          RenderTableRow {TR} at (0,0) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,10) size 92x22 [border: (1px none #000000) none none (1px none #000000)] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (2,12) size 89x19
                 text run at (2,2) width 89: "Row 2, Cell 1"
-            RenderTableCell {TD} at (91,0) size 183x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=2]
+            RenderTableCell {TD} at (91,0) size 183x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=2]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,21) size 274x21
-            RenderTableCell {TD} at (91,21) size 92x21 [border: (1px solid #000000) none none none] [r=1 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,21) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (91,21) size 92x21 [border: (1px none #000000) none none none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (182,31) size 92x22 [border: (1px solid #000000) none none none] [r=1 c=2 rs=2 cs=1]
+            RenderTableCell {TD} at (182,31) size 92x22 [border: (1px none #000000) none none none] [r=1 c=2 rs=2 cs=1]
               RenderText {#text} at (1,12) size 89x19
                 text run at (1,2) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,42) size 274x21
-            RenderTableCell {TD} at (0,42) size 183x21 [border: (1px solid #000000) none none (1px none #000000)] [r=2 c=0 rs=1 cs=2]
+          RenderTableRow {TR} at (0,42) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,42) size 183x21 [border: (1px none #000000) none none (1px none #000000)] [r=2 c=0 rs=1 cs=2]
               RenderText {#text} at (2,2) size 89x18
                 text run at (2,2) width 89: "Row 4, Cell 1"
         RenderTableSection {TFOOT} at (0,101) size 274x21
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,0) size 92x21 [border: (1px solid #000000) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,0) size 92x21 [border: (1px none #000000) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 89x18
                 text run at (2,2) width 89: "Row 5, Cell 1"
-            RenderTableCell {TD} at (91,0) size 92x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (91,0) size 92x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (182,0) size 92x21 [border: (1px solid #000000) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (182,0) size 92x21 [border: (1px none #000000) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 5, Cell 3"
       RenderTable {TABLE} at (0,3876) size 274x122
@@ -1139,7 +1139,7 @@ layer at (0,0) size 785x7608
             RenderText at (241,0) size 7x18
               text run at (241,0) width 7: ":"
         RenderTableSection {THEAD} at (0,18) size 274x20
-          RenderTableRow {TR} at (0,0) size 274x20
+          RenderTableRow {TR} at (0,0) size 274x20 [border: (1px solid #000000) none (1px solid #000000) none]
             RenderTableCell {TD} at (0,0) size 92x20 [border: none none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,1) size 89x18
                 text run at (2,1) width 89: "Row 1, Cell 1"
@@ -1150,33 +1150,33 @@ layer at (0,0) size 785x7608
               RenderText {#text} at (1,1) size 89x18
                 text run at (1,1) width 89: "Row 1, Cell 3"
         RenderTableSection {TBODY} at (0,38) size 274x63
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,10) size 92x22 [border: (1px solid #000000) none none (1px none #000000)] [r=0 c=0 rs=2 cs=1]
+          RenderTableRow {TR} at (0,0) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,10) size 92x22 [border: (1px none #000000) none none (1px none #000000)] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (2,12) size 89x19
                 text run at (2,2) width 89: "Row 2, Cell 1"
-            RenderTableCell {TD} at (91,0) size 183x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=2]
+            RenderTableCell {TD} at (91,0) size 183x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=2]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,21) size 274x21
-            RenderTableCell {TD} at (91,21) size 92x21 [border: (1px solid #000000) none none none] [r=1 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,21) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (91,21) size 92x21 [border: (1px none #000000) none none none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (182,31) size 92x22 [border: (1px solid #000000) none none none] [r=1 c=2 rs=2 cs=1]
+            RenderTableCell {TD} at (182,31) size 92x22 [border: (1px none #000000) none none none] [r=1 c=2 rs=2 cs=1]
               RenderText {#text} at (1,12) size 89x19
                 text run at (1,2) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,42) size 274x21
-            RenderTableCell {TD} at (0,42) size 183x21 [border: (1px solid #000000) none none (1px none #000000)] [r=2 c=0 rs=1 cs=2]
+          RenderTableRow {TR} at (0,42) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,42) size 183x21 [border: (1px none #000000) none none (1px none #000000)] [r=2 c=0 rs=1 cs=2]
               RenderText {#text} at (2,2) size 89x18
                 text run at (2,2) width 89: "Row 4, Cell 1"
         RenderTableSection {TFOOT} at (0,101) size 274x21
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,0) size 92x21 [border: (1px solid #000000) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,0) size 92x21 [border: (1px none #000000) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 89x18
                 text run at (2,2) width 89: "Row 5, Cell 1"
-            RenderTableCell {TD} at (91,0) size 92x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (91,0) size 92x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (182,0) size 92x21 [border: (1px solid #000000) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (182,0) size 92x21 [border: (1px none #000000) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 5, Cell 3"
       RenderTable {TABLE} at (0,4046) size 274x122 [border: none (1px solid #000000) none]
@@ -1188,7 +1188,7 @@ layer at (0,0) size 785x7608
             RenderText at (242,0) size 7x18
               text run at (242,0) width 7: ":"
         RenderTableSection {THEAD} at (0,18) size 273x20
-          RenderTableRow {TR} at (0,0) size 273x20
+          RenderTableRow {TR} at (0,0) size 273x20 [border: (1px solid #000000) none (1px solid #000000) none]
             RenderTableCell {TD} at (0,0) size 91x20 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 89x18
                 text run at (1,1) width 89: "Row 1, Cell 1"
@@ -1199,33 +1199,33 @@ layer at (0,0) size 785x7608
               RenderText {#text} at (1,1) size 89x18
                 text run at (1,1) width 89: "Row 1, Cell 3"
         RenderTableSection {TBODY} at (0,38) size 273x63
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,10) size 91x22 [border: (1px solid #000000) none none none] [r=0 c=0 rs=2 cs=1]
+          RenderTableRow {TR} at (0,0) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,10) size 91x22 [border: (1px none #000000) none none none] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (1,12) size 89x19
                 text run at (1,2) width 89: "Row 2, Cell 1"
-            RenderTableCell {TD} at (90,0) size 183x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=2]
+            RenderTableCell {TD} at (90,0) size 183x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=2]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,21) size 273x21
-            RenderTableCell {TD} at (90,21) size 92x21 [border: (1px solid #000000) none none none] [r=1 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,21) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (90,21) size 92x21 [border: (1px none #000000) none none none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (181,31) size 92x22 [border: (1px solid #000000) none none none] [r=1 c=2 rs=2 cs=1]
+            RenderTableCell {TD} at (181,31) size 92x22 [border: (1px none #000000) none none none] [r=1 c=2 rs=2 cs=1]
               RenderText {#text} at (1,12) size 89x19
                 text run at (1,2) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,42) size 273x21
-            RenderTableCell {TD} at (0,42) size 182x21 [border: (1px solid #000000) none none none] [r=2 c=0 rs=1 cs=2]
+          RenderTableRow {TR} at (0,42) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,42) size 182x21 [border: (1px none #000000) none none none] [r=2 c=0 rs=1 cs=2]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 4, Cell 1"
         RenderTableSection {TFOOT} at (0,101) size 273x21
-          RenderTableRow {TR} at (0,0) size 273x21
-            RenderTableCell {TD} at (0,0) size 91x21 [border: (1px solid #000000) none none none] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 273x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,0) size 91x21 [border: (1px none #000000) none none none] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 5, Cell 1"
-            RenderTableCell {TD} at (90,0) size 92x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (90,0) size 92x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (181,0) size 92x21 [border: (1px solid #000000) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (181,0) size 92x21 [border: (1px none #000000) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 5, Cell 3"
       RenderTable {TABLE} at (0,4216) size 275x124 [border: none]
@@ -1237,44 +1237,44 @@ layer at (0,0) size 785x7608
             RenderText at (244,0) size 7x18
               text run at (244,0) width 7: ":"
         RenderTableSection {THEAD} at (0,18) size 274x21
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,0) size 92x21 [border: (1px solid #000000) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,0) size 92x21 [border: (1px none #000000) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 89x18
                 text run at (2,2) width 89: "Row 1, Cell 1"
-            RenderTableCell {TD} at (91,0) size 92x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (91,0) size 92x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 1, Cell 2"
-            RenderTableCell {TD} at (182,0) size 92x21 [border: (1px solid #000000) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (182,0) size 92x21 [border: (1px none #000000) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 1, Cell 3"
         RenderTableSection {TBODY} at (0,39) size 274x63
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,10) size 92x22 [border: (1px solid #000000) none none (1px none #000000)] [r=0 c=0 rs=2 cs=1]
+          RenderTableRow {TR} at (0,0) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,10) size 92x22 [border: (1px none #000000) none none (1px none #000000)] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (2,12) size 89x19
                 text run at (2,2) width 89: "Row 2, Cell 1"
-            RenderTableCell {TD} at (91,0) size 183x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=2]
+            RenderTableCell {TD} at (91,0) size 183x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=2]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,21) size 274x21
-            RenderTableCell {TD} at (91,21) size 92x21 [border: (1px solid #000000) none none none] [r=1 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,21) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (91,21) size 92x21 [border: (1px none #000000) none none none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (182,31) size 92x22 [border: (1px solid #000000) none none none] [r=1 c=2 rs=2 cs=1]
+            RenderTableCell {TD} at (182,31) size 92x22 [border: (1px none #000000) none none none] [r=1 c=2 rs=2 cs=1]
               RenderText {#text} at (1,12) size 89x19
                 text run at (1,2) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,42) size 274x21
-            RenderTableCell {TD} at (0,42) size 183x21 [border: (1px solid #000000) none none (1px none #000000)] [r=2 c=0 rs=1 cs=2]
+          RenderTableRow {TR} at (0,42) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,42) size 183x21 [border: (1px none #000000) none none (1px none #000000)] [r=2 c=0 rs=1 cs=2]
               RenderText {#text} at (2,2) size 89x18
                 text run at (2,2) width 89: "Row 4, Cell 1"
         RenderTableSection {TFOOT} at (0,102) size 274x21
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,0) size 92x21 [border: (1px solid #000000) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,0) size 92x21 [border: (1px none #000000) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 89x18
                 text run at (2,2) width 89: "Row 5, Cell 1"
-            RenderTableCell {TD} at (91,0) size 92x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (91,0) size 92x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (182,0) size 92x21 [border: (1px solid #000000) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (182,0) size 92x21 [border: (1px none #000000) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 5, Cell 3"
       RenderTable {TABLE} at (0,4388) size 275x124 [border: none]
@@ -1286,44 +1286,44 @@ layer at (0,0) size 785x7608
             RenderText at (254,0) size 6x18
               text run at (254,0) width 6: ":"
         RenderTableSection {THEAD} at (0,18) size 274x21
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,0) size 92x21 [border: (1px solid #000000) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,0) size 92x21 [border: (1px none #000000) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 89x18
                 text run at (2,2) width 89: "Row 1, Cell 1"
-            RenderTableCell {TD} at (91,0) size 92x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (91,0) size 92x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 1, Cell 2"
-            RenderTableCell {TD} at (182,0) size 92x21 [border: (1px solid #000000) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (182,0) size 92x21 [border: (1px none #000000) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 1, Cell 3"
         RenderTableSection {TBODY} at (0,39) size 274x63
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,10) size 92x22 [border: (1px solid #000000) none none (1px none #000000)] [r=0 c=0 rs=2 cs=1]
+          RenderTableRow {TR} at (0,0) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,10) size 92x22 [border: (1px none #000000) none none (1px none #000000)] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (2,12) size 89x19
                 text run at (2,2) width 89: "Row 2, Cell 1"
-            RenderTableCell {TD} at (91,0) size 183x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=2]
+            RenderTableCell {TD} at (91,0) size 183x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=2]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,21) size 274x21
-            RenderTableCell {TD} at (91,21) size 92x21 [border: (1px solid #000000) none none none] [r=1 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,21) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (91,21) size 92x21 [border: (1px none #000000) none none none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 3, Cell 2"
-            RenderTableCell {TD} at (182,31) size 92x22 [border: (1px solid #000000) none none none] [r=1 c=2 rs=2 cs=1]
+            RenderTableCell {TD} at (182,31) size 92x22 [border: (1px none #000000) none none none] [r=1 c=2 rs=2 cs=1]
               RenderText {#text} at (1,12) size 89x19
                 text run at (1,2) width 89: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,42) size 274x21
-            RenderTableCell {TD} at (0,42) size 183x21 [border: (1px solid #000000) none none (1px none #000000)] [r=2 c=0 rs=1 cs=2]
+          RenderTableRow {TR} at (0,42) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,42) size 183x21 [border: (1px none #000000) none none (1px none #000000)] [r=2 c=0 rs=1 cs=2]
               RenderText {#text} at (2,2) size 89x18
                 text run at (2,2) width 89: "Row 4, Cell 1"
         RenderTableSection {TFOOT} at (0,102) size 274x21
-          RenderTableRow {TR} at (0,0) size 274x21
-            RenderTableCell {TD} at (0,0) size 92x21 [border: (1px solid #000000) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 274x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,0) size 92x21 [border: (1px none #000000) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 89x18
                 text run at (2,2) width 89: "Row 5, Cell 1"
-            RenderTableCell {TD} at (91,0) size 92x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (91,0) size 92x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 5, Cell 2"
-            RenderTableCell {TD} at (182,0) size 92x21 [border: (1px solid #000000) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (182,0) size 92x21 [border: (1px none #000000) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 89x18
                 text run at (1,2) width 89: "Row 5, Cell 3"
       RenderTable {TABLE} at (0,4560) size 275x118

--- a/LayoutTests/platform/mac/fast/table/rules-attr-dynchange2-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/rules-attr-dynchange2-expected.txt
@@ -3,29 +3,29 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576
-      RenderTable {TABLE} at (0,0) size 153x64 [border: none]
-        RenderTableSection {TBODY} at (0,0) size 152x63
+      RenderTable {TABLE} at (0,0) size 153x62 [border: none]
+        RenderTableSection {TBODY} at (0,0) size 152x61
           RenderTableRow {TR} at (0,0) size 152x21
-            RenderTableCell {TD} at (0,0) size 77x21 [border: (1px solid #808080) none none (1px none #808080)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (0,0) size 77x21 [border: (1px none #808080) none none (1px none #808080)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 74x18
                 text run at (2,2) width 74: "Row1 cell1"
-            RenderTableCell {TD} at (76,0) size 76x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (76,0) size 76x21 [border: (1px none #808080) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 74x18
                 text run at (1,2) width 74: "Row1 cell2"
-          RenderTableRow {TR} at (0,21) size 152x21
-            RenderTableCell {TD} at (0,21) size 77x21 [border: (1px solid #808080) none none (1px none #808080)] [r=1 c=0 rs=1 cs=1]
-              RenderText {#text} at (2,2) size 74x18
-                text run at (2,2) width 74: "Row2 cell1"
-            RenderTableCell {TD} at (76,21) size 76x21 [border: (1px solid #808080) none none none] [r=1 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 74x18
-                text run at (1,2) width 74: "Row2 cell2"
-          RenderTableRow {TR} at (0,42) size 152x21
-            RenderTableCell {TD} at (0,42) size 77x21 [border: (1px solid #808080) none none (1px none #808080)] [r=2 c=0 rs=1 cs=1]
-              RenderText {#text} at (2,2) size 74x18
-                text run at (2,2) width 74: "Row3 cell1"
-            RenderTableCell {TD} at (76,42) size 76x21 [border: (1px solid #808080) none none none] [r=2 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 74x18
-                text run at (1,2) width 74: "Row3 cell2"
-      RenderBlock {P} at (0,80) size 784x18
+          RenderTableRow {TR} at (0,21) size 152x20
+            RenderTableCell {TD} at (0,21) size 77x20 [border: none none none (1px none #808080)] [r=1 c=0 rs=1 cs=1]
+              RenderText {#text} at (2,1) size 74x18
+                text run at (2,1) width 74: "Row2 cell1"
+            RenderTableCell {TD} at (76,21) size 76x20 [r=1 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 74x18
+                text run at (1,1) width 74: "Row2 cell2"
+          RenderTableRow {TR} at (0,41) size 152x20
+            RenderTableCell {TD} at (0,41) size 77x20 [border: none none none (1px none #808080)] [r=2 c=0 rs=1 cs=1]
+              RenderText {#text} at (2,1) size 74x18
+                text run at (2,1) width 74: "Row3 cell1"
+            RenderTableCell {TD} at (76,41) size 76x20 [r=2 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 74x18
+                text run at (1,1) width 74: "Row3 cell2"
+      RenderBlock {P} at (0,78) size 784x18
         RenderText {#text} at (0,0) size 761x18
           text run at (0,0) width 761: "The rules attribute is first set dynamically to cols, then to rows, so the table should show only row borders. Bug 14848."

--- a/LayoutTests/platform/mac/fast/table/rules-attr-dynchange2-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/rules-attr-dynchange2-expected.txt
@@ -5,25 +5,25 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576
       RenderTable {TABLE} at (0,0) size 153x64 [border: none]
         RenderTableSection {TBODY} at (0,0) size 152x63
-          RenderTableRow {TR} at (0,0) size 152x21
-            RenderTableCell {TD} at (0,0) size 77x21 [border: (1px solid #000000) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 152x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,0) size 77x21 [border: (1px none #000000) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 74x18
                 text run at (2,2) width 74: "Row1 cell1"
-            RenderTableCell {TD} at (76,0) size 76x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (76,0) size 76x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 74x18
                 text run at (1,2) width 74: "Row1 cell2"
-          RenderTableRow {TR} at (0,21) size 152x21
-            RenderTableCell {TD} at (0,21) size 77x21 [border: (1px solid #000000) none none (1px none #000000)] [r=1 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,21) size 152x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,21) size 77x21 [border: (1px none #000000) none none (1px none #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 74x18
                 text run at (2,2) width 74: "Row2 cell1"
-            RenderTableCell {TD} at (76,21) size 76x21 [border: (1px solid #000000) none none none] [r=1 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (76,21) size 76x21 [border: (1px none #000000) none none none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 74x18
                 text run at (1,2) width 74: "Row2 cell2"
-          RenderTableRow {TR} at (0,42) size 152x21
-            RenderTableCell {TD} at (0,42) size 77x21 [border: (1px solid #000000) none none (1px none #000000)] [r=2 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,42) size 152x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,42) size 77x21 [border: (1px none #000000) none none (1px none #000000)] [r=2 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 74x18
                 text run at (2,2) width 74: "Row3 cell1"
-            RenderTableCell {TD} at (76,42) size 76x21 [border: (1px solid #000000) none none none] [r=2 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (76,42) size 76x21 [border: (1px none #000000) none none none] [r=2 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 74x18
                 text run at (1,2) width 74: "Row3 cell2"
       RenderBlock {P} at (0,80) size 784x18

--- a/LayoutTests/platform/mac/tables/mozilla/core/table_rules-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/core/table_rules-expected.txt
@@ -90,25 +90,25 @@ layer at (0,0) size 800x600
                 text run at (1,1) width 73: "col group 2"
       RenderBlock (anonymous) at (0,203) size 784x18
         RenderBR {BR} at (0,0) size 0x18
-      RenderTable {TABLE} at (0,221) size 69x43 [border: none]
-        RenderTableSection {TBODY} at (0,0) size 68x42
+      RenderTable {TABLE} at (0,221) size 69x42 [border: none]
+        RenderTableSection {TBODY} at (0,0) size 68x41
           RenderTableRow {TR} at (0,0) size 68x21
-            RenderTableCell {TD} at (0,0) size 35x21 [border: (1px solid #808080) none none (1px none #808080)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (0,0) size 35x21 [border: (1px none #808080) none none (1px none #808080)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 32x18
                 text run at (2,2) width 32: "rules"
-            RenderTableCell {TD} at (34,0) size 34x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (34,0) size 34x21 [border: (1px none #808080) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 32x18
                 text run at (1,2) width 32: "rows"
-          RenderTableRow {TR} at (0,21) size 68x21
-            RenderTableCell {TD} at (0,21) size 35x21 [border: (1px solid #808080) none none (1px none #808080)] [r=1 c=0 rs=1 cs=1]
-              RenderText {#text} at (2,2) size 32x18
-                text run at (2,2) width 32: "rules"
-            RenderTableCell {TD} at (34,21) size 34x21 [border: (1px solid #808080) none none none] [r=1 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 32x18
-                text run at (1,2) width 32: "rows"
-      RenderBlock (anonymous) at (0,264) size 784x18
+          RenderTableRow {TR} at (0,21) size 68x20
+            RenderTableCell {TD} at (0,21) size 35x20 [border: none none none (1px none #808080)] [r=1 c=0 rs=1 cs=1]
+              RenderText {#text} at (2,1) size 32x18
+                text run at (2,1) width 32: "rules"
+            RenderTableCell {TD} at (34,21) size 34x20 [r=1 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 32x18
+                text run at (1,1) width 32: "rows"
+      RenderBlock (anonymous) at (0,263) size 784x18
         RenderBR {BR} at (0,0) size 0x18
-      RenderTable {TABLE} at (0,282) size 64x42 [border: none]
+      RenderTable {TABLE} at (0,281) size 64x42 [border: none]
         RenderTableSection {TBODY} at (0,0) size 63x41
           RenderTableRow {TR} at (0,0) size 63x21
             RenderTableCell {TD} at (0,0) size 35x21 [border: (1px none #808080) none none (1px solid #808080)] [r=0 c=0 rs=1 cs=1]
@@ -124,9 +124,9 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (34,21) size 29x20 [border: none none none (1px solid #808080)] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (2,1) size 26x18
                 text run at (2,1) width 26: "cols"
-      RenderBlock (anonymous) at (0,324) size 784x18
+      RenderBlock (anonymous) at (0,323) size 784x18
         RenderBR {BR} at (0,0) size 0x18
-      RenderTable {TABLE} at (0,342) size 55x43 [border: none]
+      RenderTable {TABLE} at (0,341) size 55x43 [border: none]
         RenderTableSection {TBODY} at (0,0) size 54x42
           RenderTableRow {TR} at (0,0) size 54x21
             RenderTableCell {TD} at (0,0) size 35x21 [border: (1px solid #808080)] [r=0 c=0 rs=1 cs=1]
@@ -142,5 +142,5 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (34,21) size 20x21 [border: (1px solid #808080)] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 16x18
                 text run at (2,2) width 16: "all"
-      RenderBlock (anonymous) at (0,385) size 784x18
+      RenderBlock (anonymous) at (0,384) size 784x18
         RenderBR {BR} at (0,0) size 0x18

--- a/LayoutTests/platform/mac/tables/mozilla/core/table_rules-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/core/table_rules-expected.txt
@@ -92,18 +92,18 @@ layer at (0,0) size 800x600
         RenderBR {BR} at (0,0) size 0x18
       RenderTable {TABLE} at (0,221) size 69x43 [border: none]
         RenderTableSection {TBODY} at (0,0) size 68x42
-          RenderTableRow {TR} at (0,0) size 68x21
-            RenderTableCell {TD} at (0,0) size 35x21 [border: (1px solid #000000) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 68x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,0) size 35x21 [border: (1px none #000000) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 32x18
                 text run at (2,2) width 32: "rules"
-            RenderTableCell {TD} at (34,0) size 34x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (34,0) size 34x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 32x18
                 text run at (1,2) width 32: "rows"
-          RenderTableRow {TR} at (0,21) size 68x21
-            RenderTableCell {TD} at (0,21) size 35x21 [border: (1px solid #000000) none none (1px none #000000)] [r=1 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,21) size 68x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,21) size 35x21 [border: (1px none #000000) none none (1px none #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 32x18
                 text run at (2,2) width 32: "rules"
-            RenderTableCell {TD} at (34,21) size 34x21 [border: (1px solid #000000) none none none] [r=1 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (34,21) size 34x21 [border: (1px none #000000) none none none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 32x18
                 text run at (1,2) width 32: "rows"
       RenderBlock (anonymous) at (0,264) size 784x18

--- a/LayoutTests/platform/mac/tables/mozilla_expected_failures/marvin/table_rules_rows-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla_expected_failures/marvin/table_rules_rows-expected.txt
@@ -3,58 +3,58 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderTable {TABLE} at (0,0) size 417x111 [border: (2px outset #808080)]
+      RenderTable {TABLE} at (0,0) size 417x108 [border: (2px outset #808080)]
         RenderBlock {CAPTION} at (0,0) size 417x18
           RenderText {#text} at (10,0) size 396x18
             text run at (10,0) width 396: "Communicator 4.5 Installers for Mac and Windows Platforms"
-        RenderTableSection {TBODY} at (2,20) size 412x88
+        RenderTableSection {TBODY} at (2,20) size 412x85
           RenderTableRow {TR} at (0,0) size 412x23
-            RenderTableCell {TH} at (0,9) size 123x5 [border: (3px solid #808080) none none (3px none #808080)] [r=0 c=0 rs=1 cs=1]
-            RenderTableCell {TH} at (122,0) size 110x23 [border: (3px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TH} at (0,9) size 123x5 [border: (3px none #808080) none none (3px none #808080)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TH} at (122,0) size 110x23 [border: (3px none #808080) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,4) size 108x18
                 text run at (1,4) width 108: "Macintosh PPC"
-            RenderTableCell {TH} at (231,0) size 87x23 [border: (3px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TH} at (231,0) size 87x23 [border: (3px none #808080) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,4) size 84x18
                 text run at (1,4) width 84: "Windows 95"
-            RenderTableCell {TH} at (317,0) size 95x23 [border: (3px solid #808080) (2px none #808080) none none] [r=0 c=3 rs=1 cs=1]
+            RenderTableCell {TH} at (317,0) size 95x23 [border: (3px none #808080) (2px none #808080) none none] [r=0 c=3 rs=1 cs=1]
               RenderText {#text} at (1,4) size 90x18
                 text run at (1,4) width 90: "Windows NT"
-          RenderTableRow {TR} at (0,23) size 412x21
-            RenderTableCell {TD} at (0,23) size 123x21 [border: (1px solid #808080) none none (3px none #808080)] [r=1 c=0 rs=1 cs=1]
-              RenderText {#text} at (4,2) size 76x18
-                text run at (4,2) width 76: "Base Install"
-            RenderTableCell {TD} at (122,23) size 110x21 [border: (1px solid #808080) none none none] [r=1 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 22x18
-                text run at (1,2) width 22: "yes"
-            RenderTableCell {TD} at (231,23) size 87x21 [border: (1px solid #808080) none none none] [r=1 c=2 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 22x18
-                text run at (1,2) width 22: "yes"
-            RenderTableCell {TD} at (317,23) size 95x21 [border: (1px solid #808080) (2px none #808080) none none] [r=1 c=3 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 22x18
-                text run at (1,2) width 22: "yes"
-          RenderTableRow {TR} at (0,44) size 412x21
-            RenderTableCell {TD} at (0,44) size 123x21 [border: (1px solid #808080) none none (3px none #808080)] [r=2 c=0 rs=1 cs=1]
-              RenderText {#text} at (4,2) size 107x18
-                text run at (4,2) width 107: "Complete Install"
-            RenderTableCell {TD} at (122,44) size 110x21 [border: (1px solid #808080) none none none] [r=2 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 22x18
-                text run at (1,2) width 22: "yes"
-            RenderTableCell {TD} at (231,44) size 87x21 [border: (1px solid #808080) none none none] [r=2 c=2 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 22x18
-                text run at (1,2) width 22: "yes"
-            RenderTableCell {TD} at (317,44) size 95x21 [border: (1px solid #808080) (2px none #808080) none none] [r=2 c=3 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 22x18
-                text run at (1,2) width 22: "yes"
-          RenderTableRow {TR} at (0,65) size 412x23
-            RenderTableCell {TD} at (0,65) size 123x23 [border: (1px solid #808080) none (2px solid #808080) (3px none #808080)] [r=3 c=0 rs=1 cs=1]
-              RenderText {#text} at (4,2) size 118x18
-                text run at (4,2) width 118: "Pro Edition Install"
-            RenderTableCell {TD} at (122,65) size 110x23 [border: (1px solid #808080) none (2px solid #808080) none] [r=3 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 22x18
-                text run at (1,2) width 22: "yes"
-            RenderTableCell {TD} at (231,65) size 87x23 [border: (1px solid #808080) none (2px solid #808080) none] [r=3 c=2 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 22x18
-                text run at (1,2) width 22: "yes"
-            RenderTableCell {TD} at (317,65) size 95x23 [border: (1px solid #808080) (2px none #808080) (2px solid #808080) none] [r=3 c=3 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 22x18
-                text run at (1,2) width 22: "yes"
+          RenderTableRow {TR} at (0,23) size 412x20
+            RenderTableCell {TD} at (0,23) size 123x20 [border: none none none (3px none #808080)] [r=1 c=0 rs=1 cs=1]
+              RenderText {#text} at (4,1) size 76x18
+                text run at (4,1) width 76: "Base Install"
+            RenderTableCell {TD} at (122,23) size 110x20 [r=1 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 22x18
+                text run at (1,1) width 22: "yes"
+            RenderTableCell {TD} at (231,23) size 87x20 [r=1 c=2 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 22x18
+                text run at (1,1) width 22: "yes"
+            RenderTableCell {TD} at (317,23) size 95x20 [border: none (2px none #808080) none none] [r=1 c=3 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 22x18
+                text run at (1,1) width 22: "yes"
+          RenderTableRow {TR} at (0,43) size 412x20
+            RenderTableCell {TD} at (0,43) size 123x20 [border: none none none (3px none #808080)] [r=2 c=0 rs=1 cs=1]
+              RenderText {#text} at (4,1) size 107x18
+                text run at (4,1) width 107: "Complete Install"
+            RenderTableCell {TD} at (122,43) size 110x20 [r=2 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 22x18
+                text run at (1,1) width 22: "yes"
+            RenderTableCell {TD} at (231,43) size 87x20 [r=2 c=2 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 22x18
+                text run at (1,1) width 22: "yes"
+            RenderTableCell {TD} at (317,43) size 95x20 [border: none (2px none #808080) none none] [r=2 c=3 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 22x18
+                text run at (1,1) width 22: "yes"
+          RenderTableRow {TR} at (0,63) size 412x22
+            RenderTableCell {TD} at (0,63) size 123x22 [border: none none (2px none #808080) (3px none #808080)] [r=3 c=0 rs=1 cs=1]
+              RenderText {#text} at (4,1) size 118x18
+                text run at (4,1) width 118: "Pro Edition Install"
+            RenderTableCell {TD} at (122,63) size 110x22 [border: none none (2px none #808080) none] [r=3 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 22x18
+                text run at (1,1) width 22: "yes"
+            RenderTableCell {TD} at (231,63) size 87x22 [border: none none (2px none #808080) none] [r=3 c=2 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 22x18
+                text run at (1,1) width 22: "yes"
+            RenderTableCell {TD} at (317,63) size 95x22 [border: none (2px none #808080) (2px none #808080) none] [r=3 c=3 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 22x18
+                text run at (1,1) width 22: "yes"

--- a/LayoutTests/platform/mac/tables/mozilla_expected_failures/marvin/table_rules_rows-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla_expected_failures/marvin/table_rules_rows-expected.txt
@@ -8,53 +8,53 @@ layer at (0,0) size 800x600
           RenderText {#text} at (10,0) size 396x18
             text run at (10,0) width 396: "Communicator 4.5 Installers for Mac and Windows Platforms"
         RenderTableSection {TBODY} at (2,20) size 412x88
-          RenderTableRow {TR} at (0,0) size 412x23
-            RenderTableCell {TH} at (0,9) size 123x5 [border: (3px solid #000000) none none (3px none #000000)] [r=0 c=0 rs=1 cs=1]
-            RenderTableCell {TH} at (122,0) size 110x23 [border: (3px solid #000000) none none none] [r=0 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 412x23 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TH} at (0,9) size 123x5 [border: (3px none #000000) none none (3px none #000000)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TH} at (122,0) size 110x23 [border: (3px none #000000) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,4) size 108x18
                 text run at (1,4) width 108: "Macintosh PPC"
-            RenderTableCell {TH} at (231,0) size 87x23 [border: (3px solid #000000) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TH} at (231,0) size 87x23 [border: (3px none #000000) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,4) size 84x18
                 text run at (1,4) width 84: "Windows 95"
-            RenderTableCell {TH} at (317,0) size 95x23 [border: (3px solid #000000) (2px none #000000) none none] [r=0 c=3 rs=1 cs=1]
+            RenderTableCell {TH} at (317,0) size 95x23 [border: (3px none #000000) (2px none #000000) none none] [r=0 c=3 rs=1 cs=1]
               RenderText {#text} at (1,4) size 90x18
                 text run at (1,4) width 90: "Windows NT"
-          RenderTableRow {TR} at (0,23) size 412x21
-            RenderTableCell {TD} at (0,23) size 123x21 [border: (1px solid #000000) none none (3px none #000000)] [r=1 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,23) size 412x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,23) size 123x21 [border: (1px none #000000) none none (3px none #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (4,2) size 76x18
                 text run at (4,2) width 76: "Base Install"
-            RenderTableCell {TD} at (122,23) size 110x21 [border: (1px solid #000000) none none none] [r=1 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (122,23) size 110x21 [border: (1px none #000000) none none none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 22x18
                 text run at (1,2) width 22: "yes"
-            RenderTableCell {TD} at (231,23) size 87x21 [border: (1px solid #000000) none none none] [r=1 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (231,23) size 87x21 [border: (1px none #000000) none none none] [r=1 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 22x18
                 text run at (1,2) width 22: "yes"
-            RenderTableCell {TD} at (317,23) size 95x21 [border: (1px solid #000000) (2px none #000000) none none] [r=1 c=3 rs=1 cs=1]
+            RenderTableCell {TD} at (317,23) size 95x21 [border: (1px none #000000) (2px none #000000) none none] [r=1 c=3 rs=1 cs=1]
               RenderText {#text} at (1,2) size 22x18
                 text run at (1,2) width 22: "yes"
-          RenderTableRow {TR} at (0,44) size 412x21
-            RenderTableCell {TD} at (0,44) size 123x21 [border: (1px solid #000000) none none (3px none #000000)] [r=2 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,44) size 412x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,44) size 123x21 [border: (1px none #000000) none none (3px none #000000)] [r=2 c=0 rs=1 cs=1]
               RenderText {#text} at (4,2) size 107x18
                 text run at (4,2) width 107: "Complete Install"
-            RenderTableCell {TD} at (122,44) size 110x21 [border: (1px solid #000000) none none none] [r=2 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (122,44) size 110x21 [border: (1px none #000000) none none none] [r=2 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 22x18
                 text run at (1,2) width 22: "yes"
-            RenderTableCell {TD} at (231,44) size 87x21 [border: (1px solid #000000) none none none] [r=2 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (231,44) size 87x21 [border: (1px none #000000) none none none] [r=2 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 22x18
                 text run at (1,2) width 22: "yes"
-            RenderTableCell {TD} at (317,44) size 95x21 [border: (1px solid #000000) (2px none #000000) none none] [r=2 c=3 rs=1 cs=1]
+            RenderTableCell {TD} at (317,44) size 95x21 [border: (1px none #000000) (2px none #000000) none none] [r=2 c=3 rs=1 cs=1]
               RenderText {#text} at (1,2) size 22x18
                 text run at (1,2) width 22: "yes"
-          RenderTableRow {TR} at (0,65) size 412x23
-            RenderTableCell {TD} at (0,65) size 123x23 [border: (1px solid #000000) none (2px solid #000000) (3px none #000000)] [r=3 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,65) size 412x23 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {TD} at (0,65) size 123x23 [border: (1px none #000000) none (2px none #000000) (3px none #000000)] [r=3 c=0 rs=1 cs=1]
               RenderText {#text} at (4,2) size 118x18
                 text run at (4,2) width 118: "Pro Edition Install"
-            RenderTableCell {TD} at (122,65) size 110x23 [border: (1px solid #000000) none (2px solid #000000) none] [r=3 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (122,65) size 110x23 [border: (1px none #000000) none (2px none #000000) none] [r=3 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 22x18
                 text run at (1,2) width 22: "yes"
-            RenderTableCell {TD} at (231,65) size 87x23 [border: (1px solid #000000) none (2px solid #000000) none] [r=3 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (231,65) size 87x23 [border: (1px none #000000) none (2px none #000000) none] [r=3 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 22x18
                 text run at (1,2) width 22: "yes"
-            RenderTableCell {TD} at (317,65) size 95x23 [border: (1px solid #000000) (2px none #000000) (2px solid #000000) none] [r=3 c=3 rs=1 cs=1]
+            RenderTableCell {TD} at (317,65) size 95x23 [border: (1px none #000000) (2px none #000000) (2px none #000000) none] [r=3 c=3 rs=1 cs=1]
               RenderText {#text} at (1,2) size 22x18
                 text run at (1,2) width 22: "yes"

--- a/LayoutTests/platform/mac/tables/mozilla_expected_failures/marvin/x_table_rules_rows-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla_expected_failures/marvin/x_table_rules_rows-expected.txt
@@ -1,13 +1,13 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x143
-  RenderBlock {html} at (0,0) size 800x143
-    RenderBody {body} at (8,16) size 784x119
+layer at (0,0) size 800x140
+  RenderBlock {html} at (0,0) size 800x140
+    RenderBody {body} at (8,16) size 784x116
       RenderBlock {p} at (0,0) size 784x18
         RenderText {#text} at (0,0) size 478x18
           text run at (0,0) width 400: "There should be rules between all rows (and only rows) in the "
           text run at (399,0) width 79: "table below."
-      RenderTable {table} at (0,34) size 179x85 [border: none]
+      RenderTable {table} at (0,34) size 179x82 [border: none]
         RenderTableCol {colgroup} at (0,0) size 0x0
           RenderTableCol {col} at (0,0) size 0x0
         RenderTableCol {colgroup} at (0,0) size 0x0
@@ -16,44 +16,44 @@ layer at (0,0) size 800x143
           RenderTableCol {col} at (0,0) size 0x0
         RenderTableSection {thead} at (0,0) size 178x21
           RenderTableRow {tr} at (0,0) size 178x21
-            RenderTableCell {th} at (0,0) size 60x21 [border: (1px solid #808080) none none (1px none #808080)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {th} at (0,0) size 60x21 [border: (1px none #808080) none none (1px none #808080)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 57x18
                 text run at (2,2) width 57: "THEAD"
-            RenderTableCell {th} at (59,0) size 60x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {th} at (59,0) size 60x21 [border: (1px none #808080) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 57x18
                 text run at (1,2) width 57: "THEAD"
-            RenderTableCell {th} at (118,0) size 60x21 [border: (1px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {th} at (118,0) size 60x21 [border: (1px none #808080) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 57x18
                 text run at (1,2) width 57: "THEAD"
-        RenderTableSection {tfoot} at (0,63) size 178x21
-          RenderTableRow {tr} at (0,0) size 178x21
-            RenderTableCell {td} at (0,0) size 60x21 [border: (1px solid #808080) none none (1px none #808080)] [r=0 c=0 rs=1 cs=1]
-              RenderText {#text} at (2,2) size 52x18
-                text run at (2,2) width 52: "TFOOT"
-            RenderTableCell {td} at (59,0) size 60x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 52x18
-                text run at (1,2) width 52: "TFOOT"
-            RenderTableCell {td} at (118,0) size 60x21 [border: (1px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 52x18
-                text run at (1,2) width 52: "TFOOT"
-        RenderTableSection {tbody} at (0,21) size 178x42
-          RenderTableRow {tr} at (0,0) size 178x21
-            RenderTableCell {td} at (0,0) size 60x21 [border: (1px solid #808080) none none (1px none #808080)] [r=0 c=0 rs=1 cs=1]
-              RenderText {#text} at (2,2) size 56x18
-                text run at (2,2) width 56: "TBODY"
-            RenderTableCell {td} at (59,0) size 60x21 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 56x18
-                text run at (1,2) width 56: "TBODY"
-            RenderTableCell {td} at (118,0) size 60x21 [border: (1px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 56x18
-                text run at (1,2) width 56: "TBODY"
-          RenderTableRow {tr} at (0,21) size 178x21
-            RenderTableCell {td} at (0,21) size 60x21 [border: (1px solid #808080) none none (1px none #808080)] [r=1 c=0 rs=1 cs=1]
-              RenderText {#text} at (2,2) size 56x18
-                text run at (2,2) width 56: "TBODY"
-            RenderTableCell {td} at (59,21) size 60x21 [border: (1px solid #808080) none none none] [r=1 c=1 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 56x18
-                text run at (1,2) width 56: "TBODY"
-            RenderTableCell {td} at (118,21) size 60x21 [border: (1px solid #808080) none none none] [r=1 c=2 rs=1 cs=1]
-              RenderText {#text} at (1,2) size 56x18
-                text run at (1,2) width 56: "TBODY"
+        RenderTableSection {tfoot} at (0,61) size 178x20
+          RenderTableRow {tr} at (0,0) size 178x20
+            RenderTableCell {td} at (0,0) size 60x20 [border: none none none (1px none #808080)] [r=0 c=0 rs=1 cs=1]
+              RenderText {#text} at (2,1) size 52x18
+                text run at (2,1) width 52: "TFOOT"
+            RenderTableCell {td} at (59,0) size 60x20 [r=0 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 52x18
+                text run at (1,1) width 52: "TFOOT"
+            RenderTableCell {td} at (118,0) size 60x20 [r=0 c=2 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 52x18
+                text run at (1,1) width 52: "TFOOT"
+        RenderTableSection {tbody} at (0,21) size 178x40
+          RenderTableRow {tr} at (0,0) size 178x20
+            RenderTableCell {td} at (0,0) size 60x20 [border: none none none (1px none #808080)] [r=0 c=0 rs=1 cs=1]
+              RenderText {#text} at (2,1) size 56x18
+                text run at (2,1) width 56: "TBODY"
+            RenderTableCell {td} at (59,0) size 60x20 [r=0 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 56x18
+                text run at (1,1) width 56: "TBODY"
+            RenderTableCell {td} at (118,0) size 60x20 [r=0 c=2 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 56x18
+                text run at (1,1) width 56: "TBODY"
+          RenderTableRow {tr} at (0,20) size 178x20
+            RenderTableCell {td} at (0,20) size 60x20 [border: none none none (1px none #808080)] [r=1 c=0 rs=1 cs=1]
+              RenderText {#text} at (2,1) size 56x18
+                text run at (2,1) width 56: "TBODY"
+            RenderTableCell {td} at (59,20) size 60x20 [r=1 c=1 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 56x18
+                text run at (1,1) width 56: "TBODY"
+            RenderTableCell {td} at (118,20) size 60x20 [r=1 c=2 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 56x18
+                text run at (1,1) width 56: "TBODY"

--- a/LayoutTests/platform/mac/tables/mozilla_expected_failures/marvin/x_table_rules_rows-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla_expected_failures/marvin/x_table_rules_rows-expected.txt
@@ -15,45 +15,45 @@ layer at (0,0) size 800x143
         RenderTableCol {colgroup} at (0,0) size 0x0
           RenderTableCol {col} at (0,0) size 0x0
         RenderTableSection {thead} at (0,0) size 178x21
-          RenderTableRow {tr} at (0,0) size 178x21
-            RenderTableCell {th} at (0,0) size 60x21 [border: (1px solid #000000) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {tr} at (0,0) size 178x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {th} at (0,0) size 60x21 [border: (1px none #000000) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 57x18
                 text run at (2,2) width 57: "THEAD"
-            RenderTableCell {th} at (59,0) size 60x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {th} at (59,0) size 60x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 57x18
                 text run at (1,2) width 57: "THEAD"
-            RenderTableCell {th} at (118,0) size 60x21 [border: (1px solid #000000) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {th} at (118,0) size 60x21 [border: (1px none #000000) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 57x18
                 text run at (1,2) width 57: "THEAD"
         RenderTableSection {tfoot} at (0,63) size 178x21
-          RenderTableRow {tr} at (0,0) size 178x21
-            RenderTableCell {td} at (0,0) size 60x21 [border: (1px solid #000000) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {tr} at (0,0) size 178x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {td} at (0,0) size 60x21 [border: (1px none #000000) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 52x18
                 text run at (2,2) width 52: "TFOOT"
-            RenderTableCell {td} at (59,0) size 60x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {td} at (59,0) size 60x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 52x18
                 text run at (1,2) width 52: "TFOOT"
-            RenderTableCell {td} at (118,0) size 60x21 [border: (1px solid #000000) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {td} at (118,0) size 60x21 [border: (1px none #000000) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 52x18
                 text run at (1,2) width 52: "TFOOT"
         RenderTableSection {tbody} at (0,21) size 178x42
-          RenderTableRow {tr} at (0,0) size 178x21
-            RenderTableCell {td} at (0,0) size 60x21 [border: (1px solid #000000) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {tr} at (0,0) size 178x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {td} at (0,0) size 60x21 [border: (1px none #000000) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 56x18
                 text run at (2,2) width 56: "TBODY"
-            RenderTableCell {td} at (59,0) size 60x21 [border: (1px solid #000000) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {td} at (59,0) size 60x21 [border: (1px none #000000) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 56x18
                 text run at (1,2) width 56: "TBODY"
-            RenderTableCell {td} at (118,0) size 60x21 [border: (1px solid #000000) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {td} at (118,0) size 60x21 [border: (1px none #000000) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 56x18
                 text run at (1,2) width 56: "TBODY"
-          RenderTableRow {tr} at (0,21) size 178x21
-            RenderTableCell {td} at (0,21) size 60x21 [border: (1px solid #000000) none none (1px none #000000)] [r=1 c=0 rs=1 cs=1]
+          RenderTableRow {tr} at (0,21) size 178x21 [border: (1px solid #000000) none (1px solid #000000) none]
+            RenderTableCell {td} at (0,21) size 60x21 [border: (1px none #000000) none none (1px none #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 56x18
                 text run at (2,2) width 56: "TBODY"
-            RenderTableCell {td} at (59,21) size 60x21 [border: (1px solid #000000) none none none] [r=1 c=1 rs=1 cs=1]
+            RenderTableCell {td} at (59,21) size 60x21 [border: (1px none #000000) none none none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 56x18
                 text run at (1,2) width 56: "TBODY"
-            RenderTableCell {td} at (118,21) size 60x21 [border: (1px solid #000000) none none none] [r=1 c=2 rs=1 cs=1]
+            RenderTableCell {td} at (118,21) size 60x21 [border: (1px none #000000) none none none] [r=1 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 56x18
                 text run at (1,2) width 56: "TBODY"

--- a/LayoutTests/platform/win/fast/table/frame-and-rules-expected.txt
+++ b/LayoutTests/platform/win/fast/table/frame-and-rules-expected.txt
@@ -894,7 +894,7 @@ layer at (0,0) size 785x8148
             RenderText at (240,0) size 5x19
               text run at (240,0) width 5: ":"
         RenderTableSection {THEAD} at (0,20) size 261x22
-          RenderTableRow {TR} at (0,0) size 261x22
+          RenderTableRow {TR} at (0,0) size 261x22 [border: (1px solid #808080) none (1px solid #808080) none]
             RenderTableCell {TD} at (0,0) size 87x22 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 85x19
                 text run at (1,1) width 85: "Row 1, Cell 1"
@@ -905,33 +905,33 @@ layer at (0,0) size 785x8148
               RenderText {#text} at (1,1) size 85x19
                 text run at (1,1) width 85: "Row 1, Cell 3"
         RenderTableSection {TBODY} at (0,42) size 261x69
-          RenderTableRow {TR} at (0,0) size 261x23
-            RenderTableCell {TD} at (0,11) size 87x24 [border: (1px solid #808080) none none none] [r=0 c=0 rs=2 cs=1]
+          RenderTableRow {TR} at (0,0) size 261x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {TD} at (0,11) size 87x24 [border: (1px none #808080) none none none] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (1,2) size 85x20
                 text run at (1,3) width 85: "Row 2, Cell 1"
-            RenderTableCell {TD} at (87,0) size 174x23 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=2]
+            RenderTableCell {TD} at (87,0) size 174x23 [border: (1px none #808080) none none none] [r=0 c=1 rs=1 cs=2]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,23) size 261x23
-            RenderTableCell {TD} at (87,23) size 87x23 [border: (1px solid #808080) none none none] [r=1 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,23) size 261x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {TD} at (87,23) size 87x23 [border: (1px none #808080) none none none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 3, Cell 2"
-            RenderTableCell {TD} at (174,34) size 87x24 [border: (1px solid #808080) none none none] [r=1 c=2 rs=2 cs=1]
+            RenderTableCell {TD} at (174,34) size 87x24 [border: (1px none #808080) none none none] [r=1 c=2 rs=2 cs=1]
               RenderText {#text} at (1,2) size 85x20
                 text run at (1,3) width 85: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,46) size 261x23
-            RenderTableCell {TD} at (0,46) size 174x23 [border: (1px solid #808080) none none none] [r=2 c=0 rs=1 cs=2]
+          RenderTableRow {TR} at (0,46) size 261x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {TD} at (0,46) size 174x23 [border: (1px none #808080) none none none] [r=2 c=0 rs=1 cs=2]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 4, Cell 1"
         RenderTableSection {TFOOT} at (0,111) size 261x23
-          RenderTableRow {TR} at (0,0) size 261x23
-            RenderTableCell {TD} at (0,0) size 87x23 [border: (1px solid #808080) none none none] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 261x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {TD} at (0,0) size 87x23 [border: (1px none #808080) none none none] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 5, Cell 1"
-            RenderTableCell {TD} at (87,0) size 87x23 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (87,0) size 87x23 [border: (1px none #808080) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 5, Cell 2"
-            RenderTableCell {TD} at (174,0) size 87x23 [border: (1px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (174,0) size 87x23 [border: (1px none #808080) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 5, Cell 3"
       RenderTable {TABLE} at (0,3420) size 261x135
@@ -943,44 +943,44 @@ layer at (0,0) size 785x8148
             RenderText at (245,0) size 5x19
               text run at (245,0) width 5: ":"
         RenderTableSection {THEAD} at (0,20) size 261x23
-          RenderTableRow {TR} at (0,0) size 261x23
-            RenderTableCell {TD} at (0,0) size 87x23 [border: (1px solid #808080) none none none] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 261x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {TD} at (0,0) size 87x23 [border: (1px none #808080) none none none] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 1, Cell 1"
-            RenderTableCell {TD} at (87,0) size 87x23 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (87,0) size 87x23 [border: (1px none #808080) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 1, Cell 2"
-            RenderTableCell {TD} at (174,0) size 87x23 [border: (1px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (174,0) size 87x23 [border: (1px none #808080) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 1, Cell 3"
         RenderTableSection {TBODY} at (0,43) size 261x69
-          RenderTableRow {TR} at (0,0) size 261x23
-            RenderTableCell {TD} at (0,11) size 87x24 [border: (1px solid #808080) none none none] [r=0 c=0 rs=2 cs=1]
+          RenderTableRow {TR} at (0,0) size 261x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {TD} at (0,11) size 87x24 [border: (1px none #808080) none none none] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (1,2) size 85x20
                 text run at (1,3) width 85: "Row 2, Cell 1"
-            RenderTableCell {TD} at (87,0) size 174x23 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=2]
+            RenderTableCell {TD} at (87,0) size 174x23 [border: (1px none #808080) none none none] [r=0 c=1 rs=1 cs=2]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,23) size 261x23
-            RenderTableCell {TD} at (87,23) size 87x23 [border: (1px solid #808080) none none none] [r=1 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,23) size 261x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {TD} at (87,23) size 87x23 [border: (1px none #808080) none none none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 3, Cell 2"
-            RenderTableCell {TD} at (174,34) size 87x24 [border: (1px solid #808080) none none none] [r=1 c=2 rs=2 cs=1]
+            RenderTableCell {TD} at (174,34) size 87x24 [border: (1px none #808080) none none none] [r=1 c=2 rs=2 cs=1]
               RenderText {#text} at (1,2) size 85x20
                 text run at (1,3) width 85: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,46) size 261x23
-            RenderTableCell {TD} at (0,46) size 174x23 [border: (1px solid #808080) none none none] [r=2 c=0 rs=1 cs=2]
+          RenderTableRow {TR} at (0,46) size 261x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {TD} at (0,46) size 174x23 [border: (1px none #808080) none none none] [r=2 c=0 rs=1 cs=2]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 4, Cell 1"
         RenderTableSection {TFOOT} at (0,112) size 261x23
-          RenderTableRow {TR} at (0,0) size 261x23
-            RenderTableCell {TD} at (0,0) size 87x23 [border: (1px solid #808080) none none none] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 261x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {TD} at (0,0) size 87x23 [border: (1px none #808080) none none none] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 5, Cell 1"
-            RenderTableCell {TD} at (87,0) size 87x23 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (87,0) size 87x23 [border: (1px none #808080) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 5, Cell 2"
-            RenderTableCell {TD} at (174,0) size 87x23 [border: (1px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (174,0) size 87x23 [border: (1px none #808080) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 5, Cell 3"
       RenderTable {TABLE} at (0,3603) size 261x135 [border: none (1px solid #808080) none]
@@ -992,7 +992,7 @@ layer at (0,0) size 785x8148
             RenderText at (245,0) size 6x19
               text run at (245,0) width 6: ":"
         RenderTableSection {THEAD} at (0,20) size 261x22
-          RenderTableRow {TR} at (0,0) size 261x22
+          RenderTableRow {TR} at (0,0) size 261x22 [border: (1px solid #808080) none (1px solid #808080) none]
             RenderTableCell {TD} at (0,0) size 87x22 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 85x19
                 text run at (1,1) width 85: "Row 1, Cell 1"
@@ -1003,33 +1003,33 @@ layer at (0,0) size 785x8148
               RenderText {#text} at (1,1) size 85x19
                 text run at (1,1) width 85: "Row 1, Cell 3"
         RenderTableSection {TBODY} at (0,42) size 261x69
-          RenderTableRow {TR} at (0,0) size 261x23
-            RenderTableCell {TD} at (0,11) size 87x24 [border: (1px solid #808080) none none none] [r=0 c=0 rs=2 cs=1]
+          RenderTableRow {TR} at (0,0) size 261x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {TD} at (0,11) size 87x24 [border: (1px none #808080) none none none] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (1,2) size 85x20
                 text run at (1,3) width 85: "Row 2, Cell 1"
-            RenderTableCell {TD} at (87,0) size 174x23 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=2]
+            RenderTableCell {TD} at (87,0) size 174x23 [border: (1px none #808080) none none none] [r=0 c=1 rs=1 cs=2]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,23) size 261x23
-            RenderTableCell {TD} at (87,23) size 87x23 [border: (1px solid #808080) none none none] [r=1 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,23) size 261x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {TD} at (87,23) size 87x23 [border: (1px none #808080) none none none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 3, Cell 2"
-            RenderTableCell {TD} at (174,34) size 87x24 [border: (1px solid #808080) none none none] [r=1 c=2 rs=2 cs=1]
+            RenderTableCell {TD} at (174,34) size 87x24 [border: (1px none #808080) none none none] [r=1 c=2 rs=2 cs=1]
               RenderText {#text} at (1,2) size 85x20
                 text run at (1,3) width 85: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,46) size 261x23
-            RenderTableCell {TD} at (0,46) size 174x23 [border: (1px solid #808080) none none none] [r=2 c=0 rs=1 cs=2]
+          RenderTableRow {TR} at (0,46) size 261x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {TD} at (0,46) size 174x23 [border: (1px none #808080) none none none] [r=2 c=0 rs=1 cs=2]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 4, Cell 1"
         RenderTableSection {TFOOT} at (0,111) size 261x23
-          RenderTableRow {TR} at (0,0) size 261x23
-            RenderTableCell {TD} at (0,0) size 87x23 [border: (1px solid #808080) none none none] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 261x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {TD} at (0,0) size 87x23 [border: (1px none #808080) none none none] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 5, Cell 1"
-            RenderTableCell {TD} at (87,0) size 87x23 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (87,0) size 87x23 [border: (1px none #808080) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 5, Cell 2"
-            RenderTableCell {TD} at (174,0) size 87x23 [border: (1px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (174,0) size 87x23 [border: (1px none #808080) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 5, Cell 3"
       RenderTable {TABLE} at (0,3786) size 261x136 [border: none none (1px solid #808080) none]
@@ -1041,44 +1041,44 @@ layer at (0,0) size 785x8148
             RenderText at (246,0) size 6x19
               text run at (246,0) width 6: ":"
         RenderTableSection {THEAD} at (0,20) size 261x23
-          RenderTableRow {TR} at (0,0) size 261x23
-            RenderTableCell {TD} at (0,0) size 87x23 [border: (1px solid #808080) none none none] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 261x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {TD} at (0,0) size 87x23 [border: (1px none #808080) none none none] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 1, Cell 1"
-            RenderTableCell {TD} at (87,0) size 87x23 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (87,0) size 87x23 [border: (1px none #808080) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 1, Cell 2"
-            RenderTableCell {TD} at (174,0) size 87x23 [border: (1px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (174,0) size 87x23 [border: (1px none #808080) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 1, Cell 3"
         RenderTableSection {TBODY} at (0,43) size 261x69
-          RenderTableRow {TR} at (0,0) size 261x23
-            RenderTableCell {TD} at (0,11) size 87x24 [border: (1px solid #808080) none none none] [r=0 c=0 rs=2 cs=1]
+          RenderTableRow {TR} at (0,0) size 261x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {TD} at (0,11) size 87x24 [border: (1px none #808080) none none none] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (1,2) size 85x20
                 text run at (1,3) width 85: "Row 2, Cell 1"
-            RenderTableCell {TD} at (87,0) size 174x23 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=2]
+            RenderTableCell {TD} at (87,0) size 174x23 [border: (1px none #808080) none none none] [r=0 c=1 rs=1 cs=2]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,23) size 261x23
-            RenderTableCell {TD} at (87,23) size 87x23 [border: (1px solid #808080) none none none] [r=1 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,23) size 261x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {TD} at (87,23) size 87x23 [border: (1px none #808080) none none none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 3, Cell 2"
-            RenderTableCell {TD} at (174,34) size 87x24 [border: (1px solid #808080) none none none] [r=1 c=2 rs=2 cs=1]
+            RenderTableCell {TD} at (174,34) size 87x24 [border: (1px none #808080) none none none] [r=1 c=2 rs=2 cs=1]
               RenderText {#text} at (1,2) size 85x20
                 text run at (1,3) width 85: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,46) size 261x23
-            RenderTableCell {TD} at (0,46) size 174x23 [border: (1px solid #808080) none none none] [r=2 c=0 rs=1 cs=2]
+          RenderTableRow {TR} at (0,46) size 261x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {TD} at (0,46) size 174x23 [border: (1px none #808080) none none none] [r=2 c=0 rs=1 cs=2]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 4, Cell 1"
         RenderTableSection {TFOOT} at (0,112) size 261x23
-          RenderTableRow {TR} at (0,0) size 261x23
-            RenderTableCell {TD} at (0,0) size 87x23 [border: (1px solid #808080) none none none] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 261x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {TD} at (0,0) size 87x23 [border: (1px none #808080) none none none] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 5, Cell 1"
-            RenderTableCell {TD} at (87,0) size 87x23 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (87,0) size 87x23 [border: (1px none #808080) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 5, Cell 2"
-            RenderTableCell {TD} at (174,0) size 87x23 [border: (1px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (174,0) size 87x23 [border: (1px none #808080) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 5, Cell 3"
       RenderTable {TABLE} at (0,3970) size 263x134 [border: none (1px solid #808080) none none]
@@ -1090,7 +1090,7 @@ layer at (0,0) size 785x8148
             RenderText at (246,0) size 6x19
               text run at (246,0) width 6: ":"
         RenderTableSection {THEAD} at (0,20) size 262x22
-          RenderTableRow {TR} at (0,0) size 262x22
+          RenderTableRow {TR} at (0,0) size 262x22 [border: (1px solid #808080) none (1px solid #808080) none]
             RenderTableCell {TD} at (0,0) size 88x22 [border: none none none (1px none #808080)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,1) size 85x19
                 text run at (2,1) width 85: "Row 1, Cell 1"
@@ -1101,33 +1101,33 @@ layer at (0,0) size 785x8148
               RenderText {#text} at (1,1) size 85x19
                 text run at (1,1) width 85: "Row 1, Cell 3"
         RenderTableSection {TBODY} at (0,42) size 262x69
-          RenderTableRow {TR} at (0,0) size 262x23
-            RenderTableCell {TD} at (0,11) size 88x24 [border: (1px solid #808080) none none (1px none #000000)] [r=0 c=0 rs=2 cs=1]
+          RenderTableRow {TR} at (0,0) size 262x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {TD} at (0,11) size 88x24 [border: (1px none #808080) none none (1px none #000000)] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (2,2) size 85x20
                 text run at (2,3) width 85: "Row 2, Cell 1"
-            RenderTableCell {TD} at (88,0) size 174x23 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=2]
+            RenderTableCell {TD} at (88,0) size 174x23 [border: (1px none #808080) none none none] [r=0 c=1 rs=1 cs=2]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,23) size 262x23
-            RenderTableCell {TD} at (88,23) size 87x23 [border: (1px solid #808080) none none none] [r=1 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,23) size 262x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {TD} at (88,23) size 87x23 [border: (1px none #808080) none none none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 3, Cell 2"
-            RenderTableCell {TD} at (175,34) size 87x24 [border: (1px solid #808080) none none none] [r=1 c=2 rs=2 cs=1]
+            RenderTableCell {TD} at (175,34) size 87x24 [border: (1px none #808080) none none none] [r=1 c=2 rs=2 cs=1]
               RenderText {#text} at (1,2) size 85x20
                 text run at (1,3) width 85: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,46) size 262x23
-            RenderTableCell {TD} at (0,46) size 175x23 [border: (1px solid #808080) none none (1px none #000000)] [r=2 c=0 rs=1 cs=2]
+          RenderTableRow {TR} at (0,46) size 262x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {TD} at (0,46) size 175x23 [border: (1px none #808080) none none (1px none #000000)] [r=2 c=0 rs=1 cs=2]
               RenderText {#text} at (2,2) size 85x19
                 text run at (2,2) width 85: "Row 4, Cell 1"
         RenderTableSection {TFOOT} at (0,111) size 262x23
-          RenderTableRow {TR} at (0,0) size 262x23
-            RenderTableCell {TD} at (0,0) size 88x23 [border: (1px solid #808080) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 262x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {TD} at (0,0) size 88x23 [border: (1px none #808080) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 85x19
                 text run at (2,2) width 85: "Row 5, Cell 1"
-            RenderTableCell {TD} at (88,0) size 87x23 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (88,0) size 87x23 [border: (1px none #808080) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 5, Cell 2"
-            RenderTableCell {TD} at (175,0) size 87x23 [border: (1px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (175,0) size 87x23 [border: (1px none #808080) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 5, Cell 3"
       RenderTable {TABLE} at (0,4152) size 262x134
@@ -1139,7 +1139,7 @@ layer at (0,0) size 785x8148
             RenderText at (236,0) size 6x19
               text run at (236,0) width 6: ":"
         RenderTableSection {THEAD} at (0,20) size 262x22
-          RenderTableRow {TR} at (0,0) size 262x22
+          RenderTableRow {TR} at (0,0) size 262x22 [border: (1px solid #808080) none (1px solid #808080) none]
             RenderTableCell {TD} at (0,0) size 88x22 [border: none none none (1px none #808080)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,1) size 85x19
                 text run at (2,1) width 85: "Row 1, Cell 1"
@@ -1150,33 +1150,33 @@ layer at (0,0) size 785x8148
               RenderText {#text} at (1,1) size 85x19
                 text run at (1,1) width 85: "Row 1, Cell 3"
         RenderTableSection {TBODY} at (0,42) size 262x69
-          RenderTableRow {TR} at (0,0) size 262x23
-            RenderTableCell {TD} at (0,11) size 88x24 [border: (1px solid #808080) none none (1px none #000000)] [r=0 c=0 rs=2 cs=1]
+          RenderTableRow {TR} at (0,0) size 262x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {TD} at (0,11) size 88x24 [border: (1px none #808080) none none (1px none #000000)] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (2,2) size 85x20
                 text run at (2,3) width 85: "Row 2, Cell 1"
-            RenderTableCell {TD} at (88,0) size 174x23 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=2]
+            RenderTableCell {TD} at (88,0) size 174x23 [border: (1px none #808080) none none none] [r=0 c=1 rs=1 cs=2]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,23) size 262x23
-            RenderTableCell {TD} at (88,23) size 87x23 [border: (1px solid #808080) none none none] [r=1 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,23) size 262x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {TD} at (88,23) size 87x23 [border: (1px none #808080) none none none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 3, Cell 2"
-            RenderTableCell {TD} at (175,34) size 87x24 [border: (1px solid #808080) none none none] [r=1 c=2 rs=2 cs=1]
+            RenderTableCell {TD} at (175,34) size 87x24 [border: (1px none #808080) none none none] [r=1 c=2 rs=2 cs=1]
               RenderText {#text} at (1,2) size 85x20
                 text run at (1,3) width 85: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,46) size 262x23
-            RenderTableCell {TD} at (0,46) size 175x23 [border: (1px solid #808080) none none (1px none #000000)] [r=2 c=0 rs=1 cs=2]
+          RenderTableRow {TR} at (0,46) size 262x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {TD} at (0,46) size 175x23 [border: (1px none #808080) none none (1px none #000000)] [r=2 c=0 rs=1 cs=2]
               RenderText {#text} at (2,2) size 85x19
                 text run at (2,2) width 85: "Row 4, Cell 1"
         RenderTableSection {TFOOT} at (0,111) size 262x23
-          RenderTableRow {TR} at (0,0) size 262x23
-            RenderTableCell {TD} at (0,0) size 88x23 [border: (1px solid #808080) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 262x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {TD} at (0,0) size 88x23 [border: (1px none #808080) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 85x19
                 text run at (2,2) width 85: "Row 5, Cell 1"
-            RenderTableCell {TD} at (88,0) size 87x23 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (88,0) size 87x23 [border: (1px none #808080) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 5, Cell 2"
-            RenderTableCell {TD} at (175,0) size 87x23 [border: (1px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (175,0) size 87x23 [border: (1px none #808080) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 5, Cell 3"
       RenderTable {TABLE} at (0,4334) size 262x134 [border: none (1px solid #808080) none]
@@ -1188,7 +1188,7 @@ layer at (0,0) size 785x8148
             RenderText at (237,0) size 5x19
               text run at (237,0) width 5: ":"
         RenderTableSection {THEAD} at (0,20) size 261x22
-          RenderTableRow {TR} at (0,0) size 261x22
+          RenderTableRow {TR} at (0,0) size 261x22 [border: (1px solid #808080) none (1px solid #808080) none]
             RenderTableCell {TD} at (0,0) size 87x22 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 85x19
                 text run at (1,1) width 85: "Row 1, Cell 1"
@@ -1199,33 +1199,33 @@ layer at (0,0) size 785x8148
               RenderText {#text} at (1,1) size 85x19
                 text run at (1,1) width 85: "Row 1, Cell 3"
         RenderTableSection {TBODY} at (0,42) size 261x69
-          RenderTableRow {TR} at (0,0) size 261x23
-            RenderTableCell {TD} at (0,11) size 87x24 [border: (1px solid #808080) none none none] [r=0 c=0 rs=2 cs=1]
+          RenderTableRow {TR} at (0,0) size 261x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {TD} at (0,11) size 87x24 [border: (1px none #808080) none none none] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (1,2) size 85x20
                 text run at (1,3) width 85: "Row 2, Cell 1"
-            RenderTableCell {TD} at (87,0) size 174x23 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=2]
+            RenderTableCell {TD} at (87,0) size 174x23 [border: (1px none #808080) none none none] [r=0 c=1 rs=1 cs=2]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,23) size 261x23
-            RenderTableCell {TD} at (87,23) size 87x23 [border: (1px solid #808080) none none none] [r=1 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,23) size 261x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {TD} at (87,23) size 87x23 [border: (1px none #808080) none none none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 3, Cell 2"
-            RenderTableCell {TD} at (174,34) size 87x24 [border: (1px solid #808080) none none none] [r=1 c=2 rs=2 cs=1]
+            RenderTableCell {TD} at (174,34) size 87x24 [border: (1px none #808080) none none none] [r=1 c=2 rs=2 cs=1]
               RenderText {#text} at (1,2) size 85x20
                 text run at (1,3) width 85: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,46) size 261x23
-            RenderTableCell {TD} at (0,46) size 174x23 [border: (1px solid #808080) none none none] [r=2 c=0 rs=1 cs=2]
+          RenderTableRow {TR} at (0,46) size 261x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {TD} at (0,46) size 174x23 [border: (1px none #808080) none none none] [r=2 c=0 rs=1 cs=2]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 4, Cell 1"
         RenderTableSection {TFOOT} at (0,111) size 261x23
-          RenderTableRow {TR} at (0,0) size 261x23
-            RenderTableCell {TD} at (0,0) size 87x23 [border: (1px solid #808080) none none none] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 261x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {TD} at (0,0) size 87x23 [border: (1px none #808080) none none none] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 5, Cell 1"
-            RenderTableCell {TD} at (87,0) size 87x23 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (87,0) size 87x23 [border: (1px none #808080) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 5, Cell 2"
-            RenderTableCell {TD} at (174,0) size 87x23 [border: (1px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (174,0) size 87x23 [border: (1px none #808080) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 5, Cell 3"
       RenderTable {TABLE} at (0,4516) size 263x136 [border: none]
@@ -1237,44 +1237,44 @@ layer at (0,0) size 785x8148
             RenderText at (239,0) size 5x19
               text run at (239,0) width 5: ":"
         RenderTableSection {THEAD} at (0,20) size 262x23
-          RenderTableRow {TR} at (0,0) size 262x23
-            RenderTableCell {TD} at (0,0) size 88x23 [border: (1px solid #808080) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 262x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {TD} at (0,0) size 88x23 [border: (1px none #808080) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 85x19
                 text run at (2,2) width 85: "Row 1, Cell 1"
-            RenderTableCell {TD} at (88,0) size 87x23 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (88,0) size 87x23 [border: (1px none #808080) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 1, Cell 2"
-            RenderTableCell {TD} at (175,0) size 87x23 [border: (1px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (175,0) size 87x23 [border: (1px none #808080) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 1, Cell 3"
         RenderTableSection {TBODY} at (0,43) size 262x69
-          RenderTableRow {TR} at (0,0) size 262x23
-            RenderTableCell {TD} at (0,11) size 88x24 [border: (1px solid #808080) none none (1px none #000000)] [r=0 c=0 rs=2 cs=1]
+          RenderTableRow {TR} at (0,0) size 262x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {TD} at (0,11) size 88x24 [border: (1px none #808080) none none (1px none #000000)] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (2,2) size 85x20
                 text run at (2,3) width 85: "Row 2, Cell 1"
-            RenderTableCell {TD} at (88,0) size 174x23 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=2]
+            RenderTableCell {TD} at (88,0) size 174x23 [border: (1px none #808080) none none none] [r=0 c=1 rs=1 cs=2]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,23) size 262x23
-            RenderTableCell {TD} at (88,23) size 87x23 [border: (1px solid #808080) none none none] [r=1 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,23) size 262x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {TD} at (88,23) size 87x23 [border: (1px none #808080) none none none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 3, Cell 2"
-            RenderTableCell {TD} at (175,34) size 87x24 [border: (1px solid #808080) none none none] [r=1 c=2 rs=2 cs=1]
+            RenderTableCell {TD} at (175,34) size 87x24 [border: (1px none #808080) none none none] [r=1 c=2 rs=2 cs=1]
               RenderText {#text} at (1,2) size 85x20
                 text run at (1,3) width 85: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,46) size 262x23
-            RenderTableCell {TD} at (0,46) size 175x23 [border: (1px solid #808080) none none (1px none #000000)] [r=2 c=0 rs=1 cs=2]
+          RenderTableRow {TR} at (0,46) size 262x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {TD} at (0,46) size 175x23 [border: (1px none #808080) none none (1px none #000000)] [r=2 c=0 rs=1 cs=2]
               RenderText {#text} at (2,2) size 85x19
                 text run at (2,2) width 85: "Row 4, Cell 1"
         RenderTableSection {TFOOT} at (0,112) size 262x23
-          RenderTableRow {TR} at (0,0) size 262x23
-            RenderTableCell {TD} at (0,0) size 88x23 [border: (1px solid #808080) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 262x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {TD} at (0,0) size 88x23 [border: (1px none #808080) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 85x19
                 text run at (2,2) width 85: "Row 5, Cell 1"
-            RenderTableCell {TD} at (88,0) size 87x23 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (88,0) size 87x23 [border: (1px none #808080) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 5, Cell 2"
-            RenderTableCell {TD} at (175,0) size 87x23 [border: (1px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (175,0) size 87x23 [border: (1px none #808080) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 5, Cell 3"
       RenderTable {TABLE} at (0,4700) size 263x136 [border: none]
@@ -1286,44 +1286,44 @@ layer at (0,0) size 785x8148
             RenderText at (248,0) size 6x19
               text run at (248,0) width 6: ":"
         RenderTableSection {THEAD} at (0,20) size 262x23
-          RenderTableRow {TR} at (0,0) size 262x23
-            RenderTableCell {TD} at (0,0) size 88x23 [border: (1px solid #808080) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 262x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {TD} at (0,0) size 88x23 [border: (1px none #808080) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 85x19
                 text run at (2,2) width 85: "Row 1, Cell 1"
-            RenderTableCell {TD} at (88,0) size 87x23 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (88,0) size 87x23 [border: (1px none #808080) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 1, Cell 2"
-            RenderTableCell {TD} at (175,0) size 87x23 [border: (1px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (175,0) size 87x23 [border: (1px none #808080) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 1, Cell 3"
         RenderTableSection {TBODY} at (0,43) size 262x69
-          RenderTableRow {TR} at (0,0) size 262x23
-            RenderTableCell {TD} at (0,11) size 88x24 [border: (1px solid #808080) none none (1px none #000000)] [r=0 c=0 rs=2 cs=1]
+          RenderTableRow {TR} at (0,0) size 262x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {TD} at (0,11) size 88x24 [border: (1px none #808080) none none (1px none #000000)] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (2,2) size 85x20
                 text run at (2,3) width 85: "Row 2, Cell 1"
-            RenderTableCell {TD} at (88,0) size 174x23 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=2]
+            RenderTableCell {TD} at (88,0) size 174x23 [border: (1px none #808080) none none none] [r=0 c=1 rs=1 cs=2]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 2, Cell 2"
-          RenderTableRow {TR} at (0,23) size 262x23
-            RenderTableCell {TD} at (88,23) size 87x23 [border: (1px solid #808080) none none none] [r=1 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,23) size 262x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {TD} at (88,23) size 87x23 [border: (1px none #808080) none none none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 3, Cell 2"
-            RenderTableCell {TD} at (175,34) size 87x24 [border: (1px solid #808080) none none none] [r=1 c=2 rs=2 cs=1]
+            RenderTableCell {TD} at (175,34) size 87x24 [border: (1px none #808080) none none none] [r=1 c=2 rs=2 cs=1]
               RenderText {#text} at (1,2) size 85x20
                 text run at (1,3) width 85: "Row 3, Cell 3"
-          RenderTableRow {TR} at (0,46) size 262x23
-            RenderTableCell {TD} at (0,46) size 175x23 [border: (1px solid #808080) none none (1px none #000000)] [r=2 c=0 rs=1 cs=2]
+          RenderTableRow {TR} at (0,46) size 262x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {TD} at (0,46) size 175x23 [border: (1px none #808080) none none (1px none #000000)] [r=2 c=0 rs=1 cs=2]
               RenderText {#text} at (2,2) size 85x19
                 text run at (2,2) width 85: "Row 4, Cell 1"
         RenderTableSection {TFOOT} at (0,112) size 262x23
-          RenderTableRow {TR} at (0,0) size 262x23
-            RenderTableCell {TD} at (0,0) size 88x23 [border: (1px solid #808080) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 262x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {TD} at (0,0) size 88x23 [border: (1px none #808080) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 85x19
                 text run at (2,2) width 85: "Row 5, Cell 1"
-            RenderTableCell {TD} at (88,0) size 87x23 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (88,0) size 87x23 [border: (1px none #808080) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 5, Cell 2"
-            RenderTableCell {TD} at (175,0) size 87x23 [border: (1px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (175,0) size 87x23 [border: (1px none #808080) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 85x19
                 text run at (1,2) width 85: "Row 5, Cell 3"
       RenderTable {TABLE} at (0,4884) size 263x130

--- a/LayoutTests/platform/win/fast/table/rules-attr-dynchange2-expected.txt
+++ b/LayoutTests/platform/win/fast/table/rules-attr-dynchange2-expected.txt
@@ -5,25 +5,25 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576
       RenderTable {TABLE} at (0,0) size 144x70 [border: none]
         RenderTableSection {TBODY} at (0,0) size 143x69
-          RenderTableRow {TR} at (0,0) size 143x23
-            RenderTableCell {TD} at (0,0) size 72x23 [border: (1px solid #808080) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 143x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {TD} at (0,0) size 72x23 [border: (1px none #808080) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 69x19
                 text run at (2,2) width 69: "Row1 cell1"
-            RenderTableCell {TD} at (72,0) size 71x23 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (72,0) size 71x23 [border: (1px none #808080) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 69x19
                 text run at (1,2) width 69: "Row1 cell2"
-          RenderTableRow {TR} at (0,23) size 143x23
-            RenderTableCell {TD} at (0,23) size 72x23 [border: (1px solid #808080) none none (1px none #000000)] [r=1 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,23) size 143x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {TD} at (0,23) size 72x23 [border: (1px none #808080) none none (1px none #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 69x19
                 text run at (2,2) width 69: "Row2 cell1"
-            RenderTableCell {TD} at (72,23) size 71x23 [border: (1px solid #808080) none none none] [r=1 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (72,23) size 71x23 [border: (1px none #808080) none none none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 69x19
                 text run at (1,2) width 69: "Row2 cell2"
-          RenderTableRow {TR} at (0,46) size 143x23
-            RenderTableCell {TD} at (0,46) size 72x23 [border: (1px solid #808080) none none (1px none #000000)] [r=2 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,46) size 143x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {TD} at (0,46) size 72x23 [border: (1px none #808080) none none (1px none #000000)] [r=2 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 69x19
                 text run at (2,2) width 69: "Row3 cell1"
-            RenderTableCell {TD} at (72,46) size 71x23 [border: (1px solid #808080) none none none] [r=2 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (72,46) size 71x23 [border: (1px none #808080) none none none] [r=2 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 69x19
                 text run at (1,2) width 69: "Row3 cell2"
       RenderBlock {P} at (0,86) size 784x20

--- a/LayoutTests/platform/win/tables/mozilla/core/table_rules-expected.txt
+++ b/LayoutTests/platform/win/tables/mozilla/core/table_rules-expected.txt
@@ -92,18 +92,18 @@ layer at (0,0) size 800x600
         RenderBR {BR} at (0,0) size 0x19
       RenderTable {TABLE} at (0,243) size 64x47 [border: none]
         RenderTableSection {TBODY} at (0,0) size 63x46
-          RenderTableRow {TR} at (0,0) size 63x23
-            RenderTableCell {TD} at (0,0) size 31x23 [border: (1px solid #808080) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 63x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {TD} at (0,0) size 31x23 [border: (1px none #808080) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 28x19
                 text run at (2,2) width 28: "rules"
-            RenderTableCell {TD} at (31,0) size 32x23 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (31,0) size 32x23 [border: (1px none #808080) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 30x19
                 text run at (1,2) width 30: "rows"
-          RenderTableRow {TR} at (0,23) size 63x23
-            RenderTableCell {TD} at (0,23) size 31x23 [border: (1px solid #808080) none none (1px none #000000)] [r=1 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,23) size 63x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {TD} at (0,23) size 31x23 [border: (1px none #808080) none none (1px none #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 28x19
                 text run at (2,2) width 28: "rules"
-            RenderTableCell {TD} at (31,23) size 32x23 [border: (1px solid #808080) none none none] [r=1 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (31,23) size 32x23 [border: (1px none #808080) none none none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 30x19
                 text run at (1,2) width 30: "rows"
       RenderBlock (anonymous) at (0,290) size 784x20

--- a/LayoutTests/platform/win/tables/mozilla_expected_failures/marvin/table_rules_rows-expected.txt
+++ b/LayoutTests/platform/win/tables/mozilla_expected_failures/marvin/table_rules_rows-expected.txt
@@ -8,53 +8,53 @@ layer at (0,0) size 800x600
           RenderText {#text} at (11,0) size 373x19
             text run at (11,0) width 373: "Communicator 4.5 Installers for Mac and Windows Platforms"
         RenderTableSection {TBODY} at (2,22) size 390x96
-          RenderTableRow {TR} at (0,0) size 390x25
-            RenderTableCell {TH} at (0,10) size 112x5 [border: (3px solid #808080) none none (3px none #000000)] [r=0 c=0 rs=1 cs=1]
-            RenderTableCell {TH} at (112,0) size 106x25 [border: (3px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,0) size 390x25 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {TH} at (0,10) size 112x5 [border: (3px none #808080) none none (3px none #000000)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TH} at (112,0) size 106x25 [border: (3px none #808080) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,4) size 104x19
                 text run at (1,4) width 104: "Macintosh PPC"
-            RenderTableCell {TH} at (218,0) size 82x25 [border: (3px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TH} at (218,0) size 82x25 [border: (3px none #808080) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,4) size 80x19
                 text run at (1,4) width 80: "Windows 95"
-            RenderTableCell {TH} at (300,0) size 90x25 [border: (3px solid #808080) (2px none #808080) none none] [r=0 c=3 rs=1 cs=1]
+            RenderTableCell {TH} at (300,0) size 90x25 [border: (3px none #808080) (2px none #808080) none none] [r=0 c=3 rs=1 cs=1]
               RenderText {#text} at (1,4) size 86x19
                 text run at (1,4) width 86: "Windows NT"
-          RenderTableRow {TR} at (0,25) size 390x23
-            RenderTableCell {TD} at (0,25) size 112x23 [border: (1px solid #808080) none none (3px none #000000)] [r=1 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,25) size 390x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {TD} at (0,25) size 112x23 [border: (1px none #808080) none none (3px none #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (4,2) size 69x19
                 text run at (4,2) width 69: "Base Install"
-            RenderTableCell {TD} at (112,25) size 106x23 [border: (1px solid #808080) none none none] [r=1 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (112,25) size 106x23 [border: (1px none #808080) none none none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 20x19
                 text run at (1,2) width 20: "yes"
-            RenderTableCell {TD} at (218,25) size 82x23 [border: (1px solid #808080) none none none] [r=1 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (218,25) size 82x23 [border: (1px none #808080) none none none] [r=1 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 20x19
                 text run at (1,2) width 20: "yes"
-            RenderTableCell {TD} at (300,25) size 90x23 [border: (1px solid #808080) (2px none #808080) none none] [r=1 c=3 rs=1 cs=1]
+            RenderTableCell {TD} at (300,25) size 90x23 [border: (1px none #808080) (2px none #808080) none none] [r=1 c=3 rs=1 cs=1]
               RenderText {#text} at (1,2) size 20x19
                 text run at (1,2) width 20: "yes"
-          RenderTableRow {TR} at (0,48) size 390x23
-            RenderTableCell {TD} at (0,48) size 112x23 [border: (1px solid #808080) none none (3px none #000000)] [r=2 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,48) size 390x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {TD} at (0,48) size 112x23 [border: (1px none #808080) none none (3px none #000000)] [r=2 c=0 rs=1 cs=1]
               RenderText {#text} at (4,2) size 98x19
                 text run at (4,2) width 98: "Complete Install"
-            RenderTableCell {TD} at (112,48) size 106x23 [border: (1px solid #808080) none none none] [r=2 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (112,48) size 106x23 [border: (1px none #808080) none none none] [r=2 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 20x19
                 text run at (1,2) width 20: "yes"
-            RenderTableCell {TD} at (218,48) size 82x23 [border: (1px solid #808080) none none none] [r=2 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (218,48) size 82x23 [border: (1px none #808080) none none none] [r=2 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 20x19
                 text run at (1,2) width 20: "yes"
-            RenderTableCell {TD} at (300,48) size 90x23 [border: (1px solid #808080) (2px none #808080) none none] [r=2 c=3 rs=1 cs=1]
+            RenderTableCell {TD} at (300,48) size 90x23 [border: (1px none #808080) (2px none #808080) none none] [r=2 c=3 rs=1 cs=1]
               RenderText {#text} at (1,2) size 20x19
                 text run at (1,2) width 20: "yes"
-          RenderTableRow {TR} at (0,71) size 390x25
-            RenderTableCell {TD} at (0,71) size 112x25 [border: (1px solid #808080) none (2px solid #808080) (3px none #000000)] [r=3 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,71) size 390x25 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {TD} at (0,71) size 112x25 [border: (1px none #808080) none (2px none #808080) (3px none #000000)] [r=3 c=0 rs=1 cs=1]
               RenderText {#text} at (4,2) size 107x19
                 text run at (4,2) width 107: "Pro Edition Install"
-            RenderTableCell {TD} at (112,71) size 106x25 [border: (1px solid #808080) none (2px solid #808080) none] [r=3 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (112,71) size 106x25 [border: (1px none #808080) none (2px none #808080) none] [r=3 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 20x19
                 text run at (1,2) width 20: "yes"
-            RenderTableCell {TD} at (218,71) size 82x25 [border: (1px solid #808080) none (2px solid #808080) none] [r=3 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (218,71) size 82x25 [border: (1px none #808080) none (2px none #808080) none] [r=3 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 20x19
                 text run at (1,2) width 20: "yes"
-            RenderTableCell {TD} at (300,71) size 90x25 [border: (1px solid #808080) (2px none #808080) (2px solid #808080) none] [r=3 c=3 rs=1 cs=1]
+            RenderTableCell {TD} at (300,71) size 90x25 [border: (1px none #808080) (2px none #808080) (2px none #808080) none] [r=3 c=3 rs=1 cs=1]
               RenderText {#text} at (1,2) size 20x19
                 text run at (1,2) width 20: "yes"

--- a/LayoutTests/platform/win/tables/mozilla_expected_failures/marvin/x_table_rules_rows-expected.txt
+++ b/LayoutTests/platform/win/tables/mozilla_expected_failures/marvin/x_table_rules_rows-expected.txt
@@ -15,45 +15,45 @@ layer at (0,0) size 800x153
         RenderTableCol {colgroup} at (0,0) size 0x0
           RenderTableCol {col} at (0,0) size 0x0
         RenderTableSection {thead} at (0,0) size 172x23
-          RenderTableRow {tr} at (0,0) size 172x23
-            RenderTableCell {th} at (0,0) size 58x23 [border: (1px solid #808080) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {tr} at (0,0) size 172x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {th} at (0,0) size 58x23 [border: (1px none #808080) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 55x19
                 text run at (2,2) width 55: "THEAD"
-            RenderTableCell {th} at (58,0) size 57x23 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {th} at (58,0) size 57x23 [border: (1px none #808080) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 55x19
                 text run at (1,2) width 55: "THEAD"
-            RenderTableCell {th} at (115,0) size 57x23 [border: (1px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {th} at (115,0) size 57x23 [border: (1px none #808080) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 55x19
                 text run at (1,2) width 55: "THEAD"
         RenderTableSection {tfoot} at (0,69) size 172x23
-          RenderTableRow {tr} at (0,0) size 172x23
-            RenderTableCell {td} at (0,0) size 58x23 [border: (1px solid #808080) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {tr} at (0,0) size 172x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {td} at (0,0) size 58x23 [border: (1px none #808080) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 51x19
                 text run at (2,2) width 51: "TFOOT"
-            RenderTableCell {td} at (58,0) size 57x23 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {td} at (58,0) size 57x23 [border: (1px none #808080) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 51x19
                 text run at (1,2) width 51: "TFOOT"
-            RenderTableCell {td} at (115,0) size 57x23 [border: (1px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {td} at (115,0) size 57x23 [border: (1px none #808080) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 51x19
                 text run at (1,2) width 51: "TFOOT"
         RenderTableSection {tbody} at (0,23) size 172x46
-          RenderTableRow {tr} at (0,0) size 172x23
-            RenderTableCell {td} at (0,0) size 58x23 [border: (1px solid #808080) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
+          RenderTableRow {tr} at (0,0) size 172x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {td} at (0,0) size 58x23 [border: (1px none #808080) none none (1px none #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 53x19
                 text run at (2,2) width 53: "TBODY"
-            RenderTableCell {td} at (58,0) size 57x23 [border: (1px solid #808080) none none none] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {td} at (58,0) size 57x23 [border: (1px none #808080) none none none] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 53x19
                 text run at (1,2) width 53: "TBODY"
-            RenderTableCell {td} at (115,0) size 57x23 [border: (1px solid #808080) none none none] [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {td} at (115,0) size 57x23 [border: (1px none #808080) none none none] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 53x19
                 text run at (1,2) width 53: "TBODY"
-          RenderTableRow {tr} at (0,23) size 172x23
-            RenderTableCell {td} at (0,23) size 58x23 [border: (1px solid #808080) none none (1px none #000000)] [r=1 c=0 rs=1 cs=1]
+          RenderTableRow {tr} at (0,23) size 172x23 [border: (1px solid #808080) none (1px solid #808080) none]
+            RenderTableCell {td} at (0,23) size 58x23 [border: (1px none #808080) none none (1px none #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 53x19
                 text run at (2,2) width 53: "TBODY"
-            RenderTableCell {td} at (58,23) size 57x23 [border: (1px solid #808080) none none none] [r=1 c=1 rs=1 cs=1]
+            RenderTableCell {td} at (58,23) size 57x23 [border: (1px none #808080) none none none] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (1,2) size 53x19
                 text run at (1,2) width 53: "TBODY"
-            RenderTableCell {td} at (115,23) size 57x23 [border: (1px solid #808080) none none none] [r=1 c=2 rs=1 cs=1]
+            RenderTableCell {td} at (115,23) size 57x23 [border: (1px none #808080) none none none] [r=1 c=2 rs=1 cs=1]
               RenderText {#text} at (1,2) size 53x19
                 text run at (1,2) width 53: "TBODY"

--- a/Source/WebCore/html/HTMLTableElement.cpp
+++ b/Source/WebCore/html/HTMLTableElement.cpp
@@ -509,10 +509,10 @@ Ref<MutableStyleProperties> HTMLTableElement::createSharedCellStyle() const
         style->setProperty(CSSPropertyBorderColor, CSSPrimitiveValue::create(CSSValueInherit));
         break;
     case SolidBordersRowsOnly:
-        style->setProperty(CSSPropertyBorderTopWidth, CSSValueThin);
-        style->setProperty(CSSPropertyBorderBottomWidth, CSSValueThin);
-        style->setProperty(CSSPropertyBorderTopStyle, CSSValueSolid);
-        style->setProperty(CSSPropertyBorderBottomStyle, CSSValueSolid);
+        style->setProperty(CSSPropertyBorderTopWidth, CSSPrimitiveValue::create(0, CSSUnitType::CSS_PX));
+        style->setProperty(CSSPropertyBorderBottomWidth, CSSPrimitiveValue::create(0, CSSUnitType::CSS_PX));
+        style->setProperty(CSSPropertyBorderTopStyle, CSSPrimitiveValue::create(CSSValueNone));
+        style->setProperty(CSSPropertyBorderBottomStyle, CSSPrimitiveValue::create(CSSValueNone));
         style->setProperty(CSSPropertyBorderColor, CSSPrimitiveValue::create(CSSValueInherit));
         break;
     case SolidBorders:

--- a/Source/WebCore/html/HTMLTableElement.cpp
+++ b/Source/WebCore/html/HTMLTableElement.cpp
@@ -402,6 +402,7 @@ void HTMLTableElement::attributeChanged(const QualifiedName& name, const AtomStr
 
     CellBorders bordersBefore = cellBorders();
     unsigned short oldPadding = m_padding;
+    bool hadRowsRule = m_rulesAttr == TableRules::Rows;
 
     switch (name.nodeName()) {
     case AttributeNames::borderAttr:
@@ -442,10 +443,12 @@ void HTMLTableElement::attributeChanged(const QualifiedName& name, const AtomStr
 
     if (bordersBefore != cellBorders() || oldPadding != m_padding) {
         m_sharedCellStyle = nullptr;
-        bool cellChanged = false;
+        // A table with no cells at all still has rows whose rule comes and goes with
+        // rules="rows", and setTableCellsChanged only reports a change when it finds a cell.
+        bool changed = hadRowsRule != (m_rulesAttr == TableRules::Rows);
         for (auto& child : childrenOfType<Element>(*this))
-            cellChanged |= setTableCellsChanged(child);
-        if (cellChanged)
+            changed |= setTableCellsChanged(child);
+        if (changed)
             invalidateStyleForSubtree();
     }
 }
@@ -515,8 +518,8 @@ Ref<MutableStyleProperties> HTMLTableElement::createSharedCellStyle() const
     case CellBorders::SolidRowsOnly:
         style->setProperty(CSSPropertyBorderTopWidth, CSSValueThin);
         style->setProperty(CSSPropertyBorderBottomWidth, CSSValueThin);
-        style->setProperty(CSSPropertyBorderTopStyle, CSSValueSolid);
-        style->setProperty(CSSPropertyBorderBottomStyle, CSSValueSolid);
+        style->setProperty(CSSPropertyBorderTopStyle, CSSValueNone);
+        style->setProperty(CSSPropertyBorderBottomStyle, CSSValueNone);
         style->setProperty(CSSPropertyBorderColor, CSSKeywordValue::create(CSSValueInherit));
         break;
     case CellBorders::Solid:
@@ -574,6 +577,30 @@ const MutableStyleProperties* HTMLTableElement::additionalGroupStyle(bool rows) 
     }
     static NeverDestroyed<Ref<MutableStyleProperties>> columnBorderStyle = makeGroupBorderStyle(false);
     return columnBorderStyle->ptr();
+}
+
+static Ref<MutableStyleProperties> makeRowsRuleStyle()
+{
+    // The block-direction (logical) properties, not the physical top/bottom, so that the rule
+    // between rows follows the writing mode as the spec requires:
+    // table[rules=rows i] > tr { border-block-width: 1px; border-block-style: solid; }
+    // https://html.spec.whatwg.org/multipage/rendering.html#tables-2
+    // No border-color here: html.css already has tr { border-color: inherit }, which resolves
+    // through the row group to the table's border color.
+    auto style = MutableStyleProperties::create();
+    style->setProperty(CSSPropertyBorderBlockStartWidth, CSSValueThin);
+    style->setProperty(CSSPropertyBorderBlockEndWidth, CSSValueThin);
+    style->setProperty(CSSPropertyBorderBlockStartStyle, CSSValueSolid);
+    style->setProperty(CSSPropertyBorderBlockEndStyle, CSSValueSolid);
+    return style;
+}
+
+const MutableStyleProperties* HTMLTableElement::additionalRowStyle() const
+{
+    if (m_rulesAttr != TableRules::Rows)
+        return nullptr;
+    static NeverDestroyed<Ref<MutableStyleProperties>> rowsRuleStyle = makeRowsRuleStyle();
+    return rowsRuleStyle->ptr();
 }
 
 bool HTMLTableElement::isURLAttribute(const Attribute& attribute) const

--- a/Source/WebCore/html/HTMLTableElement.h
+++ b/Source/WebCore/html/HTMLTableElement.h
@@ -69,6 +69,7 @@ public:
 
     const MutableStyleProperties* additionalCellStyle() const;
     const MutableStyleProperties* additionalGroupStyle(bool rows) const;
+    const MutableStyleProperties* additionalRowStyle() const;
 
 private:
     HTMLTableElement(const QualifiedName&, Document&);

--- a/Source/WebCore/html/HTMLTableRowElement.cpp
+++ b/Source/WebCore/html/HTMLTableRowElement.cpp
@@ -62,6 +62,14 @@ Ref<HTMLTableRowElement> HTMLTableRowElement::create(const QualifiedName& tagNam
 
 HTMLTableRowElement::~HTMLTableRowElement() = default;
 
+const MutableStyleProperties* HTMLTableRowElement::additionalPresentationalHintStyle() const
+{
+    auto table = findParentTable();
+    if (!table)
+        return nullptr;
+    return table->additionalRowStyle();
+}
+
 static inline RefPtr<HTMLTableElement> NODELETE findTable(const HTMLTableRowElement& row)
 {
     auto* parent = row.parentNode();

--- a/Source/WebCore/html/HTMLTableRowElement.h
+++ b/Source/WebCore/html/HTMLTableRowElement.h
@@ -52,6 +52,9 @@ public:
 
 private:
     HTMLTableRowElement(const QualifiedName&, Document&);
+
+    // Used to obtain the rule between rows when the table has rules="rows".
+    const MutableStyleProperties* additionalPresentationalHintStyle() const final;
 };
 
 } // namespace


### PR DESCRIPTION
#### 30b998b5593acb3e4f5c9ec59b78c172b93aca0d
<pre>
Table rules=&quot;rows&quot; draws the rule on the cells instead of the rows
<a href="https://bugs.webkit.org/show_bug.cgi?id=257254">https://bugs.webkit.org/show_bug.cgi?id=257254</a>
<a href="https://rdar.apple.com/109765480">rdar://109765480</a>

Reviewed by NOBODY (OOPS!).

With rules=&quot;rows&quot; the line between two rows belongs to the row, not to
the cells. WebKit put it on the top and bottom of every cell, so
getComputedStyle on a cell reported a 1px solid border where there is
none.

Fix by leaving the cells without a border and giving the rows a shared
style, the way row groups already get one for rules=&quot;groups&quot;. It uses the
block-direction properties so the rule follows the writing mode. The
table looks the same as before, and as Firefox.

Also invalidate the rows when the attribute changes. The old walk stops
at the first cell it finds, so a table with rows but no cells kept its
previous rule.

Two tests are added. Nothing upstream checked computed styles for these
attributes, and <a href="https://bugs.webkit.org/show_bug.cgi?id=256850">https://bugs.webkit.org/show_bug.cgi?id=256850</a> only had a
reftest. Two subtests fail: rules=cols and rules=groups in a vertical
writing mode still use the physical properties, tracked in
<a href="https://bugs.webkit.org/show_bug.cgi?id=321071">https://bugs.webkit.org/show_bug.cgi?id=321071</a>

* LayoutTests/fast/table/border-changes-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-border-attributes-computed-style-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-border-attributes-computed-style.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-rules-computed-style-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-rules-computed-style.html: Added.
* LayoutTests/platform/glib/fast/table/frame-and-rules-expected.txt:
* LayoutTests/platform/glib/fast/table/rules-attr-dynchange2-expected.txt:
* LayoutTests/platform/glib/tables/mozilla/core/table_rules-expected.txt:
* LayoutTests/platform/glib/tables/mozilla_expected_failures/marvin/table_rules_rows-expected.txt:
* LayoutTests/platform/glib/tables/mozilla_expected_failures/marvin/x_table_rules_rows-expected.txt:
* LayoutTests/platform/ios/fast/table/frame-and-rules-expected.txt:
* LayoutTests/platform/ios/fast/table/rules-attr-dynchange2-expected.txt:
* LayoutTests/platform/ios/tables/mozilla/core/table_rules-expected.txt:
* LayoutTests/platform/ios/tables/mozilla_expected_failures/marvin/table_rules_rows-expected.txt:
* LayoutTests/platform/ios/tables/mozilla_expected_failures/marvin/x_table_rules_rows-expected.txt:
* LayoutTests/platform/mac/fast/table/frame-and-rules-expected.txt:
* LayoutTests/platform/mac/fast/table/rules-attr-dynchange2-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/core/table_rules-expected.txt:
* LayoutTests/platform/mac/tables/mozilla_expected_failures/marvin/table_rules_rows-expected.txt:
* LayoutTests/platform/mac/tables/mozilla_expected_failures/marvin/x_table_rules_rows-expected.txt:
* LayoutTests/platform/win/fast/table/frame-and-rules-expected.txt:
* LayoutTests/platform/win/fast/table/rules-attr-dynchange2-expected.txt:
* LayoutTests/platform/win/tables/mozilla/core/table_rules-expected.txt:
* LayoutTests/platform/win/tables/mozilla_expected_failures/marvin/table_rules_rows-expected.txt:
* LayoutTests/platform/win/tables/mozilla_expected_failures/marvin/x_table_rules_rows-expected.txt:
  The border annotation moves from the cell lines to the row lines.
  Nothing moves or changes size. Every port has its own dump for these
  tests, so all four are updated.

* Source/WebCore/html/HTMLTableElement.cpp:
(WebCore::HTMLTableElement::attributeChanged):
(WebCore::HTMLTableElement::createSharedCellStyle const):
(WebCore::makeRowsRuleStyle):
(WebCore::HTMLTableElement::additionalRowStyle const):
* Source/WebCore/html/HTMLTableElement.h:
* Source/WebCore/html/HTMLTableRowElement.cpp:
(WebCore::HTMLTableRowElement::additionalPresentationalHintStyle const):
* Source/WebCore/html/HTMLTableRowElement.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30b998b5593acb3e4f5c9ec59b78c172b93aca0d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179153 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53092 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46887 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188984 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/143462 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/39589780-be51-444c-8d83-e959c4b84d2e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181016 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54385 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52802 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139703 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96761 "1 flakes 3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/05bc6753-c680-4670-bf7b-7e27a963e8e5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182110 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43298 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160460 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120150 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/690fa2a9-3a37-4889-b874-6f275d8f9c86) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41969 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40314 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152369 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39964 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/290 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45698 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44560 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191202 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52762 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159977 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; Passed layout tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148942 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53442 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36590 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148688 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43371 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125713 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120555 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51960 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14943 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51345 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51586 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51406 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->