### PR TITLE
Remove cruft from ThemeMac

### DIFF
--- a/Source/WebCore/platform/Theme.h
+++ b/Source/WebCore/platform/Theme.h
@@ -70,7 +70,7 @@ public:
     // the theme needs to communicate this inflated rect to the engine so that it can invalidate the whole control.
     // The rect passed in is in zoomed coordinates, so the inflation should take that into account and make sure the inflation
     // amount is also scaled by the zoomFactor.
-    virtual void inflateControlPaintRect(StyleAppearance, OptionSet<ControlStyle::State>, FloatRect&, float) const { }
+    virtual void inflateControlPaintRect(StyleAppearance, FloatRect&, float) const { }
 
     virtual void drawNamedImage(const String&, GraphicsContext&, const FloatSize&) const;
 

--- a/Source/WebCore/platform/mac/ThemeMac.h
+++ b/Source/WebCore/platform/mac/ThemeMac.h
@@ -54,7 +54,7 @@ private:
 
     bool controlRequiresPreWhiteSpace(StyleAppearance appearance) const final { return appearance == StyleAppearance::PushButton; }
 
-    void inflateControlPaintRect(StyleAppearance, OptionSet<ControlStyle::State>, FloatRect&, float zoomFactor) const final;
+    void inflateControlPaintRect(StyleAppearance, FloatRect&, float zoomFactor) const final;
 
     bool userPrefersContrast() const final;
     bool userPrefersReducedMotion() const final;

--- a/Source/WebCore/rendering/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/RenderThemeMac.mm
@@ -740,19 +740,13 @@ void RenderThemeMac::adjustRepaintRect(const RenderObject& renderer, FloatRect& 
     switch (appearance) {
     case StyleAppearance::Button:
     case StyleAppearance::Checkbox:
-#if ENABLE(INPUT_TYPE_COLOR)
-    case StyleAppearance::ColorWell:
-#endif
     case StyleAppearance::DefaultButton:
     case StyleAppearance::InnerSpinButton:
     case StyleAppearance::PushButton:
     case StyleAppearance::Radio:
-    case StyleAppearance::SquareButton:
-    case StyleAppearance::Switch: {
-        auto states = extractControlStyleStatesForRenderer(renderer);
-        Theme::singleton().inflateControlPaintRect(renderer.style().effectiveAppearance(), states, rect, renderer.style().effectiveZoom());
+    case StyleAppearance::Switch:
+        Theme::singleton().inflateControlPaintRect(renderer.style().effectiveAppearance(), rect, renderer.style().effectiveZoom());
         break;
-    }
     case StyleAppearance::Menulist: {
         auto zoomLevel = renderer.style().effectiveZoom();
         setPopupButtonCellState(renderer, IntSize(rect.size()));


### PR DESCRIPTION
#### 20d6a4967eff10b34ccdda0fd124f549b363afee
<pre>
Remove cruft from ThemeMac
<a href="https://bugs.webkit.org/show_bug.cgi?id=266539">https://bugs.webkit.org/show_bug.cgi?id=266539</a>

Reviewed by Aditya Keerthi.

At this point in its life ThemeMac is mainly responsible for
determining the sizing of a couple of form controls as the GPU process
has taken over most of the theming aspects.

And to determine the sizing of these form controls no cells are needed
so all that code can be removed.

And then we also remove some code that eventually does not do anything,
such as StyleAppearance::ColorWell which do to not having the correct
bezel style (which is itself a concept that can be removed) never ends
up being impacted by inflateControlPaintRect().

* Source/WebCore/platform/Theme.h:
(WebCore::Theme::inflateControlPaintRect const):
* Source/WebCore/platform/mac/ThemeMac.h:
* Source/WebCore/platform/mac/ThemeMac.mm:
(WebCore::radioSize):
(WebCore::ThemeMac::inflateControlPaintRect const):
(WebCore::setControlSize): Deleted.
(WebCore::updateStates): Deleted.
(WebCore::configureToggleButton): Deleted.
(WebCore::createToggleButtonCell): Deleted.
(WebCore::sharedRadioCell): Deleted.
(WebCore::sharedCheckboxCell): Deleted.
(WebCore::buttonCell): Deleted.
(WebCore::setUpButtonCell): Deleted.
(WebCore::button): Deleted.
* Source/WebCore/rendering/RenderThemeMac.mm:
(WebCore::RenderThemeMac::adjustRepaintRect):

Canonical link: <a href="https://commits.webkit.org/272218@main">https://commits.webkit.org/272218@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f203488b2a2610ae188a160cbcfbcce400fa308

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30836 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9517 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32509 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33337 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27855 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31587 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11833 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6763 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27724 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31154 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7990 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27577 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6852 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7011 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27455 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34675 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28063 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27934 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33158 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7052 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5126 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30991 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8765 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7307 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7766 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7608 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->