### PR TITLE
:user-invalid triggering while typing date

### DIFF
--- a/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-input-and-change-events-expected.txt
+++ b/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-input-and-change-events-expected.txt
@@ -1,0 +1,26 @@
+Test for input and change events for <input type=date>
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS inputEventsFired is 0
+PASS changeEventsFired is 0
+PASS inputEventsFired is 0
+PASS changeEventsFired is 0
+PASS inputEventsFired is 1
+PASS changeEventsFired is 0
+PASS inputEventsFired is 2
+PASS changeEventsFired is 0
+PASS inputEventsFired is 3
+PASS changeEventsFired is 0
+PASS inputEventsFired is 4
+PASS changeEventsFired is 0
+PASS inputEventsFired is 4
+PASS changeEventsFired is 0
+PASS input.value is "2012-09-02"
+PASS inputEventsFired is 4
+PASS changeEventsFired is 1
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-input-and-change-events.html
+++ b/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-input-and-change-events.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/js-test.js"></script>
+<script src="../../../../resources/ui-helper.js"></script>
+</head>
+<body>
+
+<input id="input" type="date">
+
+<script>
+
+jsTestIsAsync = true;
+
+changeEventsFired = 0;
+function onChangeEvent() {
+    changeEventsFired++;
+}
+
+inputEventsFired = 0;
+function onInputEvent() {
+    inputEventsFired++;
+}
+
+input.addEventListener("change", onChangeEvent);
+input.addEventListener("input", onInputEvent);
+
+addEventListener("load", async () => {
+    description("Test for input and change events for &lt;input type=date&gt;");
+
+    input.focus();                                         // [mm]/dd/yyyy
+    UIHelper.keyDown("9");                                 // -> [09]/dd/yyyy
+    shouldBe("inputEventsFired", "0");
+    shouldBe("changeEventsFired", "0");
+
+    UIHelper.keyDown("rightArrow");                        // -> 09/[dd]/yyyy
+    UIHelper.keyDown("2");                                 // -> 09/[02]/yyyy
+    shouldBe("inputEventsFired", "0");
+    shouldBe("changeEventsFired", "0");
+
+    UIHelper.keyDown("rightArrow");                        // -> 09/02/[yyyy]
+    UIHelper.keyDown("2");                                 // -> 09/02/[0002]
+    shouldBe("inputEventsFired", "1");
+    shouldBe("changeEventsFired", "0");
+
+    UIHelper.keyDown("0");                                 // -> 09/02/[0020]
+    shouldBe("inputEventsFired", "2");
+    shouldBe("changeEventsFired", "0");
+
+    UIHelper.keyDown("1");                                 // -> 09/02/[0201]
+    shouldBe("inputEventsFired", "3");
+    shouldBe("changeEventsFired", "0");
+
+    UIHelper.keyDown("2");                                 // -> 09/02/[2012]
+    shouldBe("inputEventsFired", "4");
+    shouldBe("changeEventsFired", "0");
+
+    UIHelper.keyDown("A");                                 // Ignored.
+    shouldBe("inputEventsFired", "4");
+    shouldBe("changeEventsFired", "0");
+
+    shouldBeEqualToString("input.value", "2012-09-02");
+
+    input.blur();
+    shouldBe("inputEventsFired", "4");
+    shouldBe("changeEventsFired", "1");
+
+    finishJSTest();
+});
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-keyboard-events-expected.txt
+++ b/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-keyboard-events-expected.txt
@@ -6,33 +6,45 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 Digit keys
 PASS input.value is "2012-09-02"
-PASS changeEventsFired is 4
+PASS changeEventsFired is 0
+PASS inputEventsFired is 4
+PASS changeEventsFired is 1
 PASS inputEventsFired is 4
 
 Digit keys with leading zero
 PASS input.value is "0034-05-06"
-PASS changeEventsFired is 3
+PASS changeEventsFired is 0
+PASS inputEventsFired is 3
+PASS changeEventsFired is 1
 PASS inputEventsFired is 3
 
 Digit keys and backspace key
 PASS input.value is "2020-02-04"
-PASS changeEventsFired is 6
+PASS changeEventsFired is 0
+PASS inputEventsFired is 6
+PASS changeEventsFired is 1
 PASS inputEventsFired is 6
 
 Digit keys with timeout
 PASS input.value is "0001-02-04"
-PASS changeEventsFired is 2
+PASS changeEventsFired is 0
+PASS inputEventsFired is 2
+PASS changeEventsFired is 1
 PASS inputEventsFired is 2
 
 Digit keys clamp value
 PASS input.value is "9999-12-31"
-PASS changeEventsFired is 4
+PASS changeEventsFired is 0
+PASS inputEventsFired is 4
+PASS changeEventsFired is 1
 PASS inputEventsFired is 4
 
 Left/Right arrow keys
 PASS input.value is "0002-02-02"
 PASS input.value is "0002-03-03"
-PASS changeEventsFired is 3
+PASS changeEventsFired is 0
+PASS inputEventsFired is 3
+PASS changeEventsFired is 1
 PASS inputEventsFired is 3
 
 Left/Right arrow keys (vertical-lr)
@@ -40,7 +52,9 @@ PASS input.value is "2020-01-20"
 PASS input.value is "2020-02-20"
 PASS input.value is "2020-01-20"
 PASS input.value is "2020-12-20"
-PASS changeEventsFired is 4
+PASS changeEventsFired is 0
+PASS inputEventsFired is 4
+PASS changeEventsFired is 0
 PASS inputEventsFired is 4
 
 Left/Right arrow keys (vertical-rl)
@@ -48,7 +62,9 @@ PASS input.value is "2020-01-20"
 PASS input.value is "2020-02-20"
 PASS input.value is "2020-01-20"
 PASS input.value is "2020-12-20"
-PASS changeEventsFired is 4
+PASS changeEventsFired is 0
+PASS inputEventsFired is 4
+PASS changeEventsFired is 0
 PASS inputEventsFired is 4
 
 Advance field keys
@@ -58,7 +74,9 @@ PASS input.value is "2020-06-05"
 PASS input.value is "2020-06-06"
 PASS input.value is "2020-06-07"
 PASS input.value is "2020-06-08"
-PASS changeEventsFired is 6
+PASS changeEventsFired is 0
+PASS inputEventsFired is 6
+PASS changeEventsFired is 1
 PASS inputEventsFired is 6
 
 Up/Down arrow keys
@@ -66,19 +84,25 @@ PASS input.value is "2020-01-20"
 PASS input.value is "2020-02-20"
 PASS input.value is "2020-01-20"
 PASS input.value is "2020-12-20"
-PASS changeEventsFired is 4
+PASS changeEventsFired is 0
+PASS inputEventsFired is 4
+PASS changeEventsFired is 0
 PASS inputEventsFired is 4
 
 Up/Down arrow keys (vertical-lr)
 PASS input.value is "0002-02-02"
 PASS input.value is "0002-03-03"
-PASS changeEventsFired is 3
+PASS changeEventsFired is 0
+PASS inputEventsFired is 3
+PASS changeEventsFired is 1
 PASS inputEventsFired is 3
 
 Up/Down arrow keys (vertical-rl)
 PASS input.value is "0002-02-02"
 PASS input.value is "0002-03-03"
-PASS changeEventsFired is 3
+PASS changeEventsFired is 0
+PASS inputEventsFired is 3
+PASS changeEventsFired is 1
 PASS inputEventsFired is 3
 
 Tab key
@@ -86,17 +110,21 @@ PASS input.value is "0002-02-02"
 PASS document.activeElement.id is "after"
 PASS input.value is "0002-03-03"
 PASS document.activeElement.id is "before"
-PASS changeEventsFired is 3
+PASS changeEventsFired is 2
 PASS inputEventsFired is 3
 
 Backspace key
 PASS input.value is ""
 PASS input.value is "2020-07-26"
-PASS changeEventsFired is 2
+PASS changeEventsFired is 0
+PASS inputEventsFired is 2
+PASS changeEventsFired is 1
 PASS inputEventsFired is 2
 
 Delete key
 PASS input.value is ""
+PASS changeEventsFired is 0
+PASS inputEventsFired is 1
 PASS changeEventsFired is 1
 PASS inputEventsFired is 1
 
@@ -105,7 +133,9 @@ PASS input.value is "2020-09-01"
 PASS input.value is "2020-01-01"
 PASS input.value is "2020-01-01"
 PASS input.value is "2020-01-02"
-PASS changeEventsFired is 2
+PASS changeEventsFired is 0
+PASS inputEventsFired is 2
+PASS changeEventsFired is 1
 PASS inputEventsFired is 2
 
 EmptyString Test

--- a/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-keyboard-events.html
+++ b/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-keyboard-events.html
@@ -52,7 +52,10 @@ addEventListener("load", async () => {
     UIHelper.keyDown("2");                                 // -> 09/02/[2012]
     UIHelper.keyDown("A");                                 // Ignored.
     shouldBeEqualToString("input.value", "2012-09-02");
-    shouldBe("changeEventsFired", "4");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "4");
+    input.blur();
+    shouldBe("changeEventsFired", "1");
     shouldBe("inputEventsFired", "4");
 
     beginTest("Digit keys with leading zero");             // [mm]/dd/yyyy
@@ -67,7 +70,10 @@ addEventListener("load", async () => {
     UIHelper.keyDown("3");                                 // -> 05/06/[0003]
     UIHelper.keyDown("4");                                 // -> 05/06/[0034]
     shouldBeEqualToString("input.value", "0034-05-06");
-    shouldBe("changeEventsFired", "3");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "3");
+    input.blur();
+    shouldBe("changeEventsFired", "1");
     shouldBe("inputEventsFired", "3");
 
     beginTest("Digit keys and backspace key");             // [mm]/dd/yyyy
@@ -86,7 +92,10 @@ addEventListener("load", async () => {
     UIHelper.keyDown("2");                                 // -> 02/04/[0202]
     UIHelper.keyDown("0");                                 // -> 02/04/[2020]
     shouldBeEqualToString("input.value", "2020-02-04");
-    shouldBe("changeEventsFired", "6");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "6");
+    input.blur();
+    shouldBe("changeEventsFired", "1");
     shouldBe("inputEventsFired", "6");
 
     beginTest("Digit keys with timeout");                  // [mm]/dd/yyyy
@@ -98,7 +107,10 @@ addEventListener("load", async () => {
     await UIHelper.delayFor(1500);                         // Wait.
     UIHelper.keyDown("1");                                 // -> 02/04/[0001]
     shouldBeEqualToString("input.value", "0001-02-04");
-    shouldBe("changeEventsFired", "2");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "2");
+    input.blur();
+    shouldBe("changeEventsFired", "1");
     shouldBe("inputEventsFired", "2");
 
     beginTest("Digit keys clamp value");                   // [mm]/dd/yyyy
@@ -113,7 +125,10 @@ addEventListener("load", async () => {
     UIHelper.keyDown("9");                                 // -> 12/31/[0999]
     UIHelper.keyDown("9");                                 // -> 12/31/[9999]
     shouldBeEqualToString("input.value", "9999-12-31");
-    shouldBe("changeEventsFired", "4");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "4");
+    input.blur();
+    shouldBe("changeEventsFired", "1");
     shouldBe("inputEventsFired", "4");
 
     beginTest("Left/Right arrow keys");                    // [mm]/dd/yyyy
@@ -128,7 +143,10 @@ addEventListener("load", async () => {
     UIHelper.keyDown("leftArrow");                         // -> [02]/03/0002
     UIHelper.keyDown("3");                                 // -> [03]/03/0002
     shouldBeEqualToString("input.value", "0002-03-03");
-    shouldBe("changeEventsFired", "3");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "3");
+    input.blur();
+    shouldBe("changeEventsFired", "1");
     shouldBe("inputEventsFired", "3");
 
     beginTest("Left/Right arrow keys (vertical-lr)", "2020-12-20", "writing-mode: vertical-lr");         // [12]/20/2020
@@ -140,7 +158,10 @@ addEventListener("load", async () => {
     shouldBeEqualToString("input.value", "2020-01-20");
     UIHelper.keyDown("leftArrow");                                                                       // [12]/20/2020
     shouldBeEqualToString("input.value", "2020-12-20");
-    shouldBe("changeEventsFired", "4");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "4");
+    input.blur();
+    shouldBe("changeEventsFired", "0");
     shouldBe("inputEventsFired", "4");
 
     beginTest("Left/Right arrow keys (vertical-rl)", "2020-12-20", "writing-mode: vertical-rl");         // [12]/20/2020
@@ -152,7 +173,10 @@ addEventListener("load", async () => {
     shouldBeEqualToString("input.value", "2020-01-20");
     UIHelper.keyDown("leftArrow");                                                                       // [12]/20/2020
     shouldBeEqualToString("input.value", "2020-12-20");
-    shouldBe("changeEventsFired", "4");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "4");
+    input.blur();
+    shouldBe("changeEventsFired", "0");
     shouldBe("inputEventsFired", "4");
 
     beginTest("Advance field keys", "2020-06-05");         // [06]/05/2020
@@ -179,7 +203,10 @@ addEventListener("load", async () => {
     UIHelper.keyDown(",");                                 // -> 06/[07]/2020
     UIHelper.keyDown("8");                                 // -> 06/[08]/2020
     shouldBeEqualToString("input.value", "2020-06-08");
-    shouldBe("changeEventsFired", "6");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "6");
+    input.blur();
+    shouldBe("changeEventsFired", "1");
     shouldBe("inputEventsFired", "6");
 
     beginTest("Up/Down arrow keys", "2020-12-20");         // [12]/20/2020
@@ -191,7 +218,10 @@ addEventListener("load", async () => {
     shouldBeEqualToString("input.value", "2020-01-20");
     UIHelper.keyDown("downArrow");                         // [12]/20/2020
     shouldBeEqualToString("input.value", "2020-12-20");
-    shouldBe("changeEventsFired", "4");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "4");
+    input.blur();
+    shouldBe("changeEventsFired", "0");
     shouldBe("inputEventsFired", "4");
 
     beginTest("Up/Down arrow keys (vertical-lr)", "", "writing-mode: vertical-lr");     // [mm]/dd/yyyy
@@ -206,7 +236,10 @@ addEventListener("load", async () => {
     UIHelper.keyDown("upArrow");                                                        // -> [02]/03/0002
     UIHelper.keyDown("3");                                                              // -> [03]/03/0002
     shouldBeEqualToString("input.value", "0002-03-03");
-    shouldBe("changeEventsFired", "3");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "3");
+    input.blur();
+    shouldBe("changeEventsFired", "1");
     shouldBe("inputEventsFired", "3");
 
     beginTest("Up/Down arrow keys (vertical-rl)", "", "writing-mode: vertical-rl");     // [mm]/dd/yyyy
@@ -221,7 +254,10 @@ addEventListener("load", async () => {
     UIHelper.keyDown("upArrow");                                                        // -> [02]/03/0002
     UIHelper.keyDown("3");                                                              // -> [03]/03/0002
     shouldBeEqualToString("input.value", "0002-03-03");
-    shouldBe("changeEventsFired", "3");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "3");
+    input.blur();
+    shouldBe("changeEventsFired", "1");
     shouldBe("inputEventsFired", "3");
 
     beginTest("Tab key");
@@ -241,7 +277,7 @@ addEventListener("load", async () => {
     shouldBeEqualToString("input.value", "0002-03-03");
     UIHelper.keyDown("\t", ["shiftKey"]);                  // Focus out.
     shouldBeEqualToString("document.activeElement.id", "before");
-    shouldBe("changeEventsFired", "3");
+    shouldBe("changeEventsFired", "2");
     shouldBe("inputEventsFired", "3");
 
     beginTest("Backspace key", "2020-08-26");              // [08]/26/2020
@@ -249,12 +285,18 @@ addEventListener("load", async () => {
     shouldBeEqualToString("input.value", "");
     UIHelper.keyDown("7");                                 // -> [07]/26/2020
     shouldBeEqualToString("input.value", "2020-07-26");
-    shouldBe("changeEventsFired", "2");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "2");
+    input.blur();
+    shouldBe("changeEventsFired", "1");
     shouldBe("inputEventsFired", "2");
 
     beginTest("Delete key", "2020-08-26");                 // [08]/26/2021
     UIHelper.keyDown("delete");                            // -> [mm]/26/2021
     shouldBeEqualToString("input.value", "");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "1");
+    input.blur();
     shouldBe("changeEventsFired", "1");
     shouldBe("inputEventsFired", "1");
 
@@ -273,7 +315,10 @@ addEventListener("load", async () => {
     input.readOnly = false;
     UIHelper.keyDown("2");
     shouldBeEqualToString("input.value", "2020-01-02");
-    shouldBe("changeEventsFired", "2");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "2");
+    input.blur();
+    shouldBe("changeEventsFired", "1");
     shouldBe("inputEventsFired", "2");
 
     input.setAttribute('value', '2012-02-01');

--- a/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-user-invalid-expected.html
+++ b/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-user-invalid-expected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+
+input {
+    border: 1px solid red;
+}
+
+</style>
+</head>
+<body>
+<input id="input" type="date" value="2020-10-10">
+</body>
+</html>

--- a/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-user-invalid-uncommitted-expected.html
+++ b/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-user-invalid-uncommitted-expected.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/ui-helper.js"></script>
+<style>
+
+input {
+    border: 1px solid black;
+}
+
+</style>
+</head>
+<body>
+
+<input id="input" type="date">
+
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+addEventListener("load", async () => {
+    input.focus();
+    UIHelper.keyDown("1");
+    UIHelper.keyDown("0");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("1");
+    UIHelper.keyDown("0");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("0");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("0");
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+});
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-user-invalid-uncommitted.html
+++ b/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-user-invalid-uncommitted.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/ui-helper.js"></script>
+<style>
+
+input {
+    border: 1px solid black;
+}
+
+input:user-invalid {
+    border: 1px red solid;
+}
+
+</style>
+</head>
+<body>
+
+<input id="input" type="date" min="2020-11-11">
+
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+addEventListener("load", async () => {
+    input.focus();
+    UIHelper.keyDown("1");
+    UIHelper.keyDown("0");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("1");
+    UIHelper.keyDown("0");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("0");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("0");
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+});
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-user-invalid-with-empty-components-expected.html
+++ b/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-user-invalid-with-empty-components-expected.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/ui-helper.js"></script>
+<style>
+
+input {
+    border: 1px solid black;
+}
+
+</style>
+</head>
+<body>
+
+<p>Test that typing a partially completed date does not match :user-invalid</p>
+<input id="input" type="date">
+
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+addEventListener("load", async () => {
+    input.focus();
+    UIHelper.keyDown("9");
+    input.blur();
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+});
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-user-invalid-with-empty-components.html
+++ b/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-user-invalid-with-empty-components.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/ui-helper.js"></script>
+<style>
+
+input {
+    border: 1px solid black;
+}
+
+input:user-invalid {
+    border: 1px red solid;
+}
+
+</style>
+</head>
+<body>
+
+<p>Test that typing a partially completed date does not match :user-invalid</p>
+<input id="input" type="date">
+
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+addEventListener("load", async () => {
+    input.focus();
+    UIHelper.keyDown("9");
+    input.blur();
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+});
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-user-invalid.html
+++ b/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-user-invalid.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/ui-helper.js"></script>
+<style>
+
+input {
+    border: 1px solid black;
+}
+
+input:user-invalid {
+    border: 1px red solid;
+}
+
+</style>
+</head>
+<body>
+
+<input id="input" type="date" min="2020-11-11">
+
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+addEventListener("load", async () => {
+    input.focus();
+    UIHelper.keyDown("1");
+    UIHelper.keyDown("0");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("1");
+    UIHelper.keyDown("0");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("0");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("0");
+    input.blur();
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+});
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-user-valid-expected.html
+++ b/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-user-valid-expected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+
+input {
+    border: 1px solid green;
+}
+
+</style>
+</head>
+<body>
+<input id="input" type="date" value="2020-12-12">
+</body>
+</html>

--- a/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-user-valid-uncommitted-expected.html
+++ b/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-user-valid-uncommitted-expected.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/ui-helper.js"></script>
+<style>
+
+input {
+    border: 1px solid black;
+}
+
+</style>
+</head>
+<body>
+
+<input id="input" type="date">
+
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+addEventListener("load", async () => {
+    input.focus();
+    UIHelper.keyDown("1");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("1");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("0");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("0");
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+});
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-user-valid-uncommitted.html
+++ b/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-user-valid-uncommitted.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/ui-helper.js"></script>
+<style>
+
+input {
+    border: 1px solid black;
+}
+
+input:user-valid {
+    border: 1px solid green;
+}
+
+</style>
+</head>
+<body>
+
+<input id="input" type="date" min="2020-11-11">
+
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+addEventListener("load", async () => {
+    input.focus();
+    UIHelper.keyDown("1");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("1");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("0");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("0");
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+});
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-user-valid.html
+++ b/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-user-valid.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/ui-helper.js"></script>
+<style>
+
+input {
+    border: 1px solid black;
+}
+
+input:user-valid {
+    border: 1px solid green;
+}
+
+</style>
+</head>
+<body>
+
+<input id="input" type="date" min="2020-11-11">
+
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+addEventListener("load", async () => {
+    input.focus();
+    UIHelper.keyDown("1");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("1");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("0");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("0");
+    input.blur();
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+});
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/date/date-editable-components/date-multiple-fields-choose-default-value-after-set-value.html
+++ b/LayoutTests/fast/forms/date/date-editable-components/date-multiple-fields-choose-default-value-after-set-value.html
@@ -35,6 +35,7 @@ input.focus();
 UIHelper.keyDown('rightArrow');
 UIHelper.keyDown('rightArrow');
 UIHelper.keyDown('downArrow');
+input.blur();
 
 shouldBeEqualToString('input.value', '2000-01-01');
 shouldBe('eventsCounter.input', '1');

--- a/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-input-and-change-events-expected.txt
+++ b/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-input-and-change-events-expected.txt
@@ -1,0 +1,24 @@
+Test for keyboard operations for <input type=datetime-local>
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS inputEventsFired is 0
+PASS changeEventsFired is 0
+PASS inputEventsFired is 0
+PASS changeEventsFired is 0
+PASS inputEventsFired is 0
+PASS changeEventsFired is 0
+PASS inputEventsFired is 0
+PASS changeEventsFired is 0
+PASS inputEventsFired is 0
+PASS changeEventsFired is 0
+PASS inputEventsFired is 1
+PASS changeEventsFired is 0
+PASS input.value is "2012-09-02T00:02"
+PASS inputEventsFired is 1
+PASS changeEventsFired is 1
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-input-and-change-events.html
+++ b/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-input-and-change-events.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/js-test.js"></script>
+<script src="../../../../resources/ui-helper.js"></script>
+</head>
+<body>
+
+<input id="input" type="datetime-local">
+
+<script>
+
+jsTestIsAsync = true;
+
+changeEventsFired = 0;
+function onChangeEvent() {
+    changeEventsFired++;
+}
+
+inputEventsFired = 0;
+function onInputEvent() {
+    inputEventsFired++;
+}
+
+input.addEventListener("change", onChangeEvent);
+input.addEventListener("input", onInputEvent);
+
+addEventListener("load", async () => {
+    description("Test for keyboard operations for &lt;input type=datetime-local&gt;");
+
+    input.focus();                                              // [mm]/dd/yyyy hh:mm tt
+    UIHelper.keyDown("9");                                      // -> [09]/dd/yyyy hh:mm tt
+    shouldBe("inputEventsFired", "0");
+    shouldBe("changeEventsFired", "0");
+
+    UIHelper.keyDown("rightArrow");                             // -> 09/[dd]/yyyy hh:mm tt
+    UIHelper.keyDown("2");                                      // -> 09/[02]/yyyy hh:mm tt
+    shouldBe("inputEventsFired", "0");
+    shouldBe("changeEventsFired", "0");
+
+    UIHelper.keyDown("rightArrow");                             // -> 09/02/[yyyy] hh:mm tt
+    UIHelper.keyDown("2");                                      // -> 09/02/[0002] hh:mm tt
+    UIHelper.keyDown("0");                                      // -> 09/02/[0020] hh:mm tt
+    UIHelper.keyDown("1");                                      // -> 09/02/[0201] hh:mm tt
+    UIHelper.keyDown("2");                                      // -> 09/02/[2012] hh:mm tt
+    shouldBe("inputEventsFired", "0");
+    shouldBe("changeEventsFired", "0");
+
+    UIHelper.keyDown("rightArrow");                             // -> 09/02/2012 [hh]:mm tt
+    UIHelper.keyDown("1");                                      // -> 09/02/2012 [01]:mm tt
+    UIHelper.keyDown("2");                                      // -> 09/02/2012 [12]:mm tt
+    shouldBe("inputEventsFired", "0");
+    shouldBe("changeEventsFired", "0");
+
+    UIHelper.keyDown("rightArrow");                             // -> 09/02/2012 12:[mm] tt
+    UIHelper.keyDown("2");                                      // -> 09/02/2012 12:[02] tt
+    shouldBe("inputEventsFired", "0");
+    shouldBe("changeEventsFired", "0");
+
+    UIHelper.keyDown("rightArrow");                             // -> 09/02/2012 12:02 [tt]
+    UIHelper.keyDown("A");                                      // -> 09/02/2012 12:02 [AM]
+    shouldBe("inputEventsFired", "1");
+    shouldBe("changeEventsFired", "0");
+
+    shouldBeEqualToString("input.value", "2012-09-02T00:02");
+
+    input.blur();
+    shouldBe("inputEventsFired", "1");
+    shouldBe("changeEventsFired", "1");
+
+    finishJSTest();
+});
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-keyboard-events-expected.txt
+++ b/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-keyboard-events-expected.txt
@@ -6,11 +6,15 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 Digit keys
 PASS input.value is "2012-09-02T00:02"
+PASS changeEventsFired is 0
+PASS inputEventsFired is 1
 PASS changeEventsFired is 1
 PASS inputEventsFired is 1
 
 Digit keys with timeout
 PASS input.value is "0001-02-04T14:05"
+PASS changeEventsFired is 0
+PASS inputEventsFired is 1
 PASS changeEventsFired is 1
 PASS inputEventsFired is 1
 
@@ -28,13 +32,17 @@ PASS input.value is "9999-12-31T12:22"
 PASS input.value is "9999-12-31T13:22"
 PASS input.value is "9999-12-31T13:06"
 PASS input.value is "9999-12-31T13:59"
-PASS changeEventsFired is 13
+PASS changeEventsFired is 0
+PASS inputEventsFired is 13
+PASS changeEventsFired is 1
 PASS inputEventsFired is 13
 
 Left/Right arrow keys
 PASS input.value is "0002-02-02T02:02"
 PASS input.value is "0003-03-03T03:03"
-PASS changeEventsFired is 11
+PASS changeEventsFired is 0
+PASS inputEventsFired is 11
+PASS changeEventsFired is 1
 PASS inputEventsFired is 11
 
 Left/Right arrow keys (vertical-lr)
@@ -49,7 +57,9 @@ PASS input.value is "2020-12-20T23:59"
 PASS input.value is "2020-12-20T11:59"
 PASS input.value is "2020-12-20T23:59"
 PASS input.value is "2020-12-20T11:59"
-PASS changeEventsFired is 11
+PASS changeEventsFired is 0
+PASS inputEventsFired is 11
+PASS changeEventsFired is 1
 PASS inputEventsFired is 11
 
 Left/Right arrow keys (vertical-rl)
@@ -64,7 +74,9 @@ PASS input.value is "2020-12-20T23:59"
 PASS input.value is "2020-12-20T11:59"
 PASS input.value is "2020-12-20T23:59"
 PASS input.value is "2020-12-20T11:59"
-PASS changeEventsFired is 11
+PASS changeEventsFired is 0
+PASS inputEventsFired is 11
+PASS changeEventsFired is 1
 PASS inputEventsFired is 11
 
 Advance field keys
@@ -74,7 +86,9 @@ PASS input.value is "2020-06-05T16:27"
 PASS input.value is "2020-06-06T16:27"
 PASS input.value is "2020-06-07T16:27"
 PASS input.value is "2020-06-08T16:27"
-PASS changeEventsFired is 6
+PASS changeEventsFired is 0
+PASS inputEventsFired is 6
+PASS changeEventsFired is 1
 PASS inputEventsFired is 6
 
 Up/Down arrow keys
@@ -89,19 +103,25 @@ PASS input.value is "2020-12-20T23:59"
 PASS input.value is "2020-12-20T11:59"
 PASS input.value is "2020-12-20T23:59"
 PASS input.value is "2020-12-20T11:59"
-PASS changeEventsFired is 11
+PASS changeEventsFired is 0
+PASS inputEventsFired is 11
+PASS changeEventsFired is 1
 PASS inputEventsFired is 11
 
 Up/Down arrow keys (vertical-lr)
 PASS input.value is "0002-02-02T02:02"
 PASS input.value is "0003-03-03T03:03"
-PASS changeEventsFired is 11
+PASS changeEventsFired is 0
+PASS inputEventsFired is 11
+PASS changeEventsFired is 1
 PASS inputEventsFired is 11
 
 Up/Down arrow keys (vertical-rl)
 PASS input.value is "0002-02-02T02:02"
 PASS input.value is "0003-03-03T03:03"
-PASS changeEventsFired is 11
+PASS changeEventsFired is 0
+PASS inputEventsFired is 11
+PASS changeEventsFired is 1
 PASS inputEventsFired is 11
 
 Tab key
@@ -109,17 +129,23 @@ PASS input.value is "0002-02-02T02:02"
 PASS document.activeElement.id is "after"
 PASS input.value is "0003-03-03T03:03"
 PASS document.activeElement.id is "before"
-PASS changeEventsFired is 6
+PASS changeEventsFired is 2
+PASS inputEventsFired is 6
+PASS changeEventsFired is 2
 PASS inputEventsFired is 6
 
 Backspace key
 PASS input.value is ""
 PASS input.value is "2016-07-12T16:30"
-PASS changeEventsFired is 2
+PASS changeEventsFired is 0
+PASS inputEventsFired is 2
+PASS changeEventsFired is 1
 PASS inputEventsFired is 2
 
 Delete key
 PASS input.value is ""
+PASS changeEventsFired is 0
+PASS inputEventsFired is 1
 PASS changeEventsFired is 1
 PASS inputEventsFired is 1
 
@@ -127,8 +153,10 @@ Disabled/readonly
 PASS input.value is "2020-09-01T09:01"
 PASS input.value is "2020-01-01T09:01"
 PASS input.value is "2020-01-01T09:01"
-FAIL input.value should be 2020-09-02T09:01. Was 2020-01-02T09:01.
-PASS changeEventsFired is 2
+PASS input.value is "2020-01-02T09:01"
+PASS changeEventsFired is 0
+PASS inputEventsFired is 2
+PASS changeEventsFired is 1
 PASS inputEventsFired is 2
 PASS successfullyParsed is true
 

--- a/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-keyboard-events.html
+++ b/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-keyboard-events.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../../../resources/js-test-pre.js"></script>
+<script src="../../../../resources/js-test.js"></script>
 <script src="../../../../resources/ui-helper.js"></script>
 </head>
 <body>
@@ -58,6 +58,9 @@ addEventListener("load", async () => {
     UIHelper.keyDown("rightArrow");                             // -> 09/02/2012 12:02 [tt]
     UIHelper.keyDown("A");                                      // -> 09/02/2012 12:02 [AM]
     shouldBeEqualToString("input.value", "2012-09-02T00:02");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "1");
+    input.blur();
     shouldBe("changeEventsFired", "1");
     shouldBe("inputEventsFired", "1");
 
@@ -78,6 +81,9 @@ addEventListener("load", async () => {
     UIHelper.keyDown("rightArrow");                             // -> 02/04/0001 02:05 [tt]
     UIHelper.keyDown("P");                                      // -> 02/04/0001 02:05 [PM]
     shouldBeEqualToString("input.value", "0001-02-04T14:05");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "1");
+    input.blur();
     shouldBe("changeEventsFired", "1");
     shouldBe("inputEventsFired", "1");
 
@@ -112,7 +118,10 @@ addEventListener("load", async () => {
     shouldBeEqualToString("input.value", "9999-12-31T13:06");
     UIHelper.keyDown("1");                                      // -> 12/31/9999 13:[59] PM
     shouldBeEqualToString("input.value", "9999-12-31T13:59");
-    shouldBe("changeEventsFired", "13");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "13");
+    input.blur();
+    shouldBe("changeEventsFired", "1");
     shouldBe("inputEventsFired", "13");
 
     beginTest("Left/Right arrow keys", "2007-04-30T15:27");     // [04]/30/2007 03:27 PM
@@ -139,7 +148,10 @@ addEventListener("load", async () => {
     UIHelper.keyDown("leftArrow");                              // -> [02]/03/0003 03:03 AM
     UIHelper.keyDown("3");                                      // -> [03]/03/0003 03:03 AM
     shouldBeEqualToString("input.value", "0003-03-03T03:03");
-    shouldBe("changeEventsFired", "11");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "11");
+    input.blur();
+    shouldBe("changeEventsFired", "1");
     shouldBe("inputEventsFired", "11");
 
     beginTest("Left/Right arrow keys (vertical-lr)", "2020-12-20T23:59", "writing-mode: vertical-lr");        // [12]/20/2020 11:59 PM
@@ -170,7 +182,10 @@ addEventListener("load", async () => {
     shouldBeEqualToString("input.value", "2020-12-20T23:59");
     UIHelper.keyDown("leftArrow");                                                                            // -> 12/20/2020 11:59 [AM]
     shouldBeEqualToString("input.value", "2020-12-20T11:59");
-    shouldBe("changeEventsFired", "11");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "11");
+    input.blur();
+    shouldBe("changeEventsFired", "1");
     shouldBe("inputEventsFired", "11");
 
     beginTest("Left/Right arrow keys (vertical-rl)", "2020-12-20T23:59", "writing-mode: vertical-rl");        // [12]/20/2020 11:59 PM
@@ -201,7 +216,10 @@ addEventListener("load", async () => {
     shouldBeEqualToString("input.value", "2020-12-20T23:59");
     UIHelper.keyDown("leftArrow");                                                                            // -> 12/20/2020 11:59 [AM]
     shouldBeEqualToString("input.value", "2020-12-20T11:59");
-    shouldBe("changeEventsFired", "11");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "11");
+    input.blur();
+    shouldBe("changeEventsFired", "1");
     shouldBe("inputEventsFired", "11");
 
     beginTest("Advance field keys", "2020-06-05T16:27");        // [06]/05/2020 04:27 PM
@@ -228,7 +246,10 @@ addEventListener("load", async () => {
     UIHelper.keyDown(",");                                      // -> 06/[07]/2020 04:27 PM
     UIHelper.keyDown("8");                                      // -> 06/[08]/2020 04:27 PM
     shouldBeEqualToString("input.value", "2020-06-08T16:27");
-    shouldBe("changeEventsFired", "6");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "6");
+    input.blur();
+    shouldBe("changeEventsFired", "1");
     shouldBe("inputEventsFired", "6");
 
     beginTest("Up/Down arrow keys", "2020-12-20T23:59");        // [12]/20/2020 11:59 PM
@@ -259,7 +280,10 @@ addEventListener("load", async () => {
     shouldBeEqualToString("input.value", "2020-12-20T23:59");
     UIHelper.keyDown("downArrow");                              // -> 12/20/2020 11:59 [AM]
     shouldBeEqualToString("input.value", "2020-12-20T11:59");
-    shouldBe("changeEventsFired", "11");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "11");
+    input.blur();
+    shouldBe("changeEventsFired", "1");
     shouldBe("inputEventsFired", "11");
 
     beginTest("Up/Down arrow keys (vertical-lr)", "2007-04-30T15:27", "writing-mode: vertical-lr");     // [04]/30/2007 03:27 PM
@@ -286,7 +310,10 @@ addEventListener("load", async () => {
     UIHelper.keyDown("upArrow");                                                                        // -> [02]/03/0003 03:03 AM
     UIHelper.keyDown("3");                                                                              // -> [03]/03/0003 03:03 AM
     shouldBeEqualToString("input.value", "0003-03-03T03:03");
-    shouldBe("changeEventsFired", "11");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "11");
+    input.blur();
+    shouldBe("changeEventsFired", "1");
     shouldBe("inputEventsFired", "11");
 
     beginTest("Up/Down arrow keys (vertical-rl)", "2007-04-30T15:27", "writing-mode: vertical-rl");     // [04]/30/2007 03:27 PM
@@ -313,7 +340,10 @@ addEventListener("load", async () => {
     UIHelper.keyDown("upArrow");                                                                        // -> [02]/03/0003 03:03 AM
     UIHelper.keyDown("3");                                                                              // -> [03]/03/0003 03:03 AM
     shouldBeEqualToString("input.value", "0003-03-03T03:03");
-    shouldBe("changeEventsFired", "11");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "11");
+    input.blur();
+    shouldBe("changeEventsFired", "1");
     shouldBe("inputEventsFired", "11");
 
     beginTest("Tab key");                                       // [mm]/dd/yyyy hh:mm tt
@@ -345,7 +375,10 @@ addEventListener("load", async () => {
     shouldBeEqualToString("input.value", "0003-03-03T03:03");
     UIHelper.keyDown("\t", ["shiftKey"]);                       // Focus out.
     shouldBeEqualToString("document.activeElement.id", "before");
-    shouldBe("changeEventsFired", "6");
+    shouldBe("changeEventsFired", "2");
+    shouldBe("inputEventsFired", "6");
+    input.blur();
+    shouldBe("changeEventsFired", "2");
     shouldBe("inputEventsFired", "6");
 
     beginTest("Backspace key", "2016-11-12T16:30");             // [11]/12/2016 04:30 PM
@@ -353,7 +386,10 @@ addEventListener("load", async () => {
     shouldBeEqualToString("input.value", "");
     UIHelper.keyDown("7");                                      // -> [07]/12/2016 04:30 PM
     shouldBeEqualToString("input.value", "2016-07-12T16:30");
-    shouldBe("changeEventsFired", "2");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "2");
+    input.blur();
+    shouldBe("changeEventsFired", "1");
     shouldBe("inputEventsFired", "2");
 
     beginTest("Delete key", "2018-05-20T18:20");                // [05]/20/2018 06:20 PM
@@ -362,6 +398,9 @@ addEventListener("load", async () => {
     UIHelper.keyDown("rightArrow");                             // -> 05/20/2018 [06]:20 PM
     UIHelper.keyDown("delete");                                 // -> 05/20/2018 [hh]:20 PM
     shouldBeEqualToString("input.value", "");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "1");
+    input.blur();
     shouldBe("changeEventsFired", "1");
     shouldBe("inputEventsFired", "1");
 
@@ -379,8 +418,11 @@ addEventListener("load", async () => {
     shouldBeEqualToString("input.value", "2020-01-01T09:01");
     input.readOnly = false;
     UIHelper.keyDown("2");
-    shouldBeEqualToString("input.value", "2020-09-02T09:01");
-    shouldBe("changeEventsFired", "2");
+    shouldBeEqualToString("input.value", "2020-01-02T09:01");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "2");
+    input.blur();
+    shouldBe("changeEventsFired", "1");
     shouldBe("inputEventsFired", "2");
 
     finishJSTest();
@@ -388,6 +430,5 @@ addEventListener("load", async () => {
 
 </script>
 
-<script src="../../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-user-invalid-expected.html
+++ b/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-user-invalid-expected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+
+input {
+    border: 1px solid red;
+}
+
+</style>
+</head>
+<body>
+<input id="input" type="datetime-local" value="2020-10-10T09:29">
+</body>
+</html>

--- a/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-user-invalid-uncommitted-expected.html
+++ b/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-user-invalid-uncommitted-expected.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/ui-helper.js"></script>
+<style>
+
+input {
+    border: 1px solid black;
+}
+
+</style>
+</head>
+<body>
+
+<input id="input" type="datetime-local">
+
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+addEventListener("load", async () => {
+    input.focus();
+    UIHelper.keyDown("1");
+    UIHelper.keyDown("0");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("1");
+    UIHelper.keyDown("0");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("0");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("0");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("9");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("9");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("A");
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+});
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-user-invalid-uncommitted.html
+++ b/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-user-invalid-uncommitted.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/ui-helper.js"></script>
+<style>
+
+input {
+    border: 1px solid black;
+}
+
+input:user-invalid {
+    border: 1px red solid;
+}
+
+</style>
+</head>
+<body>
+
+<input id="input" type="datetime-local" min="2020-10-10T09:30">
+
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+addEventListener("load", async () => {
+    input.focus();
+    UIHelper.keyDown("1");
+    UIHelper.keyDown("0");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("1");
+    UIHelper.keyDown("0");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("0");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("0");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("9");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("9");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("A");
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+});
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-user-invalid-with-empty-components-expected.html
+++ b/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-user-invalid-with-empty-components-expected.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/ui-helper.js"></script>
+<style>
+
+input {
+    border: 1px solid black;
+}
+
+</style>
+</head>
+<body>
+
+<p>Test that typing a partially completed date-time does not match :user-invalid</p>
+<input id="input" type="datetime-local">
+
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+addEventListener("load", async () => {
+    input.focus();
+    UIHelper.keyDown("9");
+    input.blur();
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+});
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-user-invalid-with-empty-components.html
+++ b/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-user-invalid-with-empty-components.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/ui-helper.js"></script>
+<style>
+
+input {
+    border: 1px solid black;
+}
+
+input:user-invalid {
+    border: 1px red solid;
+}
+
+</style>
+</head>
+<body>
+
+<p>Test that typing a partially completed date-time does not match :user-invalid</p>
+<input id="input" type="datetime-local">
+
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+addEventListener("load", async () => {
+    input.focus();
+    UIHelper.keyDown("9");
+    input.blur();
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+});
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-user-invalid.html
+++ b/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-user-invalid.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/ui-helper.js"></script>
+<style>
+
+input {
+    border: 1px solid black;
+}
+
+input:user-invalid {
+    border: 1px red solid;
+}
+
+</style>
+</head>
+<body>
+
+<input id="input" type="datetime-local" min="2020-10-10T09:30">
+
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+addEventListener("load", async () => {
+    input.focus();
+    UIHelper.keyDown("1");
+    UIHelper.keyDown("0");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("1");
+    UIHelper.keyDown("0");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("0");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("0");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("9");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("9");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("A");
+    input.blur();
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+});
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-user-valid-expected.html
+++ b/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-user-valid-expected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+
+input {
+    border: 1px solid green;
+}
+
+</style>
+</head>
+<body>
+<input id="input" type="datetime-local" value="2020-10-10T09:31">
+</body>
+</html>

--- a/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-user-valid-uncommitted-expected.html
+++ b/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-user-valid-uncommitted-expected.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/ui-helper.js"></script>
+<style>
+
+input {
+    border: 1px solid black;
+}
+
+</style>
+</head>
+<body>
+
+<input id="input" type="datetime-local">
+
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+addEventListener("load", async () => {
+    input.focus();
+    UIHelper.keyDown("1");
+    UIHelper.keyDown("0");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("1");
+    UIHelper.keyDown("0");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("0");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("0");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("9");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("3");
+    UIHelper.keyDown("1");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("A");
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+});
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-user-valid-uncommitted.html
+++ b/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-user-valid-uncommitted.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/ui-helper.js"></script>
+<style>
+
+input {
+    border: 1px solid black;
+}
+
+input:user-valid {
+    border: 1px solid green;
+}
+
+</style>
+</head>
+<body>
+
+<input id="input" type="datetime-local" min="2020-10-10T09:30">
+
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+addEventListener("load", async () => {
+    input.focus();
+    UIHelper.keyDown("1");
+    UIHelper.keyDown("0");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("1");
+    UIHelper.keyDown("0");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("0");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("0");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("9");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("3");
+    UIHelper.keyDown("1");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("A");
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+});
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-user-valid.html
+++ b/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-user-valid.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/ui-helper.js"></script>
+<style>
+
+input {
+    border: 1px solid black;
+}
+
+input:user-valid {
+    border: 1px solid green;
+}
+
+</style>
+</head>
+<body>
+
+<input id="input" type="datetime-local" min="2020-10-10T09:30">
+
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+addEventListener("load", async () => {
+    input.focus();
+    UIHelper.keyDown("1");
+    UIHelper.keyDown("0");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("1");
+    UIHelper.keyDown("0");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("0");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("0");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("9");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("3");
+    UIHelper.keyDown("1");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("A");
+    input.blur();
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+});
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-multiple-fields-choose-default-value-after-set-value.html
+++ b/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-multiple-fields-choose-default-value-after-set-value.html
@@ -35,6 +35,7 @@ input.focus();
 UIHelper.keyDown('rightArrow');
 UIHelper.keyDown('rightArrow');
 UIHelper.keyDown('downArrow');
+input.blur();
 
 shouldBeEqualToString('input.value', '2000-01-01T01:01:01');
 shouldBe('eventsCounter.input', '1');

--- a/LayoutTests/fast/forms/month/month-editable-components/month-editable-components-input-and-change-events-expected.txt
+++ b/LayoutTests/fast/forms/month/month-editable-components/month-editable-components-input-and-change-events-expected.txt
@@ -1,0 +1,24 @@
+Test for input and change events for <input type=month>
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS inputEventsFired is 0
+PASS changeEventsFired is 0
+PASS inputEventsFired is 1
+PASS changeEventsFired is 0
+PASS inputEventsFired is 2
+PASS changeEventsFired is 0
+PASS inputEventsFired is 3
+PASS changeEventsFired is 0
+PASS inputEventsFired is 4
+PASS changeEventsFired is 0
+PASS inputEventsFired is 4
+PASS changeEventsFired is 0
+PASS input.value is "2012-09"
+PASS inputEventsFired is 4
+PASS changeEventsFired is 1
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/month/month-editable-components/month-editable-components-input-and-change-events.html
+++ b/LayoutTests/fast/forms/month/month-editable-components/month-editable-components-input-and-change-events.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/js-test.js"></script>
+<script src="../../../../resources/ui-helper.js"></script>
+</head>
+<body>
+
+<input id="input" type="month">
+
+<script>
+
+jsTestIsAsync = true;
+
+changeEventsFired = 0;
+function onChangeEvent() {
+    changeEventsFired++;
+}
+
+inputEventsFired = 0;
+function onInputEvent() {
+    inputEventsFired++;
+}
+
+input.addEventListener("change", onChangeEvent);
+input.addEventListener("input", onInputEvent);
+
+addEventListener("load", async () => {
+    description("Test for input and change events for &lt;input type=month&gt;");
+
+    input.focus();
+    UIHelper.keyDown("9");                                 // -> [09]/yyyy
+    shouldBe("inputEventsFired", "0");
+    shouldBe("changeEventsFired", "0");
+
+    UIHelper.keyDown("rightArrow");                        // -> 09/[yyyy]
+    UIHelper.keyDown("2");                                 // -> 09/[0002]
+    shouldBe("inputEventsFired", "1");
+    shouldBe("changeEventsFired", "0");
+
+    UIHelper.keyDown("0");                                 // -> 09/[0020]
+    shouldBe("inputEventsFired", "2");
+    shouldBe("changeEventsFired", "0");
+
+    UIHelper.keyDown("1");                                 // -> 09/[0201]
+    shouldBe("inputEventsFired", "3");
+    shouldBe("changeEventsFired", "0");
+
+    UIHelper.keyDown("2");                                 // -> 09/[2012]
+    shouldBe("inputEventsFired", "4");
+    shouldBe("changeEventsFired", "0");
+
+    UIHelper.keyDown("A");                                 // Ignored.
+    shouldBe("inputEventsFired", "4");
+    shouldBe("changeEventsFired", "0");
+
+    shouldBeEqualToString("input.value", "2012-09");
+
+    input.blur();
+    shouldBe("inputEventsFired", "4");
+    shouldBe("changeEventsFired", "1");
+
+    finishJSTest();
+});
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/month/month-editable-components/month-editable-components-keyboard-events-expected.txt
+++ b/LayoutTests/fast/forms/month/month-editable-components/month-editable-components-keyboard-events-expected.txt
@@ -6,33 +6,45 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 Digit keys
 PASS input.value is "2012-09"
-PASS changeEventsFired is 4
+PASS changeEventsFired is 0
+PASS inputEventsFired is 4
+PASS changeEventsFired is 1
 PASS inputEventsFired is 4
 
 Digit keys with leading zero
 PASS input.value is "0034-05"
-PASS changeEventsFired is 3
+PASS changeEventsFired is 0
+PASS inputEventsFired is 3
+PASS changeEventsFired is 1
 PASS inputEventsFired is 3
 
 Digit keys and backspace key
 PASS input.value is "2020-02"
-PASS changeEventsFired is 6
+PASS changeEventsFired is 0
+PASS inputEventsFired is 6
+PASS changeEventsFired is 1
 PASS inputEventsFired is 6
 
 Digit keys with timeout
 PASS input.value is "0001-02"
-PASS changeEventsFired is 2
+PASS changeEventsFired is 0
+PASS inputEventsFired is 2
+PASS changeEventsFired is 1
 PASS inputEventsFired is 2
 
 Digit keys clamp value
 PASS input.value is "9999-12"
-PASS changeEventsFired is 4
+PASS changeEventsFired is 0
+PASS inputEventsFired is 4
+PASS changeEventsFired is 1
 PASS inputEventsFired is 4
 
 Left/Right arrow keys
 PASS input.value is "0002-02"
 PASS input.value is "0002-03"
-PASS changeEventsFired is 2
+PASS changeEventsFired is 0
+PASS inputEventsFired is 2
+PASS changeEventsFired is 1
 PASS inputEventsFired is 2
 
 Left/Right arrow keys (vertical-lr)
@@ -40,7 +52,9 @@ PASS input.value is "2020-01"
 PASS input.value is "2020-02"
 PASS input.value is "2020-01"
 PASS input.value is "2020-12"
-PASS changeEventsFired is 4
+PASS changeEventsFired is 0
+PASS inputEventsFired is 4
+PASS changeEventsFired is 0
 PASS inputEventsFired is 4
 
 Left/Right arrow keys (vertical-rl)
@@ -48,7 +62,9 @@ PASS input.value is "2020-01"
 PASS input.value is "2020-02"
 PASS input.value is "2020-01"
 PASS input.value is "2020-12"
-PASS changeEventsFired is 4
+PASS changeEventsFired is 0
+PASS inputEventsFired is 4
+PASS changeEventsFired is 0
 PASS inputEventsFired is 4
 
 Advance field keys
@@ -58,7 +74,9 @@ PASS input.value is "0005-06"
 PASS input.value is "0006-06"
 PASS input.value is "0007-06"
 PASS input.value is "0008-06"
-PASS changeEventsFired is 6
+PASS changeEventsFired is 0
+PASS inputEventsFired is 6
+PASS changeEventsFired is 1
 PASS inputEventsFired is 6
 
 Up/Down arrow keys
@@ -66,19 +84,25 @@ PASS input.value is "2020-01"
 PASS input.value is "2020-02"
 PASS input.value is "2020-01"
 PASS input.value is "2020-12"
-PASS changeEventsFired is 4
+PASS changeEventsFired is 0
+PASS inputEventsFired is 4
+PASS changeEventsFired is 0
 PASS inputEventsFired is 4
 
 Up/Down arrow keys (vertical-lr)
 PASS input.value is "0002-02"
 PASS input.value is "0002-03"
-PASS changeEventsFired is 2
+PASS changeEventsFired is 0
+PASS inputEventsFired is 2
+PASS changeEventsFired is 1
 PASS inputEventsFired is 2
 
 Up/Down arrow keys (vertical-rl)
 PASS input.value is "0002-02"
 PASS input.value is "0002-03"
-PASS changeEventsFired is 2
+PASS changeEventsFired is 0
+PASS inputEventsFired is 2
+PASS changeEventsFired is 1
 PASS inputEventsFired is 2
 
 Tab key
@@ -88,15 +112,21 @@ PASS input.value is "0002-03"
 PASS document.activeElement.id is "before"
 PASS changeEventsFired is 2
 PASS inputEventsFired is 2
+PASS changeEventsFired is 2
+PASS inputEventsFired is 2
 
 Backspace key
 PASS input.value is ""
 PASS input.value is "2020-07"
-PASS changeEventsFired is 2
+PASS changeEventsFired is 0
+PASS inputEventsFired is 2
+PASS changeEventsFired is 1
 PASS inputEventsFired is 2
 
 Delete key
 PASS input.value is ""
+PASS changeEventsFired is 0
+PASS inputEventsFired is 1
 PASS changeEventsFired is 1
 PASS inputEventsFired is 1
 
@@ -105,7 +135,9 @@ PASS input.value is "2020-09"
 PASS input.value is "2020-01"
 PASS input.value is "2020-01"
 PASS input.value is "0002-01"
-PASS changeEventsFired is 2
+PASS changeEventsFired is 0
+PASS inputEventsFired is 2
+PASS changeEventsFired is 1
 PASS inputEventsFired is 2
 PASS successfullyParsed is true
 

--- a/LayoutTests/fast/forms/month/month-editable-components/month-editable-components-keyboard-events.html
+++ b/LayoutTests/fast/forms/month/month-editable-components/month-editable-components-keyboard-events.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../../../resources/js-test-pre.js"></script>
+<script src="../../../../resources/js-test.js"></script>
 <script src="../../../../resources/ui-helper.js"></script>
 </head>
 <body>
@@ -50,7 +50,10 @@ addEventListener("load", async () => {
     UIHelper.keyDown("2");                                 // -> 09/[2012]
     UIHelper.keyDown("A");                                 // Ignored.
     shouldBeEqualToString("input.value", "2012-09");
-    shouldBe("changeEventsFired", "4");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "4");
+    input.blur();
+    shouldBe("changeEventsFired", "1");
     shouldBe("inputEventsFired", "4");
 
     beginTest("Digit keys with leading zero");             // [mm]/yyyy
@@ -62,7 +65,10 @@ addEventListener("load", async () => {
     UIHelper.keyDown("3");                                 // -> 05/[0003]
     UIHelper.keyDown("4");                                 // -> 05/[0034]
     shouldBeEqualToString("input.value", "0034-05");
-    shouldBe("changeEventsFired", "3");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "3");
+    input.blur();
+    shouldBe("changeEventsFired", "1");
     shouldBe("inputEventsFired", "3");
 
     beginTest("Digit keys and backspace key");             // [mm]/yyyy
@@ -77,7 +83,10 @@ addEventListener("load", async () => {
     UIHelper.keyDown("2");                                 // -> 02/[0202]
     UIHelper.keyDown("0");                                 // -> 02/[2020]
     shouldBeEqualToString("input.value", "2020-02");
-    shouldBe("changeEventsFired", "6");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "6");
+    input.blur();
+    shouldBe("changeEventsFired", "1");
     shouldBe("inputEventsFired", "6");
 
     beginTest("Digit keys with timeout");                  // [mm]/yyyy
@@ -87,7 +96,10 @@ addEventListener("load", async () => {
     await UIHelper.delayFor(1500);                         // Wait.
     UIHelper.keyDown("1");                                 // -> 02/[0001]
     shouldBeEqualToString("input.value", "0001-02");
-    shouldBe("changeEventsFired", "2");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "2");
+    input.blur();
+    shouldBe("changeEventsFired", "1");
     shouldBe("inputEventsFired", "2");
 
     beginTest("Digit keys clamp value");                   // [mm]/yyyy
@@ -99,7 +111,10 @@ addEventListener("load", async () => {
     UIHelper.keyDown("9");                                 // -> 12/[0999]
     UIHelper.keyDown("9");                                 // -> 12/[9999]
     shouldBeEqualToString("input.value", "9999-12");
-    shouldBe("changeEventsFired", "4");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "4");
+    input.blur();
+    shouldBe("changeEventsFired", "1");
     shouldBe("inputEventsFired", "4");
 
     beginTest("Left/Right arrow keys");                    // [mm]/yyyy
@@ -110,7 +125,10 @@ addEventListener("load", async () => {
     UIHelper.keyDown("leftArrow");                         // -> [02]/0002
     UIHelper.keyDown("3");                                 // -> [03]/0002
     shouldBeEqualToString("input.value", "0002-03");
-    shouldBe("changeEventsFired", "2");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "2");
+    input.blur();
+    shouldBe("changeEventsFired", "1");
     shouldBe("inputEventsFired", "2");
 
     beginTest("Left/Right arrow keys (vertical-lr)", "2020-12", "writing-mode: vertical-lr");            // [12]/2020
@@ -122,7 +140,10 @@ addEventListener("load", async () => {
     shouldBeEqualToString("input.value", "2020-01");
     UIHelper.keyDown("leftArrow");                                                                       // [12]/2020
     shouldBeEqualToString("input.value", "2020-12");
-    shouldBe("changeEventsFired", "4");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "4");
+    input.blur();
+    shouldBe("changeEventsFired", "0");
     shouldBe("inputEventsFired", "4");
 
     beginTest("Left/Right arrow keys (vertical-rl)", "2020-12", "writing-mode: vertical-rl");            // [12]/2020
@@ -134,7 +155,10 @@ addEventListener("load", async () => {
     shouldBeEqualToString("input.value", "2020-01");
     UIHelper.keyDown("leftArrow");                                                                       // [12]/2020
     shouldBeEqualToString("input.value", "2020-12");
-    shouldBe("changeEventsFired", "4");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "4");
+    input.blur();
+    shouldBe("changeEventsFired", "0");
     shouldBe("inputEventsFired", "4");
 
     beginTest("Advance field keys", "2020-06");            // [06]/2020
@@ -161,7 +185,10 @@ addEventListener("load", async () => {
     UIHelper.keyDown(",");                                 // -> 06/[0007]
     UIHelper.keyDown("8");                                 // -> 06/[0008]
     shouldBeEqualToString("input.value", "0008-06");
-    shouldBe("changeEventsFired", "6");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "6");
+    input.blur();
+    shouldBe("changeEventsFired", "1");
     shouldBe("inputEventsFired", "6");
 
     beginTest("Up/Down arrow keys", "2020-12");            // [12]/2020
@@ -173,7 +200,10 @@ addEventListener("load", async () => {
     shouldBeEqualToString("input.value", "2020-01");
     UIHelper.keyDown("downArrow");                         // [12]/2020
     shouldBeEqualToString("input.value", "2020-12");
-    shouldBe("changeEventsFired", "4");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "4");
+    input.blur();
+    shouldBe("changeEventsFired", "0");
     shouldBe("inputEventsFired", "4");
 
     beginTest("Up/Down arrow keys (vertical-lr)", "", "writing-mode: vertical-lr");     // [mm]/yyyy
@@ -184,7 +214,10 @@ addEventListener("load", async () => {
     UIHelper.keyDown("upArrow");                                                        // -> [02]/0002
     UIHelper.keyDown("3");                                                              // -> [03]/0002
     shouldBeEqualToString("input.value", "0002-03");
-    shouldBe("changeEventsFired", "2");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "2");
+    input.blur();
+    shouldBe("changeEventsFired", "1");
     shouldBe("inputEventsFired", "2");
 
     beginTest("Up/Down arrow keys (vertical-rl)", "", "writing-mode: vertical-rl");     // [mm]/yyyy
@@ -195,7 +228,10 @@ addEventListener("load", async () => {
     UIHelper.keyDown("upArrow");                                                        // -> [02]/0002
     UIHelper.keyDown("3");                                                              // -> [03]/0002
     shouldBeEqualToString("input.value", "0002-03");
-    shouldBe("changeEventsFired", "2");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "2");
+    input.blur();
+    shouldBe("changeEventsFired", "1");
     shouldBe("inputEventsFired", "2");
 
     beginTest("Tab key");
@@ -213,18 +249,27 @@ addEventListener("load", async () => {
     shouldBeEqualToString("document.activeElement.id", "before");
     shouldBe("changeEventsFired", "2");
     shouldBe("inputEventsFired", "2");
+    input.blur();
+    shouldBe("changeEventsFired", "2");
+    shouldBe("inputEventsFired", "2");
 
     beginTest("Backspace key", "2020-08");                 // [08]/2020
     UIHelper.keyDown("\b");                                // -> [mm]/2020
     shouldBeEqualToString("input.value", "");
     UIHelper.keyDown("7");                                 // -> [07]/2020
     shouldBeEqualToString("input.value", "2020-07");
-    shouldBe("changeEventsFired", "2");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "2");
+    input.blur();
+    shouldBe("changeEventsFired", "1");
     shouldBe("inputEventsFired", "2");
 
     beginTest("Delete key", "2021-08");                    // [08]/2021
     UIHelper.keyDown("delete");                            // -> [mm]/2021
     shouldBeEqualToString("input.value", "");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "1");
+    input.blur();
     shouldBe("changeEventsFired", "1");
     shouldBe("inputEventsFired", "1");
 
@@ -243,14 +288,15 @@ addEventListener("load", async () => {
     input.readOnly = false;
     UIHelper.keyDown("2");
     shouldBeEqualToString("input.value", "0002-01");
-    shouldBe("changeEventsFired", "2");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "2");
+    input.blur();
+    shouldBe("changeEventsFired", "1");
     shouldBe("inputEventsFired", "2");
 
     finishJSTest();
 });
 
 </script>
-
-<script src="../../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/forms/month/month-editable-components/month-editable-components-user-invalid-expected.html
+++ b/LayoutTests/fast/forms/month/month-editable-components/month-editable-components-user-invalid-expected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+
+input {
+    border: 1px solid red;
+}
+
+</style>
+</head>
+<body>
+<input id="input" type="month" value="2020-10">
+</body>
+</html>

--- a/LayoutTests/fast/forms/month/month-editable-components/month-editable-components-user-invalid-uncommitted-expected.html
+++ b/LayoutTests/fast/forms/month/month-editable-components/month-editable-components-user-invalid-uncommitted-expected.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/ui-helper.js"></script>
+<style>
+
+input {
+    border: 1px solid black;
+}
+
+</style>
+</head>
+<body>
+
+<input id="input" type="month">
+
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+addEventListener("load", async () => {
+    input.focus();
+    UIHelper.keyDown("1");
+    UIHelper.keyDown("0");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("0");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("0");
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+});
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/month/month-editable-components/month-editable-components-user-invalid-uncommitted.html
+++ b/LayoutTests/fast/forms/month/month-editable-components/month-editable-components-user-invalid-uncommitted.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/ui-helper.js"></script>
+<style>
+
+input {
+    border: 1px solid black;
+}
+
+input:user-invalid {
+    border: 1px red solid;
+}
+
+</style>
+</head>
+<body>
+
+<input id="input" type="month" min="2020-11">
+
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+addEventListener("load", async () => {
+    input.focus();
+    UIHelper.keyDown("1");
+    UIHelper.keyDown("0");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("0");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("0");
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+});
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/month/month-editable-components/month-editable-components-user-invalid-with-empty-components-expected.html
+++ b/LayoutTests/fast/forms/month/month-editable-components/month-editable-components-user-invalid-with-empty-components-expected.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/ui-helper.js"></script>
+<style>
+
+input {
+    border: 1px solid black;
+}
+
+</style>
+</head>
+<body>
+
+<p>Test that typing a partially completed month does not match :user-invalid</p>
+<input id="input" type="month">
+
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+addEventListener("load", async () => {
+    input.focus();
+    UIHelper.keyDown("9");
+    input.blur();
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+});
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/month/month-editable-components/month-editable-components-user-invalid-with-empty-components.html
+++ b/LayoutTests/fast/forms/month/month-editable-components/month-editable-components-user-invalid-with-empty-components.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/ui-helper.js"></script>
+<style>
+
+input {
+    border: 1px solid black;
+}
+
+input:user-invalid {
+    border: 1px red solid;
+}
+
+</style>
+</head>
+<body>
+
+<p>Test that typing a partially completed month does not match :user-invalid</p>
+<input id="input" type="month">
+
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+addEventListener("load", async () => {
+    input.focus();
+    UIHelper.keyDown("9");
+    input.blur();
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+});
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/month/month-editable-components/month-editable-components-user-invalid.html
+++ b/LayoutTests/fast/forms/month/month-editable-components/month-editable-components-user-invalid.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/ui-helper.js"></script>
+<style>
+
+input {
+    border: 1px solid black;
+}
+
+input:user-invalid {
+    border: 1px red solid;
+}
+
+</style>
+</head>
+<body>
+
+<input id="input" type="month" min="2020-11">
+
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+addEventListener("load", async () => {
+    input.focus();
+    UIHelper.keyDown("1");
+    UIHelper.keyDown("0");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("0");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("0");
+    input.blur();
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+});
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/month/month-editable-components/month-editable-components-user-valid-expected.html
+++ b/LayoutTests/fast/forms/month/month-editable-components/month-editable-components-user-valid-expected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+
+input {
+    border: 1px solid green;
+}
+
+</style>
+</head>
+<body>
+<input id="input" type="month" value="2020-12">
+</body>
+</html>

--- a/LayoutTests/fast/forms/month/month-editable-components/month-editable-components-user-valid-uncommitted-expected.html
+++ b/LayoutTests/fast/forms/month/month-editable-components/month-editable-components-user-valid-uncommitted-expected.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/ui-helper.js"></script>
+<style>
+
+input {
+    border: 1px solid black;
+}
+
+</style>
+</head>
+<body>
+
+<input id="input" type="month">
+
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+addEventListener("load", async () => {
+    input.focus();
+    UIHelper.keyDown("1");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("0");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("0");
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+});
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/month/month-editable-components/month-editable-components-user-valid-uncommitted.html
+++ b/LayoutTests/fast/forms/month/month-editable-components/month-editable-components-user-valid-uncommitted.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/ui-helper.js"></script>
+<style>
+
+input {
+    border: 1px solid black;
+}
+
+input:user-valid {
+    border: 1px solid green;
+}
+
+</style>
+</head>
+<body>
+
+<input id="input" type="month" min="2020-11">
+
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+addEventListener("load", async () => {
+    input.focus();
+    UIHelper.keyDown("1");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("0");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("0");
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+});
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/month/month-editable-components/month-editable-components-user-valid.html
+++ b/LayoutTests/fast/forms/month/month-editable-components/month-editable-components-user-valid.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/ui-helper.js"></script>
+<style>
+
+input {
+    border: 1px solid black;
+}
+
+input:user-valid {
+    border: 1px solid green;
+}
+
+</style>
+</head>
+<body>
+
+<input id="input" type="month" min="2020-11">
+
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+addEventListener("load", async () => {
+    input.focus();
+    UIHelper.keyDown("1");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("0");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("0");
+    input.blur();
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+});
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/time/time-editable-components/time-editable-components-input-and-change-events-expected.txt
+++ b/LayoutTests/fast/forms/time/time-editable-components/time-editable-components-input-and-change-events-expected.txt
@@ -1,0 +1,18 @@
+Test for input and change events for <input type=time>
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS inputEventsFired is 0
+PASS changeEventsFired is 0
+PASS inputEventsFired is 0
+PASS changeEventsFired is 0
+PASS inputEventsFired is 1
+PASS changeEventsFired is 0
+PASS input.value is "00:02"
+PASS inputEventsFired is 1
+PASS changeEventsFired is 1
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/time/time-editable-components/time-editable-components-input-and-change-events.html
+++ b/LayoutTests/fast/forms/time/time-editable-components/time-editable-components-input-and-change-events.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/js-test.js"></script>
+<script src="../../../../resources/ui-helper.js"></script>
+</head>
+<body>
+
+<input id="input" type="time">
+
+<script>
+
+jsTestIsAsync = true;
+
+changeEventsFired = 0;
+function onChangeEvent() {
+    changeEventsFired++;
+}
+
+inputEventsFired = 0;
+function onInputEvent() {
+    inputEventsFired++;
+}
+
+input.addEventListener("change", onChangeEvent);
+input.addEventListener("input", onInputEvent);
+
+addEventListener("load", async () => {
+    description("Test for input and change events for &lt;input type=time&gt;");
+
+    input.focus();                                         // [hh]:mm tt
+    UIHelper.keyDown("1");                                 // -> [01]:mm tt
+    UIHelper.keyDown("2");                                 // -> [12]:mm tt
+    shouldBe("inputEventsFired", "0");
+    shouldBe("changeEventsFired", "0");
+
+    UIHelper.keyDown("rightArrow");                        // -> 12:[mm] tt
+    UIHelper.keyDown("2");                                 // -> 12:[02] tt
+    shouldBe("inputEventsFired", "0");
+    shouldBe("changeEventsFired", "0");
+
+    UIHelper.keyDown("rightArrow");                        // -> 12:02 [tt]
+    UIHelper.keyDown("A");                                 // -> 12:02 [AM]
+    shouldBe("inputEventsFired", "1");
+    shouldBe("changeEventsFired", "0");
+
+    shouldBeEqualToString("input.value", "00:02");
+
+    input.blur();
+    shouldBe("inputEventsFired", "1");
+    shouldBe("changeEventsFired", "1");
+
+    finishJSTest();
+});
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/time/time-editable-components/time-editable-components-keyboard-events-expected.txt
+++ b/LayoutTests/fast/forms/time/time-editable-components/time-editable-components-keyboard-events-expected.txt
@@ -6,11 +6,15 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 Digit keys
 PASS input.value is "00:02"
+PASS changeEventsFired is 0
+PASS inputEventsFired is 1
 PASS changeEventsFired is 1
 PASS inputEventsFired is 1
 
 Digit keys with timeout
 PASS input.value is "14:05"
+PASS changeEventsFired is 0
+PASS inputEventsFired is 1
 PASS changeEventsFired is 1
 PASS inputEventsFired is 1
 
@@ -20,13 +24,17 @@ PASS input.value is "12:22"
 PASS input.value is "13:22"
 PASS input.value is "13:06"
 PASS input.value is "13:59"
-PASS changeEventsFired is 5
+PASS changeEventsFired is 0
+PASS inputEventsFired is 5
+PASS changeEventsFired is 1
 PASS inputEventsFired is 5
 
 Left/Right arrow keys
 PASS input.value is "02:02"
 PASS input.value is "03:03"
-PASS changeEventsFired is 5
+PASS changeEventsFired is 0
+PASS inputEventsFired is 5
+PASS changeEventsFired is 1
 PASS inputEventsFired is 5
 
 Left/Right arrow keys (vertical-lr)
@@ -37,7 +45,9 @@ PASS input.value is "23:59"
 PASS input.value is "11:59"
 PASS input.value is "23:59"
 PASS input.value is "11:59"
-PASS changeEventsFired is 7
+PASS changeEventsFired is 0
+PASS inputEventsFired is 7
+PASS changeEventsFired is 1
 PASS inputEventsFired is 7
 
 Left/Right arrow keys (vertical-rl)
@@ -48,7 +58,9 @@ PASS input.value is "23:59"
 PASS input.value is "11:59"
 PASS input.value is "23:59"
 PASS input.value is "11:59"
-PASS changeEventsFired is 7
+PASS changeEventsFired is 0
+PASS inputEventsFired is 7
+PASS changeEventsFired is 1
 PASS inputEventsFired is 7
 
 Advance field keys
@@ -58,7 +70,9 @@ PASS input.value is "01:05"
 PASS input.value is "01:06"
 PASS input.value is "01:07"
 PASS input.value is "01:08"
-PASS changeEventsFired is 6
+PASS changeEventsFired is 0
+PASS inputEventsFired is 6
+PASS changeEventsFired is 1
 PASS inputEventsFired is 6
 
 Up/Down arrow keys
@@ -69,19 +83,25 @@ PASS input.value is "23:59"
 PASS input.value is "11:59"
 PASS input.value is "23:59"
 PASS input.value is "11:59"
-PASS changeEventsFired is 7
+PASS changeEventsFired is 0
+PASS inputEventsFired is 7
+PASS changeEventsFired is 1
 PASS inputEventsFired is 7
 
 Up/Down arrow keys (vertical-lr)
 PASS input.value is "02:02"
 PASS input.value is "03:03"
-PASS changeEventsFired is 5
+PASS changeEventsFired is 0
+PASS inputEventsFired is 5
+PASS changeEventsFired is 1
 PASS inputEventsFired is 5
 
 Up/Down arrow keys (vertical-rl)
 PASS input.value is "02:02"
 PASS input.value is "03:03"
-PASS changeEventsFired is 5
+PASS changeEventsFired is 0
+PASS inputEventsFired is 5
+PASS changeEventsFired is 1
 PASS inputEventsFired is 5
 
 Tab key
@@ -89,17 +109,19 @@ PASS input.value is "02:02"
 PASS document.activeElement.id is "after"
 PASS input.value is "03:03"
 PASS document.activeElement.id is "before"
-PASS changeEventsFired is 3
+PASS changeEventsFired is 2
 PASS inputEventsFired is 3
 
 Backspace key
 PASS input.value is ""
 PASS input.value is "19:30"
-PASS changeEventsFired is 2
+PASS changeEventsFired is 0
 PASS inputEventsFired is 2
 
 Delete key
 PASS input.value is ""
+PASS changeEventsFired is 0
+PASS inputEventsFired is 1
 PASS changeEventsFired is 1
 PASS inputEventsFired is 1
 
@@ -108,7 +130,9 @@ PASS input.value is "09:01"
 PASS input.value is "01:01"
 PASS input.value is "01:01"
 PASS input.value is "01:02"
-PASS changeEventsFired is 2
+PASS changeEventsFired is 0
+PASS inputEventsFired is 2
+PASS changeEventsFired is 1
 PASS inputEventsFired is 2
 PASS successfullyParsed is true
 

--- a/LayoutTests/fast/forms/time/time-editable-components/time-editable-components-keyboard-events.html
+++ b/LayoutTests/fast/forms/time/time-editable-components/time-editable-components-keyboard-events.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../../../resources/js-test-pre.js"></script>
+<script src="../../../../resources/js-test.js"></script>
 <script src="../../../../resources/ui-helper.js"></script>
 </head>
 <body>
@@ -49,6 +49,9 @@ addEventListener("load", async () => {
     UIHelper.keyDown("rightArrow");                        // -> 12:02 [tt]
     UIHelper.keyDown("A");                                 // -> 12:02 [AM]
     shouldBeEqualToString("input.value", "00:02");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "1");
+    input.blur();
     shouldBe("changeEventsFired", "1");
     shouldBe("inputEventsFired", "1");
 
@@ -61,6 +64,9 @@ addEventListener("load", async () => {
     UIHelper.keyDown("rightArrow");                        // -> 02:05 [tt]
     UIHelper.keyDown("P");                                 // -> 02:05 [PM]
     shouldBeEqualToString("input.value", "14:05");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "1");
+    input.blur();
     shouldBe("changeEventsFired", "1");
     shouldBe("inputEventsFired", "1");
 
@@ -76,7 +82,10 @@ addEventListener("load", async () => {
     shouldBeEqualToString("input.value", "13:06");
     UIHelper.keyDown("1");                                 // -> 13:[59] PM
     shouldBeEqualToString("input.value", "13:59");
-    shouldBe("changeEventsFired", "5");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "5");
+    input.blur();
+    shouldBe("changeEventsFired", "1");
     shouldBe("inputEventsFired", "5");
 
     beginTest("Left/Right arrow keys", "15:27");           // [03]:27 PM
@@ -91,7 +100,10 @@ addEventListener("load", async () => {
     UIHelper.keyDown("leftArrow");                         // -> [02]:03 AM
     UIHelper.keyDown("3");                                 // -> [03]:03 AM
     shouldBeEqualToString("input.value", "03:03");
-    shouldBe("changeEventsFired", "5");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "5");
+    input.blur();
+    shouldBe("changeEventsFired", "1");
     shouldBe("inputEventsFired", "5");
 
     beginTest("Left/Right arrow keys (vertical-lr)", "23:59", "writing-mode: vertical-lr");              // [11]:59 PM
@@ -111,7 +123,10 @@ addEventListener("load", async () => {
     shouldBeEqualToString("input.value", "23:59");
     UIHelper.keyDown("leftArrow");                                                                       // -> 11:59 [AM]
     shouldBeEqualToString("input.value", "11:59");
-    shouldBe("changeEventsFired", "7");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "7");
+    input.blur();
+    shouldBe("changeEventsFired", "1");
     shouldBe("inputEventsFired", "7");
 
     beginTest("Left/Right arrow keys (vertical-rl)", "23:59", "writing-mode: vertical-rl");              // [11]:59 PM
@@ -131,7 +146,10 @@ addEventListener("load", async () => {
     shouldBeEqualToString("input.value", "23:59");
     UIHelper.keyDown("leftArrow");                                                                       // -> 11:59 [AM]
     shouldBeEqualToString("input.value", "11:59");
-    shouldBe("changeEventsFired", "7");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "7");
+    input.blur();
+    shouldBe("changeEventsFired", "1");
     shouldBe("inputEventsFired", "7");
 
     beginTest("Advance field keys", "01:28");              // [01]:28 AM
@@ -158,7 +176,10 @@ addEventListener("load", async () => {
     UIHelper.keyDown(",");                                 // -> 01:[07] AM
     UIHelper.keyDown("8");                                 // -> 01:[08] AM
     shouldBeEqualToString("input.value", "01:08");
-    shouldBe("changeEventsFired", "6");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "6");
+    input.blur();
+    shouldBe("changeEventsFired", "1");
     shouldBe("inputEventsFired", "6");
 
     beginTest("Up/Down arrow keys", "23:59");              // [11]:59 PM
@@ -178,7 +199,10 @@ addEventListener("load", async () => {
     shouldBeEqualToString("input.value", "23:59");
     UIHelper.keyDown("downArrow");                         // -> 11:59 [AM]
     shouldBeEqualToString("input.value", "11:59");
-    shouldBe("changeEventsFired", "7");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "7");
+    input.blur();
+    shouldBe("changeEventsFired", "1");
     shouldBe("inputEventsFired", "7");
 
     beginTest("Up/Down arrow keys (vertical-lr)", "15:27", "writing-mode: vertical-lr");           // [03]:27 PM
@@ -193,7 +217,10 @@ addEventListener("load", async () => {
     UIHelper.keyDown("upArrow");                                                                   // -> [02]:03 AM
     UIHelper.keyDown("3");                                                                         // -> [03]:03 AM
     shouldBeEqualToString("input.value", "03:03");
-    shouldBe("changeEventsFired", "5");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "5");
+    input.blur();
+    shouldBe("changeEventsFired", "1");
     shouldBe("inputEventsFired", "5");
 
     beginTest("Up/Down arrow keys (vertical-rl)", "15:27", "writing-mode: vertical-rl");           // [03]:27 PM
@@ -208,7 +235,10 @@ addEventListener("load", async () => {
     UIHelper.keyDown("upArrow");                                                                   // -> [02]:03 AM
     UIHelper.keyDown("3");                                                                         // -> [03]:03 AM
     shouldBeEqualToString("input.value", "03:03");
-    shouldBe("changeEventsFired", "5");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "5");
+    input.blur();
+    shouldBe("changeEventsFired", "1");
     shouldBe("inputEventsFired", "5");
 
     beginTest("Tab key");                                  // [hh]:mm tt
@@ -228,7 +258,7 @@ addEventListener("load", async () => {
     shouldBeEqualToString("input.value", "03:03");
     UIHelper.keyDown("\t", ["shiftKey"]);                  // Focus out.
     shouldBeEqualToString("document.activeElement.id", "before");
-    shouldBe("changeEventsFired", "3");
+    shouldBe("changeEventsFired", "2");
     shouldBe("inputEventsFired", "3");
 
     beginTest("Backspace key", "16:30");                   // [04]:30 PM
@@ -236,12 +266,15 @@ addEventListener("load", async () => {
     shouldBeEqualToString("input.value", "");
     UIHelper.keyDown("7");                                 // -> [07]:30 PM
     shouldBeEqualToString("input.value", "19:30");
-    shouldBe("changeEventsFired", "2");
+    shouldBe("changeEventsFired", "0");
     shouldBe("inputEventsFired", "2");
 
     beginTest("Delete key", "18:20");                      // [06]:20 PM
     UIHelper.keyDown("delete");                            // -> [hh]:20 PM
     shouldBeEqualToString("input.value", "");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "1");
+    input.blur();
     shouldBe("changeEventsFired", "1");
     shouldBe("inputEventsFired", "1");
 
@@ -260,7 +293,10 @@ addEventListener("load", async () => {
     input.readOnly = false;
     UIHelper.keyDown("2");
     shouldBeEqualToString("input.value", "01:02");
-    shouldBe("changeEventsFired", "2");
+    shouldBe("changeEventsFired", "0");
+    shouldBe("inputEventsFired", "2");
+    input.blur();
+    shouldBe("changeEventsFired", "1");
     shouldBe("inputEventsFired", "2");
 
     finishJSTest();
@@ -268,6 +304,5 @@ addEventListener("load", async () => {
 
 </script>
 
-<script src="../../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/forms/time/time-editable-components/time-editable-components-user-invalid-expected.html
+++ b/LayoutTests/fast/forms/time/time-editable-components/time-editable-components-user-invalid-expected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+
+input {
+    border: 1px solid red;
+}
+
+</style>
+</head>
+<body>
+<input id="input" type="time" value="09:29">
+</body>
+</html>

--- a/LayoutTests/fast/forms/time/time-editable-components/time-editable-components-user-invalid-uncommitted-expected.html
+++ b/LayoutTests/fast/forms/time/time-editable-components/time-editable-components-user-invalid-uncommitted-expected.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/ui-helper.js"></script>
+<style>
+
+input {
+    border: 1px solid black;
+}
+
+</style>
+</head>
+<body>
+
+<input id="input" type="time">
+
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+addEventListener("load", async () => {
+    input.focus();
+    UIHelper.keyDown("9");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("9");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("A");
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+});
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/time/time-editable-components/time-editable-components-user-invalid-uncommitted.html
+++ b/LayoutTests/fast/forms/time/time-editable-components/time-editable-components-user-invalid-uncommitted.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/ui-helper.js"></script>
+<style>
+
+input {
+    border: 1px solid black;
+}
+
+input:user-invalid {
+    border: 1px red solid;
+}
+
+</style>
+</head>
+<body>
+
+<input id="input" type="time" min="09:30">
+
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+addEventListener("load", async () => {
+    input.focus();
+    UIHelper.keyDown("9");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("9");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("A");
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+});
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/time/time-editable-components/time-editable-components-user-invalid-with-empty-components-expected.html
+++ b/LayoutTests/fast/forms/time/time-editable-components/time-editable-components-user-invalid-with-empty-components-expected.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/ui-helper.js"></script>
+<style>
+
+input {
+    border: 1px solid black;
+}
+
+</style>
+</head>
+<body>
+
+<p>Test that typing a partially completed time does not match :user-invalid</p>
+<input id="input" type="time">
+
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+addEventListener("load", async () => {
+    input.focus();
+    UIHelper.keyDown("9");
+    input.blur();
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+});
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/time/time-editable-components/time-editable-components-user-invalid-with-empty-components.html
+++ b/LayoutTests/fast/forms/time/time-editable-components/time-editable-components-user-invalid-with-empty-components.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/ui-helper.js"></script>
+<style>
+
+input {
+    border: 1px solid black;
+}
+
+input:user-invalid {
+    border: 1px red solid;
+}
+
+</style>
+</head>
+<body>
+
+<p>Test that typing a partially completed time does not match :user-invalid</p>
+<input id="input" type="time">
+
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+addEventListener("load", async () => {
+    input.focus();
+    UIHelper.keyDown("9");
+    input.blur();
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+});
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/time/time-editable-components/time-editable-components-user-invalid.html
+++ b/LayoutTests/fast/forms/time/time-editable-components/time-editable-components-user-invalid.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/ui-helper.js"></script>
+<style>
+
+input {
+    border: 1px solid black;
+}
+
+input:user-invalid {
+    border: 1px red solid;
+}
+
+</style>
+</head>
+<body>
+
+<input id="input" type="time" min="09:30">
+
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+addEventListener("load", async () => {
+    input.focus();
+    UIHelper.keyDown("9");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("2");
+    UIHelper.keyDown("9");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("A");
+    input.blur();
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+});
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/time/time-editable-components/time-editable-components-user-valid-expected.html
+++ b/LayoutTests/fast/forms/time/time-editable-components/time-editable-components-user-valid-expected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+
+input {
+    border: 1px solid green;
+}
+
+</style>
+</head>
+<body>
+<input id="input" type="time" value="09:31">
+</body>
+</html>

--- a/LayoutTests/fast/forms/time/time-editable-components/time-editable-components-user-valid-uncommitted-expected.html
+++ b/LayoutTests/fast/forms/time/time-editable-components/time-editable-components-user-valid-uncommitted-expected.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/ui-helper.js"></script>
+<style>
+
+input {
+    border: 1px solid black;
+}
+
+</style>
+</head>
+<body>
+
+<input id="input" type="time">
+
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+addEventListener("load", async () => {
+    input.focus();
+    UIHelper.keyDown("9");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("3");
+    UIHelper.keyDown("1");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("A");
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+});
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/time/time-editable-components/time-editable-components-user-valid-uncommitted.html
+++ b/LayoutTests/fast/forms/time/time-editable-components/time-editable-components-user-valid-uncommitted.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/ui-helper.js"></script>
+<style>
+
+input {
+    border: 1px solid black;
+}
+
+input:user-valid {
+    border: 1px solid green;
+}
+
+</style>
+</head>
+<body>
+
+<input id="input" type="time" min="09:30">
+
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+addEventListener("load", async () => {
+    input.focus();
+    UIHelper.keyDown("9");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("3");
+    UIHelper.keyDown("1");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("A");
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+});
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/time/time-editable-components/time-editable-components-user-valid.html
+++ b/LayoutTests/fast/forms/time/time-editable-components/time-editable-components-user-valid.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/ui-helper.js"></script>
+<style>
+
+input {
+    border: 1px solid black;
+}
+
+input:user-valid {
+    border: 1px solid green;
+}
+
+</style>
+</head>
+<body>
+
+<input id="input" type="time" min="09:30">
+
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+addEventListener("load", async () => {
+    input.focus();
+    UIHelper.keyDown("9");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("3");
+    UIHelper.keyDown("1");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown("A");
+    input.blur();
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+});
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/time/time-editable-components/time-multiple-fields-choose-default-value-after-set-value.html
+++ b/LayoutTests/fast/forms/time/time-editable-components/time-multiple-fields-choose-default-value-after-set-value.html
@@ -36,6 +36,8 @@ input.focus();
 debug("Digit keys");                               // [00]/00/00
 UIHelper.keyDown('downArrow');
 
+input.blur();
+
 shouldBeEqualToString('input.value', '01:01:01');
 shouldBe('eventsCounter.input', '1');
 shouldBe('eventsCounter.change', '1');


### PR DESCRIPTION
#### 11990f0a5913ec3eb25802624dfb35975fea5a64
<pre>
:user-invalid triggering while typing date
<a href="https://bugs.webkit.org/show_bug.cgi?id=257999">https://bugs.webkit.org/show_bug.cgi?id=257999</a>
<a href="https://rdar.apple.com/110687369">rdar://110687369</a>

Reviewed by Tim Nguyen and Wenson Hsieh.

In order to dispatch input/change events for date/time inputs with multiple
editable fields, the element value is compared to the value derived from the
content of each field, every time the content of an individual field changes.

However, since the initial value of an element is a null string, and the
derived value is a sanitized string which defaults to the empty string,
comparing the two strings results in inequality. Consequently, an input event
is unexpectedly dispatched. Since the same machinery is involved in matching
`:user-invalid`, `:user-invalid` is also unexpectedly triggered as the user
types an incomplete date.

Fix by using `equalIgnoringNullity` to compare the two strings. This is correct
since `HTMLInputElement`&apos;s value uses `LegacyNullToEmptyString`.

Additionally, `:user-invalid` and `:user-valid` apply too early for date/time
inputs with editable fields. Specifically, the apply immediately once the value
of the input changes, not after the element loses focus following a value change.
This behavior also means that the &quot;change&quot; event fires too early. Since this
value is modified by typing, `:user-invalid` and `:user-valid` should only apply
after the input has lost focus, when matching for the first time. Fix by
reworking the event dispatch logic when the value is changed by typing.

Add additional test coverage for `input`, `change`, `:user-invalid`, and
`:user-valid` for date/time inputs.

* LayoutTests/fast/forms/date/date-editable-components/date-editable-components-input-and-change-events-expected.txt: Added.
* LayoutTests/fast/forms/date/date-editable-components/date-editable-components-input-and-change-events.html: Added.
* LayoutTests/fast/forms/date/date-editable-components/date-editable-components-keyboard-events-expected.txt:
* LayoutTests/fast/forms/date/date-editable-components/date-editable-components-keyboard-events.html:
* LayoutTests/fast/forms/date/date-editable-components/date-editable-components-user-invalid-expected.html: Added.
* LayoutTests/fast/forms/date/date-editable-components/date-editable-components-user-invalid-uncommitted-expected.html: Added.
* LayoutTests/fast/forms/date/date-editable-components/date-editable-components-user-invalid-uncommitted.html: Added.
* LayoutTests/fast/forms/date/date-editable-components/date-editable-components-user-invalid-with-empty-components-expected.html: Added.
* LayoutTests/fast/forms/date/date-editable-components/date-editable-components-user-invalid-with-empty-components.html: Added.
* LayoutTests/fast/forms/date/date-editable-components/date-editable-components-user-invalid.html: Added.
* LayoutTests/fast/forms/date/date-editable-components/date-editable-components-user-valid-expected.html: Added.
* LayoutTests/fast/forms/date/date-editable-components/date-editable-components-user-valid-uncommitted-expected.html: Added.
* LayoutTests/fast/forms/date/date-editable-components/date-editable-components-user-valid-uncommitted.html: Added.
* LayoutTests/fast/forms/date/date-editable-components/date-editable-components-user-valid.html: Added.
* LayoutTests/fast/forms/date/date-editable-components/date-multiple-fields-choose-default-value-after-set-value.html:
* LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-input-and-change-events-expected.txt: Added.
* LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-input-and-change-events.html: Added.
* LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-keyboard-events-expected.txt:
* LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-keyboard-events.html:
* LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-user-invalid-expected.html: Added.
* LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-user-invalid-uncommitted-expected.html: Added.
* LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-user-invalid-uncommitted.htm Added.
* LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-user-invalid-with-empty-components-expected.html: Added.
* LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-user-invalid-with-empty-components.html: Added.
* LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-user-invalid.html: Added.
* LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-user-valid-expected.html: Added.
* LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-user-valid-uncommitted-expected.html: Added.
* LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-user-valid-uncommitted.html: Added.
* LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-user-valid.html: Added.
* LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-multiple-fields-choose-default-value-after-set-value.html:
* LayoutTests/fast/forms/month/month-editable-components/month-editable-components-input-and-change-events-expected.txt: Added.
* LayoutTests/fast/forms/month/month-editable-components/month-editable-components-input-and-change-events.html: Added.
* LayoutTests/fast/forms/month/month-editable-components/month-editable-components-keyboard-events-expected.txt:
* LayoutTests/fast/forms/month/month-editable-components/month-editable-components-keyboard-events.html:
* LayoutTests/fast/forms/month/month-editable-components/month-editable-components-user-invalid-expected.html: Added.
* LayoutTests/fast/forms/month/month-editable-components/month-editable-components-user-invalid-uncommitted-expected.html: Added.
* LayoutTests/fast/forms/month/month-editable-components/month-editable-components-user-invalid-uncommitted.html: Added.
* LayoutTests/fast/forms/month/month-editable-components/month-editable-components-user-invalid-with-empty-components-expected.html: Added.
* LayoutTests/fast/forms/month/month-editable-components/month-editable-components-user-invalid-with-empty-components.html: Added.
* LayoutTests/fast/forms/month/month-editable-components/month-editable-components-user-invalid.html: Added.
* LayoutTests/fast/forms/month/month-editable-components/month-editable-components-user-valid-expected.html: Added.
* LayoutTests/fast/forms/month/month-editable-components/month-editable-components-user-valid-uncommitted-expected.html: Added.
* LayoutTests/fast/forms/month/month-editable-components/month-editable-components-user-valid-uncommitted.html: Added.
* LayoutTests/fast/forms/month/month-editable-components/month-editable-components-user-valid.html: Added.
* LayoutTests/fast/forms/time/time-editable-components/time-editable-components-input-and-change-events-expected.txt: Added.
* LayoutTests/fast/forms/time/time-editable-components/time-editable-components-input-and-change-events.html: Added.
* LayoutTests/fast/forms/time/time-editable-components/time-editable-components-keyboard-events-expected.txt:
* LayoutTests/fast/forms/time/time-editable-components/time-editable-components-keyboard-events.html:
* LayoutTests/fast/forms/time/time-editable-components/time-editable-components-user-invalid-expected.html: Added.
* LayoutTests/fast/forms/time/time-editable-components/time-editable-components-user-invalid-uncommitted-expected.html: Added.
* LayoutTests/fast/forms/time/time-editable-components/time-editable-components-user-invalid-uncommitted.html: Added.
* LayoutTests/fast/forms/time/time-editable-components/time-editable-components-user-invalid-with-empty-components-expected.html: Added.
* LayoutTests/fast/forms/time/time-editable-components/time-editable-components-user-invalid-with-empty-components.html: Added.
* LayoutTests/fast/forms/time/time-editable-components/time-editable-components-user-invalid.html: Added.
* LayoutTests/fast/forms/time/time-editable-components/time-editable-components-user-valid-expected.html: Added.
* LayoutTests/fast/forms/time/time-editable-components/time-editable-components-user-valid-uncommitted-expected.html: Added.
* LayoutTests/fast/forms/time/time-editable-components/time-editable-components-user-valid-uncommitted.html: Added.
* LayoutTests/fast/forms/time/time-editable-components/time-editable-components-user-valid.html: Added.
* LayoutTests/fast/forms/time/time-editable-components/time-multiple-fields-choose-default-value-after-set-value.html:
* Source/WebCore/html/BaseDateAndTimeInputType.cpp:
(WebCore::BaseDateAndTimeInputType::didBlurFromControl):

When a date/time input with editable fields is focused, the actual focused
element will be one of it&apos;s editable fields. If one of the fields is blurred,
dispatch the &quot;change&quot; event if the value has changed since the previous &quot;change&quot;
event.

(WebCore::BaseDateAndTimeInputType::didChangeValueFromControl):

Dispatch only the input event when the input focused, following a change via
typing in one of the editable fields.

Canonical link: <a href="https://commits.webkit.org/272346@main">https://commits.webkit.org/272346@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7be488d5f1f8bf0c99e29a24ae90c983f455bde7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31231 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9908 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32925 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33737 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28345 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31998 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12251 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7165 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27995 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31568 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8351 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27908 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7169 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7346 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27803 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35078 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28418 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28260 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33478 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7394 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5448 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31315 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9073 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/27597 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7366 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8094 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7920 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->