### PR TITLE
[IFC][Ruby] Return correct accessibility roles

### DIFF
--- a/LayoutTests/accessibility/mac/ruby-hierarchy-roles-expected.txt
+++ b/LayoutTests/accessibility/mac/ruby-hierarchy-roles-expected.txt
@@ -7,27 +7,23 @@ PASS rubyElem != null is true
 PASS axRuby != null is true
 PASS role is expectedRubyRole
 PASS subrole is expectedRubyInlineSubrole
-PASS axRubyRun != null is true
-PASS role is expectedRubyRole
-PASS subrole is expectedRubyRunSubrole
-PASS axRubyText != null is true
-PASS role is expectedRubyRole
-PASS subrole is expectedRubyTextSubrole
 PASS axRubyBase != null is true
 PASS role is expectedRubyRole
 PASS subrole is expectedRubyBaseSubrole
+PASS axRubyText != null is true
+PASS role is expectedRubyRole
+PASS subrole is expectedRubyTextSubrole
 PASS axRuby != null is true
 PASS role is expectedRubyRole
 PASS subrole is expectedRubyBlockSubrole
-PASS axRubyRun != null is true
 PASS role is expectedRubyRole
-PASS subrole is expectedRubyRunSubrole
-PASS axRubyText != null is true
-PASS role is expectedRubyRole
-PASS subrole is expectedRubyTextSubrole
+PASS subrole is expectedRubyInlineSubrole
 PASS axRubyBase != null is true
 PASS role is expectedRubyRole
 PASS subrole is expectedRubyBaseSubrole
+PASS axRubyText != null is true
+PASS role is expectedRubyRole
+PASS subrole is expectedRubyTextSubrole
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/accessibility/mac/ruby-hierarchy-roles.html
+++ b/LayoutTests/accessibility/mac/ruby-hierarchy-roles.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ CSSBasedRubyEnabled=true ] -->
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
     <head>
@@ -21,17 +22,15 @@
                     var expectedRubyRole = "AXRole: AXGroup"; // all ruby containers have AXGroup role
                     var expectedRubyInlineSubrole = "AXSubrole: AXRubyInline";
                     var expectedRubyBlockSubrole = "AXSubrole: AXRubyBlock";
-                    var expectedRubyRunSubrole = "AXSubrole: AXRubyRun";
                     var expectedRubyTextSubrole = "AXSubrole: AXRubyText";
                     var expectedRubyBaseSubrole = "AXSubrole: AXRubyBase";
                     
                     // Try inline style first, block style second
                     var rubyElem = document.getElementById("rubyElemId");
                     shouldBeTrue("rubyElem != null");
-                    rubyElem.style.display = "inline";
                     checkHierarchyAndRoles(rubyElem);
                     
-                    rubyElem.style.display = "block";
+                    rubyElem.style.position = "absolute";
                     checkHierarchyAndRoles(rubyElem);
                     
                     function checkHierarchyAndRoles(rubyElem) {
@@ -40,36 +39,33 @@
                         role = axRuby.role;
                         subrole = axRuby.subrole;
                         shouldBe("role", "expectedRubyRole");
-                        if (rubyElem.style.display == "inline") {
+                        if (rubyElem.style.position != "absolute") {
                             shouldBe("subrole", "expectedRubyInlineSubrole");
                         }
                         else {
                             shouldBe("subrole", "expectedRubyBlockSubrole");
+                            axRuby = axRuby.childAtIndex(0);
+                            role = axRuby.role;
+                            subrole = axRuby.subrole;
+                            shouldBe("role", "expectedRubyRole");
+                            shouldBe("subrole", "expectedRubyInlineSubrole");
                         }
-                        
-                        // RubyRun
-                        axRubyRun = axRuby.childAtIndex(0);
-                        shouldBeTrue("axRubyRun != null");
-                        role = axRubyRun.role;
-                        subrole = axRubyRun.subrole;
-                        shouldBe("role", "expectedRubyRole");
-                        shouldBe("subrole", "expectedRubyRunSubrole");
-                        
-                        // RubyText
-                        axRubyText = axRubyRun.childAtIndex(0);
-                        shouldBeTrue("axRubyText != null");
-                        role = axRubyText.role;
-                        subrole = axRubyText.subrole;
-                        shouldBe("role", "expectedRubyRole");
-                        shouldBe("subrole", "expectedRubyTextSubrole");
-                        
+
                         // RubyBase
-                        axRubyBase = axRubyRun.childAtIndex(1);
+                        axRubyBase = axRuby.childAtIndex(0);
                         shouldBeTrue("axRubyBase != null");
                         role = axRubyBase.role;
                         subrole = axRubyBase.subrole;
                         shouldBe("role", "expectedRubyRole");
                         shouldBe("subrole", "expectedRubyBaseSubrole");
+
+                        // RubyText
+                        axRubyText = axRuby.childAtIndex(1);
+                        shouldBeTrue("axRubyText != null");
+                        role = axRubyText.role;
+                        subrole = axRubyText.subrole;
+                        shouldBe("role", "expectedRubyRole");
+                        shouldBe("subrole", "expectedRubyTextSubrole");
                     }
                 }
             }

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2725,6 +2725,7 @@ fast/css/transform-function-perspective-crash.html [ Failure ]
 webkit.org/b/265535 inspector/layers/layers-for-node.html [ Pass Timeout ]
 
 webkit.org/b/265783 fast/ruby/ruby-line-height.html [ Skip ]
+webkit.org/b/265783 accessibility/mac/ruby-hierarchy-roles.html [ Skip ]
 
 webkit.org/b/266184 compositing/images/truncated-direct-png-image.html [ ImageOnlyFailure ]
 

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -1320,6 +1320,16 @@ bool AccessibilityRenderObject::computeAccessibilityIsIgnored() const
     if (m_renderer->isRenderRubyRun() || m_renderer->isRenderRubyAsBlock() || m_renderer->isRenderRubyAsInline())
         return false;
 
+    switch (m_renderer->style().display()) {
+    case DisplayType::Ruby:
+    case DisplayType::RubyBlock:
+    case DisplayType::RubyAnnotation:
+    case DisplayType::RubyBase:
+        return false;
+    default:
+        break;
+    }
+
     // Find out if this element is inside of a label element.
     // If so, it may be ignored because it's the label for a checkbox or radio button.
     auto* controlObject = correspondingControlForLabelElement();
@@ -2146,6 +2156,19 @@ AccessibilityRole AccessibilityRenderObject::determineAccessibilityRole()
         return AccessibilityRole::RubyBlock;
     if (m_renderer->isRenderRubyAsInline())
         return AccessibilityRole::RubyInline;
+
+    switch (m_renderer->style().display()) {
+    case DisplayType::Ruby:
+        return AccessibilityRole::RubyInline;
+    case DisplayType::RubyBlock:
+        return AccessibilityRole::RubyBlock;
+    case DisplayType::RubyAnnotation:
+        return AccessibilityRole::RubyText;
+    case DisplayType::RubyBase:
+        return AccessibilityRole::RubyBase;
+    default:
+        break;
+    }
 
     if (m_renderer->isAnonymous() && (is<RenderTableCell>(m_renderer.get()) || is<RenderTableRow>(m_renderer.get()) || is<RenderTable>(m_renderer.get())))
         return AccessibilityRole::Ignored;

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderRuby.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderRuby.cpp
@@ -252,6 +252,12 @@ RenderElement& RenderTreeBuilder::Ruby::findOrCreateParentForStyleBasedRubyChild
     if (!child.isRenderText() && child.style().display() == DisplayType::Ruby && parent.style().display() == DisplayType::RubyBlock)
         return parent;
 
+    if (parent.style().display() == DisplayType::RubyBlock && parent.firstChild()) {
+        // See if we have an anonymous ruby box already.
+        ASSERT(parent.firstChild()->style().display() == DisplayType::Ruby);
+        return downcast<RenderElement>(*parent.firstChild());
+    }
+
     if (parent.style().display() != DisplayType::Ruby) {
         auto rubyContainer = createRenderer<RenderInline>(RenderObject::Type::Inline, parent.document(), RenderStyle::createAnonymousStyleWithDisplay(parent.style(), DisplayType::Ruby));
         rubyContainer->initializeStyle();


### PR DESCRIPTION
#### 1da27950f8f1ec9d6cc023e460a1186a08b4e991
<pre>
[IFC][Ruby] Return correct accessibility roles
<a href="https://bugs.webkit.org/show_bug.cgi?id=266468">https://bugs.webkit.org/show_bug.cgi?id=266468</a>
<a href="https://rdar.apple.com/119712254">rdar://119712254</a>

Reviewed by Alan Baradlay.

* LayoutTests/accessibility/mac/ruby-hierarchy-roles-expected.txt:
* LayoutTests/accessibility/mac/ruby-hierarchy-roles.html:

Update the test for the new ruby hierarchy.
Blockify by setting position:absolute.

* LayoutTests/platform/mac-wk1/TestExpectations:

Disable for now in WK1 because the setting leaks accross tests.

* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::computeAccessibilityIsIgnored const):
(WebCore::AccessibilityRenderObject::determineAccessibilityRole):

Return the roles.

* Source/WebCore/rendering/updating/RenderTreeBuilderRuby.cpp:
(WebCore::RenderTreeBuilder::Ruby::findOrCreateParentForStyleBasedRubyChild):

Return the existing anonymous ruby box for a ruby-block parent if there is one.

Canonical link: <a href="https://commits.webkit.org/272111@main">https://commits.webkit.org/272111@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a64d4c3d1434b90e2b7eaa09b29fe7eb32b59a71

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30633 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9316 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32290 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33128 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27694 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31339 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11606 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6567 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27595 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30942 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7808 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27421 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6689 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6856 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27281 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34465 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27879 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27772 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33009 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6871 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4972 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30838 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8599 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/27057 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7249 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7597 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7427 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->