### PR TITLE
[perf.webkit.org] Increase buildTag size

### DIFF
--- a/Websites/perf.webkit.org/init-database.sql
+++ b/Websites/perf.webkit.org/init-database.sql
@@ -91,7 +91,7 @@ CREATE TABLE builds (
     build_id serial PRIMARY KEY,
     build_builder integer REFERENCES builders ON DELETE CASCADE,
     build_worker integer REFERENCES build_workers ON DELETE CASCADE,
-    build_tag varchar(64) NOT NULL,
+    build_tag varchar(128) NOT NULL,
     build_time timestamp NOT NULL,
     build_latest_revision timestamp,
     CONSTRAINT builder_build_time_tuple_must_be_unique UNIQUE(build_builder, build_tag, build_time));
@@ -203,7 +203,7 @@ CREATE TABLE reports (
     report_id serial PRIMARY KEY,
     report_builder integer NOT NULL REFERENCES builders ON DELETE RESTRICT,
     report_worker integer REFERENCES build_workers ON DELETE RESTRICT,
-    report_build_tag varchar(64),
+    report_build_tag varchar(128),
     report_build integer REFERENCES builds,
     report_created_at timestamp NOT NULL DEFAULT (CURRENT_TIMESTAMP AT TIME ZONE 'UTC'),
     report_committed_at timestamp,

--- a/Websites/perf.webkit.org/migrate-database.sql
+++ b/Websites/perf.webkit.org/migrate-database.sql
@@ -97,4 +97,7 @@ CREATE TABLE IF NOT EXISTS test_parameter_set_items (
 
 ALTER TABLE build_requests ADD COLUMN IF NOT EXISTS request_test_parameter_set integer REFERENCES test_parameter_sets DEFAULT NULL;
 
+ALTER TABLE builds ALTER COLUMN build_tag TYPE varchar(128);
+ALTER TABLE reports ALTER COLUMN report_build_tag TYPE varchar(128);
+
 END$$;


### PR DESCRIPTION
#### b3a9d388f06a74b29dd804bc2411b79a4b6bba4d
<pre>
[perf.webkit.org] Increase buildTag size
<a href="https://bugs.webkit.org/show_bug.cgi?id=266605">https://bugs.webkit.org/show_bug.cgi?id=266605</a>
<a href="https://rdar.apple.com/119835539">rdar://119835539</a>

Reviewed by NOBODY (OOPS!).

* Websites/perf.webkit.org/init-database.sql: Increase build_tag size to 128 characters.
* Websites/perf.webkit.org/migrate-database.sql: Ditto.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b3a9d388f06a74b29dd804bc2411b79a4b6bba4d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31074 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9746 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32763 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33583 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28058 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12092 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7007 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27895 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31406 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8215 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27789 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7050 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7223 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34922 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28284 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28140 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33355 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7260 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5324 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31188 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8952 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7963 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7799 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->