### PR TITLE
[GTK][WPE] Increase the crash and timeout threshold for Debug test bots

### DIFF
--- a/Tools/CISupport/build-webkit-org/config.json
+++ b/Tools/CISupport/build-webkit-org/config.json
@@ -441,6 +441,7 @@
                   {
                     "name": "GTK-Linux-64-bit-Debug-Tests", "factory": "TestAllButJSCFactory",
                     "platform": "gtk", "configuration": "debug", "architectures": ["x86_64"],
+                    "additionalArguments": ["--exit-after-n-crashes-or-timeouts=100"],
                     "workernames": ["gtk-linux-bot-7"]
                   },
                   {
@@ -592,6 +593,7 @@
                   {
                     "name": "WPE-Linux-64-bit-Debug-Tests", "factory": "TestAllButJSCFactory",
                     "platform": "wpe", "configuration": "debug", "architectures": ["x86_64"],
+                    "additionalArguments": ["--exit-after-n-crashes-or-timeouts=100"],
                     "workernames": ["wpe-linux-bot-4"]
                   },
                   {


### PR DESCRIPTION
#### ba9b89f5031f0ba8c2f62dfbfadb4570f5c04ef7
<pre>
[GTK][WPE] Increase the crash and timeout threshold for Debug test bots
<a href="https://bugs.webkit.org/show_bug.cgi?id=266627">https://bugs.webkit.org/show_bug.cgi?id=266627</a>

Reviewed by Carlos Alberto Lopez Perez.

We are increasing the threshold for crash and timeouts in the Debug bots
so that we can more easily garden the failures in the next couple of weeks.

* Tools/CISupport/build-webkit-org/config.json:

Canonical link: <a href="https://commits.webkit.org/272335@main">https://commits.webkit.org/272335@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48876f60fabe2a18a7c842f68ecbf12bccac6f23

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31157 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9833 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32849 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33664 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28304 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31923 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12176 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7091 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27954 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31493 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8290 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27855 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7119 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7296 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27750 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35006 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28357 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28207 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33428 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7331 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5388 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31267 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/30963 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9017 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8034 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4083 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7865 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->