### PR TITLE
rdar://115842409 (jsc_fuz/wktr: ASSERTION FAILED: is<Target>(source) &WTF::downcast(Source &) [Target = WebCore::CSSValuePair, Source = const WebCore::CSSValue] at StyleBuilderConverter.h:1632)

### DIFF
--- a/LayoutTests/fast/css/font-size-adjust-invalid-value-type-expected.txt
+++ b/LayoutTests/fast/css/font-size-adjust-invalid-value-type-expected.txt
@@ -1,0 +1,1 @@
+This test should not crash

--- a/LayoutTests/fast/css/font-size-adjust-invalid-value-type.html
+++ b/LayoutTests/fast/css/font-size-adjust-invalid-value-type.html
@@ -1,0 +1,8 @@
+<script>
+  if (window.testRunner)
+      testRunner.dumpAsText();
+  onload = () => {
+    document.body.attributeStyleMap.append('font-size-adjust', new CSSMathMin(0));
+  };
+</script>
+<div>This test should not crash</div>

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -1629,7 +1629,9 @@ inline FontSizeAdjust BuilderConverter::convertFontSizeAdjust(BuilderState&, con
         return { defaultMetric, FontSizeAdjust::ValueType::FromFont, std::nullopt };
     }
 
-    ASSERT(value.isPair());
+    if (!is<CSSValuePair>(value))
+        return FontCascadeDescription::initialFontSizeAdjust();
+
     const auto& pair = downcast<CSSValuePair>(value);
 
     auto metric = fromCSSValueID<FontSizeAdjust::Metric>(downcast<CSSPrimitiveValue>(pair.first()).valueID());


### PR DESCRIPTION
#### 59ecda13ecdbda262ba243715f95756bd4936eae
<pre>
<a href="https://rdar.apple.com/115842409">rdar://115842409</a> (jsc_fuz/wktr: ASSERTION FAILED: is&lt;Target&gt;(source) &amp;WTF::downcast(Source &amp;) [Target = WebCore::CSSValuePair, Source = const WebCore::CSSValue] at StyleBuilderConverter.h:1632)

Checked for an unexpected CSS type for &apos;font-size-adjust&apos; and returns a default value instead of crashing.

Reviewed by anttijk.

This prevents a crash on downcasting when an unexpected `CSSValue` subclass is provided.

Combined changes:
* LayoutTests/fast/css/font-size-adjust-invalid-value-type-expected.txt: Added.
* LayoutTests/fast/css/font-size-adjust-invalid-value-type.html: Added.
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertFontSizeAdjust):

Originally-landed-as: 267815.526@safari-7617-branch (92043c608a1c). <a href="https://rdar.apple.com/119598353">rdar://119598353</a>
Canonical link: <a href="https://commits.webkit.org/272171@main">https://commits.webkit.org/272171@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c10ebb8bd5dcbbb22dee8b610122ad989c15ccb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30760 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9438 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32427 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33255 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27795 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31501 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11742 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6686 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27674 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31073 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7918 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27522 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6791 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6941 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27398 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34592 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27991 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27880 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33103 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6982 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5073 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30935 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8699 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/27180 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7285 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7699 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7537 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->