### PR TITLE
Restrict the length of requested web locks names

### DIFF
--- a/LayoutTests/http/wpt/web-locks/lock-name-length-restriction.https-expected.txt
+++ b/LayoutTests/http/wpt/web-locks/lock-name-length-restriction.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Requested lock name cannot be too long
+

--- a/LayoutTests/http/wpt/web-locks/lock-name-length-restriction.https.html
+++ b/LayoutTests/http/wpt/web-locks/lock-name-length-restriction.https.html
@@ -1,0 +1,11 @@
+<!DOCTYPE HTML>
+<meta charset=utf-8>
+<title>Requested lock name cannot be too long</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+promise_test(async t => {
+  const name = 'x'.repeat(1025);
+  await promise_rejects_dom(t, 'NotSupportedError', navigator.locks.request(name, lock => {}));
+}, "Requested lock name cannot be too long");
+</script>

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -573,6 +573,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     Modules/system-preview/ARKitBadgeSystemImage.h
 
+    Modules/web-locks/WebLock.h
     Modules/web-locks/WebLockIdentifier.h
     Modules/web-locks/WebLockManagerSnapshot.h
     Modules/web-locks/WebLockMode.h

--- a/Source/WebCore/Modules/web-locks/WebLock.h
+++ b/Source/WebCore/Modules/web-locks/WebLock.h
@@ -36,6 +36,8 @@ class WebLock : public RefCounted<WebLock> {
 public:
     static Ref<WebLock> create(WebLockIdentifier, const String& name, WebLockMode);
 
+    static constexpr unsigned maxNameLength = { 1024 };
+
     WebLockIdentifier identifier() const { return m_identifier; }
     const String& name() const { return m_name; }
     WebLockMode mode() const { return m_mode; }

--- a/Source/WebCore/Modules/web-locks/WebLockManager.cpp
+++ b/Source/WebCore/Modules/web-locks/WebLockManager.cpp
@@ -199,6 +199,11 @@ void WebLockManager::request(const String& name, Options&& options, Ref<WebLockG
         return;
     }
 
+    if (name.length() > WebLock::maxNameLength) {
+        releasePromise->reject(ExceptionCode::NotSupportedError, makeString("Lock name cannot cannot be longer than "_s, WebLock::maxNameLength, " characters"));
+        return;
+    }
+
     if (options.steal && options.ifAvailable) {
         releasePromise->reject(ExceptionCode::NotSupportedError, "WebLockOptions's steal and ifAvailable cannot both be true"_s);
         return;

--- a/Source/WebKit/UIProcess/WebLockRegistryProxy.cpp
+++ b/Source/WebKit/UIProcess/WebLockRegistryProxy.cpp
@@ -31,6 +31,7 @@
 #include "WebLockRegistryProxyMessages.h"
 #include "WebProcessProxy.h"
 #include "WebsiteDataStore.h"
+#include <WebCore/WebLock.h>
 #include <WebCore/WebLockIdentifier.h>
 #include <WebCore/WebLockManagerSnapshot.h>
 #include <WebCore/WebLockRegistry.h>
@@ -54,6 +55,7 @@ void WebLockRegistryProxy::requestLock(WebCore::ClientOrigin&& clientOrigin, Web
 {
     MESSAGE_CHECK(lockIdentifier.processIdentifier() == m_process.coreProcessIdentifier());
     MESSAGE_CHECK(clientID.processIdentifier() == m_process.coreProcessIdentifier());
+    MESSAGE_CHECK(name.length() <= WebCore::WebLock::maxNameLength);
     m_hasEverRequestedLocks = true;
 
     auto* dataStore = m_process.websiteDataStore();


### PR DESCRIPTION
#### a94a8a66a84945d4356362880cd19e17b2a0cc7b
<pre>
Restrict the length of requested web locks names
<a href="https://bugs.webkit.org/show_bug.cgi?id=262920">https://bugs.webkit.org/show_bug.cgi?id=262920</a>
<a href="https://rdar.apple.com/116189077">rdar://116189077</a>

Reviewed by Brent Fulgham.

Restrict the length of requested web locks names to prevent abuse.

* LayoutTests/http/wpt/web-locks/lock-name-length-restriction.https-expected.txt: Added.
* LayoutTests/http/wpt/web-locks/lock-name-length-restriction.https.html: Added.
* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/web-locks/WebLock.h:
* Source/WebCore/Modules/web-locks/WebLockManager.cpp:
(WebCore::WebLockManager::request):
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebKit/UIProcess/WebLockRegistryProxy.cpp:
(WebKit::WebLockRegistryProxy::requestLock):

Originally-landed-as: 267815.246@safari-7617-branch (85aba6be5983). <a href="https://rdar.apple.com/119577065">rdar://119577065</a>
Canonical link: <a href="https://commits.webkit.org/272250@main">https://commits.webkit.org/272250@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df26dcee5b0102be8aa352ca7f845466f5b139d8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31094 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9766 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32782 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33600 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28074 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31857 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12109 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7024 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27909 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31426 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8228 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27795 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7067 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7235 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27685 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34939 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28298 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28146 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33371 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7277 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5334 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31206 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8968 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/27472 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7321 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7980 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7815 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->