### PR TITLE
[Mac] Make WebVideoViewContainer's videoViewContainerDelegate a weak property

### DIFF
--- a/Source/WebCore/platform/mac/VideoFullscreenInterfaceMac.mm
+++ b/Source/WebCore/platform/mac/VideoFullscreenInterfaceMac.mm
@@ -65,17 +65,11 @@ using WebCore::MediaPlayerEnums;
 using WebCore::VideoFullscreenInterfaceMac;
 using WebCore::PlaybackSessionModel;
 
-@interface WebVideoViewContainer : NSView {
-    __unsafe_unretained id <WebVideoViewContainerDelegate> _videoViewContainerDelegate;
-}
-
-@property (nonatomic, assign) id <WebVideoViewContainerDelegate> videoViewContainerDelegate;
-
+@interface WebVideoViewContainer : NSView
+@property (nonatomic, weak) id<WebVideoViewContainerDelegate> videoViewContainerDelegate;
 @end
 
 @implementation WebVideoViewContainer
-
-@synthesize videoViewContainerDelegate = _videoViewContainerDelegate;
 
 - (void)resizeWithOldSuperviewSize:(NSSize)oldBoundsSize
 {


### PR DESCRIPTION
#### 931edb0a5a560a009a8ca6a23f39aa4bff6d6a5a
<pre>
[Mac] Make WebVideoViewContainer&apos;s videoViewContainerDelegate a weak property
<a href="https://bugs.webkit.org/show_bug.cgi?id=264124">https://bugs.webkit.org/show_bug.cgi?id=264124</a>
<a href="https://rdar.apple.com/116049616">rdar://116049616</a>

Reviewed by Simon Fraser.

* Source/WebCore/platform/mac/VideoFullscreenInterfaceMac.mm:

Originally-landed-as: 267815.509@safari-7617-branch (1ac1a554c12b). <a href="https://rdar.apple.com/119597936">rdar://119597936</a>
Canonical link: <a href="https://commits.webkit.org/272167@main">https://commits.webkit.org/272167@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b17098b433d2ba941be204a41a8429744800a9d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30734 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9412 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32400 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33228 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27778 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31444 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11714 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6668 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27659 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31046 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7926 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27503 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6773 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6949 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27379 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34565 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27999 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27861 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33085 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6963 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5054 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30917 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8680 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7282 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7681 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7518 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->