### PR TITLE
Ruby style cleanups

### DIFF
--- a/LayoutTests/fast/ruby/ruby-block-style-not-updated-expected.txt
+++ b/LayoutTests/fast/ruby/ruby-block-style-not-updated-expected.txt
@@ -3,11 +3,9 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderRuby (block) {RUBY} at (0,0) size 784x128 [color=#0000FF]
-        RenderRubyRun (anonymous) at (0,0) size 512x128
-          RenderRubyBase (anonymous) at (0,0) size 512x128
-            RenderText {#text} at (0,0) size 512x128
-              text run at (0,0) width 512: "ABCD"
+      RenderBlock {RUBY} at (0,0) size 784x128 [color=#0000FF]
+        RenderText {#text} at (0,0) size 512x128
+          text run at (0,0) width 512: "ABCD"
       RenderBlock {DIV} at (0,128) size 784x128 [color=#008000]
         RenderText {#text} at (0,0) size 512x128
           text run at (0,0) width 512: "EFGH"

--- a/Source/WebCore/html/RubyElement.cpp
+++ b/Source/WebCore/html/RubyElement.cpp
@@ -53,11 +53,12 @@ Ref<RubyElement> RubyElement::create(Document& document)
 
 RenderPtr<RenderElement> RubyElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition& insertionPosition)
 {
-    if (style.display() == DisplayType::Inline)
-        return createRenderer<RenderRubyAsInline>(*this, WTFMove(style));
-    if (style.display() == DisplayType::Block || style.display() == DisplayType::InlineBlock)
-        return createRenderer<RenderRubyAsBlock>(*this, WTFMove(style));
-
+    if (!document().settings().cssBasedRubyEnabled()) {
+        if (style.display() == DisplayType::Inline)
+            return createRenderer<RenderRubyAsInline>(*this, WTFMove(style));
+        if (style.display() == DisplayType::Block || style.display() == DisplayType::InlineBlock)
+            return createRenderer<RenderRubyAsBlock>(*this, WTFMove(style));
+    }
     return HTMLElement::createElementRenderer(WTFMove(style), insertionPosition);
 }
 

--- a/Source/WebCore/html/RubyTextElement.cpp
+++ b/Source/WebCore/html/RubyTextElement.cpp
@@ -55,9 +55,11 @@ Ref<RubyTextElement> RubyTextElement::create(Document& document)
 
 RenderPtr<RenderElement> RubyTextElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition& insertionPosition)
 {
-    // RenderRubyText requires its parent to be RenderRubyRun.
-    if (isRuby(insertionPosition.parent()) && style.display() == DisplayType::Block)
-        return createRenderer<RenderRubyText>(*this, WTFMove(style));
+    if (!document().settings().cssBasedRubyEnabled()) {
+        // RenderRubyText requires its parent to be RenderRubyRun.
+        if (isRuby(insertionPosition.parent()) && style.display() == DisplayType::Block)
+            return createRenderer<RenderRubyText>(*this, WTFMove(style));
+    }
     return HTMLElement::createElementRenderer(WTFMove(style), insertionPosition);
 }
 

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -379,17 +379,21 @@ static bool isRubyContainerOrInternalRubyBox(const RenderStyle& style)
 }
 
 // https://drafts.csswg.org/css-ruby-1/#bidi
-static UnicodeBidi adjustUnicodeBidiForRuby(UnicodeBidi unicodeBidi)
+static UnicodeBidi forceBidiIsolationForRuby(UnicodeBidi unicodeBidi)
 {
     switch (unicodeBidi) {
     case UnicodeBidi::Normal:
     case UnicodeBidi::Embed:
+    case UnicodeBidi::Isolate:
         return UnicodeBidi::Isolate;
     case UnicodeBidi::Override:
+    case UnicodeBidi::IsolateOverride:
         return UnicodeBidi::IsolateOverride;
-    default:
-        return unicodeBidi;
+    case UnicodeBidi::Plaintext:
+        return UnicodeBidi::Plaintext;
     }
+    ASSERT_NOT_REACHED();
+    return UnicodeBidi::Isolate;
 }
 
 void Adjuster::adjust(RenderStyle& style, const RenderStyle* userAgentAppearanceStyle) const
@@ -418,9 +422,6 @@ void Adjuster::adjust(RenderStyle& style, const RenderStyle* userAgentAppearance
 
             if (m_element->hasTagName(legendTag))
                 style.setEffectiveDisplay(equivalentBlockDisplay(style));
-
-            if (isRubyContainerOrInternalRubyBox(style))
-                style.setEffectiveDisplay(style.display());
         }
 
         // Top layer elements are always position: absolute; unless the position is set to fixed.
@@ -470,7 +471,7 @@ void Adjuster::adjust(RenderStyle& style, const RenderStyle* userAgentAppearance
             style.setEffectiveDisplay(equivalentInlineDisplay(style));
         // https://drafts.csswg.org/css-ruby-1/#bidi
         if (isRubyContainerOrInternalRubyBox(style))
-            style.setUnicodeBidi(adjustUnicodeBidiForRuby(style.unicodeBidi()));
+            style.setUnicodeBidi(forceBidiIsolationForRuby(style.unicodeBidi()));
     }
 
     auto hasAutoZIndex = [](const RenderStyle& style, const RenderStyle& parentBoxStyle, const Element* element) {


### PR DESCRIPTION
#### 4be388cadb468d7b951a79e5ea6940a3aec607e6
<pre>
Ruby style cleanups
<a href="https://bugs.webkit.org/show_bug.cgi?id=266623">https://bugs.webkit.org/show_bug.cgi?id=266623</a>
<a href="https://rdar.apple.com/119856171">rdar://119856171</a>

Reviewed by Tim Nguyen and Alan Baradlay.

* LayoutTests/fast/ruby/ruby-block-style-not-updated-expected.txt:
* Source/WebCore/html/RubyElement.cpp:
(WebCore::RubyElement::createElementRenderer):
* Source/WebCore/html/RubyTextElement.cpp:
(WebCore::RubyTextElement::createElementRenderer):

Ensure we can&apos;t create legacy ruby renderers with css ruby enabled.

* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::forceBidiIsolationForRuby):

Rename and include all cases to switch.

(WebCore::Style::Adjuster::adjust const):

Remove some no-op code.

(WebCore::Style::adjustUnicodeBidiForRuby): Deleted.

Canonical link: <a href="https://commits.webkit.org/272267@main">https://commits.webkit.org/272267@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14992ae0c864c37f3c15935d5496cce09f51ad78

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31149 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9824 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32840 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33655 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/28283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31915 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12167 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7082 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27948 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31484 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8281 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27847 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7113 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7287 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27742 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34997 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28348 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28199 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33422 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7323 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5379 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31261 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9009 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7328 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8026 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7857 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->