### PR TITLE
[JSC] Async functions and generators should properly handle broken promises

### DIFF
--- a/JSTests/stress/async-function-broken-promise.js
+++ b/JSTests/stress/async-function-broken-promise.js
@@ -1,0 +1,107 @@
+const log = msg => { logsActual.push(msg); };
+const logsActual = [];
+const logsExpected = `
+CAUGHT broken promise #2
+CAUGHT broken promise #4
+CAUGHT broken promise #6
+CAUGHT broken promise #8
+Promise.all() called
+tick #1
+REJECTED broken promise #1
+tick #2
+tick #3
+REJECTED broken promise #3
+tick #4
+tick #5
+REJECTED broken promise #5
+tick #6
+tick #7
+REJECTED broken promise #7
+tick #8
+Promise.all() resolved
+`.trim();
+
+function shouldBeRejected(promise) {
+  return new Promise((resolve, reject) => {
+    promise.then(reject, err => {
+      log(`REJECTED ${err.message}`);
+      resolve();
+    });
+  });
+}
+
+function makeTick(id) {
+  Promise.resolve().then(() => {
+    log(`tick #${id}`);
+  });
+}
+
+function makeBrokenPromise(id) {
+  const brokenPromise = Promise.resolve(id);
+  Object.defineProperty(brokenPromise, "constructor", {
+    get() { throw new Error(`broken promise #${id}`); },
+  });
+  return brokenPromise;
+}
+
+async function brokenPromiseInAwaitOfAsyncFunction() {
+  makeTick(1);
+  await makeBrokenPromise(1);
+}
+
+async function brokenPromiseCaughtInAwaitOfAsyncFunction() {
+  makeTick(2);
+  try { await makeBrokenPromise(2); }
+  catch (err) { log(`CAUGHT ${err.message}`); }
+}
+
+async function* brokenPromiseInAwaitOfAsyncGeneratorFunction() {
+  makeTick(3);
+  await makeBrokenPromise(3);
+}
+
+async function* brokenPromiseCaughtInAwaitOfAsyncGeneratorFunction() {
+  makeTick(4);
+  try { await makeBrokenPromise(4); }
+  catch (err) { log(`CAUGHT ${err.message}`); }
+}
+
+async function* brokenPromiseInYieldOfAsyncGeneratorFunction() {
+  makeTick(5);
+  yield makeBrokenPromise(5);
+}
+
+async function* brokenPromiseCaughtInYieldOfAsyncGeneratorFunction() {
+  makeTick(6);
+  try { yield makeBrokenPromise(6); }
+  catch (err) { log(`CAUGHT ${err.message}`); }
+}
+
+async function* brokenPromiseInReturnOfAsyncGeneratorFunction() {
+  makeTick(7);
+  return makeBrokenPromise(7);
+}
+
+async function* brokenPromiseCaughtInReturnOfAsyncGeneratorFunction() {
+  makeTick(8);
+  try { return makeBrokenPromise(8); }
+  catch (err) { log(`CAUGHT ${err.message}`); }
+}
+
+Promise.all([
+  shouldBeRejected(brokenPromiseInAwaitOfAsyncFunction()),
+  brokenPromiseCaughtInAwaitOfAsyncFunction(),
+  shouldBeRejected(brokenPromiseInAwaitOfAsyncGeneratorFunction().next()),
+  brokenPromiseCaughtInAwaitOfAsyncGeneratorFunction().next(),
+  shouldBeRejected(brokenPromiseInYieldOfAsyncGeneratorFunction().next()),
+  brokenPromiseCaughtInYieldOfAsyncGeneratorFunction().next(),
+  shouldBeRejected(brokenPromiseInReturnOfAsyncGeneratorFunction().next()),
+  brokenPromiseCaughtInReturnOfAsyncGeneratorFunction().next(),
+  log("Promise.all() called"),
+]).then(() => {
+  log("Promise.all() resolved");
+});
+
+drainMicrotasks();
+if (logsActual.join("\n") !== logsExpected)
+  throw new Error(`Bad logs!\n\n${logsActual.join("\n")}`)

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -7,12 +7,6 @@ test/built-ins/Array/fromAsync/this-constructor-operations.js:
 test/built-ins/Array/fromAsync/this-constructor.js:
   default: 'Test262:AsyncTestFailure:Test262Error: Test262Error: constructor is called once Expected SameValue(«2», «1») to be true'
   strict mode: 'Test262:AsyncTestFailure:Test262Error: Test262Error: constructor is called once Expected SameValue(«2», «1») to be true'
-test/built-ins/AsyncGeneratorPrototype/return/return-suspendedStart-broken-promise.js:
-  default: 'Error: broken promise'
-  strict mode: 'Error: broken promise'
-test/built-ins/AsyncGeneratorPrototype/return/return-suspendedYield-broken-promise-try-catch.js:
-  default: 'Test262:AsyncTestFailure:Error: broken promise'
-  strict mode: 'Test262:AsyncTestFailure:Error: broken promise'
 test/built-ins/Function/internals/Construct/derived-return-val-realm.js:
   default: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
   strict mode: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'

--- a/Source/JavaScriptCore/builtins/PromiseOperations.js
+++ b/Source/JavaScriptCore/builtins/PromiseOperations.js
@@ -382,7 +382,13 @@ function resolveWithoutPromiseForAsyncAwait(resolution, onFulfilled, onRejected,
     "use strict";
 
     if (@isPromise(resolution)) {
-        var constructor = resolution.constructor;
+        try {
+            var { constructor } = resolution;
+        } catch (error) {
+            onRejected(error, context);
+            return;
+        }
+
         if (constructor === @Promise || constructor === @InternalPromise)
             return @performPromiseThen(resolution, onFulfilled, onRejected, @undefined, context);
     }


### PR DESCRIPTION
#### 766a344cdf5c50e18624ceda6f98f2d9d3f5eac1
<pre>
[JSC] Async functions and generators should properly handle broken promises
<a href="https://bugs.webkit.org/show_bug.cgi?id=266502">https://bugs.webkit.org/show_bug.cgi?id=266502</a>
&lt;<a href="https://rdar.apple.com/problem/119734587">rdar://problem/119734587</a>&gt;

Reviewed by Justin Michaud.

Before this change, abrupt completions of PromiseResolve [1] that arised during &quot;constructor&quot; lookup
were not handled properly in async functions and generators, resulting in exception propagation up
the call stack rather than rejecting a promise. That affected `await`, `yield`, and `return` called
with a broken promise (i.e. with throwing &quot;constructor&quot; getter).

Most likely, this is a regression from implementing async / await tick reduction proposal [2].

This patch guards &quot;constructor&quot; lookup with exception handling, ensuring that all call sites supply
onRejected() callback that is semantically equivalent to throwing an exception at that point, as per
spec. Invoking onRejected() synchronously, without extra microtask, is also required to match the
standard, V8, and SpiderMonkey.

Also, this change implements a proposal [3] to fix AsyncGenerator.prototype.return() called on a
broken promise, aligning JSC with V8.

[1]: <a href="https://tc39.es/ecma262/#sec-promise-resolve">https://tc39.es/ecma262/#sec-promise-resolve</a> (step 1.a)
[2]: <a href="https://github.com/tc39/ecma262/pull/1250">https://github.com/tc39/ecma262/pull/1250</a>
[3]: <a href="https://github.com/tc39/ecma262/pull/2683">https://github.com/tc39/ecma262/pull/2683</a>

* JSTests/stress/async-function-broken-promise.js: Added.
* JSTests/test262/expectations.yaml: Mark 4 tests as passing.
* Source/JavaScriptCore/builtins/PromiseOperations.js:
(linkTimeConstant.resolveWithoutPromiseForAsyncAwait):

Canonical link: <a href="https://commits.webkit.org/272291@main">https://commits.webkit.org/272291@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d77e4d0415b63f406c35feee76459d5eda279b9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31017 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9692 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32707 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33531 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28019 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12039 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6954 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27868 "Found 1 new test failure: media/media-source/media-source-abort-resets-parser.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31349 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8169 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27745 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7014 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7185 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27626 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34869 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/26661 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28243 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28096 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33320 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/31118 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7220 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5287 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31153 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8919 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/37537 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7927 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8039 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4062 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7765 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->