### PR TITLE
Implement 'gamepad' Permissions Policy

### DIFF
--- a/LayoutTests/http/tests/gamepad/gamepad-allow-attribute.https-expected.txt
+++ b/LayoutTests/http/tests/gamepad/gamepad-allow-attribute.https-expected.txt
@@ -1,0 +1,17 @@
+CONSOLE MESSAGE: Feature policy 'Gamepad' check failed for iframe with origin 'https://localhost:8443' and allow attribute 'gamepad 'none''.
+CONSOLE MESSAGE: Feature policy 'Gamepad' check failed for iframe with origin 'https://127.0.0.1:8443' and allow attribute 'gamepad 'none''.
+CONSOLE MESSAGE: Feature policy 'Gamepad' check failed for iframe with origin 'https://localhost:8443' and allow attribute 'gamepad 'self''.
+CONSOLE MESSAGE: Feature policy 'Gamepad' check failed for iframe with origin 'https://127.0.0.1:8443' and allow attribute 'gamepad https://localhost:8443'.
+PASS iframe src: "https://localhost:8443/gamepad/resources/gamepad-postmessage.html" with allow="" is allowed to call getGamepads().
+PASS iframe src: "https://127.0.0.1:8443/gamepad/resources/gamepad-postmessage.html" with allow="" is allowed to call getGamepads().
+PASS iframe src: "https://localhost:8443/gamepad/resources/gamepad-postmessage.html" with allow="gamepad" is allowed to call getGamepads().
+PASS iframe src: "https://127.0.0.1:8443/gamepad/resources/gamepad-postmessage.html" with allow="gamepad" is allowed to call getGamepads().
+PASS iframe src: "https://localhost:8443/gamepad/resources/gamepad-postmessage.html" with allow="gamepad *" is allowed to call getGamepads().
+PASS iframe src: "https://127.0.0.1:8443/gamepad/resources/gamepad-postmessage.html" with allow="gamepad *" is allowed to call getGamepads().
+PASS iframe src: "https://localhost:8443/gamepad/resources/gamepad-postmessage.html" with allow="gamepad 'none'" MUST NOT be allowed to call getGamepads(). SecurityError Third-party iframes are not allowed to call getGamepads() unless explicitly allowed via Feature-Policy (gamepad)
+PASS iframe src: "https://127.0.0.1:8443/gamepad/resources/gamepad-postmessage.html" with allow="gamepad 'none'" MUST NOT be allowed to call getGamepads(). SecurityError Third-party iframes are not allowed to call getGamepads() unless explicitly allowed via Feature-Policy (gamepad)
+PASS iframe src: "https://localhost:8443/gamepad/resources/gamepad-postmessage.html" with allow="gamepad 'self'" MUST NOT be allowed to call getGamepads(). SecurityError Third-party iframes are not allowed to call getGamepads() unless explicitly allowed via Feature-Policy (gamepad)
+PASS iframe src: "https://127.0.0.1:8443/gamepad/resources/gamepad-postmessage.html" with allow="gamepad 'self'" is allowed to call getGamepads().
+PASS iframe src: "https://localhost:8443/gamepad/resources/gamepad-postmessage.html" with allow="gamepad https://localhost:8443" is allowed to call getGamepads().
+PASS iframe src: "https://127.0.0.1:8443/gamepad/resources/gamepad-postmessage.html" with allow="gamepad https://localhost:8443" MUST NOT be allowed to call getGamepads(). SecurityError Third-party iframes are not allowed to call getGamepads() unless explicitly allowed via Feature-Policy (gamepad)
+

--- a/LayoutTests/http/tests/gamepad/gamepad-allow-attribute.https.html
+++ b/LayoutTests/http/tests/gamepad/gamepad-allow-attribute.https.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>
+      Test allow attribute with "gamepad" and getGamepads() method
+    </title>
+    <script src="../resources/js-test-pre.js"></script>
+    <script>
+      testRunner?.dumpAsText();
+      testRunner?.waitUntilDone();
+
+      function waitFor(target, eventName) {
+        return new Promise((resolve) => {
+          target.addEventListener(eventName, resolve, { once: true });
+        });
+      }
+
+      const iframeDetails = [
+        // Enabled by default via '*' (all) in the spec
+        {
+            src: "https://localhost:8443/gamepad/resources/gamepad-postmessage.html",
+            enabled: "true",
+        },
+        {
+          enabled: "true",
+          src: "./resources/gamepad-postmessage.html",
+        },
+        // Set permission policy explicitly going forward.
+        {
+          allow: "gamepad",
+          enabled: "true",
+          src: "https://localhost:8443/gamepad/resources/gamepad-postmessage.html",
+        },
+        {
+          allow: "gamepad",
+          enabled: "true",
+          src: "./resources/gamepad-postmessage.html",
+        },
+        {
+          allow: "gamepad *",
+          enabled: "true",
+          src: "https://localhost:8443/gamepad/resources/gamepad-postmessage.html",
+        },
+        {
+          allow: "gamepad *",
+          enabled: "true",
+          src: "./resources/gamepad-postmessage.html",
+        },
+        {
+          allow: "gamepad 'none'",
+          enabled: "false",
+          src: "https://localhost:8443/gamepad/resources/gamepad-postmessage.html",
+        },
+        {
+          allow: "gamepad 'none'",
+          enabled: "false",
+          src: "./resources/gamepad-postmessage.html",
+        },
+        {
+          allow: "gamepad 'self'",
+          enabled: "false",
+          src: "https://localhost:8443/gamepad/resources/gamepad-postmessage.html",
+        },
+        {
+          allow: "gamepad 'self'",
+          enabled: "true",
+          src: "./resources/gamepad-postmessage.html",
+        },
+        {
+          allow: "gamepad https://localhost:8443",
+          enabled: "true",
+          src: "https://localhost:8443/gamepad/resources/gamepad-postmessage.html",
+        },
+        {
+          allow: "gamepad https://localhost:8443",
+          enabled: "false",
+          src: "./resources/gamepad-postmessage.html",
+        },
+      ];
+
+      async function loadIframe(details) {
+        const iframe = document.createElement("iframe");
+        if (details.hasOwnProperty("allow")) {
+          iframe.setAttribute("allow", details.allow);
+        }
+        iframe.dataset.enabled = details.enabled;
+        iframe.src = details.src;
+        document.body.appendChild(iframe);
+        await waitFor(iframe, "load");
+        return iframe;
+      }
+
+      async function runTests() {
+        for (const details of iframeDetails) {
+          const iframe = await loadIframe(details);
+          const { enabled } = iframe.dataset;
+          const isAllowed = enabled === "true";
+          const action = "call getGamepads()";
+          iframe.contentWindow.postMessage({ action }, "*");
+          const { data } = await waitFor(window, "message");
+          const { exceptionMessage, exceptionName, result } = data;
+          const msg = `iframe src: "${iframe.src}" with allow="${
+            iframe.allow
+          }" ${
+            isAllowed ? "is allowed to" : "MUST NOT be allowed to"
+          } ${action}. ${exceptionName ?? ""} ${exceptionMessage ?? ""}`;
+          switch (result) {
+            case "[]":
+              isAllowed ? testPassed(msg) : testFailed(msg);
+              break;
+            case "exception":
+              if (
+                !isAllowed &&
+                exceptionName === "SecurityError" &&
+                exceptionMessage.endsWith("Feature-Policy (gamepad)")
+              ) {
+                testPassed(msg);
+              } else {
+                testFailed(msg);
+              }
+              break;
+            default:
+              testFailed(msg + ` - result was: ${result}`);
+          }
+          iframe.remove();
+        }
+        testRunner.notifyDone();
+      }
+    </script>
+  </head>
+  <body onload="runTests()">
+</html>

--- a/LayoutTests/http/tests/gamepad/resources/gamepad-postmessage.html
+++ b/LayoutTests/http/tests/gamepad/resources/gamepad-postmessage.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<meta viewport="width=device-width, initial-scale=1.0" />
+<body>
+    <script>
+        window.addEventListener(
+            "message",
+            (event) => {
+                const { action } = event.data;
+                let result = null;
+                let exceptionMessage;
+                let exceptionName;
+                switch (action) {
+                    case "call getGamepads()":
+                        try {
+                            result = navigator.getGamepads();
+                            result = JSON.stringify(result);
+                        } catch (e) {
+                            exceptionMessage = e.message;
+                            exceptionName = e.name;
+                            result = "exception";
+                        }
+                        break;
+                    default:
+                        throw new Error(`Unknown action: ${action}`);
+                }
+                event.source.postMessage(
+                    { action, result, exceptionMessage, exceptionName },
+                    event.origin
+                );
+            },
+            { once: true }
+        );
+    </script>
+</body>

--- a/Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp
+++ b/Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(GAMEPAD)
 
 #include "Document.h"
+#include "FeaturePolicy.h"
 #include "Gamepad.h"
 #include "GamepadManager.h"
 #include "GamepadProvider.h"
@@ -74,13 +75,12 @@ Ref<Gamepad> NavigatorGamepad::gamepadFromPlatformGamepad(PlatformGamepad& platf
     return *m_gamepads[index];
 }
 
-const Vector<RefPtr<Gamepad>>& NavigatorGamepad::getGamepads(Navigator& navigator)
+ExceptionOr<const Vector<RefPtr<Gamepad>>&> NavigatorGamepad::getGamepads(Navigator& navigator)
 {
-    RefPtr domWindow = navigator.window();
-    RefPtr document = domWindow ? domWindow->document() : nullptr;
+    RefPtr document = navigator.document() ? navigator.document() : nullptr;
     if (!document) {
         static NeverDestroyed<Vector<RefPtr<Gamepad>>> emptyGamepads;
-        return emptyGamepads;
+        return { emptyGamepads.get() };
     }
 
     if (!document->isSecureContext()) {
@@ -90,6 +90,9 @@ const Vector<RefPtr<Gamepad>>& NavigatorGamepad::getGamepads(Navigator& navigato
         });
 
     }
+
+    if (!isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::Gamepad, *document, LogFeaturePolicyFailure::Yes))
+        return Exception { ExceptionCode::SecurityError, "Third-party iframes are not allowed to call getGamepads() unless explicitly allowed via Feature-Policy (gamepad)"_s };
 
     return NavigatorGamepad::from(navigator)->gamepads();
 }

--- a/Source/WebCore/Modules/gamepad/NavigatorGamepad.h
+++ b/Source/WebCore/Modules/gamepad/NavigatorGamepad.h
@@ -36,6 +36,7 @@ namespace WebCore {
 class Gamepad;
 class Navigator;
 class PlatformGamepad;
+template<typename> class ExceptionOr;
 
 class NavigatorGamepad : public Supplement<Navigator>, public CanMakeWeakPtr<NavigatorGamepad> {
     WTF_MAKE_FAST_ALLOCATED;
@@ -47,7 +48,7 @@ public:
 
     // The array of Gamepads might be sparse.
     // Null checking each entry is necessary.
-    static const Vector<RefPtr<Gamepad>>& getGamepads(Navigator&);
+    static ExceptionOr<const Vector<RefPtr<Gamepad>>&> getGamepads(Navigator&);
 
     void gamepadConnected(PlatformGamepad&);
     void gamepadDisconnected(PlatformGamepad&);

--- a/Source/WebCore/html/FeaturePolicy.cpp
+++ b/Source/WebCore/html/FeaturePolicy.cpp
@@ -49,6 +49,8 @@ static const char* policyTypeName(FeaturePolicy::Type type)
         return "SpeakerSelection";
     case FeaturePolicy::Type::DisplayCapture:
         return "DisplayCapture";
+    case FeaturePolicy::Type::Gamepad:
+        return "Gamepad";
     case FeaturePolicy::Type::Geolocation:
         return "Geolocation";
     case FeaturePolicy::Type::Payment:
@@ -198,6 +200,7 @@ FeaturePolicy FeaturePolicy::parse(Document& document, const HTMLIFrameElement& 
     bool isMicrophoneInitialized = false;
     bool isSpeakerSelectionInitialized = false;
     bool isDisplayCaptureInitialized = false;
+    bool isGamepadInitialized = false;
     bool isGeolocationInitialized = false;
     bool isPaymentInitialized = false;
     bool isScreenWakeLockInitialized = false;
@@ -235,6 +238,11 @@ FeaturePolicy FeaturePolicy::parse(Document& document, const HTMLIFrameElement& 
         if (item.startsWith("display-capture"_s)) {
             isDisplayCaptureInitialized = true;
             updateList(document, iframe, policy.m_displayCaptureRule, item.substring(16));
+            continue;
+        }
+        if (item.startsWith("gamepad"_s)) {
+            isGamepadInitialized = true;
+            updateList(document, iframe, policy.m_gamepadRule, item.substring(8));
             continue;
         }
         if (item.startsWith("geolocation"_s)) {
@@ -309,6 +317,8 @@ FeaturePolicy FeaturePolicy::parse(Document& document, const HTMLIFrameElement& 
         policy.m_speakerSelectionRule.allowedList.add(document.securityOrigin().data());
     if (!isDisplayCaptureInitialized)
         policy.m_displayCaptureRule.allowedList.add(document.securityOrigin().data());
+    if (!isGamepadInitialized)
+        policy.m_gamepadRule.type = FeaturePolicy::AllowRule::Type::All;
     if (!isScreenWakeLockInitialized)
         policy.m_screenWakeLockRule.allowedList.add(document.securityOrigin().data());
     if (!isGeolocationInitialized)
@@ -366,6 +376,8 @@ bool FeaturePolicy::allows(Type type, const SecurityOriginData& origin) const
         return isAllowedByFeaturePolicy(m_speakerSelectionRule, origin);
     case Type::DisplayCapture:
         return isAllowedByFeaturePolicy(m_displayCaptureRule, origin);
+    case Type::Gamepad:
+        return isAllowedByFeaturePolicy(m_gamepadRule, origin);
     case Type::Geolocation:
         return isAllowedByFeaturePolicy(m_geolocationRule, origin);
     case Type::Payment:

--- a/Source/WebCore/html/FeaturePolicy.h
+++ b/Source/WebCore/html/FeaturePolicy.h
@@ -43,6 +43,7 @@ public:
         Microphone,
         SpeakerSelection,
         DisplayCapture,
+        Gamepad,
         Geolocation,
         Payment,
         ScreenWakeLock,
@@ -74,6 +75,7 @@ private:
     AllowRule m_microphoneRule;
     AllowRule m_speakerSelectionRule;
     AllowRule m_displayCaptureRule;
+    AllowRule m_gamepadRule;
     AllowRule m_geolocationRule;
     AllowRule m_paymentRule;
     AllowRule m_syncXHRRule;


### PR DESCRIPTION
#### 82e7a7f647642e9e5158ec4bdc8f628f2e86e1e4
<pre>
Implement &apos;gamepad&apos; Permissions Policy
<a href="https://bugs.webkit.org/show_bug.cgi?id=230136">https://bugs.webkit.org/show_bug.cgi?id=230136</a>
<a href="https://rdar.apple.com/83219098">rdar://83219098</a>

Reviewed by Youenn Fablet.

Implements &quot;gampad&quot; permission policy defaulting to &apos;*&apos; for the allow list.
This matches Chrome&apos;s behavior and is also what&apos;s intended to go into the spec:
<a href="https://github.com/w3c/gamepad/pull/156">https://github.com/w3c/gamepad/pull/156</a>

* LayoutTests/http/tests/gamepad/gamepad-allow-attribute.https-expected.txt: Added.
* LayoutTests/http/tests/gamepad/gamepad-allow-attribute.https.html: Added.
* LayoutTests/http/tests/gamepad/resources/gamepad-postmessage.html: Added.
* Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp:
(WebCore::NavigatorGamepad::getGamepads): Deleted.
* Source/WebCore/Modules/gamepad/NavigatorGamepad.h:
* Source/WebCore/html/FeaturePolicy.cpp:
(WebCore::policyTypeName):
(WebCore::processOriginItem):
(WebCore::FeaturePolicy::parse):
(WebCore::FeaturePolicy::allows const):
* Source/WebCore/html/FeaturePolicy.h:

Canonical link: <a href="https://commits.webkit.org/272199@main">https://commits.webkit.org/272199@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b58a693cd0410d7f4c8847617dd51bc354e2e9ac

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30916 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9590 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32593 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33421 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27928 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31669 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/11931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6847 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27796 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31238 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8076 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27659 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6927 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7092 "Unexpected infrastructure issue, retrying build") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27538 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34759 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28151 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28012 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33234 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7129 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5204 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31068 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8836 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/27322 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7297 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7838 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7679 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->