### PR TITLE
Web Inspector: HTTP/3 support

### DIFF
--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -1294,6 +1294,7 @@ localizedStrings["Protocol"] = "Protocol";
 /* Label for button that shows controls for toggling CSS pseudo-classes on the selected element. */
 localizedStrings["Pseudo @ Styles details sidebar panel"] = "Pseudo";
 localizedStrings["Pseudo-Element"] = "Pseudo-Element";
+localizedStrings["QUIC"] = "QUIC";
 localizedStrings["Query Parameters"] = "Query Parameters";
 localizedStrings["Query String"] = "Query String";
 localizedStrings["Query String Parameters"] = "Query String Parameters";

--- a/Source/WebInspectorUI/UserInterface/Controllers/HARBuilder.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/HARBuilder.js
@@ -371,18 +371,16 @@ WI.HARBuilder = class HARBuilder
     static protocolFromHARProtocol(protocol)
     {
         switch (protocol) {
+        case "HTTP/3":
+            return "h3";
         case "HTTP/2":
             return "h2";
-        case "HTTP/1.0":
-            return "http/1.0";
         case "HTTP/1.1":
             return "http/1.1";
-        case "SPDY/2":
-            return "spdy/2";
-        case "SPDY/3":
-            return "spdy/3";
-        case "SPDY/3.1":
-            return "spdy/3.1";
+        case "HTTP/1.0":
+            return "http/1.1";
+        case "HTTP/0.9":
+            return "http/1.1";
         }
 
         if (protocol)

--- a/Source/WebInspectorUI/UserInterface/Models/Resource.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Resource.js
@@ -1244,7 +1244,7 @@ WI.Resource = class Resource extends WI.SourceCode
         let lines = [];
 
         let protocol = this.protocol || "";
-        if (protocol === "http/1.1") {
+        if (!protocol || protocol === "http/1.1") {
             // HTTP/1.1 request line:
             // https://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html#sec5.1
             lines.push(`${this.requestMethod} ${this.urlComponents.path}${protocol ? " " + protocol.toUpperCase() : ""}`);
@@ -1268,7 +1268,7 @@ WI.Resource = class Resource extends WI.SourceCode
         let lines = [];
 
         let protocol = this.protocol || "";
-        if (protocol === "http/1.1") {
+        if (!protocol || protocol === "http/1.1") {
             // HTTP/1.1 response status line:
             // https://www.w3.org/Protocols/rfc2616/rfc2616-sec6.html#sec6.1
             lines.push(`${protocol ? protocol.toUpperCase() + " " : ""}${this.statusCode} ${this.statusText}`);

--- a/Source/WebInspectorUI/UserInterface/Models/Resource.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Resource.js
@@ -218,18 +218,12 @@ WI.Resource = class Resource extends WI.SourceCode
     static displayNameForProtocol(protocol)
     {
         switch (protocol) {
+        case "h3":
+            return "HTTP/3";
         case "h2":
             return "HTTP/2";
-        case "http/1.0":
-            return "HTTP/1.0";
         case "http/1.1":
             return "HTTP/1.1";
-        case "spdy/2":
-            return "SPDY/2";
-        case "spdy/3":
-            return "SPDY/3";
-        case "spdy/3.1":
-            return "SPDY/3.1";
         default:
             return null;
         }
@@ -1250,17 +1244,17 @@ WI.Resource = class Resource extends WI.SourceCode
         let lines = [];
 
         let protocol = this.protocol || "";
-        if (protocol === "h2") {
+        if (protocol === "http/1.1") {
+            // HTTP/1.1 request line:
+            // https://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html#sec5.1
+            lines.push(`${this.requestMethod} ${this.urlComponents.path}${protocol ? " " + protocol.toUpperCase() : ""}`);
+        } else {
             // HTTP/2 Request pseudo headers:
             // https://tools.ietf.org/html/rfc7540#section-8.1.2.3
             lines.push(`:method: ${this.requestMethod}`);
             lines.push(`:scheme: ${this.urlComponents.scheme}`);
             lines.push(`:authority: ${WI.h2Authority(this.urlComponents)}`);
             lines.push(`:path: ${WI.h2Path(this.urlComponents)}`);
-        } else {
-            // HTTP/1.1 request line:
-            // https://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html#sec5.1
-            lines.push(`${this.requestMethod} ${this.urlComponents.path}${protocol ? " " + protocol.toUpperCase() : ""}`);
         }
 
         for (let key in this.requestHeaders)
@@ -1274,14 +1268,14 @@ WI.Resource = class Resource extends WI.SourceCode
         let lines = [];
 
         let protocol = this.protocol || "";
-        if (protocol === "h2") {
-            // HTTP/2 Response pseudo headers:
-            // https://tools.ietf.org/html/rfc7540#section-8.1.2.4
-            lines.push(`:status: ${this.statusCode}`);
-        } else {
+        if (protocol === "http/1.1") {
             // HTTP/1.1 response status line:
             // https://www.w3.org/Protocols/rfc2616/rfc2616-sec6.html#sec6.1
             lines.push(`${protocol ? protocol.toUpperCase() + " " : ""}${this.statusCode} ${this.statusText}`);
+        } else {
+            // HTTP/2 Response pseudo headers:
+            // https://tools.ietf.org/html/rfc7540#section-8.1.2.4
+            lines.push(`:status: ${this.statusCode}`);
         }
 
         for (let key in this.responseHeaders)

--- a/Source/WebInspectorUI/UserInterface/Views/ResourceHeadersContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ResourceHeadersContentView.js
@@ -367,12 +367,12 @@ WI.ResourceHeadersContentView = class ResourceHeadersContentView extends WI.Cont
 
         let protocol = this._resource.protocol || "";
         let urlComponents = this._resource.urlComponents;
-        if (protocol.startsWith("http/1")) {
+        if (protocol === "http/1.1") {
             // HTTP/1.1 request line:
             // https://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html#sec5.1
             let requestLine = `${this._resource.requestMethod} ${urlComponents.path} ${protocol.toUpperCase()}`;
             this._requestHeadersSection.appendKeyValuePair(requestLine, null, "h1-status");
-        } else if (protocol === "h2") {
+        } else {
             // HTTP/2 Request pseudo headers:
             // https://tools.ietf.org/html/rfc7540#section-8.1.2.3
             this._requestHeadersSection.appendKeyValuePair(":method", this._resource.requestMethod, "h2-pseudo-header");
@@ -401,12 +401,12 @@ WI.ResourceHeadersContentView = class ResourceHeadersContentView extends WI.Cont
         this._responseHeadersSection.toggleIncomplete(false);
 
         let protocol = this._resource.protocol || "";
-        if (protocol.startsWith("http/1")) {
+        if (protocol === "http/1.1") {
             // HTTP/1.1 response status line:
             // https://www.w3.org/Protocols/rfc2616/rfc2616-sec6.html#sec6.1
             let responseLine = `${protocol.toUpperCase()} ${this._resource.statusCode} ${this._resource.statusText}`;
             this._responseHeadersSection.appendKeyValuePair(responseLine, null, "h1-status");
-        } else if (protocol === "h2") {
+        } else {
             // HTTP/2 Response pseudo headers:
             // https://tools.ietf.org/html/rfc7540#section-8.1.2.4
             this._responseHeadersSection.appendKeyValuePair(":status", this._resource.statusCode, "h2-pseudo-header");

--- a/Source/WebInspectorUI/UserInterface/Views/ResourceHeadersContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ResourceHeadersContentView.js
@@ -372,7 +372,7 @@ WI.ResourceHeadersContentView = class ResourceHeadersContentView extends WI.Cont
             // https://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html#sec5.1
             let requestLine = `${this._resource.requestMethod} ${urlComponents.path} ${protocol.toUpperCase()}`;
             this._requestHeadersSection.appendKeyValuePair(requestLine, null, "h1-status");
-        } else {
+        } else if (protocol) {
             // HTTP/2 Request pseudo headers:
             // https://tools.ietf.org/html/rfc7540#section-8.1.2.3
             this._requestHeadersSection.appendKeyValuePair(":method", this._resource.requestMethod, "h2-pseudo-header");
@@ -406,7 +406,7 @@ WI.ResourceHeadersContentView = class ResourceHeadersContentView extends WI.Cont
             // https://www.w3.org/Protocols/rfc2616/rfc2616-sec6.html#sec6.1
             let responseLine = `${protocol.toUpperCase()} ${this._resource.statusCode} ${this._resource.statusText}`;
             this._responseHeadersSection.appendKeyValuePair(responseLine, null, "h1-status");
-        } else {
+        } else if (protocol) {
             // HTTP/2 Response pseudo headers:
             // https://tools.ietf.org/html/rfc7540#section-8.1.2.4
             this._responseHeadersSection.appendKeyValuePair(":status", this._resource.statusCode, "h2-pseudo-header");

--- a/Source/WebInspectorUI/UserInterface/Views/ResourceTimingBreakdownView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ResourceTimingBreakdownView.js
@@ -139,6 +139,7 @@ WI.ResourceTimingBreakdownView = class ResourceTimingBreakdownView extends WI.Vi
 
         let {startTime, redirectStart, redirectEnd, fetchStart, domainLookupStart, domainLookupEnd, connectStart, connectEnd, secureConnectionStart, requestStart, responseStart, responseEnd} = this._resource.timingData;
         let serverTiming = this._resource.serverTiming;
+        let protocol = this._resource.protocol
 
         this._tableElement = this.element.appendChild(document.createElement("table"));
         this._tableElement.className = "waterfall network";
@@ -161,10 +162,15 @@ WI.ResourceTimingBreakdownView = class ResourceTimingBreakdownView extends WI.Vi
             this._appendHeaderRow(WI.UIString("Connection:"));
             if (domainLookupStart)
                 this._appendRow(WI.UIString("DNS"), "dns", domainLookupStart, domainLookupEnd || connectStart || requestStart);
-            if (connectStart)
-                this._appendRow(WI.UIString("TCP"), "connect", connectStart, connectEnd || requestStart);
-            if (secureConnectionStart)
-                this._appendRow(WI.UIString("Secure"), "secure", secureConnectionStart, connectEnd || requestStart);
+            if (protocol === "http/1.1" || protocol === "h2") {
+                if (connectStart)
+                    this._appendRow(WI.UIString("TCP"), "connect", connectStart, connectEnd || requestStart);
+                if (secureConnectionStart)
+                    this._appendRow(WI.UIString("Secure"), "secure", secureConnectionStart, connectEnd || requestStart);
+            } else {
+                if (connectStart)
+                    this._appendRow(WI.UIString("QUIC"), "connect", connectStart, connectEnd || requestStart);
+            }
         }
 
         this._appendEmptyRow();

--- a/Source/WebInspectorUI/UserInterface/Views/ResourceTimingBreakdownView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ResourceTimingBreakdownView.js
@@ -162,7 +162,7 @@ WI.ResourceTimingBreakdownView = class ResourceTimingBreakdownView extends WI.Vi
             this._appendHeaderRow(WI.UIString("Connection:"));
             if (domainLookupStart)
                 this._appendRow(WI.UIString("DNS"), "dns", domainLookupStart, domainLookupEnd || connectStart || requestStart);
-            if (protocol === "http/1.1" || protocol === "h2") {
+            if (!protocol || protocol === "http/1.1" || protocol === "h2") {
                 if (connectStart)
                     this._appendRow(WI.UIString("TCP"), "connect", connectStart, connectEnd || requestStart);
                 if (secureConnectionStart)


### PR DESCRIPTION
#### e887ff68e2e46a7001963d8fe157f711c14410f2
<pre>
Web Inspector: HTTP/3 support
<a href="https://bugs.webkit.org/show_bug.cgi?id=266517">https://bugs.webkit.org/show_bug.cgi?id=266517</a>
<a href="https://rdar.apple.com/76481788">rdar://76481788</a>

Reviewed by NOBODY (OOPS!).

This change has a few components:
1. The code is refactored so that HTTP/1.1 is the special case. All newer versions of HTTP take the new code path.
2. Any mentioning of SPDY is removed since it hasn&apos;t been supported since iOS 12 and macOS 10.14.
3. QUIC is drawn on the timeline instead of TCP in HTTP/3.

* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:
* Source/WebInspectorUI/UserInterface/Controllers/HARBuilder.js:
(WI.HARBuilder.protocolFromHARProtocol):
* Source/WebInspectorUI/UserInterface/Models/Resource.js:
(WI.Resource.displayNameForProtocol):
* Source/WebInspectorUI/UserInterface/Views/ResourceHeadersContentView.js:
(WI.ResourceHeadersContentView.prototype._refreshRequestHeadersSection):
(WI.ResourceHeadersContentView.prototype._refreshResponseHeadersSection):
* Source/WebInspectorUI/UserInterface/Views/ResourceTimingBreakdownView.js:
(WI.ResourceTimingBreakdownView.prototype.initialLayout):
(WI.ResourceTimingBreakdownView):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d9cfd735655612f6453fd7ab9617e48d3fb3fb3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30860 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9539 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32533 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33362 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27877 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11868 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6788 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27746 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31179 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8022 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27599 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6874 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7038 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27477 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34700 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28095 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27965 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33180 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7075 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5148 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31013 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8787 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7788 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7630 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->