### PR TITLE
[JSC] Adjust inlining options

### DIFF
--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -800,7 +800,7 @@ void CodeBlock::setupWithUnlinkedBaselineCode(Ref<BaselineJITCode> jitCode)
     case FunctionCode:
         // We could have already set it to false because we detected an uninlineable call.
         // Don't override that observation.
-        m_shouldAlwaysBeInlined &= canInline(capabilityLevel()) && DFG::mightInlineFunction(this);
+        m_shouldAlwaysBeInlined &= canInline(capabilityLevel()) && DFG::mightInlineFunction(JITType::FTLJIT, this);
         break;
     }
 
@@ -2138,8 +2138,8 @@ DFG::CapabilityLevel CodeBlock::computeCapabilityLevel()
 
     if (classInfo == FunctionCodeBlock::info()) {
         if (isConstructor())
-            return DFG::functionForConstructCapabilityLevel(this);
-        return DFG::functionForCallCapabilityLevel(this);
+            return DFG::functionForConstructCapabilityLevel(JITType::FTLJIT, this);
+        return DFG::functionForCallCapabilityLevel(JITType::FTLJIT, this);
     }
 
     if (classInfo == EvalCodeBlock::info())
@@ -2349,7 +2349,7 @@ void CodeBlock::noticeIncomingCall(CallFrame* callerFrame)
     if (!hasBaselineJITProfiling())
         return;
 
-    if (!DFG::mightInlineFunction(this))
+    if (!DFG::mightInlineFunction(JITType::FTLJIT, this))
         return;
 
     if (!canInline(capabilityLevelState()))

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -1694,12 +1694,11 @@ std::tuple<unsigned, InlineAttribute> ByteCodeParser::inliningCost(CallVariant c
         }
     }
 
-    CapabilityLevel capabilityLevel = inlineFunctionForCapabilityLevel(
-        codeBlock, specializationKind, callee.isClosureCall());
+    CapabilityLevel capabilityLevel = inlineFunctionForCapabilityLevel(m_graph.m_plan.jitType(), codeBlock, specializationKind, callee.isClosureCall());
     VERBOSE_LOG("    Call mode: ", callMode, "\n");
     VERBOSE_LOG("    Is closure call: ", callee.isClosureCall(), "\n");
     VERBOSE_LOG("    Capability level: ", capabilityLevel, "\n");
-    VERBOSE_LOG("    Might inline function: ", mightInlineFunctionFor(codeBlock, specializationKind), "\n");
+    VERBOSE_LOG("    Might inline function: ", mightInlineFunctionFor(m_graph.m_plan.jitType(), codeBlock, specializationKind), "\n");
     VERBOSE_LOG("    Might compile function: ", mightCompileFunctionFor(codeBlock, specializationKind), "\n");
     VERBOSE_LOG("    Is supported for inlining: ", isSupportedForInlining(codeBlock), "\n");
     VERBOSE_LOG("    Is inlining candidate: ", codeBlock->ownerExecutable()->isInliningCandidate(), "\n");
@@ -2215,11 +2214,11 @@ bool ByteCodeParser::handleVarargsInlining(Node* callTargetNode, Operand result,
 
 unsigned ByteCodeParser::getInliningBalance(const CallLinkStatus& callLinkStatus, CodeSpecializationKind specializationKind)
 {
-    unsigned inliningBalance = Options::maximumFunctionForCallInlineCandidateBytecodeCost();
+    unsigned inliningBalance = m_graph.m_plan.isFTL() ? Options::maximumFunctionForCallInlineCandidateBytecodeCostForFTL() : Options::maximumFunctionForCallInlineCandidateBytecodeCostForDFG();
     if (specializationKind == CodeForConstruct)
-        inliningBalance = std::min(inliningBalance, Options::maximumFunctionForConstructInlineCandidateBytecoodeCost());
+        inliningBalance = std::min(inliningBalance, m_graph.m_plan.isFTL() ? Options::maximumFunctionForConstructInlineCandidateBytecodeCostForFTL() : Options::maximumFunctionForConstructInlineCandidateBytecodeCostForDFG());
     if (callLinkStatus.isClosureCall())
-        inliningBalance = std::min(inliningBalance, Options::maximumFunctionForClosureCallInlineCandidateBytecodeCost());
+        inliningBalance = std::min(inliningBalance, m_graph.m_plan.isFTL() ? Options::maximumFunctionForClosureCallInlineCandidateBytecodeCostForFTL() : Options::maximumFunctionForClosureCallInlineCandidateBytecodeCostForDFG());
     return inliningBalance;
 }
 

--- a/Source/JavaScriptCore/dfg/DFGCapabilities.cpp
+++ b/Source/JavaScriptCore/dfg/DFGCapabilities.cpp
@@ -71,22 +71,43 @@ bool mightCompileFunctionForConstruct(CodeBlock* codeBlock)
         && codeBlock->ownerExecutable()->isOkToOptimize();
 }
 
-bool mightInlineFunctionForCall(CodeBlock* codeBlock)
+bool mightInlineFunctionForCall(JITType jitType, CodeBlock* codeBlock)
 {
-    if (codeBlock->ownerExecutable()->inlineAttribute() != InlineAttribute::Always && codeBlock->bytecodeCost() > Options::maximumFunctionForCallInlineCandidateBytecodeCost())
-        return false;
+    if (codeBlock->ownerExecutable()->inlineAttribute() != InlineAttribute::Always) {
+        if (jitType == JITType::DFGJIT) {
+            if (codeBlock->bytecodeCost() > Options::maximumFunctionForCallInlineCandidateBytecodeCostForDFG())
+                return false;
+        } else {
+            if (codeBlock->bytecodeCost() > Options::maximumFunctionForCallInlineCandidateBytecodeCostForFTL())
+                return false;
+        }
+    }
     return isSupportedForInlining(codeBlock);
 }
-bool mightInlineFunctionForClosureCall(CodeBlock* codeBlock)
+bool mightInlineFunctionForClosureCall(JITType jitType, CodeBlock* codeBlock)
 {
-    if (codeBlock->ownerExecutable()->inlineAttribute() != InlineAttribute::Always && codeBlock->bytecodeCost() > Options::maximumFunctionForClosureCallInlineCandidateBytecodeCost())
-        return false;
+    if (codeBlock->ownerExecutable()->inlineAttribute() != InlineAttribute::Always) {
+        if (jitType == JITType::DFGJIT) {
+            if (codeBlock->bytecodeCost() > Options::maximumFunctionForClosureCallInlineCandidateBytecodeCostForDFG())
+                return false;
+        } else {
+            if (codeBlock->bytecodeCost() > Options::maximumFunctionForClosureCallInlineCandidateBytecodeCostForFTL())
+                return false;
+        }
+    }
     return isSupportedForInlining(codeBlock);
 }
-bool mightInlineFunctionForConstruct(CodeBlock* codeBlock)
+bool mightInlineFunctionForConstruct(JITType jitType, CodeBlock* codeBlock)
 {
-    if (codeBlock->ownerExecutable()->inlineAttribute() != InlineAttribute::Always && codeBlock->bytecodeCost() > Options::maximumFunctionForConstructInlineCandidateBytecoodeCost())
-        return false;
+    if (codeBlock->ownerExecutable()->inlineAttribute() != InlineAttribute::Always) {
+        if (jitType == JITType::DFGJIT) {
+            if (codeBlock->bytecodeCost() > Options::maximumFunctionForConstructInlineCandidateBytecodeCostForDFG())
+                return false;
+        } else {
+            if (codeBlock->bytecodeCost() > Options::maximumFunctionForConstructInlineCandidateBytecodeCostForFTL())
+                return false;
+        }
+    }
     return isSupportedForInlining(codeBlock);
 }
 bool canUseOSRExitFuzzing(CodeBlock* codeBlock)

--- a/Source/JavaScriptCore/dfg/DFGCapabilities.h
+++ b/Source/JavaScriptCore/dfg/DFGCapabilities.h
@@ -40,18 +40,18 @@ bool mightCompileEval(CodeBlock*);
 bool mightCompileProgram(CodeBlock*);
 bool mightCompileFunctionForCall(CodeBlock*);
 bool mightCompileFunctionForConstruct(CodeBlock*);
-bool mightInlineFunctionForCall(CodeBlock*);
-bool mightInlineFunctionForClosureCall(CodeBlock*);
-bool mightInlineFunctionForConstruct(CodeBlock*);
+bool mightInlineFunctionForCall(JITType, CodeBlock*);
+bool mightInlineFunctionForClosureCall(JITType, CodeBlock*);
+bool mightInlineFunctionForConstruct(JITType, CodeBlock*);
 bool canUseOSRExitFuzzing(CodeBlock*);
 #else // ENABLE(DFG_JIT)
 inline bool mightCompileEval(CodeBlock*) { return false; }
 inline bool mightCompileProgram(CodeBlock*) { return false; }
 inline bool mightCompileFunctionForCall(CodeBlock*) { return false; }
 inline bool mightCompileFunctionForConstruct(CodeBlock*) { return false; }
-inline bool mightInlineFunctionForCall(CodeBlock*) { return false; }
-inline bool mightInlineFunctionForClosureCall(CodeBlock*) { return false; }
-inline bool mightInlineFunctionForConstruct(CodeBlock*) { return false; }
+inline bool mightInlineFunctionForCall(JITType, CodeBlock*) { return false; }
+inline bool mightInlineFunctionForClosureCall(JITType, CodeBlock*) { return false; }
+inline bool mightInlineFunctionForConstruct(JITType, CodeBlock*) { return false; }
 inline bool canUseOSRExitFuzzing(CodeBlock*) { return false; }
 #endif // ENABLE(DFG_JIT)
 
@@ -83,52 +83,52 @@ inline CapabilityLevel functionCapabilityLevel(bool mightCompile, bool mightInli
     return CannotCompile;
 }
 
-inline CapabilityLevel functionForCallCapabilityLevel(CodeBlock* codeBlock)
+inline CapabilityLevel functionForCallCapabilityLevel(JITType jitType, CodeBlock* codeBlock)
 {
     return functionCapabilityLevel(
         mightCompileFunctionForCall(codeBlock),
-        mightInlineFunctionForCall(codeBlock),
+        mightInlineFunctionForCall(jitType, codeBlock),
         CanCompileAndInline);
 }
 
-inline CapabilityLevel functionForConstructCapabilityLevel(CodeBlock* codeBlock)
+inline CapabilityLevel functionForConstructCapabilityLevel(JITType jitType, CodeBlock* codeBlock)
 {
     return functionCapabilityLevel(
         mightCompileFunctionForConstruct(codeBlock),
-        mightInlineFunctionForConstruct(codeBlock),
+        mightInlineFunctionForConstruct(jitType, codeBlock),
         CanCompileAndInline);
 }
 
-inline CapabilityLevel inlineFunctionForCallCapabilityLevel(CodeBlock* codeBlock)
+inline CapabilityLevel inlineFunctionForCallCapabilityLevel(JITType jitType, CodeBlock* codeBlock)
 {
-    if (!mightInlineFunctionForCall(codeBlock))
+    if (!mightInlineFunctionForCall(jitType, codeBlock))
         return CannotCompile;
     
     return CanCompileAndInline;
 }
 
-inline CapabilityLevel inlineFunctionForClosureCallCapabilityLevel(CodeBlock* codeBlock)
+inline CapabilityLevel inlineFunctionForClosureCallCapabilityLevel(JITType jitType, CodeBlock* codeBlock)
 {
-    if (!mightInlineFunctionForClosureCall(codeBlock))
+    if (!mightInlineFunctionForClosureCall(jitType, codeBlock))
         return CannotCompile;
     
     return CanCompileAndInline;
 }
 
-inline CapabilityLevel inlineFunctionForConstructCapabilityLevel(CodeBlock* codeBlock)
+inline CapabilityLevel inlineFunctionForConstructCapabilityLevel(JITType jitType, CodeBlock* codeBlock)
 {
-    if (!mightInlineFunctionForConstruct(codeBlock))
+    if (!mightInlineFunctionForConstruct(jitType, codeBlock))
         return CannotCompile;
     
     return CanCompileAndInline;
 }
 
-inline bool mightInlineFunctionFor(CodeBlock* codeBlock, CodeSpecializationKind kind)
+inline bool mightInlineFunctionFor(JITType jitType, CodeBlock* codeBlock, CodeSpecializationKind kind)
 {
     if (kind == CodeForCall)
-        return mightInlineFunctionForCall(codeBlock);
+        return mightInlineFunctionForCall(jitType, codeBlock);
     ASSERT(kind == CodeForConstruct);
-    return mightInlineFunctionForConstruct(codeBlock);
+    return mightInlineFunctionForConstruct(jitType, codeBlock);
 }
 
 inline bool mightCompileFunctionFor(CodeBlock* codeBlock, CodeSpecializationKind kind)
@@ -139,22 +139,22 @@ inline bool mightCompileFunctionFor(CodeBlock* codeBlock, CodeSpecializationKind
     return mightCompileFunctionForConstruct(codeBlock);
 }
 
-inline bool mightInlineFunction(CodeBlock* codeBlock)
+inline bool mightInlineFunction(JITType jitType, CodeBlock* codeBlock)
 {
-    return mightInlineFunctionFor(codeBlock, codeBlock->specializationKind());
+    return mightInlineFunctionFor(jitType, codeBlock, codeBlock->specializationKind());
 }
 
-inline CapabilityLevel inlineFunctionForCapabilityLevel(CodeBlock* codeBlock, CodeSpecializationKind kind, bool isClosureCall)
+inline CapabilityLevel inlineFunctionForCapabilityLevel(JITType jitType, CodeBlock* codeBlock, CodeSpecializationKind kind, bool isClosureCall)
 {
     if (isClosureCall) {
         if (kind != CodeForCall)
             return CannotCompile;
-        return inlineFunctionForClosureCallCapabilityLevel(codeBlock);
+        return inlineFunctionForClosureCallCapabilityLevel(jitType, codeBlock);
     }
     if (kind == CodeForCall)
-        return inlineFunctionForCallCapabilityLevel(codeBlock);
+        return inlineFunctionForCallCapabilityLevel(jitType, codeBlock);
     ASSERT(kind == CodeForConstruct);
-    return inlineFunctionForConstructCapabilityLevel(codeBlock);
+    return inlineFunctionForConstructCapabilityLevel(jitType, codeBlock);
 }
 
 inline bool isSmallEnoughToInlineCodeInto(CodeBlock* codeBlock)

--- a/Source/JavaScriptCore/heap/LocalAllocatorInlines.h
+++ b/Source/JavaScriptCore/heap/LocalAllocatorInlines.h
@@ -36,7 +36,7 @@ ALWAYS_INLINE void* LocalAllocator::allocate(JSC::Heap& heap, size_t cellSize, G
     if constexpr (validateDFGDoesGC)
         vm.verifyCanGC();
     return m_freeList.allocateWithCellSize(
-        [&]() -> HeapCell* {
+        [&]() ALWAYS_INLINE_LAMBDA {
             sanitizeStackForVM(vm);
             return static_cast<HeapCell*>(allocateSlowCase(heap, cellSize, deferralContext, failureMode));
         }, cellSize);

--- a/Source/JavaScriptCore/jit/JITPlan.h
+++ b/Source/JavaScriptCore/jit/JITPlan.h
@@ -28,6 +28,7 @@
 #if ENABLE(JIT)
 
 #include "CompilationResult.h"
+#include "JITCode.h"
 #include "JITCompilationKey.h"
 #include "JITCompilationMode.h"
 #include "JITPlanStage.h"
@@ -62,6 +63,19 @@ public:
 
     enum class Tier { Baseline = 0, DFG = 1, FTL = 2, Count = 3 };
     Tier tier() const;
+    JITType jitType() const
+    {
+        switch (tier()) {
+        case Tier::Baseline:
+            return JITType::BaselineJIT;
+        case Tier::DFG:
+            return JITType::DFGJIT;
+        case Tier::FTL:
+            return JITType::FTLJIT;
+        default:
+            return JITType::None;
+        }
+    }
 
     JITCompilationKey key();
 

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -556,9 +556,9 @@ static void overrideDefaults()
 #endif
 
 #if OS(LINUX) && CPU(ARM)
-    Options::maximumFunctionForCallInlineCandidateBytecodeCost() = 77;
+    Options::maximumFunctionForCallInlineCandidateBytecodeCostForDFG() = 77;
     Options::maximumOptimizationCandidateBytecodeCost() = 42403;
-    Options::maximumFunctionForClosureCallInlineCandidateBytecodeCost() = 68;
+    Options::maximumFunctionForClosureCallInlineCandidateBytecodeCostForDFG() = 68;
     Options::maximumInliningCallerBytecodeCost() = 9912;
     Options::maximumInliningDepth() = 8;
     Options::maximumInliningRecursion() = 3;

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -284,9 +284,12 @@ bool canUseHandlerIC();
     \
     v(Unsigned, maximumOptimizationCandidateBytecodeCost, 100000, Normal, nullptr) \
     \
-    v(Unsigned, maximumFunctionForCallInlineCandidateBytecodeCost, 120, Normal, nullptr) \
-    v(Unsigned, maximumFunctionForClosureCallInlineCandidateBytecodeCost, 100, Normal, nullptr) \
-    v(Unsigned, maximumFunctionForConstructInlineCandidateBytecoodeCost, 100, Normal, nullptr) \
+    v(Unsigned, maximumFunctionForCallInlineCandidateBytecodeCostForDFG, 80, Normal, nullptr) \
+    v(Unsigned, maximumFunctionForClosureCallInlineCandidateBytecodeCostForDFG, 80, Normal, nullptr) \
+    v(Unsigned, maximumFunctionForConstructInlineCandidateBytecodeCostForDFG, 80, Normal, nullptr) \
+    v(Unsigned, maximumFunctionForCallInlineCandidateBytecodeCostForFTL, 125, Normal, nullptr) \
+    v(Unsigned, maximumFunctionForClosureCallInlineCandidateBytecodeCostForFTL, 100, Normal, nullptr) \
+    v(Unsigned, maximumFunctionForConstructInlineCandidateBytecodeCostForFTL, 100, Normal, nullptr) \
     \
     v(Unsigned, maximumFTLCandidateBytecodeCost, 20000, Normal, nullptr) \
     \
@@ -633,9 +636,6 @@ enum OptionEquivalence {
     v(enableDollarVM, useDollarVM, SameOption) \
     v(enableWebAssembly, useWebAssembly, SameOption) \
     v(maximumOptimizationCandidateInstructionCount, maximumOptimizationCandidateBytecodeCost, SameOption) \
-    v(maximumFunctionForCallInlineCandidateInstructionCount, maximumFunctionForCallInlineCandidateBytecodeCost, SameOption) \
-    v(maximumFunctionForClosureCallInlineCandidateInstructionCount, maximumFunctionForClosureCallInlineCandidateBytecodeCost, SameOption) \
-    v(maximumFunctionForConstructInlineCandidateInstructionCount, maximumFunctionForConstructInlineCandidateBytecoodeCost, SameOption) \
     v(maximumFTLCandidateInstructionCount, maximumFTLCandidateBytecodeCost, SameOption) \
     v(maximumInliningCallerSize, maximumInliningCallerBytecodeCost, SameOption) \
     v(validateBCE, validateBoundsCheckElimination, SameOption)


### PR DESCRIPTION
#### f24813dedb83ca8d8fe4339fc1a97668683e20ea
<pre>
[JSC] Adjust inlining options
<a href="https://bugs.webkit.org/show_bug.cgi?id=266563">https://bugs.webkit.org/show_bug.cgi?id=266563</a>
<a href="https://rdar.apple.com/119795209">rdar://119795209</a>

Reviewed by Justin Michaud.

This patch extends JSC to have different inlining options for DFG and FTL.
This is great since DFG and FTL have different purpose and we would like
to make DFG smaller-compilation and faster and keeping FTL heavy and highly optimized.
And then, we adjust these numbers based on benchmarks.

1. DFG inlining heuristics becomes 80.
2. FTL call inlining heuristics becomes 125.

* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::setupWithUnlinkedBaselineCode):
(JSC::CodeBlock::computeCapabilityLevel):
(JSC::CodeBlock::noticeIncomingCall):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::inliningCost):
(JSC::DFG::ByteCodeParser::getInliningBalance):
* Source/JavaScriptCore/dfg/DFGCapabilities.cpp:
(JSC::DFG::mightInlineFunctionForCall):
(JSC::DFG::mightInlineFunctionForClosureCall):
(JSC::DFG::mightInlineFunctionForConstruct):
* Source/JavaScriptCore/dfg/DFGCapabilities.h:
(JSC::DFG::mightInlineFunctionForCall):
(JSC::DFG::mightInlineFunctionForClosureCall):
(JSC::DFG::mightInlineFunctionForConstruct):
(JSC::DFG::functionForCallCapabilityLevel):
(JSC::DFG::functionForConstructCapabilityLevel):
(JSC::DFG::inlineFunctionForCallCapabilityLevel):
(JSC::DFG::inlineFunctionForClosureCallCapabilityLevel):
(JSC::DFG::inlineFunctionForConstructCapabilityLevel):
(JSC::DFG::mightInlineFunctionFor):
(JSC::DFG::mightInlineFunction):
(JSC::DFG::inlineFunctionForCapabilityLevel):
* Source/JavaScriptCore/heap/LocalAllocatorInlines.h:
(JSC::LocalAllocator::allocate):
* Source/JavaScriptCore/jit/JITPlan.h:
(JSC::JITPlan::jitType const):
* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::overrideDefaults):
* Source/JavaScriptCore/runtime/OptionsList.h:

Canonical link: <a href="https://commits.webkit.org/272208@main">https://commits.webkit.org/272208@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/effb4b3846d1bcf49aefde582df59c4e8caeb475

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30927 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9600 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32605 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33433 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27938 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11935 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6859 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27808 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31250 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8083 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27670 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6939 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7099 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27549 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34771 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/26576 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28158 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28023 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33245 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/31020 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7140 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5214 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31077 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8846 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/37450 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7848 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8030 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4009 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7689 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->