### PR TITLE
Use CheckedPtr less for non-stack objects in WebKitLegacy

### DIFF
--- a/Source/WebKitLegacy/Storage/StorageNamespaceImpl.h
+++ b/Source/WebKitLegacy/Storage/StorageNamespaceImpl.h
@@ -38,7 +38,7 @@ namespace WebKit {
 
 class StorageAreaImpl;
 
-class StorageNamespaceImpl final : public WebCore::StorageNamespace, public CanMakeCheckedPtr {
+class StorageNamespaceImpl final : public WebCore::StorageNamespace, public CanMakeWeakPtr<StorageNamespaceImpl> {
 public:
     static Ref<StorageNamespaceImpl> createSessionStorageNamespace(unsigned quota, PAL::SessionID);
     static Ref<StorageNamespaceImpl> getOrCreateLocalStorageNamespace(const String& databasePath, unsigned quota, PAL::SessionID);

--- a/Source/WebKitLegacy/Storage/WebStorageNamespaceProvider.cpp
+++ b/Source/WebKitLegacy/Storage/WebStorageNamespaceProvider.cpp
@@ -33,9 +33,9 @@ using namespace WebCore;
 
 namespace WebKit {
 
-static HashSet<CheckedRef<WebStorageNamespaceProvider>>& storageNamespaceProviders()
+static HashSet<WeakRef<WebStorageNamespaceProvider>>& storageNamespaceProviders()
 {
-    static NeverDestroyed<HashSet<CheckedRef<WebStorageNamespaceProvider>>> storageNamespaceProviders;
+    static NeverDestroyed<HashSet<WeakRef<WebStorageNamespaceProvider>>> storageNamespaceProviders;
 
     return storageNamespaceProviders;
 }

--- a/Source/WebKitLegacy/Storage/WebStorageNamespaceProvider.h
+++ b/Source/WebKitLegacy/Storage/WebStorageNamespaceProvider.h
@@ -35,7 +35,7 @@ class SecurityOriginData;
 
 namespace WebKit {
 
-class WebStorageNamespaceProvider final : public WebCore::StorageNamespaceProvider, public CanMakeCheckedPtr {
+class WebStorageNamespaceProvider final : public WebCore::StorageNamespaceProvider, public CanMakeWeakPtr<WebStorageNamespaceProvider> {
 public:
     static Ref<WebStorageNamespaceProvider> create(const String& localStorageDatabasePath);
     virtual ~WebStorageNamespaceProvider();

--- a/Source/WebKitLegacy/mac/History/BackForwardList.h
+++ b/Source/WebKitLegacy/mac/History/BackForwardList.h
@@ -28,15 +28,15 @@
 #pragma once
 
 #include <WebCore/BackForwardClient.h>
-#include <wtf/CheckedRef.h>
 #include <wtf/HashSet.h>
 #include <wtf/Vector.h>
+#include <wtf/WeakPtr.h>
 
 OBJC_CLASS WebView;
 
 typedef HashSet<RefPtr<WebCore::HistoryItem>> HistoryItemHashSet;
 
-class BackForwardList : public WebCore::BackForwardClient, public CanMakeCheckedPtr {
+class BackForwardList : public WebCore::BackForwardClient, public CanMakeWeakPtr<BackForwardList> {
 public: 
     static Ref<BackForwardList> create(WebView *webView) { return adoptRef(*new BackForwardList(webView)); }
     virtual ~BackForwardList();

--- a/Source/WebKitLegacy/mac/History/WebBackForwardList.mm
+++ b/Source/WebKitLegacy/mac/History/WebBackForwardList.mm
@@ -52,7 +52,7 @@
 #import <wtf/StdLibExtras.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
-using BackForwardListMap = HashMap<CheckedRef<BackForwardList>, WebBackForwardList*>;
+using BackForwardListMap = HashMap<WeakRef<BackForwardList>, WebBackForwardList*>;
 
 // FIXME: Instead of this we could just create a class derived from BackForwardList
 // with a pointer to a WebBackForwardList in it.

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebVisitedLinkStore.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebVisitedLinkStore.h
@@ -31,7 +31,7 @@
 #import <wtf/CheckedRef.h>
 #import <wtf/Ref.h>
 
-class WebVisitedLinkStore final : public WebCore::VisitedLinkStore, public CanMakeCheckedPtr {
+class WebVisitedLinkStore final : public WebCore::VisitedLinkStore, public CanMakeWeakPtr<WebVisitedLinkStore> {
 public:
     static Ref<WebVisitedLinkStore> create();
     virtual ~WebVisitedLinkStore();

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebVisitedLinkStore.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebVisitedLinkStore.mm
@@ -38,9 +38,9 @@ using namespace WebCore;
 
 static bool s_shouldTrackVisitedLinks;
 
-static HashSet<CheckedRef<WebVisitedLinkStore>>& visitedLinkStores()
+static HashSet<WeakRef<WebVisitedLinkStore>>& visitedLinkStores()
 {
-    static NeverDestroyed<HashSet<CheckedRef<WebVisitedLinkStore>>> visitedLinkStores;
+    static NeverDestroyed<HashSet<WeakRef<WebVisitedLinkStore>>> visitedLinkStores;
 
     return visitedLinkStores;
 }


### PR DESCRIPTION
#### 43b178ad4d4a76a474acabccada2a4840826ae43
<pre>
Use CheckedPtr less for non-stack objects in WebKitLegacy
<a href="https://bugs.webkit.org/show_bug.cgi?id=266548">https://bugs.webkit.org/show_bug.cgi?id=266548</a>

Reviewed by Darin Adler.

Use CheckedPtr less for non-stack objects in WebKitLegacy. Use WeakPtr instead to
generate more actionable crashes.

* Source/WebKitLegacy/Storage/StorageNamespaceImpl.cpp:
(WebKit::localStorageNamespaceMap):
(WebKit::StorageNamespaceImpl::getOrCreateLocalStorageNamespace):
* Source/WebKitLegacy/Storage/StorageNamespaceImpl.h:
* Source/WebKitLegacy/Storage/WebStorageNamespaceProvider.cpp:
(WebKit::storageNamespaceProviders):
* Source/WebKitLegacy/Storage/WebStorageNamespaceProvider.h:
* Source/WebKitLegacy/mac/History/BackForwardList.h:
* Source/WebKitLegacy/mac/History/WebBackForwardList.mm:
* Source/WebKitLegacy/mac/WebCoreSupport/WebVisitedLinkStore.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebVisitedLinkStore.mm:
(visitedLinkStores):

Canonical link: <a href="https://commits.webkit.org/272198@main">https://commits.webkit.org/272198@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/464a515477c02561480f661b532ff41d18f808b6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30914 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9589 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32591 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33419 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27926 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11918 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6845 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/27793 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31236 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8067 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27656 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6924 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7083 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27535 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34757 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28142 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/28009 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33231 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7127 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5201 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31063 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8835 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7837 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4006 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7678 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->