### PR TITLE
Fix some potential debug assertions in WebCoreNSURLSession

### DIFF
--- a/Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.h
+++ b/Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.h
@@ -70,9 +70,9 @@ WEBCORE_EXPORT @interface WebCoreNSURLSession : NSObject {
     WeakObjCPtr<id<NSURLSessionDelegate>> _delegate;
     RetainPtr<NSOperationQueue> _queue;
     RetainPtr<NSString> _sessionDescription;
-    HashSet<RetainPtr<WebCoreNSURLSessionDataTask>> _dataTasks;
-    HashSet<RefPtr<WebCore::SecurityOrigin>> _origins;
     Lock _dataTasksLock;
+    HashSet<RetainPtr<WebCoreNSURLSessionDataTask>> _dataTasks WTF_GUARDED_BY_LOCK(_dataTasksLock);
+    HashSet<RefPtr<WebCore::SecurityOrigin>> _origins;
     BOOL _invalidated;
     std::atomic<uint64_t> _nextTaskIdentifier;
     OSObjectPtr<dispatch_queue_t> _internalQueue;
@@ -131,7 +131,7 @@ WEBCORE_EXPORT @interface WebCoreNSURLSession : NSObject {
     int64_t _countOfBytesSent;
     int64_t _countOfBytesExpectedToSend;
     int64_t _countOfBytesExpectedToReceive;
-    NSURLSessionTaskState _state;
+    std::atomic<NSURLSessionTaskState> _state;
     RetainPtr<NSError> _error;
     RetainPtr<NSString> _taskDescription;
     float _priority;
@@ -145,7 +145,7 @@ WEBCORE_EXPORT @interface WebCoreNSURLSession : NSObject {
 @property int64_t countOfBytesSent;
 @property int64_t countOfBytesExpectedToSend;
 @property int64_t countOfBytesExpectedToReceive;
-@property NSURLSessionTaskState state;
+@property (readonly) NSURLSessionTaskState state;
 @property (nullable, readonly, copy) NSError *error;
 @property (nullable, copy) NSString *taskDescription;
 @property float priority;


### PR DESCRIPTION
#### b73bcfa4b339b6caa674cf8f449ff34a1c739467
<pre>
Fix some potential debug assertions in WebCoreNSURLSession
<a href="https://bugs.webkit.org/show_bug.cgi?id=266618">https://bugs.webkit.org/show_bug.cgi?id=266618</a>
<a href="https://rdar.apple.com/115087609">rdar://115087609</a>

Reviewed by Chris Dumez.

cancel and suspend can be called on any thread.  If they are called on a background thread
and the task finishes between when the selector is called on the background thread and the
callOnMainThread lambda is called, then things can get into a bad state and we can hit the
debug assertion in taskCompleted: indicating that a task was not in the set.  To fix this,
I add some state checks in cancel and suspend.  Because _state can be written to from a
background thread in cancel, I made the ivar std::atomic.  I add WTF_GUARDED_BY_LOCK to
prevent future issues around use of _dataTasks and ASSERT(isMainThread()); around use of
_origins to verify its thread safety.

* Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.h:
* Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.mm:
(-[WebCoreNSURLSession task:addSecurityOrigin:]):
(-[WebCoreNSURLSession isCrossOrigin:]):
(-[WebCoreNSURLSessionDataTask initWithSession:identifier:request:]):
(-[WebCoreNSURLSessionDataTask state]):
(-[WebCoreNSURLSessionDataTask cancel]):
(-[WebCoreNSURLSessionDataTask suspend]):
(-[WebCoreNSURLSessionDataTask resume]):
(-[WebCoreNSURLSessionDataTask _resource:loadFinishedWithError:metrics:]):

Canonical link: <a href="https://commits.webkit.org/272274@main">https://commits.webkit.org/272274@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d24f65fe4956b50d9da1f2640b5a152cab78c38

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31135 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9807 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32823 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33640 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/28282 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31898 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12151 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7065 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27935 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31467 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8266 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27830 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7100 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7273 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27725 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34980 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28334 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28182 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33408 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7309 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5364 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31246 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8996 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8013 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4050 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7843 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->