### PR TITLE
jsc_fuz/wktr: null ptr deref in WebCore::invokeWritableStreamFunction(...) (InternalWritableStream.cpp:49)

### DIFF
--- a/LayoutTests/streams/writable-stream-create-within-multiple-workers-crash-expected.txt
+++ b/LayoutTests/streams/writable-stream-create-within-multiple-workers-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it doesn't crash.

--- a/LayoutTests/streams/writable-stream-create-within-multiple-workers-crash.html
+++ b/LayoutTests/streams/writable-stream-create-within-multiple-workers-crash.html
@@ -1,0 +1,19 @@
+<!-- webkit-test-runner [ jscOptions=--slowPathAllocsBetweenGCs=50 ] -->
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    internals.settings.setWebRTCSFrameTransformEnabled(true);
+    testRunner.waitUntilDone();
+}
+    
+onload = () => {
+    for (let i = 0; i < 100; i++) {
+        new Worker(`data:text/javascript,for (let i = 0; i < 100; i++) new SFrameTransform().readable;`);
+    }
+    setTimeout(() => {
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }, 100);
+};
+</script>
+<p>This test passes if it doesn't crash.</p>

--- a/Source/WebCore/bindings/js/InternalWritableStream.cpp
+++ b/Source/WebCore/bindings/js/InternalWritableStream.cpp
@@ -41,8 +41,8 @@ static ExceptionOr<JSC::JSValue> invokeWritableStreamFunction(JSC::JSGlobalObjec
     auto scope = DECLARE_CATCH_SCOPE(vm);
 
     auto function = globalObject.get(&globalObject, identifier);
+    RETURN_IF_EXCEPTION(scope, Exception { ExceptionCode::ExistingExceptionError });
     ASSERT(function.isCallable());
-    scope.assertNoExceptionExceptTermination();
 
     auto callData = JSC::getCallData(function);
 

--- a/Tools/DumpRenderTree/mac/DumpRenderTree.mm
+++ b/Tools/DumpRenderTree/mac/DumpRenderTree.mm
@@ -1892,6 +1892,8 @@ static NSURL *computeTestURL(NSString *pathOrURLString, NSString **relativeTestP
 
 static WTR::TestOptions testOptionsForTest(const WTR::TestCommand& command)
 {
+    // hack for cases when useDollarVM will be reset before injectInternalsObject is called in DRT
+    JSC::Options::useDollarVM() = true;
     WTR::TestFeatures features = WTR::TestOptions::defaults();
     WTR::merge(features, WTR::hardcodedFeaturesBasedOnPathForTest(command));
     WTR::merge(features, WTR::featureDefaultsFromTestHeaderForTest(command, WTR::TestOptions::keyTypeMapping()));


### PR DESCRIPTION
#### 8d900198ca1e68cca80a4b2f0d4251d661a41361
<pre>
jsc_fuz/wktr: null ptr deref in WebCore::invokeWritableStreamFunction(...) (InternalWritableStream.cpp:49)
<a href="https://bugs.webkit.org/show_bug.cgi\?id\=262865">https://bugs.webkit.org/show_bug.cgi\?id\=262865</a>
<a href="https://rdar.apple.com/116465595">rdar://116465595</a>

Reviewed by Mark Lam.

Return early when worker is terminated while trying to get function from globalObject.
Set useDollarVM in test option initialization for cases when useDollarVM will be reset before injectInternalsObject is called in DRT.

* LayoutTests/streams/writable-stream-create-within-multiple-workers-crash-expected.txt: Added.
* LayoutTests/streams/writable-stream-create-within-multiple-workers-crash.html: Added.
* Source/WebCore/bindings/js/InternalWritableStream.cpp:
(WebCore::invokeWritableStreamFunction):
* Tools/DumpRenderTree/mac/DumpRenderTree.mm:
(testOptionsForTest):

Originally-landed-as: 267815.398@safari-7617-branch (f11c81a103a8). <a href="https://rdar.apple.com/119596601">rdar://119596601</a>
Canonical link: <a href="https://commits.webkit.org/272251@main">https://commits.webkit.org/272251@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f89c8063924af4c142b52d4dffd7364495e25bbe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31095 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9767 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32783 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33601 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28075 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31858 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12110 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7025 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27908 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31427 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8230 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27798 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7066 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7247 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27688 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34940 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28300 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28153 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33373 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7278 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5335 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31208 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8969 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/27475 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7322 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7981 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7816 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->