### PR TITLE
[WebGPU] CTS test validation/buffer/mapping.html is failing

### DIFF
--- a/LayoutTests/http/tests/webgpu/webgpu/api/validation/buffer/mapping-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/validation/buffer/mapping-expected.txt
@@ -1,1 +1,37 @@
-(Populate me when we're ready to investigate this test)
+
+PASS :mapAsync,usage:
+PASS :mapAsync,invalidBuffer:
+PASS :mapAsync,state,destroyed:
+PASS :mapAsync,state,mappedAtCreation:
+PASS :mapAsync,state,mapped:
+PASS :mapAsync,state,mappingPending:
+PASS :mapAsync,sizeUnspecifiedOOB:
+PASS :mapAsync,offsetAndSizeAlignment:
+PASS :mapAsync,offsetAndSizeOOB:
+PASS :mapAsync,earlyRejection:
+PASS :mapAsync,abort_over_invalid_error:
+PASS :getMappedRange,state,mapped:
+PASS :getMappedRange,state,mappedAtCreation:
+PASS :getMappedRange,state,invalid_mappedAtCreation:
+PASS :getMappedRange,state,mappedAgain:
+PASS :getMappedRange,state,unmapped:
+PASS :getMappedRange,state,destroyed:
+PASS :getMappedRange,state,mappingPending:
+PASS :getMappedRange,subrange,mapped:mapMode=1
+PASS :getMappedRange,subrange,mapped:mapMode=2
+PASS :getMappedRange,subrange,mappedAtCreation:
+PASS :getMappedRange,offsetAndSizeAlignment,mapped:mapMode=1
+PASS :getMappedRange,offsetAndSizeAlignment,mapped:mapMode=2
+PASS :getMappedRange,offsetAndSizeAlignment,mappedAtCreation:
+PASS :getMappedRange,sizeAndOffsetOOB,mappedAtCreation:
+PASS :getMappedRange,sizeAndOffsetOOB,mapped:
+PASS :getMappedRange,disjointRanges:
+PASS :getMappedRange,disjoinRanges_many:
+PASS :unmap,state,unmapped:
+PASS :unmap,state,destroyed:
+PASS :unmap,state,mappedAtCreation:
+PASS :unmap,state,mapped:
+PASS :unmap,state,mappingPending:
+PASS :gc_behavior,mappedAtCreation:
+PASS :gc_behavior,mapAsync:
+

--- a/Source/WebCore/Modules/WebGPU/GPUBuffer.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUBuffer.cpp
@@ -45,7 +45,10 @@ GPUBuffer::GPUBuffer(Ref<WebGPU::Buffer>&& backing, size_t bufferSize, GPUBuffer
     , m_usage(usage)
     , m_mapState(mappedAtCreation ? GPUBufferMapState::Mapped : GPUBufferMapState::Unmapped)
     , m_device(device)
+    , m_mappedAtCreation(mappedAtCreation)
 {
+    if (mappedAtCreation)
+        m_mappedRangeSize = m_bufferSize;
 }
 
 String GPUBuffer::label() const
@@ -60,13 +63,8 @@ void GPUBuffer::setLabel(String&& label)
 
 void GPUBuffer::mapAsync(GPUMapModeFlags mode, std::optional<GPUSize64> offset, std::optional<GPUSize64> size, MapAsyncPromise&& promise)
 {
-    if (!m_bufferSize || (size.has_value() && !size.value())) {
-        promise.resolve(nullptr);
-        return;
-    }
-
     if (m_pendingMapPromise) {
-        promise.reject(Exception { ExceptionCode::OperationError });
+        promise.reject(Exception { ExceptionCode::OperationError, "pendingMapPromise"_s });
         return;
     }
 
@@ -75,20 +73,26 @@ void GPUBuffer::mapAsync(GPUMapModeFlags mode, std::optional<GPUSize64> offset, 
 
     m_pendingMapPromise = promise;
     // FIXME: Should this capture a weak pointer to |this| instead?
-    m_backing->mapAsync(convertMapModeFlagsToBacking(mode), offset.value_or(0), size, [promise = WTFMove(promise), protectedThis = Ref { *this }](bool success) mutable {
+    m_backing->mapAsync(convertMapModeFlagsToBacking(mode), offset.value_or(0), size, [promise = WTFMove(promise), protectedThis = Ref { *this }, offset, size](bool success) mutable {
         if (!protectedThis->m_pendingMapPromise) {
-            promise.resolve(nullptr);
+            if (protectedThis->m_destroyed)
+                promise.reject(Exception { ExceptionCode::OperationError, "buffer destroyed during mapAsync"_s });
+            else
+                promise.resolve(nullptr);
             return;
         }
 
         protectedThis->m_pendingMapPromise = std::nullopt;
         if (success) {
             protectedThis->m_mapState = GPUBufferMapState::Mapped;
+            protectedThis->m_mappedRangeOffset = offset.value_or(0);
+            protectedThis->m_mappedRangeSize = size.value_or(protectedThis->m_bufferSize - protectedThis->m_mappedRangeOffset);
             promise.resolve(nullptr);
         } else {
             if (protectedThis->m_mapState == GPUBufferMapState::Pending)
                 protectedThis->m_mapState = GPUBufferMapState::Unmapped;
-            promise.reject(Exception { ExceptionCode::OperationError });
+
+            promise.reject(Exception { ExceptionCode::OperationError, "map async was not successful"_s });
         }
     });
 }
@@ -102,16 +106,77 @@ static auto makeArrayBuffer(auto source, auto byteLength, auto& cachedArrayBuffe
     return arrayBuffer;
 }
 
-ExceptionOr<Ref<JSC::ArrayBuffer>> GPUBuffer::getMappedRange(std::optional<GPUSize64> offset, std::optional<GPUSize64> size)
+static bool containsRange(size_t offset, size_t endOffset, const auto& mappedRanges, const auto& mappedPoints)
 {
-    if (!m_bufferSize || (size.has_value() && !size.value()))
-        return makeArrayBuffer(static_cast<size_t>(0U), 1, m_arrayBuffer, m_device, *this);
+    if (offset == endOffset) {
+        if (mappedPoints.contains(offset))
+            return true;
 
-    // size is <= the size of the buffer is validated in WebGPU.framework
-    m_mappedRange = m_backing->getMappedRange(offset.value_or(0), size);
+        for (auto& range : mappedRanges) {
+            if (range.begin() < offset && offset < range.end())
+                return true;
+        }
+        return false;
+    }
+
+    if (mappedRanges.overlaps({ offset, endOffset }))
+        return true;
+
+    for (auto& i : mappedPoints) {
+        if (offset < i && i < endOffset)
+            return true;
+    }
+
+    return false;
+}
+
+ExceptionOr<Ref<JSC::ArrayBuffer>> GPUBuffer::getMappedRange(std::optional<GPUSize64> optionalOffset, std::optional<GPUSize64> optionalSize)
+{
+    if (m_mapState != GPUBufferMapState::Mapped || m_destroyed)
+        return Exception { ExceptionCode::OperationError, "not mapped or destroyed"_s };
+
+    auto offset = optionalOffset.value_or(0);
+    if (offset > m_bufferSize)
+        return Exception { ExceptionCode::OperationError, "offset > bufferSize"_s };
+
+    auto size = optionalSize.value_or(m_bufferSize - offset);
+    auto checkedEndOffset = checkedSum<uint64_t>(offset, size);
+    if (checkedEndOffset.hasOverflowed())
+        return Exception { ExceptionCode::OperationError, "has overflowed"_s };
+
+    auto endOffset = checkedEndOffset.value();
+    if (offset % 8)
+        return Exception { ExceptionCode::OperationError, "validation failed offset % 8"_s };
+
+    if (size % 4)
+        return Exception { ExceptionCode::OperationError, "validation failed size % 4"_s };
+
+    if (offset < m_mappedRangeOffset)
+        return Exception { ExceptionCode::OperationError, "validation failed offset < m_mappedRangeOffset"_s };
+
+    if (endOffset > m_mappedRangeSize + m_mappedRangeOffset)
+        return Exception { ExceptionCode::OperationError, "getMappedRangeFailed because offset + size > mappedRangeSize + mappedRangeOffset"_s };
+
+    if (endOffset > m_bufferSize)
+        return Exception { ExceptionCode::OperationError, "validation failed endOffset > bufferSie"_s };
+
+    if (containsRange(offset, endOffset, m_mappedRanges, m_mappedPoints))
+        return Exception { ExceptionCode::OperationError, "validation failed - containsRange"_s };
+
+    if (offset == endOffset)
+        m_mappedPoints.add(offset);
+    else {
+        m_mappedRanges.add({ static_cast<size_t>(offset), static_cast<size_t>(endOffset) });
+        m_mappedRanges.compact();
+    }
+
+    m_mappedRange = m_backing->getMappedRange(offset, size);
     if (!m_mappedRange.source) {
         m_arrayBuffer = nullptr;
-        return Exception { ExceptionCode::OperationError };
+        if (m_mappedAtCreation || !size)
+            return makeArrayBuffer(static_cast<size_t>(0U), 1, m_arrayBuffer, m_device, *this);
+
+        return Exception { ExceptionCode::OperationError, "getMappedRange failed"_s };
     }
 
     return makeArrayBuffer(m_mappedRange.source, m_mappedRange.byteLength, m_arrayBuffer, m_device, *this);
@@ -125,16 +190,19 @@ void GPUBuffer::unmap(ScriptExecutionContext& scriptExecutionContext)
 
 void GPUBuffer::internalUnmap(ScriptExecutionContext& scriptExecutionContext)
 {
+    m_mappedAtCreation = false;
+    m_mappedRangeOffset = 0;
+    m_mappedRangeSize = 0;
+    m_mappedRanges.clear();
+    m_mappedPoints.clear();
     if (m_pendingMapPromise) {
         m_pendingMapPromise->reject(Exception { ExceptionCode::AbortError });
         m_pendingMapPromise = std::nullopt;
     }
 
     m_mapState = GPUBufferMapState::Unmapped;
-    if (!m_bufferSize)
-        return;
 
-    if (m_arrayBuffer && m_arrayBuffer->data()) {
+    if (m_arrayBuffer && m_arrayBuffer->data() && m_mappedRange.byteLength) {
         memcpy(m_mappedRange.source, m_arrayBuffer->data(), m_mappedRange.byteLength);
         JSC::ArrayBufferContents emptyBuffer;
         m_arrayBuffer->unpin();
@@ -143,13 +211,12 @@ void GPUBuffer::internalUnmap(ScriptExecutionContext& scriptExecutionContext)
 
     m_arrayBuffer = nullptr;
     m_backing->unmap();
+    m_mappedRange = { nullptr, 0 };
 }
 
 void GPUBuffer::destroy(ScriptExecutionContext& scriptExecutionContext)
 {
-    if (!m_bufferSize)
-        return;
-
+    m_destroyed = true;
     internalUnmap(scriptExecutionContext);
     m_bufferSize = 0;
     m_backing->destroy();

--- a/Source/WebCore/Modules/WebGPU/GPUBuffer.h
+++ b/Source/WebCore/Modules/WebGPU/GPUBuffer.h
@@ -35,6 +35,9 @@
 #include <JavaScriptCore/ArrayBuffer.h>
 #include <cstdint>
 #include <optional>
+#include <wtf/HashSet.h>
+#include <wtf/Range.h>
+#include <wtf/RangeSet.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
 #include <wtf/text/WTFString.h>
@@ -77,10 +80,17 @@ private:
     WebGPU::Buffer::MappedRange m_mappedRange;
     JSC::ArrayBuffer* m_arrayBuffer { nullptr };
     size_t m_bufferSize { 0 };
+    size_t m_mappedRangeOffset { 0 };
+    size_t m_mappedRangeSize { 0 };
     const GPUBufferUsageFlags m_usage { 0 };
     GPUBufferMapState m_mapState { GPUBufferMapState::Unmapped };
     std::optional<MapAsyncPromise> m_pendingMapPromise;
     GPUDevice& m_device;
+    using MappedRanges = WTF::RangeSet<WTF::Range<size_t>>;
+    MappedRanges m_mappedRanges;
+    HashSet<size_t, DefaultHash<size_t>, WTF::UnsignedWithZeroKeyHashTraits<size_t>> m_mappedPoints;
+    bool m_destroyed { false };
+    bool m_mappedAtCreation { false };
 };
 
 }

--- a/Source/WebGPU/WebGPU/Buffer.h
+++ b/Source/WebGPU/WebGPU/Buffer.h
@@ -92,7 +92,7 @@ private:
     Buffer(Device&);
 
     bool validateGetMappedRange(size_t offset, size_t rangeSize) const;
-    bool validateMapAsync(WGPUMapModeFlags, size_t offset, size_t rangeSize) const;
+    NSString* errorValidatingMapAsync(WGPUMapModeFlags, size_t offset, size_t rangeSize) const;
     bool validateUnmap() const;
 
     id<MTLBuffer> m_buffer { nil };

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.cpp
@@ -91,12 +91,8 @@ auto RemoteBufferProxy::getMappedRange(WebCore::WebGPU::Size64 offset, std::opti
 
 void RemoteBufferProxy::unmap()
 {
-    // FIXME: Implement error handling.
-    if (!m_data)
-        return;
-
     Vector<uint8_t> data;
-    if (m_mapModeFlags.contains(WebCore::WebGPU::MapMode::Write))
+    if (m_data && m_mapModeFlags.contains(WebCore::WebGPU::MapMode::Write))
         data = WTFMove(*m_data);
     auto sendResult = send(Messages::RemoteBuffer::Unmap(WTFMove(data)));
     UNUSED_VARIABLE(sendResult);


### PR DESCRIPTION
#### e0e9721a944e9c552f34a0d4856377b7a1b43b49
<pre>
[WebGPU] CTS test validation/buffer/mapping.html is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=266497">https://bugs.webkit.org/show_bug.cgi?id=266497</a>
&lt;radar://119731119&gt;

Reviewed by Tadeu Zagallo.

Add correct validation for Buffer mapping.

With this change, all GPUBuffer CTS tests are passing.

* LayoutTests/http/tests/webgpu/webgpu/api/validation/buffer/mapping-expected.txt:
* Source/WebCore/Modules/WebGPU/GPUBuffer.cpp:
(WebCore::GPUBuffer::GPUBuffer):
(WebCore::GPUBuffer::mapAsync):
(WebCore::containsRange):
(WebCore::GPUBuffer::getMappedRange):
(WebCore::GPUBuffer::internalUnmap):
(WebCore::GPUBuffer::destroy):
* Source/WebCore/Modules/WebGPU/GPUBuffer.h:
* Source/WebGPU/WebGPU/Buffer.h:
* Source/WebGPU/WebGPU/Buffer.mm:
(WebGPU::Buffer::errorValidatingMapAsync const):
(WebGPU::Buffer::mapAsync):
(WebGPU::Buffer::validateUnmap const):
(WebGPU::Buffer::unmap):
(WebGPU::Buffer::validateMapAsync const): Deleted.
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.cpp:
(WebKit::RemoteBuffer::mapAsync):
(WebKit::RemoteBuffer::unmap):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.cpp:
(WebKit::WebGPU::RemoteBufferProxy::unmap):

Canonical link: <a href="https://commits.webkit.org/272526@main">https://commits.webkit.org/272526@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1224fb4552683a429a423f1b9aaa46b80670ddde

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31961 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10661 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33717 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34477 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28958 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32766 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13024 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7897 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28553 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32333 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9017 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28566 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7804 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7983 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28479 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35821 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29079 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28933 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34083 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8069 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6054 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31942 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9713 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7474 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8730 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8592 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->