### PR TITLE
[WIP] Re-enable 'upgrade-simple-ws.html' test

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2534,7 +2534,6 @@ webkit.org/b/153162 http/tests/security/contentSecurityPolicy/report-multiple-vi
 webkit.org/b/153162 http/tests/security/contentSecurityPolicy/report-multiple-violations-02.py [ Failure ]
 webkit.org/b/154203 http/tests/security/contentSecurityPolicy/1.1/frame-ancestors/frame-ancestors-overrides-xfo.html
 webkit.org/b/154522 http/tests/security/contentSecurityPolicy/1.1/securitypolicyviolation-base-uri-deny.html
-webkit.org/b/158480 http/tests/websocket/tests/hybi/upgrade-simple-ws.html [ Skip ]
 
 # WK CSP extension support is WebKit2 only
 http/tests/security/contentSecurityPolicy/extensions [ Skip ]

--- a/LayoutTests/http/tests/websocket/tests/hybi/upgrade-simple-ws.html
+++ b/LayoutTests/http/tests/websocket/tests/hybi/upgrade-simple-ws.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="/js-test-resources/js-test-pre.js"></script>
+<script src="/js-test-resources/js-test.js"></script>
 <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
 </head>
 <body>
@@ -57,6 +57,5 @@ function timeOutCallback()
 var timeoutID = setTimeout(timeOutCallback, 300);
 
 </script>
-<script src="/js-test-resources/js-test-post.js"></script>
 </body>
 </html>


### PR DESCRIPTION
<pre>
[WIP] Re-enable 'upgrade-simple-ws.html' test
<a href="https://bugs.webkit.org/show_bug.cgi?id=158480">https://bugs.webkit.org/show_bug.cgi?id=158480</a>

Reviewed by NOBODY (OOPS!).

WIP

* LayoutTests/TestExpectations: Re-enable 'upgrade-simple-ws.html' test
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7bf861c35918c9fd18dec49e79ab4f3a84161f33

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30801 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9481 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32470 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33298 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27828 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11791 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6724 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27696 "Found 1 new test failure: http/tests/websocket/tests/hybi/upgrade-simple-ws.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31116 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7959 "Found 1 new test failure: http/tests/websocket/tests/hybi/upgrade-simple-ws.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27552 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6821 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6970 "Exiting early after 10 failures. 10 tests run. 1 failures") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27430 "Found 1 new test failure: http/tests/websocket/tests/hybi/upgrade-simple-ws.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34635 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28028 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27909 "Found 1 new test failure: http/tests/websocket/tests/hybi/upgrade-simple-ws.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33126 "Found 1 new test failure: http/tests/websocket/tests/hybi/upgrade-simple-ws.html (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7018 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5094 "Found 1 new test failure: http/tests/websocket/tests/hybi/upgrade-simple-ws.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30960 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8735 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/27215 "Exiting early after 10 failures. 10 tests run. 1 failures") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7735 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7575 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->