### PR TITLE
[CSS] @scope prelude should take nesting into account

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-cssom.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-cssom.html
@@ -25,7 +25,7 @@ test(() => {
 }, 'CSSScopeRule.cssText, root only');
 
 test(() => {
-  assert_equals(style.sheet.rules[2].cssText, '@scope (.a) to (.b) {\n  :scope div { display: block; }\n}');
+  assert_equals(style.sheet.rules[2].cssText, '@scope (.a) to (.b) {\n  div { display: block; }\n}');
 }, 'CSSScopeRule.cssText, root and limit');
 
 test(() => {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-evaluation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-evaluation-expected.txt
@@ -10,7 +10,7 @@ PASS Inner @scope with :scope in from-selector
 PASS Multiple scopes from same @scope-rule, only one limited
 PASS Multiple scopes from same @scope-rule, both limited
 PASS Nested scopes
-FAIL Nested scopes, reverse assert_equals: expected "rgb(0, 0, 0)" but got "rgb(0, 128, 0)"
+PASS Nested scopes, reverse
 PASS Nested scopes, with to-selector
 PASS :scope selecting itself
 PASS The scoping limit is not in scope

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-nesting-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-nesting-expected.txt
@@ -1,14 +1,14 @@
 
 PASS Nesting-selector in <scope-end>
-FAIL Implicit :scope in <scope-end> assert_equals: expected "1" but got "auto"
-FAIL Relative selectors in <scope-end> assert_equals: expected "1" but got "auto"
+PASS Implicit :scope in <scope-end>
+PASS Relative selectors in <scope-end>
 PASS Nesting-selector in the scope's <stylesheet>
 PASS Nesting-selector within :scope rule
 PASS Nesting-selector within :scope rule (double nested)
 PASS @scope nested within style rule
 PASS Parent pseudo class within scope-start
 PASS Parent pseudo class within scope-end
-FAIL Parent pseudo class within body of nested @scope assert_equals: non-matching: DIVb c expected "auto" but got "1"
+PASS Parent pseudo class within body of nested @scope
 FAIL Implicit rule within nested @scope  assert_equals: expected "1" but got "auto"
 FAIL Implicit rule within nested @scope (proximity) assert_equals: expected "1" but got "2"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-visited-cssom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-visited-cssom-expected.txt
@@ -13,6 +13,6 @@ PASS :not(:visited) as scoping root, :scope
 PASS :not(:link) as scoping root, :scope
 PASS :link as scoping limit
 FAIL :visited as scoping limit assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 255, 255)"
-FAIL :not(:link) as scoping limit assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 255, 255)"
+PASS :not(:link) as scoping limit
 PASS :not(:visited) as scoping limit
 

--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -454,6 +454,11 @@ String CSSSelector::selectorText(StringView separator, StringView rightSide) con
 
     const CSSSelector* cs = this;
     while (true) {
+        if (cs->isImplicit()) {
+            // Remove the space before the implicit selector.
+            separator = separator.substring(1);
+            break;
+        }
         if (cs->match() == Match::Id) {
             builder.append('#');
             serializeIdentifier(cs->serializingValue(), builder);

--- a/Source/WebCore/css/parser/CSSParserImpl.h
+++ b/Source/WebCore/css/parser/CSSParserImpl.h
@@ -203,6 +203,7 @@ private:
         Scope,
     };
     Vector<AncestorRuleType, 16> m_ancestorRuleTypeStack;
+    static void appendImplicitSelectorIfNeeded(CSSParserSelector&, AncestorRuleType);
 
     Vector<NestingContext> m_nestingContextStack { NestingContext { } };
     const CSSParserContext& m_context;

--- a/Source/WebCore/css/parser/CSSParserSelector.cpp
+++ b/Source/WebCore/css/parser/CSSParserSelector.cpp
@@ -144,6 +144,14 @@ void CSSParserSelector::setSelectorList(std::unique_ptr<CSSSelectorList> selecto
     m_selector->setSelectorList(WTFMove(selectorList));
 }
 
+const CSSParserSelector* CSSParserSelector::leftmostSimpleSelector() const
+{
+    auto selector = this;
+    while (auto next = selector->tagHistory())
+        selector = next;
+    return selector;
+}
+
 CSSParserSelector* CSSParserSelector::leftmostSimpleSelector()
 {
     auto selector = this;
@@ -277,6 +285,12 @@ std::unique_ptr<CSSParserSelector> CSSParserSelector::releaseTagHistory()
 bool CSSParserSelector::isHostPseudoSelector() const
 {
     return match() == CSSSelector::Match::PseudoClass && pseudoClassType() == CSSSelector::PseudoClassType::Host;
+}
+
+bool CSSParserSelector::startsWithExplicitCombinator() const
+{
+    auto relation = leftmostSimpleSelector()->selector()->relation();
+    return relation != CSSSelector::RelationType::Subselector && relation != CSSSelector::RelationType::DescendantSpace;
 }
 
 }

--- a/Source/WebCore/css/parser/CSSParserSelector.h
+++ b/Source/WebCore/css/parser/CSSParserSelector.h
@@ -95,6 +95,8 @@ public:
 
     CSSParserSelector* tagHistory() const { return m_tagHistory.get(); }
     CSSParserSelector* leftmostSimpleSelector();
+    const CSSParserSelector* leftmostSimpleSelector() const;
+    bool startsWithExplicitCombinator() const;
     void setTagHistory(std::unique_ptr<CSSParserSelector> selector) { m_tagHistory = WTFMove(selector); }
     void clearTagHistory() { m_tagHistory.reset(); }
     void insertTagHistory(CSSSelector::RelationType before, std::unique_ptr<CSSParserSelector>, CSSSelector::RelationType after);


### PR DESCRIPTION
#### 25213c389f501f946d6e5516b872a69219907f81
<pre>
[CSS] @scope prelude should take nesting into account
<a href="https://bugs.webkit.org/show_bug.cgi?id=266467">https://bugs.webkit.org/show_bug.cgi?id=266467</a>
<a href="https://rdar.apple.com/119711922">rdar://119711922</a>

Reviewed by Antti Koivisto.

The &lt;scope-start&gt; should be prepended by either nothing,
&amp; or :scope (depending on the outer context).

The &lt;scope-end&gt; should be prepended by :scope.

* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-cssom.html:

<a href="https://github.com/w3c/csswg-drafts/issues/9621">https://github.com/w3c/csswg-drafts/issues/9621</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-evaluation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-nesting-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-visited-cssom-expected.txt:
* Source/WebCore/css/CSSSelector.cpp:
(WebCore::CSSSelector::selectorText const):
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::appendImplicitSelectorPseudoClassScopeIfNeeded):
(WebCore::appendImplicitSelectorNestingParentIfNeeded):
(WebCore::CSSParserImpl::appendImplicitSelectorIfNeeded):
(WebCore::CSSParserImpl::consumeScopeRule):
(WebCore::CSSParserImpl::consumeStyleRule):
* Source/WebCore/css/parser/CSSParserImpl.h:
* Source/WebCore/css/parser/CSSParserSelector.cpp:
(WebCore::CSSParserSelector::leftmostSimpleSelector const):

const version of the existing non-const one

(WebCore::CSSParserSelector::startsWithExplicitCombinator const):
* Source/WebCore/css/parser/CSSParserSelector.h:

Canonical link: <a href="https://commits.webkit.org/272117@main">https://commits.webkit.org/272117@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ae5a1fd139123a102be95d1dcd96597d0c9106a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30664 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9346 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32324 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33162 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27724 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31373 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11640 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6601 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/27615 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30975 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7841 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27455 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6716 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6879 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27316 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34499 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27911 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/27806 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/33037 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6901 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4998 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30863 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8625 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/27093 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7251 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7626 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7455 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->