### PR TITLE
[iOS] Chrome crashes when showing an edit menu when async text input is enabled

### DIFF
--- a/LayoutTests/editing/selection/ios/select-text-with-long-press-actions-disabled-expected.txt
+++ b/LayoutTests/editing/selection/ios/select-text-with-long-press-actions-disabled-expected.txt
@@ -1,0 +1,10 @@
+Verifies that text can be selected in a web view with long press actions disabled. Requires WebKitTestRunner.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS getSelection().toString() became 'Apple'
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Apple

--- a/LayoutTests/editing/selection/ios/select-text-with-long-press-actions-disabled.html
+++ b/LayoutTests/editing/selection/ios/select-text-with-long-press-actions-disabled.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true longPressActionsEnabled=false ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+.target {
+    font-size: 32px;
+    width: 300px;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+description("Verifies that text can be selected in a web view with long press actions disabled. Requires WebKitTestRunner.");
+
+addEventListener("load", async () => {
+    await UIHelper.longPressElement(document.querySelector(".target"));
+    await shouldBecomeEqual("getSelection().toString()", "'Apple'");
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <span class="target">Apple</span>
+</body>
+</html>

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -13419,7 +13419,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         configuration = asyncConfiguration.get();
     }
 #endif // HAVE(UI_CONTEXT_MENU_ASYNC_CONFIGURATION)
-    return configuration.get();
+    return configuration.autorelease();
 }
 
 - (void)_internalContextMenuInteraction:(UIContextMenuInteraction *)interaction configurationForMenuAtLocation:(CGPoint)location completion:(void(^)(UIContextMenuConfiguration *))completion

--- a/Tools/WebKitTestRunner/TestOptions.cpp
+++ b/Tools/WebKitTestRunner/TestOptions.cpp
@@ -192,6 +192,7 @@ const TestFeatures& TestOptions::defaults()
             { "suppressInputAccessoryView", false },
             { "allowsInlinePredictions", false },
             { "showsScrollIndicators", true },
+            { "longPressActionsEnabled", true },
             { "enhancedWindowingEnabled", false },
         };
         features.doubleTestRunnerFeatures = {
@@ -257,6 +258,7 @@ const std::unordered_map<std::string, TestHeaderKeyType>& TestOptions::keyTypeMa
         { "suppressInputAccessoryView", TestHeaderKeyType::BoolTestRunner },
         { "allowsInlinePredictions", TestHeaderKeyType::BoolTestRunner },
         { "showsScrollIndicators", TestHeaderKeyType::BoolTestRunner },
+        { "longPressActionsEnabled", TestHeaderKeyType::BoolTestRunner },
         { "enhancedWindowingEnabled", TestHeaderKeyType::BoolTestRunner },
     
         { "contentInset.top", TestHeaderKeyType::DoubleTestRunner },

--- a/Tools/WebKitTestRunner/TestOptions.h
+++ b/Tools/WebKitTestRunner/TestOptions.h
@@ -81,6 +81,7 @@ public:
     bool suppressInputAccessoryView() const { return boolTestRunnerFeatureValue("suppressInputAccessoryView"); }
     bool allowsInlinePredictions() const { return boolTestRunnerFeatureValue("allowsInlinePredictions"); }
     bool showsScrollIndicators() const { return boolTestRunnerFeatureValue("showsScrollIndicators"); }
+    bool longPressActionsEnabled() const { return boolTestRunnerFeatureValue("longPressActionsEnabled"); }
     bool enhancedWindowingEnabled() const { return boolTestRunnerFeatureValue("enhancedWindowingEnabled"); }
     double contentInsetTop() const { return doubleTestRunnerFeatureValue("contentInset.top"); }
     double obscuredInsetTop() const { return doubleTestRunnerFeatureValue("obscuredInset.top"); }

--- a/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
@@ -295,6 +295,7 @@ void TestController::platformCreateWebView(WKPageConfigurationRef, const TestOpt
         [copiedConfiguration setLimitsNavigationsToAppBoundDomains:YES];
 
     [copiedConfiguration _setAppInitiatedOverrideValueForTesting:options.isAppInitiated() ? _WKAttributionOverrideTestingAppInitiated : _WKAttributionOverrideTestingUserInitiated];
+    [copiedConfiguration _setLongPressActionsEnabled:options.longPressActionsEnabled()];
 #endif
 
     if (options.enableAttachmentElement())


### PR DESCRIPTION
#### 9032fde71088227c984b05588cea41003592284f
<pre>
[iOS] Chrome crashes when showing an edit menu when async text input is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=266488">https://bugs.webkit.org/show_bug.cgi?id=266488</a>
<a href="https://rdar.apple.com/119720176">rdar://119720176</a>

Reviewed by Tim Horton.

Fix an ObjC memory management error in `-contextMenuInteraction:configurationForMenuAtLocation:`
that causes Chrome on iOS to crash after long pressing text, when `UIKit/async_text_input` is
enabled. Instead of returning a reference to the `asyncConfiguration` temporary, this needs to
return an autoreleased object.

This happens because Chrome sets `_longPressActionsEnabled` on the web view configuration to `NO`,
which causes `-_internalContextMenuInteraction:configurationForMenuAtLocation:completion:` to return
immediately, which in turn causes the async configuration to be invalid after returning from the
context menu configuration delegate method.

* LayoutTests/editing/selection/ios/select-text-with-long-press-actions-disabled-expected.txt: Added.
* LayoutTests/editing/selection/ios/select-text-with-long-press-actions-disabled.html: Added.
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView contextMenuInteraction:configurationForMenuAtLocation:]):
* Tools/WebKitTestRunner/TestOptions.cpp:

Add a new test option to disable long press actions, for the new layout test.

(WTR::TestOptions::defaults):
(WTR::TestOptions::keyTypeMapping):
* Tools/WebKitTestRunner/TestOptions.h:
(WTR::TestOptions::longPressActionsEnabled const):
* Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm:
(WTR::TestController::platformCreateWebView):

Canonical link: <a href="https://commits.webkit.org/272144@main">https://commits.webkit.org/272144@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0e639b78a0bb9b2004192d2db4adcb16fbcb2d5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30705 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9385 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32369 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33201 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27758 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31415 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11686 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6642 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/27645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31017 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7882 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27490 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6755 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/6910 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27363 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34538 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27951 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27847 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/33073 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6938 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5036 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/30904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8660 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/27139 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7264 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7661 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7491 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->