### PR TITLE
Add <input type=checkbox switch> iOS vertical rendering

### DIFF
--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-writing-modes/forms/checkbox-switch-input-computed-style.tentative-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-writing-modes/forms/checkbox-switch-input-computed-style.tentative-expected.txt
@@ -1,6 +1,6 @@
 
 
 PASS horizontal-input block size should match height and inline size should match width
-FAIL vertical-lr-input block size should match width and inline size should match height assert_greater_than: expected a number greater than 51 but got 31
-FAIL vertical-rl-input block size should match width and inline size should match height assert_greater_than: expected a number greater than 51 but got 31
+PASS vertical-lr-input block size should match width and inline size should match height
+PASS vertical-rl-input block size should match width and inline size should match height
 

--- a/Source/WebCore/html/CheckboxInputType.cpp
+++ b/Source/WebCore/html/CheckboxInputType.cpp
@@ -156,7 +156,7 @@ void CheckboxInputType::handleTouchEvent(TouchEvent& event)
             return;
         RefPtr<Touch> touch = targetTouches->item(0);
 
-        startSwitchPointerTracking(IntPoint(touch->pageX(), touch->pageY()), touch->identifier());
+        startSwitchPointerTracking({ touch->pageX(), touch->pageY() }, touch->identifier());
         performSwitchAnimation(SwitchAnimationType::Pressed);
         event.setDefaultHandled();
     } else if (eventType == eventNames.touchmoveEvent) {
@@ -171,8 +171,7 @@ void CheckboxInputType::handleTouchEvent(TouchEvent& event)
         if (!touch)
             return;
 
-        auto absoluteLocation = IntPoint(touch->pageX(), touch->pageY());
-        updateIsSwitchVisuallyOnFromAbsoluteLocation(absoluteLocation);
+        updateIsSwitchVisuallyOnFromAbsoluteLocation({ touch->pageX(), touch->pageY() });
         event.setDefaultHandled();
     } else if (eventType == eventNames.touchendEvent || eventType == eventNames.touchcancelEvent) {
         if (!m_switchPointerTrackingTouchIdentifier || !isSwitchPointerTracking())

--- a/Source/WebCore/rendering/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/RenderThemeIOS.mm
@@ -707,15 +707,15 @@ constexpr auto reducedMotionProgressAnimationMinOpacity = 0.3f;
 constexpr auto reducedMotionProgressAnimationMaxOpacity = 0.6f;
 
 #if !USE(APPLE_INTERNAL_SDK)
-constexpr auto switchHeight = 31.f;
-constexpr auto switchWidth = 51.f;
+constexpr auto logicalSwitchHeight = 31.f;
+constexpr auto logicalSwitchWidth = 51.f;
 
-static bool renderThemePaintSwitchThumb(const OptionSet<ControlStyle::State>, const RenderObject&, const PaintInfo&, const FloatRect&, const Color&)
+static bool renderThemePaintSwitchThumb(OptionSet<ControlStyle::State>, const RenderObject&, const PaintInfo&, const FloatRect&, const Color&)
 {
     return true;
 }
 
-static bool renderThemePaintSwitchTrack(const OptionSet<ControlStyle::State>, const RenderObject&, const PaintInfo&, const FloatRect&, const Color&)
+static bool renderThemePaintSwitchTrack(OptionSet<ControlStyle::State>, const RenderObject&, const PaintInfo&, const FloatRect&, const Color&)
 {
     return true;
 }
@@ -726,9 +726,9 @@ void RenderThemeIOS::adjustSwitchStyle(RenderStyle& style, const Element* elemen
     if (!style.width().isAuto() && !style.height().isAuto())
         return;
 
-    auto size = std::max(style.computedFontSize(), switchHeight);
-    style.setWidth({ size * (switchWidth / switchHeight), LengthType::Fixed });
-    style.setHeight({ size, LengthType::Fixed });
+    auto size = std::max(style.computedFontSize(), logicalSwitchHeight);
+    style.setLogicalWidth({ size * (logicalSwitchWidth / logicalSwitchHeight), LengthType::Fixed });
+    style.setLogicalHeight({ size, LengthType::Fixed });
 
     if (style.outlineStyleIsAuto() == OutlineIsAuto::On)
         style.setOutlineStyle(BorderStyle::None);


### PR DESCRIPTION
#### 0fcd00f064d66f2dabe38b70a25dbe56818a2302
<pre>
Add &lt;input type=checkbox switch&gt; iOS vertical rendering
<a href="https://bugs.webkit.org/show_bug.cgi?id=266480">https://bugs.webkit.org/show_bug.cgi?id=266480</a>
<a href="https://rdar.apple.com/119721041">rdar://119721041</a>

Reviewed by Aditya Keerthi.

This builds on the macOS vertical rendering changes and excludes
painting-related changes.

* LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-writing-modes/forms/checkbox-switch-input-computed-style.tentative-expected.txt:
* Source/WebCore/html/CheckboxInputType.cpp:
(WebCore::CheckboxInputType::handleTouchEvent):
* Source/WebCore/rendering/RenderThemeIOS.mm:
(WebCore::renderThemePaintSwitchThumb):
(WebCore::renderThemePaintSwitchTrack):
(WebCore::RenderThemeIOS::adjustSwitchStyle const):

Canonical link: <a href="https://commits.webkit.org/272456@main">https://commits.webkit.org/272456@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98f3279144a5153ff040268b6e3a17cfde9754ff

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30876 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9553 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32549 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33378 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27891 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31628 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11877 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6805 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27761 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31195 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8031 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27617 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6888 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7047 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27495 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34716 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28104 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27977 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33195 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7090 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5166 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31028 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8801 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7802 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4141 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7644 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->