### PR TITLE
[JSC] Wrong B3 range analysis on 64-bit values

### DIFF
--- a/LayoutTests/http/tests/security/isolate-geolocation-watch-id-per-document-expected.txt
+++ b/LayoutTests/http/tests/security/isolate-geolocation-watch-id-per-document-expected.txt
@@ -1,0 +1,15 @@
+Tests that when the website's data is cleared, the watchID is reset, too.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS watchID should increment for every request: 2 vs 2
+PASS Success callback 1 invoked
+PASS Success callback 2 invoked
+PASS Every Document should get its own watchID counter: 1 vs 1
+PASS Every Document should get its own watchID counter: 1 vs 1
+PASS Every Document should get its own watchID counter: 1 vs 1
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/security/isolate-geolocation-watch-id-per-document.html
+++ b/LayoutTests/http/tests/security/isolate-geolocation-watch-id-per-document.html
@@ -1,0 +1,72 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../../resources/js-test-pre.js"></script>
+</head>
+<body>
+<script>
+description("Tests that when the website's data is cleared, the watchID is reset, too.");
+
+function initGeolocation() {
+    if (window.testRunner) {
+        testRunner.setGeolocationPermission(true);
+        testRunner.setMockGeolocationPosition(51.478, -0.166, 100);
+    }
+}
+
+// watchId is 1-indexed, so we initialize index 0 as true
+let watchPositionsSuccessful = [ true, false, false ];
+let popup;
+let popupCount = 0;
+
+const iframeResource = "resources/popup-watchid.html";
+
+let i = 0;
+
+function maybeOpenPopup() {
+    if (watchPositionsSuccessful.every((success) => success))
+        popup = window.open(iframeResource);
+}
+
+function getWatchPosition(i) {
+    return navigator.geolocation.watchPosition(function() {
+        testPassed(`Success callback ${i} invoked`);
+        watchPositionsSuccessful[i] = true;
+        maybeOpenPopup();
+    }, function(err) {
+        testFailed(`Error callback ${i} invoked unexpectedly`);
+        finishJSTest();
+    });
+}
+
+initGeolocation();
+
+let watchId1 = getWatchPosition(++i);
+let watchId2 = getWatchPosition(++i);
+expectTrue(watchId2 == 2, `watchID should increment for every request: ${watchId2} vs 2`);
+
+window.addEventListener("message", (e) => {
+    expectTrue(e.data == 1, `Every Document should get its own watchID counter: ${e.data} vs 1`);
+    popup.close();
+    switch (popupCount) {
+    case 0: {
+        popup = window.open(iframeResource);
+        break;
+    }
+    case 1: {
+        popup = window.open(`http://localhost:8000/security/${iframeResource}`);
+        break;
+    }
+    case 2: {
+        finishJSTest();
+        break;
+    }
+    }
+    popupCount++;
+});
+
+window.jsTestIsAsync = true;
+</script>
+<script src="../../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/http/tests/security/resources/popup-watchid.html
+++ b/LayoutTests/http/tests/security/resources/popup-watchid.html
@@ -1,0 +1,11 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<body>
+<script>
+if (window.testRunner)
+    testRunner.setGeolocationPermission(false);
+let watchID = navigator.geolocation.watchPosition(function() { });
+window.opener.postMessage(watchID, "*");
+</script>
+</body>
+</html>

--- a/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
+++ b/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
@@ -133,10 +133,12 @@ public:
     template<typename T>
     static IntRange rangeForMask(T mask)
     {
-        if (!(mask + 1))
+        if (mask == static_cast<T>(-1))
             return top<T>();
-        if (mask < 0)
-            return IntRange(INT_MIN & mask, mask & INT_MAX);
+        if constexpr (std::is_signed_v<T>) {
+            if (mask < 0)
+                return IntRange(std::numeric_limits<T>::min() & mask, mask & std::numeric_limits<T>::max());
+        }
         return IntRange(0, mask);
     }
 

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -879,6 +879,7 @@ void testCheckAddImmCommute();
 void testCheckAddImmSomeRegister();
 void testCheckAdd();
 void testCheckAdd64();
+void testCheckAdd64Range();
 void testCheckAddFold(int, int);
 void testCheckAddFoldFail(int, int);
 void test42();

--- a/Source/JavaScriptCore/b3/testb3_1.cpp
+++ b/Source/JavaScriptCore/b3/testb3_1.cpp
@@ -499,6 +499,7 @@ void run(const TestConfig* config)
     RUN(testCheckAddImmSomeRegister());
     RUN(testCheckAdd());
     RUN(testCheckAdd64());
+    RUN(testCheckAdd64Range());
     RUN(testCheckAddFold(100, 200));
     RUN(testCheckAddFoldFail(2147483647, 100));
     RUN(testCheckAddArgumentAliasing64());

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -2159,6 +2159,9 @@ static RenderObject* rendererForView(WAKView* view)
 
 - (void)_accessibilitySetFocus:(BOOL)focus
 {
+    if (![self _prepareAccessibilityCall])
+        return;
+
     if (auto* backingObject = self.axBackingObject)
         backingObject->setFocused(focus);
 }

--- a/Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.cpp
+++ b/Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.cpp
@@ -523,7 +523,7 @@ void CDMInstanceSessionClearKey::loadSession(LicenseType, const String& sessionI
 {
     ASSERT_UNUSED(sessionId, sessionId == m_sessionID);
     KeyStatusVector keyStatusVector = m_keyStore.convertToJSKeyStatusVector();
-    callOnMainThread([weakThis = WeakPtr { *this }, callback = WTFMove(callback), &keyStatusVector]() mutable {
+    callOnMainThread([weakThis = WeakPtr { *this }, callback = WTFMove(callback), keyStatusVector = WTFMove(keyStatusVector)]() mutable {
         if (!weakThis)
             return;
 


### PR DESCRIPTION
#### 7736ce7fe69a564cac39dd0c2020a0a9d3416a3c
<pre>
[JSC] Wrong B3 range analysis on 64-bit values
<a href="https://bugs.webkit.org/show_bug.cgi?id=262224">https://bugs.webkit.org/show_bug.cgi?id=262224</a>
<a href="https://rdar.apple.com/115897433">rdar://115897433</a>

Reviewed by Mark Lam.

This patch fixes B3&apos;s range analysis. When using 64bit value, we should use INT64_MIN / INT64_MAX instead of INT_MIN / INT_MAX.
We use std::numeric_limits to make it work. We also adjust `+ 1` check to avoid potential UB.

* Source/JavaScriptCore/b3/B3ReduceStrength.cpp:
* Source/JavaScriptCore/b3/testb3.h:
* Source/JavaScriptCore/b3/testb3_1.cpp:
(run):
* Source/JavaScriptCore/b3/testb3_5.cpp:
(testCheckAdd64Range):

Originally-landed-as: 267815.118@safari-7617-branch (3e7f362d98b7). <a href="https://rdar.apple.com/119594339">rdar://119594339</a>
Canonical link: <a href="https://commits.webkit.org/272223@main">https://commits.webkit.org/272223@main</a>
</pre>
----------------------------------------------------------------------
#### a0e24518e376536852236303ca67e26f706eb249
<pre>
Fix bad capture by reference in CDMInstanceSessionClearKey::loadSession()
<a href="https://bugs.webkit.org/show_bug.cgi?id=263254">https://bugs.webkit.org/show_bug.cgi?id=263254</a>
<a href="https://rdar.apple.com/117061886">rdar://117061886</a>

Reviewed by Brent Fulgham.

Fix bad capture by reference in an asynchronous callback in CDMInstanceSessionClearKey::loadSession().

* Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.cpp:
(WebCore::CDMInstanceSessionClearKey::loadSession):

Originally-landed-as: 267815.314@safari-7617-branch (80d2fe008437). <a href="https://rdar.apple.com/119595029">rdar://119595029</a>
Canonical link: <a href="https://commits.webkit.org/272222@main">https://commits.webkit.org/272222@main</a>
</pre>
----------------------------------------------------------------------
#### 9c58e7a622e8b97a50654fe6404562614e38dca8
<pre>
-[WebAccessibilityObjectWrapperIOS _accessibilitySetFocus] needs to take the WebThreadLock
<a href="https://rdar.apple.com/116882220">rdar://116882220</a>

Reviewed by Ryosuke Niwa.

Use -[WebAccessibilityObjectWrapperIOS _prepareAccessibilityCall] to
ensure the WebThreadLock is taken before running this function.

* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityObjectWrapper _accessibilitySetFocus:]):

Originally-landed-as: 267815.307@safari-7617-branch (fdc510244825). <a href="https://rdar.apple.com/119595084">rdar://119595084</a>
Canonical link: <a href="https://commits.webkit.org/272221@main">https://commits.webkit.org/272221@main</a>
</pre>
----------------------------------------------------------------------
#### 6f33895ab672a2532b6f679301fb2c1d54aa635d
<pre>
Add test for Geolocation WatchID
<a href="https://bugs.webkit.org/show_bug.cgi?id=263277">https://bugs.webkit.org/show_bug.cgi?id=263277</a>
<a href="https://rdar.apple.com/8731258">rdar://8731258</a>

Reviewed by David Kilzer.

Add a test that confirms the Geolocation WatchID is unique per document.

* LayoutTests/http/tests/security/isolate-geolocation-watch-id-per-document-expected.txt: Added.
* LayoutTests/http/tests/security/isolate-geolocation-watch-id-per-document.html: Added.
* LayoutTests/http/tests/security/resources/popup-watchid.html: Added.

Originally-landed-as: 267815.490@safari-7617-branch (837e69390e41). <a href="https://rdar.apple.com/119595145">rdar://119595145</a>
Canonical link: <a href="https://commits.webkit.org/272220@main">https://commits.webkit.org/272220@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5747a79b645b2ac6eb2bc2097ec5e07653db9ad8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30744 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9422 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32411 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33239 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27785 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31465 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11726 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6675 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27666 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31057 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7910 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27512 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6781 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6933 "Found 10 new test failures: imported/w3c/web-platform-tests/css/css-cascade/scope-hover.html, imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-below-viewport-partially-onscreen-new.html, imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-below-viewport-partially-onscreen-old.html, imported/w3c/web-platform-tests/css/selectors/invalidation/user-valid-user-invalid.html, imported/w3c/web-platform-tests/css/selectors/user-invalid.html, imported/w3c/web-platform-tests/css/selectors/valid-invalid-form-fieldset.html, imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch.tentative.html, imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative.html, imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/readwrite-readonly.html, imported/w3c/web-platform-tests/webrtc-extensions/RTCRtpSynchronizationSource-senderCaptureTimeOffset.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27388 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34576 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/26407 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27983 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27870 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33093 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/30839 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6971 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5064 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30925 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8688 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/27170 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/37280 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7688 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7999 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4018 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7526 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->