### PR TITLE
[webkitbugspy] Implement ability to relate issues

### DIFF
--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/issue.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/issue.py
@@ -56,6 +56,7 @@ class Issue(object):
         self.tracker = tracker
         self._original = None
         self._duplicates = None
+        self._related = None
 
         self._link = None
         self._title = None
@@ -140,6 +141,15 @@ class Issue(object):
         if self._duplicates is None:
             self.tracker.populate(self, 'duplicates')
         return self._duplicates
+
+    @property
+    def related(self):
+        if self._related is None:
+            self.tracker.populate(self, 'related')
+        return self._related
+
+    def relate(self, **relations):
+        return self.tracker.relate(self, **relations)
 
     @property
     def assignee(self):

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/bugzilla.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/bugzilla.py
@@ -158,6 +158,15 @@ class Bugzilla(Base, mocks.Requests):
                 issue['component'] = data['component']
             if data.get('version'):
                 issue['version'] = data['version']
+            issue['related'] = {'blocks': [], 'depends_on': [], 'regressions': [], 'regressed_by': []}
+            if data.get('depends_on'):
+                issue['related']['depends_on'] = data['depends_on']
+            if data.get('blocks'):
+                issue['related']['blocks'] = data['blocks']
+            if data.get('regressed_by'):
+                issue['related']['regressed_by'] = data['regressed_by']
+            if data.get('regressions'):
+                issue['related']['regressions'] = data['regressions']
 
             keywords = data.get('keywords', {})
             if keywords:
@@ -208,6 +217,10 @@ class Bugzilla(Base, mocks.Requests):
                 product=issue.get('project'),
                 component=issue.get('component'),
                 version=issue.get('version'),
+                depends_on=issue.get('related')['depends_on'] if issue.get('related') else None,
+                blocks=issue.get('related')['blocks'] if issue.get('related') else None,
+                regressed_by=issue.get('related')['regressed_by'] if issue.get('related') else None,
+                regressions=issue.get('related')['regressions'] if issue.get('related') else None,
                 keywords=issue.get('keywords', []),
                 creator_detail=dict(
                     email=issue['creator'].email,

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tracker.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tracker.py
@@ -164,6 +164,9 @@ class Tracker(object):
                 return self.users.get(key)
         return None
 
+    def issues_to_ids(self, issues):
+        raise NotImplementedError()
+
     @decorators.Memoize()
     def me(self):
         raise NotImplementedError()
@@ -175,6 +178,9 @@ class Tracker(object):
         raise NotImplementedError()
 
     def set(self, issue, **properties):
+        raise NotImplementedError()
+
+    def relate(self, issue, **relations):
         raise NotImplementedError()
 
     def add_comment(self, issue, text):


### PR DESCRIPTION
#### b88a46556b32c790b964a7fd4989979586c3b216
<pre>
[webkitbugspy] Implement ability to relate issues
<a href="https://bugs.webkit.org/show_bug.cgi?id=266432">https://bugs.webkit.org/show_bug.cgi?id=266432</a>
<a href="https://rdar.apple.com/problem/119679931">rdar://problem/119679931</a>

Reviewed by Jonathan Bedard.

Relations from bugs on bugzilla can now be retrieved and set. Radars coming!

* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py:
(Tracker.populate):
(Tracker.relate):
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/issue.py:
(Issue.__init__):
(Issue):
(Issue.related):
(Issue.relate):
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/bugzilla.py:
(Bugzilla._issue):
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py:
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tracker.py:
(Tracker.relate):

Canonical link: <a href="https://commits.webkit.org/272788@main">https://commits.webkit.org/272788@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c3a066c583e827f811275d4ae6ac39c5c9db5595

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33072 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11849 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34981 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35713 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/29874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/34042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/14189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/9016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/29293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33547 "Failed to checkout and rebase branch from PR 21899") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/9979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/29541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/8703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/6/builds/33347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/8852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/29508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/37044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/30042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/29908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/37044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/8995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/6934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/37044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/10695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/9582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4253 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/9635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->