### PR TITLE
Devirtualize even more type checks for RenderObject

### DIFF
--- a/Source/WebCore/rendering/RenderLineBreak.cpp
+++ b/Source/WebCore/rendering/RenderLineBreak.cpp
@@ -53,8 +53,9 @@ RenderLineBreak::RenderLineBreak(HTMLElement& element, RenderStyle&& style)
     : RenderBoxModelObject(Type::LineBreak, element, WTFMove(style), { })
     , m_inlineBoxWrapper(nullptr)
     , m_cachedLineHeight(invalidLineHeight)
-    , m_isWBR(is<HTMLWBRElement>(element))
 {
+    if (is<HTMLWBRElement>(element))
+        setLineBreakFlags(LineBreakFlag::IsWBR);
     ASSERT(isRenderLineBreak());
 }
 

--- a/Source/WebCore/rendering/RenderLineBreak.h
+++ b/Source/WebCore/rendering/RenderLineBreak.h
@@ -36,9 +36,7 @@ public:
     virtual ~RenderLineBreak();
 
     // FIXME: The lies here keep render tree dump based test results unchanged.
-    ASCIILiteral renderName() const final { return m_isWBR ? "RenderWordBreak"_s : "RenderBR"_s; }
-
-    bool isWBR() const final { return m_isWBR; }
+    ASCIILiteral renderName() const final { return isWBR() ? "RenderWordBreak"_s : "RenderBR"_s; }
 
     std::unique_ptr<LegacyInlineElementBox> createInlineBox();
     LegacyInlineElementBox* inlineBoxWrapper() const { return m_inlineBoxWrapper; }
@@ -88,7 +86,6 @@ private:
 
     LegacyInlineElementBox* m_inlineBoxWrapper;
     mutable int m_cachedLineHeight;
-    bool m_isWBR;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -123,6 +123,7 @@ struct SameSizeAsRenderObject : public CachedImageClient, public CanMakeCheckedP
     uint16_t m_renderElementTypes;
     SingleThreadPackedWeakPtr<RenderObject> m_next;
     uint8_t m_type;
+    uint8_t m_typeSpecificFlags;
     CheckedPtr<Layout::Box> layoutBox;
 };
 

--- a/Source/WebCore/rendering/svg/RenderSVGBlock.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGBlock.cpp
@@ -37,7 +37,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGBlock);
 
 RenderSVGBlock::RenderSVGBlock(Type type, SVGGraphicsElement& element, RenderStyle&& style)
-    : RenderBlockFlow(type, element, WTFMove(style))
+    : RenderBlockFlow(type, element, WTFMove(style), RenderElementType::RenderSVGBlockFlag)
 {
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGBlock.h
+++ b/Source/WebCore/rendering/svg/RenderSVGBlock.h
@@ -45,7 +45,6 @@ protected:
 
 private:
     void element() const = delete;
-    bool isRenderSVGBlock() const final { return true; }
 
     void boundingRects(Vector<LayoutRect>&, const LayoutPoint& accumulatedOffset) const override;
     void absoluteQuads(Vector<FloatQuad>&, bool* wasFixed) const override;

--- a/Source/WebCore/rendering/svg/RenderSVGContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGContainer.cpp
@@ -47,13 +47,13 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGContainer);
 
-RenderSVGContainer::RenderSVGContainer(Type type, Document& document, RenderStyle&& style)
-    : RenderSVGModelObject(type, document, WTFMove(style), RenderElementType::RenderSVGContainerFlag)
+RenderSVGContainer::RenderSVGContainer(Type type, Document& document, RenderStyle&& style, OptionSet<SVGModelObjectFlag> svgFlags)
+    : RenderSVGModelObject(type, document, WTFMove(style), svgFlags | SVGModelObjectFlag::IsContainer)
 {
 }
 
-RenderSVGContainer::RenderSVGContainer(Type type, SVGElement& element, RenderStyle&& style)
-    : RenderSVGModelObject(type, element, WTFMove(style), RenderElementType::RenderSVGContainerFlag)
+RenderSVGContainer::RenderSVGContainer(Type type, SVGElement& element, RenderStyle&& style, OptionSet<SVGModelObjectFlag> svgFlags)
+    : RenderSVGModelObject(type, element, WTFMove(style), svgFlags | SVGModelObjectFlag::IsContainer)
 {
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGContainer.h
+++ b/Source/WebCore/rendering/svg/RenderSVGContainer.h
@@ -48,8 +48,8 @@ public:
     FloatRect repaintRectInLocalCoordinates(RepaintRectCalculation = RepaintRectCalculation::Fast) const final { return SVGBoundingBoxComputation::computeRepaintBoundingBox(*this); }
 
 protected:
-    RenderSVGContainer(Type, Document&, RenderStyle&&);
-    RenderSVGContainer(Type, SVGElement&, RenderStyle&&);
+    RenderSVGContainer(Type, Document&, RenderStyle&&, OptionSet<SVGModelObjectFlag> = { });
+    RenderSVGContainer(Type, SVGElement&, RenderStyle&&, OptionSet<SVGModelObjectFlag> = { });
 
     ASCIILiteral renderName() const override { return "RenderSVGContainer"_s; }
     bool canHaveChildren() const final { return true; }

--- a/Source/WebCore/rendering/svg/RenderSVGHiddenContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGHiddenContainer.cpp
@@ -30,8 +30,8 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGHiddenContainer);
 
-RenderSVGHiddenContainer::RenderSVGHiddenContainer(Type type, SVGElement& element, RenderStyle&& style)
-    : RenderSVGContainer(type, element, WTFMove(style))
+RenderSVGHiddenContainer::RenderSVGHiddenContainer(Type type, SVGElement& element, RenderStyle&& style, OptionSet<SVGModelObjectFlag> flags)
+    : RenderSVGContainer(type, element, WTFMove(style), flags | SVGModelObjectFlag::IsHiddenContainer)
 {
     ASSERT(isRenderSVGHiddenContainer());
 }

--- a/Source/WebCore/rendering/svg/RenderSVGHiddenContainer.h
+++ b/Source/WebCore/rendering/svg/RenderSVGHiddenContainer.h
@@ -32,7 +32,7 @@ class SVGElement;
 class RenderSVGHiddenContainer : public RenderSVGContainer {
     WTF_MAKE_ISO_ALLOCATED(RenderSVGHiddenContainer);
 public:
-    RenderSVGHiddenContainer(Type, SVGElement&, RenderStyle&&);
+    RenderSVGHiddenContainer(Type, SVGElement&, RenderStyle&&, OptionSet<SVGModelObjectFlag> = { });
 
 protected:
     void layout() override;

--- a/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
@@ -55,14 +55,20 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGModelObject);
 
-RenderSVGModelObject::RenderSVGModelObject(Type type, Document& document, RenderStyle&& style, OptionSet<RenderElementType> typeFlags)
-    : RenderLayerModelObject(type, document, WTFMove(style), typeFlags)
+RenderSVGModelObject::RenderSVGModelObject(Type type, Document& document, RenderStyle&& style, OptionSet<SVGModelObjectFlag> typeFlags)
+    : RenderLayerModelObject(type, document, WTFMove(style), RenderElementType::RenderSVGModelObjectFlag)
 {
+    setSVGFlags(typeFlags);
+    ASSERT(!svgFlags().contains(SVGModelObjectFlag::IsLegacy));
+    ASSERT(isRenderSVGModelObject());
 }
 
-RenderSVGModelObject::RenderSVGModelObject(Type type, SVGElement& element, RenderStyle&& style, OptionSet<RenderElementType> typeFlags)
-    : RenderLayerModelObject(type, element, WTFMove(style), typeFlags)
+RenderSVGModelObject::RenderSVGModelObject(Type type, SVGElement& element, RenderStyle&& style, OptionSet<SVGModelObjectFlag> typeFlags)
+    : RenderLayerModelObject(type, element, WTFMove(style), RenderElementType::RenderSVGModelObjectFlag)
 {
+    setSVGFlags(typeFlags);
+    ASSERT(!svgFlags().contains(SVGModelObjectFlag::IsLegacy));
+    ASSERT(isRenderSVGModelObject());
 }
 
 void RenderSVGModelObject::updateFromStyle()

--- a/Source/WebCore/rendering/svg/RenderSVGModelObject.h
+++ b/Source/WebCore/rendering/svg/RenderSVGModelObject.h
@@ -83,8 +83,8 @@ public:
     virtual Path computeClipPath(AffineTransform&) const;
 
 protected:
-    RenderSVGModelObject(Type, Document&, RenderStyle&&, OptionSet<RenderElementType> = { });
-    RenderSVGModelObject(Type, SVGElement&, RenderStyle&&, OptionSet<RenderElementType> = { });
+    RenderSVGModelObject(Type, Document&, RenderStyle&&, OptionSet<SVGModelObjectFlag> = { });
+    RenderSVGModelObject(Type, SVGElement&, RenderStyle&&, OptionSet<SVGModelObjectFlag> = { });
 
     void willBeDestroyed() override;
     void updateFromStyle() override;
@@ -109,7 +109,6 @@ protected:
     bool applyCachedClipAndScrollPosition(RepaintRects&, const RenderLayerModelObject* container, VisibleRectContext) const final;
 
 private:
-    bool isRenderSVGModelObject() const final { return true; }
     LayoutSize cachedSizeForOverflowClip() const;
 
     LayoutRect m_layoutRect;

--- a/Source/WebCore/rendering/svg/RenderSVGResourceContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceContainer.cpp
@@ -38,7 +38,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGResourceContainer);
 
 RenderSVGResourceContainer::RenderSVGResourceContainer(Type type, SVGElement& element, RenderStyle&& style)
-    : RenderSVGHiddenContainer(type, element, WTFMove(style))
+    : RenderSVGHiddenContainer(type, element, WTFMove(style), SVGModelObjectFlag::IsResourceContainer)
     , m_id(element.getIdAttribute())
 {
     ASSERT(isRenderSVGResourceContainer());

--- a/Source/WebCore/rendering/svg/RenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGShape.cpp
@@ -55,7 +55,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGShape);
 
 RenderSVGShape::RenderSVGShape(Type type, SVGGraphicsElement& element, RenderStyle&& style)
-    : RenderSVGModelObject(type, element, WTFMove(style))
+    : RenderSVGModelObject(type, element, WTFMove(style), SVGModelObjectFlag::IsShape)
 {
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGShape.h
+++ b/Source/WebCore/rendering/svg/RenderSVGShape.h
@@ -120,7 +120,6 @@ private:
     bool fillContains(const FloatPoint&, bool requiresFill = true, const WindRule fillRule = WindRule::NonZero);
     bool strokeContains(const FloatPoint&, bool requiresStroke = true);
 
-    bool isRenderSVGShape() const final { return true; }
     bool canHaveChildren() const final { return false; }
     ASCIILiteral renderName() const override { return "RenderSVGShape"_s; }
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp
@@ -41,8 +41,8 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(LegacyRenderSVGContainer);
 
-LegacyRenderSVGContainer::LegacyRenderSVGContainer(Type type, SVGElement& element, RenderStyle&& style)
-    : LegacyRenderSVGModelObject(type, element, WTFMove(style), RenderElementType::LegacyRenderSVGContainerFlag)
+LegacyRenderSVGContainer::LegacyRenderSVGContainer(Type type, SVGElement& element, RenderStyle&& style, OptionSet<SVGModelObjectFlag> svgFlags)
+    : LegacyRenderSVGModelObject(type, element, WTFMove(style), svgFlags | SVGModelObjectFlag::IsContainer)
 {
 }
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.h
@@ -40,7 +40,7 @@ public:
     bool isObjectBoundingBoxValid() const { return m_objectBoundingBoxValid; }
 
 protected:
-    LegacyRenderSVGContainer(Type, SVGElement&, RenderStyle&&);
+    LegacyRenderSVGContainer(Type, SVGElement&, RenderStyle&&, OptionSet<SVGModelObjectFlag> = { });
 
     ASCIILiteral renderName() const override { return "RenderSVGContainer"_s; }
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGHiddenContainer.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGHiddenContainer.cpp
@@ -27,8 +27,8 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(LegacyRenderSVGHiddenContainer);
 
-LegacyRenderSVGHiddenContainer::LegacyRenderSVGHiddenContainer(Type type, SVGElement& element, RenderStyle&& style)
-    : LegacyRenderSVGContainer(type, element, WTFMove(style))
+LegacyRenderSVGHiddenContainer::LegacyRenderSVGHiddenContainer(Type type, SVGElement& element, RenderStyle&& style, OptionSet<SVGModelObjectFlag> svgFlags)
+    : LegacyRenderSVGContainer(type, element, WTFMove(style), svgFlags | SVGModelObjectFlag::IsHiddenContainer)
 {
 }
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGHiddenContainer.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGHiddenContainer.h
@@ -30,13 +30,12 @@ class SVGElement;
 class LegacyRenderSVGHiddenContainer : public LegacyRenderSVGContainer {
     WTF_MAKE_ISO_ALLOCATED(LegacyRenderSVGHiddenContainer);
 public:
-    LegacyRenderSVGHiddenContainer(Type, SVGElement&, RenderStyle&&);
+    LegacyRenderSVGHiddenContainer(Type, SVGElement&, RenderStyle&&, OptionSet<SVGModelObjectFlag> = { });
 
 protected:
     void layout() override;
 
 private:
-    bool isLegacyRenderSVGHiddenContainer() const final { return true; }
     ASCIILiteral renderName() const override { return "RenderSVGHiddenContainer"_s; }
 
     void paint(PaintInfo&, const LayoutPoint&) final;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
@@ -46,9 +46,11 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(LegacyRenderSVGModelObject);
 
-LegacyRenderSVGModelObject::LegacyRenderSVGModelObject(Type type, SVGElement& element, RenderStyle&& style, OptionSet<RenderElementType> typeFlags)
-    : RenderElement(type, element, WTFMove(style), typeFlags)
+LegacyRenderSVGModelObject::LegacyRenderSVGModelObject(Type type, SVGElement& element, RenderStyle&& style, OptionSet<SVGModelObjectFlag> typeFlags)
+    : RenderElement(type, element, WTFMove(style), { RenderElementType::RenderSVGModelObjectFlag })
 {
+    setSVGFlags(typeFlags | SVGModelObjectFlag::IsLegacy);
+    ASSERT(isLegacyRenderSVGModelObject());
 }
 
 LayoutRect LegacyRenderSVGModelObject::clippedOverflowRect(const RenderLayerModelObject* repaintContainer, VisibleRectContext context) const

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.h
@@ -65,13 +65,11 @@ public:
     SVGElement& element() const { return downcast<SVGElement>(nodeForNonAnonymous()); }
 
 protected:
-    LegacyRenderSVGModelObject(Type, SVGElement&, RenderStyle&&, OptionSet<RenderElementType> = { });
+    LegacyRenderSVGModelObject(Type, SVGElement&, RenderStyle&&, OptionSet<SVGModelObjectFlag> = { });
 
     void willBeDestroyed() override;
 
 private:
-    bool isLegacyRenderSVGModelObject() const final { return true; }
-
     // This method should never be called, SVG uses a different nodeAtPoint method
     bool nodeAtPoint(const HitTestRequest&, HitTestResult&, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction) override;
     void absoluteFocusRingQuads(Vector<FloatQuad>&) final;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp
@@ -36,7 +36,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(LegacyRenderSVGResourceContainer);
 
 LegacyRenderSVGResourceContainer::LegacyRenderSVGResourceContainer(Type type, SVGElement& element, RenderStyle&& style)
-    : LegacyRenderSVGHiddenContainer(type, element, WTFMove(style))
+    : LegacyRenderSVGHiddenContainer(type, element, WTFMove(style), SVGModelObjectFlag::IsResourceContainer)
     , m_id(element.getIdAttribute())
 {
 }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.h
@@ -36,8 +36,6 @@ public:
     void layout() override;
     void styleDidChange(StyleDifference, const RenderStyle* oldStyle) final;
 
-    bool isLegacyRenderSVGResourceContainer() const final { return true; }
-
     static float computeTextPaintingScale(const RenderElement&);
     static AffineTransform transformOnNonScalingStroke(RenderObject*, const AffineTransform& resourceTransform);
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
@@ -54,7 +54,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(LegacyRenderSVGShape);
 
 LegacyRenderSVGShape::LegacyRenderSVGShape(Type type, SVGGraphicsElement& element, RenderStyle&& style)
-    : LegacyRenderSVGModelObject(type, element, WTFMove(style))
+    : LegacyRenderSVGModelObject(type, element, WTFMove(style), SVGModelObjectFlag::IsShape)
     , m_needsBoundariesUpdate(false) // Default is false, the cached rects are empty from the beginning.
     , m_needsShapeUpdate(true) // Default is true, so we grab a Path object once from SVGGraphicsElement.
     , m_needsTransformUpdate(true) // Default is true, so we grab a AffineTransform object once from SVGGraphicsElement.

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.h
@@ -115,7 +115,6 @@ private:
     const AffineTransform& localToParentTransform() const final { return m_localTransform; }
     AffineTransform localTransform() const final { return m_localTransform; }
 
-    bool isLegacyRenderSVGShape() const final { return true; }
     bool canHaveChildren() const final { return false; }
     ASCIILiteral renderName() const override { return "RenderSVGShape"_s; }
 


### PR DESCRIPTION
#### 27999fcc9508fc5c531bccb64e3c147a5ea94cb0
<pre>
Devirtualize even more type checks for RenderObject
<a href="https://bugs.webkit.org/show_bug.cgi?id=266615">https://bugs.webkit.org/show_bug.cgi?id=266615</a>

Reviewed by Antti Koivisto.

Devirtualize the remaining type checks for SVG by introducing SVG specific flags
stored in the unused 8-bit space left after m_type. Utilize the same mechanism /
same bits to store wbr-ness of RenderLineBreak as well.

* Source/WebCore/rendering/RenderLineBreak.cpp:
(WebCore::m_cachedLineHeight):
(WebCore::m_isWBR): Deleted.
* Source/WebCore/rendering/RenderLineBreak.h:
* Source/WebCore/rendering/RenderObject.cpp:
* Source/WebCore/rendering/RenderObject.h:
(WebCore::RenderObject::isLegacyRenderSVGModelObject const):
(WebCore::RenderObject::isRenderSVGModelObject const):
(WebCore::RenderObject::svgFlags const):
(WebCore::RenderObject::setSVGFlags):
(WebCore::RenderObject::isRenderSVGBlock const):
(WebCore::RenderObject::isRenderSVGContainer const):
(WebCore::RenderObject::isLegacyRenderSVGContainer const):
(WebCore::RenderObject::isLegacyRenderSVGHiddenContainer const):
(WebCore::RenderObject::isRenderSVGShape const):
(WebCore::RenderObject::isLegacyRenderSVGShape const):
(WebCore::RenderObject::isLegacyRenderSVGResourceContainer const):
(WebCore::RenderObject::isRenderSVGResourceContainer const):
(WebCore::RenderObject::isWBR const):
(WebCore::RenderObject::lineBreakFlags const):
(WebCore::RenderObject::setLineBreakFlags):
* Source/WebCore/rendering/svg/RenderSVGBlock.cpp:
(WebCore::RenderSVGBlock::RenderSVGBlock):
* Source/WebCore/rendering/svg/RenderSVGBlock.h:
* Source/WebCore/rendering/svg/RenderSVGContainer.cpp:
(WebCore::RenderSVGContainer::RenderSVGContainer):
* Source/WebCore/rendering/svg/RenderSVGContainer.h:
(WebCore::RenderSVGContainer::RenderSVGContainer):
* Source/WebCore/rendering/svg/RenderSVGHiddenContainer.cpp:
(WebCore::RenderSVGHiddenContainer::RenderSVGHiddenContainer):
* Source/WebCore/rendering/svg/RenderSVGHiddenContainer.h:
(WebCore::RenderSVGHiddenContainer::RenderSVGHiddenContainer):
* Source/WebCore/rendering/svg/RenderSVGModelObject.cpp:
(WebCore::RenderSVGModelObject::RenderSVGModelObject):
* Source/WebCore/rendering/svg/RenderSVGModelObject.h:
(WebCore::RenderSVGModelObject::RenderSVGModelObject):
* Source/WebCore/rendering/svg/RenderSVGResourceContainer.cpp:
(WebCore::RenderSVGResourceContainer::RenderSVGResourceContainer):
* Source/WebCore/rendering/svg/RenderSVGShape.cpp:
(WebCore::RenderSVGShape::RenderSVGShape):
* Source/WebCore/rendering/svg/RenderSVGShape.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp:
(WebCore::LegacyRenderSVGContainer::LegacyRenderSVGContainer):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.h:
(WebCore::LegacyRenderSVGContainer::LegacyRenderSVGContainer):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGHiddenContainer.cpp:
(WebCore::LegacyRenderSVGHiddenContainer::LegacyRenderSVGHiddenContainer):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGHiddenContainer.h:
(WebCore::LegacyRenderSVGHiddenContainer::LegacyRenderSVGHiddenContainer):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp:
(WebCore::LegacyRenderSVGModelObject::LegacyRenderSVGModelObject):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.h:
(WebCore::LegacyRenderSVGModelObject::LegacyRenderSVGModelObject):
(): Deleted.
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp:
(WebCore::LegacyRenderSVGResourceContainer::LegacyRenderSVGResourceContainer):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp:
(WebCore::LegacyRenderSVGShape::LegacyRenderSVGShape):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.h:

Canonical link: <a href="https://commits.webkit.org/272270@main">https://commits.webkit.org/272270@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/550e93cf87617f39e5f00f707ebf7c544932b014

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31141 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9814 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32830 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33646 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/28281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31905 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12157 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7072 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27938 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31474 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8272 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27838 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7103 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7279 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27733 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34987 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28340 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28190 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33416 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7315 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5371 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31255 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9001 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8018 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4047 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7849 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->