### PR TITLE
Remove IDL duplication in RemoteDOMWindow.idl

### DIFF
--- a/Source/WebCore/bindings/js/JSRemoteDOMWindowCustom.cpp
+++ b/Source/WebCore/bindings/js/JSRemoteDOMWindowCustom.cpp
@@ -135,6 +135,21 @@ bool JSRemoteDOMWindow::defineOwnProperty(JSC::JSObject*, JSC::JSGlobalObject* l
     return false;
 }
 
+JSValue JSRemoteDOMWindow::self(JSC::JSGlobalObject&) const
+{
+    return globalThis();
+}
+
+JSValue JSRemoteDOMWindow::window(JSC::JSGlobalObject&) const
+{
+    return globalThis();
+}
+
+JSValue JSRemoteDOMWindow::frames(JSC::JSGlobalObject&) const
+{
+    return globalThis();
+}
+
 JSValue JSRemoteDOMWindow::getPrototype(JSObject*, JSGlobalObject*)
 {
     return jsNull();

--- a/Source/WebCore/page/DOMWindow.idl
+++ b/Source/WebCore/page/DOMWindow.idl
@@ -24,10 +24,18 @@
  */
 
 interface mixin DOMWindow {
-    [CallWith=CurrentGlobalObject&IncumbentWindow, DoNotCheckSecurity] undefined postMessage(any message, USVString targetOrigin, optional sequence<object> transfer = []);
-    [CallWith=CurrentGlobalObject&IncumbentWindow, DoNotCheckSecurity] undefined postMessage(any message, optional WindowPostMessageOptions options);
-    [DoNotCheckSecurity, PutForwards=href, LegacyUnforgeable] readonly attribute Location location;
     [DoNotCheckSecurity, CallWith=IncumbentDocument] undefined close();
+    [DoNotCheckSecurity] readonly attribute boolean closed;
     [DoNotCheckSecurity, CallWith=IncumbentWindow] undefined focus();
+    [DoNotCheckSecurity] undefined blur();
+    [DoNotCheckSecurity, CallWith=CurrentGlobalObject&IncumbentWindow] undefined postMessage(any message, USVString targetOrigin, optional sequence<object> transfer = []);
+    [DoNotCheckSecurity, CallWith=CurrentGlobalObject&IncumbentWindow] undefined postMessage(any message, optional WindowPostMessageOptions options);
+    [DoNotCheckSecurity, PutForwards=href, LegacyUnforgeable] readonly attribute Location location;
+    [DoNotCheckSecurity, LegacyUnforgeable, CustomGetter] readonly attribute WindowProxy window;
+    [DoNotCheckSecurityOnGetter, Replaceable, CustomGetter] readonly attribute WindowProxy self;
     [DoNotCheckSecurityOnGetter, CustomSetter] attribute WindowProxy? opener;
+    [DoNotCheckSecurityOnGetter, Replaceable, CustomGetter] readonly attribute WindowProxy frames;
+    [DoNotCheckSecurityOnGetter, Replaceable] readonly attribute unsigned long length;
+    [DoNotCheckSecurityOnGetter, LegacyUnforgeable] readonly attribute WindowProxy? top;
+    [DoNotCheckSecurityOnGetter, Replaceable] readonly attribute WindowProxy? parent;
 };

--- a/Source/WebCore/page/LocalDOMWindow.idl
+++ b/Source/WebCore/page/LocalDOMWindow.idl
@@ -46,8 +46,6 @@
     Exposed=Window
 ] interface LocalDOMWindow : EventTarget {
     // the current browsing context
-    [DoNotCheckSecurity, LegacyUnforgeable, CustomGetter] readonly attribute WindowProxy window;
-    [Replaceable, DoNotCheckSecurityOnGetter, CustomGetter] readonly attribute WindowProxy self;
     [LegacyUnforgeable] readonly attribute Document document;
     attribute [AtomString] DOMString name;
     readonly attribute History history;
@@ -60,15 +58,9 @@
     [Replaceable] readonly attribute BarProp statusbar;
     [Replaceable] readonly attribute BarProp toolbar;
     attribute DOMString status;
-    [DoNotCheckSecurity] readonly attribute boolean closed;
     undefined stop();
-    [DoNotCheckSecurity] undefined blur();
 
     // other browsing contexts
-    [Replaceable, DoNotCheckSecurityOnGetter, CustomGetter] readonly attribute WindowProxy frames;
-    [Replaceable, DoNotCheckSecurityOnGetter] readonly attribute unsigned long length;
-    [DoNotCheckSecurityOnGetter, LegacyUnforgeable] readonly attribute WindowProxy? top;
-    [Replaceable, DoNotCheckSecurityOnGetter] readonly attribute WindowProxy? parent;
     [CheckSecurityForNode] readonly attribute Element? frameElement;
     [CallWith=ActiveWindow&FirstWindow] WindowProxy? open(optional USVString url = "", optional [AtomString] DOMString target = "_blank", optional [LegacyNullToEmptyString] DOMString features = "");
 

--- a/Source/WebCore/page/RemoteDOMWindow.idl
+++ b/Source/WebCore/page/RemoteDOMWindow.idl
@@ -41,14 +41,6 @@
     Global=Window,
     Exposed=Window
 ] interface RemoteDOMWindow {
-    [LegacyUnforgeable, ImplementedAs=self] readonly attribute WindowProxy window;
-    [Replaceable] readonly attribute WindowProxy self;
-    readonly attribute boolean closed;
-    undefined blur();
-    [Replaceable, ImplementedAs=self] readonly attribute WindowProxy frames;
-    [Replaceable] readonly attribute unsigned long length;
-    [LegacyUnforgeable] readonly attribute WindowProxy? top;
-    [Replaceable] readonly attribute WindowProxy? parent;
 };
 
 RemoteDOMWindow includes DOMWindow;


### PR DESCRIPTION
#### 6ec2f0dd13a9084b135c7fe5574a91073bc6532a
<pre>
Remove IDL duplication in RemoteDOMWindow.idl
<a href="https://bugs.webkit.org/show_bug.cgi?id=266617">https://bugs.webkit.org/show_bug.cgi?id=266617</a>
<a href="https://rdar.apple.com/119851333">rdar://119851333</a>

Reviewed by Chris Dumez.

RemoteDOMWindow.idl used to have some of the functions that LocalDOMWindow.idl had.
This moves them to a shared location and removes duplicate definitions, preferring
the LocalDOMWindow definition if there were any differences.

* Source/WebCore/bindings/js/JSRemoteDOMWindowCustom.cpp:
(WebCore::JSRemoteDOMWindow::self const):
(WebCore::JSRemoteDOMWindow::window const):
(WebCore::JSRemoteDOMWindow::frames const):
* Source/WebCore/page/DOMWindow.idl:
* Source/WebCore/page/LocalDOMWindow.idl:
* Source/WebCore/page/RemoteDOMWindow.idl:

Canonical link: <a href="https://commits.webkit.org/272272@main">https://commits.webkit.org/272272@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55985488ffa4e661404333bc177e62c18a86b3ff

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31133 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9805 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32821 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33638 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28097 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31896 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12149 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7063 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27931 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31465 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8265 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27829 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7096 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7272 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27724 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34978 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28333 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28181 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33404 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7307 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5361 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31247 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8994 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8011 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4048 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7841 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->