### PR TITLE
[CSS] Implement @scope implicit

### DIFF
--- a/LayoutTests/fast/css/scope-at-rule-expected.html
+++ b/LayoutTests/fast/css/scope-at-rule-expected.html
@@ -48,3 +48,15 @@
 <div>
   <span class="green">should be green</span>
 </div>
+<div>
+  <span class="green">should be green</span>
+</div>
+<div>
+  <span>should not be green</span>
+</div>
+<div>
+  <span class="green">should be green</span>
+</div>
+<div>
+  <span>should not be green</span>
+</div>

--- a/LayoutTests/fast/css/scope-at-rule-green-14.css
+++ b/LayoutTests/fast/css/scope-at-rule-green-14.css
@@ -1,0 +1,5 @@
+@scope {
+  .green-14 {
+    color: green;
+  }
+}

--- a/LayoutTests/fast/css/scope-at-rule.html
+++ b/LayoutTests/fast/css/scope-at-rule.html
@@ -138,3 +138,25 @@ div {
     <span class="green-12">should be green</div>
   </div>
 </div>
+
+<div>
+  <div>
+    <style>
+    @scope {
+      .green-13 { color: green; }
+    }
+    </style>
+    <span class="green-13">should be green</div>
+  </div>
+  <span class="green-13">should not be green</div>
+</div>
+
+<div>
+  <div>
+    <style>
+    @import "scope-at-rule-green-14.css"
+    </style>
+    <span class="green-14">should be green</div>
+  </div>
+  <span class="green-14">should not be green</div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/at-scope-parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/at-scope-parsing-expected.txt
@@ -14,6 +14,9 @@ PASS @scope (.a) to (& > &) is valid
 PASS @scope (.a) to (> .b) is valid
 PASS @scope (.a) to (+ .b) is valid
 PASS @scope (.a) to (~ .b) is valid
+PASS @scope () is valid
+PASS @scope to () is valid
+PASS @scope () to () is valid
 PASS @scope (.c <> .d) is valid
 PASS @scope (.a, .c <> .d) is valid
 PASS @scope (.a <> .b, .c) is valid
@@ -35,4 +38,7 @@ PASS @scope ( is not valid
 PASS @scope ( {} is not valid
 PASS @scope to is not valid
 PASS @scope } is not valid
+PASS @scope (.a is not valid
+PASS @scope (.a to (.b) is not valid
+PASS @scope ( to (.b) is not valid
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/at-scope-parsing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/at-scope-parsing.html
@@ -45,6 +45,9 @@
   test_valid('@scope (.a) to (> .b)');
   test_valid('@scope (.a) to (+ .b)');
   test_valid('@scope (.a) to (~ .b)');
+  test_valid('@scope ()', '@scope');
+  test_valid('@scope to ()', '@scope');
+  test_valid('@scope () to ()', '@scope');
 
   // Forgiving behavior (keep invalid selector as-is for the serialization):
   test_valid('@scope (.c <> .d)');
@@ -69,4 +72,7 @@
   test_invalid('@scope ( {}');
   test_invalid('@scope to');
   test_invalid('@scope }');
+  test_invalid('@scope (.a');
+  test_invalid('@scope (.a to (.b)');
+  test_invalid('@scope ( to (.b)');
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-implicit-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-implicit-expected.txt
@@ -1,10 +1,10 @@
 
-FAIL @scope without prelude implicitly scopes to parent of owner node assert_equals: expected "1" but got "auto"
-FAIL :scope can style implicit root assert_equals: expected "1" but got "auto"
-FAIL @scope works with two identical stylesheets assert_equals: expected "1" but got "auto"
+PASS @scope without prelude implicitly scopes to parent of owner node
+PASS :scope can style implicit root
+PASS @scope works with two identical stylesheets
 PASS @scope with effectively empty :is() must not match anything
 PASS Implicit @scope has implicitly added :scope descendant combinator
-FAIL Implicit @scope with inner relative selector assert_equals: expected "1" but got "auto"
-FAIL Implicit @scope with inner nesting selector assert_equals: expected "1" but got "auto"
-FAIL Implicit @scope with limit assert_equals: expected "1" but got "auto"
+PASS Implicit @scope with inner relative selector
+PASS Implicit @scope with inner nesting selector
+PASS Implicit @scope with limit
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-implicit-external-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-implicit-external-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL @scope with external stylesheet assert_equals: expected "1" but got "auto"
+PASS @scope with external stylesheet
 

--- a/Source/WebCore/css/StyleRule.cpp
+++ b/Source/WebCore/css/StyleRule.cpp
@@ -565,6 +565,10 @@ StyleRuleScope::StyleRuleScope(CSSSelectorList&& scopeStart, CSSSelectorList&& s
 
 StyleRuleScope::StyleRuleScope(const StyleRuleScope&) = default;
 
+WeakPtr<const StyleSheetContents> StyleRuleScope::styleSheetContents() const { return m_styleSheetOwner; }
+
+void StyleRuleScope::setStyleSheetContents(const StyleSheetContents& sheet) { m_styleSheetOwner = &sheet; }
+
 StyleRuleCharset::StyleRuleCharset()
     : StyleRuleBase(StyleRuleType::Charset)
 {

--- a/Source/WebCore/css/StyleRule.h
+++ b/Source/WebCore/css/StyleRule.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "CSSSelector.h"
 #include "CSSSelectorList.h"
 #include "CSSVariableData.h"
 #include "CompiledSelector.h"
@@ -29,7 +30,6 @@
 #include "FontPaletteValues.h"
 #include "MediaQuery.h"
 #include "StyleRuleType.h"
-#include "css/CSSSelector.h"
 #include <map>
 #include <variant>
 #include <wtf/Ref.h>
@@ -46,6 +46,7 @@ class CSSStyleSheet;
 class MutableStyleProperties;
 class StyleRuleKeyframe;
 class StyleProperties;
+class StyleSheetContents;
 
 using CascadeLayerName = Vector<AtomString>;
     
@@ -395,6 +396,8 @@ public:
     const CSSSelectorList& originalScopeEnd() const { return m_originalScopeEnd; }
     void setScopeStart(CSSSelectorList&& scopeStart) { m_scopeStart = WTFMove(scopeStart); }
     void setScopeEnd(CSSSelectorList&& scopeEnd) { m_scopeEnd = WTFMove(scopeEnd); }
+    WeakPtr<const StyleSheetContents> styleSheetContents() const;
+    void setStyleSheetContents(const StyleSheetContents&);
 
 private:
     StyleRuleScope(CSSSelectorList&&, CSSSelectorList&&, Vector<Ref<StyleRuleBase>>&&);
@@ -406,6 +409,8 @@ private:
     // Author written selector lists
     CSSSelectorList m_originalScopeStart;
     CSSSelectorList m_originalScopeEnd;
+    // Pointer to the owner StyleSheetContent to find the implicit scope (when there is no <scope-start>)
+    WeakPtr<const StyleSheetContents> m_styleSheetOwner;
 };
 
 // This is only used by the CSS parser.

--- a/Source/WebCore/css/StyleSheetContents.cpp
+++ b/Source/WebCore/css/StyleSheetContents.cpp
@@ -80,7 +80,8 @@ StyleSheetContents::StyleSheetContents(StyleRuleImport* ownerRule, const String&
 }
 
 StyleSheetContents::StyleSheetContents(const StyleSheetContents& o)
-    : m_originalURL(o.m_originalURL)
+    : CanMakeWeakPtr<StyleSheetContents>()
+    , m_originalURL(o.m_originalURL)
     , m_encodingFromCharsetRule(o.m_encodingFromCharsetRule)
     , m_layerRulesBeforeImportRules(o.m_layerRulesBeforeImportRules.size())
     , m_importRules(o.m_importRules.size())

--- a/Source/WebCore/css/StyleSheetContents.h
+++ b/Source/WebCore/css/StyleSheetContents.h
@@ -27,6 +27,7 @@
 #include <wtf/RefCounted.h>
 #include <wtf/URL.h>
 #include <wtf/Vector.h>
+#include <wtf/WeakPtr.h>
 #include <wtf/text/AtomStringHash.h>
 
 namespace WebCore {
@@ -45,7 +46,7 @@ class StyleRuleNamespace;
 
 enum class CachePolicy : uint8_t;
 
-class StyleSheetContents final : public RefCounted<StyleSheetContents> {
+class StyleSheetContents final : public RefCounted<StyleSheetContents>, public CanMakeWeakPtr<StyleSheetContents> {
 public:
     static Ref<StyleSheetContents> create(const CSSParserContext& context = CSSParserContext(HTMLStandardMode))
     {
@@ -135,6 +136,7 @@ public:
     void registerClient(CSSStyleSheet*);
     void unregisterClient(CSSStyleSheet*);
     bool hasOneClient() { return m_clients.size() == 1; }
+    Vector<CSSStyleSheet*> clients() const { return m_clients; }
 
     bool isMutable() const { return m_isMutable; }
     void setMutable() { m_isMutable = true; }

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -1067,7 +1067,10 @@ RefPtr<StyleRuleScope> CSSParserImpl::consumeScopeRule(CSSParserTokenRange prelu
         rules.append(rule);
     });
     m_ancestorRuleTypeStack.removeLast();
-    return StyleRuleScope::create(WTFMove(scopeStart), WTFMove(scopeEnd), WTFMove(rules));
+    auto rule = StyleRuleScope::create(WTFMove(scopeStart), WTFMove(scopeEnd), WTFMove(rules));
+    if (m_styleSheet)
+        rule->setStyleSheetContents(*m_styleSheet);
+    return rule;
 }
 
 RefPtr<StyleRuleLayer> CSSParserImpl::consumeLayerRule(CSSParserTokenRange prelude, std::optional<CSSParserTokenRange> block)

--- a/Source/WebCore/style/ElementRuleCollector.h
+++ b/Source/WebCore/style/ElementRuleCollector.h
@@ -119,10 +119,10 @@ private:
     void collectMatchingRules(CascadeLevel);
     void collectMatchingRules(const MatchRequest&);
     void collectMatchingRulesForList(const RuleSet::RuleDataVector*, const MatchRequest&);
-    bool ruleMatches(const RuleData&, unsigned& specificity, ScopeOrdinal, const Element* scopingRoot = nullptr);
+    bool ruleMatches(const RuleData&, unsigned& specificity, ScopeOrdinal, const ContainerNode* scopingRoot = nullptr);
     bool containerQueriesMatch(const RuleData&, const MatchRequest&);
     struct ScopingRootWithDistance {
-        const Element* scopingRoot { nullptr };
+        const ContainerNode* scopingRoot { nullptr };
         unsigned distance { std::numeric_limits<unsigned>::max() };
     };
     std::pair<bool, std::optional<Vector<ScopingRootWithDistance>>> scopeRulesMatch(const RuleData&, const MatchRequest&);

--- a/Source/WebCore/style/RuleSetBuilder.cpp
+++ b/Source/WebCore/style/RuleSetBuilder.cpp
@@ -139,9 +139,14 @@ void RuleSetBuilder::addChildRule(Ref<StyleRuleBase> rule)
                 scopeRule->setScopeEnd(CSSSelectorParser::resolveNestingParent(scopeRule->originalScopeEnd(), &scopeRule->scopeStart()));
         }
 
-        m_selectorListStack.append(&scopeRule->scopeStart());
+        const auto& scopeStart = scopeRule->scopeStart();
+        // If <scope-start> is empty, it doesn't create a nesting context (the nesting selector might eventually be replaced by :scope)
+        if (!scopeStart.isEmpty())
+            m_selectorListStack.append(&scopeStart);
         addChildRules(scopeRule->childRules());
-        m_selectorListStack.removeLast();
+        if (!scopeStart.isEmpty())
+            m_selectorListStack.removeLast();
+
         if (m_ruleSet)
             m_currentScopeIdentifier = previousScopeIdentifier;
         return;


### PR DESCRIPTION
#### cee867893141fabf4fdeed3603a8986b74af3f88
<pre>
[CSS] Implement @scope implicit
<a href="https://bugs.webkit.org/show_bug.cgi?id=266399">https://bugs.webkit.org/show_bug.cgi?id=266399</a>
<a href="https://rdar.apple.com/119659940">rdar://119659940</a>

Reviewed by Antti Koivisto.

When the @scope rule doesn&apos;t have a &lt;scope-start&gt; prelude,
the scoping root is the parent element of the owner node of the stylesheet
where the @scope rule is defined.

We store in the @scope rule a pointer to the owner StyleSheetContent,
which will allow us to find the parent element of it at rule matching time,
to determine the scoping root(s).

<a href="https://drafts.csswg.org/css-cascade-6/#scope-limits">https://drafts.csswg.org/css-cascade-6/#scope-limits</a>

* LayoutTests/fast/css/scope-at-rule-expected.html:
* LayoutTests/fast/css/scope-at-rule-green-14.css: Added.
(@scope):
* LayoutTests/fast/css/scope-at-rule.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/at-scope-parsing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/at-scope-parsing.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-implicit-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-implicit-external-expected.txt:
* Source/WebCore/css/StyleRule.cpp:
(WebCore::StyleRuleScope::styleSheetContents const):
(WebCore::StyleRuleScope::setStyleSheetContents):
* Source/WebCore/css/StyleRule.h:
* Source/WebCore/css/StyleSheetContents.h:
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::consumeScopeRule):
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::ruleMatches):
(WebCore::Style::ElementRuleCollector::scopeRulesMatch):
* Source/WebCore/style/ElementRuleCollector.h:
* Source/WebCore/style/RuleSetBuilder.cpp:
(WebCore::Style::RuleSetBuilder::addChildRule):

Canonical link: <a href="https://commits.webkit.org/272390@main">https://commits.webkit.org/272390@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b43d30c118695b6127d60347b6c7ccefb67def53

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31492 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10167 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33196 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33980 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28522 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32262 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12516 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7414 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/28138 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31832 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8561 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28104 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7367 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7530 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28013 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35324 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28623 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28459 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/33663 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7606 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5624 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31507 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9263 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/27818 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7398 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8295 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8111 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->