### PR TITLE
Use CheckedPtr / CheckedRef less for non-stack objects

### DIFF
--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -712,7 +712,7 @@ private:
     WeakListHashSet<Node, WeakPtrImplWithEventTargetData> m_deferredNodeAddedOrRemovedList;
     WeakHashSet<Element, WeakPtrImplWithEventTargetData> m_deferredModalChangedList;
     WeakHashSet<Element, WeakPtrImplWithEventTargetData> m_deferredMenuListChange;
-    WeakHashSet<ScrollView> m_deferredScrollbarUpdateChangeList;
+    SingleThreadWeakHashSet<ScrollView> m_deferredScrollbarUpdateChangeList;
     WeakHashMap<Element, String, WeakPtrImplWithEventTargetData> m_deferredTextFormControlValue;
     Vector<AttributeChange> m_deferredAttributeChange;
     std::optional<std::pair<WeakPtr<Node, WeakPtrImplWithEventTargetData>, WeakPtr<Node, WeakPtrImplWithEventTargetData>>> m_deferredFocusedNodeChange;

--- a/Source/WebCore/accessibility/AccessibilityScrollView.h
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.h
@@ -80,7 +80,7 @@ private:
     AccessibilityScrollbar* addChildScrollbar(Scrollbar*);
     void removeChildScrollbar(AccessibilityObject*);
 
-    WeakPtr<ScrollView> m_scrollView;
+    SingleThreadWeakPtr<ScrollView> m_scrollView;
     WeakPtr<HTMLFrameOwnerElement, WeakPtrImplWithEventTargetData> m_frameOwnerElement;
     RefPtr<AccessibilityObject> m_horizontalScrollbar;
     RefPtr<AccessibilityObject> m_verticalScrollbar;

--- a/Source/WebCore/loader/ApplicationManifestLoader.h
+++ b/Source/WebCore/loader/ApplicationManifestLoader.h
@@ -56,7 +56,7 @@ public:
 private:
     void notifyFinished(CachedResource&, const NetworkLoadMetrics&);
 
-    CheckedRef<DocumentLoader> m_documentLoader;
+    SingleThreadWeakRef<DocumentLoader> m_documentLoader;
     std::optional<ApplicationManifest> m_processedManifest;
     URL m_url;
     bool m_useCredentials;

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -165,13 +165,12 @@ using ContentExtensionEnablement = std::pair<ContentExtensionDefaultEnablement, 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(DocumentLoader);
 class DocumentLoader
     : public RefCounted<DocumentLoader>
-    , public CanMakeCheckedPtr
     , public FrameDestructionObserver
     , public ContentSecurityPolicyClient
 #if ENABLE(CONTENT_FILTERING)
     , public ContentFilterClient
 #endif
-    , private CachedRawResourceClient {
+    , public CachedRawResourceClient {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(DocumentLoader);
     friend class ContentFilter;
 public:
@@ -179,6 +178,10 @@ public:
     {
         return adoptRef(*new DocumentLoader(request, data));
     }
+
+    using CachedRawResourceClient::weakPtrFactory;
+    using CachedRawResourceClient::WeakValueType;
+    using CachedRawResourceClient::WeakPtrImplType;
 
     WEBCORE_EXPORT static DocumentLoader* fromScriptExecutionContextIdentifier(ScriptExecutionContextIdentifier);
 

--- a/Source/WebCore/loader/appcache/ApplicationCacheHost.cpp
+++ b/Source/WebCore/loader/appcache/ApplicationCacheHost.cpp
@@ -49,7 +49,7 @@
 namespace WebCore {
 
 ApplicationCacheHost::ApplicationCacheHost(DocumentLoader& documentLoader)
-    : m_documentLoader(CheckedRef { documentLoader })
+    : m_documentLoader(documentLoader)
 {
 }
 

--- a/Source/WebCore/loader/appcache/ApplicationCacheHost.h
+++ b/Source/WebCore/loader/appcache/ApplicationCacheHost.h
@@ -153,7 +153,7 @@ private:
     bool maybeLoadFallbackForMainError(const ResourceRequest&, const ResourceError&);
 
     WeakPtr<DOMApplicationCache, WeakPtrImplWithEventTargetData> m_domApplicationCache;
-    CheckedRef<DocumentLoader> m_documentLoader;
+    SingleThreadWeakRef<DocumentLoader> m_documentLoader;
 
     bool m_defersEvents { true }; // Events are deferred until after document onload.
     Vector<DeferredEvent> m_deferredEvents;

--- a/Source/WebCore/loader/cache/CachedResourceLoader.h
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.h
@@ -210,7 +210,7 @@ private:
     MemoryCompactRobinHoodHashSet<URL> m_cachedSVGImagesURLs;
     mutable DocumentResourceMap m_documentResources;
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
-    CheckedPtr<DocumentLoader>  m_documentLoader;
+    SingleThreadWeakPtr<DocumentLoader> m_documentLoader;
 
     int m_requestCount { 0 };
 

--- a/Source/WebCore/loader/icon/IconLoader.h
+++ b/Source/WebCore/loader/icon/IconLoader.h
@@ -27,10 +27,10 @@
 
 #include "CachedRawResourceClient.h"
 #include "CachedResourceHandle.h"
-#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/URL.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore {
 
@@ -50,7 +50,7 @@ public:
 private:
     void notifyFinished(CachedResource&, const NetworkLoadMetrics&) final;
 
-    CheckedRef<DocumentLoader> m_documentLoader;
+    SingleThreadWeakRef<DocumentLoader> m_documentLoader;
     URL m_url;
     CachedResourceHandle<CachedRawResource> m_resource;
 };

--- a/Source/WebCore/page/DOMWindowExtension.h
+++ b/Source/WebCore/page/DOMWindowExtension.h
@@ -36,7 +36,7 @@ namespace WebCore {
 class DOMWrapperWorld;
 class LocalFrame;
 
-class DOMWindowExtension final : public RefCounted<DOMWindowExtension>, public LocalDOMWindow::Observer, public CanMakeCheckedPtr {
+class DOMWindowExtension final : public RefCounted<DOMWindowExtension>, public LocalDOMWindow::Observer {
 public:
     static Ref<DOMWindowExtension> create(LocalDOMWindow* window, DOMWrapperWorld& world)
     {

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -3057,16 +3057,16 @@ Widget* EventHandler::widgetForEventTarget(Element* eventTarget)
     return renderWidget->widget();
 }
 
-static WeakPtr<Widget> widgetForElement(const Element& element)
+static RefPtr<Widget> widgetForElement(const Element& element)
 {
     auto* renderWidget = dynamicDowncast<RenderWidget>(element.renderer());
     if (!renderWidget || !renderWidget->widget())
         return { };
 
-    return *renderWidget->widget();
+    return renderWidget->widget();
 }
 
-bool EventHandler::completeWidgetWheelEvent(const PlatformWheelEvent& event, const WeakPtr<Widget>& widget, const WeakPtr<ScrollableArea>& scrollableArea)
+bool EventHandler::completeWidgetWheelEvent(const PlatformWheelEvent& event, const SingleThreadWeakPtr<Widget>& widget, const WeakPtr<ScrollableArea>& scrollableArea)
 {
     m_isHandlingWheelEvent = false;
     
@@ -3160,8 +3160,8 @@ HandleUserInputEventResult EventHandler::handleWheelEventInternal(const Platform
             if (RefPtr remoteSubframe = dynamicDowncast<RemoteFrame>(subframeForTargetNode(result.targetNode()))) {
                 if (auto wheelEventDataForRemoteFrame = userInputEventDataForRemoteFrame(remoteSubframe.get(), result.roundedPointInInnerNodeFrame()))
                     return *wheelEventDataForRemoteFrame;
-            } else if (WeakPtr<Widget> widget = widgetForElement(*element)) {
-                if (passWheelEventToWidget(event, *widget.get(), processingSteps))
+            } else if (RefPtr widget = widgetForElement(*element)) {
+                if (passWheelEventToWidget(event, *widget, processingSteps))
                     return completeWidgetWheelEvent(event, widget, scrollableArea);
             }
         }

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -497,7 +497,7 @@ private:
     void determineWheelEventTarget(const PlatformWheelEvent&, RefPtr<Element>& eventTarget, WeakPtr<ScrollableArea>&, bool& isOverWidget);
     bool processWheelEventForScrolling(const PlatformWheelEvent&, const WeakPtr<ScrollableArea>&, OptionSet<EventHandling>);
     void processWheelEventForScrollSnap(const PlatformWheelEvent&, const WeakPtr<ScrollableArea>&);
-    bool completeWidgetWheelEvent(const PlatformWheelEvent&, const WeakPtr<Widget>&, const WeakPtr<ScrollableArea>&);
+    bool completeWidgetWheelEvent(const PlatformWheelEvent&, const SingleThreadWeakPtr<Widget>&, const WeakPtr<ScrollableArea>&);
 
     bool handleWheelEventInAppropriateEnclosingBox(Node* startNode, const WheelEvent&, FloatSize& filteredPlatformDelta, const FloatSize& filteredVelocity, OptionSet<EventHandling>);
 
@@ -646,7 +646,7 @@ private:
     RefPtr<Element> m_elementUnderMouse;
     RefPtr<Element> m_lastElementUnderMouse;
     RefPtr<LocalFrame> m_lastMouseMoveEventSubframe;
-    WeakPtr<Scrollbar> m_lastScrollbarUnderMouse;
+    SingleThreadWeakPtr<Scrollbar> m_lastScrollbarUnderMouse;
     Cursor m_currentMouseCursor;
 
     RefPtr<Node> m_clickNode;

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -5752,19 +5752,19 @@ LayoutUnit LocalFrameView::mapFromCSSToLayoutUnits(int value) const
 
 void LocalFrameView::didAddWidgetToRenderTree(Widget& widget)
 {
-    ASSERT(!m_widgetsInRenderTree.contains(&widget));
-    m_widgetsInRenderTree.add(&widget);
+    ASSERT(!m_widgetsInRenderTree.contains(widget));
+    m_widgetsInRenderTree.add(widget);
 }
 
 void LocalFrameView::willRemoveWidgetFromRenderTree(Widget& widget)
 {
-    ASSERT(m_widgetsInRenderTree.contains(&widget));
-    m_widgetsInRenderTree.remove(&widget);
+    ASSERT(m_widgetsInRenderTree.contains(widget));
+    m_widgetsInRenderTree.remove(widget);
 }
 
-static Vector<RefPtr<Widget>> collectAndProtectWidgets(const HashSet<CheckedPtr<Widget>>& set)
+static Vector<Ref<Widget>> collectAndProtectWidgets(const HashSet<SingleThreadWeakRef<Widget>>& set)
 {
-    return WTF::map(set, [](auto& widget) -> RefPtr<Widget> {
+    return WTF::map(set, [](auto& widget) -> Ref<Widget> {
         return widget.get();
     });
 }
@@ -5776,7 +5776,7 @@ void LocalFrameView::updateWidgetPositions()
     // scripts in response to NPP_SetWindow, for example), so we need to keep the Widgets
     // alive during enumeration.
     for (auto& widget : collectAndProtectWidgets(m_widgetsInRenderTree)) {
-        if (auto* renderer = RenderWidget::find(*widget)) {
+        if (auto* renderer = RenderWidget::find(widget)) {
             auto ignoreWidgetState = renderer->updateWidgetPosition();
             UNUSED_PARAM(ignoreWidgetState);
         }

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -646,7 +646,7 @@ public:
     void didAddWidgetToRenderTree(Widget&);
     void willRemoveWidgetFromRenderTree(Widget&);
 
-    const HashSet<CheckedPtr<Widget>>& widgetsInRenderTree() const { return m_widgetsInRenderTree; }
+    const HashSet<SingleThreadWeakRef<Widget>>& widgetsInRenderTree() const { return m_widgetsInRenderTree; }
 
     void notifyAllFramesThatContentAreaWillPaint() const;
 
@@ -912,7 +912,7 @@ private:
     const Ref<LocalFrame> m_frame;
     LocalFrameViewLayoutContext m_layoutContext;
 
-    HashSet<CheckedPtr<Widget>> m_widgetsInRenderTree;
+    HashSet<SingleThreadWeakRef<Widget>> m_widgetsInRenderTree;
     std::unique_ptr<ListHashSet<SingleThreadWeakRef<RenderEmbeddedObject>>> m_embeddedObjectsToUpdate;
     std::unique_ptr<SingleThreadWeakHashSet<RenderElement>> m_slowRepaintObjects;
 

--- a/Source/WebCore/page/PageOverlay.h
+++ b/Source/WebCore/page/PageOverlay.h
@@ -29,9 +29,9 @@
 #include "FloatPoint.h"
 #include "IntRect.h"
 #include "Timer.h"
-#include <wtf/CheckedRef.h>
 #include <wtf/RefCounted.h>
 #include <wtf/WallTime.h>
+#include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -43,7 +43,7 @@ class Page;
 class PageOverlayController;
 class PlatformMouseEvent;
 
-class PageOverlay final : public RefCounted<PageOverlay>, public CanMakeCheckedPtr {
+class PageOverlay final : public RefCounted<PageOverlay>, public CanMakeWeakPtr<PageOverlay> {
     WTF_MAKE_NONCOPYABLE(PageOverlay);
     WTF_MAKE_FAST_ALLOCATED;
 public:

--- a/Source/WebCore/page/scrolling/ScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinator.cpp
@@ -141,11 +141,11 @@ EventTrackingRegions ScrollingCoordinator::absoluteEventTrackingRegionsForFrame(
     }
 
     for (auto& widget : frameView->widgetsInRenderTree()) {
-        if (!is<PluginViewBase>(*widget))
+        if (!is<PluginViewBase>(widget))
             continue;
-        if (!downcast<PluginViewBase>(*widget).wantsWheelEvents())
+        if (!downcast<PluginViewBase>(widget.get()).wantsWheelEvents())
             continue;
-        auto* renderWidget = RenderWidget::find(*widget);
+        auto* renderWidget = RenderWidget::find(widget);
         if (!renderWidget)
             continue;
         nonFastScrollableRegion.unite(renderWidget->absoluteBoundingBoxRect());

--- a/Source/WebCore/platform/ScrollView.h
+++ b/Source/WebCore/platform/ScrollView.h
@@ -159,7 +159,7 @@ public:
         ~ProhibitScrollingWhenChangingContentSizeForScope();
 
     private:
-        WeakPtr<ScrollView> m_scrollView;
+        SingleThreadWeakPtr<ScrollView> m_scrollView;
     };
 
     std::unique_ptr<ProhibitScrollingWhenChangingContentSizeForScope> prohibitScrollingWhenChangingContentSizeForScope();

--- a/Source/WebCore/platform/Widget.h
+++ b/Source/WebCore/platform/Widget.h
@@ -85,7 +85,7 @@ enum WidgetNotification { WillPaintFlattened, DidPaintFlattened };
 // Scrollbar - Mac, Gtk
 // Plugin - Mac, Windows (windowed only), Qt (windowed only, widget is an HWND on windows), Gtk (windowed only)
 //
-class Widget : public RefCounted<Widget>, public CanMakeWeakPtr<Widget>, public CanMakeCheckedPtr {
+class Widget : public RefCounted<Widget>, public CanMakeSingleThreadWeakPtr<Widget> {
 public:
     WEBCORE_EXPORT explicit Widget(PlatformWidget = nullptr);
     WEBCORE_EXPORT virtual ~Widget();
@@ -213,7 +213,7 @@ private:
     bool m_selfVisible { false };
     bool m_parentVisible { false };
 
-    WeakPtr<ScrollView> m_parent;
+    SingleThreadWeakPtr<ScrollView> m_parent;
 #if !PLATFORM(COCOA)
     PlatformWidget m_widget;
 #else

--- a/Source/WebCore/platform/mac/ScrollbarThemeMac.mm
+++ b/Source/WebCore/platform/mac/ScrollbarThemeMac.mm
@@ -54,7 +54,7 @@
 
 namespace WebCore {
 
-using ScrollbarSet = HashSet<CheckedPtr<Scrollbar>>;
+using ScrollbarSet = HashSet<SingleThreadWeakRef<Scrollbar>>;
 
 static ScrollbarSet& scrollbarMap()
 {
@@ -155,12 +155,12 @@ void ScrollbarThemeMac::registerScrollbar(Scrollbar& scrollbar)
     if (scrollbar.isCustomScrollbar() || !scrollbar.shouldRegisterScrollbar())
         return;
 
-    scrollbarMap().add(&scrollbar);
+    scrollbarMap().add(scrollbar);
 }
 
 void ScrollbarThemeMac::unregisterScrollbar(Scrollbar& scrollbar)
 {
-    scrollbarMap().take(&scrollbar);
+    scrollbarMap().take(scrollbar);
 }
 
 NSScrollerImp *ScrollbarThemeMac::scrollerImpForScrollbar(Scrollbar& scrollbar)

--- a/Source/WebCore/platform/mac/ScrollbarsControllerMac.mm
+++ b/Source/WebCore/platform/mac/ScrollbarsControllerMac.mm
@@ -314,7 +314,7 @@ using WebCore::LogOverlayScrollbars;
 @end
 
 @interface WebScrollerImpDelegate : NSObject<NSAnimationDelegate, NSScrollerImpDelegate> {
-    WeakPtr<WebCore::Scrollbar> _scrollbar;
+    SingleThreadWeakPtr<WebCore::Scrollbar> _scrollbar;
 
     RetainPtr<WebScrollbarPartAnimation> _knobAlphaAnimation;
     RetainPtr<WebScrollbarPartAnimation> _trackAlphaAnimation;

--- a/Source/WebCore/rendering/CounterNode.h
+++ b/Source/WebCore/rendering/CounterNode.h
@@ -40,7 +40,7 @@ namespace WebCore {
 class RenderCounter;
 class RenderElement;
 
-class CounterNode : public RefCounted<CounterNode>, public CanMakeCheckedPtr {
+class CounterNode : public RefCounted<CounterNode>, public CanMakeSingleThreadWeakPtr<CounterNode> {
 public:
     enum class Type : uint8_t { Increment, Reset, Set };
 
@@ -86,11 +86,11 @@ private:
     RenderElement& m_owner;
     RenderCounter* m_rootRenderer { nullptr };
 
-    CheckedPtr<CounterNode> m_parent;
-    CheckedPtr<CounterNode> m_previousSibling;
-    CheckedPtr<CounterNode> m_nextSibling;
-    CheckedPtr<CounterNode> m_firstChild;
-    CheckedPtr<CounterNode> m_lastChild;
+    SingleThreadWeakPtr<CounterNode> m_parent;
+    SingleThreadWeakPtr<CounterNode> m_previousSibling;
+    SingleThreadWeakPtr<CounterNode> m_nextSibling;
+    SingleThreadWeakPtr<CounterNode> m_firstChild;
+    SingleThreadWeakPtr<CounterNode> m_lastChild;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderCounter.cpp
+++ b/Source/WebCore/rendering/RenderCounter.cpp
@@ -417,7 +417,7 @@ static CounterNode* makeCounterNode(RenderElement& renderer, const AtomString& i
         skipDescendants = currentRenderer->shouldApplyStyleContainment();
         if (!currentRenderer->hasCounterNodeMap())
             continue;
-        CheckedPtr currentCounter = maps.find(*currentRenderer)->value->get(identifier);
+        RefPtr currentCounter = maps.find(*currentRenderer)->value->get(identifier);
         if (!currentCounter)
             continue;
         skipDescendants = true;
@@ -464,7 +464,7 @@ String RenderCounter::originalText() const
     if (!m_counterNode)
         return emptyString();
 
-    CheckedPtr child = m_counterNode;
+    RefPtr child = m_counterNode.get();
     int value = child->actsAsReset() ? child->value() : child->countInParent();
 
     auto counterText = [](const ListStyleType& styleType, int value, CSSCounterStyle* counterStyle) {

--- a/Source/WebCore/rendering/RenderCounter.h
+++ b/Source/WebCore/rendering/RenderCounter.h
@@ -53,7 +53,7 @@ private:
     RefPtr<CSSCounterStyle> counterStyle() const;
 
     CounterContent m_counter;
-    CheckedPtr<CounterNode> m_counterNode;
+    SingleThreadWeakPtr<CounterNode> m_counterNode;
     RenderCounter* m_nextForSameCounter { nullptr };
     friend class CounterNode;
 };

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.cpp
@@ -40,7 +40,7 @@
 namespace WebKit {
 using namespace WebCore;
 
-using ExtensionMap = HashMap<CheckedPtr<WebCore::DOMWindowExtension>, CheckedPtr<InjectedBundleDOMWindowExtension>>;
+using ExtensionMap = HashMap<WeakRef<WebCore::DOMWindowExtension>, WeakRef<InjectedBundleDOMWindowExtension>>;
 static ExtensionMap& allExtensions()
 {
     static NeverDestroyed<ExtensionMap> map;
@@ -61,13 +61,13 @@ InjectedBundleDOMWindowExtension* InjectedBundleDOMWindowExtension::get(DOMWindo
 InjectedBundleDOMWindowExtension::InjectedBundleDOMWindowExtension(WebFrame* frame, InjectedBundleScriptWorld* world)
     : m_coreExtension(DOMWindowExtension::create(frame->coreLocalFrame() ? frame->coreLocalFrame()->window() : nullptr, world->coreWorld()))
 {
-    allExtensions().add(m_coreExtension.get(), this);
+    allExtensions().add(m_coreExtension.get(), *this);
 }
 
 InjectedBundleDOMWindowExtension::~InjectedBundleDOMWindowExtension()
 {
-    ASSERT(allExtensions().contains(m_coreExtension.get()));
-    allExtensions().remove(m_coreExtension.get());
+    ASSERT(allExtensions().contains(m_coreExtension));
+    allExtensions().remove(m_coreExtension);
 }
 
 RefPtr<WebFrame> InjectedBundleDOMWindowExtension::frame() const

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.h
@@ -27,8 +27,8 @@
 #define InjectedBundleDOMWindowExtension_h
 
 #include "APIObject.h"
-#include <wtf/CheckedRef.h>
 #include <wtf/RefPtr.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
@@ -41,7 +41,7 @@ namespace WebKit {
 class InjectedBundleScriptWorld;
 class WebFrame;
 
-class InjectedBundleDOMWindowExtension : public API::ObjectImpl<API::Object::Type::BundleDOMWindowExtension>, public CanMakeCheckedPtr {
+class InjectedBundleDOMWindowExtension : public API::ObjectImpl<API::Object::Type::BundleDOMWindowExtension>, public CanMakeWeakPtr<InjectedBundleDOMWindowExtension> {
 public:
     static Ref<InjectedBundleDOMWindowExtension> create(WebFrame*, InjectedBundleScriptWorld*);
     static InjectedBundleDOMWindowExtension* get(WebCore::DOMWindowExtension*);
@@ -54,7 +54,7 @@ public:
 private:
     InjectedBundleDOMWindowExtension(WebFrame*, InjectedBundleScriptWorld*);
 
-    RefPtr<WebCore::DOMWindowExtension> m_coreExtension;
+    Ref<WebCore::DOMWindowExtension> m_coreExtension;
     mutable RefPtr<InjectedBundleScriptWorld> m_world;
 };
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -233,7 +233,7 @@ protected:
     bool hudEnabled() const;
 #endif
 
-    WeakPtr<PluginView> m_view;
+    SingleThreadWeakPtr<PluginView> m_view;
     WeakPtr<WebFrame> m_frame;
     WeakPtr<WebCore::HTMLPlugInElement, WebCore::WeakPtrImplWithEventTargetData> m_element;
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2187,7 +2187,7 @@ private:
     WebCore::Color m_underlayColor;
 
 #if ENABLE(PDF_PLUGIN)
-    WeakHashSet<PluginView> m_pluginViews;
+    SingleThreadWeakHashSet<PluginView> m_pluginViews;
 #endif
 #if ENABLE(PDF_HUD)
     HashMap<PDFPluginIdentifier, WeakPtr<PDFPluginBase>> m_pdfPlugInsWithHUD;

--- a/Source/WebKit/WebProcess/WebPage/WebPageOverlay.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPageOverlay.cpp
@@ -37,9 +37,9 @@
 namespace WebKit {
 using namespace WebCore;
 
-static HashMap<CheckedPtr<PageOverlay>, CheckedPtr<WebPageOverlay>>& overlayMap()
+static HashMap<WeakRef<PageOverlay>, WeakRef<WebPageOverlay>>& overlayMap()
 {
-    static NeverDestroyed<HashMap<CheckedPtr<PageOverlay>, CheckedPtr<WebPageOverlay>>> map;
+    static NeverDestroyed<HashMap<WeakRef<PageOverlay>, WeakRef<WebPageOverlay>>> map;
     return map;
 }
 
@@ -53,7 +53,7 @@ WebPageOverlay::WebPageOverlay(std::unique_ptr<WebPageOverlay::Client> client, P
     , m_client(WTFMove(client))
 {
     ASSERT(m_client);
-    overlayMap().add(m_overlay.get(), this);
+    overlayMap().add(*m_overlay, *this);
 }
 
 WebPageOverlay::~WebPageOverlay()
@@ -61,13 +61,13 @@ WebPageOverlay::~WebPageOverlay()
     if (!m_overlay)
         return;
 
-    overlayMap().remove(m_overlay.get());
+    overlayMap().remove(*m_overlay);
     m_overlay = nullptr;
 }
 
 WebPageOverlay* WebPageOverlay::fromCoreOverlay(PageOverlay& overlay)
 {
-    return overlayMap().get(&overlay);
+    return overlayMap().get(overlay);
 }
 
 void WebPageOverlay::setNeedsDisplay(const IntRect& dirtyRect)

--- a/Source/WebKit/WebProcess/WebPage/WebPageOverlay.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPageOverlay.h
@@ -29,8 +29,8 @@
 #include <WebCore/FloatPoint.h>
 #include <WebCore/PageOverlay.h>
 #include <WebCore/SimpleRange.h>
-#include <wtf/CheckedRef.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/WeakPtr.h>
 
 #if HAVE(SECURE_ACTION_CONTEXT)
 OBJC_CLASS DDSecureActionContext;
@@ -49,7 +49,7 @@ namespace WebKit {
 class WebFrame;
 class WebPage;
 
-class WebPageOverlay : public API::ObjectImpl<API::Object::Type::BundlePageOverlay>, private WebCore::PageOverlay::Client, public CanMakeCheckedPtr {
+class WebPageOverlay : public API::ObjectImpl<API::Object::Type::BundlePageOverlay>, public CanMakeWeakPtr<WebPageOverlay>, private WebCore::PageOverlay::Client {
 public:
     struct ActionContext;
 


### PR DESCRIPTION
#### 98667dc58f6ddf80965e72e370be7a878e89122d
<pre>
Use CheckedPtr / CheckedRef less for non-stack objects
<a href="https://bugs.webkit.org/show_bug.cgi?id=266503">https://bugs.webkit.org/show_bug.cgi?id=266503</a>

Reviewed by Darin Adler and Ryosuke Niwa.

* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/AccessibilityScrollView.h:
* Source/WebCore/loader/ApplicationManifestLoader.h:
* Source/WebCore/loader/DocumentLoader.h:
* Source/WebCore/loader/appcache/ApplicationCacheHost.cpp:
(WebCore::ApplicationCacheHost::ApplicationCacheHost):
* Source/WebCore/loader/appcache/ApplicationCacheHost.h:
* Source/WebCore/loader/cache/CachedResourceLoader.h:
* Source/WebCore/loader/icon/IconLoader.h:
* Source/WebCore/page/DOMWindowExtension.h:
* Source/WebCore/page/EventHandler.cpp:
(WebCore::widgetForElement):
(WebCore::EventHandler::completeWidgetWheelEvent):
(WebCore::EventHandler::handleWheelEventInternal):
* Source/WebCore/page/EventHandler.h:
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::didAddWidgetToRenderTree):
(WebCore::LocalFrameView::willRemoveWidgetFromRenderTree):
(WebCore::collectAndProtectWidgets):
(WebCore::LocalFrameView::updateWidgetPositions):
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/PageOverlay.h:
* Source/WebCore/page/scrolling/ScrollingCoordinator.cpp:
(WebCore::ScrollingCoordinator::absoluteEventTrackingRegionsForFrame const):
* Source/WebCore/platform/ScrollView.h:
* Source/WebCore/platform/Widget.h:
* Source/WebCore/platform/mac/ScrollbarThemeMac.mm:
(WebCore::ScrollbarThemeMac::registerScrollbar):
(WebCore::ScrollbarThemeMac::unregisterScrollbar):
* Source/WebCore/platform/mac/ScrollbarsControllerMac.mm:
* Source/WebCore/rendering/CounterNode.cpp:
(WebCore::CounterNode::~CounterNode):
(WebCore::CounterNode::nextInPreOrderAfterChildren const):
(WebCore::CounterNode::lastDescendant const):
(WebCore::CounterNode::previousInPreOrder const):
(WebCore::CounterNode::resetThisAndDescendantsRenderers):
(WebCore::CounterNode::recount):
(WebCore::CounterNode::insertAfter):
(WebCore::CounterNode::removeChild):
* Source/WebCore/rendering/CounterNode.h:
* Source/WebCore/rendering/RenderCounter.cpp:
(WebCore::makeCounterNode):
(WebCore::RenderCounter::originalText const):
* Source/WebCore/rendering/RenderCounter.h:
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.cpp:
(WebKit::InjectedBundleDOMWindowExtension::InjectedBundleDOMWindowExtension):
(WebKit::InjectedBundleDOMWindowExtension::~InjectedBundleDOMWindowExtension):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPageOverlay.cpp:
(WebKit::overlayMap):
(WebKit::WebPageOverlay::WebPageOverlay):
(WebKit::WebPageOverlay::~WebPageOverlay):
(WebKit::WebPageOverlay::fromCoreOverlay):
* Source/WebKit/WebProcess/WebPage/WebPageOverlay.h:

Canonical link: <a href="https://commits.webkit.org/272165@main">https://commits.webkit.org/272165@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3685f97aed70b1c7c08f43bfc74812a0dcb1dcd9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30791 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9470 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32459 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33287 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27822 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31536 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11778 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6713 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/27693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31105 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7944 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27544 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6816 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/6964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27420 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34624 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28017 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27901 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33120 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7009 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5088 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30953 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8726 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7726 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3991 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7565 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->