### PR TITLE
[InteractionRegions] Add support for all non-uniform border-radius

### DIFF
--- a/LayoutTests/interaction-region/aria-roles-expected.txt
+++ b/LayoutTests/interaction-region/aria-roles-expected.txt
@@ -18,17 +18,17 @@ This works like a switch.
 
       (interaction regions [
         (interaction (0,0) width=800 height=20)
-        (borderRadius 8.00),
+        (cornerRadius 8.00),
         (interaction (0,20) width=800 height=20)
-        (borderRadius 8.00),
+        (cornerRadius 8.00),
         (interaction (40,56) width=760 height=20)
-        (borderRadius 8.00),
+        (cornerRadius 8.00),
         (interaction (40,76) width=760 height=20)
-        (borderRadius 8.00),
+        (cornerRadius 8.00),
         (interaction (40,96) width=760 height=20)
-        (borderRadius 8.00),
+        (cornerRadius 8.00),
         (interaction (0,132) width=800 height=20)
-        (borderRadius 8.00)])
+        (cornerRadius 8.00)])
       )
     )
   )

--- a/LayoutTests/interaction-region/border-radii-expected.txt
+++ b/LayoutTests/interaction-region/border-radii-expected.txt
@@ -1,4 +1,4 @@
-uniform half pill diagonal tongue degenerate changing default explicit
+uniform half pill diagonal tongue degenerate big border changing default explicit
 (GraphicsLayer
   (anchor 0.00 0.00)
   (bounds 800.00 600.00)
@@ -12,22 +12,31 @@ uniform half pill diagonal tongue degenerate changing default explicit
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (interaction (10,10) width=83.50 height=52)
-        (borderRadius 12.00),
-        (interaction (117.50,10) width=82.50 height=52)
-        (borderRadius 20 0 0 20),
-        (interaction (224,10) width=87 height=52)
-        (borderRadius 16 0 16 0),
-        (interaction (335,10) width=75.50 height=52)
-        (borderRadius 0 0 10 10),
-        (interaction (434.50,10) width=101 height=52)
-        (borderRadius 2.00),
-        (interaction (559.50,10) width=91 height=52)
-        (borderRadius 20.00),
-        (interaction (674.50,10) width=76.50 height=52)
-        (borderRadius 8.00),
-        (interaction (10,82) width=80 height=52)
-        (borderRadius 0.00)])
+        (interaction (10,16) width=91.50 height=60)
+        (cornerRadius 12.00),
+        (interaction (125.50,20) width=82.50 height=52)
+        (cornerRadius 20 0 0 20),
+        (interaction (232,18) width=91 height=56)
+        (cornerRadius 16 0 16 0),
+        (interaction (347,20) width=75.50 height=52)
+        (cornerRadius 0 0 10 10),
+        (interaction (446.50,19) width=103 height=54)
+        (clipPath add rounded rect (0,0) width=103.28 height=54
+          (top-left width=2 height=2)
+          (top-right width=16 height=16)
+          (bottom-left width=18 height=18)
+          (bottom-right width=10 height=10)),
+        (interaction (573.50,10) width=138.50 height=72)
+        (clipPath add rounded rect (0,0) width=138.20 height=72
+          (top-left width=0 height=0)
+          (top-right width=16 height=16)
+          (bottom-left width=0 height=0)
+          (bottom-right width=18 height=18)),
+        (interaction (10,102) width=90.50 height=52)
+        (cornerRadius 20.00),
+        (interaction (124.50,102) width=76.50 height=52)
+        (cornerRadius 8.00),
+        (interaction (225,102) width=80 height=52)])
       )
     )
   )

--- a/LayoutTests/interaction-region/border-radii.html
+++ b/LayoutTests/interaction-region/border-radii.html
@@ -12,18 +12,26 @@
     }
     .uniform {
         border-radius: 12px;
+        border: 4px black solid;
     }
     .half-pill {
         border-radius: 20px 0 0 20px;
     }
     .diagonal {
         border-radius: 16px 0 16px 0;
+        border: 2px black solid;
     }
     .tongue {
         border-radius: 0 0 10px 10px;
     }
     .degenerate {
         border-radius: 2px 16px 10px 18px;
+        border: 1px black solid;
+    }
+    .big-border {
+        border-radius: 0 16px 18px 0;
+        border: 10px purple solid;
+        border-left: 30px red solid;
     }
     .changed {
         border-radius: 20px;
@@ -44,6 +52,7 @@
 <div class="diagonal">diagonal</div>
 <div class="tongue">tongue</div>
 <div class="degenerate">degenerate</div>
+<div class="big-border">big border</div>
 <div class="changing">changing</div>
 <div class="default">default</div>
 <div class="explicit">explicit</div>

--- a/LayoutTests/interaction-region/button-in-link-expected.txt
+++ b/LayoutTests/interaction-region/button-in-link-expected.txt
@@ -12,10 +12,9 @@ Some text but also a button
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (interaction (20,20) width=442 height=67)
-        (borderRadius 0.00),
+        (interaction (20,20) width=442 height=67),
         (interaction (270,41) width=171 height=23)
-        (borderRadius 6.00)])
+        (cornerRadius 6.00)])
       )
     )
   )

--- a/LayoutTests/interaction-region/click-handler-dynamically-added-expected.txt
+++ b/LayoutTests/interaction-region/click-handler-dynamically-added-expected.txt
@@ -12,7 +12,7 @@
 
       (interaction regions [
         (interaction (0,0) width=100 height=100)
-        (borderRadius 10.00)])
+        (cornerRadius 10.00)])
       )
     )
   )

--- a/LayoutTests/interaction-region/click-handler-expected.txt
+++ b/LayoutTests/interaction-region/click-handler-expected.txt
@@ -12,7 +12,7 @@
 
       (interaction regions [
         (interaction (0,0) width=100 height=100)
-        (borderRadius 10.00)])
+        (cornerRadius 10.00)])
       )
     )
   )

--- a/LayoutTests/interaction-region/click-handler-in-shadowed-layer-expected.txt
+++ b/LayoutTests/interaction-region/click-handler-in-shadowed-layer-expected.txt
@@ -21,7 +21,7 @@
 
           (interaction regions [
             (interaction (28,28) width=100 height=100)
-            (borderRadius 10.00)])
+            (cornerRadius 10.00)])
           )
         )
       )

--- a/LayoutTests/interaction-region/consolidated-nested-regions-expected.txt
+++ b/LayoutTests/interaction-region/consolidated-nested-regions-expected.txt
@@ -15,25 +15,22 @@ labels y aligned Secondary
 
       (interaction regions [
         (interaction (0,0) width=124.50 height=100)
-        (borderRadius 12.00),
+        (cornerRadius 12.00),
         (interaction (128.50,0) width=124.50 height=100)
-        (borderRadius 12.00),
+        (cornerRadius 12.00),
         (interaction (148.50,20) width=84.50 height=60)
-        (borderRadius 8.00),
+        (cornerRadius 8.00),
         (interaction (257,0) width=124.50 height=100)
-        (borderRadius 12.00),
+        (cornerRadius 12.00),
         (interaction (294,20) width=67.50 height=20)
-        (borderRadius 5.00),
-        (interaction (0,100) width=400 height=400)
-        (borderRadius 0.00),
-        (interaction (200,150) width=122 height=122)
-        (borderRadius 0.00),
+        (cornerRadius 5.00),
+        (interaction (0,100) width=400 height=400),
+        (interaction (200,150) width=122 height=122),
         (interaction (253.50,151) width=67.50 height=20)
-        (borderRadius 5.00),
-        (interaction (0,500) width=240 height=100)
-        (borderRadius 0.00),
+        (cornerRadius 5.00),
+        (interaction (0,500) width=240 height=100),
         (interaction (172.50,500) width=67.50 height=20)
-        (borderRadius 5.00)])
+        (cornerRadius 5.00)])
       )
     )
   )

--- a/LayoutTests/interaction-region/display-table-expected.txt
+++ b/LayoutTests/interaction-region/display-table-expected.txt
@@ -13,10 +13,9 @@ is a link with display: table.
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (guard (0,-10) width=28.45 height=39)
-        (borderRadius 0.00),
+        (guard (0,-10) width=28.45 height=39),
         (interaction (0,0) width=28.45 height=19)
-        (borderRadius 8.00)])
+        (cornerRadius 8.00)])
       )
     )
   )

--- a/LayoutTests/interaction-region/event-region-overflow-expected.txt
+++ b/LayoutTests/interaction-region/event-region-overflow-expected.txt
@@ -13,7 +13,7 @@ Hi
 
       (interaction regions [
         (interaction (29,21) width=50 height=50)
-        (borderRadius 8.75)])
+        (cornerRadius 8.75)])
       )
     )
   )

--- a/LayoutTests/interaction-region/full-page-overlay-expected.txt
+++ b/LayoutTests/interaction-region/full-page-overlay-expected.txt
@@ -11,8 +11,7 @@
         (rect (0,0) width=1536 height=5013)
 
       (interaction regions [
-        (occlusion (0,0) width=1536 height=5000)
-        (borderRadius 0.00)])
+        (occlusion (0,0) width=1536 height=5000)])
       )
     )
   )

--- a/LayoutTests/interaction-region/guard-overlap-expected.txt
+++ b/LayoutTests/interaction-region/guard-overlap-expected.txt
@@ -1,4 +1,7 @@
 
+
+This is a multi-line
+line link.
 (GraphicsLayer
   (anchor 0.00 0.00)
   (bounds 800.00 600.00)
@@ -12,16 +15,14 @@
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (interaction (0,0) width=100 height=10)
-        (borderRadius 0.00),
-        (interaction (0,10) width=50 height=10)
-        (borderRadius 0.00),
-        (interaction (0,40) width=100 height=25)
-        (borderRadius 0.00),
-        (guard (-10,55) width=30 height=30)
-        (borderRadius 0.00),
-        (interaction (0,65) width=10 height=10)
-        (borderRadius 0.00)])
+        (interaction (0,0) width=100 height=10),
+        (interaction (0,10) width=50 height=10),
+        (interaction (0,40) width=100 height=25),
+        (guard (-10,55) width=30 height=30),
+        (interaction (0,65) width=10 height=10),
+        (interaction (-4,91) width=129.32 height=47)
+        (clipPath move to (0,8), add line to (0,8), add curve to (0,3.58) (3.58,0) (8,0), add line to (121.32,0), add line to (121.32,0), add curve to (125.74,0) (129.32,3.58) (129.32,8), add line to (129.32,19), add line to (129.32,19), add curve to (129.32,23.42) (125.74,27) (121.32,27), add line to (72.88,27), add line to (72.88,27), add curve to (68.46,27) (64.88,30.58) (64.88,35), add line to (64.88,39), add line to (64.88,39), add curve to (64.88,43.42) (61.30,47) (56.88,47), add line to (8,47), add line to (8,47), add curve to (3.58,47) (0,43.42) (0,39), add line to (0,30.50), add line to (0,27), add line to (0,23.50), add line to (0,20), close subpath),
+        (interaction (0,135) width=50 height=10)])
       )
     )
   )

--- a/LayoutTests/interaction-region/guard-overlap.html
+++ b/LayoutTests/interaction-region/guard-overlap.html
@@ -19,6 +19,14 @@
 <div class="interaction" style="height: 25px; width: 100px" onclick="click()"></div>
 <div class="interaction" style="width: 10px" onclick="click()"></div>
 
+<br />
+
+<a href="#">
+    This is a multi-line<br />
+    line link.
+</a>
+<div class="interaction" style="width: 50px" onclick="click()"></div>
+
 <pre id="results"></pre>
 <script>
 if (window.testRunner)

--- a/LayoutTests/interaction-region/hover-style-expected.txt
+++ b/LayoutTests/interaction-region/hover-style-expected.txt
@@ -13,11 +13,10 @@ not a button
 
       (interaction regions [
         (interaction (0,0) width=100 height=100)
-        (borderRadius 10.00),
-        (interaction (0,100) width=108 height=108)
-        (borderRadius 0.00),
+        (cornerRadius 10.00),
+        (interaction (0,100) width=108 height=108),
         (interaction (0,358) width=100 height=100)
-        (borderRadius 10.00)])
+        (cornerRadius 10.00)])
       )
     )
   )

--- a/LayoutTests/interaction-region/icon-inside-button-single-region-expected.txt
+++ b/LayoutTests/interaction-region/icon-inside-button-single-region-expected.txt
@@ -15,7 +15,7 @@ button
 
       (interaction regions [
         (interaction (0,3) width=58.50 height=30)
-        (borderRadius 14.00)])
+        (cornerRadius 15.00)])
       )
     )
   )

--- a/LayoutTests/interaction-region/ignore-catch-all-body-expected.txt
+++ b/LayoutTests/interaction-region/ignore-catch-all-body-expected.txt
@@ -13,7 +13,7 @@ an actual link
 
       (interaction regions [
         (interaction (-4,196) width=94.19 height=27)
-        (borderRadius 8.00)])
+        (cornerRadius 8.00)])
       )
     )
   )

--- a/LayoutTests/interaction-region/inline-link-dark-background-expected.txt
+++ b/LayoutTests/interaction-region/inline-link-dark-background-expected.txt
@@ -13,7 +13,7 @@ This is a link.
 
       (interaction regions [
         (interaction (-4,-4) width=36.45 height=27)
-        (borderRadius 8.00)])
+        (cornerRadius 8.00)])
       )
     )
   )

--- a/LayoutTests/interaction-region/inline-link-expected.txt
+++ b/LayoutTests/interaction-region/inline-link-expected.txt
@@ -13,33 +13,23 @@ This is a link. This is a wiki-style link. This is a link with a background. Thi
 
       (interaction regions [
         (interaction (-4,-4) width=36.45 height=27)
-        (borderRadius 8.00),
+        (cornerRadius 8.00),
         (interaction (87.11,-4) width=36.45 height=27)
-        (borderRadius 8.00),
-        (guard (250.21,-10) width=28.45 height=39)
-        (borderRadius 0.00),
-        (interaction (250.21,0) width=28.45 height=19)
-        (borderRadius 0.00),
-        (guard (464.40,-10) width=28.45 height=39)
-        (borderRadius 0.00),
-        (interaction (464.40,0) width=28.45 height=19)
-        (borderRadius 0.00),
-        (guard (657.49,-10) width=28.45 height=39)
-        (borderRadius 0.00),
-        (interaction (657.49,0) width=28.45 height=19)
-        (borderRadius 0.00),
-        (guard (131.98,10) width=28.45 height=39)
-        (borderRadius 0.00),
-        (interaction (131.98,20) width=28.45 height=19)
-        (borderRadius 0.00),
-        (guard (431.60,10) width=28.45 height=39)
-        (borderRadius 0.00),
-        (interaction (431.60,20) width=28.45 height=19)
-        (borderRadius 0.00),
+        (cornerRadius 8.00),
+        (guard (250.21,-10) width=28.45 height=39),
+        (interaction (250.21,0) width=28.45 height=19),
+        (guard (464.40,-10) width=28.45 height=39),
+        (interaction (464.40,0) width=28.45 height=19),
+        (guard (657.49,-10) width=28.45 height=39),
+        (interaction (657.49,0) width=28.45 height=19),
+        (guard (131.98,10) width=28.45 height=39),
+        (interaction (131.98,20) width=28.45 height=19),
+        (guard (431.60,10) width=28.45 height=39),
+        (interaction (431.60,20) width=28.45 height=19),
         (interaction (642.10,16) width=128.99 height=27)
-        (borderRadius 8.00),
+        (cornerRadius 8.00),
         (interaction (767.09,16) width=36.45 height=27)
-        (borderRadius 8.00)])
+        (cornerRadius 8.00)])
       )
     )
   )

--- a/LayoutTests/interaction-region/inline-link-in-composited-iframe-expected.txt
+++ b/LayoutTests/interaction-region/inline-link-in-composited-iframe-expected.txt
@@ -14,7 +14,7 @@ This is a link, outside the frame.
 
       (interaction regions [
         (interaction (-4,-4) width=36.45 height=27)
-        (borderRadius 8.00)])
+        (cornerRadius 8.00)])
       )
       (children 1
         (GraphicsLayer
@@ -26,7 +26,7 @@ This is a link, outside the frame.
 
           (interaction regions [
             (interaction (6,6) width=36.45 height=27)
-            (borderRadius 8.00)])
+            (cornerRadius 8.00)])
           )
         )
       )

--- a/LayoutTests/interaction-region/inline-link-in-layer-expected.txt
+++ b/LayoutTests/interaction-region/inline-link-in-layer-expected.txt
@@ -14,7 +14,7 @@ This is a link, inside the layer.
 
       (interaction regions [
         (interaction (-4,-4) width=36.45 height=27)
-        (borderRadius 8.00)])
+        (cornerRadius 8.00)])
       )
       (children 1
         (GraphicsLayer
@@ -26,7 +26,7 @@ This is a link, inside the layer.
 
           (interaction regions [
             (interaction (-4,-4) width=36.45 height=27)
-            (borderRadius 8.00)])
+            (cornerRadius 8.00)])
           )
         )
       )

--- a/LayoutTests/interaction-region/inline-link-in-non-composited-iframe-expected.txt
+++ b/LayoutTests/interaction-region/inline-link-in-non-composited-iframe-expected.txt
@@ -14,9 +14,9 @@ This is a link, outside the frame.
 
       (interaction regions [
         (interaction (-4,-4) width=36.45 height=27)
-        (borderRadius 8.00),
+        (cornerRadius 8.00),
         (interaction (6,26) width=36.45 height=27)
-        (borderRadius 8.00)])
+        (cornerRadius 8.00)])
       )
     )
   )

--- a/LayoutTests/interaction-region/inline-link-with-pointer-events-none-content-expected.txt
+++ b/LayoutTests/interaction-region/inline-link-with-pointer-events-none-content-expected.txt
@@ -13,7 +13,7 @@ Link Child Disabled Link
 
       (interaction regions [
         (interaction (-4,-4) width=77.78 height=27)
-        (borderRadius 8.00)])
+        (cornerRadius 8.00)])
       )
     )
   )

--- a/LayoutTests/interaction-region/input-type-file-region-expected.txt
+++ b/LayoutTests/interaction-region/input-type-file-region-expected.txt
@@ -12,10 +12,9 @@
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (guard (1,-8) width=84 height=38)
-        (borderRadius 0.00),
+        (guard (1,-8) width=84 height=38),
         (interaction (1,2) width=84 height=18)
-        (borderRadius 9.00)])
+        (cornerRadius 10.00)])
       )
     )
   )

--- a/LayoutTests/interaction-region/input-type-range-region-expected.txt
+++ b/LayoutTests/interaction-region/input-type-range-region-expected.txt
@@ -12,10 +12,9 @@
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (guard (48.50,-8) width=36 height=36)
-        (borderRadius 0.00),
+        (guard (48.50,-8) width=36 height=36),
         (interaction (58.50,2) width=16 height=16)
-        (borderRadius 8.00)])
+        (cornerRadius 8.00)])
       )
     )
   )

--- a/LayoutTests/interaction-region/interaction-layers-culling-expected.txt
+++ b/LayoutTests/interaction-region/interaction-layers-culling-expected.txt
@@ -1,339 +1,78 @@
 
 (CALayer tree root
-  (layer bounds [x: 0 y: 0 width: 800 height: 600])
-  (layer position [x: 400 y: 400])
+  (layer bounds [x: 0 y: 0 width: 800 height: 86050])
+  (layer anchorPoint [x: 0 y: 0])
   (sublayers
     (
-      (layer bounds [x: 0 y: 0 width: 800 height: 600])
-      (layer position [x: 400 y: 400])
+      (layer bounds [x: 0 y: 0 width: 800 height: 86050])
+      (layer anchorPoint [x: 0 y: 0])
       (sublayers
         (
           (layer bounds [x: 0 y: 0 width: 800 height: 86050])
-          (layer anchorPoint [x: 0 y: 0])
+          (layer position [x: 400 y: 400])
           (sublayers
             (
               (layer bounds [x: 0 y: 0 width: 800 height: 86050])
-              (layer anchorPoint [x: 0 y: 0])
-              (sublayers
-                (
-                  (layer bounds [x: 0 y: 0 width: 800 height: 86050])
-                  (layer position [x: 400 y: 400])
-                  (sublayers
-                    (
-                      (layer bounds [x: 0 y: 0 width: 800 height: 86050])
-                      (layer position [x: 400 y: 400])
-                      (sublayers
-                        (
-                          (layer bounds [x: 0 y: 0 width: 800 height: 86050])
-                          (layer anchorPoint [x: 0 y: 0])
-                          (sublayers
-                            (
-                              (layer bounds [x: 0 y: 0 width: 800 height: 86050])
-                              (layer anchorPoint [x: 0 y: 0])
-                              (sublayers
-                                (
-                                  (layer bounds [x: 0 y: 0 width: 0 height: 0])
-                                  (sublayers
-                                    (
-                                      (layer bounds [x: 0 y: 0 width: 800 height: 512])
-                                      (layer anchorPoint [x: 0 y: 0]))
-                                    (
-                                      (layer bounds [x: 0 y: 0 width: 800 height: 512])
-                                      (layer position [x: 0 y: 0])
-                                      (layer anchorPoint [x: 0 y: 0]))))
-                                (
-                                  (layer bounds [x: 0 y: 0 width: 0 height: 0])
-                                  (layer anchorPoint [x: 0 y: 0]))
-                                (
-                                  (layer bounds [x: 0 y: 0 width: 0 height: 0])
-                                  (sublayers
-                                    (
-                                      (type 0)
-                                      (layer bounds [x: 0 y: 0 width: 700 height: 36])
-                                      (layer position [x: 400 y: 400])
-                                      (layer cornerRadius 8))
-                                    (
-                                      (type 0)
-                                      (layer bounds [x: 0 y: 0 width: 700 height: 36])
-                                      (layer position [x: 400 y: 400])
-                                      (layer cornerRadius 8))
-                                    (
-                                      (type 0)
-                                      (layer bounds [x: 0 y: 0 width: 700 height: 36])
-                                      (layer position [x: 400 y: 400])
-                                      (layer cornerRadius 8))
-                                    (
-                                      (type 0)
-                                      (layer bounds [x: 0 y: 0 width: 700 height: 36])
-                                      (layer position [x: 400 y: 400])
-                                      (layer cornerRadius 8))
-                                    (
-                                      (type 0)
-                                      (layer bounds [x: 0 y: 0 width: 700 height: 36])
-                                      (layer position [x: 400 y: 400])
-                                      (layer cornerRadius 8))
-                                    (
-                                      (type 0)
-                                      (layer bounds [x: 0 y: 0 width: 700 height: 36])
-                                      (layer position [x: 400 y: 400])
-                                      (layer cornerRadius 8))
-                                    (
-                                      (type 0)
-                                      (layer bounds [x: 0 y: 0 width: 700 height: 36])
-                                      (layer position [x: 400 y: 400])
-                                      (layer cornerRadius 8))))))))))))))
-            (
-              (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
-        (
-          (layer bounds [x: 0 y: 0 width: 0 height: 0])
-          (layer anchorPoint [x: 0 y: 0]))
-        (
-          (layer bounds [x: 0 y: 0 width: 800 height: 12])
-          (layer position [x: 400 y: 400])
-          (layer zPosition 1000)
-          (layer opacity 0)
-          (sublayers
-            (
-              (layer bounds [x: 0 y: 0 width: 116 height: 32])
-              (layer position [x: 400 y: 400]))
-            (
-              (layer bounds [x: 0 y: 0 width: 800 height: 12])
               (layer position [x: 400 y: 400])
               (sublayers
                 (
-                  (layer bounds [x: 0 y: 0 width: 96 height: 12])
-                  (layer position [x: 400 y: 400])
-                  (layer cornerRadius 6)
+                  (layer bounds [x: 0 y: 0 width: 800 height: 86050])
+                  (layer anchorPoint [x: 0 y: 0])
                   (sublayers
                     (
-                      (layer bounds [x: 0 y: 0 width: 96 height: 12])
-                      (layer position [x: 48 y: 48])
-                      (layer cornerRadius 6))
-                    (
-                      (layer bounds [x: 0 y: 0 width: 96 height: 12])
-                      (layer position [x: 48 y: 48])
-                      (layer cornerRadius 6))
-                    (
-                      (layer bounds [x: 0 y: 0 width: 96 height: 12])
-                      (layer position [x: 48 y: 48])
-                      (layer cornerRadius 6))
-                    (
-                      (layer bounds [x: 0 y: 0 width: 96 height: 12])
-                      (layer position [x: 48 y: 48])
-                      (layer cornerRadius 6))
-                    (
-                      (layer bounds [x: 0 y: 0 width: 96 height: 12])
-                      (layer position [x: 48 y: 48])
-                      (layer cornerRadius 6))
-                    (
-                      (layer bounds [x: 0 y: 0 width: 96 height: 12])
-                      (layer position [x: 48 y: 48])
-                      (layer cornerRadius 6))
-                    (
-                      (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
-                      (layer position [x: 48 y: 48])
-                      (layer opacity 0)
+                      (layer bounds [x: 0 y: 0 width: 800 height: 86050])
+                      (layer anchorPoint [x: 0 y: 0])
                       (sublayers
                         (
-                          (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
-                          (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                          (layer opacity 0.15)
+                          (layer bounds [x: 0 y: 0 width: 0 height: 0])
                           (sublayers
                             (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))
+                              (layer bounds [x: 0 y: 0 width: 800 height: 512])
+                              (layer anchorPoint [x: 0 y: 0]))
                             (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))))))
-                    (
-                      (layer bounds [x: 0 y: 0 width: 90 height: 6])
-                      (layer position [x: 48 y: 48])
-                      (layer opacity 0.15)
-                      (layer cornerRadius 3))))))))
-        (
-          (layer bounds [x: 0 y: 0 width: 12 height: 600])
-          (layer position [x: 791 y: 791])
-          (layer zPosition 1000)
-          (layer opacity 0)
-          (sublayers
-            (
-              (layer bounds [x: 0 y: 0 width: 32 height: 116])
-              (layer position [x: 6 y: 6]))
-            (
-              (layer bounds [x: 0 y: 0 width: 12 height: 600])
-              (layer position [x: 6 y: 6])
-              (sublayers
-                (
-                  (layer bounds [x: 0 y: 0 width: 12 height: 96])
-                  (layer position [x: 6 y: 6])
-                  (layer cornerRadius 6)
-                  (sublayers
-                    (
-                      (layer bounds [x: 0 y: 0 width: 12 height: 96])
-                      (layer position [x: 6 y: 6])
-                      (layer cornerRadius 6))
-                    (
-                      (layer bounds [x: 0 y: 0 width: 12 height: 96])
-                      (layer position [x: 6 y: 6])
-                      (layer cornerRadius 6))
-                    (
-                      (layer bounds [x: 0 y: 0 width: 12 height: 96])
-                      (layer position [x: 6 y: 6])
-                      (layer cornerRadius 6))
-                    (
-                      (layer bounds [x: 0 y: 0 width: 12 height: 96])
-                      (layer position [x: 6 y: 6])
-                      (layer cornerRadius 6))
-                    (
-                      (layer bounds [x: 0 y: 0 width: 12 height: 96])
-                      (layer position [x: 6 y: 6])
-                      (layer cornerRadius 6))
-                    (
-                      (layer bounds [x: 0 y: 0 width: 12 height: 96])
-                      (layer position [x: 6 y: 6])
-                      (layer cornerRadius 6))
-                    (
-                      (layer bounds [x: 0 y: 0 width: 6 height: 90])
-                      (layer position [x: 6 y: 6])
-                      (layer opacity 0)
-                      (sublayers
+                              (layer bounds [x: 0 y: 0 width: 800 height: 512])
+                              (layer position [x: 0 y: 0])
+                              (layer anchorPoint [x: 0 y: 0]))))
                         (
-                          (layer bounds [x: 0 y: 0 width: 6 height: 90])
-                          (layer position [x: 3 y: 3])
-                          (layer opacity 0.15)
+                          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                          (layer anchorPoint [x: 0 y: 0]))
+                        (
+                          (layer bounds [x: 0 y: 0 width: 0 height: 0])
                           (sublayers
                             (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))
+                              (type 0)
+                              (layer bounds [x: 0 y: 0 width: 700 height: 36])
+                              (layer position [x: 400 y: 400])
+                              (layer cornerRadius 8))
                             (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))
+                              (type 0)
+                              (layer bounds [x: 0 y: 0 width: 700 height: 36])
+                              (layer position [x: 400 y: 400])
+                              (layer cornerRadius 8))
                             (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))
+                              (type 0)
+                              (layer bounds [x: 0 y: 0 width: 700 height: 36])
+                              (layer position [x: 400 y: 400])
+                              (layer cornerRadius 8))
                             (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))
+                              (type 0)
+                              (layer bounds [x: 0 y: 0 width: 700 height: 36])
+                              (layer position [x: 400 y: 400])
+                              (layer cornerRadius 8))
                             (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))
+                              (type 0)
+                              (layer bounds [x: 0 y: 0 width: 700 height: 36])
+                              (layer position [x: 400 y: 400])
+                              (layer cornerRadius 8))
                             (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))
+                              (type 0)
+                              (layer bounds [x: 0 y: 0 width: 700 height: 36])
+                              (layer position [x: 400 y: 400])
+                              (layer cornerRadius 8))
                             (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))))))
-                    (
-                      (layer bounds [x: 0 y: 0 width: 6 height: 28])
-                      (layer position [x: 6 y: 6])
-                      (layer opacity 0.15)
-                      (layer cornerRadius 3))))))))))))
+                              (type 0)
+                              (layer bounds [x: 0 y: 0 width: 700 height: 36])
+                              (layer position [x: 400 y: 400])
+                              (layer cornerRadius 8))))))))))))))
+    (
+      (layer bounds [x: 0 y: 0 width: 0 height: 0]))))

--- a/LayoutTests/interaction-region/interaction-layers-culling-layer-type-change-expected.txt
+++ b/LayoutTests/interaction-region/interaction-layers-culling-layer-type-change-expected.txt
@@ -1,324 +1,63 @@
 
 (CALayer tree root
-  (layer bounds [x: 0 y: 0 width: 800 height: 600])
-  (layer position [x: 400 y: 400])
+  (layer bounds [x: 0 y: 0 width: 800 height: 713])
+  (layer anchorPoint [x: 0 y: 0])
   (sublayers
     (
-      (layer bounds [x: 0 y: 0 width: 800 height: 600])
-      (layer position [x: 400 y: 400])
+      (layer bounds [x: 0 y: 0 width: 800 height: 713])
+      (layer anchorPoint [x: 0 y: 0])
       (sublayers
         (
           (layer bounds [x: 0 y: 0 width: 800 height: 713])
-          (layer anchorPoint [x: 0 y: 0])
+          (layer position [x: 400 y: 400])
           (sublayers
             (
               (layer bounds [x: 0 y: 0 width: 800 height: 713])
-              (layer anchorPoint [x: 0 y: 0])
+              (layer position [x: 400 y: 400])
               (sublayers
                 (
                   (layer bounds [x: 0 y: 0 width: 800 height: 713])
-                  (layer position [x: 400 y: 400])
+                  (layer anchorPoint [x: 0 y: 0])
                   (sublayers
                     (
                       (layer bounds [x: 0 y: 0 width: 800 height: 713])
-                      (layer position [x: 400 y: 400])
+                      (layer anchorPoint [x: 0 y: 0])
                       (sublayers
                         (
-                          (layer bounds [x: 0 y: 0 width: 800 height: 713])
+                          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                          (sublayers
+                            (
+                              (layer bounds [x: 0 y: 0 width: 800 height: 512])
+                              (layer anchorPoint [x: 0 y: 0]))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 800 height: 201])
+                              (layer position [x: 0 y: 0])
+                              (layer anchorPoint [x: 0 y: 0]))))
+                        (
+                          (layer bounds [x: 0 y: 0 width: 0 height: 0])
                           (layer anchorPoint [x: 0 y: 0])
                           (sublayers
                             (
-                              (layer bounds [x: 0 y: 0 width: 800 height: 713])
-                              (layer anchorPoint [x: 0 y: 0])
+                              (layer bounds [x: 0 y: 0 width: 800 height: 700])
+                              (layer position [x: 400 y: 400])
                               (sublayers
                                 (
                                   (layer bounds [x: 0 y: 0 width: 0 height: 0])
                                   (sublayers
                                     (
-                                      (layer bounds [x: 0 y: 0 width: 800 height: 512])
-                                      (layer anchorPoint [x: 0 y: 0]))
-                                    (
-                                      (layer bounds [x: 0 y: 0 width: 800 height: 201])
-                                      (layer position [x: 0 y: 0])
-                                      (layer anchorPoint [x: 0 y: 0]))))
-                                (
-                                  (layer bounds [x: 0 y: 0 width: 0 height: 0])
-                                  (layer anchorPoint [x: 0 y: 0])
-                                  (sublayers
-                                    (
-                                      (layer bounds [x: 0 y: 0 width: 800 height: 700])
+                                      (type 0)
+                                      (layer bounds [x: 0 y: 0 width: 700 height: 36])
                                       (layer position [x: 400 y: 400])
-                                      (sublayers
-                                        (
-                                          (layer bounds [x: 0 y: 0 width: 0 height: 0])
-                                          (sublayers
-                                            (
-                                              (type 0)
-                                              (layer bounds [x: 0 y: 0 width: 700 height: 36])
-                                              (layer position [x: 400 y: 400])
-                                              (layer cornerRadius 8))
-                                            (
-                                              (type 0)
-                                              (layer bounds [x: 0 y: 0 width: 700 height: 36])
-                                              (layer position [x: 400 y: 400])
-                                              (layer cornerRadius 8))
-                                            (
-                                              (type 0)
-                                              (layer bounds [x: 0 y: 0 width: 700 height: 36])
-                                              (layer position [x: 400 y: 400])
-                                              (layer cornerRadius 8))))))))))))))))))
-            (
-              (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
-        (
-          (layer bounds [x: 0 y: 0 width: 0 height: 0])
-          (layer anchorPoint [x: 0 y: 0]))
-        (
-          (layer bounds [x: 0 y: 0 width: 800 height: 12])
-          (layer position [x: 400 y: 400])
-          (layer zPosition 1000)
-          (layer opacity 0)
-          (sublayers
-            (
-              (layer bounds [x: 0 y: 0 width: 116 height: 32])
-              (layer position [x: 400 y: 400]))
-            (
-              (layer bounds [x: 0 y: 0 width: 800 height: 12])
-              (layer position [x: 400 y: 400])
-              (sublayers
-                (
-                  (layer bounds [x: 0 y: 0 width: 96 height: 12])
-                  (layer position [x: 400 y: 400])
-                  (layer cornerRadius 6)
-                  (sublayers
-                    (
-                      (layer bounds [x: 0 y: 0 width: 96 height: 12])
-                      (layer position [x: 48 y: 48])
-                      (layer cornerRadius 6))
-                    (
-                      (layer bounds [x: 0 y: 0 width: 96 height: 12])
-                      (layer position [x: 48 y: 48])
-                      (layer cornerRadius 6))
-                    (
-                      (layer bounds [x: 0 y: 0 width: 96 height: 12])
-                      (layer position [x: 48 y: 48])
-                      (layer cornerRadius 6))
-                    (
-                      (layer bounds [x: 0 y: 0 width: 96 height: 12])
-                      (layer position [x: 48 y: 48])
-                      (layer cornerRadius 6))
-                    (
-                      (layer bounds [x: 0 y: 0 width: 96 height: 12])
-                      (layer position [x: 48 y: 48])
-                      (layer cornerRadius 6))
-                    (
-                      (layer bounds [x: 0 y: 0 width: 96 height: 12])
-                      (layer position [x: 48 y: 48])
-                      (layer cornerRadius 6))
-                    (
-                      (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
-                      (layer position [x: 48 y: 48])
-                      (layer opacity 0)
-                      (sublayers
-                        (
-                          (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
-                          (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                          (layer opacity 0.15)
-                          (sublayers
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))))))
-                    (
-                      (layer bounds [x: 0 y: 0 width: 90 height: 6])
-                      (layer position [x: 48 y: 48])
-                      (layer opacity 0.15)
-                      (layer cornerRadius 3))))))))
-        (
-          (layer bounds [x: 0 y: 0 width: 12 height: 600])
-          (layer position [x: 791 y: 791])
-          (layer zPosition 1000)
-          (layer opacity 0)
-          (sublayers
-            (
-              (layer bounds [x: 0 y: 0 width: 32 height: 116])
-              (layer position [x: 6 y: 6]))
-            (
-              (layer bounds [x: 0 y: 0 width: 12 height: 600])
-              (layer position [x: 6 y: 6])
-              (sublayers
-                (
-                  (layer bounds [x: 0 y: 0 width: 12 height: 96])
-                  (layer position [x: 6 y: 6])
-                  (layer cornerRadius 6)
-                  (sublayers
-                    (
-                      (layer bounds [x: 0 y: 0 width: 12 height: 96])
-                      (layer position [x: 6 y: 6])
-                      (layer cornerRadius 6))
-                    (
-                      (layer bounds [x: 0 y: 0 width: 12 height: 96])
-                      (layer position [x: 6 y: 6])
-                      (layer cornerRadius 6))
-                    (
-                      (layer bounds [x: 0 y: 0 width: 12 height: 96])
-                      (layer position [x: 6 y: 6])
-                      (layer cornerRadius 6))
-                    (
-                      (layer bounds [x: 0 y: 0 width: 12 height: 96])
-                      (layer position [x: 6 y: 6])
-                      (layer cornerRadius 6))
-                    (
-                      (layer bounds [x: 0 y: 0 width: 12 height: 96])
-                      (layer position [x: 6 y: 6])
-                      (layer cornerRadius 6))
-                    (
-                      (layer bounds [x: 0 y: 0 width: 12 height: 96])
-                      (layer position [x: 6 y: 6])
-                      (layer cornerRadius 6))
-                    (
-                      (layer bounds [x: 0 y: 0 width: 6 height: 90])
-                      (layer position [x: 6 y: 6])
-                      (layer opacity 0)
-                      (sublayers
-                        (
-                          (layer bounds [x: 0 y: 0 width: 6 height: 90])
-                          (layer position [x: 3 y: 3])
-                          (layer opacity 0.15)
-                          (sublayers
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))))))
-                    (
-                      (layer bounds [x: 0 y: 0 width: 6 height: 75.5])
-                      (layer position [x: 6 y: 6])
-                      (layer opacity 0.15)
-                      (layer cornerRadius 3))))))))))))
+                                      (layer cornerRadius 8))
+                                    (
+                                      (type 0)
+                                      (layer bounds [x: 0 y: 0 width: 700 height: 36])
+                                      (layer position [x: 400 y: 400])
+                                      (layer cornerRadius 8))
+                                    (
+                                      (type 0)
+                                      (layer bounds [x: 0 y: 0 width: 700 height: 36])
+                                      (layer position [x: 400 y: 400])
+                                      (layer cornerRadius 8))))))))))))))))))
+    (
+      (layer bounds [x: 0 y: 0 width: 0 height: 0]))))

--- a/LayoutTests/interaction-region/interaction-region-size-limit-expected.txt
+++ b/LayoutTests/interaction-region/interaction-region-size-limit-expected.txt
@@ -11,10 +11,8 @@
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (interaction (0,0) width=395 height=295)
-        (borderRadius 0.00),
-        (interaction (0,305) width=395 height=295)
-        (borderRadius 0.00)])
+        (interaction (0,0) width=395 height=295),
+        (interaction (0,305) width=395 height=295)])
       )
     )
   )

--- a/LayoutTests/interaction-region/labels-expected.txt
+++ b/LayoutTests/interaction-region/labels-expected.txt
@@ -15,12 +15,11 @@ Disabled input
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (guard (273,13) width=36 height=36)
-        (borderRadius 0.00),
+        (guard (273,13) width=36 height=36),
         (interaction (283,23) width=16 height=16)
-        (borderRadius 5.00),
+        (cornerRadius 5.00),
         (interaction (30,52) width=260 height=42)
-        (borderRadius 16.00)])
+        (cornerRadius 16.00)])
       )
     )
   )

--- a/LayoutTests/interaction-region/layer-tree-expected.txt
+++ b/LayoutTests/interaction-region/layer-tree-expected.txt
@@ -1,362 +1,122 @@
 
 (CALayer tree root
   (layer bounds [x: 0 y: 0 width: 800 height: 600])
-  (layer position [x: 400 y: 400])
+  (layer anchorPoint [x: 0 y: 0])
   (sublayers
     (
       (layer bounds [x: 0 y: 0 width: 800 height: 600])
-      (layer position [x: 400 y: 400])
+      (layer anchorPoint [x: 0 y: 0])
       (sublayers
         (
           (layer bounds [x: 0 y: 0 width: 800 height: 600])
-          (layer anchorPoint [x: 0 y: 0])
+          (layer position [x: 400 y: 400])
           (sublayers
             (
               (layer bounds [x: 0 y: 0 width: 800 height: 600])
-              (layer anchorPoint [x: 0 y: 0])
+              (layer position [x: 400 y: 400])
               (sublayers
                 (
                   (layer bounds [x: 0 y: 0 width: 800 height: 600])
-                  (layer position [x: 400 y: 400])
+                  (layer anchorPoint [x: 0 y: 0])
                   (sublayers
                     (
                       (layer bounds [x: 0 y: 0 width: 800 height: 600])
-                      (layer position [x: 400 y: 400])
+                      (layer anchorPoint [x: 0 y: 0])
                       (sublayers
                         (
-                          (layer bounds [x: 0 y: 0 width: 800 height: 600])
-                          (layer anchorPoint [x: 0 y: 0])
+                          (layer bounds [x: 0 y: 0 width: 0 height: 0])
                           (sublayers
                             (
                               (layer bounds [x: 0 y: 0 width: 800 height: 600])
-                              (layer anchorPoint [x: 0 y: 0])
+                              (layer anchorPoint [x: 0 y: 0]))))
+                        (
+                          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                          (sublayers
+                            (
+                              (type 0)
+                              (layer bounds [x: 0 y: 0 width: 58.5 height: 20])
+                              (layer position [x: 29.25 y: 29.25])
+                              (layer cornerRadius 10))
+                            (
+                              (type 0)
+                              (layer bounds [x: 0 y: 0 width: 284 height: 192])
+                              (layer position [x: 152 y: 152])
+                              (layer cornerRadius 8))
+                            (
+                              (type 0)
+                              (layer bounds [x: 0 y: 0 width: 200 height: 100])
+                              (layer position [x: 100 y: 100]))
+                            (
+                              (type 0)
+                              (layer bounds [x: 0 y: 0 width: 100 height: 100])
+                              (layer position [x: 50 y: 50]))
+                            (
+                              (type 0)
+                              (layer bounds [x: 0 y: 0 width: 100 height: 100])
+                              (layer position [x: 150 y: 150])
+                              (layer cornerRadius 16))
+                            (
+                              (type 0)
+                              (layer bounds [x: 0 y: 0 width: 100 height: 100])
+                              (layer position [x: 250 y: 250])
+                              (layer cornerRadius 14)
+                              (layer masked corners 5))
+                            (
+                              (type 0)
+                              (mask
+                                (frame [x: 0 y: 0 width: 100 height: 100]))
+                              (layer bounds [x: 0 y: 0 width: 100 height: 100])
+                              (layer position [x: 350 y: 350]))))
+                        (
+                          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                          (layer anchorPoint [x: 0 y: 0])
+                          (sublayers
+                            (
+                              (layer bounds [x: 0 y: 0 width: 200 height: 200])
+                              (layer position [x: 100 y: 100])
+                              (layer opacity 0)
                               (sublayers
                                 (
                                   (layer bounds [x: 0 y: 0 width: 0 height: 0])
                                   (sublayers
                                     (
-                                      (layer bounds [x: 0 y: 0 width: 800 height: 600])
-                                      (layer anchorPoint [x: 0 y: 0]))))
+                                      (type 0)
+                                      (layer bounds [x: 0 y: 0 width: 75.9921875 height: 27])
+                                      (layer position [x: 33.99609375 y: 33.99609375])
+                                      (layer cornerRadius 8))))))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                              (layer position [x: 400 y: 400])
+                              (layer opacity 0.8)
+                              (sublayers
+                                (
+                                  (layer bounds [x: 0 y: 0 width: 800 height: 20])
+                                  (layer position [x: 400 y: 400]))
                                 (
                                   (layer bounds [x: 0 y: 0 width: 0 height: 0])
                                   (sublayers
                                     (
                                       (type 0)
-                                      (layer bounds [x: 0 y: 0 width: 58.5 height: 20])
-                                      (layer position [x: 29.25 y: 29.25])
-                                      (layer cornerRadius 9))
-                                    (
-                                      (type 0)
-                                      (layer bounds [x: 0 y: 0 width: 284 height: 192])
-                                      (layer position [x: 152 y: 152])
-                                      (layer cornerRadius 8))
-                                    (
-                                      (type 0)
-                                      (layer bounds [x: 0 y: 0 width: 200 height: 100])
-                                      (layer position [x: 100 y: 100]))))
+                                      (layer bounds [x: 0 y: 0 width: 32.890625 height: 27])
+                                      (layer position [x: 12.4453125 y: 12.4453125])
+                                      (layer cornerRadius 8))))
                                 (
-                                  (layer bounds [x: 0 y: 0 width: 0 height: 0])
-                                  (layer anchorPoint [x: 0 y: 0])
+                                  (layer bounds [x: 0 y: 0 width: 800 height: 40])
+                                  (layer position [x: 400 y: 400])
                                   (sublayers
                                     (
-                                      (layer bounds [x: 0 y: 0 width: 200 height: 200])
-                                      (layer position [x: 100 y: 100])
-                                      (layer opacity 0)
-                                      (sublayers
-                                        (
-                                          (layer bounds [x: 0 y: 0 width: 0 height: 0])
-                                          (sublayers
-                                            (
-                                              (type 0)
-                                              (layer bounds [x: 0 y: 0 width: 75.9921875 height: 27])
-                                              (layer position [x: 33.99609375 y: 33.99609375])
-                                              (layer cornerRadius 8))))))
+                                      (layer bounds [x: 0 y: 0 width: 800 height: 20])
+                                      (layer position [x: 400 y: 400]))
                                     (
-                                      (layer bounds [x: 0 y: 0 width: 800 height: 600])
-                                      (layer position [x: 400 y: 400])
-                                      (layer opacity 0.8)
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
                                       (sublayers
                                         (
-                                          (layer bounds [x: 0 y: 0 width: 800 height: 20])
-                                          (layer position [x: 400 y: 400]))
-                                        (
-                                          (layer bounds [x: 0 y: 0 width: 0 height: 0])
-                                          (sublayers
-                                            (
-                                              (type 0)
-                                              (layer bounds [x: 0 y: 0 width: 32.890625 height: 27])
-                                              (layer position [x: 12.4453125 y: 12.4453125])
-                                              (layer cornerRadius 8))))
-                                        (
-                                          (layer bounds [x: 0 y: 0 width: 800 height: 40])
-                                          (layer position [x: 400 y: 400])
-                                          (sublayers
-                                            (
-                                              (layer bounds [x: 0 y: 0 width: 800 height: 20])
-                                              (layer position [x: 400 y: 400]))
-                                            (
-                                              (layer bounds [x: 0 y: 0 width: 0 height: 0])
-                                              (sublayers
-                                                (
-                                                  (type 0)
-                                                  (layer bounds [x: 0 y: 0 width: 115.0859375 height: 27])
-                                                  (layer position [x: 155.71484375 y: 155.71484375])
-                                                  (layer cornerRadius 8))))))
-                                        (
-                                          (layer bounds [x: 0 y: 0 width: 800 height: 20])
-                                          (layer position [x: 400 y: 400]))))))))))))))))
-            (
-              (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
-        (
-          (layer bounds [x: 0 y: 0 width: 0 height: 0])
-          (layer anchorPoint [x: 0 y: 0]))
-        (
-          (layer bounds [x: 0 y: 0 width: 800 height: 12])
-          (layer position [x: 400 y: 400])
-          (layer zPosition 1000)
-          (layer opacity 0)
-          (sublayers
-            (
-              (layer bounds [x: 0 y: 0 width: 116 height: 32])
-              (layer position [x: 400 y: 400]))
-            (
-              (layer bounds [x: 0 y: 0 width: 800 height: 12])
-              (layer position [x: 400 y: 400])
-              (sublayers
-                (
-                  (layer bounds [x: 0 y: 0 width: 96 height: 12])
-                  (layer position [x: 400 y: 400])
-                  (layer cornerRadius 6)
-                  (sublayers
-                    (
-                      (layer bounds [x: 0 y: 0 width: 96 height: 12])
-                      (layer position [x: 48 y: 48])
-                      (layer cornerRadius 6))
-                    (
-                      (layer bounds [x: 0 y: 0 width: 96 height: 12])
-                      (layer position [x: 48 y: 48])
-                      (layer cornerRadius 6))
-                    (
-                      (layer bounds [x: 0 y: 0 width: 96 height: 12])
-                      (layer position [x: 48 y: 48])
-                      (layer cornerRadius 6))
-                    (
-                      (layer bounds [x: 0 y: 0 width: 96 height: 12])
-                      (layer position [x: 48 y: 48])
-                      (layer cornerRadius 6))
-                    (
-                      (layer bounds [x: 0 y: 0 width: 96 height: 12])
-                      (layer position [x: 48 y: 48])
-                      (layer cornerRadius 6))
-                    (
-                      (layer bounds [x: 0 y: 0 width: 96 height: 12])
-                      (layer position [x: 48 y: 48])
-                      (layer cornerRadius 6))
-                    (
-                      (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
-                      (layer position [x: 48 y: 48])
-                      (layer opacity 0)
-                      (sublayers
-                        (
-                          (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
-                          (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                          (layer opacity 0.15)
-                          (sublayers
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
-                              (layer cornerRadius 1))))))
-                    (
-                      (layer bounds [x: 0 y: 0 width: 90 height: 6])
-                      (layer position [x: 48 y: 48])
-                      (layer opacity 0.15)
-                      (layer cornerRadius 3))))))))
-        (
-          (layer bounds [x: 0 y: 0 width: 12 height: 600])
-          (layer position [x: 791 y: 791])
-          (layer zPosition 1000)
-          (layer opacity 0)
-          (sublayers
-            (
-              (layer bounds [x: 0 y: 0 width: 32 height: 116])
-              (layer position [x: 6 y: 6]))
-            (
-              (layer bounds [x: 0 y: 0 width: 12 height: 600])
-              (layer position [x: 6 y: 6])
-              (sublayers
-                (
-                  (layer bounds [x: 0 y: 0 width: 12 height: 96])
-                  (layer position [x: 6 y: 6])
-                  (layer cornerRadius 6)
-                  (sublayers
-                    (
-                      (layer bounds [x: 0 y: 0 width: 12 height: 96])
-                      (layer position [x: 6 y: 6])
-                      (layer cornerRadius 6))
-                    (
-                      (layer bounds [x: 0 y: 0 width: 12 height: 96])
-                      (layer position [x: 6 y: 6])
-                      (layer cornerRadius 6))
-                    (
-                      (layer bounds [x: 0 y: 0 width: 12 height: 96])
-                      (layer position [x: 6 y: 6])
-                      (layer cornerRadius 6))
-                    (
-                      (layer bounds [x: 0 y: 0 width: 12 height: 96])
-                      (layer position [x: 6 y: 6])
-                      (layer cornerRadius 6))
-                    (
-                      (layer bounds [x: 0 y: 0 width: 12 height: 96])
-                      (layer position [x: 6 y: 6])
-                      (layer cornerRadius 6))
-                    (
-                      (layer bounds [x: 0 y: 0 width: 12 height: 96])
-                      (layer position [x: 6 y: 6])
-                      (layer cornerRadius 6))
-                    (
-                      (layer bounds [x: 0 y: 0 width: 6 height: 90])
-                      (layer position [x: 6 y: 6])
-                      (layer opacity 0)
-                      (sublayers
-                        (
-                          (layer bounds [x: 0 y: 0 width: 6 height: 90])
-                          (layer position [x: 3 y: 3])
-                          (layer opacity 0.15)
-                          (sublayers
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))
-                            (
-                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
-                              (layer position [x: 3 y: 3])
-                              (layer cornerRadius 1))))))
-                    (
-                      (layer bounds [x: 0 y: 0 width: 6 height: 90])
-                      (layer position [x: 6 y: 6])
-                      (layer opacity 0.15)
-                      (layer cornerRadius 3))))))))))))
+                                          (type 0)
+                                          (layer bounds [x: 0 y: 0 width: 115.0859375 height: 27])
+                                          (layer position [x: 155.71484375 y: 155.71484375])
+                                          (layer cornerRadius 8))))))
+                                (
+                                  (layer bounds [x: 0 y: 0 width: 800 height: 20])
+                                  (layer position [x: 400 y: 400]))))))))))))))))
+    (
+      (layer bounds [x: 0 y: 0 width: 0 height: 0]))))

--- a/LayoutTests/interaction-region/layer-tree-shape-reset-expected.txt
+++ b/LayoutTests/interaction-region/layer-tree-shape-reset-expected.txt
@@ -1,0 +1,55 @@
+
+(CALayer tree root
+  (layer bounds [x: 0 y: 0 width: 800 height: 600])
+  (layer anchorPoint [x: 0 y: 0])
+  (sublayers
+    (
+      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+      (layer anchorPoint [x: 0 y: 0])
+      (sublayers
+        (
+          (layer bounds [x: 0 y: 0 width: 800 height: 600])
+          (layer position [x: 400 y: 400])
+          (sublayers
+            (
+              (layer bounds [x: 0 y: 0 width: 800 height: 600])
+              (layer position [x: 400 y: 400])
+              (sublayers
+                (
+                  (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                  (layer anchorPoint [x: 0 y: 0])
+                  (sublayers
+                    (
+                      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                      (layer anchorPoint [x: 0 y: 0])
+                      (sublayers
+                        (
+                          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                          (sublayers
+                            (
+                              (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                              (layer anchorPoint [x: 0 y: 0]))))
+                        (
+                          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                          (layer anchorPoint [x: 0 y: 0]))
+                        (
+                          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                          (sublayers
+                            (
+                              (type 0)
+                              (layer bounds [x: 0 y: 0 width: 100 height: 100])
+                              (layer position [x: 50 y: 50]))
+                            (
+                              (type 0)
+                              (layer bounds [x: 0 y: 0 width: 100 height: 100])
+                              (layer position [x: 150 y: 150]))
+                            (
+                              (type 0)
+                              (layer bounds [x: 0 y: 0 width: 100 height: 100])
+                              (layer position [x: 250 y: 250]))
+                            (
+                              (type 0)
+                              (layer bounds [x: 0 y: 0 width: 100 height: 100])
+                              (layer position [x: 350 y: 350]))))))))))))))
+    (
+      (layer bounds [x: 0 y: 0 width: 0 height: 0]))))

--- a/LayoutTests/interaction-region/layer-tree-shape-reset.html
+++ b/LayoutTests/interaction-region/layer-tree-shape-reset.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html>
+<style>
+    body { margin: 0; }
+    .shape {
+        float: left;
+        background: blue;
+        width: 100px;
+        height: 100px;
+        cursor: pointer;
+    }
+    #radius {
+        border-radius: 16px;
+    }
+    #partial-radius {
+        border-radius: 0px 14px 0px 14px;
+    }
+    #non-uniform-radius {
+        border-radius: 10px 11px 12px 13px;
+    }
+
+</style>
+<script src="../resources/ui-helper.js"></script>
+<body>
+<section id="test">
+    <div id="noradius" class="shape">
+    </div>
+    <div id="radius" class="shape">
+    </div>
+    <div id="partial-radius" class="shape">
+    </div>
+    <div id="non-uniform-radius" class="shape">
+    </div>
+</div>
+
+</section>
+
+<pre id="results"></pre>
+<script>
+document.body.addEventListener("click", function(e) {
+    console.log(e, "event delegation");
+});
+
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+window.onload = async function () {
+    if (!window.internals)
+        return;
+
+    await UIHelper.animationFrame();
+    await UIHelper.ensureStablePresentationUpdate();
+
+    Array.from(document.querySelectorAll(".shape"))
+        .forEach(el => el.style.borderRadius = 0 );
+
+    await UIHelper.animationFrame();
+    await UIHelper.ensureStablePresentationUpdate();
+
+    results.textContent = await UIHelper.getCALayerTree();
+    document.getElementById('test').remove();
+
+    testRunner.notifyDone();
+};
+</script>
+</body>
+</html>
+

--- a/LayoutTests/interaction-region/layer-tree.html
+++ b/LayoutTests/interaction-region/layer-tree.html
@@ -35,6 +35,22 @@
         height: 100px;
         cursor: pointer;
     }
+    .shape {
+        float: left;
+        background: blue;
+        width: 100px;
+        height: 100px;
+        cursor: pointer;
+    }
+    #radius {
+        border-radius: 16px;
+    }
+    #partial-radius {
+        border-radius: 14px 0 0 14px;
+    }
+    #non-uniform-radius {
+        border-radius: 10px 11px 12px 13px;
+    }
 
 </style>
 <script src="../resources/ui-helper.js"></script>
@@ -61,6 +77,14 @@
     <div id="faded">
         <a href="#">Faded link</a>
     </div>
+    <div id="noradius" class="shape">
+    </div>
+    <div id="radius" class="shape">
+    </div>
+    <div id="partial-radius" class="shape">
+    </div>
+    <div id="non-uniform-radius" class="shape">
+    </div>
     <div id="resized" onclick="click()">
         will be resized
     </div>
@@ -70,6 +94,10 @@
 
 <pre id="results"></pre>
 <script>
+document.body.addEventListener("click", function(e) {
+    console.log(e, "event delegation");
+});
+
 if (window.testRunner) {
     testRunner.waitUntilDone();
     testRunner.dumpAsText();

--- a/LayoutTests/interaction-region/nested-composited-text-painter-expected.txt
+++ b/LayoutTests/interaction-region/nested-composited-text-painter-expected.txt
@@ -12,7 +12,7 @@
 
       (interaction regions [
         (interaction (0,0) width=100 height=100)
-        (borderRadius 10.00)])
+        (cornerRadius 10.00)])
       )
       (children 1
         (GraphicsLayer

--- a/LayoutTests/interaction-region/overlap-expected.txt
+++ b/LayoutTests/interaction-region/overlap-expected.txt
@@ -11,10 +11,8 @@
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (occlusion (0,0) width=200 height=100)
-        (borderRadius 0.00),
-        (interaction (0,0) width=200 height=100)
-        (borderRadius 0.00)])
+        (occlusion (0,0) width=200 height=100),
+        (interaction (0,0) width=200 height=100)])
       )
     )
   )

--- a/LayoutTests/interaction-region/overlap-same-group-expected.txt
+++ b/LayoutTests/interaction-region/overlap-same-group-expected.txt
@@ -11,12 +11,8 @@
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (interaction (50,0) width=150 height=100)
-        (borderRadius 12 12 0 12),
-        (interaction (200,25) width=50 height=75)
-        (borderRadius 0 12 0 0),
-        (interaction (100,100) width=150 height=25)
-        (borderRadius 0 0 12 12)])
+        (interaction (50,0) width=200 height=125)
+        (clipPath move to (0,12), add line to (0,12), add curve to (0,5.37) (5.37,0) (12,0), add line to (138,0), add line to (138,0), add curve to (144.63,0) (150,5.37) (150,12), add line to (150,13), add line to (150,13), add curve to (150,19.63) (155.37,25) (162,25), add line to (188,25), add line to (188,25), add curve to (194.63,25) (200,30.37) (200,37), add line to (200,113), add line to (200,113), add curve to (200,119.63) (194.63,125) (188,125), add line to (62,125), add line to (62,125), add curve to (55.37,125) (50,119.63) (50,113), add line to (50,112), add line to (50,112), add curve to (50,105.37) (44.63,100) (38,100), add line to (12,100), add line to (12,100), add curve to (5.37,100) (0,94.63) (0,88), close subpath)])
       )
     )
   )

--- a/LayoutTests/interaction-region/overlay-expected.txt
+++ b/LayoutTests/interaction-region/overlay-expected.txt
@@ -11,10 +11,8 @@
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (occlusion (0,0) width=200 height=100)
-        (borderRadius 0.00),
-        (occlusion (0,200) width=200 height=100)
-        (borderRadius 0.00)])
+        (occlusion (0,0) width=200 height=100),
+        (occlusion (0,200) width=200 height=100)])
       )
       (children 3
         (GraphicsLayer

--- a/LayoutTests/interaction-region/paused-video-regions-expected.txt
+++ b/LayoutTests/interaction-region/paused-video-regions-expected.txt
@@ -35,7 +35,7 @@
 
                   (interaction regions [
                     (interaction (0,0) width=51 height=51)
-                    (borderRadius 25.50)])
+                    (cornerRadius 25.50)])
                   )
                   (children 1
                     (GraphicsLayer

--- a/LayoutTests/interaction-region/position-only-update-expected.txt
+++ b/LayoutTests/interaction-region/position-only-update-expected.txt
@@ -14,7 +14,7 @@ compositing
 
       (interaction regions [
         (interaction (107.98,76) width=81.77 height=27)
-        (borderRadius 8.00)])
+        (cornerRadius 8.00)])
       )
       (children 2
         (GraphicsLayer

--- a/LayoutTests/interaction-region/pseudo-element-expected.txt
+++ b/LayoutTests/interaction-region/pseudo-element-expected.txt
@@ -12,7 +12,7 @@
 
       (interaction regions [
         (interaction (0,0) width=100 height=100)
-        (borderRadius 10.00)])
+        (cornerRadius 10.00)])
       )
     )
   )

--- a/LayoutTests/interaction-region/split-inline-link-expected.txt
+++ b/LayoutTests/interaction-region/split-inline-link-expected.txt
@@ -13,10 +13,8 @@ short second line.
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (interaction (197.27,-4) width=31.99 height=27)
-        (borderRadius 8.00),
-        (interaction (-4,16) width=117 height=27)
-        (borderRadius 8.00)])
+        (interaction (-4,-4) width=233.27 height=47)
+        (clipPath move to (201.27,8), add line to (201.27,8), add curve to (201.27,3.58) (204.86,0) (209.27,0), add line to (225.27,0), add line to (225.27,0), add curve to (229.68,0) (233.27,3.58) (233.27,8), add line to (233.27,19), add line to (233.27,19), add curve to (233.27,23.42) (229.68,27) (225.27,27), add line to (209.27,27), add line to (209.27,27), add curve to (204.86,27) (201.27,23.42) (201.27,19), close subpath, move to (0,28), add line to (0,28), add curve to (0,23.58) (3.58,20) (8,20), add line to (108.42,20), add line to (108.42,20), add curve to (112.84,20) (116.42,23.58) (116.42,28), add line to (116.42,39), add line to (116.42,39), add curve to (116.42,43.42) (112.84,47) (108.42,47), add line to (8,47), add line to (8,47), add curve to (3.58,47) (0,43.42) (0,39), close subpath)])
       )
     )
   )

--- a/LayoutTests/interaction-region/text-controls-expected.txt
+++ b/LayoutTests/interaction-region/text-controls-expected.txt
@@ -13,9 +13,9 @@
 
       (interaction regions [
         (interaction (9,9) width=211 height=204)
-        (borderRadius 5.00),
+        (cornerRadius 5.00),
         (interaction (226,178) width=330 height=55)
-        (borderRadius 5.00)])
+        (cornerRadius 5.00)])
       )
     )
   )

--- a/LayoutTests/interaction-region/text-input-expected.txt
+++ b/LayoutTests/interaction-region/text-input-expected.txt
@@ -13,17 +13,14 @@
 
       (interaction regions [
         (interaction (161,126) width=98 height=38)
-        (borderRadius 5.00),
+        (cornerRadius 5.00),
         (interaction (344,120) width=110 height=50)
-        (borderRadius 5.00),
+        (cornerRadius 5.00),
         (interaction (160,250) width=110 height=50)
-        (borderRadius 5.00),
-        (interaction (161,381) width=98 height=38)
-        (borderRadius 0.00),
-        (interaction (161,461) width=110 height=50)
-        (borderRadius 0.00),
-        (interaction (161,553) width=110 height=50)
-        (borderRadius 0.00)])
+        (cornerRadius 5.00),
+        (interaction (161,381) width=98 height=38),
+        (interaction (161,461) width=110 height=50),
+        (interaction (161,553) width=110 height=50)])
       )
     )
   )

--- a/LayoutTests/interaction-region/tiny-regions-expected.txt
+++ b/LayoutTests/interaction-region/tiny-regions-expected.txt
@@ -11,12 +11,9 @@
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (guard (-10,0) width=30 height=30)
-        (borderRadius 0.00),
-        (interaction (0,10) width=10 height=10)
-        (borderRadius 0.00),
-        (occlusion (0,20) width=10 height=10)
-        (borderRadius 0.00)])
+        (guard (-10,0) width=30 height=30),
+        (interaction (0,10) width=10 height=10),
+        (occlusion (0,20) width=10 height=10)])
       )
     )
   )

--- a/LayoutTests/interaction-region/wrapped-inline-link-expected.txt
+++ b/LayoutTests/interaction-region/wrapped-inline-link-expected.txt
@@ -19,24 +19,10 @@ Line
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (interaction (-4,-4) width=37.32 height=27)
-        (borderRadius 8 8 0 0),
-        (interaction (-4,23) width=38 height=20)
-        (borderRadius 0.00),
-        (interaction (-4,43) width=38 height=20)
-        (borderRadius 0.00),
-        (interaction (-4,63) width=38 height=20)
-        (borderRadius 0 0 8 8),
-        (interaction (6,82) width=65.34 height=27)
-        (borderRadius 8 8 0 0),
-        (interaction (72,94) width=41 height=15)
-        (borderRadius 0 8 0 0),
-        (interaction (6,109) width=107 height=12)
-        (borderRadius 0 0 8 0),
-        (interaction (6,121) width=71 height=12)
-        (borderRadius 0 0 8 0),
-        (interaction (6,133) width=38 height=12)
-        (borderRadius 0 0 8 8)])
+        (interaction (-4,-4) width=37.32 height=87)
+        (clipPath move to (0,8), add line to (0,8), add curve to (0,3.58) (3.58,0) (8,0), add line to (29.32,0), add line to (29.32,0), add curve to (33.74,0) (37.32,3.58) (37.32,8), add line to (37.32,16.50), add line to (37.32,20), add line to (37.32,23.50), add line to (37.32,27), add line to (37.32,36.50), add line to (37.32,40), add line to (37.32,43.50), add line to (37.32,47), add line to (37.32,56.50), add line to (37.32,60), add line to (37.32,63.50), add line to (37.32,67), add line to (37.32,79), add line to (37.32,79), add curve to (37.32,83.42) (33.74,87) (29.32,87), add line to (8,87), add line to (8,87), add curve to (3.58,87) (0,83.42) (0,79), add line to (0,70.50), add line to (0,67), add line to (0,63.50), add line to (0,60), add line to (0,50.50), add line to (0,47), add line to (0,43.50), add line to (0,40), add line to (0,30.50), add line to (0,27), add line to (0,23.50), add line to (0,20), close subpath),
+        (interaction (6,82) width=106.20 height=63)
+        (clipPath move to (0,6), add line to (0,6), add curve to (0,2.69) (2.69,0) (6,0), add line to (59.34,0), add line to (59.34,0), add curve to (62.65,0) (65.34,2.69) (65.34,6), add line to (65.34,6), add line to (65.34,6), add curve to (65.34,9.31) (68.02,12) (71.34,12), add line to (98.20,12), add line to (98.20,12), add curve to (102.61,12) (106.20,15.58) (106.20,20), add line to (106.20,31), add line to (106.20,31), add curve to (106.20,35.42) (102.61,39) (98.20,39), add line to (76.66,39), add line to (76.66,39), add curve to (73.35,39) (70.66,41.69) (70.66,45), add line to (70.66,45), add line to (70.66,45), add curve to (70.66,48.31) (67.98,51) (64.66,51), add line to (43.32,51), add line to (43.32,51), add curve to (40.01,51) (37.32,53.69) (37.32,57), add line to (37.32,57), add line to (37.32,57), add curve to (37.32,60.31) (34.63,63) (31.32,63), add line to (6,63), add line to (6,63), add curve to (2.69,63) (0,60.31) (0,57), add line to (0,57), add line to (0,51), add line to (0,40.50), add line to (0,39), add line to (0,37.50), add line to (0,36), add line to (0,28.50), add line to (0,27), add line to (0,25.50), add line to (0,24), add line to (0,18), add line to (0,12), close subpath)])
       )
     )
   )

--- a/Source/WebCore/page/DebugPageOverlays.cpp
+++ b/Source/WebCore/page/DebugPageOverlays.cpp
@@ -378,7 +378,7 @@ std::optional<InteractionRegion> InteractionRegionOverlay::activeRegion() const
         if (!boundingRect.contains(m_mouseLocationInContentCoordinates))
             continue;
 
-        auto paths = pathsForRect(rectInOverlayCoordinates, region.borderRadius);
+        auto paths = pathsForRect(rectInOverlayCoordinates, region.cornerRadius);
         bool didHitRegion = false;
         for (const auto& path : paths) {
             if (path.contains(m_mouseLocationInContentCoordinates)) {
@@ -534,7 +534,7 @@ void InteractionRegionOverlay::drawRect(PageOverlay&, GraphicsContext& context, 
         Vector<Path> clipPaths;
 
         if (shouldClip)
-            clipPaths = pathsForRect(region->rectInLayerCoordinates, region->borderRadius);
+            clipPaths = pathsForRect(region->rectInLayerCoordinates, region->cornerRadius);
 
         bool shouldUseBackdropGradient = !shouldClip || !region || (!valueForSetting("wash"_s) && valueForSetting("clip"_s));
 

--- a/Source/WebCore/page/InteractionRegion.h
+++ b/Source/WebCore/page/InteractionRegion.h
@@ -27,6 +27,7 @@
 
 #include "ElementIdentifier.h"
 #include "FloatRect.h"
+#include "Path.h"
 #include "Region.h"
 
 namespace IPC {
@@ -56,13 +57,23 @@ struct InteractionRegion {
     Type type;
     ElementIdentifier elementIdentifier;
     FloatRect rectInLayerCoordinates;
-    float borderRadius { 0 };
+    float cornerRadius { 0 };
     OptionSet<CornerMask> maskedCorners { };
+    std::optional<Path> clipPath { std::nullopt };
 
     WEBCORE_EXPORT ~InteractionRegion();
-
-    friend bool operator==(const InteractionRegion&, const InteractionRegion&) = default;
 };
+
+inline bool operator==(const InteractionRegion& a, const InteractionRegion& b)
+{
+    return a.type == b.type
+        && a.elementIdentifier == b.elementIdentifier
+        && a.rectInLayerCoordinates == b.rectInLayerCoordinates
+        && a.cornerRadius == b.cornerRadius
+        && a.maskedCorners == b.maskedCorners
+        && a.clipPath.has_value() == b.clipPath.has_value()
+        && (!a.clipPath || &a.clipPath.value() == &b.clipPath.value());
+}
 
 WEBCORE_EXPORT std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject&, const FloatRect&);
 WEBCORE_EXPORT bool elementMatchesHoverRules(Element&);

--- a/Source/WebCore/rendering/EventRegion.h
+++ b/Source/WebCore/rendering/EventRegion.h
@@ -73,7 +73,7 @@ private:
     HashSet<IntRect> m_occlusionRects;
     HashSet<ElementIdentifier> m_containerRemovalCandidates;
     HashSet<ElementIdentifier> m_containersToRemove;
-    HashMap<ElementIdentifier, Region> m_discoveredRegionsByElement;
+    HashMap<ElementIdentifier, Vector<FloatRect>> m_discoveredRectsByElement;
 #endif
 };
 

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -753,6 +753,15 @@ LayoutUnit RenderBox::constrainContentBoxLogicalHeightByMinMax(LayoutUnit logica
     return logicalHeight;
 }
 
+RoundedRect RenderBox::borderRoundedRect() const
+{
+    auto& style = this->style();
+    LayoutRect bounds = frameRect();
+    bounds.setLocation({ });
+
+    return style.getRoundedBorderFor(bounds);
+}
+
 RoundedRect::Radii RenderBox::borderRadii() const
 {
     auto& style = this->style();

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -111,6 +111,7 @@ public:
     inline LayoutSize borderBoxLogicalSize() const;
 
     WEBCORE_EXPORT RoundedRectRadii borderRadii() const;
+    RoundedRect borderRoundedRect() const;
     RoundedRect roundedBorderBoxRect() const;
 
     // The content area of the box (excludes padding - and intrinsic padding for table cells, etc... - and border).

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -3747,7 +3747,7 @@ void RenderLayerBacking::paintDebugOverlays(const GraphicsLayer* graphicsLayer, 
             
             auto rect = region.rectInLayerCoordinates;
             Path path;
-            path.addRoundedRect(rect, { region.borderRadius, region.borderRadius });
+            path.addRoundedRect(rect, { region.cornerRadius, region.cornerRadius });
             context.strokePath(path);
         }
     }

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -5583,8 +5583,9 @@ struct WebCore::InteractionRegion {
     WebCore::InteractionRegion::Type type;
     WebCore::ElementIdentifier elementIdentifier;
     WebCore::FloatRect rectInLayerCoordinates;
-    float borderRadius;
+    float cornerRadius;
     OptionSet<WebCore::InteractionRegion::CornerMask> maskedCorners;
+    std::optional<WebCore::Path> clipPath;
 };
 
 [Nested, AdditionalEncoder=StreamConnectionEncoder] struct WebCore::Region::Span {

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm
@@ -275,8 +275,8 @@ void updateLayersForInteractionRegions(RemoteLayerTreeNode& node)
             [regionLayer setFrame:rect];
 
         if (region.type == InteractionRegion::Type::Interaction) {
-            [regionLayer setCornerRadius:region.borderRadius];
-            if (region.borderRadius)
+            [regionLayer setCornerRadius:region.cornerRadius];
+            if (region.cornerRadius)
                 [regionLayer setCornerCurve:kCACornerCurveCircular];
 
             constexpr CACornerMask allCorners = kCALayerMinXMinYCorner | kCALayerMaxXMinYCorner | kCALayerMinXMaxYCorner | kCALayerMaxXMaxYCorner;
@@ -284,6 +284,18 @@ void updateLayersForInteractionRegions(RemoteLayerTreeNode& node)
                 [regionLayer setMaskedCorners:allCorners];
             else
                 [regionLayer setMaskedCorners:convertToCACornerMask(region.maskedCorners)];
+
+            if (region.clipPath) {
+                RetainPtr<CAShapeLayer> mask = [regionLayer mask];
+                if (!mask) {
+                    mask = adoptNS([[CAShapeLayer alloc] init]);
+                    [regionLayer setMask:mask.get()];
+                }
+
+                [mask setFrame:[regionLayer bounds]];
+                [mask setPath:region.clipPath->platformPath()];
+            } else
+                [regionLayer setMask:nil];
         }
 
         if ([container.sublayers objectAtIndex:insertionPoint] != regionLayer) {


### PR DESCRIPTION
#### b52ad6b19d1a80071f1aef489edf65ae1abcaed1
<pre>
[InteractionRegions] Add support for all non-uniform border-radius
<a href="https://bugs.webkit.org/show_bug.cgi?id=266491">https://bugs.webkit.org/show_bug.cgi?id=266491</a>
&lt;<a href="https://rdar.apple.com/118884255">rdar://118884255</a>&gt;

Reviewed by Tim Horton.

To support all `border-radius` configurations on InteractionRegions,
introduce an optional clip path.
Generate RoundedRect based Paths when the corner radii are not uniform.
Continue using masked corners when they can fully capture the shape.
Use `PathUtilities::pathWithShrinkWrappedRects` for elements with
multiple rects (like multi-line links).

* Source/WebCore/page/InteractionRegion.h:
Add an optional clip Path.
Rename borderRadius to cornerRadius to make it clearer that it works
with maskedCorners.
(WebCore::operator==):
Re-introduce a custom `==` operator. The compiler can&apos;t generate one now
that the struct contains a Path.
* Source/WebCore/page/InteractionRegion.cpp:
Remove the unused `PathUtilities.h` include.
(WebCore::interactionRegionForRenderedRegion):
Add an optional clip Path.
When the border radii are not uniform, generate a `clipPath` from
`RenderBox#borderRoundedRect()`.
(WebCore::operator&lt;&lt;):
Update the dump format for the new clipPath field.
Only dump the cornerRadius/masked corners when it is greater than 0.

* Source/WebCore/rendering/RenderBox.h:
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::borderRoundedRect const):
Add a method we can use for to generate either clip paths or masked
corners.

* Source/WebCore/rendering/EventRegion.h:
Instead of accumulating the discovered rects for an element in a Region,
use a Vector&lt;FloatRect&gt;&gt; (to avoid rounding to an IntRect).
* Source/WebCore/rendering/EventRegion.cpp:
(WebCore::EventRegionContext::uniteInteractionRegions):
Accumulate the discovered rects for an element in a Vector instead of a
Region.
(WebCore::EventRegionContext::shouldConsolidateInteractionRegion):
Only consider consolidation with elements that have a single discovered
rect (can&apos;t consolidate to a multi-line link).
(WebCore::EventRegionContext::shrinkWrapInteractionRegions):
Replace the shrink wrapping code with the great
`PathUtilities::pathsWithShrinkWrappedRects`.
This yields a single InteractionRegion with the proper rect and clip
path.
(WebCore::EventRegionContext::removeSuperfluousInteractionRegions):
Update the guard overlapping logic to iterate over all known interaction
rects (as opposed to checking once against each discovered Region).

* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
Add an optional clip Path.

* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::paintDebugOverlays):
* Source/WebCore/page/DebugPageOverlays.cpp:
(WebCore::InteractionRegionOverlay::activeRegion const):
(WebCore::InteractionRegionOverlay::drawRect):
borderRadius -&gt; cornerRadius

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm:
(WebKit::updateLayersForInteractionRegions):
Generate a CAShapeLayer from the clipPath when present, and use it to
mask the InteractionRegion layer.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _caLayerTreeAsText]):
Dump the layer tree of the content view instead of the whole WKWebView.
This makes the expectation files clearer and will help prevent churn
when unrelated part of the code change.
(dumpCALayer):
Add basic support for layer and corner masking in the dump.

* LayoutTests/interaction-region/border-radii.html:
* LayoutTests/interaction-region/border-radii-expected.txt:
This test already has non-uniform examples. Add borders and update
expectations.
* LayoutTests/interaction-region/guard-overlap.html:
* LayoutTests/interaction-region/guard-overlap-expected.txt:
Add a test with a guard overlapping a multi-line link.
* LayoutTests/interaction-region/layer-tree.html:
* LayoutTests/interaction-region/layer-tree-expected.txt:
Add various shape cases to the layer test to cover the UIProcess
changes.
* LayoutTests/interaction-region/layer-tree-shape-reset-expected.txt: Added.
* LayoutTests/interaction-region/layer-tree-shape-reset.html: Added.
Add a new test making sure all shaping properties on InteractionRegion
layers are properly reset if the style updates.
* LayoutTests/interaction-region/aria-roles-expected.txt:
* LayoutTests/interaction-region/button-in-link-expected.txt:
* LayoutTests/interaction-region/click-handler-dynamically-added-expected.txt:
* LayoutTests/interaction-region/click-handler-expected.txt:
* LayoutTests/interaction-region/click-handler-in-shadowed-layer-expected.txt:
* LayoutTests/interaction-region/consolidated-nested-regions-expected.txt:
* LayoutTests/interaction-region/display-table-expected.txt:
* LayoutTests/interaction-region/event-region-overflow-expected.txt:
* LayoutTests/interaction-region/full-page-overlay-expected.txt:
* LayoutTests/interaction-region/hover-style-expected.txt:
* LayoutTests/interaction-region/icon-inside-button-single-region-expected.txt:
* LayoutTests/interaction-region/ignore-catch-all-body-expected.txt:
* LayoutTests/interaction-region/inline-link-dark-background-expected.txt:
* LayoutTests/interaction-region/inline-link-expected.txt:
* LayoutTests/interaction-region/inline-link-in-composited-iframe-expected.txt:
* LayoutTests/interaction-region/inline-link-in-layer-expected.txt:
* LayoutTests/interaction-region/inline-link-in-non-composited-iframe-expected.txt:
* LayoutTests/interaction-region/inline-link-with-pointer-events-none-content-expected.txt:
* LayoutTests/interaction-region/input-type-file-region-expected.txt:
* LayoutTests/interaction-region/input-type-range-region-expected.txt:
* LayoutTests/interaction-region/interaction-layers-culling-expected.txt:
* LayoutTests/interaction-region/interaction-layers-culling-layer-type-change-expected.txt:
* LayoutTests/interaction-region/interaction-region-size-limit-expected.txt:
* LayoutTests/interaction-region/labels-expected.txt:
* LayoutTests/interaction-region/nested-composited-text-painter-expected.txt:
* LayoutTests/interaction-region/overlap-expected.txt:
* LayoutTests/interaction-region/overlap-same-group-expected.txt:
* LayoutTests/interaction-region/overlay-expected.txt:
* LayoutTests/interaction-region/paused-video-regions-expected.txt:
* LayoutTests/interaction-region/position-only-update-expected.txt:
* LayoutTests/interaction-region/pseudo-element-expected.txt:
* LayoutTests/interaction-region/split-inline-link-expected.txt:
* LayoutTests/interaction-region/text-controls-expected.txt:
* LayoutTests/interaction-region/text-input-expected.txt:
* LayoutTests/interaction-region/tiny-regions-expected.txt:
* LayoutTests/interaction-region/wrapped-inline-link-expected.txt:
Update test expectations with clip paths and the new dump format.

Canonical link: <a href="https://commits.webkit.org/272377@main">https://commits.webkit.org/272377@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/539fdd6ae8e5d85a5a9016e190e34ae82221495f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31278 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9948 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32971 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33780 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28370 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32045 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12293 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7202 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28020 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31614 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8384 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27937 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7203 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7373 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27835 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35123 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28451 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28291 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33504 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7427 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5473 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31341 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9103 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/27630 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7383 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8126 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7951 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->