### PR TITLE
Move RenderElementType to RenderObject to simplify and devirtualize type checks

### DIFF
--- a/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp
@@ -129,8 +129,8 @@ private:
     unsigned m_ordinalIteration;
 };
 
-RenderDeprecatedFlexibleBox::RenderDeprecatedFlexibleBox(Type type, Element& element, RenderStyle&& style)
-    : RenderBlock(type, element, WTFMove(style), { })
+RenderDeprecatedFlexibleBox::RenderDeprecatedFlexibleBox(Element& element, RenderStyle&& style)
+    : RenderBlock(RenderObject::Type::DeprecatedFlexibleBox, element, WTFMove(style), { })
 {
     setChildrenInline(false); // All of our children must be block-level
     m_stretchingChildren = false;

--- a/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.h
+++ b/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.h
@@ -31,7 +31,7 @@ class FlexBoxIterator;
 class RenderDeprecatedFlexibleBox final : public RenderBlock {
     WTF_MAKE_ISO_ALLOCATED(RenderDeprecatedFlexibleBox);
 public:
-    RenderDeprecatedFlexibleBox(Type, Element&, RenderStyle&&);
+    RenderDeprecatedFlexibleBox(Element&, RenderStyle&&);
     virtual ~RenderDeprecatedFlexibleBox();
 
     Element& element() const { return downcast<Element>(nodeForNonAnonymous()); }
@@ -52,7 +52,6 @@ public:
     void placeChild(RenderBox* child, const LayoutPoint& location, LayoutSize* childLayoutDelta = nullptr);
 
 private:
-    bool isRenderDeprecatedFlexibleBox() const override { return true; }
     void computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const override;
     void computePreferredLogicalWidths() override;
 

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -116,10 +116,9 @@ struct SameSizeAsRenderElement : public RenderObject {
 
 static_assert(sizeof(RenderElement) == sizeof(SameSizeAsRenderElement), "RenderElement should stay small");
 
-inline RenderElement::RenderElement(Type type, ContainerNode& elementOrDocument, RenderStyle&& style, OptionSet<RenderElementType> typeFlags)
-    : RenderObject(type, elementOrDocument)
+inline RenderElement::RenderElement(Type type, ContainerNode& elementOrDocument, RenderStyle&& style, OptionSet<RenderElementType> flags)
+    : RenderObject(type, elementOrDocument, flags)
     , m_firstChild(nullptr)
-    , m_typeFlags(typeFlags.toRaw())
     , m_ancestorLineBoxDirty(false)
     , m_hasInitializedStyle(false)
     , m_hasPausedImageAnimations(false)
@@ -211,7 +210,7 @@ RenderPtr<RenderElement> RenderElement::createFor(Element& element, RenderStyle&
         return createRenderer<RenderGrid>(element, WTFMove(style));
     case DisplayType::Box:
     case DisplayType::InlineBox:
-        return createRenderer<RenderDeprecatedFlexibleBox>(RenderObject::Type::DeprecatedFlexibleBox, element, WTFMove(style));
+        return createRenderer<RenderDeprecatedFlexibleBox>(element, WTFMove(style));
     case DisplayType::RubyBase:
         return createRenderer<RenderInline>(RenderObject::Type::Inline, element, WTFMove(style));
     case DisplayType::RubyAnnotation:

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -123,16 +123,6 @@ public:
     const RenderStyle* spellingErrorPseudoStyle() const;
     const RenderStyle* grammarErrorPseudoStyle() const;
 
-    // FIXME: Make these standalone and move to relevant files.
-    bool isRenderLayerModelObject() const;
-    bool isRenderBoxModelObject() const;
-    bool isRenderBlock() const;
-    bool isRenderBlockFlow() const;
-    bool isRenderReplaced() const;
-    bool isRenderInline() const;
-    bool isRenderFlexibleBox() const;
-    bool isRenderTextControl() const;
-
     virtual bool isChildAllowed(const RenderObject&, const RenderStyle&) const { return true; }
     void didAttachChild(RenderObject& child, RenderObject* beforeChild);
 
@@ -304,17 +294,6 @@ public:
     void clearNeedsLayoutForDescendants();
 
 protected:
-    enum class RenderElementType {
-        RenderLayerModelObjectFlag  = 1 << 0,
-        RenderBoxModelObjectFlag    = 1 << 1,
-        RenderInlineFlag            = 1 << 2,
-        RenderReplacedFlag          = 1 << 3,
-        RenderBlockFlag             = 1 << 4,
-        RenderBlockFlowFlag         = 1 << 5,
-        RenderFlexibleBoxFlag       = 1 << 6,
-        RenderTextControlFlag       = 1 << 7,
-    };
-
     RenderElement(Type, Element&, RenderStyle&&, OptionSet<RenderElementType>);
     RenderElement(Type, Document&, RenderStyle&&, OptionSet<RenderElementType>);
 
@@ -366,7 +345,6 @@ private:
     void isRenderText() const = delete;
     void isRenderElement() const = delete;
 
-    OptionSet<RenderElementType> typeFlags() const { return OptionSet<RenderElementType>::fromRaw(m_typeFlags); }
     RenderObject* firstChildSlow() const final { return firstChild(); }
     RenderObject* lastChildSlow() const final { return lastChild(); }
 
@@ -403,13 +381,14 @@ private:
     const RenderStyle* textSegmentPseudoStyle(PseudoId) const;
 
     SingleThreadPackedWeakPtr<RenderObject> m_firstChild;
-    unsigned m_typeFlags : 8;
     unsigned m_ancestorLineBoxDirty : 1;
     unsigned m_hasInitializedStyle : 1;
 
     unsigned m_hasPausedImageAnimations : 1;
     unsigned m_hasCounterNodeMap : 1;
     unsigned m_hasContinuationChainNode : 1;
+
+    // 11 bits free.
 
     SingleThreadPackedWeakPtr<RenderObject> m_lastChild;
 
@@ -424,8 +403,9 @@ private:
 
     unsigned m_isRegisteredForVisibleInViewportCallback : 1;
     unsigned m_visibleInViewportState : 2;
-
     unsigned m_didContributeToVisuallyNonEmptyPixelCount : 1;
+
+    // 3 bits free.
 
     RenderStyle m_style;
 };
@@ -451,45 +431,6 @@ inline void RenderElement::setChildNeedsLayout(MarkingBehavior markParents)
         markContainingBlocksForLayout();
 }
 
-inline bool RenderElement::isRenderLayerModelObject() const
-{
-    return typeFlags().contains(RenderElementType::RenderLayerModelObjectFlag);
-}
-
-inline bool RenderElement::isRenderBoxModelObject() const
-{
-    return typeFlags().contains(RenderElementType::RenderBoxModelObjectFlag);
-}
-
-inline bool RenderElement::isRenderBlock() const
-{
-    return typeFlags().contains(RenderElementType::RenderBlockFlag);
-}
-
-inline bool RenderElement::isRenderBlockFlow() const
-{
-    return typeFlags().contains(RenderElementType::RenderBlockFlowFlag);
-}
-
-inline bool RenderElement::isRenderReplaced() const
-{
-    return typeFlags().contains(RenderElementType::RenderReplacedFlag);
-}
-
-inline bool RenderElement::isRenderInline() const
-{
-    return typeFlags().contains(RenderElementType::RenderInlineFlag);
-}
-
-inline bool RenderElement::isRenderFlexibleBox() const
-{
-    return typeFlags().contains(RenderElementType::RenderFlexibleBoxFlag);
-}
-
-inline bool RenderElement::isRenderTextControl() const
-{
-    return typeFlags().contains(RenderElementType::RenderTextControlFlag);
-}
 
 inline Element* RenderElement::generatingElement() const
 {
@@ -499,51 +440,6 @@ inline Element* RenderElement::generatingElement() const
 inline bool RenderElement::canEstablishContainingBlockWithTransform() const
 {
     return isRenderBlock() || (isTablePart() && !isRenderTableCol());
-}
-
-inline bool RenderObject::isRenderLayerModelObject() const
-{
-    return is<RenderElement>(*this) && downcast<RenderElement>(*this).isRenderLayerModelObject();
-}
-
-inline bool RenderObject::isRenderBoxModelObject() const
-{
-    return is<RenderElement>(*this) && downcast<RenderElement>(*this).isRenderBoxModelObject();
-}
-
-inline bool RenderObject::isRenderBlock() const
-{
-    return is<RenderElement>(*this) && downcast<RenderElement>(*this).isRenderBlock();
-}
-
-inline bool RenderObject::isRenderBlockFlow() const
-{
-    return is<RenderElement>(*this) && downcast<RenderElement>(*this).isRenderBlockFlow();
-}
-
-inline bool RenderObject::isRenderReplaced() const
-{
-    return is<RenderElement>(*this) && downcast<RenderElement>(*this).isRenderReplaced();
-}
-
-inline bool RenderObject::isRenderInline() const
-{
-    return is<RenderElement>(*this) && downcast<RenderElement>(*this).isRenderInline();
-}
-
-inline bool RenderObject::isRenderFlexibleBox() const
-{
-    return is<RenderElement>(*this) && downcast<RenderElement>(*this).isRenderFlexibleBox();
-}
-
-inline bool RenderObject::isRenderTextControl() const
-{
-    return is<RenderElement>(*this) && downcast<RenderElement>(*this).isRenderTextControl();
-}
-
-inline bool RenderObject::isFlexibleBoxIncludingDeprecated() const
-{
-    return isRenderFlexibleBox() || isRenderDeprecatedFlexibleBox();
 }
 
 inline const RenderStyle& RenderObject::style() const

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -118,7 +118,9 @@ struct SameSizeAsRenderObject : public CachedImageClient, public CanMakeCheckedP
 #endif
     unsigned m_bitfields;
     CheckedRef<Node> node;
-    SingleThreadWeakPtr<RenderObject> pointers[2];
+    SingleThreadWeakPtr<RenderObject> pointers;
+    SingleThreadPackedWeakPtr<RenderObject> m_previous;
+    uint16_t m_renderElementTypes;
     SingleThreadPackedWeakPtr<RenderObject> m_next;
     uint8_t m_type;
     CheckedPtr<Layout::Box> layoutBox;
@@ -135,7 +137,7 @@ void RenderObjectDeleter::operator() (RenderObject* renderer) const
     renderer->destroy();
 }
 
-RenderObject::RenderObject(Type type, Node& node)
+RenderObject::RenderObject(Type type, Node& node, OptionSet<RenderElementType> typeFlags)
     : CachedImageClient()
 #if ASSERT_ENABLED
     , m_hasAXObject(false)
@@ -143,6 +145,7 @@ RenderObject::RenderObject(Type type, Node& node)
 #endif
     , m_bitfields(node)
     , m_node(node)
+    , m_renderElementTypeFlags(typeFlags)
     , m_type(type)
 {
     if (CheckedPtr renderView = node.document().renderView())

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -251,7 +251,7 @@ static unsigned offsetForPositionInRun(const InlineIterator::TextBox& textBox, f
 }
 
 inline RenderText::RenderText(Type type, Node& node, const String& text)
-    : RenderObject(type, node)
+    : RenderObject(type, node, { })
     , m_text(text)
     , m_containsOnlyASCII(text.impl()->containsOnlyASCII())
 {

--- a/Source/WebCore/rendering/RenderTextControlSingleLine.cpp
+++ b/Source/WebCore/rendering/RenderTextControlSingleLine.cpp
@@ -62,6 +62,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderTextControlInnerBlock);
 RenderTextControlSingleLine::RenderTextControlSingleLine(Type type, HTMLInputElement& element, RenderStyle&& style)
     : RenderTextControl(type, element, WTFMove(style))
 {
+    ASSERT(isRenderTextControlSingleLine());
 }
 
 RenderTextControlSingleLine::~RenderTextControlSingleLine() = default;

--- a/Source/WebCore/rendering/RenderTextControlSingleLine.h
+++ b/Source/WebCore/rendering/RenderTextControlSingleLine.h
@@ -43,7 +43,6 @@ private:
 
     bool hasControlClip() const override;
     LayoutRect controlClipRect(const LayoutPoint&) const override;
-    bool isRenderTextControlSingleLine() const final { return true; }
 
     void layout() override;
 

--- a/Source/WebCore/rendering/svg/RenderSVGContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGContainer.cpp
@@ -48,12 +48,12 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGContainer);
 
 RenderSVGContainer::RenderSVGContainer(Type type, Document& document, RenderStyle&& style)
-    : RenderSVGModelObject(type, document, WTFMove(style))
+    : RenderSVGModelObject(type, document, WTFMove(style), RenderElementType::RenderSVGContainer)
 {
 }
 
 RenderSVGContainer::RenderSVGContainer(Type type, SVGElement& element, RenderStyle&& style)
-    : RenderSVGModelObject(type, element, WTFMove(style))
+    : RenderSVGModelObject(type, element, WTFMove(style), RenderElementType::RenderSVGContainer)
 {
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGContainer.h
+++ b/Source/WebCore/rendering/svg/RenderSVGContainer.h
@@ -68,9 +68,6 @@ protected:
     FloatRect m_objectBoundingBox;
     FloatRect m_objectBoundingBoxWithoutTransformations;
     mutable Markable<FloatRect, FloatRect::MarkableTraits> m_strokeBoundingBox;
-
-private:
-    bool isRenderSVGContainer() const final { return true; }
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
@@ -55,13 +55,13 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGModelObject);
 
-RenderSVGModelObject::RenderSVGModelObject(Type type, Document& document, RenderStyle&& style)
-    : RenderLayerModelObject(type, document, WTFMove(style), { })
+RenderSVGModelObject::RenderSVGModelObject(Type type, Document& document, RenderStyle&& style, OptionSet<RenderElementType> typeFlags)
+    : RenderLayerModelObject(type, document, WTFMove(style), typeFlags)
 {
 }
 
-RenderSVGModelObject::RenderSVGModelObject(Type type, SVGElement& element, RenderStyle&& style)
-    : RenderLayerModelObject(type, element, WTFMove(style), { })
+RenderSVGModelObject::RenderSVGModelObject(Type type, SVGElement& element, RenderStyle&& style, OptionSet<RenderElementType> typeFlags)
+    : RenderLayerModelObject(type, element, WTFMove(style), typeFlags)
 {
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGModelObject.h
+++ b/Source/WebCore/rendering/svg/RenderSVGModelObject.h
@@ -83,8 +83,8 @@ public:
     virtual Path computeClipPath(AffineTransform&) const;
 
 protected:
-    RenderSVGModelObject(Type, Document&, RenderStyle&&);
-    RenderSVGModelObject(Type, SVGElement&, RenderStyle&&);
+    RenderSVGModelObject(Type, Document&, RenderStyle&&, OptionSet<RenderElementType> = { });
+    RenderSVGModelObject(Type, SVGElement&, RenderStyle&&, OptionSet<RenderElementType> = { });
 
     void willBeDestroyed() override;
     void updateFromStyle() override;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp
@@ -42,7 +42,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(LegacyRenderSVGContainer);
 
 LegacyRenderSVGContainer::LegacyRenderSVGContainer(Type type, SVGElement& element, RenderStyle&& style)
-    : LegacyRenderSVGModelObject(type, element, WTFMove(style))
+    : LegacyRenderSVGModelObject(type, element, WTFMove(style), RenderElementType::LegacyRenderSVGContainer)
 {
 }
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.h
@@ -70,8 +70,6 @@ protected:
     void updateCachedBoundaries();
 
 private:
-    bool isLegacyRenderSVGContainer() const final { return true; }
-
     FloatRect m_objectBoundingBox;
     mutable Markable<FloatRect, FloatRect::MarkableTraits> m_strokeBoundingBox;
     FloatRect m_repaintBoundingBox;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
@@ -46,8 +46,8 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(LegacyRenderSVGModelObject);
 
-LegacyRenderSVGModelObject::LegacyRenderSVGModelObject(Type type, SVGElement& element, RenderStyle&& style)
-    : RenderElement(type, element, WTFMove(style), { })
+LegacyRenderSVGModelObject::LegacyRenderSVGModelObject(Type type, SVGElement& element, RenderStyle&& style, OptionSet<RenderElementType> typeFlags)
+    : RenderElement(type, element, WTFMove(style), typeFlags)
 {
 }
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.h
@@ -65,7 +65,7 @@ public:
     SVGElement& element() const { return downcast<SVGElement>(nodeForNonAnonymous()); }
 
 protected:
-    LegacyRenderSVGModelObject(Type, SVGElement&, RenderStyle&&);
+    LegacyRenderSVGModelObject(Type, SVGElement&, RenderStyle&&, OptionSet<RenderElementType> = { });
 
     void willBeDestroyed() override;
 


### PR DESCRIPTION
#### 5b7421b95b8ca058e421a83a8436f0db859648e3
<pre>
Move RenderElementType to RenderObject to simplify and devirtualize type checks
<a href="https://bugs.webkit.org/show_bug.cgi?id=266531">https://bugs.webkit.org/show_bug.cgi?id=266531</a>

Reviewed by Chris Dumez.

This PR moves OptionSet&lt;RenderElementType&gt; from RenderElement to RenderObject to eliminate
isRenderElement checks from isRenderReplaced, isRenderBoxModelObject, etc...

It also devirtualizes isRenderSVGContainer() and isLegacyRenderSVGContainer() with two more
bit flags: LegacyRenderSVGContainer and RenderSVGContainer. This eliminates the last virtual
function calls in RenderTreeBuilder::detach.

* Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp:
(WebCore::RenderDeprecatedFlexibleBox::RenderDeprecatedFlexibleBox):
* Source/WebCore/rendering/RenderDeprecatedFlexibleBox.h:
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::RenderElement):
(WebCore::RenderElement::createFor):
* Source/WebCore/rendering/RenderElement.h:
(WebCore::RenderElement::typeFlags const): Deleted.
(WebCore::RenderElement::isRenderLayerModelObject const): Deleted.
(WebCore::RenderElement::isRenderBoxModelObject const): Deleted.
(WebCore::RenderElement::isRenderBlock const): Deleted.
(WebCore::RenderElement::isRenderBlockFlow const): Deleted.
(WebCore::RenderElement::isRenderReplaced const): Deleted.
(WebCore::RenderElement::isRenderInline const): Deleted.
(WebCore::RenderElement::isRenderFlexibleBox const): Deleted.
(WebCore::RenderElement::isRenderTextControl const): Deleted.
(WebCore::RenderObject::isRenderLayerModelObject const): Deleted.
(WebCore::RenderObject::isRenderBoxModelObject const): Deleted.
(WebCore::RenderObject::isRenderBlock const): Deleted.
(WebCore::RenderObject::isRenderBlockFlow const): Deleted.
(WebCore::RenderObject::isRenderReplaced const): Deleted.
(WebCore::RenderObject::isRenderInline const): Deleted.
(WebCore::RenderObject::isRenderFlexibleBox const): Deleted.
(WebCore::RenderObject::isRenderTextControl const): Deleted.
(WebCore::RenderObject::isFlexibleBoxIncludingDeprecated const): Deleted.
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::RenderObject):
* Source/WebCore/rendering/RenderObject.h:
(WebCore::RenderObject::isRenderReplaced const):
(WebCore::RenderObject::isRenderBoxModelObject const):
(WebCore::RenderObject::isRenderBlock const):
(WebCore::RenderObject::isRenderBlockFlow const):
(WebCore::RenderObject::isRenderInline const):
(WebCore::RenderObject::isRenderLayerModelObject const):
(WebCore::RenderObject::isRenderTextControl const):
(WebCore::RenderObject::isRenderTextControlSingleLine const):
(WebCore::RenderObject::isRenderSVGContainer const):
(WebCore::RenderObject::isLegacyRenderSVGContainer const):
(WebCore::RenderObject::isRenderDeprecatedFlexibleBox const):
(WebCore::RenderObject::isRenderFlexibleBox const):
(WebCore::RenderObject::isFlexibleBoxIncludingDeprecated const):
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::RenderText::RenderText):
* Source/WebCore/rendering/RenderTextControlSingleLine.cpp:
(WebCore::RenderTextControlSingleLine::RenderTextControlSingleLine):
* Source/WebCore/rendering/RenderTextControlSingleLine.h:
* Source/WebCore/rendering/svg/RenderSVGContainer.cpp:
(WebCore::RenderSVGContainer::RenderSVGContainer):
* Source/WebCore/rendering/svg/RenderSVGContainer.h:
* Source/WebCore/rendering/svg/RenderSVGModelObject.cpp:
(WebCore::RenderSVGModelObject::RenderSVGModelObject):
* Source/WebCore/rendering/svg/RenderSVGModelObject.h:
(WebCore::RenderSVGModelObject::RenderSVGModelObject):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp:
(WebCore::LegacyRenderSVGContainer::LegacyRenderSVGContainer):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp:
(WebCore::LegacyRenderSVGModelObject::LegacyRenderSVGModelObject):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.h:
(WebCore::LegacyRenderSVGModelObject::LegacyRenderSVGModelObject):

Canonical link: <a href="https://commits.webkit.org/272195@main">https://commits.webkit.org/272195@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/793a47884a195c113532fb4c25e40111cc3a3b2b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30867 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9545 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32540 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33369 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27883 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31619 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11866 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6795 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27754 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31186 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8020 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27608 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6882 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7036 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27486 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34707 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28093 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27967 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33189 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7082 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5158 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31022 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8793 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7794 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4003 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7636 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->