### PR TITLE
Implement errorOccured in webNavigation.getFrame/getAllFrames

### DIFF
--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -342,6 +342,8 @@ public:
 
     void switchBrowsingContextsGroup();
 
+    bool errorOccurredInLoading() const { return m_errorOccurredInLoading; }
+
     // HistoryController specific.
     void loadItem(HistoryItem&, HistoryItem* fromItem, FrameLoadType, ShouldTreatAsContinuingLoad);
     HistoryItem* requestedHistoryItem() const { return m_requestedHistoryItem.get(); }
@@ -525,6 +527,8 @@ private:
     bool m_inStopForBackForwardCache { false };
     bool m_isHTTPFallbackInProgress { false };
     bool m_shouldRestoreScrollPositionAndViewState { false };
+
+    bool m_errorOccurredInLoading { false };
 };
 
 // This function is called by createWindow() in JSDOMWindowBase.cpp, for example, for

--- a/Source/WebKit/Shared/FrameInfoData.h
+++ b/Source/WebKit/Shared/FrameInfoData.h
@@ -44,6 +44,7 @@ struct FrameInfoData {
     std::optional<WebCore::FrameIdentifier> parentFrameID;
     ProcessID processID;
     bool isFocused { false };
+    bool errorOccurred { false };
 };
 
 }

--- a/Source/WebKit/Shared/FrameInfoData.serialization.in
+++ b/Source/WebKit/Shared/FrameInfoData.serialization.in
@@ -34,4 +34,5 @@ struct WebKit::FrameInfoData {
     std::optional<WebCore::FrameIdentifier> parentFrameID
     WTF::ProcessID processID
     bool isFocused
+    bool errorOccurred
 }

--- a/Source/WebKit/UIProcess/API/APIFrameInfo.h
+++ b/Source/WebKit/UIProcess/API/APIFrameInfo.h
@@ -58,6 +58,7 @@ public:
     RefPtr<FrameHandle> parentFrameHandle() const;
     ProcessID processID() const { return m_data.processID; }
     bool isFocused() const { return m_data.isFocused; }
+    bool errorOccurred() const { return m_data.errorOccurred; }
 
 private:
     FrameInfo(WebKit::FrameInfoData&&, RefPtr<WebKit::WebPageProxy>&&);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKFrameInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKFrameInfo.mm
@@ -114,4 +114,9 @@
     return _frameInfo->isFocused();
 }
 
+- (BOOL)_errorOccurred
+{
+    return _frameInfo->errorOccurred();
+}
+
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKFrameInfoPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKFrameInfoPrivate.h
@@ -34,5 +34,6 @@
 @property (nonatomic, readonly) pid_t _processIdentifier WK_API_AVAILABLE(macos(13.3), ios(16.4));
 @property (nonatomic, readonly) BOOL _isLocalFrame WK_API_AVAILABLE(macos(14.0), ios(17.0));
 @property (nonatomic, readonly) BOOL _isFocused WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+@property (nonatomic, readonly) BOOL _errorOccurred WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 @end

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWebNavigationCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWebNavigationCocoa.mm
@@ -51,8 +51,7 @@ static WebExtensionFrameParameters frameParametersForFrame(_WKFrameTreeNode *fra
 
     return {
         // errorOccured
-        // FIXME: Correctly populate this based on whether or not an error occurred loading this frame
-        false,
+        (bool)frameInfo._errorOccurred,
 
         // url
         extensionContext->hasPermission(frameURL, tab) ? std::optional { frameURL } : std::nullopt,

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -248,7 +248,8 @@ FrameInfoData WebFrame::info() const
         frameID(),
         parent ? std::optional<WebCore::FrameIdentifier> { parent->frameID() } : std::nullopt,
         getCurrentProcessID(),
-        isFocused()
+        isFocused(),
+        coreLocalFrame() ? coreLocalFrame()->loader().errorOccurredInLoading() : false
     };
 
     return info;


### PR DESCRIPTION
#### baf3eae87da202e1ab9d7ccb2dff883fe503e2bc
<pre>
Implement errorOccured in webNavigation.getFrame/getAllFrames
<a href="https://bugs.webkit.org/show_bug.cgi?id=266499">https://bugs.webkit.org/show_bug.cgi?id=266499</a>
<a href="https://rdar.apple.com/118340990">rdar://118340990</a>

Reviewed by Alex Christensen and Timothy Hatcher.

Before this change, there was no way to determine if an error occurred in the load of a frame given a WKFrameInfo.

This patch pipes that information from the FrameLoader -&gt; WebFrame -&gt; WKFrameInfo, and exposes it as SPI on the WKFrameInfo.

This patch also adds some tests for both the new WKFrameInfo SPI and how it is exposed to extensions.

* Source/WebCore/loader/FrameLoader.cpp: Clear m_errorOccurredInLoading in all of the places that load start.
(WebCore::FrameLoader::dispatchDidFailProvisionalLoad): Set m_errorOccurredInLoading to true.
(WebCore::FrameLoader::checkLoadCompleteForThisFrame): Set m_errorOccurredInLoading to true if necessary.
* Source/WebCore/loader/FrameLoader.h:
* Source/WebKit/Shared/FrameInfoData.h: Add the new parameter.
* Source/WebKit/Shared/FrameInfoData.serialization.in: Ditto.
* Source/WebKit/UIProcess/API/APIFrameInfo.h:
* Source/WebKit/UIProcess/API/Cocoa/WKFrameInfo.mm:
(-[WKFrameInfo _errorOccurred]):
* Source/WebKit/UIProcess/API/Cocoa/WKFrameInfoPrivate.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWebNavigationCocoa.mm:
(WebKit::frameParametersForFrame): Include whether or not an error occurred.
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::info const): Include whether or not an error occurred.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWebNavigation.mm:
(TestWebKitAPI::TEST): Add a test that when a frame load fails with an error, errorOccurred is set in the getFrame call. There
are two flavors of this test, one with a failed provisional load, the other with a failed load after it had been committed.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm: Enhance the Frames test to:
1) Make sure the WKFrameInfo _errorOccurred SPI value is correct when loads fail and complete.
2) Perform an additional load after the failed load to make sure the error occurred state is reset.

Canonical link: <a href="https://commits.webkit.org/272303@main">https://commits.webkit.org/272303@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9be4906a66bac5c1f6ebc2b3c84ef9b1dce1809b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31179 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9857 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32873 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33687 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28318 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31946 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12199 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7115 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27968 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31516 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8310 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27875 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7138 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7315 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27770 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35029 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28377 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28226 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33451 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7353 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5410 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31290 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9038 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8054 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4071 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7887 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->