### PR TITLE
Remove more cruft from ThemeMac

### DIFF
--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
@@ -66,8 +66,6 @@
 #import "WAKWindow.h"
 #import "WKGraphics.h"
 #import "WebCoreThread.h"
-#else
-#import "ThemeMac.h"
 #endif
 
 #import <pal/cocoa/AVFoundationSoftLink.h>
@@ -1242,11 +1240,6 @@ void PlatformCALayer::drawLayerContents(GraphicsContext& graphicsContext, WebCor
         }
 
         {
-#if PLATFORM(MAC)
-            // It's important to get the clip from the context, because it may be significantly
-            // smaller than the layer bounds (e.g. tiled layers)
-            ThemeMac::setFocusRingClipRect(graphicsContext.clipBounds());
-#endif
             if (dirtyRects.size() == 1)
                 layerContents->platformCALayerPaintContents(platformCALayer, graphicsContext, dirtyRects[0], layerPaintBehavior);
             else {
@@ -1256,10 +1249,6 @@ void PlatformCALayer::drawLayerContents(GraphicsContext& graphicsContext, WebCor
                     layerContents->platformCALayerPaintContents(platformCALayer, graphicsContext, rect, layerPaintBehavior);
                 }
             }
-
-#if PLATFORM(MAC)
-            ThemeMac::setFocusRingClipRect(FloatRect());
-#endif
         }
     }
 

--- a/Source/WebCore/platform/mac/ThemeMac.h
+++ b/Source/WebCore/platform/mac/ThemeMac.h
@@ -35,11 +35,6 @@ class ThemeMac final : public ThemeCocoa {
 public:
     static bool supportsLargeFormControls();
 
-    static NSView *ensuredView(ScrollView*, OptionSet<ControlStyle::State>, bool useUnparentedView = false);
-    WEBCORE_EXPORT static void setUseFormSemanticContext(bool);
-    static bool useFormSemanticContext();
-    static void setFocusRingClipRect(const FloatRect&);
-
 private:
     friend NeverDestroyed<ThemeMac>;
     ThemeMac() = default;

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -156,7 +156,8 @@ public:
 
     virtual bool supportsBoxShadow(const RenderStyle&) const { return false; }
 
-    virtual bool useFormSemanticContext() const { return false; }
+    bool useFormSemanticContext() const { return m_useFormSemanticContext; }
+    void setUseFormSemanticContext(bool value) { m_useFormSemanticContext = value; }
     virtual bool supportsLargeFormControls() const { return false; }
 
     virtual bool searchFieldShouldAppearAsTextField(const RenderStyle&) const { return false; }
@@ -451,6 +452,8 @@ private:
     Color grammarMarkerColor(OptionSet<StyleColorOptions>) const;
 
     mutable HashMap<uint8_t, ColorCache, DefaultHash<uint8_t>, WTF::UnsignedWithZeroKeyHashTraits<uint8_t>> m_colorCacheMap;
+
+    bool m_useFormSemanticContext { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderThemeMac.h
+++ b/Source/WebCore/rendering/RenderThemeMac.h
@@ -86,8 +86,6 @@ public:
 
     // Controls color values returned from platformFocusRingColor(). systemColor() will be used when false.
     bool usesTestModeFocusRingColor() const;
-    // A view associated to the contained document.
-    NSView* documentViewFor(const RenderObject&) const;
 
     WEBCORE_EXPORT static RetainPtr<NSImage> iconForAttachment(const String& fileName, const String& attachmentType, const String& title);
 
@@ -101,7 +99,6 @@ private:
 
     int baselinePosition(const RenderBox&) const final;
 
-    bool useFormSemanticContext() const final;
     bool supportsLargeFormControls() const final;
 
     void adjustTextFieldStyle(RenderStyle&, const Element*) const final;

--- a/Source/WebCore/rendering/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/RenderThemeMac.mm
@@ -240,20 +240,9 @@ int RenderThemeMac::baselinePosition(const RenderBox& renderer) const
     return baseline;
 }
 
-bool RenderThemeMac::useFormSemanticContext() const
-{
-    return ThemeMac::useFormSemanticContext();
-}
-
 bool RenderThemeMac::supportsLargeFormControls() const
 {
     return ThemeMac::supportsLargeFormControls();
-}
-
-NSView *RenderThemeMac::documentViewFor(const RenderObject& renderer) const
-{
-    LocalDefaultSystemAppearance localAppearance(renderer.useDarkAppearance());
-    return ThemeMac::ensuredView(&renderer.view().frameView(), extractControlStyleStatesForRenderer(renderer));
 }
 
 Color RenderThemeMac::platformActiveSelectionBackgroundColor(OptionSet<StyleColorOptions> options) const

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -96,7 +96,6 @@
 #import <WebCore/ScrollView.h>
 #import <WebCore/StyleInheritedData.h>
 #import <WebCore/TextIterator.h>
-#import <WebCore/ThemeMac.h>
 #import <WebCore/VisibleUnits.h>
 #import <WebCore/WindowsKeyboardCodes.h>
 #import <pal/spi/cocoa/LaunchServicesSPI.h>
@@ -621,7 +620,7 @@ void WebPage::setBottomOverhangImage(WebImage* image)
 
 void WebPage::setUseFormSemanticContext(bool useFormSemanticContext)
 {
-    ThemeMac::setUseFormSemanticContext(useFormSemanticContext);
+    RenderTheme::singleton().setUseFormSemanticContext(useFormSemanticContext);
 }
 
 void WebPage::semanticContextDidChange(bool useFormSemanticContext)


### PR DESCRIPTION
#### 45f6e1268ddc571baf89cf94b2acf413348d592e
<pre>
Remove more cruft from ThemeMac
<a href="https://bugs.webkit.org/show_bug.cgi?id=266582">https://bugs.webkit.org/show_bug.cgi?id=266582</a>

Reviewed by Aditya Keerthi.

ensuredView() was dead code and as such all the view interface
definitions were not actually doing anything.

_useFormSemanticContext was doing something (despite the noise) and to
preserve its functionality we move it to RenderTheme. This should work
as RenderTheme::singleton() is NeverDestroyed.

* Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm:
(WebCore::PlatformCALayer::drawLayerContents):
* Source/WebCore/platform/mac/ThemeMac.h:
* Source/WebCore/platform/mac/ThemeMac.mm:
(-[WebCoreThemeWindow hasKeyAppearance]): Deleted.
(-[WebCoreThemeWindow isKeyWindow]): Deleted.
(-[WebCoreThemeView init]): Deleted.
(-[WebCoreThemeView window]): Deleted.
(-[WebCoreThemeView isFlipped]): Deleted.
(-[WebCoreThemeView currentEditor]): Deleted.
(-[WebCoreThemeView _automaticFocusRingDisabled]): Deleted.
(-[WebCoreThemeView _focusRingVisibleRect]): Deleted.
(-[WebCoreThemeView _focusRingClipAncestor]): Deleted.
(-[WebCoreThemeView _viewRoot]): Deleted.
(-[WebCoreThemeView addSubview:]): Deleted.
(WebCore::ThemeMac::ensuredView): Deleted.
(WebCore::ThemeMac::useFormSemanticContext): Deleted.
(WebCore::ThemeMac::setUseFormSemanticContext): Deleted.
(WebCore::ThemeMac::setFocusRingClipRect): Deleted.
* Source/WebCore/rendering/RenderTheme.h:
(WebCore::RenderTheme::useFormSemanticContext const):
(WebCore::RenderTheme::setUseFormSemanticContext):
* Source/WebCore/rendering/RenderThemeMac.h:
* Source/WebCore/rendering/RenderThemeMac.mm:
(WebCore::RenderThemeMac::useFormSemanticContext const): Deleted.
(WebCore::RenderThemeMac::documentViewFor const): Deleted.
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::setUseFormSemanticContext):

Canonical link: <a href="https://commits.webkit.org/272368@main">https://commits.webkit.org/272368@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ef6c07be5d8f794d46e8eca145567a5c1e3771b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30994 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9668 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32683 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33511 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28002 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31757 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12015 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6931 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27855 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31326 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8146 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27726 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6996 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7187 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27605 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34849 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28221 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28075 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33304 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7201 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5271 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31135 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8903 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7378 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7909 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7748 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->