### PR TITLE
Array iterator creation intrinsics need ToThis

### DIFF
--- a/JSTests/stress/ClassInfo-across-structure-transition.js
+++ b/JSTests/stress/ClassInfo-across-structure-transition.js
@@ -1,0 +1,11 @@
+//@ runDefault("--useDollarVM=1", "--jitPolicyScale=0.01")
+var createDOMJITCheckJSCastObject = $vm.createDOMJITCheckJSCastObject;
+
+function calling(obj)
+{
+    return obj.func();
+}
+noInline(calling);
+
+for (var i = 0; i < 1e5; ++i)
+    calling(createDOMJITCheckJSCastObject());

--- a/JSTests/stress/array-iterator-to-this.js
+++ b/JSTests/stress/array-iterator-to-this.js
@@ -1,0 +1,27 @@
+function opt(f, length = 5) {
+    (function () {
+        f;
+        length;
+    })();
+
+    return f();
+}
+
+function main() {
+    opt(function () {});
+
+    for (let i = 0; i < 10000; i++) {
+        let threw = false;
+        try {
+            const iterator = opt(Array.prototype.keys);
+            print([...iterator]);
+        } catch {
+            threw = true;
+        }
+
+        if (!threw)
+            throw new Error();
+    }
+}
+
+main();

--- a/LayoutTests/fast/dom/HTMLObjectElement/updateWidget-crash-expected.txt
+++ b/LayoutTests/fast/dom/HTMLObjectElement/updateWidget-crash-expected.txt
@@ -1,0 +1,3 @@
+This test passes if it doesn't crash
+
+

--- a/LayoutTests/fast/dom/HTMLObjectElement/updateWidget-crash.html
+++ b/LayoutTests/fast/dom/HTMLObjectElement/updateWidget-crash.html
@@ -1,0 +1,17 @@
+<body>
+<p>This test passes if it doesn't crash</p>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+onload = () => {
+    let firstObject = document.getElementById("firstObject");
+    let secondObject = document.getElementById("secondObject");
+    secondObject.data = "x";
+    let secondObjectDocument = secondObject.contentDocument;
+    secondObject.align = "left";
+    secondObjectDocument.adoptNode(firstObject);
+    firstObject.reportValidity();
+}
+</script>
+<object id="firstObject"></object>
+<object id="secondObject"></object>

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -2586,9 +2586,10 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
             // Add the constant before exit becomes invalid because we may want to insert (redundant) checks on it in Fixup.
             Node* kindNode = jsConstant(jsNumber(static_cast<uint32_t>(*kind)));
 
+            Node* thisValue = addToGraph(ToThis, OpInfo(ECMAMode::strict()), OpInfo(getPrediction()), get(virtualRegisterForArgumentIncludingThis(0, registerOffset)));
             // We don't have an existing error string.
             unsigned errorStringIndex = UINT32_MAX;
-            Node* object = addToGraph(ToObject, OpInfo(errorStringIndex), OpInfo(SpecNone), get(virtualRegisterForArgumentIncludingThis(0, registerOffset)));
+            Node* object = addToGraph(ToObject, OpInfo(errorStringIndex), OpInfo(SpecNone), thisValue);
 
             Node* iterator = addToGraph(NewInternalFieldObject, OpInfo(m_graph.registerStructure(globalObject->arrayIteratorStructure())));
 

--- a/Source/JavaScriptCore/dfg/DFGClobbersExitState.cpp
+++ b/Source/JavaScriptCore/dfg/DFGClobbersExitState.cpp
@@ -112,11 +112,11 @@ bool clobbersExitState(Graph& graph, Node* node)
         clobberize(
             graph, node, NoOpClobberize(),
             [&] (const AbstractHeap& heap) {
-                // There shouldn't be such a thing as a strict subtype of SideState. That's what allows
-                // us to use a fast != check, below.
-                ASSERT(!heap.isStrictSubtypeOf(SideState));
+                // There shouldn't be such a thing as a strict subtype of SideState or HeapObjectCount.
+                // That's what allows us to use a fast != check, below.
+                ASSERT(!heap.isStrictSubtypeOf(SideState) && !heap.isStrictSubtypeOf(HeapObjectCount));
 
-                if (heap != SideState)
+                if (heap != SideState && heap != HeapObjectCount)
                     result = true;
             },
             NoOpClobberize());

--- a/Source/ThirdParty/ANGLE/src/libANGLE/Context.cpp
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/Context.cpp
@@ -892,6 +892,7 @@ egl::Error Context::onDestroy(const egl::Display *display)
 
     releaseShaderCompiler();
 
+    mState.ensureNoPendingLink(this);
     mState.reset(this);
 
     releaseSharedObjects();


### PR DESCRIPTION
#### ecb7da686a5066eea209b6f4b2b6dcddbd0d551f
<pre>
Array iterator creation intrinsics need ToThis
<a href="https://bugs.webkit.org/show_bug.cgi?id=263408">https://bugs.webkit.org/show_bug.cgi?id=263408</a>
<a href="https://rdar.apple.com/113898245">rdar://113898245</a>

Reviewed by Yusuke Suzuki.

Currently, we don&apos;t ToThis the &apos;this&apos; value when we intrinsicify
the various Array iterator creation functions, which we should.
This patch also changes `clobbersExitState` to say exit state
is not clobbered if a node only writes to `HeapObjectCount`.
Our previous behavior was overly conservative, which caused
assertion failures as the `ToObject` following the `ToThis`
would get converted to a `Check(Object)` when exit was invalid.

* JSTests/stress/array-iterator-to-this.js: Added.
(opt):
(main):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
* Source/JavaScriptCore/dfg/DFGClobbersExitState.cpp:
(JSC::DFG::clobbersExitState):

Originally-landed-as: 267815.357@safari-7617-branch (ae764a813e03). <a href="https://rdar.apple.com/119597428">rdar://119597428</a>
Canonical link: <a href="https://commits.webkit.org/272163@main">https://commits.webkit.org/272163@main</a>
</pre>
----------------------------------------------------------------------
#### 7b97f35198fd00c74cd21c039e4e56c9f5a1876f
<pre>
[ANGLE] Clear pending program linking in Context::onDestroy
<a href="https://rdar.apple.com/116661298">rdar://116661298</a>

Reviewed by Kimmo Kinnunen.

When destroying Context, ANGLE resets any internal state before releasing
allocated objects, such as Programs and Shaders. When destroying a program, any
pending program linking is resolved via Program::resolveLink. This results in
trying to access the Context state that’s just been reset, leading to a nullptr
access.

To work around this, we ensure there are no pending links before resetting the
Context state.

* Source/ThirdParty/ANGLE/src/libANGLE/Context.cpp:
(gl::Context::onDestroy):
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/TestGraphicsContextGLCocoa.mm:
(TestWebKitAPI::TEST_F):

Originally-landed-as: 267815.356@safari-7617-branch (d32cd290f021). <a href="https://rdar.apple.com/119597554">rdar://119597554</a>
Canonical link: <a href="https://commits.webkit.org/272162@main">https://commits.webkit.org/272162@main</a>
</pre>
----------------------------------------------------------------------
#### b600073ca93043073733879f37051cec72c99811
<pre>
Assertion hit under Document::dispatchPagehideEvent()
<a href="https://bugs.webkit.org/show_bug.cgi?id=263204">https://bugs.webkit.org/show_bug.cgi?id=263204</a>
<a href="https://rdar.apple.com/116715579">rdar://116715579</a>

Reviewed by Ryosuke Niwa.

Delay the load if we&apos;re not allowed to run script right now. Scheduling a load will
cancel / stop any pending load, which may cause events to be fired and script to run.

The synchronous code path is kept when we&apos;re allowed to run script to avoid breaking
tests such as:
- imported/w3c/web-platform-tests/css/css-writing-modes/abs-pos-non-replaced-icb-vlr-*.xht
- imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/sandbox_004.htm
- imported/blink/svg/dom/viewspec-*.html
- fast/css/acid2.html

* LayoutTests/fast/dom/HTMLObjectElement/updateWidget-crash-expected.txt: Added.
* LayoutTests/fast/dom/HTMLObjectElement/updateWidget-crash.html: Added.
* Source/WebCore/html/HTMLPlugInImageElement.cpp:
(WebCore::HTMLPlugInImageElement::requestObject):

Originally-landed-as: 267815.354@safari-7617-branch (c34793cc5793). <a href="https://rdar.apple.com/119597568">rdar://119597568</a>
Canonical link: <a href="https://commits.webkit.org/272161@main">https://commits.webkit.org/272161@main</a>
</pre>
----------------------------------------------------------------------
#### c0ddab9c4c8f0b03d9f1f471c3883b1fd95eb7a7
<pre>
Load compact ClassInfo from structure correctly in FTL
<a href="https://bugs.webkit.org/show_bug.cgi?id=263356">https://bugs.webkit.org/show_bug.cgi?id=263356</a>
<a href="https://rdar.apple.com/115494572">rdar://115494572</a>

Reviewed by Mark Lam.

Currently, FTL assumes loading the m_classInfo from a structure is a
loadPtr on all platforms - this is not the case, since ClassInfo is
represented as a 32-bit CompactPtr&lt;ClassInfo&gt; on platforms with 36-bit
addresses. As a result, when loading the ClassInfo in some FTL nodes, it
results in a junk value with the lower bits being the unshifted ClassInfo
address, and the upper bits being taken erroneously from
m_transitionPropertyName. This patch introduces a new loadCompactPtr()
helper to FTLLowerDFGToB3 that correctly loads and shifts compact pointer
fields, which in current FTL is just Structure.m_classInfo.

* JSTests/stress/ClassInfo-across-structure-transition.js: Added.
(calling):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCreatePromise):
(JSC::FTL::DFG::LowerDFGToB3::compileCreateInternalFieldObject):
(JSC::FTL::DFG::LowerDFGToB3::compileFunctionToString):
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):

Originally-landed-as: 267815.353@safari-7617-branch (20234c667f25). <a href="https://rdar.apple.com/119597685">rdar://119597685</a>
Canonical link: <a href="https://commits.webkit.org/272160@main">https://commits.webkit.org/272160@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ec78d512c7b3391bb02211e3fc6a6563bf786d3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30748 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9426 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32415 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33243 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27787 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31480 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11730 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6677 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27668 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31061 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7912 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27511 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6784 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6935 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27387 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34580 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/26409 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27985 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27869 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33096 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/30841 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6973 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5065 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30928 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8690 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/27169 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/37283 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7280 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7690 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8000 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7528 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->