### PR TITLE
[WIP] [CSS] Don't compile very long selectors. 

### DIFF
--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -63,7 +63,8 @@ struct PossiblyQuotedIdentifier {
         std::array<uint8_t, 3> computeSpecificityTuple() const;
         unsigned specificityForPage() const;
 
-        bool visitAllSimpleSelectors(auto& apply) const;
+        using Functor = std::function<bool(CSSSelector&)>;
+        bool visitAllSimpleSelectors(Functor& apply) const;
 
         bool hasExplicitNestingParent() const;
         bool hasExplicitPseudoClassScope() const;


### PR DESCRIPTION
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/css/CSSSelector.cpp: (WebCore::CSSSelector::CSSSelector):
(WebCore::CSSSelector::visitAllSimpleSelectors const): (WebCore::CSSSelector::resolveNestingParentSelectors): (WebCore::CSSSelector::replaceNestingParentByPseudoClassScope): (WebCore::CSSSelector::hasExplicitNestingParent const):
* Source/WebCore/css/CSSSelector.h:
* Source/WebCore/cssjit/SelectorCompiler.cpp: (WebCore::SelectorCompiler::compileSelector):<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4141c48944fec54313be96573f01944b51befb83

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30972 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9645 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32660 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33487 "Hash 4141c489 for PR 21965 does not build (failure)") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27982 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31734 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11992 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6909 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/33487 "Hash 4141c489 for PR 21965 does not build (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31303 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8125 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27708 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/33487 "Hash 4141c489 for PR 21965 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7147 "Too many flaky failures: imported/w3c/web-platform-tests/css/css-cascade/scope-hover.html, imported/w3c/web-platform-tests/css/css-nesting/cssom.html, imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-below-viewport-partially-onscreen-new.html, imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-below-viewport-partially-onscreen-old.html, imported/w3c/web-platform-tests/css/css-view-transitions/window-resize-aborts-transition.html, imported/w3c/web-platform-tests/css/selectors/invalidation/user-valid-user-invalid.html, imported/w3c/web-platform-tests/css/selectors/user-invalid.html, imported/w3c/web-platform-tests/css/selectors/valid-invalid-form-fieldset.html, imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch.tentative.html, imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative.html, imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/readwrite-readonly.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27587 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-nesting/cssom.html, inspector/css/getMatchedStylesForNodeNestingStyleGrouping.html (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34826 "Hash 4141c489 for PR 21965 does not build (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28200 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28079 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-nesting/cssom.html, inspector/css/getMatchedStylesForNodeNestingStyleGrouping.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/34826 "Hash 4141c489 for PR 21965 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7182 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5252 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-nesting/cssom.html, inspector/css/getMatchedStylesForNodeNestingStyleGrouping.html (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/34826 "Hash 4141c489 for PR 21965 does not build (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8886 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7890 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7729 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->