### PR TITLE
Clean up most of remaining EnumTraits specializations under WebCore/platform/graphics

### DIFF
--- a/Source/WebCore/html/track/AudioTrack.cpp
+++ b/Source/WebCore/html/track/AudioTrack.cpp
@@ -191,25 +191,25 @@ void AudioTrack::willRemove()
 void AudioTrack::updateKindFromPrivate()
 {
     switch (m_private->kind()) {
-    case AudioTrackPrivate::Alternative:
+    case AudioTrackPrivate::Kind::Alternative:
         setKind(alternativeAtom());
         break;
-    case AudioTrackPrivate::Description:
+    case AudioTrackPrivate::Kind::Description:
         setKind(AudioTrack::descriptionKeyword());
         break;
-    case AudioTrackPrivate::Main:
+    case AudioTrackPrivate::Kind::Main:
         setKind(mainAtom());
         break;
-    case AudioTrackPrivate::MainDesc:
+    case AudioTrackPrivate::Kind::MainDesc:
         setKind(AudioTrack::mainDescKeyword());
         break;
-    case AudioTrackPrivate::Translation:
+    case AudioTrackPrivate::Kind::Translation:
         setKind(AudioTrack::translationKeyword());
         break;
-    case AudioTrackPrivate::Commentary:
+    case AudioTrackPrivate::Kind::Commentary:
         setKind(commentaryAtom());
         break;
-    case AudioTrackPrivate::None:
+    case AudioTrackPrivate::Kind::None:
         setKind(emptyAtom());
         break;
     default:

--- a/Source/WebCore/html/track/VideoTrack.cpp
+++ b/Source/WebCore/html/track/VideoTrack.cpp
@@ -212,25 +212,25 @@ void VideoTrack::setLanguage(const AtomString& language)
 void VideoTrack::updateKindFromPrivate()
 {
     switch (m_private->kind()) {
-    case VideoTrackPrivate::Alternative:
+    case VideoTrackPrivate::Kind::Alternative:
         setKind(alternativeAtom());
         return;
-    case VideoTrackPrivate::Captions:
+    case VideoTrackPrivate::Kind::Captions:
         setKind(captionsAtom());
         return;
-    case VideoTrackPrivate::Main:
+    case VideoTrackPrivate::Kind::Main:
         setKind(mainAtom());
         return;
-    case VideoTrackPrivate::Sign:
+    case VideoTrackPrivate::Kind::Sign:
         setKind(VideoTrack::signKeyword());
         return;
-    case VideoTrackPrivate::Subtitles:
+    case VideoTrackPrivate::Kind::Subtitles:
         setKind(subtitlesAtom());
         return;
-    case VideoTrackPrivate::Commentary:
+    case VideoTrackPrivate::Kind::Commentary:
         setKind(commentaryAtom());
         return;
-    case VideoTrackPrivate::None:
+    case VideoTrackPrivate::Kind::None:
         setKind(emptyAtom());
         return;
     }

--- a/Source/WebCore/platform/graphics/AudioTrackPrivate.h
+++ b/Source/WebCore/platform/graphics/AudioTrackPrivate.h
@@ -55,8 +55,8 @@ public:
 
     bool enabled() const { return m_enabled; }
 
-    enum Kind { Alternative, Description, Main, MainDesc, Translation, Commentary, None };
-    virtual Kind kind() const { return None; }
+    enum class Kind : uint8_t { Alternative, Description, Main, MainDesc, Translation, Commentary, None };
+    virtual Kind kind() const { return Kind::None; }
 
     virtual bool isBackedByMediaStreamTrack() const { return false; }
 
@@ -103,22 +103,5 @@ private:
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::AudioTrackPrivate)
 static bool isType(const WebCore::TrackPrivateBase& track) { return track.type() == WebCore::TrackPrivateBase::Type::Audio; }
 SPECIALIZE_TYPE_TRAITS_END()
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::AudioTrackPrivate::Kind> {
-    using values = EnumValues<
-        WebCore::AudioTrackPrivate::Kind,
-        WebCore::AudioTrackPrivate::Kind::Alternative,
-        WebCore::AudioTrackPrivate::Kind::Description,
-        WebCore::AudioTrackPrivate::Kind::Main,
-        WebCore::AudioTrackPrivate::Kind::MainDesc,
-        WebCore::AudioTrackPrivate::Kind::Translation,
-        WebCore::AudioTrackPrivate::Kind::Commentary,
-        WebCore::AudioTrackPrivate::Kind::None
-    >;
-};
-
-} // namespace WTF
 
 #endif

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -113,6 +113,12 @@ using GraphicsContextGLEGLImageSource = std::variant<
     >;
 #endif // PLATFORM(COCOA)
 
+
+enum class GraphicsContextGLSurfaceBuffer : bool {
+    DrawingBuffer,
+    DisplayBuffer
+};
+
 // Base class for graphics context for implementing WebGL rendering model.
 class GraphicsContextGL : public RefCounted<GraphicsContextGL> {
 public:
@@ -1637,10 +1643,7 @@ public:
     // FIXME: these should be removed, they're part of drawing buffer and
     // display buffer abstractions that the caller should hold separate to
     // the context.
-    enum class SurfaceBuffer : uint8_t {
-        DrawingBuffer,
-        DisplayBuffer
-    };
+    using SurfaceBuffer = GraphicsContextGLSurfaceBuffer;
     virtual void drawSurfaceBufferToImageBuffer(SurfaceBuffer, ImageBuffer&) = 0;
 #if ENABLE(MEDIA_STREAM) || ENABLE(WEB_CODECS)
     virtual RefPtr<VideoFrame> surfaceBufferToVideoFrame(SurfaceBuffer) = 0;
@@ -1753,17 +1756,5 @@ IMPLEMENT_GCGL_OWNED(Texture)
 #undef IMPLEMENT_GCGL_OWNED
 
 } // namespace WebCore
-
-namespace WTF {
-
-template <> struct EnumTraits<WebCore::GraphicsContextGL::SurfaceBuffer> {
-    using values = EnumValues<
-        WebCore::GraphicsContextGL::SurfaceBuffer,
-        WebCore::GraphicsContextGL::SurfaceBuffer::DrawingBuffer,
-        WebCore::GraphicsContextGL::SurfaceBuffer::DisplayBuffer
-    >;
-};
-
-}
 
 #endif

--- a/Source/WebCore/platform/graphics/GraphicsContextState.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextState.h
@@ -209,36 +209,3 @@ TextStream& operator<<(TextStream&, GraphicsContextState::Change);
 TextStream& operator<<(TextStream&, const GraphicsContextState&);
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::GraphicsContextState::Change> {
-    using values = EnumValues<
-        WebCore::GraphicsContextState::Change,
-        WebCore::GraphicsContextState::Change::FillBrush,
-        WebCore::GraphicsContextState::Change::FillRule,
-
-        WebCore::GraphicsContextState::Change::StrokeBrush,
-        WebCore::GraphicsContextState::Change::StrokeThickness,
-        WebCore::GraphicsContextState::Change::StrokeStyle,
-
-        WebCore::GraphicsContextState::Change::CompositeMode,
-        WebCore::GraphicsContextState::Change::DropShadow,
-        WebCore::GraphicsContextState::Change::Style,
-
-        WebCore::GraphicsContextState::Change::Alpha,
-        WebCore::GraphicsContextState::Change::TextDrawingMode,
-        WebCore::GraphicsContextState::Change::ImageInterpolationQuality,
-
-        WebCore::GraphicsContextState::Change::ShouldAntialias,
-        WebCore::GraphicsContextState::Change::ShouldSmoothFonts,
-        WebCore::GraphicsContextState::Change::ShouldSubpixelQuantizeFonts,
-        WebCore::GraphicsContextState::Change::ShadowsIgnoreTransforms,
-        WebCore::GraphicsContextState::Change::DrawLuminanceMask
-#if HAVE(OS_DARK_MODE_SUPPORT)
-        , WebCore::GraphicsContextState::Change::UseDarkAppearance
-#endif
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -49,7 +49,6 @@
 #include "TransformOperations.h"
 #include "WindRule.h"
 #include <wtf/CheckedRef.h>
-#include <wtf/EnumTraits.h>
 #include <wtf/Function.h>
 #include <wtf/TypeCasts.h>
 
@@ -590,7 +589,7 @@ public:
     virtual void setDebugBackgroundColor(const Color&) { }
     virtual void setDebugBorder(const Color&, float /*borderWidth*/) { }
 
-    enum class CustomAppearance : uint8_t {
+    enum class CustomAppearance : bool {
         None,
         ScrollingShadow
     };
@@ -842,15 +841,3 @@ SPECIALIZE_TYPE_TRAITS_END()
 // Outside the WebCore namespace for ease of invocation from the debugger.
 void showGraphicsLayerTree(const WebCore::GraphicsLayer* layer);
 #endif
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::GraphicsLayer::CustomAppearance> {
-    using values = EnumValues<
-        WebCore::GraphicsLayer::CustomAppearance,
-        WebCore::GraphicsLayer::CustomAppearance::None,
-        WebCore::GraphicsLayer::CustomAppearance::ScrollingShadow
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/platform/graphics/GraphicsTypesGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsTypesGL.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <cstdint>
-#include <wtf/EnumTraits.h>
 #include <wtf/OptionSet.h>
 
 // GCGL types match the corresponding GL types as defined in OpenGL ES 2.0
@@ -84,19 +83,3 @@ enum class GCGLErrorCode : uint8_t {
     InvalidEnum = 1 << 6
 };
 using GCGLErrorCodeSet = OptionSet<GCGLErrorCode>;
-
-namespace WTF {
-
-template <> struct EnumTraits<GCGLErrorCode> {
-    using values = EnumValues <
-    GCGLErrorCode,
-    GCGLErrorCode::ContextLost,
-    GCGLErrorCode::InvalidFramebufferOperation,
-    GCGLErrorCode::OutOfMemory,
-    GCGLErrorCode::InvalidOperation,
-    GCGLErrorCode::InvalidValue,
-    GCGLErrorCode::InvalidEnum
-    >;
-};
-
-}

--- a/Source/WebCore/platform/graphics/Image.h
+++ b/Source/WebCore/platform/graphics/Image.h
@@ -36,7 +36,6 @@
 #include "ImageTypes.h"
 #include "NativeImage.h"
 #include "Timer.h"
-#include <wtf/EnumTraits.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
 #include <wtf/RetainPtr.h>
@@ -232,18 +231,3 @@ WTF::TextStream& operator<<(WTF::TextStream&, const Image&);
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ToClassName) \
     static bool isType(const WebCore::Image& image) { return image.is##ToClassName(); } \
 SPECIALIZE_TYPE_TRAITS_END()
-
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::Image::TileRule> {
-    using values = EnumValues<
-        WebCore::Image::TileRule,
-        WebCore::Image::TileRule::StretchTile,
-        WebCore::Image::TileRule::RoundTile,
-        WebCore::Image::TileRule::SpaceTile,
-        WebCore::Image::TileRule::RepeatTile
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/platform/graphics/SystemImage.h
+++ b/Source/WebCore/platform/graphics/SystemImage.h
@@ -64,22 +64,3 @@ private:
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::SystemImageType> {
-    using values = EnumValues<
-        WebCore::SystemImageType
-#if ENABLE(APPLE_PAY)
-        , WebCore::SystemImageType::ApplePayLogo
-#endif
-#if USE(SYSTEM_PREVIEW)
-        , WebCore::SystemImageType::ARKitBadge
-#endif
-#if USE(APPKIT)
-        , WebCore::SystemImageType::AppKitControl
-#endif
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/platform/graphics/VideoTrackPrivate.h
+++ b/Source/WebCore/platform/graphics/VideoTrackPrivate.h
@@ -54,8 +54,8 @@ public:
     }
     virtual bool selected() const { return m_selected; }
 
-    enum Kind { Alternative, Captions, Main, Sign, Subtitles, Commentary, None };
-    virtual Kind kind() const { return None; }
+    enum class Kind : uint8_t { Alternative, Captions, Main, Sign, Subtitles, Commentary, None };
+    virtual Kind kind() const { return Kind::None; }
 
 #if !RELEASE_LOG_DISABLED
     const char* logClassName() const final { return "VideoTrackPrivate"; }
@@ -101,22 +101,5 @@ private:
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::VideoTrackPrivate)
 static bool isType(const WebCore::TrackPrivateBase& track) { return track.type() == WebCore::TrackPrivateBase::Type::Video; }
 SPECIALIZE_TYPE_TRAITS_END()
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::VideoTrackPrivate::Kind> {
-    using values = EnumValues<
-        WebCore::VideoTrackPrivate::Kind,
-        WebCore::VideoTrackPrivate::Kind::Alternative,
-        WebCore::VideoTrackPrivate::Kind::Captions,
-        WebCore::VideoTrackPrivate::Kind::Main,
-        WebCore::VideoTrackPrivate::Kind::Sign,
-        WebCore::VideoTrackPrivate::Kind::Subtitles,
-        WebCore::VideoTrackPrivate::Kind::Commentary,
-        WebCore::VideoTrackPrivate::Kind::None
-    >;
-};
-
-} // namespace WTF
 
 #endif

--- a/Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm
@@ -120,58 +120,58 @@ AudioTrackPrivate::Kind AVTrackPrivateAVFObjCImpl::audioKind() const
 {
     if (m_assetTrack) {
         if ([m_assetTrack hasMediaCharacteristic:AVMediaCharacteristicIsAuxiliaryContent])
-            return AudioTrackPrivate::Alternative;
+            return AudioTrackPrivate::Kind::Alternative;
         if ([m_assetTrack hasMediaCharacteristic:AVMediaCharacteristicDescribesVideoForAccessibility])
-            return AudioTrackPrivate::Description;
+            return AudioTrackPrivate::Kind::Description;
         if ([m_assetTrack hasMediaCharacteristic:AVMediaCharacteristicIsMainProgramContent])
-            return AudioTrackPrivate::Main;
-        return AudioTrackPrivate::None;
+            return AudioTrackPrivate::Kind::Main;
+        return AudioTrackPrivate::Kind::None;
     }
 
     if (m_mediaSelectionOption) {
         AVMediaSelectionOption *option = m_mediaSelectionOption->avMediaSelectionOption();
         if ([option hasMediaCharacteristic:AVMediaCharacteristicIsAuxiliaryContent])
-            return AudioTrackPrivate::Alternative;
+            return AudioTrackPrivate::Kind::Alternative;
         if ([option hasMediaCharacteristic:AVMediaCharacteristicDescribesVideoForAccessibility])
-            return AudioTrackPrivate::Description;
+            return AudioTrackPrivate::Kind::Description;
         if ([option hasMediaCharacteristic:AVMediaCharacteristicIsMainProgramContent])
-            return AudioTrackPrivate::Main;
-        return AudioTrackPrivate::None;
+            return AudioTrackPrivate::Kind::Main;
+        return AudioTrackPrivate::Kind::None;
     }
 
     ASSERT_NOT_REACHED();
-    return AudioTrackPrivate::None;
+    return AudioTrackPrivate::Kind::None;
 }
 
 VideoTrackPrivate::Kind AVTrackPrivateAVFObjCImpl::videoKind() const
 {
     if (m_assetTrack) {
         if ([m_assetTrack hasMediaCharacteristic:AVMediaCharacteristicDescribesVideoForAccessibility])
-            return VideoTrackPrivate::Sign;
+            return VideoTrackPrivate::Kind::Sign;
         if ([m_assetTrack hasMediaCharacteristic:AVMediaCharacteristicTranscribesSpokenDialogForAccessibility])
-            return VideoTrackPrivate::Captions;
+            return VideoTrackPrivate::Kind::Captions;
         if ([m_assetTrack hasMediaCharacteristic:AVMediaCharacteristicIsAuxiliaryContent])
-            return VideoTrackPrivate::Alternative;
+            return VideoTrackPrivate::Kind::Alternative;
         if ([m_assetTrack hasMediaCharacteristic:AVMediaCharacteristicIsMainProgramContent])
-            return VideoTrackPrivate::Main;
-        return VideoTrackPrivate::None;
+            return VideoTrackPrivate::Kind::Main;
+        return VideoTrackPrivate::Kind::None;
     }
 
     if (m_mediaSelectionOption) {
         AVMediaSelectionOption *option = m_mediaSelectionOption->avMediaSelectionOption();
         if ([option hasMediaCharacteristic:AVMediaCharacteristicDescribesVideoForAccessibility])
-            return VideoTrackPrivate::Sign;
+            return VideoTrackPrivate::Kind::Sign;
         if ([option hasMediaCharacteristic:AVMediaCharacteristicTranscribesSpokenDialogForAccessibility])
-            return VideoTrackPrivate::Captions;
+            return VideoTrackPrivate::Kind::Captions;
         if ([option hasMediaCharacteristic:AVMediaCharacteristicIsAuxiliaryContent])
-            return VideoTrackPrivate::Alternative;
+            return VideoTrackPrivate::Kind::Alternative;
         if ([option hasMediaCharacteristic:AVMediaCharacteristicIsMainProgramContent])
-            return VideoTrackPrivate::Main;
-        return VideoTrackPrivate::None;
+            return VideoTrackPrivate::Kind::Main;
+        return VideoTrackPrivate::Kind::None;
     }
 
     ASSERT_NOT_REACHED();
-    return VideoTrackPrivate::None;
+    return VideoTrackPrivate::Kind::None;
 }
 
 int AVTrackPrivateAVFObjCImpl::index() const

--- a/Source/WebCore/platform/graphics/avfoundation/AudioTrackPrivateAVF.h
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioTrackPrivateAVF.h
@@ -47,7 +47,7 @@ protected:
     void setLanguage(const AtomString& language) { m_language = language; }
     void setTrackIndex(int index) { m_index = index; }
     
-    Kind m_kind { None };
+    Kind m_kind { Kind::None };
     TrackID m_id;
     AtomString m_label;
     AtomString m_language;

--- a/Source/WebCore/platform/graphics/avfoundation/VideoTrackPrivateAVF.h
+++ b/Source/WebCore/platform/graphics/avfoundation/VideoTrackPrivateAVF.h
@@ -48,7 +48,7 @@ protected:
     void setTrackIndex(int index) { m_index = index; }
 
 
-    Kind m_kind { None };
+    Kind m_kind { Kind::None };
     TrackID m_id;
     AtomString m_label;
     AtomString m_language;

--- a/Source/WebCore/platform/graphics/transforms/TransformOperation.h
+++ b/Source/WebCore/platform/graphics/transforms/TransformOperation.h
@@ -36,33 +36,35 @@ namespace WebCore {
 
 struct BlendingContext;
 
+enum class TransformOperationType : uint8_t {
+    ScaleX,
+    ScaleY,
+    Scale,
+    TranslateX,
+    TranslateY,
+    Translate,
+    RotateX,
+    RotateY,
+    Rotate,
+    SkewX,
+    SkewY,
+    Skew,
+    Matrix,
+    ScaleZ,
+    Scale3D,
+    TranslateZ,
+    Translate3D,
+    RotateZ,
+    Rotate3D,
+    Matrix3D,
+    Perspective,
+    Identity,
+    None
+};
+
 class TransformOperation : public RefCounted<TransformOperation> {
 public:
-    enum class Type : uint8_t {
-        ScaleX,
-        ScaleY,
-        Scale,
-        TranslateX,
-        TranslateY,
-        Translate,
-        RotateX,
-        RotateY,
-        Rotate,
-        SkewX,
-        SkewY,
-        Skew,
-        Matrix,
-        ScaleZ,
-        Scale3D,
-        TranslateZ,
-        Translate3D,
-        RotateZ,
-        Rotate3D,
-        Matrix3D,
-        Perspective,
-        Identity,
-        None
-    };
+    using Type = TransformOperationType;
 
     TransformOperation(Type type)
         : m_type(type)
@@ -155,39 +157,6 @@ WTF::TextStream& operator<<(WTF::TextStream&, TransformOperation::Type);
 WTF::TextStream& operator<<(WTF::TextStream&, const TransformOperation&);
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::TransformOperation::Type> {
-    using values = EnumValues<
-        WebCore::TransformOperation::Type,
-        WebCore::TransformOperation::Type::ScaleX,
-        WebCore::TransformOperation::Type::ScaleY,
-        WebCore::TransformOperation::Type::Scale,
-        WebCore::TransformOperation::Type::TranslateX,
-        WebCore::TransformOperation::Type::TranslateY,
-        WebCore::TransformOperation::Type::Translate,
-        WebCore::TransformOperation::Type::RotateX,
-        WebCore::TransformOperation::Type::RotateY,
-        WebCore::TransformOperation::Type::Rotate,
-        WebCore::TransformOperation::Type::SkewX,
-        WebCore::TransformOperation::Type::SkewY,
-        WebCore::TransformOperation::Type::Skew,
-        WebCore::TransformOperation::Type::Matrix,
-        WebCore::TransformOperation::Type::ScaleZ,
-        WebCore::TransformOperation::Type::Scale3D,
-        WebCore::TransformOperation::Type::TranslateZ,
-        WebCore::TransformOperation::Type::Translate3D,
-        WebCore::TransformOperation::Type::RotateZ,
-        WebCore::TransformOperation::Type::Rotate3D,
-        WebCore::TransformOperation::Type::Matrix3D,
-        WebCore::TransformOperation::Type::Perspective,
-        WebCore::TransformOperation::Type::Identity,
-        WebCore::TransformOperation::Type::None
-    >;
-};
-
-} // namespace WTF
 
 #define SPECIALIZE_TYPE_TRAITS_TRANSFORMOPERATION(ToValueTypeName, predicate) \
 SPECIALIZE_TYPE_TRAITS_BEGIN(ToValueTypeName) \

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -7228,3 +7228,69 @@ enum class WebCore::PredefinedColorSpace : uint8_t {
     , DisplayP3
 #endif
 };
+
+header: <WebCore/TransformOperation.h>
+enum class WebCore::TransformOperationType : uint8_t {
+    ScaleX,
+    ScaleY,
+    Scale,
+    TranslateX,
+    TranslateY,
+    Translate,
+    RotateX,
+    RotateY,
+    Rotate,
+    SkewX,
+    SkewY,
+    Skew,
+    Matrix,
+    ScaleZ,
+    Scale3D,
+    TranslateZ,
+    Translate3D,
+    RotateZ,
+    Rotate3D,
+    Matrix3D,
+    Perspective,
+    Identity,
+    None
+};
+
+enum class WebCore::GraphicsContextGLSurfaceBuffer : bool;
+
+[Nested] enum class WebCore::GraphicsLayer::CustomAppearance : bool;
+
+[OptionSet] enum class GCGLErrorCode : uint8_t {
+    ContextLost,
+    InvalidFramebufferOperation,
+    OutOfMemory,
+    InvalidOperation,
+    InvalidValue,
+    InvalidEnum
+};
+
+#if ENABLE(VIDEO)
+
+header: <WebCore/AudioTrackPrivate.h>
+[Nested] enum class WebCore::AudioTrackPrivate::Kind : uint8_t {
+    Alternative,
+    Description,
+    Main,
+    MainDesc,
+    Translation,
+    Commentary,
+    None
+};
+
+header: <WebCore/VideoTrackPrivate.h>
+[Nested] enum class WebCore::VideoTrackPrivate::Kind : uint8_t {
+    Alternative,
+    Captions,
+    Main,
+    Sign,
+    Subtitles,
+    Commentary,
+    None
+};
+
+#endif

--- a/Source/WebKit/WebProcess/GPU/media/AudioTrackPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/AudioTrackPrivateRemote.h
@@ -60,7 +60,7 @@ private:
     MediaTime startTimeVariance() const final { return m_startTimeVariance; }
 
     ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;
-    AudioTrackKind m_kind { None };
+    AudioTrackKind m_kind { AudioTrackKind::None };
     WebCore::TrackID m_id;
     AtomString m_label;
     AtomString m_language;

--- a/Source/WebKit/WebProcess/GPU/media/VideoTrackPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/VideoTrackPrivateRemote.h
@@ -62,7 +62,7 @@ private:
     void setSelected(bool) final;
 
     ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;
-    VideoTrackKind m_kind { None };
+    VideoTrackKind m_kind { VideoTrackKind::None };
     AtomString m_label;
     AtomString m_language;
     int m_trackIndex { -1 };


### PR DESCRIPTION
#### 84f0f7a833047fe9256aeaa8408bf7c26ba1de7f
<pre>
Clean up most of remaining EnumTraits specializations under WebCore/platform/graphics
<a href="https://bugs.webkit.org/show_bug.cgi?id=266625">https://bugs.webkit.org/show_bug.cgi?id=266625</a>

Reviewed by Chris Dumez.

Run through most of EnumTraits specializations under WebCore/platform/graphics,
removing if unused or replacing them with corresponding serialization specifications
in WebKit&apos;s WebCoreArgumentCoders serialization input file.

* Source/WebCore/html/track/AudioTrack.cpp:
(WebCore::AudioTrack::updateKindFromPrivate):
* Source/WebCore/html/track/VideoTrack.cpp:
(WebCore::VideoTrack::updateKindFromPrivate):
* Source/WebCore/platform/graphics/AudioTrackPrivate.h:
(WebCore::AudioTrackPrivate::kind const):
* Source/WebCore/platform/graphics/GraphicsContextGL.h:
* Source/WebCore/platform/graphics/GraphicsContextState.h:
* Source/WebCore/platform/graphics/GraphicsLayer.h:
* Source/WebCore/platform/graphics/GraphicsTypesGL.h:
* Source/WebCore/platform/graphics/Image.h:
* Source/WebCore/platform/graphics/SystemImage.h:
* Source/WebCore/platform/graphics/VideoTrackPrivate.h:
(WebCore::VideoTrackPrivate::kind const):
* Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm:
(WebCore::AVTrackPrivateAVFObjCImpl::audioKind const):
(WebCore::AVTrackPrivateAVFObjCImpl::videoKind const):
* Source/WebCore/platform/graphics/avfoundation/AudioTrackPrivateAVF.h:
* Source/WebCore/platform/graphics/avfoundation/VideoTrackPrivateAVF.h:
* Source/WebCore/platform/graphics/transforms/TransformOperation.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/GPU/media/AudioTrackPrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/VideoTrackPrivateRemote.h:

Canonical link: <a href="https://commits.webkit.org/272841@main">https://commits.webkit.org/272841@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/10fe9cd4aeeaac77e258671821808ca3cdd9ea06

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33237 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12013 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35151 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35874 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/30260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34208 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14358 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9186 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29395 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33712 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10135 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29687 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8831 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8980 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29662 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37205 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30201 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30041 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35092 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9106 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7054 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32953 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10835 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7715 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9689 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9789 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->