### PR TITLE
Migrate CacheStorageConnection::open to NativePromise

### DIFF
--- a/Source/WTF/wtf/Forward.h
+++ b/Source/WTF/wtf/Forward.h
@@ -132,7 +132,7 @@ template<typename ValueArg, typename = DefaultHash<ValueArg>, typename = HashTra
 template<typename ResolveValueT, typename RejectValueT, unsigned options = 0> class NativePromise;
 using GenericPromise = NativePromise<void, void>;
 using GenericNonExclusivePromise = NativePromise<void, void, 1>;
-template<typename T> class NativePromiseRequest;
+class NativePromiseRequest;
 }
 
 namespace JSON {

--- a/Source/WTF/wtf/NativePromise.h
+++ b/Source/WTF/wtf/NativePromise.h
@@ -36,6 +36,7 @@
 #include <wtf/Assertions.h>
 #include <wtf/CrossThreadCopier.h>
 #include <wtf/Expected.h>
+#include <wtf/FastMalloc.h>
 #include <wtf/Forward.h>
 #include <wtf/FunctionDispatcher.h>
 #include <wtf/Lock.h>
@@ -48,6 +49,7 @@
 #include <wtf/TypeTraits.h>
 #include <wtf/Unexpected.h>
 #include <wtf/Vector.h>
+#include <wtf/WeakPtr.h>
 
 namespace WTF {
 
@@ -59,7 +61,7 @@ namespace WTF {
  * A NativePromise object is thread safe, and may be ->then()/whenSettle()ed on any threads.
  * The then() call accepts either a resolve and reject callback, while whenSettled() accepts a resolveOrReject one.
  *
- * NativePromise::then() and NativePromise::whenSettled() returns a NativePromise::Request object. This request can be either:
+ * NativePromise::then() and NativePromise::whenSettled() returns a NativePromise::ThenCommand object. This object can be either:
  * 1- Converted back to a NativePromise which will be resolved or rejected once the resolve/reject callbacks are run.
  *    This new NativePromise can be then()ed again to chain multiple operations.
  * 2- Be tracked using a NativePromiseRequest: this allows the caller to cancel the delivery of the resolve/reject result if it has not already occurred.
@@ -148,7 +150,7 @@ namespace WTF {
  *    }
  *
  * 3. Using a NativePromiseRequest
- *    NativePromiseRequest<GenericPromise> request;
+ *    NativePromiseRequest request;
  *
  *    GenericPromise::Producer p;
  *    // Note that if you're not interested in the result you can provide a Function<void()>
@@ -273,8 +275,52 @@ public:
 
 class ConvertibleToNativePromise { };
 
-template<typename T>
-class NativePromiseRequest;
+class NativePromiseRequest :  public CanMakeWeakPtr<NativePromiseRequest> {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    NativePromiseRequest() = default;
+    NativePromiseRequest(NativePromiseRequest&& other) = default;
+    NativePromiseRequest& operator=(NativePromiseRequest&& other) = default;
+    ~NativePromiseRequest()
+    {
+        ASSERT(!m_callback, "complete() or disconnect() wasn't called");
+    }
+
+    class Callback : public ThreadSafeRefCounted<Callback> {
+    public:
+        virtual ~Callback() = default;
+        virtual void disconnect() = 0;
+    };
+
+
+    void track(Ref<Callback> callback)
+    {
+        ASSERT(!m_callback);
+        m_callback = WTFMove(callback);
+    }
+
+    explicit operator bool() const { return !!m_callback; }
+
+    void complete()
+    {
+        ASSERT(m_callback);
+        m_callback = nullptr;
+    }
+
+    // Disconnect and forget an outstanding promise. The resolve/reject methods will never be called.
+    void disconnect()
+    {
+        ASSERT(m_callback);
+        if (!m_callback)
+            return;
+        m_callback->disconnect();
+        m_callback = nullptr;
+
+    }
+
+private:
+    RefPtr<Callback> m_callback;
+};
 
 template<typename ResolveValueT, typename RejectValueT, unsigned options = 0>
 class NativePromiseProducer;
@@ -331,13 +377,6 @@ public:
     // We split the functionalities from a "Producer" that can create and resolve/reject a promise and a "Consumer"
     // that will then()/whenSettled() on such promise.
     using Producer = NativePromiseProducer<ResolveValueT, RejectValueT, options>;
-
-    // Request is the object returned by NativePromise::then()/whenSettled is used by NativePromiseRequest holder to track/disconnect.
-    class Request : public ThreadSafeRefCounted<Request> {
-    public:
-        virtual ~Request() = default;
-        virtual void disconnect() = 0;
-    };
 
     virtual ~NativePromise()
     {
@@ -647,7 +686,7 @@ private:
         PROMISE_LOG("creating ", *this);
     }
 
-    class ThenCallbackBase : public Request {
+    class ThenCallbackBase : public NativePromiseRequest::Callback {
 
     public:
         ThenCallbackBase(RefPtr<RefCountedSerialFunctionDispatcher>&& targetQueue, const Logger::LogSiteIdentifier& callSite)
@@ -864,7 +903,7 @@ private:
             return completionPromise()->whenSettled(targetQueue, thisVal, std::forward<SettleMethod>(settleMethod), callSite);
         }
 
-        void track(NativePromiseRequest<NativePromise>& requestHolder)
+        void track(NativePromiseRequest& requestHolder)
         {
             ASSERT(m_thenCallback, "Can only track a request once");
             requestHolder.track(*m_thenCallback);
@@ -1376,46 +1415,6 @@ using GenericPromise = NativePromise<void, void>;
 
 // A generic, non-exclusive promise type that does the trick for simple use cases.
 using GenericNonExclusivePromise = NativePromise<void, void, PromiseOption::Default | PromiseOption::NonExclusive>;
-
-template<typename PromiseType>
-class NativePromiseRequest final {
-public:
-    NativePromiseRequest() = default;
-    NativePromiseRequest(NativePromiseRequest&& other) = default;
-    NativePromiseRequest& operator=(NativePromiseRequest&& other) = default;
-    ~NativePromiseRequest()
-    {
-        ASSERT(!m_request, "complete() or disconnect() wasn't called");
-    }
-
-    void track(Ref<typename PromiseType::Request> request)
-    {
-        ASSERT(!m_request);
-        m_request = WTFMove(request);
-    }
-
-    explicit operator bool() const { return !!m_request; }
-
-    void complete()
-    {
-        ASSERT(m_request);
-        m_request = nullptr;
-    }
-
-    // Disconnect and forget an outstanding promise. The resolve/reject methods will never be called.
-    void disconnect()
-    {
-        ASSERT(m_request);
-        if (!m_request)
-            return;
-        m_request->disconnect();
-        m_request = nullptr;
-
-    }
-
-private:
-    RefPtr<typename PromiseType::Request> m_request;
-};
 
 template<typename S, typename E>
 Ref<NativePromise<S, E>> createSettledPromise(Expected<S, E>&& result)

--- a/Source/WebCore/Modules/cache/CacheStorageConnection.h
+++ b/Source/WebCore/Modules/cache/CacheStorageConnection.h
@@ -28,6 +28,7 @@
 
 #include "DOMCacheEngine.h"
 #include "RetrieveRecordsOptions.h"
+#include <wtf/Forward.h>
 #include <wtf/HashMap.h>
 #include <wtf/ThreadSafeRefCounted.h>
 
@@ -40,7 +41,8 @@ class CacheStorageConnection : public ThreadSafeRefCounted<CacheStorageConnectio
 public:
     virtual ~CacheStorageConnection() = default;
 
-    virtual void open(const ClientOrigin&, const String& cacheName, DOMCacheEngine::CacheIdentifierCallback&&) = 0;
+    using OpenPromise = NativePromise<DOMCacheEngine::CacheIdentifierOperationResult, DOMCacheEngine::Error>;
+    virtual Ref<OpenPromise> open(const ClientOrigin&, const String& cacheName) = 0;
     virtual void remove(DOMCacheIdentifier, DOMCacheEngine::RemoveCacheIdentifierCallback&&) = 0;
     virtual void retrieveCaches(const ClientOrigin&, uint64_t updateCounter, DOMCacheEngine::CacheInfosCallback&&) = 0;
 

--- a/Source/WebCore/Modules/cache/WorkerCacheStorageConnection.h
+++ b/Source/WebCore/Modules/cache/WorkerCacheStorageConnection.h
@@ -46,7 +46,7 @@ private:
     explicit WorkerCacheStorageConnection(WorkerGlobalScope&);
 
     // WebCore::CacheStorageConnection.
-    void open(const ClientOrigin&, const String& cacheName, DOMCacheEngine::CacheIdentifierCallback&&) final;
+    Ref<OpenPromise> open(const ClientOrigin&, const String& cacheName) final;
     void remove(DOMCacheIdentifier, DOMCacheEngine::RemoveCacheIdentifierCallback&&) final;
     void retrieveCaches(const ClientOrigin&, uint64_t updateCounter, DOMCacheEngine::CacheInfosCallback&&) final;
 
@@ -59,7 +59,6 @@ private:
     void lockStorage(const ClientOrigin&) final;
     void unlockStorage(const ClientOrigin&) final;
 
-    void openCompleted(uint64_t requestIdentifier, const DOMCacheEngine::CacheIdentifierOrError&);
     void removeCompleted(uint64_t requestIdentifier, const DOMCacheEngine::RemoveCacheIdentifierOrError&);
     void retrieveCachesCompleted(uint64_t requestIdentifier, DOMCacheEngine::CacheInfosOrError&&);
     void retrieveRecordsCompleted(uint64_t requestIdentifier, DOMCacheEngine::CrossThreadRecordsOrError&&);
@@ -70,7 +69,6 @@ private:
 
     Ref<CacheStorageConnection> m_mainThreadConnection;
 
-    HashMap<uint64_t, DOMCacheEngine::CacheIdentifierCallback> m_openCachePendingRequests;
     HashMap<uint64_t, DOMCacheEngine::RemoveCacheIdentifierCallback> m_removeCachePendingRequests;
     HashMap<uint64_t, DOMCacheEngine::CacheInfosCallback> m_retrieveCachesPendingRequests;
     HashMap<uint64_t, DOMCacheEngine::CrossThreadRecordsCallback> m_retrieveRecordsPendingRequests;

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.h
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.h
@@ -256,8 +256,8 @@ private:
     bool m_mediaSourceEnded { false };
     Ref<TimeRanges> m_buffered;
     Vector<PlatformTimeRanges> m_trackBuffers;
-    NativePromiseRequest<MediaPromise> m_appendBufferPromise;
-    NativePromiseRequest<MediaPromise> m_removeCodedFramesPromise;
+    NativePromiseRequest m_appendBufferPromise;
+    NativePromiseRequest m_removeCodedFramesPromise;
 
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;

--- a/Source/WebCore/page/CacheStorageProvider.h
+++ b/Source/WebCore/page/CacheStorageProvider.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "CacheStorageConnection.h"
+#include <wtf/NativePromise.h>
 #include <wtf/RefCounted.h>
 
 namespace WebCore {
@@ -41,7 +42,7 @@ public:
         {
         }
 
-        void open(const ClientOrigin&, const String&, DOMCacheEngine::CacheIdentifierCallback&&) final { }
+        Ref<OpenPromise> open(const ClientOrigin&, const String&) final { return OpenPromise::createAndReject(DOMCacheEngine::Error::Stopped); }
         void remove(DOMCacheIdentifier, DOMCacheEngine::RemoveCacheIdentifierCallback&&) final { }
         void retrieveCaches(const ClientOrigin&, uint64_t, DOMCacheEngine::CacheInfosCallback&&) final { }
         void retrieveRecords(DOMCacheIdentifier, RetrieveRecordsOptions&&, DOMCacheEngine::CrossThreadRecordsCallback&&) final { }

--- a/Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.h
+++ b/Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.h
@@ -55,7 +55,7 @@ private:
     IPC::Connection& connection();
 
     // WebCore::CacheStorageConnection
-    void open(const WebCore::ClientOrigin&, const String& cacheName, WebCore::DOMCacheEngine::CacheIdentifierCallback&&) final;
+    Ref<OpenPromise> open(const WebCore::ClientOrigin&, const String& cacheName) final;
     void remove(WebCore::DOMCacheIdentifier, WebCore::DOMCacheEngine::RemoveCacheIdentifierCallback&&) final;
     void retrieveCaches(const WebCore::ClientOrigin&, uint64_t updateCounter, WebCore::DOMCacheEngine::CacheInfosCallback&&) final;
 

--- a/Tools/TestWebKitAPI/Tests/WTF/NativePromise.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/NativePromise.cpp
@@ -296,7 +296,7 @@ TEST(NativePromise, GenericPromise)
 
         GenericPromise::Producer producer3;
         Ref<GenericPromise> promise3 = producer3;
-        NativePromiseRequest<GenericPromise> request3;
+        NativePromiseRequest request3;
 
         // Note that if you're not interested in the result you can provide two Function<void()> to then()
         promise3->then(queue, doFail(), doFail()).track(request3);
@@ -422,7 +422,7 @@ TEST(NativePromise, PromiseRequest)
     // We declare the Request holder before using the runLoop to ensure it stays in scope for the entire run.
     // ASSERTION FAILED: !m_request
     using MyPromise = NativePromise<bool, bool>;
-    NativePromiseRequest<MyPromise> request1;
+    NativePromiseRequest request1;
 
     runInCurrentRunLoop([&](auto& runLoop) {
         MyPromise::Producer producer1;
@@ -443,7 +443,7 @@ TEST(NativePromise, PromiseRequest)
     // lifetime of the object.
     bool objectToShare = true;
     runInCurrentRunLoop([&](auto& runLoop) {
-        NativePromiseRequest<GenericPromise> request2;
+        NativePromiseRequest request2;
         GenericPromise::Producer producer2;
         Ref<GenericPromise> promise2 = producer2;
         promise2->whenSettled(runLoop,
@@ -465,7 +465,7 @@ TEST(NativePromise, PromiseRequest)
 TEST(NativePromise, PromiseRequestDisconnected1)
 {
     runInCurrentRunLoop([](auto& runLoop) {
-        NativePromiseRequest<TestPromise> request;
+        NativePromiseRequest request;
 
         TestPromise::Producer producer;
         Ref<TestPromise> promise = producer;
@@ -480,7 +480,7 @@ TEST(NativePromise, PromiseRequestDisconnected1)
 TEST(NativePromise, PromiseRequestDisconnected2)
 {
     runInCurrentRunLoop([](auto& runLoop) {
-        NativePromiseRequest<TestPromise> request;
+        NativePromiseRequest request;
 
         TestPromise::Producer producer;
         Ref<TestPromise> promise = producer;
@@ -928,7 +928,7 @@ TEST(NativePromise, PromiseAllSettledAsync)
 TEST(NativePromise, Chaining)
 {
     // We declare this variable before |awq| to ensure the destructor is run after |holder.disconnect()|.
-    NativePromiseRequest<TestPromise> holder;
+    NativePromiseRequest holder;
 
     AutoWorkQueue awq;
     auto queue = awq.queue();
@@ -1261,7 +1261,7 @@ TEST(NativePromise, HeterogeneousChaining)
     using Promise1 = NativePromise<std::unique_ptr<char>, bool>;
     using Promise2 = NativePromise<std::unique_ptr<int>, bool>;
 
-    NativePromiseRequest<Promise2> holder;
+    NativePromiseRequest holder;
 
     AutoWorkQueue awq;
     auto queue = awq.queue();


### PR DESCRIPTION
#### 43bf0bb142ab5ea9b74e0cd70cbca969aacb8840
<pre>
Migrate CacheStorageConnection::open to NativePromise
<a href="https://bugs.webkit.org/show_bug.cgi?id=266568">https://bugs.webkit.org/show_bug.cgi?id=266568</a>
<a href="https://rdar.apple.com/119804320">rdar://119804320</a>

Reviewed by Jean-Yves Avenard.

The goal is first to simplify CacheStorage operations handling from workers.
We should as a follow-up step allow to send/receive IPC out of main thread, which will be made easier with promises.

Given it runs in workers, we need to have a way to register NativePromise callbacks that are guaranteed to be destroyed in workers.
We do this by registering these callbacks in a WorkerGlobalScope so that we can destroy them when WorkerGlobalScope gets stopped.

To do this, we allow a promise to either take a RefCountedGuaranteedSerialFunctionDispatcher or a NativePromiseDispatcher.
The latter is a RefCountedSerialFunctionDispatcher but without any guarantee that the function will be dispatched or not.
To handle this possibility, the NativePromiseDispatcher is responsible to disconnect the NativePromiseCallback that it is given in registerCallback
in the same context as its RefCountedSerialFunctionDispatcher.

* Source/WTF/wtf/Forward.h:
* Source/WTF/wtf/NativePromise.h:
(WTF::NativePromiseRequest::~NativePromiseRequest):
(WTF::NativePromiseRequest::track):
(WTF::NativePromiseRequest::operator bool const):
(WTF::NativePromiseRequest::complete):
(WTF::NativePromiseRequest::disconnect):
* Source/WebCore/Modules/cache/CacheStorageConnection.h:
* Source/WebCore/Modules/cache/DOMCacheStorage.cpp:
(WebCore::DOMCacheStorage::doOpen):
* Source/WebCore/Modules/cache/WorkerCacheStorageConnection.cpp:
(WebCore::WorkerCacheStorageConnection::open):
(WebCore::WorkerCacheStorageConnection::clearPendingRequests):
(WebCore::WorkerCacheStorageConnection::openCompleted): Deleted.
* Source/WebCore/Modules/cache/WorkerCacheStorageConnection.h:
* Source/WebCore/Modules/mediasource/SourceBuffer.h:
* Source/WebCore/dom/ScriptExecutionContext.cpp:
(WebCore::ScriptExecutionContext::stopActiveDOMObjects):
(WebCore::ScriptExecutionContext::nativePromiseDispatcher):
* Source/WebCore/dom/ScriptExecutionContext.h:
(WebCore::ScriptExecutionContext::Task::Task):
(WebCore::ScriptExecutionContext::Task::m_isCleanupTask):
(WebCore::ScriptExecutionContext::enqueueTaskWhenPromiseIsSettled):
(WebCore::ScriptExecutionContext::AddConsoleMessageTask::AddConsoleMessageTask):
* Source/WebCore/page/CacheStorageProvider.h:
* Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.cpp:
(WebKit::WebCacheStorageConnection::open):
* Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.h:
* Tools/TestWebKitAPI/Tests/WTF/NativePromise.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/273828@main">https://commits.webkit.org/273828@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d3cbc688a1f27f9a5213e51038b126d403ce5556

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/36953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15739 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39071 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39445 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32965 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/38049 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18245 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12854 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31524 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37366 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13285 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32525 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11608 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11615 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32813 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40694 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/30859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33384 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33155 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37534 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/36546 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11898 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9714 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35654 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13557 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/43364 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8341 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12291 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/8959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12798 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->