### PR TITLE
[WPE] WPE Platform: make sure we release all wayland resources before the display

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp
@@ -154,6 +154,9 @@ static void wpeDisplayWaylandDispose(GObject* object)
         priv->eventSource = nullptr;
     }
 
+    priv->wlSeat = nullptr;
+    priv->wlCursor = nullptr;
+    priv->wlOutputs.clear();
     g_clear_pointer(&priv->linuxDMABuf, zwp_linux_dmabuf_v1_destroy);
     g_clear_pointer(&priv->wlSHM, wl_shm_destroy);
     g_clear_pointer(&priv->xdgWMBase, xdg_wm_base_destroy);

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandOutput.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandOutput.cpp
@@ -36,7 +36,10 @@ WaylandOutput::WaylandOutput(struct wl_output* output)
 
 WaylandOutput::~WaylandOutput()
 {
-    wl_output_destroy(m_output);
+    if (wl_output_get_version(m_output) >= WL_OUTPUT_RELEASE_SINCE_VERSION)
+        wl_output_release(m_output);
+    else
+        wl_output_destroy(m_output);
 }
 
 const struct wl_output_listener WaylandOutput::s_listener = {


### PR DESCRIPTION
#### fc2b98d725a247025bd6c91e80d20153d9b950dc
<pre>
[WPE] WPE Platform: make sure we release all wayland resources before the display
<a href="https://bugs.webkit.org/show_bug.cgi?id=266626">https://bugs.webkit.org/show_bug.cgi?id=266626</a>

Reviewed by Michael Catanzaro.

The display is explicitly released in the dispose method, but other
resources wrapped by smart pointers are released later in the finalize.
Also use wl_output_release instead of wl_output_destroy when available.

* Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp:
(wpeDisplayWaylandDispose):
* Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandOutput.cpp:
(WPE::WaylandOutput::~WaylandOutput):

Canonical link: <a href="https://commits.webkit.org/272268@main">https://commits.webkit.org/272268@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df1f5d5e9c9cd440cc5d2bc1e64b26362c926d5e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31156 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9832 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32848 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33663 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/28303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12175 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7090 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27952 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31492 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8289 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27853 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7117 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7295 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35005 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28356 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28205 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33427 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7330 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5387 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31266 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/attributes (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9016 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8033 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4046 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7864 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->