### PR TITLE
Devirtualize more RenderObject type checks

### DIFF
--- a/Source/WebCore/rendering/RenderBlockFlow.h
+++ b/Source/WebCore/rendering/RenderBlockFlow.h
@@ -439,8 +439,6 @@ protected:
     std::optional<LayoutUnit> lastLineBaseline() const override;
     std::optional<LayoutUnit> inlineBlockBaseline(LineDirectionMode) const override;
 
-    bool isMultiColumnBlockFlow() const override { return multiColumnFlow(); }
-    
     void setComputedColumnCountAndWidth(int, LayoutUnit);
 
     LayoutUnit computedColumnWidth() const;

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -145,8 +145,8 @@ void RenderImage::collectSelectionGeometries(Vector<SelectionGeometry>& geometri
 
 using namespace HTMLNames;
 
-RenderImage::RenderImage(Type type, Element& element, RenderStyle&& style, StyleImage* styleImage, const float imageDevicePixelRatio)
-    : RenderReplaced(type, element, WTFMove(style), IntSize())
+RenderImage::RenderImage(Type type, Element& element, RenderStyle&& style, OptionSet<RenderElementType> typeFlags, StyleImage* styleImage, const float imageDevicePixelRatio)
+    : RenderReplaced(type, element, WTFMove(style), IntSize(), typeFlags | RenderElementType::RenderImageFlag)
     , m_imageResource(styleImage ? makeUnique<RenderImageResourceStyleImage>(*styleImage) : makeUnique<RenderImageResource>())
     , m_hasImageOverlay(is<HTMLElement>(element) && ImageOverlay::hasOverlay(downcast<HTMLElement>(element)))
     , m_imageDevicePixelRatio(imageDevicePixelRatio)
@@ -158,8 +158,13 @@ RenderImage::RenderImage(Type type, Element& element, RenderStyle&& style, Style
 #endif
 }
 
+RenderImage::RenderImage(Type type, Element& element, RenderStyle&& style, StyleImage* styleImage, const float imageDevicePixelRatio)
+    : RenderImage(type, element, WTFMove(style), RenderElementType::RenderImageFlag, styleImage, imageDevicePixelRatio)
+{
+}
+
 RenderImage::RenderImage(Type type, Document& document, RenderStyle&& style, StyleImage* styleImage)
-    : RenderReplaced(type, document, WTFMove(style), IntSize())
+    : RenderReplaced(type, document, WTFMove(style), IntSize(), RenderElementType::RenderImageFlag)
     , m_imageResource(styleImage ? makeUnique<RenderImageResourceStyleImage>(*styleImage) : makeUnique<RenderImageResource>())
 {
 }

--- a/Source/WebCore/rendering/RenderImage.h
+++ b/Source/WebCore/rendering/RenderImage.h
@@ -40,7 +40,7 @@ enum ImageSizeChangeType {
 class RenderImage : public RenderReplaced {
     WTF_MAKE_ISO_ALLOCATED(RenderImage);
 public:
-    RenderImage(Type, Element&, RenderStyle&&, StyleImage* = nullptr, const float = 1.0f);
+    RenderImage(Type, Element&, RenderStyle&&, StyleImage* = nullptr, const float imageDevicePixelRatio = 1.0f);
     RenderImage(Type, Document&, RenderStyle&&, StyleImage* = nullptr);
     virtual ~RenderImage();
 
@@ -84,6 +84,7 @@ public:
     bool hasAnimatedImage() const;
 
 protected:
+    RenderImage(Type, Element&, RenderStyle&&, OptionSet<RenderElementType>, StyleImage* = nullptr, const float imageDevicePixelRatio = 1.0f);
     void willBeDestroyed() override;
 
     bool needsPreferredWidthsRecalculation() const final;
@@ -111,7 +112,6 @@ private:
     bool canHaveChildren() const override;
 
     bool isImage() const override { return true; }
-    bool isRenderImage() const final { return true; }
 
     void paintReplaced(PaintInfo&, const LayoutPoint&) override;
     void paintIncompleteImageOutline(PaintInfo&, LayoutPoint, LayoutUnit) const;

--- a/Source/WebCore/rendering/RenderMedia.cpp
+++ b/Source/WebCore/rendering/RenderMedia.cpp
@@ -40,13 +40,13 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderMedia);
 
 RenderMedia::RenderMedia(Type type, HTMLMediaElement& element, RenderStyle&& style)
-    : RenderImage(type, element, WTFMove(style))
+    : RenderImage(type, element, WTFMove(style), RenderElementType::RenderMediaFlag)
 {
     setHasShadowControls(true);
 }
 
 RenderMedia::RenderMedia(Type type, HTMLMediaElement& element, RenderStyle&& style, const IntSize& intrinsicSize)
-    : RenderImage(type, element, WTFMove(style))
+    : RenderImage(type, element, WTFMove(style), RenderElementType::RenderMediaFlag)
 {
     setIntrinsicSize(intrinsicSize);
     setHasShadowControls(true);

--- a/Source/WebCore/rendering/RenderMedia.h
+++ b/Source/WebCore/rendering/RenderMedia.h
@@ -55,7 +55,6 @@ private:
     bool canHaveChildren() const final { return true; }
 
     ASCIILiteral renderName() const override { return "RenderMedia"_s; }
-    bool isRenderMedia() const final { return true; }
     bool isImage() const final { return false; }
     void paintReplaced(PaintInfo&, const LayoutPoint&) override;
 };

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -231,10 +231,14 @@ public:
         RenderBlockFlowFlag = 1 << 5,
         RenderFlexibleBoxFlag = 1 << 6,
         RenderTextControlFlag = 1 << 7,
-        LegacyRenderSVGContainer = 1 << 8,
+        RenderImageFlag = 1 << 8,
+        RenderMediaFlag = 1 << 9,
+        RenderWidgetFlag = 1 << 10,
+        LegacyRenderSVGContainerFlag = 1 << 11,
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
-        RenderSVGContainer = 1 << 9,
+        RenderSVGContainerFlag = 1 << 12,
 #endif
+
     };
 
     // Anonymous objects should pass the document as their node, and they will then automatically be
@@ -357,13 +361,13 @@ public:
     bool isRenderListBox() const { return type() == Type::ListBox; }
     bool isRenderListItem() const { return type() == Type::ListItem; }
     bool isRenderListMarker() const { return type() == Type::ListMarker; }
-    virtual bool isRenderMedia() const { return false; }
+    bool isRenderMedia() const { return m_renderElementTypeFlags.contains(RenderElementType::RenderMediaFlag); }
     bool isRenderMenuList() const { return type() == Type::MenuList; }
     bool isRenderMeter() const { return type() == Type::Meter; }
     bool isRenderProgress() const { return type() == Type::Progress; }
     bool isRenderButton() const { return type() == Type::Button; }
     bool isRenderIFrame() const { return type() == Type::IFrame; }
-    virtual bool isRenderImage() const { return false; }
+    bool isRenderImage() const { return m_renderElementTypeFlags.contains(RenderElementType::RenderImageFlag); }
     bool isRenderTextFragment() const { return type() == Type::TextFragment; }
 #if ENABLE(MODEL_ELEMENT)
     bool isRenderModel() const { return type() == Type::Model; }
@@ -389,14 +393,13 @@ public:
     bool isRenderSearchField() const { return type() == Type::SearchField; }
     bool isRenderTextControlInnerBlock() const { return type() == Type::TextControlInnerBlock; }
     bool isRenderVideo() const { return type() == Type::Video; }
-    virtual bool isRenderWidget() const { return false; }
+    bool isRenderWidget() const { return m_renderElementTypeFlags.contains(RenderElementType::RenderWidgetFlag); }
     bool isRenderHTMLCanvas() const { return type() == Type::HTMLCanvas; }
 #if ENABLE(ATTACHMENT_ELEMENT)
     bool isRenderAttachment() const { return type() == Type::Attachment; }
 #endif
     bool isRenderGrid() const { return type() == Type::Grid; }
 
-    virtual bool isMultiColumnBlockFlow() const { return false; }
     bool isRenderMultiColumnSet() const { return type() == Type::MultiColumnSet; }
     bool isRenderMultiColumnFlow() const { return type() == Type::MultiColumnFlow; }
     bool isRenderMultiColumnSpannerPlaceholder() const { return type() == Type::MultiColumnSpannerPlaceholder; }
@@ -465,9 +468,9 @@ public:
     bool isLegacyRenderSVGRoot() const { return type() == Type::LegacySVGRoot; }
     bool isRenderSVGRoot() const { return type() == Type::SVGRoot; }
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
-    bool isRenderSVGContainer() const { return m_renderElementTypeFlags.contains(RenderElementType::RenderSVGContainer); }
+    bool isRenderSVGContainer() const { return m_renderElementTypeFlags.contains(RenderElementType::RenderSVGContainerFlag); }
 #endif
-    bool isLegacyRenderSVGContainer() const { return m_renderElementTypeFlags.contains(RenderElementType::LegacyRenderSVGContainer); }
+    bool isLegacyRenderSVGContainer() const { return m_renderElementTypeFlags.contains(RenderElementType::LegacyRenderSVGContainerFlag); }
     bool isRenderSVGTransformableContainer() const { return type() == Type::SVGTransformableContainer; }
     bool isLegacyRenderSVGTransformableContainer() const { return type() == Type::LegacySVGTransformableContainer; }
     bool isRenderSVGViewportContainer() const { return type() == Type::SVGViewportContainer; }

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -64,24 +64,24 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderReplaced);
 const int cDefaultWidth = 300;
 const int cDefaultHeight = 150;
 
-RenderReplaced::RenderReplaced(Type type, Element& element, RenderStyle&& style)
-    : RenderBox(type, element, WTFMove(style), RenderElementType::RenderReplacedFlag)
+RenderReplaced::RenderReplaced(Type type, Element& element, RenderStyle&& style, OptionSet<RenderElementType> typeFlags)
+    : RenderBox(type, element, WTFMove(style), typeFlags | RenderElementType::RenderReplacedFlag)
     , m_intrinsicSize(cDefaultWidth, cDefaultHeight)
 {
     setReplacedOrInlineBlock(true);
     ASSERT(isRenderReplaced());
 }
 
-RenderReplaced::RenderReplaced(Type type, Element& element, RenderStyle&& style, const LayoutSize& intrinsicSize)
-    : RenderBox(type, element, WTFMove(style), RenderElementType::RenderReplacedFlag)
+RenderReplaced::RenderReplaced(Type type, Element& element, RenderStyle&& style, const LayoutSize& intrinsicSize, OptionSet<RenderElementType> typeFlags)
+    : RenderBox(type, element, WTFMove(style), typeFlags | RenderElementType::RenderReplacedFlag)
     , m_intrinsicSize(intrinsicSize)
 {
     setReplacedOrInlineBlock(true);
     ASSERT(isRenderReplaced());
 }
 
-RenderReplaced::RenderReplaced(Type type, Document& document, RenderStyle&& style, const LayoutSize& intrinsicSize)
-    : RenderBox(type, document, WTFMove(style), RenderElementType::RenderReplacedFlag)
+RenderReplaced::RenderReplaced(Type type, Document& document, RenderStyle&& style, const LayoutSize& intrinsicSize, OptionSet<RenderElementType> typeFlags)
+    : RenderBox(type, document, WTFMove(style), typeFlags | RenderElementType::RenderReplacedFlag)
     , m_intrinsicSize(intrinsicSize)
 {
     setReplacedOrInlineBlock(true);

--- a/Source/WebCore/rendering/RenderReplaced.h
+++ b/Source/WebCore/rendering/RenderReplaced.h
@@ -50,9 +50,9 @@ public:
     void computeIntrinsicRatioInformation(FloatSize& intrinsicSize, FloatSize& intrinsicRatio) const override;
 
 protected:
-    RenderReplaced(Type, Element&, RenderStyle&&);
-    RenderReplaced(Type, Element&, RenderStyle&&, const LayoutSize& intrinsicSize);
-    RenderReplaced(Type, Document&, RenderStyle&&, const LayoutSize& intrinsicSize);
+    RenderReplaced(Type, Element&, RenderStyle&&, OptionSet<RenderElementType> = { });
+    RenderReplaced(Type, Element&, RenderStyle&&, const LayoutSize& intrinsicSize, OptionSet<RenderElementType> = { });
+    RenderReplaced(Type, Document&, RenderStyle&&, const LayoutSize& intrinsicSize, OptionSet<RenderElementType> = { });
 
     void layout() override;
 

--- a/Source/WebCore/rendering/RenderWidget.cpp
+++ b/Source/WebCore/rendering/RenderWidget.cpp
@@ -95,7 +95,7 @@ static void moveWidgetToParentSoon(Widget& child, LocalFrameView* parent)
 }
 
 RenderWidget::RenderWidget(Type type, HTMLFrameOwnerElement& element, RenderStyle&& style)
-    : RenderReplaced(type, element, WTFMove(style))
+    : RenderReplaced(type, element, WTFMove(style), RenderElementType::RenderWidgetFlag)
 {
     relaxAdoptionRequirement();
     setInline(false);

--- a/Source/WebCore/rendering/RenderWidget.h
+++ b/Source/WebCore/rendering/RenderWidget.h
@@ -95,8 +95,6 @@ protected:
 private:
     void element() const = delete;
 
-    bool isRenderWidget() const final { return true; }
-
     bool needsPreferredWidthsRecalculation() const final;
     RenderBox* embeddedContentBox() const final;
 

--- a/Source/WebCore/rendering/svg/RenderSVGContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGContainer.cpp
@@ -48,12 +48,12 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGContainer);
 
 RenderSVGContainer::RenderSVGContainer(Type type, Document& document, RenderStyle&& style)
-    : RenderSVGModelObject(type, document, WTFMove(style), RenderElementType::RenderSVGContainer)
+    : RenderSVGModelObject(type, document, WTFMove(style), RenderElementType::RenderSVGContainerFlag)
 {
 }
 
 RenderSVGContainer::RenderSVGContainer(Type type, SVGElement& element, RenderStyle&& style)
-    : RenderSVGModelObject(type, element, WTFMove(style), RenderElementType::RenderSVGContainer)
+    : RenderSVGModelObject(type, element, WTFMove(style), RenderElementType::RenderSVGContainerFlag)
 {
 }
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp
@@ -42,7 +42,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(LegacyRenderSVGContainer);
 
 LegacyRenderSVGContainer::LegacyRenderSVGContainer(Type type, SVGElement& element, RenderStyle&& style)
-    : LegacyRenderSVGModelObject(type, element, WTFMove(style), RenderElementType::LegacyRenderSVGContainer)
+    : LegacyRenderSVGModelObject(type, element, WTFMove(style), RenderElementType::LegacyRenderSVGContainerFlag)
 {
 }
 


### PR DESCRIPTION
#### 57feb7424beb442bf5df7ca404f4439bbad72717
<pre>
Devirtualize more RenderObject type checks
<a href="https://bugs.webkit.org/show_bug.cgi?id=266592">https://bugs.webkit.org/show_bug.cgi?id=266592</a>

Reviewed by Chris Dumez.

This PR adds more RenderElementType flags to devirtualize more type check functions.

Also add Flag suffix to LegacyRenderSVGContainer and RenderSVGContainer for consistency.

Also delete isMultiColumnBlockFlow(), which is never used.

* Source/WebCore/rendering/RenderBlockFlow.h:
* Source/WebCore/rendering/RenderImage.cpp:
(WebCore::RenderImage::RenderImage):
* Source/WebCore/rendering/RenderImage.h:
* Source/WebCore/rendering/RenderMedia.cpp:
(WebCore::RenderMedia::RenderMedia):
* Source/WebCore/rendering/RenderMedia.h:
* Source/WebCore/rendering/RenderObject.h:
(WebCore::RenderObject::isRenderMedia const):
(WebCore::RenderObject::isRenderImage const):
(WebCore::RenderObject::isRenderWidget const):
(WebCore::RenderObject::isRenderSVGContainer const):
(WebCore::RenderObject::isLegacyRenderSVGContainer const):
(WebCore::RenderObject::isMultiColumnBlockFlow const): Deleted.
* Source/WebCore/rendering/RenderReplaced.cpp:
(WebCore::RenderReplaced::RenderReplaced):
* Source/WebCore/rendering/RenderReplaced.h:
(WebCore::RenderReplaced::RenderReplaced):
* Source/WebCore/rendering/RenderWidget.cpp:
(WebCore::RenderWidget::RenderWidget):
* Source/WebCore/rendering/RenderWidget.h:
(WebCore::RenderWidget::isRenderWidget): Deleted.
* Source/WebCore/rendering/svg/RenderSVGContainer.cpp:
(WebCore::RenderSVGContainer::RenderSVGContainer):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp:
(WebCore::LegacyRenderSVGContainer::LegacyRenderSVGContainer):

Canonical link: <a href="https://commits.webkit.org/272248@main">https://commits.webkit.org/272248@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf93e89124628bd50e53716805bcbf24bd371f45

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31083 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9755 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32771 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33589 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/28064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31846 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12098 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7013 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/27899 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31415 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8221 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27790 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7055 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7228 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27679 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34928 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28290 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28141 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33375 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7266 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5326 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31202 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/8958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7969 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4035 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/7805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->