### PR TITLE
Remove NSCell-based-sizing from RenderThemeMac

### DIFF
--- a/Source/WebCore/rendering/RenderThemeMac.h
+++ b/Source/WebCore/rendering/RenderThemeMac.h
@@ -101,15 +101,9 @@ private:
 
     bool supportsLargeFormControls() const final;
 
-    void adjustTextFieldStyle(RenderStyle&, const Element*) const final;
-
-    void adjustTextAreaStyle(RenderStyle&, const Element*) const final;
-
     void adjustMenuListStyle(RenderStyle&, const Element*) const final;
 
     void adjustMenuListButtonStyle(RenderStyle&, const Element*) const final;
-
-    void adjustProgressBarStyle(RenderStyle&, const Element*) const final;
 
     void adjustSliderTrackStyle(RenderStyle&, const Element*) const final;
 
@@ -147,34 +141,12 @@ private:
 
     bool searchFieldShouldAppearAsTextField(const RenderStyle&) const final;
 
-    // Get the control size based off the font. Used by some of the controls (like buttons).
-    NSControlSize controlSizeForFont(const RenderStyle&) const;
-    NSControlSize controlSizeForSystemFont(const RenderStyle&) const;
-    NSControlSize controlSizeForCell(NSCell*, const IntSize* sizes, const IntSize& minSize, float zoomLevel = 1.0f) const;
-    void setControlSize(NSCell*, const IntSize* sizes, const IntSize& minSize, float zoomLevel = 1.0f);
-    void setSizeFromFont(RenderStyle&, const IntSize* sizes) const;
-    IntSize sizeForFont(const RenderStyle&, const IntSize* sizes) const;
-    IntSize sizeForSystemFont(const RenderStyle&, const IntSize* sizes) const;
-    void setFontFromControlSize(RenderStyle&, NSControlSize) const;
-
-    void updateCheckedState(NSCell*, const RenderObject&);
-    void updateEnabledState(NSCell*, const RenderObject&);
-    void updatePressedState(NSCell*, const RenderObject&);
-
-    // Helpers for adjusting appearance and for painting
-
-    void setPopupButtonCellState(const RenderObject&, const IntSize&);
-    const IntSize* popupButtonSizes() const;
-    const int* popupButtonMargins() const;
-    const int* popupButtonPadding(NSControlSize, bool isRTL) const;
     const IntSize* menuListSizes() const;
 
     const IntSize* searchFieldSizes() const;
     const IntSize* cancelButtonSizes() const;
     const IntSize* resultsButtonSizes() const;
     void setSearchFieldSize(RenderStyle&) const;
-
-    NSPopUpButtonCell *popupButton() const;
 
 #if ENABLE(SERVICE_CONTROLS)
     IntSize imageControlsButtonSize() const final;


### PR DESCRIPTION
#### 7b07821e498923b349108cd877609f8969d6b251
<pre>
Remove NSCell-based-sizing from RenderThemeMac
<a href="https://bugs.webkit.org/show_bug.cgi?id=266620">https://bugs.webkit.org/show_bug.cgi?id=266620</a>

Reviewed by Aditya Keerthi.

Apply the lessons from 272218@main to RenderThemeMac. There is no need
for an NSCell to determine the size of a control.

Additionally, we make a number of things static that have no class
dependency and remove no-op final methods that were already no-op.

This lays the groundwork for merging more of ThemeMac into
RenderThemeMac.

* Source/WebCore/rendering/RenderThemeMac.h:
* Source/WebCore/rendering/RenderThemeMac.mm:
(WebCore::controlSizeFromPixelSize):
(WebCore::popupButtonMargins):
(WebCore::popupButtonSizes):
(WebCore::popupButtonPadding):
(WebCore::RenderThemeMac::adjustRepaintRect):
(WebCore::controlSizeForSystemFont):
(WebCore::controlSizeForFont):
(WebCore::sizeForFont):
(WebCore::sizeForSystemFont):
(WebCore::setSizeFromFont):
(WebCore::setFontFromControlSize):
(WebCore::RenderThemeMac::popupMenuSize const):
(WebCore::RenderThemeMac::updateCheckedState): Deleted.
(WebCore::RenderThemeMac::updateEnabledState): Deleted.
(WebCore::RenderThemeMac::updatePressedState): Deleted.
(WebCore::RenderThemeMac::controlSizeForFont const): Deleted.
(WebCore::RenderThemeMac::controlSizeForCell const): Deleted.
(WebCore::RenderThemeMac::setControlSize): Deleted.
(WebCore::RenderThemeMac::sizeForFont const): Deleted.
(WebCore::RenderThemeMac::sizeForSystemFont const): Deleted.
(WebCore::RenderThemeMac::setSizeFromFont const): Deleted.
(WebCore::RenderThemeMac::setFontFromControlSize const): Deleted.
(WebCore::RenderThemeMac::controlSizeForSystemFont const): Deleted.
(WebCore::RenderThemeMac::adjustTextFieldStyle const): Deleted.
(WebCore::RenderThemeMac::adjustTextAreaStyle const): Deleted.
(WebCore::RenderThemeMac::popupButtonMargins const): Deleted.
(WebCore::RenderThemeMac::popupButtonSizes const): Deleted.
(WebCore::RenderThemeMac::popupButtonPadding const): Deleted.
(WebCore::RenderThemeMac::adjustProgressBarStyle const): Deleted.
(WebCore::RenderThemeMac::setPopupButtonCellState): Deleted.
(WebCore::RenderThemeMac::popupButton const): Deleted.

Canonical link: <a href="https://commits.webkit.org/272403@main">https://commits.webkit.org/272403@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b67bc42a2fffcd64f489cfb4c03cc80fdebc3bdf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31140 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9813 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32829 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33645 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28299 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31904 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12156 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7071 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27939 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31473 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8271 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27836 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7104 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7278 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27731 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34986 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28339 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28188 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33411 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7314 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5370 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31250 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9000 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7403 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8017 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7848 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->