### PR TITLE
[WebGPU] CTS api,validation,texture,destroy test is failing

### DIFF
--- a/LayoutTests/http/tests/webgpu/webgpu/api/validation/texture/destroy-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/validation/texture/destroy-expected.txt
@@ -1,1 +1,32 @@
-(Populate me when we're ready to investigate this test)
+
+PASS :base:
+PASS :twice:
+PASS :invalid_texture:
+PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="all";colorTextureState="valid";depthStencilTextureState="valid"
+PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="all";colorTextureState="valid";depthStencilTextureState="destroyedBeforeEncode"
+PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="all";colorTextureState="valid";depthStencilTextureState="destroyedAfterEncode"
+PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="all";colorTextureState="destroyedBeforeEncode";depthStencilTextureState="valid"
+PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="all";colorTextureState="destroyedBeforeEncode";depthStencilTextureState="destroyedBeforeEncode"
+PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="all";colorTextureState="destroyedBeforeEncode";depthStencilTextureState="destroyedAfterEncode"
+PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="all";colorTextureState="destroyedAfterEncode";depthStencilTextureState="valid"
+PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="all";colorTextureState="destroyedAfterEncode";depthStencilTextureState="destroyedBeforeEncode"
+PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="all";colorTextureState="destroyedAfterEncode";depthStencilTextureState="destroyedAfterEncode"
+PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="depth-only";colorTextureState="valid";depthStencilTextureState="valid"
+PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="depth-only";colorTextureState="valid";depthStencilTextureState="destroyedBeforeEncode"
+PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="depth-only";colorTextureState="valid";depthStencilTextureState="destroyedAfterEncode"
+PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="depth-only";colorTextureState="destroyedBeforeEncode";depthStencilTextureState="valid"
+PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="depth-only";colorTextureState="destroyedBeforeEncode";depthStencilTextureState="destroyedBeforeEncode"
+PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="depth-only";colorTextureState="destroyedBeforeEncode";depthStencilTextureState="destroyedAfterEncode"
+PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="depth-only";colorTextureState="destroyedAfterEncode";depthStencilTextureState="valid"
+PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="depth-only";colorTextureState="destroyedAfterEncode";depthStencilTextureState="destroyedBeforeEncode"
+PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="depth-only";colorTextureState="destroyedAfterEncode";depthStencilTextureState="destroyedAfterEncode"
+PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="stencil-only";colorTextureState="valid";depthStencilTextureState="valid"
+PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="stencil-only";colorTextureState="valid";depthStencilTextureState="destroyedBeforeEncode"
+PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="stencil-only";colorTextureState="valid";depthStencilTextureState="destroyedAfterEncode"
+PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="stencil-only";colorTextureState="destroyedBeforeEncode";depthStencilTextureState="valid"
+PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="stencil-only";colorTextureState="destroyedBeforeEncode";depthStencilTextureState="destroyedBeforeEncode"
+PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="stencil-only";colorTextureState="destroyedBeforeEncode";depthStencilTextureState="destroyedAfterEncode"
+PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="stencil-only";colorTextureState="destroyedAfterEncode";depthStencilTextureState="valid"
+PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="stencil-only";colorTextureState="destroyedAfterEncode";depthStencilTextureState="destroyedBeforeEncode"
+PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="stencil-only";colorTextureState="destroyedAfterEncode";depthStencilTextureState="destroyedAfterEncode"
+

--- a/Source/WebGPU/WebGPU/CommandBuffer.h
+++ b/Source/WebGPU/WebGPU/CommandBuffer.h
@@ -28,6 +28,7 @@
 #import <wtf/FastMalloc.h>
 #import <wtf/Ref.h>
 #import <wtf/RefCounted.h>
+#import <wtf/WeakPtr.h>
 
 struct WGPUCommandBufferImpl {
 };
@@ -37,7 +38,7 @@ namespace WebGPU {
 class Device;
 
 // https://gpuweb.github.io/gpuweb/#gpucommandbuffer
-class CommandBuffer : public WGPUCommandBufferImpl, public RefCounted<CommandBuffer> {
+class CommandBuffer : public WGPUCommandBufferImpl, public RefCounted<CommandBuffer>, public CanMakeWeakPtr<CommandBuffer> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     static Ref<CommandBuffer> create(id<MTLCommandBuffer> commandBuffer, Device& device)

--- a/Source/WebGPU/WebGPU/CommandEncoder.h
+++ b/Source/WebGPU/WebGPU/CommandEncoder.h
@@ -30,6 +30,7 @@
 #import <wtf/Ref.h>
 #import <wtf/RefCounted.h>
 #import <wtf/Vector.h>
+#import <wtf/WeakPtr.h>
 
 @interface TextureAndClearColor : NSObject
 - (instancetype)initWithTexture:(id<MTLTexture>)texture NS_DESIGNATED_INITIALIZER;
@@ -52,7 +53,7 @@ class RenderPassEncoder;
 class Texture;
 
 // https://gpuweb.github.io/gpuweb/#gpucommandencoder
-class CommandEncoder : public WGPUCommandEncoderImpl, public RefCounted<CommandEncoder>, public CommandsMixin {
+class CommandEncoder : public WGPUCommandEncoderImpl, public RefCounted<CommandEncoder>, public CommandsMixin, public CanMakeWeakPtr<CommandEncoder> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     static Ref<CommandEncoder> create(id<MTLCommandBuffer> commandBuffer, Device& device)
@@ -91,7 +92,7 @@ public:
 
     void runClearEncoder(NSMutableDictionary<NSNumber*, TextureAndClearColor*> *attachmentsToClear, id<MTLTexture> depthStencilAttachmentToClear, bool depthAttachmentToClear, bool stencilAttachmentToClear, float depthClearValue = 0, uint32_t stencilClearValue = 0, id<MTLRenderCommandEncoder> = nil);
     static void clearTexture(const WGPUImageCopyTexture&, NSUInteger, id<MTLDevice>, id<MTLBlitCommandEncoder>);
-    void makeInvalid() { m_commandBuffer = nil; }
+    void makeInvalid();
 
 private:
     CommandEncoder(id<MTLCommandBuffer>, Device&);
@@ -115,6 +116,7 @@ private:
     };
     Vector<PendingTimestampWrites> m_pendingTimestampWrites;
     uint64_t m_debugGroupStackSize { 0 };
+    WeakPtr<CommandBuffer> m_cachedCommandBuffer;
 
     const Ref<Device> m_device;
 };

--- a/Source/WebGPU/WebGPU/ComputePassEncoder.h
+++ b/Source/WebGPU/WebGPU/ComputePassEncoder.h
@@ -52,9 +52,9 @@ public:
     {
         return adoptRef(*new ComputePassEncoder(computeCommandEncoder, descriptor, parentEncoder, device));
     }
-    static Ref<ComputePassEncoder> createInvalid(Device& device)
+    static Ref<ComputePassEncoder> createInvalid(CommandEncoder& parentEncoder, Device& device)
     {
-        return adoptRef(*new ComputePassEncoder(device));
+        return adoptRef(*new ComputePassEncoder(parentEncoder, device));
     }
 
     ~ComputePassEncoder();
@@ -75,7 +75,7 @@ public:
 
 private:
     ComputePassEncoder(id<MTLComputeCommandEncoder>, const WGPUComputePassDescriptor&, CommandEncoder&, Device&);
-    ComputePassEncoder(Device&);
+    ComputePassEncoder(CommandEncoder&, Device&);
 
     bool validatePopDebugGroup() const;
 
@@ -95,7 +95,7 @@ private:
     MTLSize m_threadsPerThreadgroup;
     Vector<uint32_t> m_computeDynamicOffsets;
     const ComputePipeline* m_pipeline { nullptr };
-    RefPtr<CommandEncoder> m_parentEncoder;
+    Ref<CommandEncoder> m_parentEncoder;
     HashMap<uint32_t, Vector<uint32_t>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_bindGroupDynamicOffsets;
 };
 

--- a/Source/WebGPU/WebGPU/ComputePassEncoder.mm
+++ b/Source/WebGPU/WebGPU/ComputePassEncoder.mm
@@ -38,7 +38,7 @@ namespace WebGPU {
 ComputePassEncoder::ComputePassEncoder(id<MTLComputeCommandEncoder> computeCommandEncoder, const WGPUComputePassDescriptor& descriptor, CommandEncoder& parentEncoder, Device& device)
     : m_computeCommandEncoder(computeCommandEncoder)
     , m_device(device)
-    , m_parentEncoder(&parentEncoder)
+    , m_parentEncoder(parentEncoder)
 {
     m_parentEncoder->lock(true);
 
@@ -51,8 +51,9 @@ ComputePassEncoder::ComputePassEncoder(id<MTLComputeCommandEncoder> computeComma
     }
 }
 
-ComputePassEncoder::ComputePassEncoder(Device& device)
+ComputePassEncoder::ComputePassEncoder(CommandEncoder& parentEncoder, Device& device)
     : m_device(device)
+    , m_parentEncoder(parentEncoder)
 {
 }
 
@@ -105,11 +106,6 @@ void ComputePassEncoder::dispatchIndirect(const Buffer& indirectBuffer, uint64_t
 
 void ComputePassEncoder::endPass()
 {
-    if (!m_parentEncoder) {
-        ASSERT(!m_computeCommandEncoder);
-        return;
-    }
-
     if (m_debugGroupStackSize || !isValid()) {
         m_parentEncoder->makeInvalid();
         return;

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.h
@@ -57,9 +57,9 @@ public:
     {
         return adoptRef(*new RenderPassEncoder(renderCommandEncoder, descriptor, visibilityResultBufferSize, depthReadOnly, stencilReadOnly, parentEncoder, visibilityResultBuffer, device));
     }
-    static Ref<RenderPassEncoder> createInvalid(Device& device)
+    static Ref<RenderPassEncoder> createInvalid(CommandEncoder& parentEncoder, Device& device)
     {
-        return adoptRef(*new RenderPassEncoder(device));
+        return adoptRef(*new RenderPassEncoder(parentEncoder, device));
     }
 
     ~RenderPassEncoder();
@@ -91,7 +91,7 @@ public:
 
 private:
     RenderPassEncoder(id<MTLRenderCommandEncoder>, const WGPURenderPassDescriptor&, NSUInteger, bool depthReadOnly, bool stencilReadOnly, CommandEncoder&, id<MTLBuffer>, Device&);
-    RenderPassEncoder(Device&);
+    RenderPassEncoder(CommandEncoder&, Device&);
 
     bool validatePopDebugGroup() const;
 
@@ -119,7 +119,7 @@ private:
     Vector<uint32_t> m_vertexDynamicOffsets;
     Vector<uint32_t> m_fragmentDynamicOffsets;
     const RenderPipeline* m_pipeline { nullptr };
-    RefPtr<CommandEncoder> m_parentEncoder;
+    Ref<CommandEncoder> m_parentEncoder;
     HashMap<uint32_t, Vector<uint32_t>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_bindGroupDynamicOffsets;
     float m_minDepth { 0.f };
     float m_maxDepth { 1.f };

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -43,7 +43,7 @@ RenderPassEncoder::RenderPassEncoder(id<MTLRenderCommandEncoder> renderCommandEn
     , m_visibilityResultBufferSize(visibilityResultBufferSize)
     , m_depthReadOnly(depthReadOnly)
     , m_stencilReadOnly(stencilReadOnly)
-    , m_parentEncoder(&parentEncoder)
+    , m_parentEncoder(parentEncoder)
     , m_visibilityResultBuffer(visibilityResultBuffer)
 {
     m_parentEncoder->lock(true);
@@ -102,9 +102,11 @@ RenderPassEncoder::RenderPassEncoder(id<MTLRenderCommandEncoder> renderCommandEn
     }
 }
 
-RenderPassEncoder::RenderPassEncoder(Device& device)
+RenderPassEncoder::RenderPassEncoder(CommandEncoder& parentEncoder, Device& device)
     : m_device(device)
+    , m_parentEncoder(parentEncoder)
 {
+    m_parentEncoder->lock(true);
 }
 
 RenderPassEncoder::~RenderPassEncoder()
@@ -221,11 +223,6 @@ void RenderPassEncoder::endOcclusionQuery()
 
 void RenderPassEncoder::endPass()
 {
-    if (!m_parentEncoder) {
-        ASSERT(!m_renderCommandEncoder);
-        return;
-    }
-
     if (m_debugGroupStackSize || !isValid()) {
         m_parentEncoder->makeInvalid();
         return;

--- a/Source/WebGPU/WebGPU/Texture.h
+++ b/Source/WebGPU/WebGPU/Texture.h
@@ -31,6 +31,7 @@
 #import <wtf/Ref.h>
 #import <wtf/RefCounted.h>
 #import <wtf/Vector.h>
+#import <wtf/WeakPtr.h>
 
 struct WGPUTextureImpl {
 };
@@ -137,6 +138,7 @@ private:
     using ClearedToZeroInnerContainer = HashSet<uint32_t, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
     using ClearedToZeroContainer = HashMap<uint32_t, ClearedToZeroInnerContainer, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
     ClearedToZeroContainer m_clearedToZero;
+    Vector<WeakPtr<TextureView>> m_textureViews;
     bool m_destroyed { false };
     bool m_canvasBacking { false };
 };

--- a/Source/WebGPU/WebGPU/Texture.mm
+++ b/Source/WebGPU/WebGPU/Texture.mm
@@ -2720,7 +2720,9 @@ Ref<TextureView> Texture::createView(const WGPUTextureViewDescriptor& inputDescr
     if (m_usage & WGPUTextureUsage_RenderAttachment)
         renderExtent = computeRenderExtent({ m_width, m_height, m_depthOrArrayLayers }, descriptor->baseMipLevel);
 
-    return TextureView::create(texture, *descriptor, renderExtent, *this, m_device);
+    auto result = TextureView::create(texture, *descriptor, renderExtent, *this, m_device);
+    m_textureViews.append(result);
+    return result;
 }
 
 void Texture::recreateIfNeeded()
@@ -2740,6 +2742,12 @@ void Texture::destroy()
     if (!m_canvasBacking)
         m_texture = nil;
     m_destroyed = true;
+    for (auto& view : m_textureViews) {
+        if (view.get())
+            view->destroy();
+    }
+
+    m_textureViews.clear();
 }
 
 void Texture::setLabel(String&& label)

--- a/Source/WebGPU/WebGPU/TextureView.h
+++ b/Source/WebGPU/WebGPU/TextureView.h
@@ -28,17 +28,19 @@
 #import <wtf/FastMalloc.h>
 #import <wtf/Ref.h>
 #import <wtf/RefCounted.h>
+#import <wtf/WeakPtr.h>
 
 struct WGPUTextureViewImpl {
 };
 
 namespace WebGPU {
 
+class CommandEncoder;
 class Device;
 class Texture;
 
 // https://gpuweb.github.io/gpuweb/#gputextureview
-class TextureView : public WGPUTextureViewImpl, public RefCounted<TextureView> {
+class TextureView : public WGPUTextureViewImpl, public RefCounted<TextureView>, public CanMakeWeakPtr<TextureView> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     static Ref<TextureView> create(id<MTLTexture> texture, const WGPUTextureViewDescriptor& descriptor, const std::optional<WGPUExtent3D>& renderExtent, Texture& parentTexture, Device& device)
@@ -70,18 +72,21 @@ public:
     WGPUTextureFormat format() const;
     uint32_t mipLevelCount() const;
     bool isDestroyed() const;
+    void destroy();
+    void setCommandEncoder(CommandEncoder&);
 
 private:
     TextureView(id<MTLTexture>, const WGPUTextureViewDescriptor&, const std::optional<WGPUExtent3D>&, Texture&, Device&);
     TextureView(Texture&, Device&);
 
-    const id<MTLTexture> m_texture { nil };
+    id<MTLTexture> m_texture { nil };
 
     const WGPUTextureViewDescriptor m_descriptor;
     const std::optional<WGPUExtent3D> m_renderExtent;
 
     const Ref<Device> m_device;
     Texture& m_parentTexture;
+    WeakPtr<CommandEncoder> m_commandEncoder;
 };
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/TextureView.mm
+++ b/Source/WebGPU/WebGPU/TextureView.mm
@@ -27,6 +27,7 @@
 #import "TextureView.h"
 
 #import "APIConversions.h"
+#import "CommandEncoder.h"
 
 namespace WebGPU {
 
@@ -96,6 +97,20 @@ uint32_t TextureView::mipLevelCount() const
 bool TextureView::isDestroyed() const
 {
     return m_parentTexture.isDestroyed();
+}
+
+void TextureView::destroy()
+{
+    m_texture = nil;
+    if (m_commandEncoder)
+        m_commandEncoder.get()->makeInvalid();
+
+    m_commandEncoder = nullptr;
+}
+
+void TextureView::setCommandEncoder(CommandEncoder& commandEncoder)
+{
+    m_commandEncoder = &commandEncoder;
 }
 
 } // namespace WebGPU


### PR DESCRIPTION
#### c22ca98693565713efde37e8311190dd00e165ef
<pre>
[WebGPU] CTS api,validation,texture,destroy test is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=266593">https://bugs.webkit.org/show_bug.cgi?id=266593</a>
&lt;radar://119829762&gt;

Reviewed by Tadeu Zagallo.

The spec requires us to fail command buffer submission if a texture
is destroyed before the command buffer is submitted to the queue.

With this change, all validation/texture/* CTS tests pass.

* LayoutTests/http/tests/webgpu/webgpu/api/validation/texture/destroy-expected.txt:
* Source/WebGPU/WebGPU/CommandBuffer.h:
* Source/WebGPU/WebGPU/CommandEncoder.h:
(WebGPU::CommandEncoder::makeInvalid): Deleted.
* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::beginComputePass):
(WebGPU::CommandEncoder::beginRenderPass):
(WebGPU::CommandEncoder::makeInvalid):
(WebGPU::CommandEncoder::finish):
* Source/WebGPU/WebGPU/ComputePassEncoder.h:
(WebGPU::ComputePassEncoder::createInvalid):
* Source/WebGPU/WebGPU/ComputePassEncoder.mm:
(WebGPU::ComputePassEncoder::ComputePassEncoder):
(WebGPU::ComputePassEncoder::endPass):
* Source/WebGPU/WebGPU/RenderPassEncoder.h:
(WebGPU::RenderPassEncoder::createInvalid):
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::RenderPassEncoder):
(WebGPU::RenderPassEncoder::endPass):
* Source/WebGPU/WebGPU/Texture.h:
* Source/WebGPU/WebGPU/Texture.mm:
(WebGPU::Texture::createView):
(WebGPU::Texture::destroy):
* Source/WebGPU/WebGPU/TextureView.h:
* Source/WebGPU/WebGPU/TextureView.mm:
(WebGPU::TextureView::destroy):
(WebGPU::TextureView::setCommandEncoder):

Canonical link: <a href="https://commits.webkit.org/272725@main">https://commits.webkit.org/272725@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3896591a3efd1b25059a5b14fc52868fec5ef10e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32769 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11521 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34691 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35395 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29607 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13866 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8706 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29079 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33212 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9721 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29316 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8470 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8603 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29272 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36686 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29778 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29676 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34721 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8720 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6687 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32597 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10405 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7623 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9330 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9334 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->