### PR TITLE
Generate CFDate serializer using existing wrapper

### DIFF
--- a/Source/WebKit/Shared/Cocoa/CoreIPCDate.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCDate.h
@@ -52,7 +52,7 @@ public:
     {
     }
 
-    RetainPtr<CFDateRef> createDate() const
+    RetainPtr<CFDateRef> createCFDate() const
     {
         return adoptCF(CFDateCreate(0, m_absoluteTime));
     }
@@ -64,7 +64,7 @@ public:
 
     RetainPtr<id> toID() const
     {
-        return bridge_cast(createDate().get());
+        return bridge_cast(createCFDate().get());
     }
 
 private:

--- a/Source/WebKit/Shared/cf/ArgumentCodersCF.cpp
+++ b/Source/WebKit/Shared/cf/ArgumentCodersCF.cpp
@@ -431,25 +431,6 @@ std::optional<RetainPtr<CFCharacterSetRef>> ArgumentCoder<RetainPtr<CFCharacterS
 }
 
 template<typename Encoder>
-void ArgumentCoder<CFDateRef>::encode(Encoder& encoder, CFDateRef date)
-{
-    encoder << static_cast<double>(CFDateGetAbsoluteTime(date));
-}
-
-template void ArgumentCoder<CFDateRef>::encode<Encoder>(Encoder&, CFDateRef);
-template void ArgumentCoder<CFDateRef>::encode<StreamConnectionEncoder>(StreamConnectionEncoder&, CFDateRef);
-
-std::optional<RetainPtr<CFDateRef>> ArgumentCoder<RetainPtr<CFDateRef>>::decode(Decoder& decoder)
-{
-    std::optional<double> absoluteTime;
-    decoder >> absoluteTime;
-    if (!absoluteTime)
-        return std::nullopt;
-
-    return adoptCF(CFDateCreate(0, *absoluteTime));
-}
-
-template<typename Encoder>
 void ArgumentCoder<CFDictionaryRef>::encode(Encoder& encoder, CFDictionaryRef dictionary)
 {
     if (!dictionary) {

--- a/Source/WebKit/Shared/cf/ArgumentCodersCF.h
+++ b/Source/WebKit/Shared/cf/ArgumentCodersCF.h
@@ -70,13 +70,6 @@ template<> struct ArgumentCoder<RetainPtr<CFCharacterSetRef>> : CFRetainPtrArgum
     static std::optional<RetainPtr<CFCharacterSetRef>> decode(Decoder&);
 };
 
-template<> struct ArgumentCoder<CFDateRef> {
-    template<typename Encoder> static void encode(Encoder&, CFDateRef);
-};
-template<> struct ArgumentCoder<RetainPtr<CFDateRef>> : CFRetainPtrArgumentCoder<CFDateRef> {
-    static std::optional<RetainPtr<CFDateRef>> decode(Decoder&);
-};
-
 template<> struct ArgumentCoder<CFDictionaryRef> {
     template<typename Encoder> static void encode(Encoder&, CFDictionaryRef);
 };

--- a/Source/WebKit/Shared/cf/CFTypes.serialization.in
+++ b/Source/WebKit/Shared/cf/CFTypes.serialization.in
@@ -34,6 +34,9 @@
 [WebKitPlatform, CustomHeader, AdditionalEncoder=StreamConnectionEncoder, ToCFMethod=result->createCFNumber()] CFNumberRef wrapped by WebKit::CoreIPCNumber {
 }
 
+[WebKitPlatform, CustomHeader, AdditionalEncoder=StreamConnectionEncoder, ToCFMethod=result->createCFDate()] CFDateRef wrapped by WebKit::CoreIPCDate {
+}
+
 #endif
 
 #if USE(CG)


### PR DESCRIPTION
#### 1d4e789888d87dc921c184d042628f7d7aa25cc6
<pre>
Generate CFDate serializer using existing wrapper
<a href="https://rdar.apple.com/119751053">rdar://119751053</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=266530">https://bugs.webkit.org/show_bug.cgi?id=266530</a>

Reviewed by Alex Christensen.

* Source/WebKit/Shared/Cocoa/CoreIPCDate.h:
(WebKit::CoreIPCDate::createCFDate const):
(WebKit::CoreIPCDate::toID const):
(WebKit::CoreIPCDate::createDate const): Deleted.
* Source/WebKit/Shared/cf/ArgumentCodersCF.cpp:
(IPC::ArgumentCoder&lt;CFDateRef&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;RetainPtr&lt;CFDateRef&gt;&gt;::decode): Deleted.
* Source/WebKit/Shared/cf/ArgumentCodersCF.h:
* Source/WebKit/Shared/cf/CFTypes.serialization.in:

Canonical link: <a href="https://commits.webkit.org/272181@main">https://commits.webkit.org/272181@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/225923e8765260953f334e82d60461c9a29cba0e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30806 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9485 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32475 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33303 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27832 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11797 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6729 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27700 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31121 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7962 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27556 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6826 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6975 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34640 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28035 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27913 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33132 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7022 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5098 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30965 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8739 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7292 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7739 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7579 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->