### PR TITLE
RemoteLayerWithInProcessRenderingBackingStore::createContextAndPaintContents() contains redundant lambdas

### DIFF
--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm
@@ -99,26 +99,6 @@ void RemoteLayerWithInProcessRenderingBackingStore::createContextAndPaintContent
         return;
     }
 
-    auto markFrontBufferNotCleared = makeScopeExit([&]() {
-        m_frontBuffer.isCleared = false;
-    });
-
-    auto clipAndDrawInContext = [&](GraphicsContext& context) {
-        if (m_paintingRects.size() == 1)
-            context.clip(m_paintingRects[0]);
-        else {
-            Path clipPath;
-            for (auto rect : m_paintingRects)
-                clipPath.addRect(rect);
-            context.clipPath(clipPath);
-        }
-
-        if (drawingRequiresClearedPixels() && !m_frontBuffer.isCleared)
-            context.clearRect(layerBounds());
-
-        drawInContext(context);
-    };
-
     GraphicsContext& context = m_frontBuffer.imageBuffer->context();
 
     // We never need to copy forward when using display list drawing, since we don't do partial repaint.
@@ -135,7 +115,21 @@ void RemoteLayerWithInProcessRenderingBackingStore::createContextAndPaintContent
         }
     }
 
-    clipAndDrawInContext(context);
+    if (m_paintingRects.size() == 1)
+        context.clip(m_paintingRects[0]);
+    else {
+        Path clipPath;
+        for (auto rect : m_paintingRects)
+            clipPath.addRect(rect);
+        context.clipPath(clipPath);
+    }
+
+    if (drawingRequiresClearedPixels() && !m_frontBuffer.isCleared)
+        context.clearRect(layerBounds());
+
+    drawInContext(context);
+
+    m_frontBuffer.isCleared = false;
 }
 
 Vector<std::unique_ptr<WebCore::ThreadSafeImageBufferFlusher>> RemoteLayerWithInProcessRenderingBackingStore::createFlushers()


### PR DESCRIPTION
#### 2a3cc4327213f8be23ef259a4835fd822c4ed9d3
<pre>
RemoteLayerWithInProcessRenderingBackingStore::createContextAndPaintContents() contains redundant lambdas
<a href="https://bugs.webkit.org/show_bug.cgi?id=266632">https://bugs.webkit.org/show_bug.cgi?id=266632</a>
<a href="https://rdar.apple.com/problem/119863593">rdar://problem/119863593</a>

Reviewed by Matt Woodrow.

Remove the in-function lambda, it was just called once and it did not
contain early returns.

Remove the scoped restore lambda. It was executed unconditionally
and there are no early returns.

This is work towards being able to run the clip code in WP.

* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm:
(WebKit::RemoteLayerWithInProcessRenderingBackingStore::createContextAndPaintContents):

Canonical link: <a href="https://commits.webkit.org/272331@main">https://commits.webkit.org/272331@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4af5fb41f227ec3ae137b16f148f952b5bc21246

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31166 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9842 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32858 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33673 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28312 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12185 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7100 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27961 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31502 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8299 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27863 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7128 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7306 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35015 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28366 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28215 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33437 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7340 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5397 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31280 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9026 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7361 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8042 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7874 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->