### PR TITLE
[CSS] Don't crash when trying to insert namespace rule after layer rule

### DIFF
--- a/LayoutTests/fast/css/insertrule-namespace-after-layer-expected.txt
+++ b/LayoutTests/fast/css/insertrule-namespace-after-layer-expected.txt
@@ -1,0 +1,2 @@
+CONSOLE MESSAGE: HierarchyRequestError: The operation would yield an incorrect node tree.
+Test passes if doesn't crash

--- a/LayoutTests/fast/css/insertrule-namespace-after-layer.html
+++ b/LayoutTests/fast/css/insertrule-namespace-after-layer.html
@@ -1,0 +1,12 @@
+<style>
+    @layer x;
+</style>
+<script>
+if(window.testRunner)
+  testRunner.dumpAsText();
+
+onload = () => {
+  console.log(document.styleSheets[0].insertRule(`@namespace url();`, 1));
+};
+</script>
+Test passes if doesn't crash

--- a/Source/WebCore/css/StyleSheetContents.cpp
+++ b/Source/WebCore/css/StyleSheetContents.cpp
@@ -301,7 +301,7 @@ bool StyleSheetContents::wrapperInsertRule(Ref<StyleRuleBase>&& rule, unsigned i
             return false;
         // Inserting @namespace rule when rules other than import/namespace/charset
         // are present is not allowed.
-        if (!m_childRules.isEmpty())
+        if (!m_childRules.isEmpty() || !m_layerRulesBeforeImportRules.isEmpty())
             return false;
 
         m_namespaceRules.insert(index, *namespaceRule);


### PR DESCRIPTION
#### 334b3cb1ae81c30f5a72dccad4c7f019df15e321
<pre>
[CSS] Don&apos;t crash when trying to insert namespace rule after layer rule
<a href="https://rdar.apple.com/117071899">rdar://117071899</a>

Reviewed by Antti Koivisto.

By spec, namespace rule can&apos;t be inserted after a layer rule.

<a href="https://drafts.csswg.org/css-namespaces/#syntax">https://drafts.csswg.org/css-namespaces/#syntax</a>

* LayoutTests/fast/css/insertrule-namespace-after-layer-expected.txt: Added.
* LayoutTests/fast/css/insertrule-namespace-after-layer.html: Added.
* Source/WebCore/css/StyleSheetContents.cpp:
(WebCore::StyleSheetContents::wrapperInsertRule):

Originally-landed-as: 267815.351@safari-7617-branch (cf04124d9563). <a href="https://rdar.apple.com/119597833">rdar://119597833</a>
Canonical link: <a href="https://commits.webkit.org/272170@main">https://commits.webkit.org/272170@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52ecd51e1806068d1b5f482ec3053361a4eef658

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30754 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9432 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32421 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33249 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27790 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31486 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11736 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6681 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27671 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31067 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7938 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27514 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6788 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6959 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27390 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34586 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28011 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27881 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33099 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6977 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5066 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30931 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8694 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/27172 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7284 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7694 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7532 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->