### PR TITLE
Allow scrolling right-to-left or bottom-to-top scrollable areas by dragging the scrollbar.

### DIFF
--- a/LayoutTests/fast/scrolling/rtl-bt-drag-scroller-expected.txt
+++ b/LayoutTests/fast/scrolling/rtl-bt-drag-scroller-expected.txt
@@ -1,0 +1,11 @@
+This test makes sure that a div with right-to-left or bottom-to-top scroll directions can be scrolled by dragging the scrollbar.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS scrollMe.scrollLeft is not 0
+PASS scrollMe.scrollTop is not 0
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/rtl-bt-drag-scroller.html
+++ b/LayoutTests/fast/scrolling/rtl-bt-drag-scroller.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body style="margin: 0px;">
+<div id="scrollMe" style="writing-mode: vertical-rl; direction: rtl; width: 100px; height: 100px; position: absolute; left: 0px; top: 0px; overflow: scroll;">
+<div style="width: 300px; height: 300px; background-color: yellow;"></div>
+</div>
+<script>
+description("This test makes sure that a div with right-to-left or bottom-to-top scroll directions can be scrolled by dragging the scrollbar.");
+
+if (window.eventSender) {
+    eventSender.mouseMoveTo(96, 96);
+    eventSender.mouseDown();
+    eventSender.mouseMoveTo(4, 96);
+    eventSender.mouseUp();
+
+    eventSender.mouseMoveTo(4, 81);
+    eventSender.mouseDown();
+    eventSender.mouseMoveTo(4, 4);
+    eventSender.mouseUp();
+}
+
+var scrollMe = document.getElementById("scrollMe");
+shouldNotBe("scrollMe.scrollLeft", "0");
+shouldNotBe("scrollMe.scrollTop", "0");
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -2418,6 +2418,7 @@ fast/images/image-map-outline-with-scale-transform.html [ Pass ImageOnlyFailure 
 fast/dom/Window/child-window-focus.html
 
 # iOS does not allow you to scroll by dragging the scrollbar thumb.
+webkit.org/b/266555 fast/scrolling/rtl-bt-drag-scroller.html [ Failure ]
 webkit.org/b/157201 fast/scrolling/rtl-drag-vertical-scroller.html [ Failure ]
 webkit.org/b/157201 css3/scroll-snap/scroll-snap-drag-scrollbar-thumb.html [ Failure ]
 webkit.org/b/157201 css3/scroll-snap/scroll-snap-drag-scrollbar-thumb-with-relayouts.html [ Failure ]

--- a/Source/WebCore/platform/ScrollableArea.cpp
+++ b/Source/WebCore/platform/ScrollableArea.cpp
@@ -172,6 +172,15 @@ void ScrollableArea::scrollToPositionWithoutAnimation(const FloatPoint& position
     scrollAnimator().scrollToPositionWithoutAnimation(position, clamping);
 }
 
+void ScrollableArea::scrollToPositionWithoutAnimation(ScrollbarOrientation orientation, float position)
+{
+    auto currentPosition = scrollAnimator().currentPosition();
+    if (orientation == ScrollbarOrientation::Horizontal)
+        scrollAnimator().scrollToPositionWithoutAnimation(FloatPoint(position, currentPosition.y()));
+    else
+        scrollAnimator().scrollToPositionWithoutAnimation(FloatPoint(currentPosition.x(), position));
+}
+
 void ScrollableArea::scrollToPositionWithAnimation(const FloatPoint& position, const ScrollPositionChangeOptions& options)
 {
     LOG_WITH_STREAM(Scrolling, stream << "ScrollableArea " << this << " scrollToPositionWithAnimation " << position);
@@ -205,11 +214,11 @@ void ScrollableArea::scrollToOffsetWithoutAnimation(const FloatPoint& offset, Sc
 
 void ScrollableArea::scrollToOffsetWithoutAnimation(ScrollbarOrientation orientation, float offset)
 {
-    auto currentPosition = scrollAnimator().currentPosition();
+    auto currentOffset = scrollOffsetFromPosition(scrollAnimator().currentPosition(), toFloatSize(scrollOrigin()));
     if (orientation == ScrollbarOrientation::Horizontal)
-        scrollAnimator().scrollToPositionWithoutAnimation(FloatPoint(offset, currentPosition.y()));
+        scrollToOffsetWithoutAnimation(FloatPoint(offset, currentOffset.y()));
     else
-        scrollAnimator().scrollToPositionWithoutAnimation(FloatPoint(currentPosition.x(), offset));
+        scrollToOffsetWithoutAnimation(FloatPoint(currentOffset.x(), offset));
 }
 
 void ScrollableArea::notifyScrollPositionChanged(const ScrollPosition& position)

--- a/Source/WebCore/platform/ScrollableArea.h
+++ b/Source/WebCore/platform/ScrollableArea.h
@@ -82,6 +82,7 @@ public:
     WEBCORE_EXPORT bool scroll(ScrollDirection, ScrollGranularity, unsigned stepCount = 1);
     WEBCORE_EXPORT void scrollToPositionWithAnimation(const FloatPoint&, const ScrollPositionChangeOptions& options = ScrollPositionChangeOptions::createProgrammatic());
     WEBCORE_EXPORT void scrollToPositionWithoutAnimation(const FloatPoint&, ScrollClamping = ScrollClamping::Clamped);
+    WEBCORE_EXPORT void scrollToPositionWithoutAnimation(ScrollbarOrientation, float position);
 
     WEBCORE_EXPORT void scrollToOffsetWithoutAnimation(const FloatPoint&, ScrollClamping = ScrollClamping::Clamped);
     WEBCORE_EXPORT void scrollToOffsetWithoutAnimation(ScrollbarOrientation, float offset);

--- a/Source/WebCore/platform/Scrollbar.cpp
+++ b/Source/WebCore/platform/Scrollbar.cpp
@@ -286,7 +286,7 @@ void Scrollbar::moveThumb(int pos, bool draggingDocument)
             destinationPosition = std::min(destinationPosition + delta, maximum());
         else if (delta < 0)
             destinationPosition = std::max(destinationPosition + delta, 0);
-        m_scrollableArea.scrollToOffsetWithoutAnimation(m_orientation, destinationPosition);
+        m_scrollableArea.scrollToPositionWithoutAnimation(m_orientation, destinationPosition);
         m_documentDragPos = pos;
         return;
     }
@@ -307,8 +307,8 @@ void Scrollbar::moveThumb(int pos, bool draggingDocument)
         delta = std::max(-thumbPos, delta);
     
     if (delta) {
-        float newPosition = static_cast<float>(thumbPos + delta) * maximum() / (trackLen - thumbLen);
-        m_scrollableArea.scrollToOffsetWithoutAnimation(m_orientation, newPosition);
+        float newOffset = static_cast<float>(thumbPos + delta) * maximum() / (trackLen - thumbLen);
+        m_scrollableArea.scrollToOffsetWithoutAnimation(m_orientation, newOffset);
     }
 }
 

--- a/Source/WebCore/rendering/RenderListBox.cpp
+++ b/Source/WebCore/rendering/RenderListBox.cpp
@@ -184,7 +184,7 @@ void RenderListBox::layout()
         m_scrollbar->setSteps(1, std::max(1, numVisibleItems() - 1), itemLogicalHeight());
         m_scrollbar->setProportion(numVisibleItems(), numItems());
         if (!enabled) {
-            scrollToOffsetWithoutAnimation(m_scrollbar->orientation(), 0);
+            scrollToPositionWithoutAnimation(m_scrollbar->orientation(), 0);
             m_scrollPosition = { };
         }
 
@@ -722,16 +722,16 @@ bool RenderListBox::scrollToRevealElementAtListIndex(int index)
     if (index < 0 || index >= numItems() || listIndexIsVisible(index))
         return false;
 
-    int newOffset;
+    int newIndex;
     if (index < indexOffset())
-        newOffset = index;
+        newIndex = index;
     else
-        newOffset = index - numVisibleItems() + 1;
+        newIndex = index - numVisibleItems() + 1;
 
     if (style().isFlippedBlocksWritingMode())
-        newOffset *= -1;
+        newIndex *= -1;
 
-    scrollToOffsetWithoutAnimation(scrollbarOrientationForWritingMode(), newOffset);
+    scrollToPositionWithoutAnimation(scrollbarOrientationForWritingMode(), newIndex);
 
     return true;
 }
@@ -963,7 +963,7 @@ void RenderListBox::setLogicalScrollTop(int newLogicalScrollTop)
         index *= -1;
 
     setupWheelEventTestMonitor(*this);
-    scrollToOffsetWithoutAnimation(scrollbarOrientationForWritingMode(), index);
+    scrollToPositionWithoutAnimation(scrollbarOrientationForWritingMode(), index);
 }
 
 bool RenderListBox::nodeAtPoint(const HitTestRequest& request, HitTestResult& result, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction hitTestAction)


### PR DESCRIPTION
#### 8074107aa32e4b5d15c17939e7ae877a03a40f8d
<pre>
Allow scrolling right-to-left or bottom-to-top scrollable areas by dragging the scrollbar.
<a href="https://bugs.webkit.org/show_bug.cgi?id=266555">https://bugs.webkit.org/show_bug.cgi?id=266555</a>

Reviewed by NOBODY (OOPS!).

ScrollableArea::scrollToOffsetWithoutAnimation(ScrollbarOrientation, float offset)
should convert the offsets into scroll positions before calling
scrollToPositionWithoutAnimation, hence taking the scrollOrigin into consideration.

This fixes issues that right-to-left or bottom-to-top scrollable areas are not
scrollable by dragging the scrollbar.

* LayoutTests/fast/scrolling/rtl-bt-drag-scroller-expected.txt: Added.
* LayoutTests/fast/scrolling/rtl-bt-drag-scroller.html: Added.
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/platform/ScrollableArea.cpp:
(WebCore::ScrollableArea::scrollToPositionWithoutAnimation):
(WebCore::ScrollableArea::scrollToOffsetWithoutAnimation):
* Source/WebCore/platform/ScrollableArea.h:
* Source/WebCore/rendering/RenderListBox.cpp:
(WebCore::RenderListBox::layout):
(WebCore::RenderListBox::scrollToRevealElementAtListIndex):
(WebCore::RenderListBox::setLogicalScrollTop):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f80b57870337763f95c4f22bc96cce3dd813dc91

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31357 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10026 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33050 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33851 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28423 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32124 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12371 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7276 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28063 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31693 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8443 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27996 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7265 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7428 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27940 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35192 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28507 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28351 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33560 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7493 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5523 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31399 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9156 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/27703 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8186 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8004 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->