### PR TITLE
[WPE] WPE Platform: add stride parameter to WPEBufferSHM constructor

### DIFF
--- a/Source/WebKit/UIProcess/API/wpe/WPEWebView.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebView.cpp
@@ -927,7 +927,7 @@ void View::setCursor(const WebCore::Cursor& cursor)
     }, surface.leakRef()));
 
     WebCore::IntPoint hotspot = WebCore::determineHotSpot(image.get(), cursor.hotSpot());
-    wpe_view_set_cursor_from_bytes(m_wpeView.get(), bytes.get(), width, height, hotspot.x(), hotspot.y());
+    wpe_view_set_cursor_from_bytes(m_wpeView.get(), bytes.get(), width, height, stride, hotspot.x(), hotspot.y());
 #else
     UNUSED_PARAM(cursor);
 #endif

--- a/Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.cpp
+++ b/Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.cpp
@@ -102,11 +102,12 @@ void AcceleratedBackingStoreDMABuf::didCreateBufferSHM(uint64_t id, ShareableBit
     auto size = bitmap->size();
     const auto* data = bitmap->data();
     auto dataSize = bitmap->sizeInBytes();
+    auto stride = bitmap->bytesPerRow();
     GRefPtr<GBytes> bytes = adoptGRef(g_bytes_new_with_free_func(data, dataSize, [](gpointer userData) {
         delete static_cast<ShareableBitmap*>(userData);
     }, bitmap.leakRef()));
 
-    GRefPtr<WPEBuffer> buffer = adoptGRef(WPE_BUFFER(wpe_buffer_shm_new(display, size.width(), size.height(), WPE_PIXEL_FORMAT_ARGB8888, bytes.get())));
+    GRefPtr<WPEBuffer> buffer = adoptGRef(WPE_BUFFER(wpe_buffer_shm_new(display, size.width(), size.height(), WPE_PIXEL_FORMAT_ARGB8888, bytes.get(), stride)));
     m_bufferIDs.add(buffer.get(), id);
     m_buffers.add(id, WTFMove(buffer));
 }

--- a/Source/WebKit/WPEPlatform/wpe/WPEBufferSHM.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEBufferSHM.cpp
@@ -37,6 +37,7 @@
 struct _WPEBufferSHMPrivate {
     WPEPixelFormat format;
     GRefPtr<GBytes> data;
+    unsigned stride;
 };
 WEBKIT_DEFINE_FINAL_TYPE(WPEBufferSHM, wpe_buffer_shm, WPE_TYPE_BUFFER, WPEBuffer)
 
@@ -45,6 +46,7 @@ enum {
 
     PROP_FORMAT,
     PROP_DATA,
+    PROP_STRIDE,
 
     N_PROPERTIES
 };
@@ -62,6 +64,9 @@ static void wpeBufferSHMSetProperty(GObject* object, guint propId, const GValue*
     case PROP_DATA:
         buffer->priv->data = static_cast<GBytes*>(g_value_get_boxed(value));
         break;
+    case PROP_STRIDE:
+        buffer->priv->stride = g_value_get_uint(value);
+        break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propId, paramSpec);
     }
@@ -77,6 +82,9 @@ static void wpeBufferSHMGetProperty(GObject* object, guint propId, GValue* value
         break;
     case PROP_DATA:
         g_value_set_boxed(value, wpe_buffer_shm_get_data(buffer));
+        break;
+    case PROP_STRIDE:
+        g_value_set_uint(value, wpe_buffer_shm_get_stride(buffer));
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propId, paramSpec);
@@ -122,6 +130,18 @@ static void wpe_buffer_shm_class_init(WPEBufferSHMClass* bufferSHMClass)
             G_TYPE_BYTES,
             static_cast<GParamFlags>(WEBKIT_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
 
+    /**
+     * WPEBufferSHM:stride:
+     *
+     * The buffer stride
+     */
+    sObjProperties[PROP_STRIDE] =
+        g_param_spec_uint(
+            "stride",
+            nullptr, nullptr,
+            0, G_MAXUINT, 0,
+            static_cast<GParamFlags>(WEBKIT_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+
     g_object_class_install_properties(objectClass, N_PROPERTIES, sObjProperties);
 }
 
@@ -132,12 +152,13 @@ static void wpe_buffer_shm_class_init(WPEBufferSHMClass* bufferSHMClass)
  * @height: the buffer height
  * @format: the buffer format
  * @data: the buffer data
+ * @stride: the buffer stride
  *
  * Crerate a new #WPEBufferSHM for the given parameters.
  *
  * Returns: (transfer full): a #WPEBufferSHM
  */
-WPEBufferSHM* wpe_buffer_shm_new(WPEDisplay* display, int width, int height, WPEPixelFormat format, GBytes* data)
+WPEBufferSHM* wpe_buffer_shm_new(WPEDisplay* display, int width, int height, WPEPixelFormat format, GBytes* data, guint stride)
 {
     g_return_val_if_fail(WPE_IS_DISPLAY(display), nullptr);
     g_return_val_if_fail(data, nullptr);
@@ -148,6 +169,7 @@ WPEBufferSHM* wpe_buffer_shm_new(WPEDisplay* display, int width, int height, WPE
         "height", height,
         "format", format,
         "data", data,
+        "stride", stride,
         nullptr));
 }
 
@@ -157,7 +179,7 @@ WPEBufferSHM* wpe_buffer_shm_new(WPEDisplay* display, int width, int height, WPE
  *
  * Get the @buffer pixel format
  *
- * Return: a #WPEPixelFormat
+ * Returns: a #WPEPixelFormat
  */
 WPEPixelFormat wpe_buffer_shm_get_format(WPEBufferSHM* buffer)
 {
@@ -172,11 +194,26 @@ WPEPixelFormat wpe_buffer_shm_get_format(WPEBufferSHM* buffer)
  *
  * Get the @buffer data
  *
- * Return: (transfer none): a #GBytes
+ * Returns: (transfer none): a #GBytes
  */
 GBytes* wpe_buffer_shm_get_data(WPEBufferSHM* buffer)
 {
     g_return_val_if_fail(WPE_IS_BUFFER_SHM(buffer), nullptr);
 
     return buffer->priv->data.get();
+}
+
+/**
+ * wpe_buffer_shm_get_stride:
+ * @buffer: a #WPEBufferSHM
+ *
+ * Get the @buffer stride
+ *
+ * Returns: the buffer stride
+ */
+guint wpe_buffer_shm_get_stride(WPEBufferSHM* buffer)
+{
+    g_return_val_if_fail(WPE_IS_BUFFER_SHM(buffer), 0);
+
+    return buffer->priv->stride;
 }

--- a/Source/WebKit/WPEPlatform/wpe/WPEBufferSHM.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEBufferSHM.h
@@ -53,9 +53,11 @@ WPE_API WPEBufferSHM  *wpe_buffer_shm_new        (WPEDisplay    *display,
                                                   int            width,
                                                   int            height,
                                                   WPEPixelFormat format,
-                                                  GBytes        *data);
+                                                  GBytes        *data,
+                                                  guint          stride);
 WPE_API WPEPixelFormat wpe_buffer_shm_get_format (WPEBufferSHM  *buffer);
 WPE_API GBytes        *wpe_buffer_shm_get_data   (WPEBufferSHM  *buffer);
+WPE_API guint          wpe_buffer_shm_get_stride (WPEBufferSHM  *buffer);
 
 G_END_DECLS
 

--- a/Source/WebKit/WPEPlatform/wpe/WPEView.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEView.cpp
@@ -521,19 +521,20 @@ void wpe_view_set_cursor_from_name(WPEView* view, const char* name)
  * @bytes: the cursor image data
  * @width: the cursor width
  * @height: the cursor height
+ * @stride: the cursor image data stride
  * @hotspot_x: the cursor hotspot x coordinate
  * @hotspot_y: the cursor hotspot y coordinate
  *
  * Set the @view cursor from the given @bytes. Pixel format must be %WPE_PIXEL_FORMAT_ARGB8888.
  */
-void wpe_view_set_cursor_from_bytes(WPEView* view, GBytes* bytes, guint width, guint height, guint hotspotX, guint hotspotY)
+void wpe_view_set_cursor_from_bytes(WPEView* view, GBytes* bytes, guint width, guint height, guint stride, guint hotspotX, guint hotspotY)
 {
     g_return_if_fail(WPE_IS_VIEW(view));
     g_return_if_fail(bytes);
 
     auto* viewClass = WPE_VIEW_GET_CLASS(view);
     if (viewClass->set_cursor_from_bytes)
-        viewClass->set_cursor_from_bytes(view, bytes, width, height, hotspotX, hotspotY);
+        viewClass->set_cursor_from_bytes(view, bytes, width, height, stride, hotspotX, hotspotY);
 }
 
 /**

--- a/Source/WebKit/WPEPlatform/wpe/WPEView.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEView.h
@@ -58,6 +58,7 @@ struct _WPEViewClass
                                                 GBytes     *bytes,
                                                 guint       width,
                                                 guint       height,
+                                                guint       stride,
                                                 guint       hotspot_x,
                                                 guint       hotspot_y);
 
@@ -108,6 +109,7 @@ WPE_API void         wpe_view_set_cursor_from_bytes         (WPEView     *view,
                                                              GBytes      *bytes,
                                                              guint        width,
                                                              guint        height,
+                                                             guint        stride,
                                                              guint        hotspot_x,
                                                              guint        hotspot_y);
 WPE_API WPEViewState wpe_view_get_state                     (WPEView     *view);

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDRMCursor.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDRMCursor.cpp
@@ -64,11 +64,13 @@ bool Cursor::tryEnsureBuffer()
     return true;
 }
 
-void Cursor::updateBuffer(const uint8_t* pixels, uint32_t width, uint32_t height)
+void Cursor::updateBuffer(const uint8_t* pixels, uint32_t width, uint32_t height, uint32_t stride)
 {
+    RELEASE_ASSERT(width <= m_deviceWidth);
+    RELEASE_ASSERT(height <= m_deviceHeight);
+
     uint32_t deviceBuffer[m_deviceWidth * m_deviceHeight];
     memset(deviceBuffer, 0, sizeof(deviceBuffer));
-    auto stride = width * 4;
     for (uint32_t i = 0; i < height; ++i)
         memcpy(deviceBuffer + i * m_deviceWidth, pixels + i * stride, stride);
     gbm_bo_write(m_buffer->bufferObject(), deviceBuffer, sizeof(deviceBuffer));
@@ -99,19 +101,19 @@ void Cursor::setFromName(const char* name, double scale)
         return;
 
     m_isHidden = false;
-    updateBuffer(reinterpret_cast<const uint8_t*>(cursor[0].pixels.data()), cursor[0].width, cursor[0].height);
+    updateBuffer(reinterpret_cast<const uint8_t*>(cursor[0].pixels.data()), cursor[0].width, cursor[0].height, cursor[0].width * 4);
     m_hotspot.x = cursor[0].hotspotX;
     m_hotspot.y = cursor[0].hotspotY;
 }
 
-void Cursor::setFromBytes(GBytes* bytes, uint32_t width, uint32_t height, uint32_t hotspotX, uint32_t hotspotY)
+void Cursor::setFromBytes(GBytes* bytes, uint32_t width, uint32_t height, uint32_t stride, uint32_t hotspotX, uint32_t hotspotY)
 {
     if (!tryEnsureBuffer())
         return;
 
     m_isHidden = false;
     m_name = nullptr;
-    updateBuffer(reinterpret_cast<const uint8_t*>(g_bytes_get_data(bytes, nullptr)), width, height);
+    updateBuffer(reinterpret_cast<const uint8_t*>(g_bytes_get_data(bytes, nullptr)), width, height, stride);
     m_hotspot.x = hotspotX;
     m_hotspot.y = hotspotY;
 }

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDRMCursor.h
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDRMCursor.h
@@ -44,7 +44,7 @@ public:
     ~Cursor();
 
     void setFromName(const char*, double);
-    void setFromBytes(GBytes*, uint32_t width, uint32_t height, uint32_t hotspotX, uint32_t hotspotY);
+    void setFromBytes(GBytes*, uint32_t width, uint32_t height, uint32_t stride, uint32_t hotspotX, uint32_t hotspotY);
     bool setPosition(uint32_t x, uint32_t y);
     uint32_t x() const { return m_position.x - m_hotspot.x; }
     uint32_t y() const { return m_position.y - m_hotspot.y; }
@@ -56,7 +56,7 @@ public:
 
 private:
     bool tryEnsureBuffer();
-    void updateBuffer(const uint8_t*, uint32_t width, uint32_t height);
+    void updateBuffer(const uint8_t*, uint32_t width, uint32_t height, uint32_t stride);
 
     std::unique_ptr<Plane> m_plane;
     struct gbm_device* m_device { nullptr };

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEViewDRM.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEViewDRM.cpp
@@ -449,10 +449,10 @@ static void wpeViewDRMSetCursorFromName(WPEView* view, const char* name)
         cursor->setFromName(name, wpe_view_get_scale(view));
 }
 
-static void wpeViewDRMSetCursorFromBytes(WPEView* view, GBytes* bytes, guint width, guint height, guint hotspotX, guint hotspotY)
+static void wpeViewDRMSetCursorFromBytes(WPEView* view, GBytes* bytes, guint width, guint height, guint stride, guint hotspotX, guint hotspotY)
 {
     if (auto* cursor = wpeDisplayDRMGetCursor(WPE_DISPLAY_DRM(wpe_view_get_display(view))))
-        cursor->setFromBytes(bytes, width, height, hotspotX, hotspotY);
+        cursor->setFromBytes(bytes, width, height, stride, hotspotX, hotspotY);
 }
 
 static void wpeViewDRMScheduleCursorUpdate(WPEViewDRM* view)


### PR DESCRIPTION
#### 1f9ac8dd937e4d715a84f4a6c5d6fdfec5704cd8
<pre>
[WPE] WPE Platform: add stride parameter to WPEBufferSHM constructor
<a href="https://bugs.webkit.org/show_bug.cgi?id=266572">https://bugs.webkit.org/show_bug.cgi?id=266572</a>

Reviewed by Adrian Perez de Castro.

And use a explicit stride for the custom cursors API too.

* Source/WebKit/UIProcess/API/wpe/WPEWebView.cpp:
(WKWPE::View::setCursor):
* Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.cpp:
(WebKit::AcceleratedBackingStoreDMABuf::didCreateBufferSHM):
* Source/WebKit/WPEPlatform/wpe/WPEBufferSHM.cpp:
(wpeBufferSHMGetProperty):
(wpe_buffer_shm_class_init):
(wpe_buffer_shm_new):
(wpe_buffer_shm_get_stride):
* Source/WebKit/WPEPlatform/wpe/WPEBufferSHM.h:
* Source/WebKit/WPEPlatform/wpe/WPEView.cpp:
(wpe_view_set_cursor_from_bytes):
* Source/WebKit/WPEPlatform/wpe/WPEView.h:
* Source/WebKit/WPEPlatform/wpe/drm/WPEDRMCursor.cpp:
(WPE::DRM::Cursor::updateBuffer):
(WPE::DRM::Cursor::setFromName):
(WPE::DRM::Cursor::setFromBytes):
* Source/WebKit/WPEPlatform/wpe/drm/WPEDRMCursor.h:
* Source/WebKit/WPEPlatform/wpe/drm/WPEViewDRM.cpp:
(wpeViewDRMSetCursorFromBytes):
* Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp:
(sharedMemoryBufferCreate):
(createWaylandBufferSHM):

Canonical link: <a href="https://commits.webkit.org/272252@main">https://commits.webkit.org/272252@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dbc058c423e776b99ef1af8d4dd92728ba26c08d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30964 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9635 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32650 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33479 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27973 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11981 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6901 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27835 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31295 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8114 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27700 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6970 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7137 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34817 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28189 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28049 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33276 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7174 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5243 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31108 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8878 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7881 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4036 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7721 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->