### PR TITLE
[webkitscmpy] Read and write GitHub PR comments

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/pull_request.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/pull_request.py
@@ -243,16 +243,21 @@ class PullRequest(object):
             self._comments = list(self.generator.comments(self))
         return self._comments
 
-    def review(self, comment=None, approve=None):
+    def review(self, comment=None, approve=None, diff_comments=None):
         if not self.generator:
             raise self.Exception('No associated pull-request generator')
-        return self.generator.review(self, comment=comment, approve=approve)
+        return self.generator.review(self, comment=comment, approve=approve, diff_comments=diff_comments)
 
     @property
     def statuses(self):
         if self._statuses is None and self.generator:
             self._statuses = list(self.generator.statuses(self))
         return self._statuses
+
+    def diff(self, comments=False):
+        if not self.generator:
+            raise self.Exception('No associated pull-request generator')
+        return self.generator.diff(self, comments=comments)
 
     def __repr__(self):
         return 'PR {}{}'.format(self.number, ' | {}'.format(self.title) if self.title else '')

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py
@@ -321,7 +321,7 @@ class BitBucket(Scm):
                         content=comment.get('text'),
                     )
 
-        def review(self, pull_request, comment=None, approve=None):
+        def review(self, pull_request, comment=None, approve=None, diff_comments=None):
             failed = False
             if comment and not self.comment(pull_request, comment):
                 failed = True

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
@@ -2014,6 +2014,14 @@ Reviewed by NOBODY (OOPS!).
             ), draft=False,
         )]
 
+        result.commits['eng/pull-request'] = [
+            result.commits['main'][-1],
+            Commit(
+                hash='95507e3a1a4a919d1a156abbc279fdf6d24b13f5',
+                message='Example Change\nhttps://bugs.webkit.org/show_bug.cgi?id=1234\n\nReviewed by NOBODY (OOPS!).\n* Source/file.cpp:\n',
+            ),
+        ]
+
         result.statuses['95507e3a1a4a'] = PullRequest.Status.Encoder().default([
             PullRequest.Status(name='test-webkitpy', status='pending', description='Running...'),
             PullRequest.Status(name='test-webkitcorepy', status='success', description='Finished!'),
@@ -2119,6 +2127,109 @@ Reviewed by NOBODY (OOPS!).
                 ['pending', 'success', 'failure'],
             )
 
+    def test_diff(self):
+        with self.webserver():
+            repo = remote.GitHub(self.remote)
+            pr = repo.pull_requests.get(1)
+            self.assertEqual([
+                'diff --git a/ChangeLog b/ChangeLog',
+                '--- a/ChangeLog',
+                '+++ b/ChangeLog',
+                '@@ -1,0 +1,0 @@',
+                '+Example Change',
+                '+https://bugs.webkit.org/show_bug.cgi?id=1234',
+                '+',
+                '+Reviewed by NOBODY (OOPS!).',
+                '+* Source/file.cpp:',
+            ], list(pr.diff()))
+
+    def test_no_comments(self):
+        with self.webserver():
+            repo = remote.GitHub(self.remote)
+            pr = repo.pull_requests.get(1)
+            self.assertEqual([
+                'diff --git a/ChangeLog b/ChangeLog',
+                '--- a/ChangeLog',
+                '+++ b/ChangeLog',
+                '@@ -1,0 +1,0 @@',
+                '+Example Change',
+                '+https://bugs.webkit.org/show_bug.cgi?id=1234',
+                '+',
+                '+Reviewed by NOBODY (OOPS!).',
+                '+* Source/file.cpp:',
+            ], list(pr.diff(comments=True)))
+
+    def test_comment(self):
+        with self.webserver():
+            repo = remote.GitHub(self.remote)
+            pr = repo.pull_requests.get(1)
+            pr.review(diff_comments=dict(ChangeLog={4: ['We need a review before landing']}))
+            self.assertEqual([
+                'diff --git a/ChangeLog b/ChangeLog',
+                '--- a/ChangeLog',
+                '+++ b/ChangeLog',
+                '@@ -1,0 +1,0 @@',
+                '+Example Change',
+                '+https://bugs.webkit.org/show_bug.cgi?id=1234',
+                '+',
+                '+Reviewed by NOBODY (OOPS!).',
+                '>>>>',
+                'username <?>: We need a review before landing',
+                '<<<<',
+                '+* Source/file.cpp:',
+            ], list(pr.diff(comments=True)))
+
+    def test_file_comment(self):
+        with self.webserver():
+            repo = remote.GitHub(self.remote)
+            pr = repo.pull_requests.get(1)
+            pr.review(diff_comments=dict(ChangeLog={None: ['ChangeLogs are deprecated, please remove']}))
+            self.assertEqual([
+                'diff --git a/ChangeLog b/ChangeLog',
+                '--- a/ChangeLog',
+                '+++ b/ChangeLog',
+                '>>>>',
+                'username <?>: ChangeLogs are deprecated, please remove',
+                '<<<<',
+                '@@ -1,0 +1,0 @@',
+                '+Example Change',
+                '+https://bugs.webkit.org/show_bug.cgi?id=1234',
+                '+',
+                '+Reviewed by NOBODY (OOPS!).',
+                '+* Source/file.cpp:',
+            ], list(pr.diff(comments=True)))
+
+    def test_comment_reply(self):
+        with self.webserver():
+            repo = remote.GitHub(self.remote)
+            pr = repo.pull_requests.get(1)
+            pr.review(diff_comments=dict(ChangeLog={
+                None: ['Top-level comment 1'],
+                4: ['Line comment 1'],
+            }))
+            pr.review(diff_comments=dict(ChangeLog={
+                None: ['Top-level comment 2'],
+                4: ['Line comment 2'],
+            }))
+            self.assertEqual([
+                'diff --git a/ChangeLog b/ChangeLog',
+                '--- a/ChangeLog',
+                '+++ b/ChangeLog',
+                '>>>>',
+                'username <?>: Top-level comment 1',
+                'username <?>: Top-level comment 2',
+                '<<<<',
+                '@@ -1,0 +1,0 @@',
+                '+Example Change',
+                '+https://bugs.webkit.org/show_bug.cgi?id=1234',
+                '+',
+                '+Reviewed by NOBODY (OOPS!).',
+                '>>>>',
+                'username <?>: Line comment 1',
+                'username <?>: Line comment 2',
+                '<<<<',
+                '+* Source/file.cpp:',
+            ], list(pr.diff(comments=True)))
 
 
 class TestNetworkPullRequestBitBucket(unittest.TestCase):


### PR DESCRIPTION
#### 373c9a4b07136b26e325a3590e4227228ec23f65
<pre>
[webkitscmpy] Read and write GitHub PR comments
<a href="https://bugs.webkit.org/show_bug.cgi?id=266516">https://bugs.webkit.org/show_bug.cgi?id=266516</a>
<a href="https://rdar.apple.com/119739688">rdar://119739688</a>

Reviewed by Elliott Williams.

Provide Python functions to both write and read in-line PR comments.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/git_hub.py:
(GitHub.request): Mock endpoints to write and read PR comments.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/pull_request.py:
(PullRequest.review): Add &apos;diff_comments&apos; argument.
(PullRequest.diff): Added.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py:
(BitBucket.PRGenerator.review): Add currently unused &apos;diff_comments&apos; argument.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py:
(GitHub.PRGenerator._diff_comments): Return a dictionary of diff comments for this PR.
(GitHub.PRGenerator._make_comment): Construct a comment on this PR, passing the specified
kwargs directly to GitHub in the request body.
(GitHub.PRGenerator.review): Allow user to add comments to a specific file in
this PR, or to a specific line in a specific file.
(GitHub.PRGenerator.diff): Return the diff proposed by this pull-request, with
embedded comments if requested.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/scm.py:
(Scm.PRGenerator.diff): Added.
(Scm.insert_diff_comments): Function which inserts inline diff comments from an
SCM provider into a diff as if they were conflicts.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py:
(TestNetworkPullRequestGitHub.webserver):
(TestNetworkPullRequestGitHub.test_diff):
(TestNetworkPullRequestGitHub.test_no_comments):
(TestNetworkPullRequestGitHub.test_comment):
(TestNetworkPullRequestGitHub.test_file_comment):
(TestNetworkPullRequestGitHub.test_comment_reply):

Canonical link: <a href="https://commits.webkit.org/277752@main">https://commits.webkit.org/277752@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1057b31d3d9d37bbdc0f80962880d0a8a83e4b2e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48469 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27681 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51429 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51157 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44534 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50775 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33617 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25204 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/39638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49051 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/25362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/41843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/20748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/48326 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/22845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/43016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6526 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/44786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/43499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53062 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/23516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/19842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/46947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/48500 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/24781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/42041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/45859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/25586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6900 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/24504 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->