### PR TITLE
Add NativeImageBackend to support GPUP NativeImage

### DIFF
--- a/Source/WebCore/platform/graphics/NativeImage.h
+++ b/Source/WebCore/platform/graphics/NativeImage.h
@@ -32,10 +32,13 @@
 #include "IntSize.h"
 #include "PlatformImage.h"
 #include "RenderingResource.h"
+#include <wtf/UniqueRef.h>
 
 namespace WebCore {
 
 class GraphicsContext;
+
+class NativeImageBackend;
 
 class NativeImage final : public RenderingResource {
     WTF_MAKE_FAST_ALLOCATED;
@@ -44,8 +47,7 @@ public:
     // Creates a NativeImage that is intended to be drawn once or only few times. Signals the platform to avoid generating any caches for the image.
     static WEBCORE_EXPORT RefPtr<NativeImage> createTransient(PlatformImagePtr&&, RenderingResourceIdentifier = RenderingResourceIdentifier::generate());
 
-    WEBCORE_EXPORT void setPlatformImage(PlatformImagePtr&&);
-    const PlatformImagePtr& platformImage() const { return m_platformImage; }
+    WEBCORE_EXPORT const PlatformImagePtr& platformImage() const;
 
     WEBCORE_EXPORT IntSize size() const;
     bool hasAlpha() const;
@@ -55,12 +57,35 @@ public:
     void draw(GraphicsContext&, const FloatSize& imageSize, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions);
     void clearSubimages();
 
-private:
-    NativeImage(PlatformImagePtr&&, RenderingResourceIdentifier);
+    WEBCORE_EXPORT void replaceContents(PlatformImagePtr);
+protected:
+    NativeImage(UniqueRef<NativeImageBackend>, RenderingResourceIdentifier);
 
     bool isNativeImage() const final { return true; }
 
+    UniqueRef<NativeImageBackend> m_backend;
+};
+
+class NativeImageBackend {
+public:
+    WEBCORE_EXPORT virtual ~NativeImageBackend();
+    virtual const PlatformImagePtr& platformImage() const = 0;
+    virtual IntSize size() const = 0;
+    virtual bool hasAlpha() const = 0;
+    virtual DestinationColorSpace colorSpace() const = 0;
+};
+
+class PlatformImageNativeImageBackend final : public NativeImageBackend {
+public:
+    WEBCORE_EXPORT ~PlatformImageNativeImageBackend() final;
+    WEBCORE_EXPORT const PlatformImagePtr& platformImage() const final;
+    WEBCORE_EXPORT IntSize size() const final;
+    WEBCORE_EXPORT bool hasAlpha() const final;
+    WEBCORE_EXPORT DestinationColorSpace colorSpace() const final;
+private:
+    PlatformImageNativeImageBackend(PlatformImagePtr);
     PlatformImagePtr m_platformImage;
+    friend class NativeImage;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/cairo/NativeImageCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/NativeImageCairo.cpp
@@ -35,14 +35,20 @@
 
 namespace WebCore {
 
-IntSize NativeImage::size() const
+IntSize PlatformImageNativeImageBackend::size() const
 {
     return cairoSurfaceSize(m_platformImage.get());
 }
 
-bool NativeImage::hasAlpha() const
+bool PlatformImageNativeImageBackend::hasAlpha() const
 {
     return cairo_surface_get_content(m_platformImage.get()) != CAIRO_CONTENT_COLOR;
+}
+
+DestinationColorSpace PlatformImageNativeImageBackend::colorSpace() const
+{
+    notImplemented();
+    return DestinationColorSpace::SRGB();
 }
 
 Color NativeImage::singlePixelSolidColor() const
@@ -50,17 +56,12 @@ Color NativeImage::singlePixelSolidColor() const
     if (size() != IntSize(1, 1))
         return Color();
 
-    if (cairo_surface_get_type(m_platformImage.get()) != CAIRO_SURFACE_TYPE_IMAGE)
+    auto platformImage = this->platformImage().get();
+    if (cairo_surface_get_type(platformImage) != CAIRO_SURFACE_TYPE_IMAGE)
         return Color();
 
-    unsigned* pixel = reinterpret_cast_ptr<unsigned*>(cairo_image_surface_get_data(m_platformImage.get()));
+    unsigned* pixel = reinterpret_cast_ptr<unsigned*>(cairo_image_surface_get_data(platformImage));
     return unpremultiplied(asSRGBA(PackedColor::ARGB { *pixel }));
-}
-
-DestinationColorSpace NativeImage::colorSpace() const
-{
-    notImplemented();
-    return DestinationColorSpace::SRGB();
 }
 
 void NativeImage::draw(GraphicsContext& context, const FloatSize& imageSize, const FloatRect& destinationRect, const FloatRect& sourceRect, ImagePaintingOptions options)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
@@ -108,11 +108,11 @@ inline static std::optional<ShareableBitmap::Handle> createShareableBitmapFromNa
 #endif
 
     // If we failed to create ShareableBitmap or PlatformImage, fall back to image-draw method.
-    if (!platformImage)
+    if (!platformImage) {
         bitmap = ShareableBitmap::createFromImageDraw(image);
-
-    if (!platformImage && bitmap)
-        platformImage = bitmap->createPlatformImage(DontCopyBackingStore, ShouldInterpolate::Yes);
+        if (bitmap)
+            platformImage = bitmap->createPlatformImage(DontCopyBackingStore, ShouldInterpolate::Yes);
+    }
 
     if (!platformImage)
         return std::nullopt;
@@ -124,7 +124,7 @@ inline static std::optional<ShareableBitmap::Handle> createShareableBitmapFromNa
     handle->takeOwnershipOfMemory(MemoryLedger::Graphics);
 
     // Replace the PlatformImage of the input NativeImage with the shared one.
-    image.setPlatformImage(WTFMove(platformImage));
+    image.replaceContents(WTFMove(platformImage));
     return handle;
 }
 


### PR DESCRIPTION
#### 7412c32e31ca3a1627bc7a13ab915b919ff1af00
<pre>
Add NativeImageBackend to support GPUP NativeImage
<a href="https://bugs.webkit.org/show_bug.cgi?id=266216">https://bugs.webkit.org/show_bug.cgi?id=266216</a>
<a href="https://rdar.apple.com/119489321">rdar://119489321</a>

Reviewed by Matt Woodrow.

Add NativeImageBackend interface that future work can use to implement
NativeImage that exists in GPUP.

NativeImage instances are held as members of objects. Thus the interface
cannot be based on NativeImage itself, because this would mean that
transitioning from local to remote would need the held objects replaced.
Instead, make the polymorphic extension point the &quot;backend&quot;, similar to
current ImageBuffer.

Reland after revert. Revert targeted 271976@main and this was built on
that. Land without the dependency to 271976@main.

* Source/WebCore/platform/graphics/NativeImage.cpp:
(WebCore::PlatformImageNativeImageBackend::platformImage const):
(WebCore::PlatformImageNativeImageBackend::PlatformImageNativeImageBackend):
(WebCore::NativeImage::create):
(WebCore::NativeImage::NativeImage):
(WebCore::NativeImage::platformImage const):
(WebCore::NativeImage::replaceContents):
(WebCore::NativeImage::setPlatformImage): Deleted.
* Source/WebCore/platform/graphics/NativeImage.h:
* Source/WebCore/platform/graphics/cg/NativeImageCG.cpp:
(WebCore::NativeImage::create):
(WebCore::NativeImage::size const):
(WebCore::NativeImage::hasAlpha const):
(WebCore::NativeImage::singlePixelSolidColor const):
(WebCore::NativeImage::colorSpace const):
(WebCore::NativeImage::clearSubimages):
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp:
(WebKit::createShareableBitmapFromNativeImage):

Canonical link: <a href="https://commits.webkit.org/272266@main">https://commits.webkit.org/272266@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a12ff4d6887d88fbb04d8753eac99d2aa29c18aa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31154 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9829 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32845 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33660 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/28290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31920 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12172 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7087 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27953 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31489 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8287 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27852 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7118 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7301 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27747 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35002 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28354 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28204 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33425 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7328 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5386 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31264 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9014 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7327 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8031 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7862 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->