### PR TITLE
[WPE] WPE Platform: fix a crash when handling wayland DMA-BUF feedback with some compositors

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp
@@ -56,26 +56,54 @@ typedef struct wl_buffer *(EGLAPIENTRYP PFNEGLCREATEWAYLANDBUFFERFROMIMAGEWL)(EG
 struct DMABufFeedback {
     WTF_MAKE_STRUCT_FAST_ALLOCATED;
 
-    DMABufFeedback(unsigned size, int fd)
-    {
-        formatTable.size = size;
-        formatTable.data = static_cast<FormatTable::Data*>(mmap(nullptr, size, PROT_READ, MAP_PRIVATE, fd, 0));
-    }
-
-    ~DMABufFeedback()
-    {
-        if (formatTable.data && formatTable.data != MAP_FAILED)
-            munmap(formatTable.data, formatTable.size);
-    }
-
     struct FormatTable {
-        unsigned size { 0 };
         struct Data {
             uint32_t format { 0 };
             uint32_t padding { 0 };
             uint64_t modifier { 0 };
-        } *data { nullptr };
+        };
+
+        FormatTable(const FormatTable&) = delete;
+        FormatTable& operator=(const FormatTable&) = delete;
+        FormatTable(FormatTable&& other)
+            : size(other.size)
+            , data(other.data)
+        {
+            other.size = 0;
+            other.data = nullptr;
+        }
+
+        FormatTable(unsigned size, Data* data)
+            : size(size)
+            , data(data)
+        {
+        }
+
+        ~FormatTable()
+        {
+            if (data)
+                munmap(data, size);
+        }
+
+        unsigned size { 0 };
+        Data* data { nullptr };
     };
+
+    static std::unique_ptr<DMABufFeedback> create(unsigned size, int fd)
+    {
+        auto* data = static_cast<FormatTable::Data*>(mmap(nullptr, size, PROT_READ, MAP_PRIVATE, fd, 0));
+        if (data == MAP_FAILED)
+            return nullptr;
+
+        return makeUnique<DMABufFeedback>(FormatTable(size, data));
+    }
+
+    explicit DMABufFeedback(FormatTable&& table)
+        : formatTable(WTFMove(table))
+    {
+    }
+
+    ~DMABufFeedback() = default;
 
     struct Tranche {
         uint32_t flags { 0 };
@@ -84,8 +112,6 @@ struct DMABufFeedback {
 
     std::pair<uint32_t, uint64_t> format(uint16_t index)
     {
-        if (!formatTable.data || formatTable.data == MAP_FAILED)
-            return { 0, 0 };
         return { formatTable.data[index].format, formatTable.data[index].modifier };
     }
 
@@ -240,32 +266,37 @@ static const struct zwp_linux_dmabuf_feedback_v1_listener linuxDMABufFeedbackLis
     [](void* data, struct zwp_linux_dmabuf_feedback_v1*, int32_t fd, uint32_t size)
     {
         auto* priv = WPE_VIEW_WAYLAND(data)->priv;
-        priv->pendingDMABufFeedback = makeUnique<DMABufFeedback>(size, fd);
+        priv->pendingDMABufFeedback = DMABufFeedback::create(size, fd);
         close(fd);
     },
     // main_device
-    [](void*, struct zwp_linux_dmabuf_feedback_v1*, struct wl_array*)
+    [](void* data, struct zwp_linux_dmabuf_feedback_v1*, struct wl_array*)
     {
+        auto* priv = WPE_VIEW_WAYLAND(data)->priv;
+        // Compositor might not re-send the format table. In that case, try to reuse the previous one.
+        if (!priv->pendingDMABufFeedback && priv->committedDMABufFeedback)
+            priv->pendingDMABufFeedback = makeUnique<DMABufFeedback>(WTFMove(priv->committedDMABufFeedback->formatTable));
+
         // FIXME: handle main device.
     },
     // tranche_done
     [](void* data, struct zwp_linux_dmabuf_feedback_v1*)
     {
         auto* priv = WPE_VIEW_WAYLAND(data)->priv;
+        if (!priv->pendingDMABufFeedback)
+            return;
+
         priv->pendingDMABufFeedback->tranches.append(WTFMove(priv->pendingDMABufFeedback->pendingTranche));
     },
     // tranche_target_device
     [](void*, struct zwp_linux_dmabuf_feedback_v1*, struct wl_array*)
     {
-        // FIXME: handle target device.
     },
     // tranche_formats
     [](void* data, struct zwp_linux_dmabuf_feedback_v1*, struct wl_array* indices)
     {
         auto* priv = WPE_VIEW_WAYLAND(data)->priv;
-        if (!priv->pendingDMABufFeedback->formatTable.data && priv->committedDMABufFeedback)
-            priv->pendingDMABufFeedback->formatTable = WTFMove(priv->committedDMABufFeedback->formatTable);
-        if (!priv->pendingDMABufFeedback->formatTable.data || priv->pendingDMABufFeedback->formatTable.data == MAP_FAILED)
+        if (!priv->pendingDMABufFeedback)
             return;
 
         const char* end = static_cast<const char*>(indices->data) + indices->size;
@@ -276,7 +307,8 @@ static const struct zwp_linux_dmabuf_feedback_v1_listener linuxDMABufFeedbackLis
     [](void* data, struct zwp_linux_dmabuf_feedback_v1*, uint32_t flags)
     {
         auto* priv = WPE_VIEW_WAYLAND(data)->priv;
-        priv->pendingDMABufFeedback->pendingTranche.flags |= flags;
+        if (priv->pendingDMABufFeedback)
+            priv->pendingDMABufFeedback->pendingTranche.flags |= flags;
     }
 };
 


### PR DESCRIPTION
#### ec311d6d964b58d9d62362b5d64d84fbb54f7e19
<pre>
[WPE] WPE Platform: fix a crash when handling wayland DMA-BUF feedback with some compositors
<a href="https://bugs.webkit.org/show_bug.cgi?id=266622">https://bugs.webkit.org/show_bug.cgi?id=266622</a>

Reviewed by Alejandro G. Castro.

Some compositors like weston don&apos;t sent the format table on every
feedback message, but only the first time. Handle that case in main
device message by stealing the format table from the previous committed
feedback.

* Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp:
(DMABufFeedback::FormatTable::FormatTable):
(DMABufFeedback::FormatTable::~FormatTable):
(DMABufFeedback::create):
(DMABufFeedback::DMABufFeedback):
(DMABufFeedback::format):
(DMABufFeedback::~DMABufFeedback): Deleted.

Canonical link: <a href="https://commits.webkit.org/272262@main">https://commits.webkit.org/272262@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a928c4452528341f03825dc1cbd6b2c8a175e5e7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31142 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9815 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32831 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33647 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28177 "Failed to checkout and rebase branch from PR 22012") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12158 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7073 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/27941 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31475 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8275 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27839 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7106 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7282 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34988 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28343 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28191 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33414 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7316 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5374 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/31253 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9002 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8019 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4043 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7850 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->