### PR TITLE
Add ConsoleEntryView to allow setMessageLevel by message views and groups.

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Main.html
+++ b/Source/WebInspectorUI/UserInterface/Main.html
@@ -558,6 +558,7 @@
     <script src="Controllers/SelectionController.js"></script>
 
     <script src="Views/ConsoleCommandView.js"></script>
+    <script src="Views/ConsoleEntryView.js"></script>
     <script src="Views/ConsoleMessageView.js"></script>
     <script src="Views/ContentBrowser.js"></script>
     <script src="Views/ContentView.js"></script>

--- a/Source/WebInspectorUI/UserInterface/Views/ConsoleEntryView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ConsoleEntryView.js
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2023 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * 3.  Neither the name of Apple Inc. ("Apple") nor the names of
+ *     its contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+WI.ConsoleEntryView = class ConsoleEntryView extends WI.Object
+{
+    constructor()
+    {
+        super();
+    }
+    
+    // Public
+
+    setMessageLevel(messageLevel)
+    {
+        console.assert(this._element);
+    
+        switch (messageLevel) {
+        case WI.ConsoleMessage.MessageLevel.Log:
+            this._element.classList.add("console-log-level");
+            this._element.setAttribute("data-labelprefix", WI.UIString("Log: "));
+            break;
+        case WI.ConsoleMessage.MessageLevel.Info:
+            this._element.classList.add("console-info-level");
+            this._element.setAttribute("data-labelprefix", WI.UIString("Info: "));
+            break;
+        case WI.ConsoleMessage.MessageLevel.Debug:
+            this._element.classList.add("console-debug-level");
+            this._element.setAttribute("data-labelprefix", WI.UIString("Debug: "));
+            break;
+        case WI.ConsoleMessage.MessageLevel.Warning:
+            this._element.classList.add("console-warning-level");
+            this._element.setAttribute("data-labelprefix", WI.UIString("Warning: "));
+            break;
+        case WI.ConsoleMessage.MessageLevel.Error:
+            this._element.classList.add("console-error-level");
+            this._element.setAttribute("data-labelprefix", WI.UIString("Error: "));
+            break;
+        }
+    }
+};

--- a/Source/WebInspectorUI/UserInterface/Views/ConsoleGroup.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ConsoleGroup.js
@@ -27,7 +27,7 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-WI.ConsoleGroup = class ConsoleGroup extends WI.Object
+WI.ConsoleGroup = class ConsoleGroup extends WI.ConsoleEntryView
 {
     constructor(parentGroup)
     {
@@ -83,33 +83,33 @@ WI.ConsoleGroup = class ConsoleGroup extends WI.Object
     }
     
     // FIXME: <https://webkit.org/b/264489> We should merge this logic with `WI.ConsoleMessageView.prototype.render`
-    setMessageLevel(messageLevel)
-    {
-        console.assert(this._element);
-  
-        switch (messageLevel) {
-        case WI.ConsoleMessage.MessageLevel.Log:
-            this._element.classList.add("console-log-level");
-            this._element.setAttribute("data-labelprefix", WI.UIString("Log: "));
-            break;
-        case WI.ConsoleMessage.MessageLevel.Info:
-            this._element.classList.add("console-info-level");
-            this._element.setAttribute("data-labelprefix", WI.UIString("Info: "));
-            break;
-        case WI.ConsoleMessage.MessageLevel.Debug:
-            this._element.classList.add("console-debug-level");
-            this._element.setAttribute("data-labelprefix", WI.UIString("Debug: "));
-            break;
-        case WI.ConsoleMessage.MessageLevel.Warning:
-            this._element.classList.add("console-warning-level");
-            this._element.setAttribute("data-labelprefix", WI.UIString("Warning: "));
-            break;
-        case WI.ConsoleMessage.MessageLevel.Error:
-            this._element.classList.add("console-error-level");
-            this._element.setAttribute("data-labelprefix", WI.UIString("Error: "));
-            break;
-        }
-    }
+  //   setMessageLevel(messageLevel)
+  //   {
+  //       console.assert(this._element);
+  // 
+  //       switch (messageLevel) {
+  //       case WI.ConsoleMessage.MessageLevel.Log:
+  //           this._element.classList.add("console-log-level");
+  //           this._element.setAttribute("data-labelprefix", WI.UIString("Log: "));
+  //           break;
+  //       case WI.ConsoleMessage.MessageLevel.Info:
+  //           this._element.classList.add("console-info-level");
+  //           this._element.setAttribute("data-labelprefix", WI.UIString("Info: "));
+  //           break;
+  //       case WI.ConsoleMessage.MessageLevel.Debug:
+  //           this._element.classList.add("console-debug-level");
+  //           this._element.setAttribute("data-labelprefix", WI.UIString("Debug: "));
+  //           break;
+  //       case WI.ConsoleMessage.MessageLevel.Warning:
+  //           this._element.classList.add("console-warning-level");
+  //           this._element.setAttribute("data-labelprefix", WI.UIString("Warning: "));
+  //           break;
+  //       case WI.ConsoleMessage.MessageLevel.Error:
+  //           this._element.classList.add("console-error-level");
+  //           this._element.setAttribute("data-labelprefix", WI.UIString("Error: "));
+  //           break;
+  //       }
+  //   }
 
     // Private
 

--- a/Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.js
@@ -28,7 +28,7 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-WI.ConsoleMessageView = class ConsoleMessageView extends WI.Object
+WI.ConsoleMessageView = class ConsoleMessageView extends WI.ConsoleEntryView
 {
     constructor(message)
     {
@@ -67,28 +67,30 @@ WI.ConsoleMessageView = class ConsoleMessageView extends WI.Object
         } else if (this._message.type === WI.ConsoleMessage.MessageType.StartGroup || this._message.type === WI.ConsoleMessage.MessageType.StartGroupCollapsed)
             this._element.classList.add("console-group-title");
 
-        switch (this._message.level) {
-        case WI.ConsoleMessage.MessageLevel.Log:
-            this._element.classList.add("console-log-level");
-            this._element.setAttribute("data-labelprefix", WI.UIString("Log: "));
-            break;
-        case WI.ConsoleMessage.MessageLevel.Info:
-            this._element.classList.add("console-info-level");
-            this._element.setAttribute("data-labelprefix", WI.UIString("Info: "));
-            break;
-        case WI.ConsoleMessage.MessageLevel.Debug:
-            this._element.classList.add("console-debug-level");
-            this._element.setAttribute("data-labelprefix", WI.UIString("Debug: "));
-            break;
-        case WI.ConsoleMessage.MessageLevel.Warning:
-            this._element.classList.add("console-warning-level");
-            this._element.setAttribute("data-labelprefix", WI.UIString("Warning: "));
-            break;
-        case WI.ConsoleMessage.MessageLevel.Error:
-            this._element.classList.add("console-error-level");
-            this._element.setAttribute("data-labelprefix", WI.UIString("Error: "));
-            break;
-        }
+        this.setMessageLevel(this._message.level);
+
+        // switch (this._message.level) {
+        // case WI.ConsoleMessage.MessageLevel.Log:
+        //     this._element.classList.add("console-log-level");
+        //     this._element.setAttribute("data-labelprefix", WI.UIString("Log: "));
+        //     break;
+        // case WI.ConsoleMessage.MessageLevel.Info:
+        //     this._element.classList.add("console-info-level");
+        //     this._element.setAttribute("data-labelprefix", WI.UIString("Info: "));
+        //     break;
+        // case WI.ConsoleMessage.MessageLevel.Debug:
+        //     this._element.classList.add("console-debug-level");
+        //     this._element.setAttribute("data-labelprefix", WI.UIString("Debug: "));
+        //     break;
+        // case WI.ConsoleMessage.MessageLevel.Warning:
+        //     this._element.classList.add("console-warning-level");
+        //     this._element.setAttribute("data-labelprefix", WI.UIString("Warning: "));
+        //     break;
+        // case WI.ConsoleMessage.MessageLevel.Error:
+        //     this._element.classList.add("console-error-level");
+        //     this._element.setAttribute("data-labelprefix", WI.UIString("Error: "));
+        //     break;
+        // }
 
         // FIXME: The location link should include stack trace information.
         this._appendLocationLink();


### PR DESCRIPTION
#### 69649139378dc072eec12763233e240da22cfc16
<pre>
Add ConsoleEntryView to allow setMessageLevel by message views and groups.
<a href="https://bugs.webkit.org/show_bug.cgi?id=264489">https://bugs.webkit.org/show_bug.cgi?id=264489</a>
<a href="https://rdar.apple.com/problem/118510401">rdar://problem/118510401</a>

Reviewed by NOBODY (OOPS!).

The addition of grouping source maps required ConsoleGroup to be able
to set a message level in the same manner as ConsoleMessageView. Adding
ConsoleEntryView as a common ancestor allows both ConsoleMessageView
and ConsoleGroup to use the same code.

* Source/WebInspectorUI/UserInterface/Main.html:
* Source/WebInspectorUI/UserInterface/Views/ConsoleEntryView.js: Added.
(WI.ConsoleEntryView):
(WI.ConsoleEntryView.prototype.setMessageLevel):
* Source/WebInspectorUI/UserInterface/Views/ConsoleGroup.js:
(WI.ConsoleGroup.prototype.setMessageLevel): Deleted.
* Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.js:
(WI.ConsoleMessageView.prototype.render):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69649139378dc072eec12763233e240da22cfc16

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30690 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9370 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32353 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33188 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27745 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11670 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6627 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27633 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31002 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7871 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27477 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6740 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6902 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27344 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34525 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27941 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27832 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33059 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6924 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5024 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30886 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8647 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7648 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7477 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->