### PR TITLE
Address several HTMLAreaElement issues

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-area-element/area-processing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-area-element/area-processing-expected.txt
@@ -13,5 +13,5 @@ PASS negative radius: "20,40,-10" (circle)
 PASS zero radius: "20,40,0" (circle)
 PASS too few numbers: "100,100,120,100,100" (poly)
 PASS one too many numbers: "100,100,120,100,100,120,300" (poly)
-FAIL even-odd rule: "100,100,200,100,100,200,150,50,200,200" (poly) assert_equals: elementFromPoint(150, 125) expected Element node <img src="/images/threecolors.png" usemap="#x" id="img" w... but got Element node <area id="area" shape="poly" coords="100,100,200,100,100,...
+PASS even-odd rule: "100,100,200,100,100,200,150,50,200,200" (poly)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-area-element/support/hit-test.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-area-element/support/hit-test.js
@@ -20,7 +20,7 @@ var tests;
 onload = function() {
   tests.forEach(function(t) {
     test(function(t_obj) {
-      if (area.shape === null) {
+      if (t.shape === null) {
         area.removeAttribute('shape');
       } else {
         area.shape = t.shape;

--- a/Source/WebCore/html/HTMLAreaElement.cpp
+++ b/Source/WebCore/html/HTMLAreaElement.cpp
@@ -43,8 +43,6 @@ using namespace HTMLNames;
 
 inline HTMLAreaElement::HTMLAreaElement(const QualifiedName& tagName, Document& document)
     : HTMLAnchorElement(tagName, document)
-    , m_lastSize(-1, -1)
-    , m_shape(Unknown)
 {
     ASSERT(hasTagName(areaTag));
 }
@@ -59,14 +57,13 @@ void HTMLAreaElement::attributeChanged(const QualifiedName& name, const AtomStri
     switch (name.nodeName()) {
     case AttributeNames::shapeAttr:
         if (equalLettersIgnoringASCIICase(newValue, "default"_s))
-            m_shape = Default;
+            m_shape = Shape::Default;
         else if (equalLettersIgnoringASCIICase(newValue, "circle"_s) || equalLettersIgnoringASCIICase(newValue, "circ"_s))
-            m_shape = Circle;
+            m_shape = Shape::Circle;
         else if (equalLettersIgnoringASCIICase(newValue, "poly"_s) || equalLettersIgnoringASCIICase(newValue, "polygon"_s))
-            m_shape = Poly;
+            m_shape = Shape::Poly;
         else {
-            // The missing value default is the rectangle state.
-            m_shape = Rect;
+            m_shape = Shape::Rect;
         }
         invalidateCachedRegion();
         break;
@@ -95,7 +92,7 @@ bool HTMLAreaElement::mapMouseEvent(LayoutPoint location, const LayoutSize& size
         m_lastSize = size;
     }
 
-    if (!m_region->contains(location))
+    if (!m_region->contains(location, WindRule::EvenOdd))
         return false;
     
     result.setInnerNode(this);
@@ -114,7 +111,7 @@ Path HTMLAreaElement::computePath(RenderObject* obj) const
 
     // Default should default to the size of the containing object.
     LayoutSize size = m_lastSize;
-    if (m_shape == Default)
+    if (isDefault())
         size = obj->absoluteOutlineBounds().size();
     
     Path p = getRegion(size);
@@ -131,7 +128,7 @@ Path HTMLAreaElement::computePath(RenderObject* obj) const
 
 Path HTMLAreaElement::computePathForFocusRing(const LayoutSize& elementSize) const
 {
-    return getRegion(m_shape == Default ? elementSize : m_lastSize);
+    return getRegion(isDefault() ? elementSize : m_lastSize);
 }
 
 // FIXME: Use RenderElement* instead of RenderObject* once we upstream iOS's DOMUIKitExtensions.{h, mm}.
@@ -142,57 +139,40 @@ LayoutRect HTMLAreaElement::computeRect(RenderObject* obj) const
 
 Path HTMLAreaElement::getRegion(const LayoutSize& size) const
 {
-    if (m_coords.isEmpty() && m_shape != Default)
+    if (m_coords.isEmpty() && !isDefault())
         return Path();
 
-    LayoutUnit width = size.width();
-    LayoutUnit height = size.height();
-
-    // If element omits the shape attribute, select shape based on number of coordinates.
-    Shape shape = m_shape;
-    if (shape == Unknown) {
-        if (m_coords.size() == 3)
-            shape = Circle;
-        else if (m_coords.size() == 4)
-            shape = Rect;
-        else if (m_coords.size() >= 6)
-            shape = Poly;
-    }
-
     Path path;
-    switch (shape) {
-        case Poly:
-            if (m_coords.size() >= 6) {
-                int numPoints = m_coords.size() / 2;
-                path.moveTo(FloatPoint(m_coords[0], m_coords[1]));
-                for (int i = 1; i < numPoints; ++i)
-                    path.addLineTo(FloatPoint(m_coords[i * 2], m_coords[i * 2 + 1]));
-                path.closeSubpath();
-            }
-            break;
-        case Circle:
-            if (m_coords.size() >= 3) {
-                double radius = m_coords[2];
-                if (radius > 0)
-                    path.addEllipseInRect(FloatRect(m_coords[0] - radius, m_coords[1] - radius, 2 * radius, 2 * radius));
-            }
-            break;
-        case Rect:
-            if (m_coords.size() >= 4) {
-                double x0 = m_coords[0];
-                double y0 = m_coords[1];
-                double x1 = m_coords[2];
-                double y1 = m_coords[3];
-                path.addRect(FloatRect(x0, y0, x1 - x0, y1 - y0));
-            }
-            break;
-        case Default:
-            path.addRect(FloatRect(0, 0, width, height));
-            break;
-        case Unknown:
-            break;
+    switch (m_shape) {
+    case Shape::Poly:
+        if (m_coords.size() >= 6) {
+            int numPoints = m_coords.size() / 2;
+            path.moveTo(FloatPoint(m_coords[0], m_coords[1]));
+            for (int i = 1; i < numPoints; ++i)
+                path.addLineTo(FloatPoint(m_coords[i * 2], m_coords[i * 2 + 1]));
+            path.closeSubpath();
+        }
+        break;
+    case Shape::Circle:
+        if (m_coords.size() >= 3) {
+            auto radius = m_coords[2];
+            if (radius > 0)
+                path.addEllipseInRect(FloatRect(m_coords[0] - radius, m_coords[1] - radius, 2 * radius, 2 * radius));
+        }
+        break;
+    case Shape::Rect:
+        if (m_coords.size() >= 4) {
+            auto x0 = m_coords[0];
+            auto y0 = m_coords[1];
+            auto x1 = m_coords[2];
+            auto y1 = m_coords[3];
+            path.addRect(FloatRect(x0, y0, x1 - x0, y1 - y0));
+        }
+        break;
+    case Shape::Default:
+        path.addRect({ { 0, 0 }, size });
+        break;
     }
-
     return path;
 }
 

--- a/Source/WebCore/html/HTMLAreaElement.h
+++ b/Source/WebCore/html/HTMLAreaElement.h
@@ -37,7 +37,7 @@ class HTMLAreaElement final : public HTMLAnchorElement {
 public:
     static Ref<HTMLAreaElement> create(const QualifiedName&, Document&);
 
-    bool isDefault() const { return m_shape == Default; }
+    bool isDefault() const { return m_shape == Shape::Default; }
 
     bool mapMouseEvent(LayoutPoint location, const LayoutSize&, HitTestResult&);
 
@@ -61,14 +61,14 @@ private:
     RefPtr<Element> focusAppearanceUpdateTarget() final;
     void setFocus(bool, FocusVisibility = FocusVisibility::Invisible) final;
 
-    enum Shape { Default, Poly, Rect, Circle, Unknown };
+    enum class Shape : uint8_t { Default, Poly, Rect, Circle };
     Path getRegion(const LayoutSize&) const;
     void invalidateCachedRegion();
 
     std::unique_ptr<Path> m_region;
     Vector<double> m_coords;
-    LayoutSize m_lastSize;
-    Shape m_shape;
+    LayoutSize m_lastSize { -1, -1 };
+    Shape m_shape { Shape::Rect };
 };
 
 } //namespace


### PR DESCRIPTION
#### 58de43fa036103b85219dd3bea560d1708ffdbb4
<pre>
Address several HTMLAreaElement issues
<a href="https://bugs.webkit.org/show_bug.cgi?id=257229">https://bugs.webkit.org/show_bug.cgi?id=257229</a>
<a href="https://rdar.apple.com/110028213">rdar://110028213</a>

Reviewed by Chris Dumez.

web-platform-tests did not have adequate coverage for the shape
attribute being missing due to a typo. Despite that, WebKit was alone
in inferring the shape from the coords attribute. So remove that logic
and firmly establish Shape::Rect as the default. (This also matches the
HTML Standard.)

Then, WebKit failed a test for not using the even-odd winding rule for
hit testing. The HTML Standard requires that with this sentence:

&gt; The shape is a polygon whose vertices are given by the coordinates,
&gt; and whose interior is established using the even-odd rule.

And then finally, we clean up the code by turning m_shape into an enum
class and generally tidying up.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-area-element/area-processing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-area-element/support/hit-test.js:
(onload):
* Source/WebCore/html/HTMLAreaElement.cpp:
(WebCore::HTMLAreaElement::HTMLAreaElement):
(WebCore::HTMLAreaElement::attributeChanged):
(WebCore::HTMLAreaElement::mapMouseEvent):
(WebCore::HTMLAreaElement::computePath const):
(WebCore::HTMLAreaElement::computePathForFocusRing const):
(WebCore::HTMLAreaElement::getRegion const):
* Source/WebCore/html/HTMLAreaElement.h:

Canonical link: <a href="https://commits.webkit.org/272217@main">https://commits.webkit.org/272217@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c3474ea62ca22de428b40787490f93745132d97

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30961 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9631 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32646 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33475 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27970 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31722 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11977 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6897 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27829 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31291 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8112 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27697 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6965 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7129 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27576 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34813 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28187 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28047 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33274 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7171 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5239 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31106 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8875 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7305 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7878 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7718 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->