### PR TITLE
Port PopupMenuSize to the new IPC serialization format

### DIFF
--- a/Source/WebCore/platform/PopupMenuStyle.h
+++ b/Source/WebCore/platform/PopupMenuStyle.h
@@ -36,14 +36,14 @@ class PopupMenuStyle {
 public:
     enum PopupMenuType { SelectPopup, AutofillPopup };
     enum BackgroundColorType { DefaultBackgroundColor, CustomBackgroundColor };
-    enum PopupMenuSize {
-        PopupMenuSizeNormal,
-        PopupMenuSizeSmall,
-        PopupMenuSizeMini,
-        PopupMenuSizeLarge,
+    enum class Size : uint8_t {
+        Normal,
+        Small,
+        Mini,
+        Large,
     };
 
-    PopupMenuStyle(const Color& foreground, const Color& background, const FontCascade& font, bool visible, bool isDisplayNone, bool hasDefaultAppearance, Length textIndent, TextDirection textDirection, bool hasTextDirectionOverride, BackgroundColorType backgroundColorType = DefaultBackgroundColor, PopupMenuType menuType = SelectPopup, PopupMenuSize menuSize = PopupMenuSizeNormal)
+    PopupMenuStyle(const Color& foreground, const Color& background, const FontCascade& font, bool visible, bool isDisplayNone, bool hasDefaultAppearance, Length textIndent, TextDirection textDirection, bool hasTextDirectionOverride, BackgroundColorType backgroundColorType = DefaultBackgroundColor, PopupMenuType menuType = SelectPopup, Size menuSize = Size::Normal)
         : m_foregroundColor(foreground)
         , m_backgroundColor(background)
         , m_font(font)
@@ -70,7 +70,7 @@ public:
     bool hasTextDirectionOverride() const { return m_hasTextDirectionOverride; }
     BackgroundColorType backgroundColorType() const { return m_backgroundColorType; }
     PopupMenuType menuType() const { return m_menuType; }
-    PopupMenuSize menuSize() const { return m_menuSize; }
+    Size menuSize() const { return m_menuSize; }
 
 private:
     Color m_foregroundColor;
@@ -84,21 +84,7 @@ private:
     bool m_hasTextDirectionOverride;
     BackgroundColorType m_backgroundColorType;
     PopupMenuType m_menuType;
-    PopupMenuSize m_menuSize;
+    Size m_menuSize;
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::PopupMenuStyle::PopupMenuSize> {
-    using values = EnumValues<
-        WebCore::PopupMenuStyle::PopupMenuSize,
-        WebCore::PopupMenuStyle::PopupMenuSize::PopupMenuSizeNormal,
-        WebCore::PopupMenuStyle::PopupMenuSize::PopupMenuSizeSmall,
-        WebCore::PopupMenuStyle::PopupMenuSize::PopupMenuSizeMini,
-        WebCore::PopupMenuStyle::PopupMenuSize::PopupMenuSizeLarge
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -207,7 +207,7 @@ public:
 
     virtual LengthBox popupInternalPaddingBox(const RenderStyle&) const { return { 0, 0, 0, 0 }; }
     virtual bool popupOptionSupportsTextIndent() const { return false; }
-    virtual PopupMenuStyle::PopupMenuSize popupMenuSize(const RenderStyle&, IntRect&) const { return PopupMenuStyle::PopupMenuSizeNormal; }
+    virtual PopupMenuStyle::Size popupMenuSize(const RenderStyle&, IntRect&) const { return PopupMenuStyle::Size::Normal; }
 
     virtual ScrollbarWidth scrollbarWidthStyleForPart(StyleAppearance) { return ScrollbarWidth::Auto; }
 

--- a/Source/WebCore/rendering/RenderThemeMac.h
+++ b/Source/WebCore/rendering/RenderThemeMac.h
@@ -75,7 +75,7 @@ public:
 #endif
 
     LengthBox popupInternalPaddingBox(const RenderStyle&) const final;
-    PopupMenuStyle::PopupMenuSize popupMenuSize(const RenderStyle&, IntRect&) const final;
+    PopupMenuStyle::Size popupMenuSize(const RenderStyle&, IntRect&) const final;
 
     bool popsMenuByArrowKeys() const final { return true; }
 

--- a/Source/WebCore/rendering/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/RenderThemeMac.mm
@@ -1064,21 +1064,21 @@ LengthBox RenderThemeMac::popupInternalPaddingBox(const RenderStyle& style) cons
     return { 0, 0, 0, 0 };
 }
 
-PopupMenuStyle::PopupMenuSize RenderThemeMac::popupMenuSize(const RenderStyle& style, IntRect& rect) const
+PopupMenuStyle::Size RenderThemeMac::popupMenuSize(const RenderStyle& style, IntRect& rect) const
 {
     NSPopUpButtonCell* popupButton = this->popupButton();
     NSControlSize size = controlSizeForCell(popupButton, popupButtonSizes(), rect.size(), style.effectiveZoom());
     switch (size) {
     case NSControlSizeRegular:
-        return PopupMenuStyle::PopupMenuSizeNormal;
+        return PopupMenuStyle::Size::Normal;
     case NSControlSizeSmall:
-        return PopupMenuStyle::PopupMenuSizeSmall;
+        return PopupMenuStyle::Size::Small;
     case NSControlSizeMini:
-        return PopupMenuStyle::PopupMenuSizeMini;
+        return PopupMenuStyle::Size::Mini;
     case NSControlSizeLarge:
-        return ThemeMac::supportsLargeFormControls() ? PopupMenuStyle::PopupMenuSizeLarge : PopupMenuStyle::PopupMenuSizeNormal;
+        return ThemeMac::supportsLargeFormControls() ? PopupMenuStyle::Size::Large : PopupMenuStyle::Size::Normal;
     default:
-        return PopupMenuStyle::PopupMenuSizeNormal;
+        return PopupMenuStyle::Size::Normal;
     }
 }
 

--- a/Source/WebKit/Shared/PlatformPopupMenuData.h
+++ b/Source/WebKit/Shared/PlatformPopupMenuData.h
@@ -37,7 +37,7 @@ struct PlatformPopupMenuData {
     WebKit::FontInfo fontInfo;
     bool shouldPopOver { false };
     bool hideArrows { false };
-    WebCore::PopupMenuStyle::PopupMenuSize menuSize { WebCore::PopupMenuStyle::PopupMenuSize::PopupMenuSizeNormal };
+    WebCore::PopupMenuStyle::Size menuSize { WebCore::PopupMenuStyle::Size::Normal };
 #elif PLATFORM(WIN)
     int m_clientPaddingLeft { 0 };
     int m_clientPaddingRight { 0 };

--- a/Source/WebKit/Shared/PlatformPopupMenuData.serialization.in
+++ b/Source/WebKit/Shared/PlatformPopupMenuData.serialization.in
@@ -25,7 +25,7 @@ struct WebKit::PlatformPopupMenuData {
     WebKit::FontInfo fontInfo;
     bool shouldPopOver;
     bool hideArrows;
-    WebCore::PopupMenuStyle::PopupMenuSize menuSize;
+    WebCore::PopupMenuStyle::Size menuSize;
 #endif
 #if PLATFORM(WIN)
     int m_clientPaddingLeft;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -7212,3 +7212,10 @@ enum class WebCore::ContextMenuItemType : uint8_t {
     Separator,
     Submenu,
 };
+
+[Nested] enum class WebCore::PopupMenuStyle::Size : uint8_t {
+    Normal,
+    Small,
+    Mini,
+    Large,
+};

--- a/Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.mm
@@ -158,16 +158,16 @@ void WebPopupMenuProxyMac::showPopupMenu(const IntRect& rect, TextDirection text
 
     NSControlSize controlSize;
     switch (data.menuSize) {
-    case WebCore::PopupMenuStyle::PopupMenuSizeNormal:
+    case WebCore::PopupMenuStyle::Size::Normal:
         controlSize = NSControlSizeRegular;
         break;
-    case WebCore::PopupMenuStyle::PopupMenuSizeSmall:
+    case WebCore::PopupMenuStyle::Size::Small:
         controlSize = NSControlSizeSmall;
         break;
-    case WebCore::PopupMenuStyle::PopupMenuSizeMini:
+    case WebCore::PopupMenuStyle::Size::Mini:
         controlSize = NSControlSizeMini;
         break;
-    case PopupMenuStyle::PopupMenuSizeLarge:
+    case WebCore::PopupMenuStyle::Size::Large:
         controlSize = NSControlSizeLarge;
         break;
     }

--- a/Source/WebKitLegacy/mac/WebCoreSupport/PopupMenuMac.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/PopupMenuMac.mm
@@ -199,16 +199,16 @@ void PopupMenuMac::show(const IntRect& r, LocalFrameView* v, int selectedIndex)
 
     NSControlSize controlSize;
     switch (m_client->menuStyle().menuSize()) {
-    case PopupMenuStyle::PopupMenuSizeNormal:
+    case PopupMenuStyle::Size::Normal:
         controlSize = NSControlSizeRegular;
         break;
-    case PopupMenuStyle::PopupMenuSizeSmall:
+    case PopupMenuStyle::Size::Small:
         controlSize = NSControlSizeSmall;
         break;
-    case PopupMenuStyle::PopupMenuSizeMini:
+    case PopupMenuStyle::Size::Mini:
         controlSize = NSControlSizeMini;
         break;
-    case PopupMenuStyle::PopupMenuSizeLarge:
+    case PopupMenuStyle::Size::Large:
         controlSize = NSControlSizeLarge;
         break;
     }


### PR DESCRIPTION
#### d53053272d0deb10e08ef4a5cf0a01cdea69a692
<pre>
Port PopupMenuSize to the new IPC serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=266584">https://bugs.webkit.org/show_bug.cgi?id=266584</a>

Reviewed by Aditya Keerthi.

Remove the EnumTraits for PopupMenuSize and also take
the chance to rename the enum to remove redundance,
both in its name and their elements.

* Source/WebCore/platform/PopupMenuStyle.h:
(WebCore::PopupMenuStyle::PopupMenuStyle):
(WebCore::PopupMenuStyle::menuSize const):
* Source/WebCore/rendering/RenderTheme.h:
(WebCore::RenderTheme::popupMenuSize const):
* Source/WebCore/rendering/RenderThemeMac.h:
* Source/WebCore/rendering/RenderThemeMac.mm:
(WebCore::RenderThemeMac::popupMenuSize const):
* Source/WebKit/Shared/PlatformPopupMenuData.h:
* Source/WebKit/Shared/PlatformPopupMenuData.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.mm:
(WebKit::WebPopupMenuProxyMac::showPopupMenu):
* Source/WebKitLegacy/mac/WebCoreSupport/PopupMenuMac.mm:
(PopupMenuMac::show):

Canonical link: <a href="https://commits.webkit.org/272243@main">https://commits.webkit.org/272243@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/648561e119815b70aa2ebc2eeaebbd995329679d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31004 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9678 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32693 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33519 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28008 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31767 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12025 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6941 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27863 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31336 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8155 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27735 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7009 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7174 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27614 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34857 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28229 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28085 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33317 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7208 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5278 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31150 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8909 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7315 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7916 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7755 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->