### PR TITLE
NEW TEST (271377@main): [ Sonoma x86_64 ] http/wpt/webcodecs/encoder-task-failing.html is constant failure

### DIFF
--- a/LayoutTests/http/wpt/webcodecs/encoder-task-failing-expected.txt
+++ b/LayoutTests/http/wpt/webcodecs/encoder-task-failing-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: VideoEncoder encode failed: Encoding task failed
 
 PASS Test that H264 encoding failure is propagated to JavaScript
 

--- a/LayoutTests/http/wpt/webcodecs/encoder-task-failing.html
+++ b/LayoutTests/http/wpt/webcodecs/encoder-task-failing.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html><!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
 <!DOCTYPE html>
 <html>
 <header>
@@ -43,12 +44,17 @@ async function doTest(t, codec)
     encoder.encode(frame, { keyFrame: true });
     frame.close();
 
-    // We use EncodingError since we are not detecting correctly that the config cannot be supported until starting to encode.
-    // When we improve the config checks, we should get a NotSupportedError here.
-    await promise_rejects_dom(t, "EncodingError", encoder.flush());
+    const flushPromise = encoder.flush();
 
-    assert_equals(frameCount, 0);
-    assert_equals(errorCount, 1);
+    await flushPromise.catch(() => { });
+
+    assert_equals(frameCount + errorCount, 1);
+
+    if (errorCount) {
+        // We use EncodingError since we are not detecting correctly that the config cannot be supported until starting to encode.
+        // When we improve the config checks, we should get a NotSupportedError here.
+        await promise_rejects_dom(t, "EncodingError", flushPromise);
+    }
 }
 
 promise_test(async (t) => {

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2190,6 +2190,9 @@ webkit.org/b/231463 fast/css/accent-color/range.html [ ImageOnlyFailure ]
 [ Monterey+ ] imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.any.worker.html [ Pass ]
 [ Monterey+ ] imported/w3c/web-platform-tests/webcodecs/videoFrame-drawImage.any.worker.html [ Pass ]
 
+# Encoder specific behavior that is not covered for Monterey.
+[ Monterey ] http/wpt/webcodecs/encoder-task-failing.html [ Failure ]
+
 webkit.org/b/229521 pointer-lock/lock-already-locked.html [ Pass Failure ]
 
 webkit.org/b/228176 [ BigSur Monterey ] fast/text/variable-system-font-2.html [ Pass ]
@@ -2592,8 +2595,6 @@ webkit.org/b/264607 [ Sonoma+ ] css1/box_properties/acid_test.html [ Pass Timeou
 # webkit.org/b/265536 ([ macOS ] 2 tests in inspector/layers are flaky failures)
 inspector/layers/layers-compositing-reasons.html [ Pass Failure ]
 inspector/layers/layers-blending-compositing-reasons.html [ Pass Failure ]
-
-webkit.org/b/265685 [ Sonoma+ ] http/wpt/webcodecs/encoder-task-failing.html [ Failure ]
 
 # webkit.org/b/266168 Two wheel/mousewheel passive event listeners WPT test pass on macOS Sonoma and up
 [ Sonoma+ ] imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-mousewheel-event-listener-on-div.html [ Pass ]


### PR DESCRIPTION
#### 24dc374004d3b30be7622ef2dae7b796c94a18e8
<pre>
NEW TEST (271377@main): [ Sonoma x86_64 ] http/wpt/webcodecs/encoder-task-failing.html is constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=265685">https://bugs.webkit.org/show_bug.cgi?id=265685</a>
<a href="https://rdar.apple.com/119043575">rdar://119043575</a>

Reviewed by Eric Carlson.

Some encoders will not error in case of large frame with low profile.
Update the test to cope with this, the important thing being that either the output or error callback is called.
We enable the test for Ventura but not MontereWe enable the test for Ventura but not Montereyy

* LayoutTests/http/wpt/webcodecs/encoder-task-failing-expected.txt:
* LayoutTests/http/wpt/webcodecs/encoder-task-failing.html:
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/272205@main">https://commits.webkit.org/272205@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01f8103f3beab783628aedf828a6d8ec6da0c417

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30939 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9611 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32621 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33450 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27950 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11952 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6875 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27816 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31266 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8092 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27680 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6950 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7108 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27559 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34788 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28167 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28033 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33257 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7152 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5226 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31089 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8857 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/27343 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7300 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7859 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7700 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->