### PR TITLE
[ARM] Add release build type check to downcast<T>()

### DIFF
--- a/Source/WTF/wtf/Ref.h
+++ b/Source/WTF/wtf/Ref.h
@@ -303,11 +303,26 @@ inline Ref<match_constness_t<Source, Target>> checkedDowncast(Ref<Source, PtrTra
 }
 
 template<typename Target, typename Source, typename PtrTraits>
-inline Ref<match_constness_t<Source, Target>> downcast(Ref<Source, PtrTraits> source)
+inline Ref<match_constness_t<Source, Target>> uncheckedDowncast(Ref<Source, PtrTraits> source)
 {
     static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
     static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
     ASSERT_WITH_SECURITY_IMPLICATION(is<Target>(source));
+    return static_reference_cast<match_constness_t<Source, Target>>(WTFMove(source));
+}
+
+template<typename Target, typename Source, typename PtrTraits>
+inline Ref<match_constness_t<Source, Target>> downcast(Ref<Source, PtrTraits> source)
+{
+    static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
+    static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
+    // FIXME: This is too expensive to enable on x86 for now but we should try and
+    // enable the RELEASE_ASSERT() on all architectures.
+#if CPU(ARM64)
+    RELEASE_ASSERT(is<Target>(source));
+#else
+    ASSERT_WITH_SECURITY_IMPLICATION(is<Target>(source));
+#endif
     return static_reference_cast<match_constness_t<Source, Target>>(WTFMove(source));
 }
 

--- a/Source/WTF/wtf/RefPtr.h
+++ b/Source/WTF/wtf/RefPtr.h
@@ -269,11 +269,26 @@ inline RefPtr<match_constness_t<Source, Target>> checkedDowncast(RefPtr<Source, 
 }
 
 template<typename Target, typename Source, typename PtrTraits, typename RefDerefTraits>
-inline RefPtr<match_constness_t<Source, Target>> downcast(RefPtr<Source, PtrTraits, RefDerefTraits> source)
+inline RefPtr<match_constness_t<Source, Target>> uncheckedDowncast(RefPtr<Source, PtrTraits, RefDerefTraits> source)
 {
     static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
     static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
     ASSERT_WITH_SECURITY_IMPLICATION(!source || is<Target>(*source));
+    return static_pointer_cast<match_constness_t<Source, Target>>(WTFMove(source));
+}
+
+template<typename Target, typename Source, typename PtrTraits, typename RefDerefTraits>
+inline RefPtr<match_constness_t<Source, Target>> downcast(RefPtr<Source, PtrTraits, RefDerefTraits> source)
+{
+    static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
+    static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
+    // FIXME: This is too expensive to enable on x86 for now but we should try and
+    // enable the RELEASE_ASSERT() on all architectures.
+#if CPU(ARM64)
+    RELEASE_ASSERT(!source || is<Target>(*source));
+#else
+    ASSERT_WITH_SECURITY_IMPLICATION(!source || is<Target>(*source));
+#endif
     return static_pointer_cast<match_constness_t<Source, Target>>(WTFMove(source));
 }
 

--- a/Source/WTF/wtf/TypeCasts.h
+++ b/Source/WTF/wtf/TypeCasts.h
@@ -79,6 +79,7 @@ inline match_constness_t<Source, Target>& checkedDowncast(Source& source)
     RELEASE_ASSERT(is<Target>(source));
     return static_cast<match_constness_t<Source, Target>&>(source);
 }
+
 template<typename Target, typename Source>
 inline match_constness_t<Source, Target>* checkedDowncast(Source* source)
 {
@@ -89,19 +90,50 @@ inline match_constness_t<Source, Target>* checkedDowncast(Source* source)
 }
 
 template<typename Target, typename Source>
-inline match_constness_t<Source, Target>& downcast(Source& source)
+inline match_constness_t<Source, Target>& uncheckedDowncast(Source& source)
 {
     static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
     static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
     ASSERT_WITH_SECURITY_IMPLICATION(is<Target>(source));
     return static_cast<match_constness_t<Source, Target>&>(source);
 }
+
+template<typename Target, typename Source>
+inline match_constness_t<Source, Target>* uncheckedDowncast(Source* source)
+{
+    static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
+    static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
+    ASSERT_WITH_SECURITY_IMPLICATION(!source || is<Target>(*source));
+    return static_cast<match_constness_t<Source, Target>*>(source);
+}
+
+template<typename Target, typename Source>
+inline match_constness_t<Source, Target>& downcast(Source& source)
+{
+    static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
+    static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
+    // FIXME: This is too expensive to enable on x86 for now but we should try and
+    // enable the RELEASE_ASSERT() on all architectures.
+#if CPU(ARM64)
+    RELEASE_ASSERT(is<Target>(source));
+#else
+    ASSERT_WITH_SECURITY_IMPLICATION(is<Target>(source));
+#endif
+    return static_cast<match_constness_t<Source, Target>&>(source);
+}
+
 template<typename Target, typename Source>
 inline match_constness_t<Source, Target>* downcast(Source* source)
 {
     static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
     static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
+    // FIXME: This is too expensive to enable on x86 for now but we should try and
+    // enable the RELEASE_ASSERT() on all architectures.
+#if CPU(ARM64)
+    RELEASE_ASSERT(!source || is<Target>(*source));
+#else
     ASSERT_WITH_SECURITY_IMPLICATION(!source || is<Target>(*source));
+#endif
     return static_cast<match_constness_t<Source, Target>*>(source);
 }
 
@@ -112,6 +144,7 @@ inline match_constness_t<Source, Target>* dynamicDowncast(Source& source)
     static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
     return is<Target>(source) ? &static_cast<match_constness_t<Source, Target>&>(source) : nullptr;
 }
+
 template<typename Target, typename Source>
 inline match_constness_t<Source, Target>* dynamicDowncast(Source* source)
 {
@@ -154,3 +187,4 @@ using WTF::is;
 using WTF::checkedDowncast;
 using WTF::downcast;
 using WTF::dynamicDowncast;
+using WTF::uncheckedDowncast;

--- a/Source/WTF/wtf/WeakPtr.h
+++ b/Source/WTF/wtf/WeakPtr.h
@@ -476,7 +476,13 @@ inline WeakPtr<match_constness_t<Source, Target>, WeakPtrImpl, PtrTraits> downca
 {
     static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
     static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
+    // FIXME: This is too expensive to enable on x86 for now but we should try and
+    // enable the RELEASE_ASSERT() on all architectures.
+#if CPU(ARM64)
+    RELEASE_ASSERT(!source || is<Target>(*source));
+#else
     ASSERT_WITH_SECURITY_IMPLICATION(!source || is<Target>(*source));
+#endif
     return WeakPtr<match_constness_t<Source, Target>, WeakPtrImpl, PtrTraits> { static_pointer_cast<match_constness_t<Source, Target>>(source.releaseImpl()), source.enableWeakPtrThreadingAssertions() };
 }
 

--- a/Source/WTF/wtf/WeakRef.h
+++ b/Source/WTF/wtf/WeakRef.h
@@ -289,7 +289,13 @@ inline WeakRef<match_constness_t<Source, Target>, WeakPtrImpl> downcast(WeakRef<
 {
     static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
     static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
+    // FIXME: This is too expensive to enable on x86 for now but we should try and
+    // enable the RELEASE_ASSERT() on all architectures.
+#if CPU(ARM64)
+    RELEASE_ASSERT(is<Target>(source));
+#else
     ASSERT_WITH_SECURITY_IMPLICATION(is<Target>(source));
+#endif
     return WeakRef<match_constness_t<Source, Target>, WeakPtrImpl> { static_reference_cast<match_constness_t<Source, Target>>(source.releaseImpl()), source.enableWeakPtrThreadingAssertions() };
 }
 

--- a/Source/WebCore/bindings/js/JSNodeCustom.cpp
+++ b/Source/WebCore/bindings/js/JSNodeCustom.cpp
@@ -134,7 +134,7 @@ static ALWAYS_INLINE JSValue createWrapperInline(JSGlobalObject* lexicalGlobalOb
             break;
         case Node::DOCUMENT_NODE:
             // we don't want to cache the document itself in the per-document dictionary
-            return toJS(lexicalGlobalObject, globalObject, downcast<Document>(node.get()));
+            return toJS(lexicalGlobalObject, globalObject, uncheckedDowncast<Document>(node.get()));
         case Node::DOCUMENT_TYPE_NODE:
             wrapper = createWrapper<DocumentType>(globalObject, WTFMove(node));
             break;

--- a/Source/WebCore/css/BasicShapeFunctions.cpp
+++ b/Source/WebCore/css/BasicShapeFunctions.cpp
@@ -118,7 +118,7 @@ Ref<CSSValue> valueForBasicShape(const RenderStyle& style, const BasicShape& bas
 
     switch (basicShape.type()) {
     case BasicShape::Type::Circle: {
-        auto& circle = downcast<BasicShapeCircle>(basicShape);
+        auto& circle = uncheckedDowncast<BasicShapeCircle>(basicShape);
         RefPtr radius = basicShapeRadiusToCSSValue(style, circle.radius());
 
         if (circle.positionWasOmitted())
@@ -129,7 +129,7 @@ Ref<CSSValue> valueForBasicShape(const RenderStyle& style, const BasicShape& bas
             valueForCenterCoordinate(style, circle.centerY(), BoxOrient::Vertical));
     }
     case BasicShape::Type::Ellipse: {
-        auto& ellipse = downcast<BasicShapeEllipse>(basicShape);
+        auto& ellipse = uncheckedDowncast<BasicShapeEllipse>(basicShape);
         RefPtr radiusX = basicShapeRadiusToCSSValue(style, ellipse.radiusX());
         RefPtr radiusY = basicShapeRadiusToCSSValue(style, ellipse.radiusY());
 
@@ -142,33 +142,33 @@ Ref<CSSValue> valueForBasicShape(const RenderStyle& style, const BasicShape& bas
             valueForCenterCoordinate(style, ellipse.centerY(), BoxOrient::Vertical));
     }
     case BasicShape::Type::Polygon: {
-        auto& polygon = downcast<BasicShapePolygon>(basicShape);
+        auto& polygon = uncheckedDowncast<BasicShapePolygon>(basicShape);
         CSSValueListBuilder values;
         for (auto& value : polygon.values())
             values.append(CSSPrimitiveValue::create(value, style));
         return CSSPolygonValue::create(WTFMove(values), polygon.windRule());
     }
     case BasicShape::Type::Path: {
-        auto& pathShape = downcast<BasicShapePath>(basicShape);
+        auto& pathShape = uncheckedDowncast<BasicShapePath>(basicShape);
         ASSERT(pathShape.pathData());
         return CSSPathValue::create(copySVGPathByteStream(*pathShape.pathData(), conversion), pathShape.windRule());
     }
     case BasicShape::Type::Inset: {
-        auto& inset = downcast<BasicShapeInset>(basicShape);
+        auto& inset = uncheckedDowncast<BasicShapeInset>(basicShape);
         return CSSInsetShapeValue::create(createValue(inset.top()), createValue(inset.right()),
             createValue(inset.bottom()), createValue(inset.left()),
             createPair(inset.topLeftRadius()), createPair(inset.topRightRadius()),
             createPair(inset.bottomRightRadius()), createPair(inset.bottomLeftRadius()));
     }
     case BasicShape::Type::Xywh: {
-        auto& xywh = downcast<BasicShapeXywh>(basicShape);
+        auto& xywh = uncheckedDowncast<BasicShapeXywh>(basicShape);
         return CSSInsetShapeValue::create(createValue(xywh.insetY()), createReflectedSumValue(xywh.insetX(), xywh.width()),
             createReflectedSumValue(xywh.insetY(), xywh.height()), createValue(xywh.insetX()),
             createPair(xywh.topLeftRadius()), createPair(xywh.topRightRadius()),
             createPair(xywh.bottomRightRadius()), createPair(xywh.bottomLeftRadius()));
     }
     case BasicShape::Type::Rect: {
-        auto& rect = downcast<BasicShapeRect>(basicShape);
+        auto& rect = uncheckedDowncast<BasicShapeRect>(basicShape);
         return CSSInsetShapeValue::create(createValue(rect.top()), createReflectedValue(rect.right()),
             createReflectedValue(rect.bottom()), createValue(rect.left()),
             createPair(rect.topLeftRadius()), createPair(rect.topRightRadius()),

--- a/Source/WebCore/css/CSSValue.cpp
+++ b/Source/WebCore/css/CSSValue.cpp
@@ -100,138 +100,138 @@ template<typename Visitor> constexpr decltype(auto) CSSValue::visitDerived(Visit
 {
     switch (classType()) {
     case AspectRatioClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSAspectRatioValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSAspectRatioValue>(*this));
     case BackgroundRepeatClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSBackgroundRepeatValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSBackgroundRepeatValue>(*this));
     case BorderImageSliceClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSBorderImageSliceValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSBorderImageSliceValue>(*this));
     case BorderImageWidthClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSBorderImageWidthValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSBorderImageWidthValue>(*this));
     case CalculationClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSCalcValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSCalcValue>(*this));
     case CanvasClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSCanvasValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSCanvasValue>(*this));
     case CircleClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSCircleValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSCircleValue>(*this));
     case ConicGradientClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSConicGradientValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSConicGradientValue>(*this));
     case ContentDistributionClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSContentDistributionValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSContentDistributionValue>(*this));
     case CounterClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSCounterValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSCounterValue>(*this));
     case CrossfadeClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSCrossfadeValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSCrossfadeValue>(*this));
     case CubicBezierTimingFunctionClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSCubicBezierTimingFunctionValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSCubicBezierTimingFunctionValue>(*this));
     case CursorImageClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSCursorImageValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSCursorImageValue>(*this));
     case CustomPropertyClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSCustomPropertyValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSCustomPropertyValue>(*this));
     case DeprecatedLinearGradientClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSDeprecatedLinearGradientValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSDeprecatedLinearGradientValue>(*this));
     case DeprecatedRadialGradientClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSDeprecatedRadialGradientValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSDeprecatedRadialGradientValue>(*this));
     case EllipseClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSEllipseValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSEllipseValue>(*this));
     case FilterImageClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSFilterImageValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSFilterImageValue>(*this));
     case FontClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSFontValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSFontValue>(*this));
     case FontFaceSrcLocalClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSFontFaceSrcLocalValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSFontFaceSrcLocalValue>(*this));
     case FontFaceSrcResourceClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSFontFaceSrcResourceValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSFontFaceSrcResourceValue>(*this));
     case FontFeatureClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSFontFeatureValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSFontFeatureValue>(*this));
     case FontPaletteValuesOverrideColorsClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSFontPaletteValuesOverrideColorsValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSFontPaletteValuesOverrideColorsValue>(*this));
     case FontStyleWithAngleClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSFontStyleWithAngleValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSFontStyleWithAngleValue>(*this));
     case FontStyleRangeClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSFontStyleRangeValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSFontStyleRangeValue>(*this));
     case FontVariantAlternatesClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSFontVariantAlternatesValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSFontVariantAlternatesValue>(*this));
     case FontVariationClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSFontVariationValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSFontVariationValue>(*this));
     case FunctionClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSFunctionValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSFunctionValue>(*this));
     case GridAutoRepeatClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSGridAutoRepeatValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSGridAutoRepeatValue>(*this));
     case GridIntegerRepeatClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSGridIntegerRepeatValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSGridIntegerRepeatValue>(*this));
     case GridLineNamesClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSGridLineNamesValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSGridLineNamesValue>(*this));
     case GridTemplateAreasClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSGridTemplateAreasValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSGridTemplateAreasValue>(*this));
     case ImageClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSImageValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSImageValue>(*this));
     case ImageSetOptionClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSImageSetOptionValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSImageSetOptionValue>(*this));
     case ImageSetClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSImageSetValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSImageSetValue>(*this));
     case InsetShapeClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSInsetShapeValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSInsetShapeValue>(*this));
     case LineBoxContainClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSLineBoxContainValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSLineBoxContainValue>(*this));
     case LinearGradientClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSLinearGradientValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSLinearGradientValue>(*this));
     case LinearTimingFunctionClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSLinearTimingFunctionValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSLinearTimingFunctionValue>(*this));
     case NamedImageClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSNamedImageValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSNamedImageValue>(*this));
     case PrefixedLinearGradientClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSPrefixedLinearGradientValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSPrefixedLinearGradientValue>(*this));
     case PrefixedRadialGradientClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSPrefixedRadialGradientValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSPrefixedRadialGradientValue>(*this));
     case RadialGradientClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSRadialGradientValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSRadialGradientValue>(*this));
     case OffsetRotateClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSOffsetRotateValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSOffsetRotateValue>(*this));
     case PathClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSPathValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSPathValue>(*this));
     case PendingSubstitutionValueClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSPendingSubstitutionValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSPendingSubstitutionValue>(*this));
     case PolygonClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSPolygonValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSPolygonValue>(*this));
     case PrimitiveClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSPrimitiveValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSPrimitiveValue>(*this));
     case QuadClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSQuadValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSQuadValue>(*this));
     case RayClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSRayValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSRayValue>(*this));
     case RectClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSRectValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSRectValue>(*this));
     case RectShapeClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSRectShapeValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSRectShapeValue>(*this));
     case ReflectClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSReflectValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSReflectValue>(*this));
     case ScrollClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSScrollValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSScrollValue>(*this));
     case ShadowClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSShadowValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSShadowValue>(*this));
     case SubgridClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSSubgridValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSSubgridValue>(*this));
     case StepsTimingFunctionClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSStepsTimingFunctionValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSStepsTimingFunctionValue>(*this));
     case SpringTimingFunctionClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSSpringTimingFunctionValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSSpringTimingFunctionValue>(*this));
     case TransformListClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSTransformListValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSTransformListValue>(*this));
     case UnicodeRangeClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSUnicodeRangeValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSUnicodeRangeValue>(*this));
     case ValueListClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSValueList>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSValueList>(*this));
     case ValuePairClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSValuePair>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSValuePair>(*this));
     case VariableReferenceClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSVariableReferenceValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSVariableReferenceValue>(*this));
     case ViewClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSViewValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSViewValue>(*this));
     case XywhShapeClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSXywhValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSXywhValue>(*this));
 #if ENABLE(CSS_PAINTING_API)
     case PaintImageClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSPaintImageValue>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSPaintImageValue>(*this));
 #endif
     }
 
@@ -365,7 +365,7 @@ Ref<DeprecatedCSSOMValue> CSSValue::createDeprecatedCSSOMWrapper(CSSStyleDeclara
 {
     switch (classType()) {
     case ImageClass:
-        return downcast<CSSImageValue>(*this).createDeprecatedCSSOMWrapper(styleDeclaration);
+        return uncheckedDowncast<CSSImageValue>(*this).createDeprecatedCSSOMWrapper(styleDeclaration);
     case PrimitiveClass:
     case CounterClass:
     case QuadClass:

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -1534,7 +1534,7 @@ static Ref<CSSValue> valueForAnimationTimingFunction(const TimingFunction& timin
 {
     switch (timingFunction.type()) {
     case TimingFunction::Type::CubicBezierFunction: {
-        auto& function = downcast<CubicBezierTimingFunction>(timingFunction);
+        auto& function = uncheckedDowncast<CubicBezierTimingFunction>(timingFunction);
         if (function.timingFunctionPreset() != CubicBezierTimingFunction::TimingFunctionPreset::Custom) {
             CSSValueID valueId = CSSValueInvalid;
             switch (function.timingFunctionPreset()) {
@@ -1558,15 +1558,15 @@ static Ref<CSSValue> valueForAnimationTimingFunction(const TimingFunction& timin
         return CSSCubicBezierTimingFunctionValue::create(function.x1(), function.y1(), function.x2(), function.y2());
     }
     case TimingFunction::Type::StepsFunction: {
-        auto& function = downcast<StepsTimingFunction>(timingFunction);
+        auto& function = uncheckedDowncast<StepsTimingFunction>(timingFunction);
         return CSSStepsTimingFunctionValue::create(function.numberOfSteps(), function.stepPosition());
     }
     case TimingFunction::Type::SpringFunction: {
-        auto& function = downcast<SpringTimingFunction>(timingFunction);
+        auto& function = uncheckedDowncast<SpringTimingFunction>(timingFunction);
         return CSSSpringTimingFunctionValue::create(function.mass(), function.stiffness(), function.damping(), function.initialVelocity());
     }
     case TimingFunction::Type::LinearFunction: {
-        auto& function = downcast<LinearTimingFunction>(timingFunction);
+        auto& function = uncheckedDowncast<LinearTimingFunction>(timingFunction);
         if (function.points().isEmpty())
             return CSSPrimitiveValue::create(CSSValueLinear);
         return CSSLinearTimingFunctionValue::create(function.points());
@@ -1731,10 +1731,10 @@ static Ref<CSSValue> valueForPathOperation(const RenderStyle& style, const PathO
 
     switch (operation->type()) {
     case PathOperation::Reference:
-        return CSSPrimitiveValue::createURI(downcast<ReferencePathOperation>(*operation).url());
+        return CSSPrimitiveValue::createURI(uncheckedDowncast<ReferencePathOperation>(*operation).url());
 
     case PathOperation::Shape: {
-        auto& shapeOperation = downcast<ShapePathOperation>(*operation);
+        auto& shapeOperation = uncheckedDowncast<ShapePathOperation>(*operation);
         if (shapeOperation.referenceBox() == CSSBoxType::BoxMissing)
             return CSSValueList::createSpaceSeparated(valueForBasicShape(style, shapeOperation.basicShape(), conversion));
         return CSSValueList::createSpaceSeparated(valueForBasicShape(style, shapeOperation.basicShape(), conversion),
@@ -1742,10 +1742,10 @@ static Ref<CSSValue> valueForPathOperation(const RenderStyle& style, const PathO
     }
 
     case PathOperation::Box:
-        return createConvertingToCSSValueID(downcast<BoxPathOperation>(*operation).referenceBox());
+        return createConvertingToCSSValueID(uncheckedDowncast<BoxPathOperation>(*operation).referenceBox());
 
     case PathOperation::Ray: {
-        auto& ray = downcast<RayPathOperation>(*operation);
+        auto& ray = uncheckedDowncast<RayPathOperation>(*operation);
         auto angle = CSSPrimitiveValue::create(ray.angle(), CSSUnitType::CSS_DEG);
         RefPtr<CSSValuePair> position = ray.position().x().isAuto() ? nullptr : RefPtr { CSSValuePair::createNoncoalescing(Ref { zoomAdjustedPixelValueForLength(ray.position().x(), style) }, Ref { zoomAdjustedPixelValueForLength(ray.position().y(), style) }) };
         return CSSRayValue::create(WTFMove(angle), valueIDForRaySize(ray.size()), ray.isContaining(), WTFMove(position), ray.referenceBox());

--- a/Source/WebCore/css/StyleRule.cpp
+++ b/Source/WebCore/css/StyleRule.cpp
@@ -83,44 +83,44 @@ template<typename Visitor> constexpr decltype(auto) StyleRuleBase::visitDerived(
 {
     switch (type()) {
     case StyleRuleType::Style:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<StyleRule>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<StyleRule>(*this));
     case StyleRuleType::StyleWithNesting:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<StyleRuleWithNesting>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<StyleRuleWithNesting>(*this));
     case StyleRuleType::Page:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<StyleRulePage>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<StyleRulePage>(*this));
     case StyleRuleType::FontFace:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<StyleRuleFontFace>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<StyleRuleFontFace>(*this));
     case StyleRuleType::FontFeatureValues:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<StyleRuleFontFeatureValues>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<StyleRuleFontFeatureValues>(*this));
     case StyleRuleType::FontFeatureValuesBlock:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<StyleRuleFontFeatureValuesBlock>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<StyleRuleFontFeatureValuesBlock>(*this));
     case StyleRuleType::FontPaletteValues:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<StyleRuleFontPaletteValues>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<StyleRuleFontPaletteValues>(*this));
     case StyleRuleType::Media:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<StyleRuleMedia>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<StyleRuleMedia>(*this));
     case StyleRuleType::Supports:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<StyleRuleSupports>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<StyleRuleSupports>(*this));
     case StyleRuleType::Import:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<StyleRuleImport>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<StyleRuleImport>(*this));
     case StyleRuleType::Keyframes:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<StyleRuleKeyframes>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<StyleRuleKeyframes>(*this));
     case StyleRuleType::Namespace:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<StyleRuleNamespace>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<StyleRuleNamespace>(*this));
     case StyleRuleType::Keyframe:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<StyleRuleKeyframe>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<StyleRuleKeyframe>(*this));
     case StyleRuleType::Charset:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<StyleRuleCharset>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<StyleRuleCharset>(*this));
     case StyleRuleType::CounterStyle:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<StyleRuleCounterStyle>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<StyleRuleCounterStyle>(*this));
     case StyleRuleType::LayerBlock:
     case StyleRuleType::LayerStatement:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<StyleRuleLayer>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<StyleRuleLayer>(*this));
     case StyleRuleType::Container:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<StyleRuleContainer>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<StyleRuleContainer>(*this));
     case StyleRuleType::Property:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<StyleRuleProperty>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<StyleRuleProperty>(*this));
     case StyleRuleType::Scope:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<StyleRuleScope>(*this));
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<StyleRuleScope>(*this));
     case StyleRuleType::Margin:
         break;
     case StyleRuleType::Unknown:

--- a/Source/WebCore/css/StyleSheetContents.cpp
+++ b/Source/WebCore/css/StyleSheetContents.cpp
@@ -518,13 +518,13 @@ bool StyleSheetContents::traverseSubresources(const Function<bool(const CachedRe
     return traverseRules([&] (const StyleRuleBase& rule) {
         switch (rule.type()) {
         case StyleRuleType::Style:
-            return downcast<StyleRule>(rule).properties().traverseSubresources(handler);
+            return uncheckedDowncast<StyleRule>(rule).properties().traverseSubresources(handler);
         case StyleRuleType::StyleWithNesting:
-            return downcast<StyleRuleWithNesting>(rule).properties().traverseSubresources(handler);
+            return uncheckedDowncast<StyleRuleWithNesting>(rule).properties().traverseSubresources(handler);
         case StyleRuleType::FontFace:
-            return downcast<StyleRuleFontFace>(rule).properties().traverseSubresources(handler);
+            return uncheckedDowncast<StyleRuleFontFace>(rule).properties().traverseSubresources(handler);
         case StyleRuleType::Import:
-            if (auto* cachedResource = downcast<StyleRuleImport>(rule).cachedCSSStyleSheet())
+            if (auto* cachedResource = uncheckedDowncast<StyleRuleImport>(rule).cachedCSSStyleSheet())
                 return handler(*cachedResource);
             return false;
         case StyleRuleType::CounterStyle:

--- a/Source/WebCore/css/calc/CSSCalcValue.cpp
+++ b/Source/WebCore/css/calc/CSSCalcValue.cpp
@@ -93,28 +93,28 @@ static RefPtr<CSSCalcExpressionNode> createCSS(const CalcExpressionNode& node, c
 {
     switch (node.type()) {
     case CalcExpressionNodeType::Number: {
-        float value = downcast<CalcExpressionNumber>(node).value(); // double?
+        float value = uncheckedDowncast<CalcExpressionNumber>(node).value(); // double?
         return CSSCalcPrimitiveValueNode::create(CSSPrimitiveValue::create(value));
     }
     case CalcExpressionNodeType::Length: {
-        auto& length = downcast<CalcExpressionLength>(node).length();
+        auto& length = uncheckedDowncast<CalcExpressionLength>(node).length();
         return createCSS(length, style);
     }
 
     case CalcExpressionNodeType::Negation: {
-        auto childNode = createCSS(*downcast<CalcExpressionNegation>(node).child(), style);
+        auto childNode = createCSS(*uncheckedDowncast<CalcExpressionNegation>(node).child(), style);
         if (!childNode)
             return nullptr;
         return CSSCalcNegateNode::create(childNode.releaseNonNull());
     }
     case CalcExpressionNodeType::Inversion: {
-        auto childNode = createCSS(*downcast<CalcExpressionInversion>(node).child(), style);
+        auto childNode = createCSS(*uncheckedDowncast<CalcExpressionInversion>(node).child(), style);
         if (!childNode)
             return nullptr;
         return CSSCalcInvertNode::create(childNode.releaseNonNull());
     }
     case CalcExpressionNodeType::Operation: {
-        auto& operationNode = downcast<CalcExpressionOperation>(node);
+        auto& operationNode = uncheckedDowncast<CalcExpressionOperation>(node);
         auto& operationChildren = operationNode.children();
         CalcOperator op = operationNode.getOperator();
         
@@ -258,7 +258,7 @@ static RefPtr<CSSCalcExpressionNode> createCSS(const CalcExpressionNode& node, c
     }
     case CalcExpressionNodeType::BlendLength: {
         // FIXME: (http://webkit.org/b/122036) Create a CSSCalcExpressionNode equivalent of CalcExpressionBlendLength.
-        auto& blend = downcast<CalcExpressionBlendLength>(node);
+        auto& blend = uncheckedDowncast<CalcExpressionBlendLength>(node);
         float progress = blend.progress();
         return CSSCalcOperationNode::create(CalcOperator::Add, createBlendHalf(blend.from(), style, 1 - progress), createBlendHalf(blend.to(), style, progress));
     }

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -1224,7 +1224,7 @@ ExceptionOr<Ref<Node>> Document::importNode(Node& nodeToImport, bool deep)
         return nodeToImport.cloneNodeInternal(document(), deep ? CloningOperation::Everything : CloningOperation::OnlySelf);
 
     case ATTRIBUTE_NODE: {
-        auto& attribute = downcast<Attr>(nodeToImport);
+        auto& attribute = uncheckedDowncast<Attr>(nodeToImport);
         return Ref<Node> { Attr::create(*this, attribute.qualifiedName(), attribute.value()) };
     }
     case DOCUMENT_NODE: // Can't import a document into another document.
@@ -1244,7 +1244,7 @@ ExceptionOr<Ref<Node>> Document::adoptNode(Node& source)
     case DOCUMENT_NODE:
         return Exception { ExceptionCode::NotSupportedError };
     case ATTRIBUTE_NODE: {
-        auto& attr = downcast<Attr>(source);
+        auto& attr = uncheckedDowncast<Attr>(source);
         if (RefPtr element = attr.ownerElement()) {
             auto result = element->removeAttributeNode(attr);
             if (result.hasException())
@@ -4557,7 +4557,7 @@ bool Document::canAcceptChild(const Node& newChild, const Node* refChild, Accept
         return true;
     case DOCUMENT_FRAGMENT_NODE: {
         bool hasSeenElementChild = false;
-        for (RefPtr node = downcast<DocumentFragment>(newChild).firstChild(); node; node = node->nextSibling()) {
+        for (RefPtr node = uncheckedDowncast<DocumentFragment>(newChild).firstChild(); node; node = node->nextSibling()) {
             if (is<Element>(*node)) {
                 if (hasSeenElementChild)
                     return false;

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -5163,7 +5163,7 @@ void Element::createUniqueElementData()
     if (!m_elementData)
         m_elementData = UniqueElementData::create();
     else
-        m_elementData = downcast<ShareableElementData>(*m_elementData).makeUniqueCopy();
+        m_elementData = uncheckedDowncast<ShareableElementData>(*m_elementData).makeUniqueCopy();
 }
 
 bool Element::canContainRangeEndPoint() const

--- a/Source/WebCore/dom/ElementData.cpp
+++ b/Source/WebCore/dom/ElementData.cpp
@@ -45,7 +45,7 @@ void ElementData::destroy()
     if (auto* uniqueData = dynamicDowncast<UniqueElementData>(*this))
         delete uniqueData;
     else
-        delete downcast<ShareableElementData>(this);
+        delete uncheckedDowncast<ShareableElementData>(this);
 }
 
 ElementData::ElementData()

--- a/Source/WebCore/dom/ElementData.h
+++ b/Source/WebCore/dom/ElementData.h
@@ -252,7 +252,7 @@ inline const Attribute* ElementData::attributeBase() const
 {
     if (auto* uniqueData = dynamicDowncast<UniqueElementData>(*this))
         return uniqueData->m_attributeVector.data();
-    return downcast<ShareableElementData>(*this).m_attributeArray;
+    return uncheckedDowncast<ShareableElementData>(*this).m_attributeArray;
 }
 
 inline const ImmutableStyleProperties* ElementData::presentationalHintStyle() const

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -248,7 +248,7 @@ void Node::dumpStatistics()
                 ++elementNodes;
 
                 // Tag stats
-                Element& element = downcast<Element>(node);
+                Element& element = uncheckedDowncast<Element>(node);
                 HashMap<String, size_t>::AddResult result = perTagCount.add(element.tagName(), 1);
                 if (!result.isNewEntry)
                     result.iterator->value++;
@@ -709,7 +709,7 @@ void Node::normalize()
             continue;
         }
 
-        Ref text = downcast<Text>(*node);
+        Ref text = uncheckedDowncast<Text>(*node);
 
         // Remove empty text nodes.
         if (!text->length()) {
@@ -723,7 +723,7 @@ void Node::normalize()
         while (RefPtr nextSibling = node->nextSibling()) {
             if (nextSibling->nodeType() != TEXT_NODE)
                 break;
-            Ref nextText = downcast<Text>(nextSibling.releaseNonNull());
+            Ref nextText = uncheckedDowncast<Text>(nextSibling.releaseNonNull());
 
             // Remove empty text nodes.
             if (!nextText->length()) {
@@ -1490,8 +1490,8 @@ bool Node::isEqualNode(Node* other) const
     
     switch (nodeType) {
     case Node::DOCUMENT_TYPE_NODE: {
-        auto& thisDocType = downcast<DocumentType>(*this);
-        auto& otherDocType = downcast<DocumentType>(*other);
+        auto& thisDocType = uncheckedDowncast<DocumentType>(*this);
+        auto& otherDocType = uncheckedDowncast<DocumentType>(*other);
         if (thisDocType.name() != otherDocType.name())
             return false;
         if (thisDocType.publicId() != otherDocType.publicId())
@@ -1501,8 +1501,8 @@ bool Node::isEqualNode(Node* other) const
         break;
         }
     case Node::ELEMENT_NODE: {
-        auto& thisElement = downcast<Element>(*this);
-        auto& otherElement = downcast<Element>(*other);
+        auto& thisElement = uncheckedDowncast<Element>(*this);
+        auto& otherElement = uncheckedDowncast<Element>(*other);
         if (thisElement.tagQName() != otherElement.tagQName())
             return false;
         if (!thisElement.hasEquivalentAttributes(otherElement))
@@ -1510,8 +1510,8 @@ bool Node::isEqualNode(Node* other) const
         break;
         }
     case Node::PROCESSING_INSTRUCTION_NODE: {
-        auto& thisProcessingInstruction = downcast<ProcessingInstruction>(*this);
-        auto& otherProcessingInstruction = downcast<ProcessingInstruction>(*other);
+        auto& thisProcessingInstruction = uncheckedDowncast<ProcessingInstruction>(*this);
+        auto& otherProcessingInstruction = uncheckedDowncast<ProcessingInstruction>(*other);
         if (thisProcessingInstruction.target() != otherProcessingInstruction.target())
             return false;
         if (thisProcessingInstruction.data() != otherProcessingInstruction.data())
@@ -1521,15 +1521,15 @@ bool Node::isEqualNode(Node* other) const
     case Node::CDATA_SECTION_NODE:
     case Node::TEXT_NODE:
     case Node::COMMENT_NODE: {
-        auto& thisCharacterData = downcast<CharacterData>(*this);
-        auto& otherCharacterData = downcast<CharacterData>(*other);
+        auto& thisCharacterData = uncheckedDowncast<CharacterData>(*this);
+        auto& otherCharacterData = uncheckedDowncast<CharacterData>(*other);
         if (thisCharacterData.data() != otherCharacterData.data())
             return false;
         break;
         }
     case Node::ATTRIBUTE_NODE: {
-        auto& thisAttribute = downcast<Attr>(*this);
-        auto& otherAttribute = downcast<Attr>(*other);
+        auto& thisAttribute = uncheckedDowncast<Attr>(*this);
+        auto& otherAttribute = uncheckedDowncast<Attr>(*other);
         if (thisAttribute.qualifiedName() != otherAttribute.qualifiedName())
             return false;
         if (thisAttribute.value() != otherAttribute.value())
@@ -1568,7 +1568,7 @@ static const AtomString& locateDefaultNamespace(const Node& node, const AtomStri
         if (prefix == xmlnsAtom())
             return XMLNSNames::xmlnsNamespaceURI.get();
 
-        auto& element = downcast<Element>(node);
+        auto& element = uncheckedDowncast<Element>(node);
         auto& namespaceURI = element.namespaceURI();
         if (!namespaceURI.isNull() && element.prefix() == prefix)
             return namespaceURI;
@@ -1588,14 +1588,14 @@ static const AtomString& locateDefaultNamespace(const Node& node, const AtomStri
         return parent ? locateDefaultNamespace(*parent, prefix) : nullAtom();
     }
     case Node::DOCUMENT_NODE:
-        if (auto* documentElement = downcast<Document>(node).documentElement())
+        if (auto* documentElement = uncheckedDowncast<Document>(node).documentElement())
             return locateDefaultNamespace(*documentElement, prefix);
         return nullAtom();
     case Node::DOCUMENT_TYPE_NODE:
     case Node::DOCUMENT_FRAGMENT_NODE:
         return nullAtom();
     case Node::ATTRIBUTE_NODE:
-        if (auto* ownerElement = downcast<Attr>(node).ownerElement())
+        if (auto* ownerElement = uncheckedDowncast<Attr>(node).ownerElement())
             return locateDefaultNamespace(*ownerElement, prefix);
         return nullAtom();
     default:
@@ -1643,16 +1643,16 @@ const AtomString& Node::lookupPrefix(const AtomString& namespaceURI) const
     
     switch (nodeType()) {
     case ELEMENT_NODE:
-        return locateNamespacePrefix(downcast<Element>(*this), namespaceURI);
+        return locateNamespacePrefix(uncheckedDowncast<Element>(*this), namespaceURI);
     case DOCUMENT_NODE:
-        if (auto* documentElement = downcast<Document>(*this).documentElement())
+        if (auto* documentElement = uncheckedDowncast<Document>(*this).documentElement())
             return locateNamespacePrefix(*documentElement, namespaceURI);
         return nullAtom();
     case DOCUMENT_FRAGMENT_NODE:
     case DOCUMENT_TYPE_NODE:
         return nullAtom();
     case ATTRIBUTE_NODE:
-        if (auto* ownerElement = downcast<Attr>(*this).ownerElement())
+        if (auto* ownerElement = uncheckedDowncast<Attr>(*this).ownerElement())
             return locateNamespacePrefix(*ownerElement, namespaceURI);
         return nullAtom();
     default:
@@ -1669,17 +1669,17 @@ static void appendTextContent(const Node* node, bool convertBRsToNewlines, bool&
     case Node::CDATA_SECTION_NODE:
     case Node::COMMENT_NODE:
         isNullString = false;
-        content.append(downcast<CharacterData>(*node).data());
+        content.append(uncheckedDowncast<CharacterData>(*node).data());
         break;
 
     case Node::PROCESSING_INSTRUCTION_NODE:
         isNullString = false;
-        content.append(downcast<ProcessingInstruction>(*node).data());
+        content.append(uncheckedDowncast<ProcessingInstruction>(*node).data());
         break;
     
     case Node::ATTRIBUTE_NODE:
         isNullString = false;
-        content.append(downcast<Attr>(*node).value());
+        content.append(uncheckedDowncast<Attr>(*node).value());
         break;
 
     case Node::ELEMENT_NODE:
@@ -1724,7 +1724,7 @@ void Node::setTextContent(String&& text)
         return;
     case ELEMENT_NODE:
     case DOCUMENT_FRAGMENT_NODE:
-        downcast<ContainerNode>(*this).stringReplaceAll(WTFMove(text));
+        uncheckedDowncast<ContainerNode>(*this).stringReplaceAll(WTFMove(text));
         return;
     case DOCUMENT_NODE:
     case DOCUMENT_TYPE_NODE:
@@ -1959,7 +1959,7 @@ void Node::showNodePathForThis() const
         case ELEMENT_NODE: {
             fprintf(stderr, "/%s", node->nodeName().utf8().data());
 
-            const Element& element = downcast<Element>(*node);
+            const Element& element = uncheckedDowncast<Element>(*node);
             const AtomString& idattr = element.getIdAttribute();
             bool hasIdAttr = !idattr.isNull() && !idattr.isEmpty();
             if (node->previousSibling() || node->nextSibling()) {

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -394,7 +394,7 @@ auto Scope::collectActiveStyleSheets() -> ActiveStyleSheetCollection
                 styleSheetsForStyleSheetsList.append(sheet);
             LOG_WITH_STREAM(StyleSheets, stream << " adding sheet " << sheet << " from ProcessingInstruction node " << node);
         } else if (is<HTMLLinkElement>(node) || is<HTMLStyleElement>(node) || is<SVGStyleElement>(node)) {
-            Element& element = downcast<Element>(node);
+            Element& element = uncheckedDowncast<Element>(node);
             AtomString title = element.isInShadowTree() ? nullAtom() : element.attributeWithoutSynchronization(titleAttr);
             bool enabledViaScript = false;
             if (auto* linkElement = dynamicDowncast<HTMLLinkElement>(element)) {


### PR DESCRIPTION
#### 79e81a318c92f39fccf9f61711d49a7ba5525413
<pre>
[ARM] Add release build type check to downcast&lt;T&gt;()
<a href="https://bugs.webkit.org/show_bug.cgi?id=266588">https://bugs.webkit.org/show_bug.cgi?id=266588</a>

Reviewed by Brent Fulgham and Ryosuke Niwa.

Add release build type check to downcast&lt;T&gt;() on ARM, where this tested as
performance neutral. Some more work will be needed to make it affordable on
Intel.

This patch introduces an uncheckedDowncast&lt;&gt;() which only does the type check
on debug builds (like downcast&lt;&gt;() used to do). It is useful for cases where
it is clear the code is safe (e.g. in a switch statement for the type),
especially in hot code.

This patch also converts some more `is&lt;&gt;() + downcast&lt;&gt;()` calls with
`dynamicDowncast&lt;&gt;()`, which is now more efficient.

* Source/WTF/wtf/Ref.h:
(WTF::uncheckedDowncast):
(WTF::downcast):
* Source/WTF/wtf/RefPtr.h:
(WTF::uncheckedDowncast):
(WTF::downcast):
* Source/WTF/wtf/TypeCasts.h:
(WTF::uncheckedDowncast):
(WTF::downcast):
* Source/WTF/wtf/WeakPtr.h:
(WTF::downcast):
* Source/WTF/wtf/WeakRef.h:
(WTF::downcast):
* Source/WebCore/animation/AcceleratedTimeline.cpp:
(WebCore::AcceleratedTimeline::updateEffectStacks):
* Source/WebCore/animation/AnimationEffect.cpp:
(WebCore::AnimationEffect::bindingsUpdateTiming):
(WebCore::AnimationEffect::progressUntilNextStep const):
* Source/WebCore/animation/AnimationTimeline.cpp:
(WebCore::AnimationTimeline::animationTimingDidChange):
* Source/WebCore/animation/CSSAnimation.cpp:
(WebCore::CSSAnimation::keyframesRuleDidChange):
(WebCore::CSSAnimation::updateKeyframesIfNeeded):
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::blendFunc):
* Source/WebCore/animation/DocumentTimeline.cpp:
(WebCore::DocumentTimeline::animationCanBeRemoved):
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::getKeyframes):
(WebCore::KeyframeEffect::setBindingsKeyframes):
(WebCore::KeyframeEffect::computeCSSAnimationBlendingKeyframes):
(WebCore::KeyframeEffect::computeCSSTransitionBlendingKeyframes):
(WebCore::isLinearTimingFunctionWithPoints):
(WebCore::KeyframeEffect::computeSomeKeyframesUseStepsOrLinearTimingFunctionWithPoints):
(WebCore::KeyframeEffect::setAnimatedPropertiesInStyle):
(WebCore::KeyframeEffect::computeExtentOfTransformAnimation const):
(WebCore::KeyframeEffect::progressUntilNextStep const):
(WebCore::KeyframeEffect::timingFunctionForKeyframe const):
* Source/WebCore/animation/ViewTimeline.cpp:
(WebCore::ViewTimeline::createFromCSSValue):
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::setEffectInternal):
(WebCore::WebAnimation::setTimeline):
(WebCore::WebAnimation::acceleratedStateDidChange):
(WebCore::WebAnimation::updateRelevance):
(WebCore::WebAnimation::isReplaceable const):
(WebCore::WebAnimation::commitStyles):
* Source/WebCore/animation/WebAnimationUtilities.cpp:
(WebCore::compareAnimationsByCompositeOrder):
(WebCore::compareDeclarativeAnimationEvents):
* Source/WebCore/bindings/js/JSNodeCustom.cpp:
(WebCore::createWrapperInline):
* Source/WebCore/css/BasicShapeFunctions.cpp:
(WebCore::valueForBasicShape):
* Source/WebCore/css/CSSValue.cpp:
(WebCore::CSSValue::visitDerived):
(WebCore::CSSValue::createDeprecatedCSSOMWrapper const):
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::valueForAnimationTimingFunction):
(WebCore::valueForPathOperation):
* Source/WebCore/css/StyleRule.cpp:
(WebCore::StyleRuleBase::visitDerived):
* Source/WebCore/css/StyleSheetContents.cpp:
(WebCore::StyleSheetContents::traverseSubresources const):
* Source/WebCore/css/TransformFunctions.cpp:
(WebCore::transformForValue):
* Source/WebCore/css/calc/CSSCalcValue.cpp:
(WebCore::createCSS):
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::consumeFontFeatureValuesRule):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::importNode):
(WebCore::Document::adoptNode):
(WebCore::Document::canAcceptChild const):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::createUniqueElementData):
* Source/WebCore/dom/ElementData.cpp:
(WebCore::ElementData::destroy):
* Source/WebCore/dom/ElementData.h:
(WebCore::ElementData::attributeBase const):
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::dumpStatistics):
(WebCore::Node::normalize):
(WebCore::Node::isEqualNode const):
(WebCore::locateDefaultNamespace):
(WebCore::Node::lookupPrefix const):
(WebCore::appendTextContent):
(WebCore::Node::setTextContent):
(WebCore::Node::showNodePathForThis const):
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::applyProperty):
(WebCore::Style::Builder::resolveVariableReferences):
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertTextDecorationLine):
(WebCore::Style::BuilderConverter::convertTextTransform):
(WebCore::Style::BuilderConverter::convertColorScheme):
(WebCore::Style::BuilderConverter::convertTextEmphasisPosition):
(WebCore::Style::BuilderConverter::convertPathOperation):
(WebCore::Style::BuilderConverter::convertQuotes):
(WebCore::Style::BuilderConverter::convertShapeValue):
(WebCore::Style::BuilderConverter::convertScrollbarGutter):
(WebCore::Style::BuilderConverter::createGridTrackSize):
(WebCore::Style::BuilderConverter::createGridTrackList):
(WebCore::Style::BuilderConverter::createGridPosition):
(WebCore::Style::BuilderConverter::convertGridTrackSizeList):
(WebCore::Style::BuilderConverter::convertGridAutoFlow):
(WebCore::Style::BuilderConverter::convertFontSizeAdjust):
(WebCore::Style::BuilderConverter::convertTouchAction):
(WebCore::Style::BuilderConverter::convertContentAlignmentData):
(WebCore::Style::BuilderConverter::convertSpeakAs):
(WebCore::Style::BuilderConverter::convertHangingPunctuation):
(WebCore::Style::BuilderConverter::convertContainerName):
(WebCore::Style::BuilderConverter::convertViewTransitionName):
(WebCore::Style::BuilderConverter::convertWillChange):
(WebCore::Style::BuilderConverter::convertScrollTimelineName):
(WebCore::Style::BuilderConverter::convertScrollTimelineAxis):
(WebCore::Style::BuilderConverter::convertViewTimelineInset):
* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::BuilderCustom::applyValueSize):
(WebCore::Style::maybeUpdateFontForLetterSpacing):
(WebCore::Style::BuilderCustom::applyValueAspectRatio):
(WebCore::Style::BuilderCustom::applyValueTextEmphasisStyle):
(WebCore::Style::BuilderCustom::applyValueCursor):
(WebCore::Style::BuilderCustom::applyValueFill):
(WebCore::Style::BuilderCustom::applyValueStroke):
(WebCore::Style::BuilderCustom::applyValueContent):
(WebCore::Style::BuilderCustom::applyValueContainIntrinsicWidth):
(WebCore::Style::BuilderCustom::applyValueContainIntrinsicHeight):
* Source/WebCore/style/StyleBuilderState.cpp:
(WebCore::Style::BuilderState::createStyleImage):
* Source/WebCore/style/StyleInvalidator.cpp:
(WebCore::Style::shouldDirtyAllStyle):
(WebCore::Style::invalidateAssignedElements):
(WebCore::Style::Invalidator::invalidateIfNeeded):
* Source/WebCore/style/StylePendingResources.cpp:
(WebCore::Style::loadPendingResources):
* Source/WebCore/style/StyleResolveForFontRaw.cpp:
(WebCore::Style::resolveForFontRaw):
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::styleForKeyframe):
* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::releaseMemory):
(WebCore::Style::Scope::collectXSLTransforms):
(WebCore::Style::Scope::collectActiveStyleSheets):
(WebCore::Style::filterEnabledNonemptyCSSStyleSheets):
(WebCore::Style::Scope::activeStyleSheetsForInspector):
* Source/WebCore/style/StyleSharingResolver.cpp:
(WebCore::Style::elementHasDirectionAuto):
(WebCore::Style::SharingResolver::resolve):
(WebCore::Style::SharingResolver::findSibling const):
(WebCore::Style::SharingResolver::canShareStyleWithElement const):
* Source/WebCore/style/Styleable.cpp:
(WebCore::Styleable::fromRenderer):
(WebCore::Styleable::renderer const):
(WebCore::updateCSSTransitionsForStyleableAndProperty):
* Source/WebCore/style/Styleable.h:
(WebCore::Styleable::fromElement):
* Source/WebCore/svg/SVGAnimateElementBase.h:
(isType):
* Source/WebCore/svg/SVGComponentTransferFunctionElementInlines.h:
(isType):
* Source/WebCore/svg/SVGDocument.h:
(isType):
* Source/WebCore/svg/SVGElementInlines.h:
(WebCore::Node::hasTagName const):
* Source/WebCore/svg/SVGGeometryElement.h:
(isType):
* Source/WebCore/svg/SVGGradientElement.h:
(isType):
* Source/WebCore/svg/SVGGraphicsElement.h:
(isType):
* Source/WebCore/svg/SVGLengthContext.cpp:
(WebCore::SVGLengthContext::computeViewportSize const):
* Source/WebCore/svg/SVGLengthValue.cpp:
(WebCore::SVGLengthValue::toCSSPrimitiveValue const):
* Source/WebCore/svg/SVGLinearGradientElement.cpp:
(WebCore::SVGLinearGradientElement::collectGradientAttributes):
* Source/WebCore/svg/SVGLocatable.cpp:
(WebCore::SVGLocatable::computeCTM):
(WebCore::SVGLocatable::getTransformToElement):
* Source/WebCore/svg/SVGMPathElement.cpp:
(WebCore::SVGMPathElement::buildPendingResource):
(WebCore::SVGMPathElement::pathElement):
(WebCore::SVGMPathElement::notifyParentOfPathChange):
* Source/WebCore/svg/SVGPathElement.cpp:
(WebCore::SVGPathElement::invalidateMPathDependencies):
* Source/WebCore/svg/SVGPolyElement.h:
(isType):
* Source/WebCore/svg/SVGRadialGradientElement.cpp:
(WebCore::SVGRadialGradientElement::collectGradientAttributes):
* Source/WebCore/svg/SVGSVGElement.cpp:
(WebCore::SVGSVGElement::localCoordinateSpaceTransform const):
* Source/WebCore/svg/SVGTextContentElement.cpp:
(WebCore::SVGTextContentElement::elementFromRenderer):
* Source/WebCore/svg/SVGTextContentElement.h:
(isType):
* Source/WebCore/svg/SVGUseElement.cpp:
(WebCore::isDisallowedElement):
(WebCore::SVGUseElement::toClipPath):
(WebCore::disassociateAndRemoveClones):
(WebCore::SVGUseElement::findTarget const):
* Source/WebCore/svg/animation/SVGSMILElement.cpp:
(WebCore::SVGSMILElement::buildPendingResource):
(WebCore::SVGSMILElement::connectConditions):
* Source/WebCore/svg/animation/SVGSMILElement.h:
(isType):
* Source/WebCore/svg/graphics/SVGImage.cpp:
(WebCore::SVGImage::renderingTaintsOrigin const):
* Source/WebCore/svg/properties/SVGPropertyAnimator.h:
(WebCore::SVGPropertyAnimator::computeInheritedCSSPropertyValue const):

Canonical link: <a href="https://commits.webkit.org/272296@main">https://commits.webkit.org/272296@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/378098c55fe108882d11653e4b151cce85c0ad27

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/31276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/9947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/32970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/33779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/28369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/32043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/12292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/7201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/33779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/31612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/12292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/32970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/33779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/12292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/32970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/35121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/26845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/12292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/32970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/35121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/31344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/7426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/7201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/35121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/9102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/32970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/37793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/8125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/8066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4065 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/7950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->