### PR TITLE
Invalid coordinates on gesture (and resulting wheel) events inside iframe

### DIFF
--- a/LayoutTests/fast/events/gesture/resources/gesture-iframe.html
+++ b/LayoutTests/fast/events/gesture/resources/gesture-iframe.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+body, html {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100vh;
+    margin: 0;
+}
+
+p {
+    text-align: center;
+}
+</style>
+<script>
+
+["wheel", "gesturestart", "gesturechange", "gestureend"].forEach((eventType) => {
+    addEventListener(eventType, (event) => {
+        window.top.postMessage({
+            type: "iframeEvent",
+            data: {
+                eventType: event.type,
+                clientX: event.clientX,
+                clientY: event.clientY
+            }
+        }, "*");
+    }, { once: true });
+});
+
+</script>
+</head>
+<body>
+    <p>Make a gesture here.</p>
+</body>
+</html>

--- a/LayoutTests/fast/events/gesture/wheel-gesture-event-coordinates-in-iframe-expected.txt
+++ b/LayoutTests/fast/events/gesture/wheel-gesture-event-coordinates-in-iframe-expected.txt
@@ -1,0 +1,13 @@
+This test verifies that gesture events (and wheel events generated from gestures) originating from an iframe have the correct coordinates relative to the iframe.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS gesturestart: 'event.clientX' is 150 and 'event.clientY' is 150.
+PASS wheel: 'event.clientX' is 150 and 'event.clientY' is 150.
+PASS gesturechange: 'event.clientX' is 150 and 'event.clientY' is 150.
+PASS gestureend: 'event.clientX' is 150 and 'event.clientY' is 150.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/events/gesture/wheel-gesture-event-coordinates-in-iframe.html
+++ b/LayoutTests/fast/events/gesture/wheel-gesture-event-coordinates-in-iframe.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+body, html {
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    padding; 0;
+}
+
+iframe {
+    border: 1px solid red;
+    width: 300px;
+    height: 300px;
+    margin: 0;
+    padding: 0;
+}
+</style>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<script>
+jsTestIsAsync = true;
+
+const eventTypeWasObservedMap = new Map([
+    ["wheel", false],
+    ["gesturestart", false],
+    ["gesturechange", false],
+    ["gestureend", false],
+]);
+
+function eventTypeWasObserved(eventType) {
+    eventTypeWasObservedMap.set(eventType, true);
+}
+
+function allEventsWereObserved() {
+    let result = true;
+    for (const [_, eventTypeWasObserved] of eventTypeWasObservedMap)
+        result &&= eventTypeWasObserved;
+    return result;
+}
+
+addEventListener("load", async () => {
+    description(`This test verifies that gesture events (and wheel events generated from gestures) originating from an iframe have the correct coordinates relative to the iframe.`);
+
+    const iframe = document.querySelector("iframe");
+    const iframeStyle = window.getComputedStyle(iframe);
+    const expectedEventPositionInIframe = {
+        x: parseInt(iframeStyle.getPropertyValue("width"))/2,
+        y: parseInt(iframeStyle.getPropertyValue("height"))/2
+    };
+
+    window.onmessage = (event) => {
+        if (event.data.type === "iframeEvent") {
+            const data = event.data.data;
+            if (!eventTypeWasObservedMap.has(data.eventType))
+                testFailed(`Unexpected event of type '${data.eventType}' observed.`);
+            eventTypeWasObservedMap.set(data.eventType, true);
+            if (data.clientX === expectedEventPositionInIframe.x && data.clientY === expectedEventPositionInIframe.y)
+                testPassed(`${data.eventType}: 'event.clientX' is ${expectedEventPositionInIframe.x} and 'event.clientY' is ${expectedEventPositionInIframe.y}.`);
+            else
+                testFailed(`${data.eventType}: 'event.clientX' is ${data.clientX} (expected ${expectedEventPositionInIframe.x}) and 'event.clientY' is ${data.clientY} (expected ${expectedEventPositionInIframe.y}).`);
+        }
+
+        if (allEventsWereObserved())
+            finishJSTest();
+    };
+
+    if (!window.eventSender) {
+        debug("FAIL: This test requires window.eventSender.");
+        return;
+    }
+
+    const middleOfIframeInWindow = {
+        x: (iframe.offsetLeft + (iframe.offsetWidth / 2)),
+        y: (iframe.offsetTop + (iframe.offsetHeight / 2))
+    };
+    await UIHelper.moveMouseAndWaitForFrame(middleOfIframeInWindow.x, middleOfIframeInWindow.y);
+    eventSender.scaleGestureStart(0.01);
+    eventSender.scaleGestureChange(0.01);
+    eventSender.scaleGestureEnd(0.01);
+});
+</script>
+</head>
+<body>
+    <iframe id="iframe" src="resources/gesture-iframe.html"></iframe>
+</body>
+</html>


### PR DESCRIPTION
#### c8a66bff2703a2099a9e61c75382cef21ee0c822
<pre>
Invalid coordinates on gesture (and resulting wheel) events inside iframe
<a href="https://bugs.webkit.org/show_bug.cgi?id=266523">https://bugs.webkit.org/show_bug.cgi?id=266523</a>
<a href="https://rdar.apple.com/105243167">rdar://105243167</a>

Reviewed by Wenson Hsieh.

`gesture*` events (and resulting wheel events) originating from an iframe
have incorrect coordinates. Notably, these coordinates are not relative
to the child frame&apos;s origin. This happens because we pass events on to a
child frame&apos;s nodes without accounting for the coordinate space conversion
between the parent frame and the child frame.

This bug is addressed in WebKitAdditions by adopting the &quot;pass event to
subframe&apos;s event handler&quot; pattern in the the gesture event handling code -
as used for other event handling codepaths.

This open source commit adds a layout test in which gesture events are
originated in an embedded frame. The test asserts that the event
coordinates are relative to the child frame, thus providing some
correctness guarantees for the aforementioned fix.

* LayoutTests/fast/events/gesture/resources/gesture-iframe.html: Added.
* LayoutTests/fast/events/gesture/wheel-gesture-event-coordinates-in-iframe-expected.txt: Added.
* LayoutTests/fast/events/gesture/wheel-gesture-event-coordinates-in-iframe.html: Added.

Canonical link: <a href="https://commits.webkit.org/272176@main">https://commits.webkit.org/272176@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24ca43ebc6b8bc9e932394053c5e6640c740509d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30812 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9491 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32482 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33311 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27838 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11806 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6737 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/27705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31129 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7969 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27562 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/6833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6981 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27440 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34648 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28042 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27919 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/33138 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7028 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5106 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30971 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8745 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/27225 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7290 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7746 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7586 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->