### PR TITLE
[Wasm-GC] Update "read the imports" part of JS API for globals

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/global-import.tentative.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/global-import.tentative.any-expected.txt
@@ -1,0 +1,13 @@
+
+PASS anyref import
+PASS eqref import
+PASS structref import
+PASS arrayref import
+PASS i31ref import
+PASS funcref import
+PASS externref import
+PASS null import
+PASS concrete struct import
+PASS concrete array import
+PASS concrete func import
+

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/global-import.tentative.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/global-import.tentative.any.html
@@ -1,0 +1,2 @@
+<!-- webkit-test-runner [ jscOptions=--useWebAssemblyTypedFunctionReferences=true,--useWebAssemblyGC=true ] -->
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/global-import.tentative.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/global-import.tentative.any.js
@@ -1,0 +1,344 @@
+// META: global=window,dedicatedworker,jsshell
+// META: script=/wasm/jsapi/wasm-module-builder.js
+
+let exports = {};
+let doLink = null;
+setup(() => {
+  const globalDescs = [
+    { name: "any", code: kWasmAnyRef },
+    { name: "eq", code: kWasmEqRef },
+    { name: "struct", code: kWasmStructRef },
+    { name: "array", code: kWasmArrayRef },
+    { name: "i31", code: kWasmI31Ref },
+    { name: "func", code: kWasmFuncRef },
+    { name: "extern", code: kWasmExternRef },
+    { name: "none", code: kWasmNullRef },
+    { name: "nofunc", code: kWasmNullFuncRef },
+    { name: "noextern", code: kWasmNullExternRef },
+    { name: "concreteStruct", code: (builder) => builder.addStruct([makeField(kWasmI32, true)]) },
+    { name: "concreteArray", code: (builder) => builder.addArray(kWasmI32, true) },
+    { name: "concreteFunc", code: (builder) => builder.addType({ params: [], results: [] }) },
+  ];
+
+  modulesToLink = {};
+  for (const desc of globalDescs) {
+    let builder = new WasmModuleBuilder();
+    if (typeof(desc.code) === "function") {
+      const index = desc.code(builder);
+      builder.addImportedGlobal("import", "global", wasmRefType(index));
+    } else
+      builder.addImportedGlobal("import", "global", wasmRefType(desc.code));
+    modulesToLink[desc.name] = new WebAssembly.Module(builder.toBuffer());
+
+    builder = new WasmModuleBuilder();
+    if (typeof(desc.code) === "function") {
+      const index = desc.code(builder);
+      builder.addImportedGlobal("import", "global", wasmRefNullType(index));
+    } else
+      builder.addImportedGlobal("import", "global", wasmRefNullType(desc.code));
+    modulesToLink[desc.name + "Nullable"] = new WebAssembly.Module(builder.toBuffer());
+  }
+
+  doLink = (moduleName, value) => {
+    const module = modulesToLink[moduleName];
+    new WebAssembly.Instance(module, { "import": { "global": value } });
+  };
+
+  const builder = new WasmModuleBuilder();
+  const structIndex = builder.addStruct([makeField(kWasmI32, true)]);
+  const arrayIndex = builder.addArray(kWasmI32, true);
+  const structIndex2 = builder.addStruct([makeField(kWasmF32, true)]);
+  const arrayIndex2 = builder.addArray(kWasmF32, true);
+  const funcIndex = builder.addType({ params: [], results: [] });
+  const funcIndex2 = builder.addType({ params: [], results: [kWasmI32] });
+
+  builder
+    .addFunction("makeStruct", makeSig_r_v(wasmRefType(structIndex)))
+    .addBody([...wasmI32Const(42),
+              ...GCInstr(kExprStructNew), structIndex])
+    .exportFunc();
+
+  builder
+    .addFunction("makeArray", makeSig_r_v(wasmRefType(arrayIndex)))
+    .addBody([...wasmI32Const(5), ...wasmI32Const(42),
+              ...GCInstr(kExprArrayNew), arrayIndex])
+    .exportFunc();
+
+  builder
+    .addFunction("makeStruct2", makeSig_r_v(wasmRefType(structIndex2)))
+    .addBody([...wasmF32Const(42),
+              ...GCInstr(kExprStructNew), structIndex2])
+    .exportFunc();
+
+  builder
+    .addFunction("makeArray2", makeSig_r_v(wasmRefType(arrayIndex2)))
+    .addBody([...wasmF32Const(42), ...wasmI32Const(5),
+              ...GCInstr(kExprArrayNew), arrayIndex2])
+    .exportFunc();
+
+  builder
+    .addFunction("testFunc", funcIndex)
+    .addBody([])
+    .exportFunc();
+
+  builder
+    .addFunction("testFunc2", funcIndex2)
+    .addBody([...wasmI32Const(42)])
+    .exportFunc();
+
+  const buffer = builder.toBuffer();
+  const instance = new WebAssembly.Instance(new WebAssembly.Module(buffer), {});
+  exports = instance.exports;
+});
+
+test(() => {
+  doLink("any", exports.makeStruct());
+  doLink("any", exports.makeArray());
+  doLink("any", 42);
+  doLink("any", 42n);
+  doLink("any", "foo");
+  doLink("any", {});
+  doLink("any", () => {});
+  doLink("any", exports.testFunc);
+  assert_throws_js(WebAssembly.LinkError, () => doLink("any", null));
+
+  doLink("anyNullable", null);
+  doLink("anyNullable", exports.makeStruct());
+  doLink("anyNullable", exports.makeArray());
+  doLink("anyNullable", 42);
+  doLink("anyNullable", 42n);
+  doLink("anyNullable", "foo");
+  doLink("anyNullable", {});
+  doLink("anyNullable", () => {});
+  doLink("anyNullable", exports.testFunc);
+}, "anyref import");
+
+test(() => {
+  doLink("eq", exports.makeStruct());
+  doLink("eq", exports.makeArray());
+  doLink("eq", 42);
+  assert_throws_js(WebAssembly.LinkError, () => doLink("eq", 42n));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("eq", "foo"));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("eq", {}));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("eq", exports.testFunc));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("eq", () => {}));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("eq", null));
+
+  doLink("eqNullable", null);
+  doLink("eqNullable", exports.makeStruct());
+  doLink("eqNullable", exports.makeArray());
+  doLink("eqNullable", 42);
+  assert_throws_js(WebAssembly.LinkError, () => doLink("eqNullable", 42n));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("eqNullable", "foo"));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("eqNullable", {}));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("eqNullable", exports.testFunc));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("eqNullable", () => {}));
+}, "eqref import");
+
+test(() => {
+  doLink("struct", exports.makeStruct());
+  assert_throws_js(WebAssembly.LinkError, () => doLink("struct", exports.makeArray()));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("struct", 42));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("struct", 42n));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("struct", "foo"));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("struct", {}));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("struct", exports.testFunc));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("struct", () => {}));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("struct", null));
+
+  doLink("structNullable", null);
+  doLink("structNullable", exports.makeStruct());
+  assert_throws_js(WebAssembly.LinkError, () => doLink("structNullable", exports.makeArray()));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("structNullable", 42));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("structNullable", 42n));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("structNullable", "foo"));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("structNullable", {}));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("structNullable", exports.testFunc));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("structNullable", () => {}));
+}, "structref import");
+
+test(() => {
+  doLink("array", exports.makeArray());
+  assert_throws_js(WebAssembly.LinkError, () => doLink("array", exports.makeStruct()));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("array", 42));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("array", 42n));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("array", "foo"));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("array", {}));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("array", exports.testFunc));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("array", () => {}));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("array", null));
+
+  doLink("arrayNullable", null);
+  doLink("arrayNullable", exports.makeArray());
+  assert_throws_js(WebAssembly.LinkError, () => doLink("arrayNullable", exports.makeStruct()));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("arrayNullable", 42));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("arrayNullable", 42n));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("arrayNullable", "foo"));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("arrayNullable", {}));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("arrayNullable", exports.testFunc));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("arrayNullable", () => {}));
+}, "arrayref import");
+
+test(() => {
+  doLink("i31", 42);
+  assert_throws_js(WebAssembly.LinkError, () => doLink("i31", exports.makeStruct()));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("i31", exports.makeArray()));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("i31", 42n));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("i31", "foo"));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("i31", {}));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("i31", exports.testFunc));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("i31", () => {}));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("i31", null));
+
+  doLink("i31Nullable", null);
+  doLink("i31Nullable", 42);
+  assert_throws_js(WebAssembly.LinkError, () => doLink("i31Nullable", exports.makeStruct()));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("i31Nullable", exports.makeArray()));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("i31Nullable", 42n));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("i31Nullable", "foo"));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("i31Nullable", {}));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("i31Nullable", exports.testFunc));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("i31Nullable", () => {}));
+}, "i31ref import");
+
+test(() => {
+  doLink("func", exports.testFunc);
+  assert_throws_js(WebAssembly.LinkError, () => doLink("func", exports.makeStruct()));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("func", exports.makeArray()));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("func", 42));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("func", 42n));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("func", "foo"));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("func", {}));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("func", () => {}));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("func", null));
+
+  doLink("funcNullable", null);
+  doLink("funcNullable", exports.testFunc);
+  assert_throws_js(WebAssembly.LinkError, () => doLink("funcNullable", exports.makeStruct()));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("funcNullable", exports.makeArray()));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("funcNullable", 42));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("funcNullable", 42n));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("funcNullable", "foo"));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("funcNullable", {}));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("funcNullable", () => {}));
+}, "funcref import");
+
+test(() => {
+  doLink("extern", exports.makeArray());
+  doLink("extern", exports.makeStruct());
+  doLink("extern", 42);
+  doLink("extern", 42n);
+  doLink("extern", "foo");
+  doLink("extern", {});
+  doLink("extern", exports.testFunc);
+  doLink("extern", () => {});
+  assert_throws_js(WebAssembly.LinkError, () => doLink("extern", null));
+
+  doLink("externNullable", null);
+  doLink("externNullable", exports.makeArray());
+  doLink("externNullable", exports.makeStruct());
+  doLink("externNullable", 42);
+  doLink("externNullable", 42n);
+  doLink("externNullable", "foo");
+  doLink("externNullable", {});
+  doLink("externNullable", exports.testFunc);
+  doLink("externNullable", () => {});
+}, "externref import");
+
+test(() => {
+  for (const nullKind of ["none", "nofunc", "noextern"]) {
+    assert_throws_js(WebAssembly.LinkError, () => doLink(nullKind, exports.makeStruct()));
+    assert_throws_js(WebAssembly.LinkError, () => doLink(nullKind, exports.makeArray()));
+    assert_throws_js(WebAssembly.LinkError, () => doLink(nullKind, 42));
+    assert_throws_js(WebAssembly.LinkError, () => doLink(nullKind, 42n));
+    assert_throws_js(WebAssembly.LinkError, () => doLink(nullKind, "foo"));
+    assert_throws_js(WebAssembly.LinkError, () => doLink(nullKind, {}));
+    assert_throws_js(WebAssembly.LinkError, () => doLink(nullKind, exports.testFunc));
+    assert_throws_js(WebAssembly.LinkError, () => doLink(nullKind, () => {}));
+    assert_throws_js(WebAssembly.LinkError, () => doLink(nullKind, null));
+  }
+
+  for (const nullKind of ["noneNullable", "nofuncNullable", "noexternNullable"]) {
+    doLink(nullKind, null);
+    assert_throws_js(WebAssembly.LinkError, () => doLink(nullKind, exports.makeStruct()));
+    assert_throws_js(WebAssembly.LinkError, () => doLink(nullKind, exports.makeArray()));
+    assert_throws_js(WebAssembly.LinkError, () => doLink(nullKind, 42));
+    assert_throws_js(WebAssembly.LinkError, () => doLink(nullKind, 42n));
+    assert_throws_js(WebAssembly.LinkError, () => doLink(nullKind, "foo"));
+    assert_throws_js(WebAssembly.LinkError, () => doLink(nullKind, {}));
+    assert_throws_js(WebAssembly.LinkError, () => doLink(nullKind, exports.testFunc));
+    assert_throws_js(WebAssembly.LinkError, () => doLink(nullKind, () => {}));
+  }
+}, "null import");
+
+test(() => {
+  doLink("concreteStruct", exports.makeStruct());
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteStruct", exports.makeStruct2()));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteStruct", exports.makeArray()));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteStruct", 42));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteStruct", 42n));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteStruct", "foo"));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteStruct", {}));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteStruct", exports.testFunc));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteStruct", () => {}));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteStruct", null));
+
+  doLink("concreteStructNullable", null);
+  doLink("concreteStructNullable", exports.makeStruct());
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteStructNullable", exports.makeStruct2()));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteStructNullable", exports.makeArray()));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteStructNullable", 42));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteStructNullable", 42n));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteStructNullable", "foo"));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteStructNullable", {}));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteStructNullable", exports.testFunc));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteStructNullable", () => {}));
+}, "concrete struct import");
+
+test(() => {
+  doLink("concreteArray", exports.makeArray());
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteArray", exports.makeArray2()));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteArray", exports.makeStruct()));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteArray", 42));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteArray", 42n));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteArray", "foo"));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteArray", {}));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteArray", exports.testFunc));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteArray", () => {}));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteArray", null));
+
+  doLink("concreteArrayNullable", null);
+  doLink("concreteArrayNullable", exports.makeArray());
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteArrayNullable", exports.makeArray2()));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteArrayNullable", exports.makeStruct()));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteArrayNullable", 42));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteArrayNullable", 42n));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteArrayNullable", "foo"));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteArrayNullable", {}));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteArrayNullable", exports.testFunc));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteArrayNullable", () => {}));
+}, "concrete array import");
+
+test(() => {
+  doLink("concreteFunc", exports.testFunc);
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteFunc", exports.testFunc2));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteFunc", exports.makeArray()));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteFunc", exports.makeStruct()));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteFunc", 42));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteFunc", 42n));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteFunc", "foo"));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteFunc", {}));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteFunc", () => {}));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteFunc", null));
+
+  doLink("concreteFuncNullable", null);
+  doLink("concreteFuncNullable", exports.testFunc);
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteFuncNullable", exports.testFunc2));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteFuncNullable", exports.makeArray()));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteFuncNullable", exports.makeStruct()));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteFuncNullable", 42));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteFuncNullable", 42n));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteFuncNullable", "foo"));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteFuncNullable", {}));
+  assert_throws_js(WebAssembly.LinkError, () => doLink("concreteFuncNullable", () => {}));
+}, "concrete func import");

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyHelpers.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyHelpers.h
@@ -224,6 +224,7 @@ ALWAYS_INLINE uint64_t fromJSValue(JSGlobalObject* globalObject, const Wasm::Typ
                     return throwVMTypeError(globalObject, scope, "Argument function did not match the reference type"_s);
             }
         } else {
+            ASSERT(Options::useWebAssemblyGC());
             value = Wasm::internalizeExternref(value);
             if (!Wasm::TypeInformation::castReference(value, type.isNullable(), type.index)) {
                 // FIXME: provide a better error message here


### PR DESCRIPTION
#### 62e8e45c7ec28d76b723e476b5ab7978a3f82b7b
<pre>
[Wasm-GC] Update &quot;read the imports&quot; part of JS API for globals
<a href="https://bugs.webkit.org/show_bug.cgi?id=264655">https://bugs.webkit.org/show_bug.cgi?id=264655</a>

Reviewed by Justin Michaud.

The GC proposal JS API was recently updated
(<a href="https://github.com/WebAssembly/gc/pull/467)">https://github.com/WebAssembly/gc/pull/467)</a> to allow direct import of reftype
globals in more cases.

This patch also includes a version of the pending WPT tests for this case
(tracked upstream here: <a href="https://github.com/WebAssembly/gc/pull/498)">https://github.com/WebAssembly/gc/pull/498)</a> which
should be updated later if there are any changes in the accepted upstream
version.

* JSTests/wasm/gc/js-api.js:
(testImport.):
(testImport):
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/global-import.tentative.any.js: Added.
(setup.doLink):
(setup):
(test):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyHelpers.h:
(JSC::fromJSValue):
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp:
(JSC::WebAssemblyModuleRecord::initializeImports):

Canonical link: <a href="https://commits.webkit.org/272367@main">https://commits.webkit.org/272367@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af522d24da5017747a6008766f6745eeb64f23a2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31091 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9763 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32779 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33597 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28071 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12106 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7021 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27905 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31423 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8229 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27794 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7063 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7345 "Too many flaky failures: imported/w3c/web-platform-tests/css/css-cascade/scope-hover.html, imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-below-viewport-partially-onscreen-new.html, imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-below-viewport-partially-onscreen-old.html, imported/w3c/web-platform-tests/css/selectors/invalidation/user-valid-user-invalid.html, imported/w3c/web-platform-tests/css/selectors/user-invalid.html, imported/w3c/web-platform-tests/css/selectors/valid-invalid-form-fieldset.html, imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-allowed-for-all.https.sub.html, imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch.tentative.html, imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative.html, imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/readwrite-readonly.html, imported/w3c/web-platform-tests/mixed-content/gen/worker-classic.http-rp/unset/fetch.https.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27684 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34936 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/26817 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28299 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28145 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33366 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/31173 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7274 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5331 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31201 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8965 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/27471 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/37610 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7379 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7977 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8053 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7812 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->