### PR TITLE
[Cocoa] Support HLS AES-128 segment encryption via unprefixed EME ClearKey CDM

### DIFF
--- a/LayoutTests/http/tests/media/clearkey/modern-clear-key-hls-aes128-expected.txt
+++ b/LayoutTests/http/tests/media/clearkey/modern-clear-key-hls-aes128-expected.txt
@@ -1,0 +1,13 @@
+
+RUN(video.src = "../resources/hls/clearkey/prog_index.m3u8")
+EVENT(encrypted)
+EXPECTED (bufferToString(encryptedEvent.initData) == 'crypt0.key') OK
+EVENT(message)
+EXPECTED (messageEvent.messageType == 'license-request') OK
+EXPECTED (messageData.kids.length == '1') OK
+EXPECTED (atob(messageData.kids[0]) == 'crypt0.key') OK
+RUN(session.update(responseData))
+Promise resolved OK
+EVENT(canplay)
+END OF TEST
+

--- a/LayoutTests/http/tests/media/clearkey/modern-clear-key-hls-aes128.html
+++ b/LayoutTests/http/tests/media/clearkey/modern-clear-key-hls-aes128.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>clearkey</title>
+    <script src=../../media-resources/video-test.js></script>
+    <script src="support.js"></script>
+    <script>
+        var encryptedEvent;
+        var keyIdString;
+        var session;
+        var messageEvent;
+        var initData;
+        var responseData;
+
+        window.addEventListener('load', event => {
+            runTest().then(endTest).catch(failTest);
+        });
+
+        async function runTest()
+        {
+            findMediaElement();
+            run('video.src = "../resources/hls/clearkey/prog_index.m3u8"');
+            encryptedEvent = await waitFor(video, 'encrypted');
+            testExpected('bufferToString(encryptedEvent.initData)', 'crypt0.key');
+
+            if (!video.mediaKeys) {
+                const clearKeyOptions = [{
+                    initDataTypes: ['keyids'],
+                    audioCapabilities: [{ contentType: 'application/x-mpegurl' }],
+                    videoCapabilities: [{ contentType: 'application/x-mpegurl' }],
+                }];
+
+                let access = await navigator.requestMediaKeySystemAccess('org.w3.clearkey', clearKeyOptions);
+
+                await video.setMediaKeys(await access.createMediaKeys());
+            }
+
+            let keyId = base64EncodeBuffer(encryptedEvent.initData);
+            let keyRequest = stringToUInt8Array(JSON.stringify({ kids: [ keyId ] }));
+
+            session = video.mediaKeys.createSession('temporary');
+            session.generateRequest('keyids', keyRequest);
+            messageEvent = await waitFor(session, 'message');
+
+            testExpected('messageEvent.messageType', 'license-request');
+            messageData = JSON.parse(bufferToString(messageEvent.message));
+            testExpected('messageData.kids.length', 1);
+            testExpected('atob(messageData.kids[0])', 'crypt0.key');
+
+            let keyResponse = await fetch(`../resources/hls/clearkey/${atob(messageData.kids[0])}`);
+            let keyData = new Uint8Array(await keyResponse.arrayBuffer());
+
+            var responseObject = {
+                keys: [{
+                    'kty': 'oct',
+                    'alg': 'A128KW',
+                    'kid': keyId,
+                    'k': base64EncodeUint8Array(keyData)
+                }]
+            };
+            var responseString = JSON.stringify(responseObject);
+            responseData = stringToUInt8Array(responseString);
+
+            await shouldResolve(run('session.update(responseData)'));
+            await waitFor(video, 'canplay');
+        }
+    </script>
+</head>
+<body>
+    <video controls></video>
+</body>
+</html>

--- a/LayoutTests/http/tests/media/clearkey/support.js
+++ b/LayoutTests/http/tests/media/clearkey/support.js
@@ -11,6 +11,11 @@ function uInt8ArrayToString(array) {
     return String.fromCharCode.apply(null, uint8array);
 }
 
+function bufferToString(buffer)
+{
+    return uInt8ArrayToString(new Uint8Array(buffer))
+}
+
 function base64EncodeUint8Array(input) {
     var keyStr = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
     var output = "";
@@ -37,3 +42,10 @@ function base64EncodeUint8Array(input) {
     }
     return output;
 }
+
+function base64EncodeBuffer(buffer)
+{
+    return base64EncodeUint8Array(new Uint8Array(buffer))
+}
+
+

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2682,6 +2682,7 @@ fast/shadow-dom/focus-ring-on-shadow-host-sibling.html [ Skip ]
 
 # HLS media playback support is disabled in the GStreamer ports.
 http/tests/media/clearkey/clear-key-hls-aes128.html [ Skip ]
+http/tests/media/clearkey/modern-clear-key-hls-aes128.html [ Skip ]
 http/tests/media/hls/ [ Skip ]
 http/tests/media/track-in-band-hls-metadata-crash.html [ Skip ]
 http/tests/media/track-in-band-hls-metadata.html [ Skip ]

--- a/Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.cpp
+++ b/Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.cpp
@@ -442,6 +442,20 @@ RefPtr<CDMInstanceSession> CDMInstanceClearKey::createSession()
     return adoptRef(new CDMInstanceSessionClearKey(*this));
 }
 
+auto CDMInstanceClearKey::getKeyHandleValue(const KeyIDType& keyID) const -> Ref<KeyHandleValuePromise>
+{
+    auto* cdmProxy = this->cdmProxy();
+    if (!cdmProxy)
+        return KeyHandleValuePromise::createAndReject();
+
+    return cdmProxy->getKeyHandleValue(keyID)
+    ->whenSettled(RunLoop::current(), [] (const auto& result) {
+        if (!result || !std::holds_alternative<KeyHandleValue>(*result))
+            return KeyHandleValuePromise::createAndReject();
+        return KeyHandleValuePromise::createAndResolve(std::get<KeyHandleValue>(*result));
+    });
+}
+
 void CDMInstanceSessionClearKey::requestLicense(LicenseType, KeyGroupingStrategy, const AtomString& initDataType, Ref<SharedBuffer>&& initData, LicenseCallback&& callback)
 {
     static uint32_t s_sessionIdValue = 0;

--- a/Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.h
+++ b/Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.h
@@ -53,7 +53,7 @@ enum {
 
 } // namespace ClearKey
 
-class CDMFactoryClearKey final : public CDMFactory {
+class CDMFactoryClearKey final : public CDMFactory, public CDMProxyFactory {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     static CDMFactoryClearKey& singleton();
@@ -61,6 +61,7 @@ public:
     virtual ~CDMFactoryClearKey();
 
     std::unique_ptr<CDMPrivate> createCDM(const String&, const CDMPrivateClient&) final;
+    RefPtr<CDMProxy> createCDMProxy(const String&) final { return new CDMProxy(); }
     bool supportsKeySystem(const String&) final;
 
 private:
@@ -103,6 +104,10 @@ public:
     void setStorageDirectory(const String&) final;
     const String& keySystem() const final;
     RefPtr<CDMInstanceSession> createSession() final;
+
+    using KeyHandleValue = Vector<uint8_t>;
+    using KeyHandleValuePromise = NativePromise<KeyHandleValue, void, PromiseOption::Default | PromiseOption::NonExclusive>;
+    Ref<KeyHandleValuePromise> getKeyHandleValue(const KeyIDType&) const;
 };
 
 class CDMInstanceSessionClearKey final : public CDMInstanceSessionProxy {

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
@@ -367,6 +367,8 @@ private:
     bool containsDisabledTracks() const;
     bool trackIsPlayable(AVAssetTrack*) const;
 
+    bool requestKeyHandleForKeyID(const String&, RetainPtr<AVAssetResourceLoadingRequest>);
+
     RetainPtr<AVURLAsset> m_avAsset;
     RetainPtr<AVPlayer> m_avPlayer;
     RetainPtr<AVPlayerItem> m_avPlayerItem;
@@ -426,8 +428,8 @@ private:
     bool m_waitingForKey { false };
 #endif
 
-#if ENABLE(ENCRYPTED_MEDIA) && HAVE(AVCONTENTKEYSESSION)
-    RefPtr<CDMInstanceFairPlayStreamingAVFObjC> m_cdmInstance;
+#if ENABLE(ENCRYPTED_MEDIA)
+    RefPtr<CDMInstance> m_cdmInstance;
 #endif
 
     RetainPtr<AVPlayerItemMetadataCollector> m_metadataCollector;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -34,6 +34,7 @@
 #import "AudioSourceProviderAVFObjC.h"
 #import "AudioTrackPrivateAVFObjC.h"
 #import "AuthenticationChallenge.h"
+#import "CDMClearKey.h"
 #import "CDMInstanceFairPlayStreamingAVFObjC.h"
 #import "CDMSessionAVFoundationObjC.h"
 #import "CVUtilities.h"
@@ -103,6 +104,7 @@
 #import <wtf/BlockObjCExceptions.h>
 #import <wtf/FileSystem.h>
 #import <wtf/ListHashSet.h>
+#import <wtf/NativePromise.h>
 #import <wtf/NeverDestroyed.h>
 #import <wtf/OSObjectPtr.h>
 #import <wtf/URL.h>
@@ -2154,19 +2156,32 @@ bool MediaPlayerPrivateAVFoundationObjC::shouldWaitForLoadingOfResource(AVAssetR
         return true;
     }
 
-#if ENABLE(LEGACY_ENCRYPTED_MEDIA)
     if (scheme == "clearkey"_s) {
         String keyID = [[[avRequest request] URL] resourceSpecifier];
         auto encodedKeyId = PAL::TextCodecUTF8::encodeUTF8(keyID);
         auto initData = SharedBuffer::create(WTFMove(encodedKeyId));
 
+#if ENABLE(ENCRYPTED_MEDIA)
+        if (requestKeyHandleForKeyID(keyID, avRequest))
+            return true;
+#endif
+
+#if ENABLE(LEGACY_ENCRYPTED_MEDIA)
         auto keyData = player->cachedKeyForKeyId(keyID);
         if (keyData) {
             fulfillRequestWithKeyData(avRequest, keyData.get());
             return false;
         }
+#endif
 
+#if ENABLE(ENCRYPTED_MEDIA)
+        player->initializationDataEncountered(scheme, initData->tryCreateArrayBuffer());
+        setWaitingForKey(true);
+#endif
+
+#if ENABLE(LEGACY_ENCRYPTED_MEDIA)
         player->keyNeeded(initData);
+#endif
 
         if (!player->shouldContinueAfterKeyNeeded())
             return false;
@@ -2174,12 +2189,30 @@ bool MediaPlayerPrivateAVFoundationObjC::shouldWaitForLoadingOfResource(AVAssetR
         m_keyURIToRequestMap.set(keyID, avRequest);
         return true;
     }
-#endif
-#endif
+#endif // ENABLE(LEGACY_ENCRYPTED_MEDIA) || ENABLE(ENCRYPTED_MEDIA)
 
     auto resourceLoader = WebCoreAVFResourceLoader::create(this, avRequest);
     m_resourceLoaderMap.add((__bridge CFTypeRef)avRequest, resourceLoader.copyRef());
     resourceLoader->startLoading();
+    return true;
+}
+
+bool MediaPlayerPrivateAVFoundationObjC::requestKeyHandleForKeyID(const String& keyID, RetainPtr<AVAssetResourceLoadingRequest> avRequest)
+{
+    auto* clearKeyInstance = dynamicDowncast<CDMInstanceClearKey>(m_cdmInstance.get());
+    if (!clearKeyInstance)
+        return false;
+
+    auto encodedKeyId = PAL::TextCodecUTF8::encodeUTF8(keyID);
+
+    auto promise = clearKeyInstance->getKeyHandleValue(encodedKeyId)->whenSettled(RunLoop::main(), [avRequest = WTFMove(avRequest)] (const auto& result) mutable {
+        if (result) {
+            auto resultBuffer = ArrayBuffer::create(*result);
+            fulfillRequestWithKeyData(avRequest.get(), resultBuffer.ptr());
+        } else
+            [avRequest finishLoadingWithError:nil];
+    });
+
     return true;
 }
 
@@ -2917,8 +2950,8 @@ void MediaPlayerPrivateAVFoundationObjC::outputObscuredDueToInsufficientExternal
 #endif
 
 #if ENABLE(ENCRYPTED_MEDIA) && HAVE(AVCONTENTKEYSESSION)
-    if (m_cdmInstance)
-        m_cdmInstance->outputObscuredDueToInsufficientExternalProtectionChanged(newValue);
+    if (auto cdmInstanceFairPlay = dynamicDowncast<CDMInstanceFairPlayStreamingAVFObjC>(m_cdmInstance.get()))
+        cdmInstanceFairPlay->outputObscuredDueToInsufficientExternalProtectionChanged(newValue);
 #elif !ENABLE(LEGACY_ENCRYPTED_MEDIA)
     UNUSED_PARAM(newValue);
 #endif
@@ -2927,21 +2960,31 @@ void MediaPlayerPrivateAVFoundationObjC::outputObscuredDueToInsufficientExternal
 #if ENABLE(ENCRYPTED_MEDIA)
 void MediaPlayerPrivateAVFoundationObjC::cdmInstanceAttached(CDMInstance& instance)
 {
-#if HAVE(AVCONTENTKEYSESSION)
-    if (!is<CDMInstanceFairPlayStreamingAVFObjC>(instance))
-        return;
-
-    auto& fpsInstance = downcast<CDMInstanceFairPlayStreamingAVFObjC>(instance);
-    if (&fpsInstance == m_cdmInstance)
+    if (&instance == m_cdmInstance)
         return;
 
     if (m_cdmInstance)
         cdmInstanceDetached(*m_cdmInstance);
 
-    m_cdmInstance = &fpsInstance;
-#else
-    UNUSED_PARAM(instance);
+#if HAVE(AVCONTENTKEYSESSION)
+    if (auto* fpsInstance = dynamicDowncast<CDMInstanceFairPlayStreamingAVFObjC>(instance))
+        m_cdmInstance = fpsInstance;
 #endif
+
+    if (auto* clearKeyInstance = dynamicDowncast<CDMInstanceClearKey>(instance)) {
+        m_cdmInstance = clearKeyInstance;
+
+        Vector<String> removedRequests;
+        removedRequests.reserveInitialCapacity(m_keyURIToRequestMap.size());
+
+        for (auto& pair : m_keyURIToRequestMap) {
+            if (requestKeyHandleForKeyID(pair.key, pair.value))
+                removedRequests.append(pair.key);
+        }
+
+        for (auto& keyID : removedRequests)
+            m_keyURIToRequestMap.remove(keyID);
+    }
 }
 
 void MediaPlayerPrivateAVFoundationObjC::cdmInstanceDetached(CDMInstance& instance)
@@ -2960,7 +3003,11 @@ void MediaPlayerPrivateAVFoundationObjC::attemptToDecryptWithInstance(CDMInstanc
     if (!m_keyID || !m_cdmInstance)
         return;
 
-    auto instanceSession = m_cdmInstance->sessionForKeyIDs(Vector<Ref<SharedBuffer>>::from(*m_keyID));
+    auto cdmInstanceFairPlay = dynamicDowncast<CDMInstanceFairPlayStreamingAVFObjC>(m_cdmInstance.get());
+    if (!cdmInstanceFairPlay)
+        return;
+
+    auto instanceSession = cdmInstanceFairPlay->sessionForKeyIDs(Vector<Ref<SharedBuffer>>::from(*m_keyID));
     if (!instanceSession)
         return;
 


### PR DESCRIPTION
#### 3c1cdf50c9e298d121f2b600b81d5ff74955a41e
<pre>
[Cocoa] Support HLS AES-128 segment encryption via unprefixed EME ClearKey CDM
<a href="https://bugs.webkit.org/show_bug.cgi?id=266485">https://bugs.webkit.org/show_bug.cgi?id=266485</a>
<a href="https://rdar.apple.com/119054483">rdar://119054483</a>

Reviewed by NOBODY (OOPS!).

In 159283@main, support was added in the Legacy EME API for key delivery of full-segment
encrypted HLS streams. This support never even initialized a CDM; it merely passed the
resulting key data back into AVURLAsset&apos;s resource loader. A similar technique can be
used for the modern EME path, and can utilize the existing CDMClearKey for parsing and
responding to key requests.

A key store back-end was added via CDMProxy for the GStreamer port, but by default a
CDMClearKey will not create a CDMProxy to hold keys. Fix that (for non-GStreamer ports)
and add a mechanism where clients can request key data from a CDMProxy and receive it
via a NativePromise.

* LayoutTests/http/tests/media/clearkey/modern-clear-key-hls-aes128-expected.txt: Added.
* LayoutTests/http/tests/media/clearkey/modern-clear-key-hls-aes128.html: Added.
* LayoutTests/http/tests/media/clearkey/support.js:
(bufferToString):
(base64EncodeBuffer):
* Source/WebCore/platform/encryptedmedia/CDMProxy.cpp:
(WebCore::CDMProxy::updateKeyStore):
(WebCore::CDMProxy::getKeyHandleValue const):
* Source/WebCore/platform/encryptedmedia/CDMProxy.h:
(WebCore::CDMInstanceProxy::cdmProxy):
(WebCore::CDMInstanceProxy::cdmProxy const):
* Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.cpp:
(WebCore::CDMInstanceClearKey::getKeyHandleValue const):
* Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::shouldWaitForLoadingOfResource):
(WebCore::MediaPlayerPrivateAVFoundationObjC::requestKeyHandleForKeyID):
(WebCore::MediaPlayerPrivateAVFoundationObjC::outputObscuredDueToInsufficientExternalProtectionChanged):
(WebCore::MediaPlayerPrivateAVFoundationObjC::cdmInstanceAttached):
(WebCore::MediaPlayerPrivateAVFoundationObjC::attemptToDecryptWithInstance):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c1cdf50c9e298d121f2b600b81d5ff74955a41e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30883 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9560 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32556 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33385 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27898 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31635 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11884 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6812 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27767 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31202 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8149 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27624 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6894 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7053 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27502 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34723 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28110 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27984 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33201 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7097 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5172 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31034 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8808 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/27287 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7809 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7651 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->