### PR TITLE
[GTK][WPE] Fallback to timer based vblank monitor if drmWaitVBlank fails

### DIFF
--- a/Source/WebKit/UIProcess/glib/DisplayVBlankMonitorDRM.h
+++ b/Source/WebKit/UIProcess/glib/DisplayVBlankMonitorDRM.h
@@ -35,7 +35,7 @@ namespace WebKit {
 class DisplayVBlankMonitorDRM final : public DisplayVBlankMonitor {
 public:
     static std::unique_ptr<DisplayVBlankMonitor> create(PlatformDisplayID);
-    DisplayVBlankMonitorDRM(unsigned, WTF::UnixFileDescriptor&&, uint32_t);
+    DisplayVBlankMonitorDRM(unsigned, WTF::UnixFileDescriptor&&, int);
     ~DisplayVBlankMonitorDRM() = default;
 
 private:


### PR DESCRIPTION
#### 910ef55e5f787cf9079423de90ffb44b9b8c4d47
<pre>
[GTK][WPE] Fallback to timer based vblank monitor if drmWaitVBlank fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=266629">https://bugs.webkit.org/show_bug.cgi?id=266629</a>

Reviewed by Alejandro G. Castro.

* Source/WebKit/UIProcess/glib/DisplayVBlankMonitorDRM.cpp:
(WebKit::crtcBitmaskForIndex):
(WebKit::DisplayVBlankMonitorDRM::create):
(WebKit::DisplayVBlankMonitorDRM::DisplayVBlankMonitorDRM):
* Source/WebKit/UIProcess/glib/DisplayVBlankMonitorDRM.h:

Canonical link: <a href="https://commits.webkit.org/272328@main">https://commits.webkit.org/272328@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7651dc8660755a28ecba05e563cef6e456c85f12

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31161 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9837 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32853 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33668 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28307 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12180 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7095 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27956 "Found 1 new test failure: media/media-source/media-source-abort-resets-parser.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31497 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8294 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27860 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7122 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7300 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35010 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28361 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28212 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33431 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7335 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5392 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31270 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9021 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8037 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4080 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7869 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->