### PR TITLE
[css-contain][css-grid] Relax size containment constraints on "Expand Flexible Tracks," portion of grid track sizing algorithm.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-inline-size-grid-indefinite-height-min-height-flex-row-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-inline-size-grid-indefinite-height-min-height-flex-row-expected.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-inline-size-grid-indefinite-height-min-height-flex-row.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-inline-size-grid-indefinite-height-min-height-flex-row.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-contain/#containment-size">
+<link rel="help" href="https://drafts.csswg.org/css-grid-2/#algo-flex-tracks"
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="Grid with inline-size containment, an indefinite height, and min-height will properly size flex rows">
+<style>
+grid {
+    display: grid;
+    min-height: 100px;
+    grid-template-rows: 1fr;
+    contain: inline-size;
+}
+.absolute {
+    position: absolute;
+}
+.align-last-baseline{
+    align-self: last baseline;
+}
+.item {
+    width: 100px;
+    height: 50px;
+    background-color: green;
+}
+</style>
+</head>
+<body>
+    <p>Test passes if there is a filled green square.</p>
+    <grid>
+        <div class="absolute item"></div>
+        <div class="item align-last-baseline"></div>
+    </grid>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-size-grid-indefinite-height-min-height-flex-row-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-size-grid-indefinite-height-min-height-flex-row-expected.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-size-grid-indefinite-height-min-height-flex-row.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-size-grid-indefinite-height-min-height-flex-row.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-contain/#containment-size">
+<link rel="help" href="https://drafts.csswg.org/css-grid-2/#algo-flex-tracks">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="Grid with size containment, an indefinite height, and min-height will properly size flex rows">
+<style>
+grid {
+    display: grid;
+    min-height: 100px;
+    grid-template-rows: 1fr;
+    contain: size;
+}
+.absolute {
+    position: absolute;
+}
+.align-last-baseline{
+    align-self: last baseline;
+}
+.item {
+    width: 100px;
+    height: 50px;
+    background-color: green;
+}
+</style>
+</head>
+<body>
+    <p>Test passes if there is a filled green square.</p>
+    <grid>
+        <div class="absolute item"></div>
+        <div class="item align-last-baseline"></div>
+    </grid>
+</body>
+</html>

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -1148,7 +1148,10 @@ double IndefiniteSizeStrategy::findUsedFlexFraction(Vector<unsigned>& flexibleSi
     }
 
     const Grid& grid = m_algorithm.grid();
-    if (!grid.hasGridItems())
+    // If we are computing the flex fraction of the grid while under the "Sizing as if empty," phase,
+    // then we should use the flex fraction computed up to this point since we do not want to avoid
+    // taking into consideration the grid items.
+    if (!grid.hasGridItems() || (isComputingSizeOrInlineSizeContainment() && !m_algorithm.renderGrid()->explicitIntrinsicInnerLogicalSize(direction)))
         return flexFraction;
 
     SingleThreadWeakHashSet<RenderBox> itemsSet;
@@ -1726,8 +1729,7 @@ void GridTrackSizingAlgorithm::run()
     m_strategy->maximizeTracks(tracks(m_direction), m_direction == GridTrackSizingDirection::ForColumns ? m_freeSpaceColumns : m_freeSpaceRows);
 
     // Step 4.
-    if (!m_strategy->isComputingSizeOrInlineSizeContainment() || m_renderGrid->explicitIntrinsicInnerLogicalSize(m_direction))
-        stretchFlexibleTracks(initialFreeSpace);
+    stretchFlexibleTracks(initialFreeSpace);
 
     // Step 5.
     stretchAutoTracks();

--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -76,6 +76,7 @@ public:
     LayoutUnit guttersSize(GridTrackSizingDirection, unsigned startLine, unsigned span, std::optional<LayoutUnit> availableSize) const;
     LayoutUnit gridItemOffset(GridTrackSizingDirection) const;
 
+    std::optional<LayoutUnit> explicitIntrinsicInnerLogicalSize(GridTrackSizingDirection) const;
     void updateGridAreaLogicalSize(RenderBox&, std::optional<LayoutUnit> width, std::optional<LayoutUnit> height) const;
     bool isBaselineAlignmentForChild(const RenderBox&) const;
     bool isBaselineAlignmentForChild(const RenderBox& child, GridAxis, AllowedBaseLine = AllowedBaseLine::BothLines) const;
@@ -150,7 +151,6 @@ private:
     bool implicitGridLinesDefinitionDidChange(const RenderStyle&) const;
 
     bool shouldCheckExplicitIntrinsicInnerLogicalSize(GridTrackSizingDirection) const;
-    std::optional<LayoutUnit> explicitIntrinsicInnerLogicalSize(GridTrackSizingDirection) const;
     unsigned computeAutoRepeatTracksCount(GridTrackSizingDirection, std::optional<LayoutUnit> availableSize) const;
 
     unsigned clampAutoRepeatTracks(GridTrackSizingDirection, unsigned autoRepeatTracks) const;


### PR DESCRIPTION
#### 57fdd17822df399a4c26a0a3f3ad8342051c1eff
<pre>
[css-contain][css-grid] Relax size containment constraints on &quot;Expand Flexible Tracks,&quot; portion of grid track sizing algorithm.
<a href="https://bugs.webkit.org/show_bug.cgi?id=266506">https://bugs.webkit.org/show_bug.cgi?id=266506</a>
<a href="https://rdar.apple.com/119736473">rdar://119736473</a>

Reviewed by Alan Baradlay.

This patch expands upon 272085@main which fixed a bug related to an
interaction between grid layout and size containment. In particular,
the patch allowed the grid track sizing algorithm to stretch auto sized
tracks even during size containment.

For the exact same reason we also want to relax the size containment
constraint imposed upon the grid track sizing algorithm to allow it to
perform portions of the &quot;Expand Flexible Tracks,&quot; section. The only
portion of this step we want to skip is when we are computing the flex
fraction and the free space is indefinite, since this is the only part of
this section that takes into consideration the grid&apos;s contents. To
compute the flex fraction in this case, the spec says that it is the
maximum of:

- For each flexible track, if the flexible track’s flex factor is
greater than one, the result of dividing the track’s base size by its
flex factor; otherwise, the track’s base size.
- For each grid item that crosses a flexible track, the result of
finding the size of an fr using all the grid tracks that the item
crosses and a space to fill of the item’s max-content contribution.

During the size containment &quot;Sizing as if empty,&quot; phase we can
completely take into consideration the first computation, but we should
not compute or consider the second.

<a href="https://drafts.csswg.org/css-contain/#containment-size">https://drafts.csswg.org/css-contain/#containment-size</a>
<a href="https://drafts.csswg.org/css-grid-2/#algo-flex-tracks">https://drafts.csswg.org/css-grid-2/#algo-flex-tracks</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-inline-size-grid-indefinite-height-min-height-flex-row-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-inline-size-grid-indefinite-height-min-height-flex-row.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-size-grid-indefinite-height-min-height-flex-row-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-size-grid-indefinite-height-min-height-flex-row.html: Added.
* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::IndefiniteSizeStrategy::findUsedFlexFraction const):
(WebCore::GridTrackSizingAlgorithm::run):
* Source/WebCore/rendering/RenderGrid.h:

Canonical link: <a href="https://commits.webkit.org/272276@main">https://commits.webkit.org/272276@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d13427d4a5d7ac2a9c7873b21471c02318af7615

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31084 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9756 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32772 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33590 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28065 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31847 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12099 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7014 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27901 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31416 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8220 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27796 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7057 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7227 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27686 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34929 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28289 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28147 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33361 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7267 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5325 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31195 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8959 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/27473 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7331 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7970 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7806 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->