### PR TITLE
[Wasm-GC] Inline Wasm array operations & allocation

### DIFF
--- a/JSTests/wasm/gc/arrays.js
+++ b/JSTests/wasm/gc/arrays.js
@@ -669,6 +669,32 @@ function testArrayTable() {
   }
 }
 
+function testArrayLimit() {
+  assert.throws(
+    () => instantiate(`
+      (module
+        (type (array i8))
+        (start 0)
+        (func
+          (array.new 0 (i32.const 1) (i32.const 2_147_483_648)) drop))
+    `),
+    WebAssembly.RuntimeError,
+    "Failed to allocate new array"
+  );
+
+  assert.throws(
+    () => instantiate(`
+      (module
+        (type (array i8))
+        (start 0)
+        (func
+          (array.new_default 0 (i32.const 2_147_483_648)) drop))
+    `),
+    WebAssembly.RuntimeError,
+    "Failed to allocate new array"
+  );
+}
+
 testArrayDeclaration();
 testArrayJS();
 testArrayNew();
@@ -677,3 +703,4 @@ testArrayGet();
 testArraySet();
 testArrayLen();
 testArrayTable();
+testArrayLimit();

--- a/Source/JavaScriptCore/wasm/WasmExceptionType.h
+++ b/Source/JavaScriptCore/wasm/WasmExceptionType.h
@@ -50,6 +50,7 @@ namespace Wasm {
     macro(InvalidGCTypeUse, "Unsupported use of struct or array type"_s) \
     macro(OutOfBoundsArrayGet, "Out of bounds array.get"_s) \
     macro(OutOfBoundsArraySet, "Out of bounds array.set"_s) \
+    macro(BadArrayNew, "Failed to allocate new array"_s) \
     macro(NullArrayGet, "array.get to a null reference"_s) \
     macro(NullArraySet, "array.set to a null reference"_s) \
     macro(NullArrayLen, "array.len to a null reference"_s) \
@@ -103,6 +104,7 @@ ALWAYS_INLINE bool isTypeErrorExceptionType(ExceptionType type)
     case ExceptionType::StackOverflow:
     case ExceptionType::OutOfBoundsArrayGet:
     case ExceptionType::OutOfBoundsArraySet:
+    case ExceptionType::BadArrayNew:
     case ExceptionType::NullArrayGet:
     case ExceptionType::NullArraySet:
     case ExceptionType::NullArrayLen:

--- a/Source/JavaScriptCore/wasm/WasmLimits.h
+++ b/Source/JavaScriptCore/wasm/WasmLimits.h
@@ -59,6 +59,9 @@ constexpr size_t maxFunctionReturns = 1000;
 constexpr size_t maxTableEntries = 10000000;
 constexpr unsigned maxTables = 1000000;
 
+// Limit of GC arrays in bytes. This is not included in the limits in the
+// JS API spec, but we set a limit to avoid complicated boundary conditions.
+constexpr size_t maxArraySizeInBytes = 1 << 30;
 
 } } // namespace JSC::Wasm
 

--- a/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
+++ b/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
@@ -74,6 +74,9 @@ inline EncodedJSValue arrayNew(Instance* instance, uint32_t typeIndex, uint32_t 
 
     size_t elementSize = fieldType.type.elementSize();
 
+    if (UNLIKELY(productOverflows<uint32_t>(elementSize * size) || elementSize * size > maxArraySizeInBytes))
+        return JSValue::encode(jsNull());
+
     JSWebAssemblyArray* array = nullptr;
 
     switch (elementSize) {

--- a/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
@@ -431,7 +431,10 @@ WASM_SLOW_PATH_DECL(array_new)
         WASM_RETURN(Wasm::arrayNewFixed(instance, instruction.m_typeIndex, size, reinterpret_cast<uint64_t*>(&callFrame->r(instruction.m_value))));
     }
     }
-    WASM_RETURN(Wasm::arrayNew(instance, instruction.m_typeIndex, size, value));
+    EncodedJSValue result = Wasm::arrayNew(instance, instruction.m_typeIndex, size, value);
+    if (JSValue::decode(result).isNull())
+        WASM_THROW(Wasm::ExceptionType::BadArrayNew);
+    WASM_RETURN(result);
 }
 
 WASM_SLOW_PATH_DECL(array_get)

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h
@@ -132,10 +132,38 @@ public:
     }
 
     static ptrdiff_t offsetOfSize() { return OBJECT_OFFSETOF(JSWebAssemblyArray, m_size); }
-    static ptrdiff_t offsetOfPayload()
+    static ptrdiff_t offsetOfPayload() { return OBJECT_OFFSETOF(JSWebAssemblyArray, m_payload8) + FixedVector<uint8_t>::offsetOfStorage(); }
+    static ptrdiff_t offsetOfElements(Wasm::StorageType type)
     {
-        ASSERT(OBJECT_OFFSETOF(JSWebAssemblyArray, m_payload32) == OBJECT_OFFSETOF(JSWebAssemblyArray, m_payload64));
-        return OBJECT_OFFSETOF(JSWebAssemblyArray, m_payload32);
+        if (type.is<Wasm::PackedType>()) {
+            switch (type.as<Wasm::PackedType>()) {
+            case Wasm::PackedType::I8:
+                return FixedVector<uint8_t>::Storage::offsetOfData();
+            case Wasm::PackedType::I16:
+                return FixedVector<uint16_t>::Storage::offsetOfData();
+            }
+        }
+
+        ASSERT(type.is<Wasm::Type>());
+
+        switch (type.as<Wasm::Type>().kind) {
+        case Wasm::TypeKind::I32:
+        case Wasm::TypeKind::F32:
+            return FixedVector<uint32_t>::Storage::offsetOfData();
+        case Wasm::TypeKind::I64:
+        case Wasm::TypeKind::F64:
+        case Wasm::TypeKind::Ref:
+        case Wasm::TypeKind::RefNull:
+            return FixedVector<uint64_t>::Storage::offsetOfData();
+        case Wasm::TypeKind::V128:
+            ASSERT_NOT_IMPLEMENTED_YET();
+            break;
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+            break;
+        }
+
+        return 0;
     }
 
 protected:


### PR DESCRIPTION
#### dcb4e4846eeaf91edfb9a06f791f5920ab4a3e8c
<pre>
[Wasm-GC] Inline Wasm array operations &amp; allocation
<a href="https://bugs.webkit.org/show_bug.cgi?id=245405">https://bugs.webkit.org/show_bug.cgi?id=245405</a>

Reviewed by Justin Michaud.

Adds JIT inlining for array.get/set operations in both BBQ and B3 tiers.
Allocation inlining is not done yet as it&apos;s more complex.

Sets an arbitrary limit on max array length to avoid boundary conditions on the
array index type.

Also simplify some code for struct.get/set as well.

* JSTests/wasm/gc/arrays.js:
(testArrayLimit):
* Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp:
(JSC::Wasm::B3IRGenerator::emitStructSet):
(JSC::Wasm::B3IRGenerator::pushArrayNew):
(JSC::Wasm::B3IRGenerator::addArrayGet):
(JSC::Wasm::B3IRGenerator::emitArraySetUnchecked):
(JSC::Wasm::B3IRGenerator::addStructGet):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJIT::addArrayNew):
(JSC::Wasm::BBQJIT::addArrayNewDefault):
(JSC::Wasm::BBQJIT::emitArraySetUnchecked):
(JSC::Wasm::BBQJIT::addArrayNewFixed):
(JSC::Wasm::BBQJIT::addArrayGet):
(JSC::Wasm::BBQJIT::addStructGet):
* Source/JavaScriptCore/wasm/WasmExceptionType.h:
(JSC::Wasm::isTypeErrorExceptionType):
* Source/JavaScriptCore/wasm/WasmLimits.h:
* Source/JavaScriptCore/wasm/WasmOperationsInlines.h:
(JSC::Wasm::arrayNew):
* Source/JavaScriptCore/wasm/WasmSlowPaths.cpp:
(JSC::LLInt::WASM_SLOW_PATH_DECL):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h:

Canonical link: <a href="https://commits.webkit.org/272642@main">https://commits.webkit.org/272642@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4aa6771a58918e5051f21c5853dc89c7d9d27fb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32479 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11215 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34313 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35032 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29374 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13567 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8414 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28902 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32903 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9455 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29021 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8231 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8372 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28954 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36368 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/27877 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29517 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29379 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34496 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/32553 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8505 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6455 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32358 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10170 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/38978 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7564 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9124 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8234 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9083 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->