### PR TITLE
[JSC] DFG might force a local to be double even if we store non-numeric values into it

### DIFF
--- a/JSTests/stress/double-inlined-call-argument.js
+++ b/JSTests/stress/double-inlined-call-argument.js
@@ -1,0 +1,22 @@
+function foo(a, b, c, p) {
+    a = b + c;
+    if (p) {
+        a++;
+        return a;
+    }
+}
+
+function bar(a, b) {
+    return foo("hello", a, b, a <= b);
+}
+
+noInline(bar);
+
+for (var i = 0; i < 100000; ++i) {
+    var result = bar(2000000000, 2000000000.5);
+    if (result != 4000000001.5)
+        throw new Error(`Bad result: ${result}!`);
+}
+
+if (reoptimizationRetryCount(bar) != 0)
+    throw new Error(`Should not have reoptimized bar, but reoptimized ${reoptimizationRetryCount(bar)} times.`);

--- a/JSTests/stress/regress-116397731.js
+++ b/JSTests/stress/regress-116397731.js
@@ -1,0 +1,16 @@
+var out;
+
+function func0(value) {
+  if (value) {}
+  out = value;
+  value = value + 1 + 2;
+}
+
+function main() {
+  for (let i = 0; i < 0x100000; i++)
+    func0(undefined);
+  if (out !== undefined)
+    throw new Error(`Bad value: ${out}!`);
+}
+
+main();

--- a/Source/JavaScriptCore/dfg/DFGVariableAccessData.cpp
+++ b/Source/JavaScriptCore/dfg/DFGVariableAccessData.cpp
@@ -131,7 +131,7 @@ bool VariableAccessData::tallyVotesForShouldUseDoubleFormat()
     if (!newValueOfShouldUseDoubleFormat) {
         // We monotonically convert to double. Hence, if the fixpoint leads us to conclude that we should
         // switch back to int, we instead ignore this and stick with double.
-        return false;
+        return DFG::mergeDoubleFormatState(m_doubleFormatState, NotUsingDoubleFormat);
     }
         
     if (m_doubleFormatState == UsingDoubleFormat)


### PR DESCRIPTION
#### bf2f05e02c8a12f6b716ea8bc21e62852d8493ac
<pre>
[JSC] DFG might force a local to be double even if we store non-numeric values into it
<a href="https://bugs.webkit.org/show_bug.cgi?id=263090">https://bugs.webkit.org/show_bug.cgi?id=263090</a>
&lt;<a href="https://rdar.apple.com/116397731">rdar://116397731</a>&gt;

Reviewed by Keith Miller.

This changes fixes tallyVotesForShouldUseDoubleFormat() to set NotUsingDoubleFormat if the variable
is no longer predicted to hold only doubles.

* JSTests/stress/double-inlined-call-argument.js: Added.
* JSTests/stress/regress-116397731.js: Added.
* Source/JavaScriptCore/dfg/DFGVariableAccessData.cpp:
(JSC::DFG::VariableAccessData::tallyVotesForShouldUseDoubleFormat):

Originally-landed-as: 267815.352@safari-7617-branch (11987a2c00bf). <a href="https://rdar.apple.com/119597752">rdar://119597752</a>
Canonical link: <a href="https://commits.webkit.org/272168@main">https://commits.webkit.org/272168@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc5a2abdebf4fa01feb9619475b7d3a36f01cdd8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30752 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9430 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32419 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33247 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27788 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11734 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6679 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27669 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31065 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7913 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27540 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6785 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6936 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27416 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34584 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/26411 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27986 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27897 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33097 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/30845 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6975 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5067 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30929 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8692 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/37287 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7283 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7692 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8001 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7530 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->