### PR TITLE
Replace RenderElement::BaseTypeFlags with an enum class

### DIFF
--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -304,14 +304,14 @@ private:
     bool m_hadVerticalLayoutOverflow;
 };
 
-RenderBlock::RenderBlock(Type type, Element& element, RenderStyle&& style, BaseTypeFlags baseTypeFlags)
-    : RenderBox(type, element, WTFMove(style), baseTypeFlags | RenderBlockFlag)
+RenderBlock::RenderBlock(Type type, Element& element, RenderStyle&& style, OptionSet<RenderElementType> baseTypeFlags)
+    : RenderBox(type, element, WTFMove(style), baseTypeFlags | RenderElementType::RenderBlockFlag)
 {
     ASSERT(isRenderBlock());
 }
 
-RenderBlock::RenderBlock(Type type, Document& document, RenderStyle&& style, BaseTypeFlags baseTypeFlags)
-    : RenderBox(type, document, WTFMove(style), baseTypeFlags | RenderBlockFlag)
+RenderBlock::RenderBlock(Type type, Document& document, RenderStyle&& style, OptionSet<RenderElementType> baseTypeFlags)
+    : RenderBox(type, document, WTFMove(style), baseTypeFlags | RenderElementType::RenderBlockFlag)
 {
     ASSERT(isRenderBlock());
 }

--- a/Source/WebCore/rendering/RenderBlock.h
+++ b/Source/WebCore/rendering/RenderBlock.h
@@ -59,8 +59,8 @@ public:
     virtual ~RenderBlock();
 
 protected:
-    RenderBlock(Type, Element&, RenderStyle&&, BaseTypeFlags);
-    RenderBlock(Type, Document&, RenderStyle&&, BaseTypeFlags);
+    RenderBlock(Type, Element&, RenderStyle&&, OptionSet<RenderElementType>);
+    RenderBlock(Type, Document&, RenderStyle&&, OptionSet<RenderElementType>);
 
 public:
     // These two functions are overridden for inline-block.

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -115,8 +115,8 @@ RenderBlockFlow::MarginInfo::MarginInfo(const RenderBlockFlow& block, LayoutUnit
     m_negativeMargin = m_canCollapseMarginBeforeWithChildren ? block.maxNegativeMarginBefore() : 0_lu;
 }
 
-RenderBlockFlow::RenderBlockFlow(Type type, Element& element, RenderStyle&& style, BaseTypeFlags baseTypeFlags)
-    : RenderBlock(type, element, WTFMove(style), baseTypeFlags | RenderBlockFlowFlag)
+RenderBlockFlow::RenderBlockFlow(Type type, Element& element, RenderStyle&& style, OptionSet<RenderElementType> baseTypeFlags)
+    : RenderBlock(type, element, WTFMove(style), baseTypeFlags | RenderElementType::RenderBlockFlowFlag)
 #if ENABLE(TEXT_AUTOSIZING)
     , m_widthForTextAutosizing(-1)
     , m_lineCountForTextAutosizing(NOT_SET)
@@ -126,8 +126,8 @@ RenderBlockFlow::RenderBlockFlow(Type type, Element& element, RenderStyle&& styl
     setChildrenInline(true);
 }
 
-RenderBlockFlow::RenderBlockFlow(Type type, Document& document, RenderStyle&& style, BaseTypeFlags baseTypeFlags)
-    : RenderBlock(type, document, WTFMove(style), baseTypeFlags | RenderBlockFlowFlag)
+RenderBlockFlow::RenderBlockFlow(Type type, Document& document, RenderStyle&& style, OptionSet<RenderElementType> baseTypeFlags)
+    : RenderBlock(type, document, WTFMove(style), baseTypeFlags | RenderElementType::RenderBlockFlowFlag)
 #if ENABLE(TEXT_AUTOSIZING)
     , m_widthForTextAutosizing(-1)
     , m_lineCountForTextAutosizing(NOT_SET)

--- a/Source/WebCore/rendering/RenderBlockFlow.h
+++ b/Source/WebCore/rendering/RenderBlockFlow.h
@@ -54,8 +54,8 @@ enum LineCount {
 class RenderBlockFlow : public RenderBlock {
     WTF_MAKE_ISO_ALLOCATED(RenderBlockFlow);
 public:
-    RenderBlockFlow(Type, Element&, RenderStyle&&, BaseTypeFlags = 0);
-    RenderBlockFlow(Type, Document&, RenderStyle&&, BaseTypeFlags = 0);
+    RenderBlockFlow(Type, Element&, RenderStyle&&, OptionSet<RenderElementType> = { });
+    RenderBlockFlow(Type, Document&, RenderStyle&&, OptionSet<RenderElementType> = { });
     virtual ~RenderBlockFlow();
         
     void layoutBlock(bool relayoutChildren, LayoutUnit pageLogicalHeight = 0_lu) override;

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -132,14 +132,14 @@ static const unsigned backgroundObscurationTestMaxDepth = 4;
 
 bool RenderBox::s_hadNonVisibleOverflow = false;
 
-RenderBox::RenderBox(Type type, Element& element, RenderStyle&& style, BaseTypeFlags baseTypeFlags)
+RenderBox::RenderBox(Type type, Element& element, RenderStyle&& style, OptionSet<RenderElementType> baseTypeFlags)
     : RenderBoxModelObject(type, element, WTFMove(style), baseTypeFlags)
 {
     setIsRenderBox();
     ASSERT(isRenderBox());
 }
 
-RenderBox::RenderBox(Type type, Document& document, RenderStyle&& style, BaseTypeFlags baseTypeFlags)
+RenderBox::RenderBox(Type type, Document& document, RenderStyle&& style, OptionSet<RenderElementType> baseTypeFlags)
     : RenderBoxModelObject(type, document, WTFMove(style), baseTypeFlags)
 {
     setIsRenderBox();

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -660,8 +660,8 @@ public:
     bool computeHasTransformRelatedProperty(const RenderStyle&) const;
 
 protected:
-    RenderBox(Type, Element&, RenderStyle&&, BaseTypeFlags);
-    RenderBox(Type, Document&, RenderStyle&&, BaseTypeFlags);
+    RenderBox(Type, Element&, RenderStyle&&, OptionSet<RenderElementType>);
+    RenderBox(Type, Document&, RenderStyle&&, OptionSet<RenderElementType>);
 
     void styleWillChange(StyleDifference, const RenderStyle& newStyle) override;
     void styleDidChange(StyleDifference, const RenderStyle* oldStyle) override;

--- a/Source/WebCore/rendering/RenderBoxModelObject.cpp
+++ b/Source/WebCore/rendering/RenderBoxModelObject.cpp
@@ -167,14 +167,14 @@ bool RenderBoxModelObject::hasAcceleratedCompositing() const
     return view().compositor().hasAcceleratedCompositing();
 }
 
-RenderBoxModelObject::RenderBoxModelObject(Type type, Element& element, RenderStyle&& style, BaseTypeFlags baseTypeFlags)
-    : RenderLayerModelObject(type, element, WTFMove(style), baseTypeFlags | RenderBoxModelObjectFlag)
+RenderBoxModelObject::RenderBoxModelObject(Type type, Element& element, RenderStyle&& style, OptionSet<RenderElementType> baseTypeFlags)
+    : RenderLayerModelObject(type, element, WTFMove(style), baseTypeFlags | RenderElementType::RenderBoxModelObjectFlag)
 {
     ASSERT(isRenderBoxModelObject());
 }
 
-RenderBoxModelObject::RenderBoxModelObject(Type type, Document& document, RenderStyle&& style, BaseTypeFlags baseTypeFlags)
-    : RenderLayerModelObject(type, document, WTFMove(style), baseTypeFlags | RenderBoxModelObjectFlag)
+RenderBoxModelObject::RenderBoxModelObject(Type type, Document& document, RenderStyle&& style, OptionSet<RenderElementType> baseTypeFlags)
+    : RenderLayerModelObject(type, document, WTFMove(style), baseTypeFlags | RenderElementType::RenderBoxModelObjectFlag)
 {
     ASSERT(isRenderBoxModelObject());
 }

--- a/Source/WebCore/rendering/RenderBoxModelObject.h
+++ b/Source/WebCore/rendering/RenderBoxModelObject.h
@@ -213,8 +213,8 @@ public:
     void applyTransform(TransformationMatrix&, const RenderStyle&, const FloatRect& boundingBox, OptionSet<RenderStyle::TransformOperationOption>) const override;
 
 protected:
-    RenderBoxModelObject(Type, Element&, RenderStyle&&, BaseTypeFlags);
-    RenderBoxModelObject(Type, Document&, RenderStyle&&, BaseTypeFlags);
+    RenderBoxModelObject(Type, Element&, RenderStyle&&, OptionSet<RenderElementType>);
+    RenderBoxModelObject(Type, Document&, RenderStyle&&, OptionSet<RenderElementType>);
 
     void willBeDestroyed() override;
 

--- a/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp
@@ -130,7 +130,7 @@ private:
 };
 
 RenderDeprecatedFlexibleBox::RenderDeprecatedFlexibleBox(Type type, Element& element, RenderStyle&& style)
-    : RenderBlock(type, element, WTFMove(style), 0)
+    : RenderBlock(type, element, WTFMove(style), { })
 {
     setChildrenInline(false); // All of our children must be block-level
     m_stretchingChildren = false;

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -116,10 +116,10 @@ struct SameSizeAsRenderElement : public RenderObject {
 
 static_assert(sizeof(RenderElement) == sizeof(SameSizeAsRenderElement), "RenderElement should stay small");
 
-inline RenderElement::RenderElement(Type type, ContainerNode& elementOrDocument, RenderStyle&& style, BaseTypeFlags baseTypeFlags)
+inline RenderElement::RenderElement(Type type, ContainerNode& elementOrDocument, RenderStyle&& style, OptionSet<RenderElementType> typeFlags)
     : RenderObject(type, elementOrDocument)
     , m_firstChild(nullptr)
-    , m_baseTypeFlags(baseTypeFlags)
+    , m_typeFlags(typeFlags.toRaw())
     , m_ancestorLineBoxDirty(false)
     , m_hasInitializedStyle(false)
     , m_hasPausedImageAnimations(false)
@@ -141,12 +141,12 @@ inline RenderElement::RenderElement(Type type, ContainerNode& elementOrDocument,
     ASSERT(RenderObject::isRenderElement());
 }
 
-RenderElement::RenderElement(Type type, Element& element, RenderStyle&& style, BaseTypeFlags baseTypeFlags)
+RenderElement::RenderElement(Type type, Element& element, RenderStyle&& style, OptionSet<RenderElementType> baseTypeFlags)
     : RenderElement(type, static_cast<ContainerNode&>(element), WTFMove(style), baseTypeFlags)
 {
 }
 
-RenderElement::RenderElement(Type type, Document& document, RenderStyle&& style, BaseTypeFlags baseTypeFlags)
+RenderElement::RenderElement(Type type, Document& document, RenderStyle&& style, OptionSet<RenderElementType> baseTypeFlags)
     : RenderElement(type, static_cast<ContainerNode&>(document), WTFMove(style), baseTypeFlags)
 {
 }

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -304,7 +304,7 @@ public:
     void clearNeedsLayoutForDescendants();
 
 protected:
-    enum BaseTypeFlag {
+    enum class RenderElementType {
         RenderLayerModelObjectFlag  = 1 << 0,
         RenderBoxModelObjectFlag    = 1 << 1,
         RenderInlineFlag            = 1 << 2,
@@ -314,11 +314,9 @@ protected:
         RenderFlexibleBoxFlag       = 1 << 6,
         RenderTextControlFlag       = 1 << 7,
     };
-    
-    typedef unsigned BaseTypeFlags;
 
-    RenderElement(Type, Element&, RenderStyle&&, BaseTypeFlags);
-    RenderElement(Type, Document&, RenderStyle&&, BaseTypeFlags);
+    RenderElement(Type, Element&, RenderStyle&&, OptionSet<RenderElementType>);
+    RenderElement(Type, Document&, RenderStyle&&, OptionSet<RenderElementType>);
 
     bool layerCreationAllowedForSubtree() const;
 
@@ -361,13 +359,14 @@ protected:
     inline bool shouldApplySizeOrStyleContainment(bool) const;
 
 private:
-    RenderElement(Type, ContainerNode&, RenderStyle&&, BaseTypeFlags);
+    RenderElement(Type, ContainerNode&, RenderStyle&&, OptionSet<RenderElementType>);
     void node() const = delete;
     void nonPseudoNode() const = delete;
     void generatingNode() const = delete;
     void isRenderText() const = delete;
     void isRenderElement() const = delete;
 
+    OptionSet<RenderElementType> typeFlags() const { return OptionSet<RenderElementType>::fromRaw(m_typeFlags); }
     RenderObject* firstChildSlow() const final { return firstChild(); }
     RenderObject* lastChildSlow() const final { return lastChild(); }
 
@@ -404,7 +403,7 @@ private:
     const RenderStyle* textSegmentPseudoStyle(PseudoId) const;
 
     SingleThreadPackedWeakPtr<RenderObject> m_firstChild;
-    unsigned m_baseTypeFlags : 8;
+    unsigned m_typeFlags : 8;
     unsigned m_ancestorLineBoxDirty : 1;
     unsigned m_hasInitializedStyle : 1;
 
@@ -454,42 +453,42 @@ inline void RenderElement::setChildNeedsLayout(MarkingBehavior markParents)
 
 inline bool RenderElement::isRenderLayerModelObject() const
 {
-    return m_baseTypeFlags & RenderLayerModelObjectFlag;
+    return typeFlags().contains(RenderElementType::RenderLayerModelObjectFlag);
 }
 
 inline bool RenderElement::isRenderBoxModelObject() const
 {
-    return m_baseTypeFlags & RenderBoxModelObjectFlag;
+    return typeFlags().contains(RenderElementType::RenderBoxModelObjectFlag);
 }
 
 inline bool RenderElement::isRenderBlock() const
 {
-    return m_baseTypeFlags & RenderBlockFlag;
+    return typeFlags().contains(RenderElementType::RenderBlockFlag);
 }
 
 inline bool RenderElement::isRenderBlockFlow() const
 {
-    return m_baseTypeFlags & RenderBlockFlowFlag;
+    return typeFlags().contains(RenderElementType::RenderBlockFlowFlag);
 }
 
 inline bool RenderElement::isRenderReplaced() const
 {
-    return m_baseTypeFlags & RenderReplacedFlag;
+    return typeFlags().contains(RenderElementType::RenderReplacedFlag);
 }
 
 inline bool RenderElement::isRenderInline() const
 {
-    return m_baseTypeFlags & RenderInlineFlag;
+    return typeFlags().contains(RenderElementType::RenderInlineFlag);
 }
 
 inline bool RenderElement::isRenderFlexibleBox() const
 {
-    return m_baseTypeFlags & RenderFlexibleBoxFlag;
+    return typeFlags().contains(RenderElementType::RenderFlexibleBoxFlag);
 }
 
 inline bool RenderElement::isRenderTextControl() const
 {
-    return m_baseTypeFlags & RenderTextControlFlag;
+    return typeFlags().contains(RenderElementType::RenderTextControlFlag);
 }
 
 inline Element* RenderElement::generatingElement() const

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -81,14 +81,14 @@ struct RenderFlexibleBox::LineState {
 };
 
 RenderFlexibleBox::RenderFlexibleBox(Type type, Element& element, RenderStyle&& style)
-    : RenderBlock(type, element, WTFMove(style), RenderFlexibleBoxFlag)
+    : RenderBlock(type, element, WTFMove(style), RenderElementType::RenderFlexibleBoxFlag)
 {
     ASSERT(isRenderFlexibleBox());
     setChildrenInline(false); // All of our children must be block-level.
 }
 
 RenderFlexibleBox::RenderFlexibleBox(Type type, Document& document, RenderStyle&& style)
-    : RenderBlock(type, document, WTFMove(style), RenderFlexibleBoxFlag)
+    : RenderBlock(type, document, WTFMove(style), RenderElementType::RenderFlexibleBoxFlag)
 {
     ASSERT(isRenderFlexibleBox());
     setChildrenInline(false); // All of our children must be block-level.

--- a/Source/WebCore/rendering/RenderFrameSet.cpp
+++ b/Source/WebCore/rendering/RenderFrameSet.cpp
@@ -55,7 +55,7 @@ static constexpr auto borderFillColor = SRGBA<uint8_t> { 208, 208, 208 };
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderFrameSet);
 
 RenderFrameSet::RenderFrameSet(HTMLFrameSetElement& frameSet, RenderStyle&& style)
-    : RenderBox(Type::FrameSet, frameSet, WTFMove(style), 0)
+    : RenderBox(Type::FrameSet, frameSet, WTFMove(style), { })
     , m_isResizing(false)
 {
     ASSERT(isRenderFrameSet());

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -51,7 +51,7 @@ enum class TrackSizeRestriction : uint8_t {
 };
 
 RenderGrid::RenderGrid(Element& element, RenderStyle&& style)
-    : RenderBlock(Type::Grid, element, WTFMove(style), 0)
+    : RenderBlock(Type::Grid, element, WTFMove(style), { })
     , m_grid(*this)
     , m_trackSizingAlgorithm(this, currentGrid())
     , m_masonryLayout(*this)

--- a/Source/WebCore/rendering/RenderInline.cpp
+++ b/Source/WebCore/rendering/RenderInline.cpp
@@ -65,14 +65,14 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderInline);
 
 RenderInline::RenderInline(Type type, Element& element, RenderStyle&& style)
-    : RenderBoxModelObject(type, element, WTFMove(style), RenderInlineFlag)
+    : RenderBoxModelObject(type, element, WTFMove(style), RenderElementType::RenderInlineFlag)
 {
     setChildrenInline(true);
     ASSERT(isRenderInline());
 }
 
 RenderInline::RenderInline(Type type, Document& document, RenderStyle&& style)
-    : RenderBoxModelObject(type, document, WTFMove(style), RenderInlineFlag)
+    : RenderBoxModelObject(type, document, WTFMove(style), RenderElementType::RenderInlineFlag)
 {
     setChildrenInline(true);
     ASSERT(isRenderInline());

--- a/Source/WebCore/rendering/RenderLayerModelObject.cpp
+++ b/Source/WebCore/rendering/RenderLayerModelObject.cpp
@@ -63,14 +63,14 @@ bool RenderLayerModelObject::s_hadLayer = false;
 bool RenderLayerModelObject::s_wasTransformed = false;
 bool RenderLayerModelObject::s_layerWasSelfPainting = false;
 
-RenderLayerModelObject::RenderLayerModelObject(Type type, Element& element, RenderStyle&& style, BaseTypeFlags baseTypeFlags)
-    : RenderElement(type, element, WTFMove(style), baseTypeFlags | RenderLayerModelObjectFlag)
+RenderLayerModelObject::RenderLayerModelObject(Type type, Element& element, RenderStyle&& style, OptionSet<RenderElementType> baseTypeFlags)
+    : RenderElement(type, element, WTFMove(style), baseTypeFlags | RenderElementType::RenderLayerModelObjectFlag)
 {
     ASSERT(isRenderLayerModelObject());
 }
 
-RenderLayerModelObject::RenderLayerModelObject(Type type, Document& document, RenderStyle&& style, BaseTypeFlags baseTypeFlags)
-    : RenderElement(type, document, WTFMove(style), baseTypeFlags | RenderLayerModelObjectFlag)
+RenderLayerModelObject::RenderLayerModelObject(Type type, Document& document, RenderStyle&& style, OptionSet<RenderElementType> baseTypeFlags)
+    : RenderElement(type, document, WTFMove(style), baseTypeFlags | RenderElementType::RenderLayerModelObjectFlag)
 {
     ASSERT(isRenderLayerModelObject());
 }

--- a/Source/WebCore/rendering/RenderLayerModelObject.h
+++ b/Source/WebCore/rendering/RenderLayerModelObject.h
@@ -108,8 +108,8 @@ public:
     void applyTransform(TransformationMatrix&, const RenderStyle&, const FloatRect& boundingBox) const;
 
 protected:
-    RenderLayerModelObject(Type, Element&, RenderStyle&&, BaseTypeFlags);
-    RenderLayerModelObject(Type, Document&, RenderStyle&&, BaseTypeFlags);
+    RenderLayerModelObject(Type, Element&, RenderStyle&&, OptionSet<RenderElementType>);
+    RenderLayerModelObject(Type, Document&, RenderStyle&&, OptionSet<RenderElementType>);
 
     void createLayer();
     void willBeDestroyed() override;

--- a/Source/WebCore/rendering/RenderLineBreak.cpp
+++ b/Source/WebCore/rendering/RenderLineBreak.cpp
@@ -50,7 +50,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderLineBreak);
 static const int invalidLineHeight = -1;
 
 RenderLineBreak::RenderLineBreak(HTMLElement& element, RenderStyle&& style)
-    : RenderBoxModelObject(Type::LineBreak, element, WTFMove(style), 0)
+    : RenderBoxModelObject(Type::LineBreak, element, WTFMove(style), { })
     , m_inlineBoxWrapper(nullptr)
     , m_cachedLineHeight(invalidLineHeight)
     , m_isWBR(is<HTMLWBRElement>(element))

--- a/Source/WebCore/rendering/RenderListMarker.cpp
+++ b/Source/WebCore/rendering/RenderListMarker.cpp
@@ -50,7 +50,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderListMarker);
 constexpr int cMarkerPadding = 7;
 
 RenderListMarker::RenderListMarker(RenderListItem& listItem, RenderStyle&& style)
-    : RenderBox(Type::ListMarker, listItem.document(), WTFMove(style), 0)
+    : RenderBox(Type::ListMarker, listItem.document(), WTFMove(style), { })
     , m_listItem(listItem)
 {
     setInline(true);

--- a/Source/WebCore/rendering/RenderMultiColumnSpannerPlaceholder.cpp
+++ b/Source/WebCore/rendering/RenderMultiColumnSpannerPlaceholder.cpp
@@ -49,7 +49,7 @@ RenderPtr<RenderMultiColumnSpannerPlaceholder> RenderMultiColumnSpannerPlacehold
 }
 
 RenderMultiColumnSpannerPlaceholder::RenderMultiColumnSpannerPlaceholder(RenderMultiColumnFlow& fragmentedFlow, RenderBox& spanner, RenderStyle&& style)
-    : RenderBox(Type::MultiColumnSpannerPlaceholder, fragmentedFlow.document(), WTFMove(style), RenderBoxModelObjectFlag)
+    : RenderBox(Type::MultiColumnSpannerPlaceholder, fragmentedFlow.document(), WTFMove(style), RenderElementType::RenderBoxModelObjectFlag)
     , m_spanner(spanner)
     , m_fragmentedFlow(fragmentedFlow)
 {

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -65,7 +65,7 @@ const int cDefaultWidth = 300;
 const int cDefaultHeight = 150;
 
 RenderReplaced::RenderReplaced(Type type, Element& element, RenderStyle&& style)
-    : RenderBox(type, element, WTFMove(style), RenderReplacedFlag)
+    : RenderBox(type, element, WTFMove(style), RenderElementType::RenderReplacedFlag)
     , m_intrinsicSize(cDefaultWidth, cDefaultHeight)
 {
     setReplacedOrInlineBlock(true);
@@ -73,7 +73,7 @@ RenderReplaced::RenderReplaced(Type type, Element& element, RenderStyle&& style)
 }
 
 RenderReplaced::RenderReplaced(Type type, Element& element, RenderStyle&& style, const LayoutSize& intrinsicSize)
-    : RenderBox(type, element, WTFMove(style), RenderReplacedFlag)
+    : RenderBox(type, element, WTFMove(style), RenderElementType::RenderReplacedFlag)
     , m_intrinsicSize(intrinsicSize)
 {
     setReplacedOrInlineBlock(true);
@@ -81,7 +81,7 @@ RenderReplaced::RenderReplaced(Type type, Element& element, RenderStyle&& style,
 }
 
 RenderReplaced::RenderReplaced(Type type, Document& document, RenderStyle&& style, const LayoutSize& intrinsicSize)
-    : RenderBox(type, document, WTFMove(style), RenderReplacedFlag)
+    : RenderBox(type, document, WTFMove(style), RenderElementType::RenderReplacedFlag)
     , m_intrinsicSize(intrinsicSize)
 {
     setReplacedOrInlineBlock(true);

--- a/Source/WebCore/rendering/RenderReplica.cpp
+++ b/Source/WebCore/rendering/RenderReplica.cpp
@@ -40,7 +40,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderReplica);
 
 RenderReplica::RenderReplica(Document& document, RenderStyle&& style)
-    : RenderBox(Type::Replica, document, WTFMove(style), 0)
+    : RenderBox(Type::Replica, document, WTFMove(style), { })
 {
     // This is a hack. Replicas are synthetic, and don't pick up the attributes of the
     // renderers being replicated, so they always report that they are inline, non-replaced.

--- a/Source/WebCore/rendering/RenderScrollbarPart.cpp
+++ b/Source/WebCore/rendering/RenderScrollbarPart.cpp
@@ -41,7 +41,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderScrollbarPart);
 
 RenderScrollbarPart::RenderScrollbarPart(Document& document, RenderStyle&& style, RenderScrollbar* scrollbar, ScrollbarPart part)
-    : RenderBlock(Type::ScrollbarPart, document, WTFMove(style), 0)
+    : RenderBlock(Type::ScrollbarPart, document, WTFMove(style), { })
     , m_scrollbar(scrollbar)
     , m_part(part)
 {

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -68,7 +68,7 @@ using namespace HTMLNames;
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderTable);
 
 RenderTable::RenderTable(Type type, Element& element, RenderStyle&& style)
-    : RenderBlock(type, element, WTFMove(style), 0)
+    : RenderBlock(type, element, WTFMove(style), { })
     , m_columnPos(1, 0)
     , m_currentBorder(nullptr)
     , m_collapsedBordersValid(false)
@@ -88,7 +88,7 @@ RenderTable::RenderTable(Type type, Element& element, RenderStyle&& style)
 }
 
 RenderTable::RenderTable(Type type, Document& document, RenderStyle&& style)
-    : RenderBlock(type, document, WTFMove(style), 0)
+    : RenderBlock(type, document, WTFMove(style), { })
     , m_columnPos(1, 0)
     , m_currentBorder(nullptr)
     , m_collapsedBordersValid(false)

--- a/Source/WebCore/rendering/RenderTableCol.cpp
+++ b/Source/WebCore/rendering/RenderTableCol.cpp
@@ -46,7 +46,7 @@ using namespace HTMLNames;
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderTableCol);
 
 RenderTableCol::RenderTableCol(Element& element, RenderStyle&& style)
-    : RenderBox(Type::TableCol, element, WTFMove(style), 0)
+    : RenderBox(Type::TableCol, element, WTFMove(style), { })
 {
     // init RenderObject attributes
     setInline(true); // our object is not Inline
@@ -55,7 +55,7 @@ RenderTableCol::RenderTableCol(Element& element, RenderStyle&& style)
 }
 
 RenderTableCol::RenderTableCol(Document& document, RenderStyle&& style)
-    : RenderBox(Type::TableCol, document, WTFMove(style), 0)
+    : RenderBox(Type::TableCol, document, WTFMove(style), { })
 {
     setInline(true);
     ASSERT(isRenderTableCol());

--- a/Source/WebCore/rendering/RenderTableRow.cpp
+++ b/Source/WebCore/rendering/RenderTableRow.cpp
@@ -48,7 +48,7 @@ using namespace HTMLNames;
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderTableRow);
 
 RenderTableRow::RenderTableRow(Element& element, RenderStyle&& style)
-    : RenderBox(Type::TableRow, element, WTFMove(style), 0)
+    : RenderBox(Type::TableRow, element, WTFMove(style), { })
     , m_rowIndex(unsetRowIndex)
 {
     setInline(false);
@@ -56,7 +56,7 @@ RenderTableRow::RenderTableRow(Element& element, RenderStyle&& style)
 }
 
 RenderTableRow::RenderTableRow(Document& document, RenderStyle&& style)
-    : RenderBox(Type::TableRow, document, WTFMove(style), 0)
+    : RenderBox(Type::TableRow, document, WTFMove(style), { })
     , m_rowIndex(unsetRowIndex)
 {
     setInline(false);

--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -91,14 +91,14 @@ static inline void updateLogicalHeightForCell(RenderTableSection::RowStruct& row
 }
 
 RenderTableSection::RenderTableSection(Element& element, RenderStyle&& style)
-    : RenderBox(Type::TableSection, element, WTFMove(style), 0)
+    : RenderBox(Type::TableSection, element, WTFMove(style), { })
 {
     setInline(false);
     ASSERT(isRenderTableSection());
 }
 
 RenderTableSection::RenderTableSection(Document& document, RenderStyle&& style)
-    : RenderBox(Type::TableSection, document, WTFMove(style), 0)
+    : RenderBox(Type::TableSection, document, WTFMove(style), { })
 {
     setInline(false);
     ASSERT(isRenderTableSection());

--- a/Source/WebCore/rendering/RenderTextControl.cpp
+++ b/Source/WebCore/rendering/RenderTextControl.cpp
@@ -44,7 +44,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderTextControl);
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderTextControlInnerContainer);
 
 RenderTextControl::RenderTextControl(Type type, HTMLTextFormControlElement& element, RenderStyle&& style)
-    : RenderBlockFlow(type, element, WTFMove(style), RenderTextControlFlag)
+    : RenderBlockFlow(type, element, WTFMove(style), RenderElementType::RenderTextControlFlag)
 {
     ASSERT(isRenderTextControl());
 }

--- a/Source/WebCore/rendering/mathml/RenderMathMLBlock.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLBlock.cpp
@@ -52,14 +52,14 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderMathMLBlock);
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderMathMLTable);
 
 RenderMathMLBlock::RenderMathMLBlock(Type type, MathMLPresentationElement& container, RenderStyle&& style)
-    : RenderBlock(type, container, WTFMove(style), 0)
+    : RenderBlock(type, container, WTFMove(style), { })
     , m_mathMLStyle(MathMLStyle::create())
 {
     setChildrenInline(false); // All of our children must be block-level.
 }
 
 RenderMathMLBlock::RenderMathMLBlock(Type type, Document& document, RenderStyle&& style)
-    : RenderBlock(type, document, WTFMove(style), 0)
+    : RenderBlock(type, document, WTFMove(style), { })
     , m_mathMLStyle(MathMLStyle::create())
 {
     setChildrenInline(false); // All of our children must be block-level.

--- a/Source/WebCore/rendering/svg/RenderSVGGradientStop.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGGradientStop.cpp
@@ -38,7 +38,7 @@ using namespace SVGNames;
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGGradientStop);
 
 RenderSVGGradientStop::RenderSVGGradientStop(SVGStopElement& element, RenderStyle&& style)
-    : RenderElement(Type::SVGGradientStop, element, WTFMove(style), 0)
+    : RenderElement(Type::SVGGradientStop, element, WTFMove(style), { })
 {
     ASSERT(isRenderSVGGradientStop());
 }

--- a/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
@@ -56,12 +56,12 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGModelObject);
 
 RenderSVGModelObject::RenderSVGModelObject(Type type, Document& document, RenderStyle&& style)
-    : RenderLayerModelObject(type, document, WTFMove(style), 0)
+    : RenderLayerModelObject(type, document, WTFMove(style), { })
 {
 }
 
 RenderSVGModelObject::RenderSVGModelObject(Type type, SVGElement& element, RenderStyle&& style)
-    : RenderLayerModelObject(type, element, WTFMove(style), 0)
+    : RenderLayerModelObject(type, element, WTFMove(style), { })
 {
 }
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
@@ -47,7 +47,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(LegacyRenderSVGModelObject);
 
 LegacyRenderSVGModelObject::LegacyRenderSVGModelObject(Type type, SVGElement& element, RenderStyle&& style)
-    : RenderElement(type, element, WTFMove(style), 0)
+    : RenderElement(type, element, WTFMove(style), { })
 {
 }
 


### PR DESCRIPTION
#### 45bb9b8ab9d2b4e9ec0039b88002a5adcc721f8c
<pre>
Replace RenderElement::BaseTypeFlags with an enum class
<a href="https://bugs.webkit.org/show_bug.cgi?id=266504">https://bugs.webkit.org/show_bug.cgi?id=266504</a>

Reviewed by Simon Fraser.

Replaced BaseTypeFlags enum with RenderElementType enum class.

* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::RenderBlock):
* Source/WebCore/rendering/RenderBlock.h:
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::RenderBlockFlow):
* Source/WebCore/rendering/RenderBlockFlow.h:
(WebCore::RenderBlockFlow::RenderBlockFlow):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::RenderBox):
* Source/WebCore/rendering/RenderBox.h:
* Source/WebCore/rendering/RenderBoxModelObject.cpp:
(WebCore::RenderBoxModelObject::RenderBoxModelObject):
* Source/WebCore/rendering/RenderBoxModelObject.h:
* Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp:
(WebCore::RenderDeprecatedFlexibleBox::RenderDeprecatedFlexibleBox):
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::RenderElement):
* Source/WebCore/rendering/RenderElement.h:
(WebCore::RenderElement::typeFlags const):
(WebCore::RenderElement::isRenderLayerModelObject const):
(WebCore::RenderElement::isRenderBoxModelObject const):
(WebCore::RenderElement::isRenderBlock const):
(WebCore::RenderElement::isRenderBlockFlow const):
(WebCore::RenderElement::isRenderReplaced const):
(WebCore::RenderElement::isRenderInline const):
(WebCore::RenderElement::isRenderFlexibleBox const):
(WebCore::RenderElement::isRenderTextControl const):
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::RenderFlexibleBox):
* Source/WebCore/rendering/RenderFrameSet.cpp:
(WebCore::RenderFrameSet::RenderFrameSet):
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::RenderGrid):
* Source/WebCore/rendering/RenderInline.cpp:
(WebCore::RenderInline::RenderInline):
* Source/WebCore/rendering/RenderLayerModelObject.cpp:
(WebCore::RenderLayerModelObject::RenderLayerModelObject):
* Source/WebCore/rendering/RenderLayerModelObject.h:
* Source/WebCore/rendering/RenderLineBreak.cpp:
(WebCore::RenderLineBreak::RenderLineBreak):
* Source/WebCore/rendering/RenderListMarker.cpp:
(WebCore::RenderListMarker::RenderListMarker):
* Source/WebCore/rendering/RenderMultiColumnSpannerPlaceholder.cpp:
(WebCore::RenderMultiColumnSpannerPlaceholder::RenderMultiColumnSpannerPlaceholder):
* Source/WebCore/rendering/RenderReplaced.cpp:
(WebCore::RenderReplaced::RenderReplaced):
* Source/WebCore/rendering/RenderReplica.cpp:
(WebCore::RenderReplica::RenderReplica):
* Source/WebCore/rendering/RenderScrollbarPart.cpp:
(WebCore::RenderScrollbarPart::RenderScrollbarPart):
* Source/WebCore/rendering/RenderTable.cpp:
(WebCore::RenderTable::RenderTable):
* Source/WebCore/rendering/RenderTableCol.cpp:
(WebCore::RenderTableCol::RenderTableCol):
* Source/WebCore/rendering/RenderTableRow.cpp:
(WebCore::RenderTableRow::RenderTableRow):
* Source/WebCore/rendering/RenderTableSection.cpp:
(WebCore::RenderTableSection::RenderTableSection):
* Source/WebCore/rendering/RenderTextControl.cpp:
(WebCore::RenderTextControl::RenderTextControl):
* Source/WebCore/rendering/mathml/RenderMathMLBlock.cpp:
(WebCore::RenderMathMLBlock::RenderMathMLBlock):
* Source/WebCore/rendering/svg/RenderSVGGradientStop.cpp:
(WebCore::RenderSVGGradientStop::RenderSVGGradientStop):
* Source/WebCore/rendering/svg/RenderSVGModelObject.cpp:
(WebCore::RenderSVGModelObject::RenderSVGModelObject):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp:
(WebCore::LegacyRenderSVGModelObject::LegacyRenderSVGModelObject):

Canonical link: <a href="https://commits.webkit.org/272166@main">https://commits.webkit.org/272166@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92d4baadd8d83928bea5f8e681c0d9a8fa63f200

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30738 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9417 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32405 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33233 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27782 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31458 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11720 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6672 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27663 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31051 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7905 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27507 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6777 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6929 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27383 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34570 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27978 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27865 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33091 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6967 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5059 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30923 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8684 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7685 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3990 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7522 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->