### PR TITLE
Increase usage of dynamicDowncast in AccessibilityRenderObject

### DIFF
--- a/Source/WebCore/rendering/RenderThemeMac.h
+++ b/Source/WebCore/rendering/RenderThemeMac.h
@@ -186,9 +186,6 @@ private:
 
     mutable RetainPtr<NSPopUpButtonCell> m_popupButton;
 
-    bool m_isSliderThumbHorizontalPressed { false };
-    bool m_isSliderThumbVerticalPressed { false };
-
     RetainPtr<WebCoreRenderThemeNotificationObserver> m_notificationObserver;
 };
 


### PR DESCRIPTION
#### dcd42ae35333b577043cbe9e3eda1c4a5c66a471
<pre>
Increase usage of dynamicDowncast in AccessibilityRenderObject
<a href="https://bugs.webkit.org/show_bug.cgi?id=266553">https://bugs.webkit.org/show_bug.cgi?id=266553</a>

Reviewed by Chris Dumez.

Also sprinkle some RefPtr around, but not too much as many methods in
this part of the code are not prepared to handle them.

* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::isInlineWithContinuation):
(WebCore::startOfContinuations):
(WebCore::firstChildIsInlineContinuation):
(WebCore::AccessibilityRenderObject::setValue):
(WebCore::AccessibilityRenderObject::widget const):
(WebCore::AccessibilityRenderObject::documentLinks):
(WebCore::AccessibilityRenderObject::accessibilityHitTest const):
(WebCore::AccessibilityRenderObject::renderObjectIsObservable const):
(WebCore::AccessibilityRenderObject::determineAccessibilityRole):
(WebCore::AccessibilityRenderObject::inheritsPresentationalRole const):
(WebCore::AccessibilityRenderObject::addImageMapChildren):
(WebCore::AccessibilityRenderObject::addTextFieldChildren):
(WebCore::AccessibilityRenderObject::remoteSVGRootElement const):
(WebCore::AccessibilityRenderObject::addNodeOnlyChildren):
(WebCore::AccessibilityRenderObject::setAccessibleName):
(WebCore::AccessibilityRenderObject::getScrollableAreaIfScrollable const):
(WebCore::AccessibilityRenderObject::scrollTo const):
* Source/WebCore/rendering/RenderThemeMac.h:

Drive-by fix to remove some no longer used class members.

Canonical link: <a href="https://commits.webkit.org/272204@main">https://commits.webkit.org/272204@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0218e965cbdd1220d19fa6bfcf9afc07a3f787f7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30930 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9602 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32608 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33437 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27940 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31685 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11939 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6863 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27812 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31254 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8087 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27676 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6943 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7116 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27555 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34775 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28162 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28029 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33250 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7143 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5218 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31082 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8848 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7299 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7850 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7691 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->