### PR TITLE
Unreviewed, fix the internal macOS build after CVDisplayLink deprecation

### DIFF
--- a/Source/WebCore/platform/graphics/mac/LegacyDisplayRefreshMonitorMac.cpp
+++ b/Source/WebCore/platform/graphics/mac/LegacyDisplayRefreshMonitorMac.cpp
@@ -54,7 +54,9 @@ void LegacyDisplayRefreshMonitorMac::stop()
 {
     DisplayRefreshMonitor::stop();
     LOG_WITH_STREAM(DisplayLink, stream << "LegacyDisplayRefreshMonitorMac::stop for dipslay " << displayID() << " destroying display link");
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     CVDisplayLinkRelease(m_displayLink);
+ALLOW_DEPRECATED_DECLARATIONS_END
     m_displayLink = nullptr;
 }
 
@@ -81,7 +83,9 @@ void LegacyDisplayRefreshMonitorMac::dispatchDisplayDidRefresh(const DisplayUpda
 
 WebCore::FramesPerSecond LegacyDisplayRefreshMonitorMac::nominalFramesPerSecondFromDisplayLink(CVDisplayLinkRef displayLink)
 {
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     CVTime refreshPeriod = CVDisplayLinkGetNominalOutputVideoRefreshPeriod(displayLink);
+ALLOW_DEPRECATED_DECLARATIONS_END
     return round((double)refreshPeriod.timeScale / (double)refreshPeriod.timeValue);
 }
 
@@ -90,11 +94,15 @@ bool LegacyDisplayRefreshMonitorMac::ensureDisplayLink()
     if (m_displayLink)
         return true;
 
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     auto error = CVDisplayLinkCreateWithCGDisplay(displayID(), &m_displayLink);
+ALLOW_DEPRECATED_DECLARATIONS_END
     if (error)
         return false;
 
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     error = CVDisplayLinkSetOutputCallback(m_displayLink, displayLinkCallback, this);
+ALLOW_DEPRECATED_DECLARATIONS_END
     if (error)
         return false;
         
@@ -111,7 +119,9 @@ bool LegacyDisplayRefreshMonitorMac::startNotificationMechanism()
     if (!m_displayLinkIsActive) {
         LOG_WITH_STREAM(DisplayLink, stream << "LegacyDisplayRefreshMonitorMac::startNotificationMechanism for display " << displayID() << " starting display link");
 
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         auto error = CVDisplayLinkStart(m_displayLink);
+ALLOW_DEPRECATED_DECLARATIONS_END
         if (error)
             return false;
         
@@ -129,7 +139,9 @@ void LegacyDisplayRefreshMonitorMac::stopNotificationMechanism()
 
     if (m_displayLink) {
         LOG_WITH_STREAM(DisplayLink, stream << "LegacyDisplayRefreshMonitorMac::stopNotificationMechanism for display " << displayID() << " stopping display link");
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         CVDisplayLinkStop(m_displayLink);
+ALLOW_DEPRECATED_DECLARATIONS_END
     }
         
     m_displayLinkIsActive = false;

--- a/Source/WebKit/UIProcess/mac/DisplayLinkMac.cpp
+++ b/Source/WebKit/UIProcess/mac/DisplayLinkMac.cpp
@@ -41,13 +41,17 @@ void DisplayLink::platformInitialize()
     // FIXME: We can get here with displayID == 0 (webkit.org/b/212120), in which case CVDisplayLinkCreateWithCGDisplay()
     // probably defaults to the main screen.
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanCommunicateWithWindowServer));
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     CVReturn error = CVDisplayLinkCreateWithCGDisplay(m_displayID, &m_displayLink);
+ALLOW_DEPRECATED_DECLARATIONS_END
     if (error) {
         RELEASE_LOG_FAULT(DisplayLink, "Could not create a display link for display %u: error %d", m_displayID, error);
         return;
     }
 
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     error = CVDisplayLinkSetOutputCallback(m_displayLink, displayLinkCallback, this);
+ALLOW_DEPRECATED_DECLARATIONS_END
     if (error) {
         RELEASE_LOG_FAULT(DisplayLink, "DisplayLink: Could not set the display link output callback for display %u: error %d", m_displayID, error);
         return;
@@ -63,13 +67,17 @@ void DisplayLink::platformFinalize()
     if (!m_displayLink)
         return;
 
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     CVDisplayLinkStop(m_displayLink);
     CVDisplayLinkRelease(m_displayLink);
+ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
 FramesPerSecond DisplayLink::nominalFramesPerSecondFromDisplayLink(CVDisplayLinkRef displayLink)
 {
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     CVTime refreshPeriod = CVDisplayLinkGetNominalOutputVideoRefreshPeriod(displayLink);
+ALLOW_DEPRECATED_DECLARATIONS_END
     if (!refreshPeriod.timeValue)
         return FullSpeedFramesPerSecond;
 
@@ -79,19 +87,25 @@ FramesPerSecond DisplayLink::nominalFramesPerSecondFromDisplayLink(CVDisplayLink
 
 bool DisplayLink::platformIsRunning() const
 {
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     return CVDisplayLinkIsRunning(m_displayLink);
+ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
 void DisplayLink::platformStart()
 {
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     CVReturn error = CVDisplayLinkStart(m_displayLink);
+ALLOW_DEPRECATED_DECLARATIONS_END
     if (error)
         RELEASE_LOG_FAULT(DisplayLink, "DisplayLink: Could not start the display link: %d", error);
 }
 
 void DisplayLink::platformStop()
 {
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     CVDisplayLinkStop(m_displayLink);
+ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
 CVReturn DisplayLink::displayLinkCallback(CVDisplayLinkRef displayLinkRef, const CVTimeStamp*, const CVTimeStamp*, CVOptionFlags, CVOptionFlags*, void* data)


### PR DESCRIPTION
#### 280cb48f7500653f70db940ceb4c3c02148b6e8c
<pre>
Unreviewed, fix the internal macOS build after CVDisplayLink deprecation

Unreviewed build fix for macOS when building against the Apple internal
SDK, where the CVDisplayLink interface has now been deprecated.

* Source/WebCore/platform/graphics/mac/LegacyDisplayRefreshMonitorMac.cpp:
(WebCore::LegacyDisplayRefreshMonitorMac::stop):
(WebCore::LegacyDisplayRefreshMonitorMac::nominalFramesPerSecondFromDisplayLink):
(WebCore::LegacyDisplayRefreshMonitorMac::ensureDisplayLink):
(WebCore::LegacyDisplayRefreshMonitorMac::startNotificationMechanism):
(WebCore::LegacyDisplayRefreshMonitorMac::stopNotificationMechanism):
* Source/WebKit/UIProcess/mac/DisplayLinkMac.cpp:
(WebKit::DisplayLink::platformInitialize):
(WebKit::DisplayLink::platformFinalize):
(WebKit::DisplayLink::nominalFramesPerSecondFromDisplayLink):
(WebKit::DisplayLink::platformIsRunning const):
(WebKit::DisplayLink::platformStart):
(WebKit::DisplayLink::platformStop):

Canonical link: <a href="https://commits.webkit.org/272201@main">https://commits.webkit.org/272201@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30e35e5b0838b95cab04c40c067ab2e2f86c6111

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30925 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9598 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32602 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33430 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27936 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31678 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11932 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6856 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27805 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31247 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8080 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27667 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6936 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7096 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27546 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34768 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28155 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/28020 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33243 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7138 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5213 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31075 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8844 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7298 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7846 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7687 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->