### PR TITLE
[iOS] Overriding -[WKWebView textInputTraits] no longer works when async text input is enabled

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -509,6 +509,7 @@ struct ImageAnalysisContextMenuActionData {
 
     BOOL _focusRequiresStrongPasswordAssistance;
     BOOL _waitingForEditDragSnapshot;
+    std::optional<BOOL> _cachedRequiresLegacyTextInputTraits;
     NSInteger _dropAnimationCount;
 
     BOOL _hasSetUpInteractions;


### PR DESCRIPTION
#### 6a0bff521d3a7d30cbdf289850dd561337374f6e
<pre>
[iOS] Overriding -[WKWebView textInputTraits] no longer works when async text input is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=266545">https://bugs.webkit.org/show_bug.cgi?id=266545</a>
<a href="https://rdar.apple.com/119768117">rdar://119768117</a>

Reviewed by Megan Gardner.

Ensure binary compatibility with internal clients (e.g. Mail, News) that override the SPI method
`-[WKWebView _textInputTraits]`, to override or customize the private text input traits object. To
do this, we detect whether or not the embedding client overrides `-_textInputTraits`, and fall back
to returning private text input traits (`UITextInputTraits`) in `-extendedTraitsDelegate`, which
consults the embedding client in the process.

We also suppress the async text input assertion in this case. Covered by running the API test
`KeyboardInputTests.OverrideTextInputTraits` when `UIKit/async_text_input` is enabled.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView insertionPointColor]):
(-[WKContentView selectionBarColor]):
(-[WKContentView selectionHighlightColor]):
(-[WKContentView _requiresLegacyTextInputTraits]):
(-[WKContentView textInputTraits]):
(-[WKContentView extendedTraitsDelegate]):
(-[WKContentView textContentTypeForTesting]):

Canonical link: <a href="https://commits.webkit.org/272187@main">https://commits.webkit.org/272187@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aefde09906f407f2bb6edd07998e069e7fa45eac

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30855 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9535 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32529 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33357 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27873 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11854 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6783 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27743 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31174 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8008 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27597 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6871 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7034 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34695 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28081 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27955 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33175 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7071 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5146 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31008 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8783 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7294 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7784 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7626 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->