### PR TITLE
WTFCrashWithSecurityImplication in WebCore::RenderFragmentedFlow::removeLineFragmentInfo()

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -3526,6 +3526,7 @@ webkit.org/b/172864 imported/blink/storage/indexeddb/blob-delete-objectstore-db.
 webkit.org/b/187183 http/tests/security/pasteboard-file-url.html [ Skip ]
 
 [ Debug ] fast/multicol/crash-in-vertical-writing-mode.html [ Skip ]
+[ Debug ] fast/multicol/last-set-crash.html [ Skip ]
 
 webkit.org/b/202805 [ Debug ] fast/multicol/fragflow-gains-new-in-flow-descendant-crash.html [ Skip ]
 

--- a/LayoutTests/fast/multicol/last-set-crash-expected.txt
+++ b/LayoutTests/fast/multicol/last-set-crash-expected.txt
@@ -1,0 +1,3 @@
+} This test passes if it doesn't crash.
+
+

--- a/LayoutTests/fast/multicol/last-set-crash.html
+++ b/LayoutTests/fast/multicol/last-set-crash.html
@@ -1,0 +1,27 @@
+<style>
+*:first-of-type { position: fixed; }
+*:first-child { -webkit-column-count: 1; }
+*:nth-last-child(odd) { position: static;}
+*:only-child { perspective: 0.56em;overflow-y: -webkit-paged-y;writing-mode: tb-rl; }
+* { column-count: 6381;-webkit-border-before: ridge }
+.class0 {column-span: all}
+</style>
+}
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+function main() {
+    v27 = document.defaultView.getSelection();
+    x23.prepend(x28);
+    v27.collapse(x49);
+    document.execCommand("insertOrderedList",false,null);
+}
+</script>
+<body onload="main()">
+This test passes if it doesn't crash.
+<div contenteditable="true">
+<li id="x23" class="class0">
+<br>
+<div>
+<div id="x28">
+<div id="x49">

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3748,6 +3748,8 @@ webkit.org/b/266571 [ Debug ] imported/w3c/web-platform-tests/webcodecs/audio-en
 webkit.org/b/266571 [ Debug ] imported/w3c/web-platform-tests/webcodecs/audio-encoder-config.https.any.worker.html [ Crash ]
 webkit.org/b/266571 [ Debug ] imported/w3c/web-platform-tests/webcodecs/audio-encoder.https.any.html [ Crash ]
 
+webkit.org/b/266636 fast/multicol/last-set-crash.html [ Skip ]
+
 # End: Common failures between GTK and WPE.
 
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/Source/WebCore/rendering/RenderMultiColumnFlow.cpp
+++ b/Source/WebCore/rendering/RenderMultiColumnFlow.cpp
@@ -220,7 +220,10 @@ RenderFragmentContainer* RenderMultiColumnFlow::fragmentAtBlockOffset(const Rend
     // Layout in progress. We are calculating the set heights as we speak, so the fragment range
     // information is not up-to-date.
 
-    RenderMultiColumnSet* columnSet = m_lastSetWorkedOn ? m_lastSetWorkedOn : firstMultiColumnSet();
+    if (m_lastSetWorkedOn && m_lastSetWorkedOn->fragmentedFlow() != this)
+        m_lastSetWorkedOn = nullptr;
+
+    RenderMultiColumnSet* columnSet = m_lastSetWorkedOn ? m_lastSetWorkedOn.get() : firstMultiColumnSet();
     if (!columnSet) {
         // If there's no set, bail. This multicol is empty or only consists of spanners. There
         // are no fragments.

--- a/Source/WebCore/rendering/RenderMultiColumnFlow.h
+++ b/Source/WebCore/rendering/RenderMultiColumnFlow.h
@@ -119,7 +119,7 @@ private:
     // The last set we worked on. It's not to be used as the "current set". The concept of a
     // "current set" is difficult, since layout may jump back and forth in the tree, due to wrong
     // top location estimates (due to e.g. margin collapsing), and possibly for other reasons.
-    RenderMultiColumnSet* m_lastSetWorkedOn { nullptr };
+    mutable SingleThreadWeakPtr<RenderMultiColumnSet> m_lastSetWorkedOn { nullptr };
 
     unsigned m_columnCount { 1 }; // The default column count/width that are based off our containing block width. These values represent only the default,
     LayoutUnit m_columnWidth { 0 }; // A multi-column block that is split across variable width pages or fragments will have different column counts and widths in each. These values will be cached (eventually) for multi-column blocks.


### PR DESCRIPTION
#### de47ae4003e992e436df92a14ed69138601d9039
<pre>
WTFCrashWithSecurityImplication in WebCore::RenderFragmentedFlow::removeLineFragmentInfo()
<a href="https://bugs.webkit.org/show_bug.cgi?id=264327">https://bugs.webkit.org/show_bug.cgi?id=264327</a>
<a href="https://rdar.apple.com/114559559">rdar://114559559</a>

Reviewed by Alan Baradlay.

* LayoutTests/TestExpectations:

Skip test on debug due to some assertion failures.

* LayoutTests/fast/multicol/last-set-crash-expected.txt: Added.
* LayoutTests/fast/multicol/last-set-crash.html: Added.
* Source/WebCore/rendering/RenderMultiColumnFlow.cpp:
(WebCore::RenderMultiColumnFlow::fragmentAtBlockOffset const):

Tree mutations may have made m_lastSetWorkedOn cache invalid by moving the multicolumn set under a different multicolumn flow.
Check for this.

* Source/WebCore/rendering/RenderMultiColumnFlow.h:

Also make it use WeakPtr.

Originally-landed-as: 267815.546@safari-7617-branch (f524a15d0633). <a href="https://rdar.apple.com/114559559">rdar://114559559</a>
Canonical link: <a href="https://commits.webkit.org/272294@main">https://commits.webkit.org/272294@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cbe4713133afd7d5b7d264204f7086be98e68100

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31177 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9855 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32870 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33685 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28317 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31944 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12197 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7113 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27966 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31514 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8308 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27873 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7135 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7313 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27768 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35076 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28375 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28224 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33476 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7351 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5407 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31323 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9036 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/27555 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7342 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8052 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7885 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->