### PR TITLE
cssText setter should change style attribute when the serialization differs

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSStyleSheet-constructable-invalidation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSStyleSheet-constructable-invalidation-expected.txt
@@ -1,0 +1,6 @@
+Should be green. Should be green.
+
+PASS mutating constructed CSSStyleSheet applied to root invalidates styles
+PASS mutating constructed CSSStyleSheet applied to shadowdom invalidates styles
+PASS mutating dependent constructed CSSStyleSheet applied to shadowdom invalidates styles
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSStyleSheet-constructable-invalidation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSStyleSheet-constructable-invalidation.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSSStyleSheet rule mutation invalidation</title>
+<link rel="author" href="mailto:wpt@keithcirkel.co.uk" title="Keith Cirkel">
+<link rel="help" href="https://drafts.csswg.org/cssom/#extensions-to-the-document-or-shadow-root-interface">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<span id="span1">Should be green.</span>
+<span id="span2">Should be green.</span>
+<script>
+promise_test(async function(t) {
+  const sheet = new CSSStyleSheet();
+  sheet.replaceSync('span {color:var(--color, red);}');
+  document.adoptedStyleSheets = [sheet];
+  t.add_cleanup(() => {
+    document.adoptedStyleSheets = [];
+  })
+  assert_equals(getComputedStyle(span1).color, "rgb(255, 0, 0)", "Sheet should apply");
+  sheet.rules[0].style.setProperty('--color', 'green');
+  assert_equals(getComputedStyle(span1).color, "rgb(0, 128, 0)", "Sheet should invalidate style");
+  document.adoptedStyleSheets = [];
+  assert_equals(getComputedStyle(span1).color, "rgb(0, 0, 0)", "Removing sheet should apply");
+}, "mutating constructed CSSStyleSheet applied to root invalidates styles");
+
+promise_test(async function() {
+  span1.attachShadow({mode:'open'})
+  span1.shadowRoot.append(document.createElement('slot'))
+  const sheet = new CSSStyleSheet();
+  sheet.replaceSync(':host {color:var(--color, red);}');
+  span1.shadowRoot.adoptedStyleSheets = [sheet];
+  assert_equals(getComputedStyle(span1).color, "rgb(255, 0, 0)", "Sheet should apply");
+  sheet.rules[0].style.setProperty('--color', 'green');
+  assert_equals(getComputedStyle(span1).color, "rgb(0, 128, 0)", "Sheet should invalidate style");
+}, "mutating constructed CSSStyleSheet applied to shadowdom invalidates styles");
+
+promise_test(async function() {
+  span2.attachShadow({mode:'open'})
+  span2.shadowRoot.append(document.createElement('slot'))
+  const sheet1 = new CSSStyleSheet();
+  const sheet2 = new CSSStyleSheet();
+  sheet1.replaceSync(':host {color:var(--color, hotpink);}');
+  sheet2.replaceSync(':host {--color: blue}');
+  const style2 = sheet2.rules[0].style;
+  span2.shadowRoot.adoptedStyleSheets = [sheet1, sheet2];
+  assert_equals(getComputedStyle(span2).color, "rgb(0, 0, 255)", "Sheet should apply");
+  style2.setProperty('--color', 'green');
+  assert_equals(getComputedStyle(span2).color, "rgb(0, 128, 0)", "Sheet should invalidate style");
+}, "mutating dependent constructed CSSStyleSheet applied to shadowdom invalidates styles");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-csstext-setter.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-csstext-setter.window-expected.txt
@@ -1,0 +1,11 @@
+
+PASS cssText setter should set style attribute even when there are no style changes (body)
+PASS cssText setter should set style attribute even when there are no style changes, part 2 (body)
+PASS cssText setter should set style attribute even when there are no style changes, part 3 (body)
+PASS cssText setter should set style attribute even when there are no style changes, part 4 (body)
+PASS cssText setter should set style attribute even when there are no style changes (cool-beans)
+PASS cssText setter should set style attribute even when there are no style changes, part 2 (cool-beans)
+PASS cssText setter should set style attribute even when there are no style changes, part 3 (cool-beans)
+PASS cssText setter should set style attribute even when there are no style changes, part 4 (cool-beans)
+PASS cssText setter and selector invalidation
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-csstext-setter.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-csstext-setter.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-csstext-setter.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-csstext-setter.window.js
@@ -1,0 +1,64 @@
+// https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-csstext
+
+[
+  document.body,
+  document.createElement("cool-beans")
+].forEach(element => {
+  test(t => {
+    t.add_cleanup(() => element.removeAttribute("style"));
+
+    element.style.background = "red";
+    assert_equals(element.getAttribute("style"), "background: red;");
+
+    element.style.cssText = "background:red";
+    assert_equals(element.getAttribute("style"), "background: red;");
+  }, `cssText setter should set style attribute even when there are no style changes (${element.localName})`);
+
+  test(t => {
+    t.add_cleanup(() => element.removeAttribute("style"));
+
+    element.setAttribute("style", "background:   red");
+    assert_equals(element.getAttribute("style"), "background:   red");
+
+    element.style.cssText = "background:red";
+    assert_equals(element.getAttribute("style"), "background: red;");
+  }, `cssText setter should set style attribute even when there are no style changes, part 2 (${element.localName})`);
+
+  test(t => {
+    t.add_cleanup(() => element.removeAttribute("style"));
+
+    element.setAttribute("style", "background:   red");
+    assert_equals(element.getAttribute("style"), "background:   red");
+
+    element.style.cssText = "background:red "; // trailing space
+    assert_equals(element.getAttribute("style"), "background: red;");
+  }, `cssText setter should set style attribute even when there are no style changes, part 3 (${element.localName})`);
+
+  test(t => {
+    t.add_cleanup(() => element.removeAttribute("style"));
+
+    element.setAttribute("style", "background:   red");
+    assert_equals(element.getAttribute("style"), "background:   red");
+
+    element.style.cssText = "background:red;";
+    assert_equals(element.getAttribute("style"), "background: red;");
+  }, `cssText setter should set style attribute even when there are no style changes, part 4 (${element.localName})`);
+});
+
+test(t => {
+  const style = document.createElement("style");
+  t.add_cleanup(() => {
+    document.body.removeAttribute("style");
+    style.remove();
+  });
+  style.textContent = `[style="background: red;"] { background:white !important; }`;
+  document.body.appendChild(style);
+
+  document.body.setAttribute("style", "background:red");
+  assert_true(document.body.matches("[style=\"background:red\"]"));
+  assert_equals(getComputedStyle(document.body).backgroundColor, "rgb(255, 0, 0)");
+    
+  document.body.style.cssText = "background:red";
+  assert_equals(getComputedStyle(document.body).backgroundColor, "rgb(255, 255, 255)");
+  assert_true(document.body.matches("[style=\"background: red;\"]"));
+}, `cssText setter and selector invalidation`);

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/w3c-import.log
@@ -37,6 +37,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSStyleSheet-constructable-disabled-regular-sheet-insertion.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSStyleSheet-constructable-disallow-import.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSStyleSheet-constructable-duplicate.html
+/LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSStyleSheet-constructable-invalidation.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSStyleSheet-constructable-replace-cssRules.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSStyleSheet-constructable-replace-on-regular-sheet.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSStyleSheet-constructable.html
@@ -93,6 +94,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-csstext-all-shorthand.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-csstext-final-delimiter.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-csstext-important.html
+/LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-csstext-setter.window.js
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-csstext.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-custom-properties.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-mutability.html

--- a/Source/WebCore/css/PropertySetCSSStyleDeclaration.h
+++ b/Source/WebCore/css/PropertySetCSSStyleDeclaration.h
@@ -53,7 +53,7 @@ public:
     StyleSheetContents* contextStyleSheet() const;
 
 protected:
-    enum MutationType { NoChanges, PropertyChanged };
+    enum class MutationType : uint8_t { NoChanges, StyleAttributeChanged, PropertyChanged };
 
     virtual CSSParserContext cssParserContext() const;
 

--- a/Source/WebCore/dom/StyledElement.cpp
+++ b/Source/WebCore/dom/StyledElement.cpp
@@ -162,6 +162,20 @@ void StyledElement::styleAttributeChanged(const AtomString& newStyleString, Attr
     InspectorInstrumentation::didInvalidateStyleAttr(*this);
 }
 
+void StyledElement::dirtyStyleAttribute()
+{
+    elementData()->setStyleAttributeIsDirty(true);
+
+    if (styleResolver().ruleSets().hasSelectorsForStyleAttribute()) {
+        if (auto* inlineStyle = this->inlineStyle()) {
+            elementData()->setStyleAttributeIsDirty(false);
+            auto newValue = inlineStyle->asTextAtom();
+            Style::AttributeChangeInvalidation styleInvalidation(*this, styleAttr, attributeWithoutSynchronization(styleAttr), newValue);
+            setSynchronizedLazyAttribute(styleAttr, newValue);
+        }
+    }
+}
+
 void StyledElement::invalidateStyleAttribute()
 {
     if (auto* inlineStyle = this->inlineStyle()) {

--- a/Source/WebCore/dom/StyledElement.h
+++ b/Source/WebCore/dom/StyledElement.h
@@ -44,6 +44,7 @@ class StyledElement : public Element {
 public:
     virtual ~StyledElement();
 
+    void dirtyStyleAttribute();
     void invalidateStyleAttribute();
 
     const StyleProperties* inlineStyle() const { return elementData() ? elementData()->m_inlineStyle.get() : nullptr; }

--- a/Source/WebCore/style/StyleScopeRuleSets.cpp
+++ b/Source/WebCore/style/StyleScopeRuleSets.cpp
@@ -370,6 +370,11 @@ const HashSet<AtomString>& ScopeRuleSets::customPropertyNamesInStyleContainerQue
     return *m_customPropertyNamesInStyleContainerQueries;
 }
 
+bool ScopeRuleSets::hasSelectorsForStyleAttribute() const
+{
+    return !!attributeInvalidationRuleSets(HTMLNames::styleAttr->localName());
+}
+
 bool ScopeRuleSets::hasComplexSelectorsForStyleAttribute() const
 {
     auto compute = [&] {

--- a/Source/WebCore/style/StyleScopeRuleSets.h
+++ b/Source/WebCore/style/StyleScopeRuleSets.h
@@ -78,6 +78,7 @@ public:
 
     const HashSet<AtomString>& customPropertyNamesInStyleContainerQueries() const;
 
+    bool hasSelectorsForStyleAttribute() const;
     bool hasComplexSelectorsForStyleAttribute() const;
 
     void setUsesSharedUserStyle(bool b) { m_usesSharedUserStyle = b; }


### PR DESCRIPTION
#### 9494ab07d911afea7e49aff95c0105ab8b8bce6c
<pre>
cssText setter should change style attribute when the serialization differs
<a href="https://bugs.webkit.org/show_bug.cgi?id=166716">https://bugs.webkit.org/show_bug.cgi?id=166716</a>
<a href="https://rdar.apple.com/29861252">rdar://29861252</a>

Reviewed by Antti Koivisto.

173663@main regressed our behavior with regards to the standard. This
attempts to correct it while preserving as much of the optimization as
possible.

WPT css/cssom is synchronized up to and including:
<a href="https://github.com/web-platform-tests/wpt/pull/45019">https://github.com/web-platform-tests/wpt/pull/45019</a>

* LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSStyleSheet-constructable-invalidation-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSStyleSheet-constructable-invalidation.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-csstext-setter.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-csstext-setter.window.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-csstext-setter.window.js: Added.
(document.createElement.string_appeared_here.forEach.element.cssText.setter.should.set style):
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/w3c-import.log:
* Source/WebCore/css/PropertySetCSSStyleDeclaration.cpp:
(WebCore::PropertySetCSSStyleDeclaration::setCssText):
(WebCore::PropertySetCSSStyleDeclaration::setProperty):
(WebCore::PropertySetCSSStyleDeclaration::removeProperty):
(WebCore::PropertySetCSSStyleDeclaration::setPropertyInternal):
(WebCore::StyleRuleCSSStyleDeclaration::didMutate):
(WebCore::InlineCSSStyleDeclaration::didMutate):
* Source/WebCore/css/PropertySetCSSStyleDeclaration.h:
* Source/WebCore/dom/StyledElement.cpp:
(WebCore::StyledElement::dirtyStyleAttribute):
* Source/WebCore/dom/StyledElement.h:
* Source/WebCore/style/StyleScopeRuleSets.cpp:
(WebCore::Style::ScopeRuleSets::hasSimpleSelectorsForStyleAttribute const):
* Source/WebCore/style/StyleScopeRuleSets.h:

Canonical link: <a href="https://commits.webkit.org/276176@main">https://commits.webkit.org/276176@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc214afe3ddbab6854afa01bfe5bcc709631e1ff

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43953 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23019 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46390 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46603 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40028 "Failed to checkout and rebase branch from PR 22022") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46258 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26922 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20413 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44531 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20046 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/37863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/17277 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/17551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38949 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2014 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40131 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/39242 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48178 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18960 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15533 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43095 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/20347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/38133 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41808 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9775 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20554 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/19973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->