### PR TITLE
Avoid unnecessary work when grouping source map errors.

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Controllers/JavaScriptLogViewController.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/JavaScriptLogViewController.js
@@ -368,17 +368,15 @@ WI.JavaScriptLogViewController = class JavaScriptLogViewController extends WI.Ob
             if (parentGroup)
                 this._currentSessionOrGroup = parentGroup;
         } else {
-            if (type === WI.ConsoleMessage.MessageType.StartGroup || type === WI.ConsoleMessage.MessageType.StartGroupCollapsed) {
+            if (this._addConsoleMessageToConsoleSourceMapErrorGroup(messageView)) {
+                return;
+            } else if (type === WI.ConsoleMessage.MessageType.StartGroup || type === WI.ConsoleMessage.MessageType.StartGroupCollapsed) {
                 var group = new WI.ConsoleGroup(this._currentSessionOrGroup);
                 var groupElement = group.render(messageView);
                 this._currentSessionOrGroup.append(groupElement);
                 this._currentSessionOrGroup = group;
             } else
                 this._currentSessionOrGroup.addMessageView(messageView);
-            
-            // FIXME: <https://webkit.org/b/264490> (Improve failed SourceMap error grouping to avoid unnecessary work)
-            if (WI.settings.experimentalGroupSourceMapErrors.value && WI.consoleManager.failedSourceMapConsoleMessages.has(messageView.message))
-                this._addConsoleMessageToConsoleSourceMapErrorGroup(messageView);
         }
 
         if (this.delegate && typeof this.delegate.didAppendConsoleMessageView === "function")
@@ -387,9 +385,15 @@ WI.JavaScriptLogViewController = class JavaScriptLogViewController extends WI.Ob
     
     _addConsoleMessageToConsoleSourceMapErrorGroup(messageView)
     {
+        if (!WI.settings.experimentalGroupSourceMapErrors.value)
+            return false;
+            
+        if (!WI.consoleManager.failedSourceMapConsoleMessages.has(messageView.message))
+            return false;
+        
         if (!this._firstSourceMapErrorMessageView) {
             this._firstSourceMapErrorMessageView = messageView;
-            return;
+            return true;
         }
         
         if (!this._failedSourceMapsGroup) {
@@ -400,6 +404,7 @@ WI.JavaScriptLogViewController = class JavaScriptLogViewController extends WI.Ob
         }
 
         this._failedSourceMapsGroup.addMessageView(messageView);
+        return true;
     }
 
     _handleShowConsoleMessageTimestampsSettingChanged()


### PR DESCRIPTION
#### 938669b32cb90f4b08900ef63e7eabf8e8df733a
<pre>
Avoid unnecessary work when grouping source map errors.
<a href="https://bugs.webkit.org/show_bug.cgi?id=264490">https://bugs.webkit.org/show_bug.cgi?id=264490</a>
<a href="https://rdar.apple.com/problem/118510795">rdar://problem/118510795</a>

Reviewed by NOBODY (OOPS!).

This change avoids adding an error message to the console, then re-attaching
to the source map group when it is determined to be a source map error. Instead
it when a source map error is attached, an early return avoids the extra work.

* Source/WebInspectorUI/UserInterface/Controllers/JavaScriptLogViewController.js:
(WI.JavaScriptLogViewController.prototype._didRenderConsoleMessageView):
(WI.JavaScriptLogViewController.prototype._addConsoleMessageToConsoleSourceMapErrorGroup):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/938669b32cb90f4b08900ef63e7eabf8e8df733a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30686 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9366 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32349 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33184 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27741 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11666 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6623 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27637 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30998 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7868 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27474 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6744 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6899 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27341 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34521 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27938 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27830 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33067 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6920 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5022 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30897 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8643 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7644 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7473 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->