### PR TITLE
Stop using CheckedPtr with Range

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -5467,17 +5467,16 @@ void Document::nodeWillBeRemoved(Node& node)
 
 void Document::parentlessNodeMovedToNewDocument(Node& node)
 {
-    Vector<WeakPtr<Range>, 5> rangesAffected;
+    Vector<Ref<Range>, 5> rangesAffected;
 
-    for (auto& range : m_ranges) {
-        if (Ref { range.get() }->parentlessNodeMovedToNewDocumentAffectsRange(node))
-            rangesAffected.append(range.get());
+    for (auto& weakRange : m_ranges) {
+        Ref range = weakRange.get();
+        if (range->parentlessNodeMovedToNewDocumentAffectsRange(node))
+            rangesAffected.append(WTFMove(range));
     }
 
-    for (auto& weakRange : rangesAffected) {
-        if (RefPtr range = weakRange.get())
-            range->updateRangeForParentlessNodeMovedToNewDocument(node);
-    }
+    for (auto& range : rangesAffected)
+        range->updateRangeForParentlessNodeMovedToNewDocument(node);
 }
 
 static Node* fallbackFocusNavigationStartingNodeAfterRemoval(Node& node)

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -2051,7 +2051,7 @@ private:
     mutable String m_uniqueIdentifier;
 
     WeakHashSet<NodeIterator> m_nodeIterators;
-    HashSet<CheckedRef<Range>> m_ranges;
+    HashSet<SingleThreadWeakRef<Range>> m_ranges;
 
     UniqueRef<Style::Scope> m_styleScope;
     std::unique_ptr<ExtensionStyleSheets> m_extensionStyleSheets;

--- a/Source/WebCore/dom/Range.h
+++ b/Source/WebCore/dom/Range.h
@@ -40,7 +40,7 @@ class Text;
 
 struct SimpleRange;
 
-class Range final : public AbstractRange, public CanMakeWeakPtr<Range>, public CanMakeCheckedPtr {
+class Range final : public AbstractRange, public CanMakeSingleThreadWeakPtr<Range> {
     WTF_MAKE_ISO_ALLOCATED(Range);
     WTF_MAKE_NONCOPYABLE(Range);
 public:

--- a/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleRangeHandle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleRangeHandle.cpp
@@ -57,7 +57,7 @@
 namespace WebKit {
 using namespace WebCore;
 
-using DOMRangeHandleCache = HashMap<CheckedPtr<WebCore::Range>, CheckedPtr<InjectedBundleRangeHandle>>;
+using DOMRangeHandleCache = HashMap<SingleThreadWeakRef<WebCore::Range>, CheckedPtr<InjectedBundleRangeHandle>>;
 
 static DOMRangeHandleCache& domRangeHandleCache()
 {
@@ -74,7 +74,7 @@ RefPtr<InjectedBundleRangeHandle> InjectedBundleRangeHandle::getOrCreate(WebCore
 {
     if (!range)
         return nullptr;
-    auto result = domRangeHandleCache().add(range, nullptr);
+    auto result = domRangeHandleCache().add(*range, nullptr);
     if (!result.isNewEntry)
         return result.iterator->value.get();
     auto rangeHandle = adoptRef(*new InjectedBundleRangeHandle(*range));
@@ -89,7 +89,7 @@ InjectedBundleRangeHandle::InjectedBundleRangeHandle(WebCore::Range& range)
 
 InjectedBundleRangeHandle::~InjectedBundleRangeHandle()
 {
-    domRangeHandleCache().remove(m_range.ptr());
+    domRangeHandleCache().remove(m_range.get());
 }
 
 WebCore::Range& InjectedBundleRangeHandle::coreRange() const


### PR DESCRIPTION
#### dd8019d9d4f10eac0565f6d7eb5c64cc3c1ca58d
<pre>
Stop using CheckedPtr with Range
<a href="https://bugs.webkit.org/show_bug.cgi?id=266526">https://bugs.webkit.org/show_bug.cgi?id=266526</a>

Reviewed by Ryosuke Niwa.

Stop using CheckedPtr with Range. Use WeakPtr instead to generate more
actionable crashes. This tested as performance neutral on Speedometer
2 &amp; 3.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::parentlessNodeMovedToNewDocument):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/Range.h:
* Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleRangeHandle.cpp:
(WebKit::InjectedBundleRangeHandle::getOrCreate):
(WebKit::InjectedBundleRangeHandle::~InjectedBundleRangeHandle):

Canonical link: <a href="https://commits.webkit.org/272169@main">https://commits.webkit.org/272169@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ed5a1a12251ab50f0274828a0ee45cb887f5912

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30795 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9474 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32463 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33291 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27825 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31540 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11783 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6717 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/27695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31109 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7947 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27546 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6819 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6966 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27423 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34628 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28020 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27903 "Found 1 new test failure: tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-mainframe-vertical-then-horizontal.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33125 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7013 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5090 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30959 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8730 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7730 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3992 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7569 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->