### PR TITLE
Move file descriptor in SharedMemory::map

### DIFF
--- a/Source/WebCore/platform/unix/SharedMemoryUnix.cpp
+++ b/Source/WebCore/platform/unix/SharedMemoryUnix.cpp
@@ -137,9 +137,9 @@ RefPtr<SharedMemory> SharedMemory::allocate(size_t size)
         return nullptr;
 
     RefPtr<SharedMemory> instance = adoptRef(new SharedMemory());
+    instance->m_size = size;
     instance->m_data = data;
     instance->m_fileDescriptor = WTFMove(fileDescriptor);
-    instance->m_size = size;
     return instance;
 }
 
@@ -150,16 +150,17 @@ RefPtr<SharedMemory> SharedMemory::map(Handle&& handle, Protection protection)
         return nullptr;
 
     RefPtr<SharedMemory> instance = adoptRef(new SharedMemory());
-    instance->m_data = data;
     instance->m_size = handle.size();
+    instance->m_data = data;
+    instance->m_fileDescriptor = WTFMove(handle.m_handle);
     return instance;
 }
 
 RefPtr<SharedMemory> SharedMemory::wrapMap(void* data, size_t size, int fileDescriptor)
 {
     RefPtr<SharedMemory> instance = adoptRef(new SharedMemory());
-    instance->m_data = data;
     instance->m_size = size;
+    instance->m_data = data;
     instance->m_fileDescriptor = UnixFileDescriptor { fileDescriptor, UnixFileDescriptor::Adopt };
     instance->m_isWrappingMap = true;
     return instance;


### PR DESCRIPTION
#### 467c4ea3ba16141ebde1297d15844a20653eb97a
<pre>
Move file descriptor in SharedMemory::map
<a href="https://bugs.webkit.org/show_bug.cgi?id=266495">https://bugs.webkit.org/show_bug.cgi?id=266495</a>

Reviewed by NOBODY (OOPS!).

The Unix implementation of `SharedMemory::map` was not moving the
`Handle` into the newly created instance. Sort the setting of member
variables to be declaration order to make it more obvious that all
members are present.

* Source/WebCore/platform/unix/SharedMemoryUnix.cpp:
(WebCore::SharedMemory::allocate):
(WebCore::SharedMemory::map):
(WebCore::SharedMemory::wrapMap):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/467c4ea3ba16141ebde1297d15844a20653eb97a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80777 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/299 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34713 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85304 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31761 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82888 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/316 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8097 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63081 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20871 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83846 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/143 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73522 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43383 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/81 "Build was cancelled. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests (exception)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27682 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30218 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71635 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28214 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86736 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8004 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5655 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71377 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8181 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69358 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70616 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14643 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13582 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7966 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13487 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7805 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11324 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9611 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->