### PR TITLE
REGRESSION (UI-side compositing): Unable to scroll to top of page after double tapping trackpad causes page to scroll down

### DIFF
--- a/LayoutTests/view-gestures/smart-magnify/double-tap-zoom-scroll-above-top-expected.html
+++ b/LayoutTests/view-gestures/smart-magnify/double-tap-zoom-scroll-above-top-expected.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body {
+            height: 2000px;
+            margin: 0;
+        }
+        .target {
+            margin-top: 400px;
+            width: 100%;
+            height: 1200px;
+            background-color: silver;
+        }
+        
+        .top-stripe {
+            width: 100%;
+            height: 20px;
+            background-color: green;
+        }
+    </style>
+</head>
+<body>
+    <div class="top-stripe"></div>
+    <div class="target"></div>
+</body>
+</html>

--- a/LayoutTests/view-gestures/smart-magnify/double-tap-zoom-scroll-above-top.html
+++ b/LayoutTests/view-gestures/smart-magnify/double-tap-zoom-scroll-above-top.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body {
+            height: 2000px;
+            margin: 0;
+        }
+        .target {
+            margin-top: 400px;
+            width: 100%;
+            height: 1200px;
+            background-color: silver;
+        }
+        
+        .top-stripe {
+            width: 100%;
+            height: 20px;
+            background-color: green;
+        }
+    </style>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+        if (window.testRunner)
+            testRunner.waitUntilDone();
+
+        async function doSmartMagnify()
+        {
+            await UIHelper.setWebViewAllowsMagnification(true);
+            await UIHelper.smartMagnifyAt(400, 500);
+
+            window.scrollTo(0, 0);
+            await UIHelper.ensurePresentationUpdate();
+
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }
+        
+        window.addEventListener('load', () => {
+            doSmartMagnify();
+        }, false);
+    </script>   
+</head>
+<body>
+    <div class="top-stripe"></div>
+    <div class="target"></div>
+</body>
+</html>

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h
@@ -53,6 +53,8 @@ public:
 
     void updateZoomTransactionID();
     WebCore::PlatformLayerIdentifier pageScalingLayerID() { return m_pageScalingLayerID; }
+    WebCore::PlatformLayerIdentifier pageScrollingLayerID() { return m_pageScrollingLayerID; }
+
 private:
     WebCore::DelegatedScrollingMode delegatedScrollingMode() const override;
     std::unique_ptr<RemoteScrollingCoordinatorProxy> createScrollingCoordinatorProxy() const override;
@@ -93,7 +95,10 @@ private:
     std::optional<DisplayLinkObserverID> m_displayRefreshObserverID;
     std::optional<DisplayLinkObserverID> m_fullSpeedUpdateObserverID;
     std::unique_ptr<RemoteLayerTreeDisplayLinkClient> m_displayLinkClient;
+
     WebCore::PlatformLayerIdentifier m_pageScalingLayerID;
+    WebCore::PlatformLayerIdentifier m_pageScrollingLayerID;
+
     bool m_usesOverlayScrollbars { false };
 
     std::optional<TransactionID> m_transactionIDAfterEndingTransientZoom;


### PR DESCRIPTION
#### 3a5a2dc6d7b110ce9ee677a6f033b51343b1ddb0
<pre>
REGRESSION (UI-side compositing): Unable to scroll to top of page after double tapping trackpad causes page to scroll down
<a href="https://bugs.webkit.org/show_bug.cgi?id=266529">https://bugs.webkit.org/show_bug.cgi?id=266529</a>
<a href="https://rdar.apple.com/116419609">rdar://116419609</a>

Reviewed by Tim Horton.

The smart magnify gesture (two-finger double tap on the trackpad) results in some combination of
scrolling and zooming. `RemoteLayerTreeDrawingAreaProxyMac::commitTransientZoom()` uses a
CAAnimation to animate to the final state, but the completion handler of that animation put the
transform directly onto the `layerForPageScale`.

That&apos;s OK if the gesture results in a scale change; that transform will get replaced by one that
comes from the web process. However, if a gesture just resulted in a scroll with no scale change,
we never get a new transform from the web process, so we leave that transform on
`layerForPageScale`. This transform has a translation baked in, so this causes a permanent scroll
offset.

So we have to stop shoving the transform onto this layer. This revealed an issue where there was a
jump when the animation was removed. Fixing this just requires two things:

1. Delay removing the transient zoom animations until we know the web process has committed the new
   scale and scroll position (via a `callAfterNextPresentationUpdate()`).

2. Override any scroll position changes that come from the web process before this by adding a
   CAAnimation onto the scrolled contents layer which overrides the `position` property. If we
   don&apos;t do this, scroll position changes cause a flash of offset content. This requires tracking
   m_pageScrollingLayerID, but that information was already in the transaction for banner hookup.

* LayoutTests/view-gestures/smart-magnify/double-tap-zoom-scroll-above-top-expected.html: Added.
* LayoutTests/view-gestures/smart-magnify/double-tap-zoom-scroll-above-top.html: Added.
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::didCommitLayerTree):
(WebKit::fillFowardsAnimationWithKeyPath):
(WebKit::transientZoomTransformOverrideAnimation):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::applyTransientZoomToLayer):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::removeTransientZoomFromLayer):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::commitTransientZoom):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::sendCommitTransientZoom):

Canonical link: <a href="https://commits.webkit.org/272229@main">https://commits.webkit.org/272229@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5150b032a11de6bb670440cecb0729409ceef459

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30805 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9484 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32474 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33302 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27831 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11796 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6728 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27698 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31120 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7958 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27555 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6824 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6973 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27433 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34639 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28032 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27912 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33131 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7021 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5097 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30964 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8738 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/27218 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7313 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7738 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7578 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->