### PR TITLE
[JHBuild] Fix build for Ubuntu 20.04 after 271940@main

### DIFF
--- a/Tools/gstreamer/jhbuild.modules
+++ b/Tools/gstreamer/jhbuild.modules
@@ -67,18 +67,26 @@
     </branch>
   </autotools>
 
+  <meson id="libxkbcommon" mesonargs="-Denable-docs=false">
+    <branch module="xkbcommon/libxkbcommon"
+            tag="xkbcommon-1.0.3"
+            version="1.0.3"
+            repo="github.com" />
+  </meson>
+
   <!-- GStreamer plugins have been moved with the base code to a monorepo.
   Is not longer needed to fetch different tarballs when using the main repository.
   See: https://gstreamer.freedesktop.org/documentation/frequently-asked-questions/mono-repository.html -->
   <meson id="gstreamer" mesonargs="-Dlibnice=enabled -Dpython=enabled -Dintrospection=enabled -Dgst-plugins-bad:microdns=disabled -Dgst-plugins-bad:avtp=disabled -Dexamples=disabled -Dtests=disabled -Ddoc=disabled">
     <dependencies>
-      <dep package="libva"/>
-      <dep package="orc"/>
-      <dep package="graphene"/>
-      <dep package="openh264"/>
       <dep package="aom"/>
-      <dep package="libsrtp"/>
       <dep package="ffmpeg"/>
+      <dep package="graphene"/>
+      <dep package="libsrtp"/>
+      <dep package="libva"/>
+      <dep package="libxkbcommon"/>
+      <dep package="openh264"/>
+      <dep package="orc"/>
     </dependencies>
     <branch repo="gstreamer"
             checkoutdir="gstreamer-${version}"

--- a/Tools/jhbuild/jhbuild-minimal.modules
+++ b/Tools/jhbuild/jhbuild-minimal.modules
@@ -75,6 +75,15 @@
   <repository type="tarball" name="gnupg.org"
       href="https://www.gnupg.org/ftp/gcrypt/"/>
 
+  <!-- meson 0.62.0  required to build gstreamer-1.22.7 -->
+  <distutils id="meson" python3="1">
+    <branch module="mesonbuild/meson"
+            version="0.62.2"
+            tag="0.62.2"
+            checkoutdir="meson-${version}"
+            repo="github.com"/>
+  </distutils>
+
 <!-- This moduleset is used when the environment variable WEBKIT_JHBUILD_MODULESET=minimal is set -->
 <!-- Its intended to allow building WebKit using as much as libraries from your distribution as possible -->
 <!-- In order to ensure its minimal, all the modules should have a pkg-config declaration line -->
@@ -139,15 +148,6 @@
             version="0.2.4"
             hash="sha256:4fe0a4bed6b4c3ae7249d341031c27b32f8d9e0ffb5337d71cbcec7160362cf7"/>
   </meson>
-
-  <!-- meson 0.56.2+ required to build atk 2.38 -->
-  <distutils id="meson" python3="1">
-    <branch repo="github-tarball"
-            version="0.61.5"
-            module="mesonbuild/meson/releases/download/${version}/meson-${version}.tar.gz"
-            checkoutdir="meson-${version}"
-            hash="sha256:5e9a0d65c1a51936362b9686d1c5e9e184a6fd245d57e7269750ce50c20f5d9a"/>
-  </distutils>
 
   <!-- OpenXR required for WebXR support -->
   <cmake id="openxr">


### PR DESCRIPTION
#### daa89c7a41532ef0f6b0d34bf2a27206a1d182db
<pre>
[JHBuild] Fix build for Ubuntu 20.04 after 271940@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=266229">https://bugs.webkit.org/show_bug.cgi?id=266229</a>

Reviewed by Philippe Normand.

Update meson to 0.62 and libxkbcommon to 1.0.3.

* Tools/gstreamer/jhbuild.modules:
* Tools/jhbuild/jhbuild-minimal.modules:

Canonical link: <a href="https://commits.webkit.org/272173@main">https://commits.webkit.org/272173@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef62e003e21820c1d1dd044f0b15f9085aa22152

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30766 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9444 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32433 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33261 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27799 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31512 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11749 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6690 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27679 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31079 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7921 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27523 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6796 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6945 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27399 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34598 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27994 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27882 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33105 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6986 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5075 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30937 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8703 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7288 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7703 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7542 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->