### PR TITLE
Add test function for WebCore::DocumentFragment::parseXML

### DIFF
--- a/Source/WebCore/dom/DocumentFragment.h
+++ b/Source/WebCore/dom/DocumentFragment.h
@@ -34,7 +34,7 @@ public:
     WEBCORE_EXPORT static Ref<DocumentFragment> create(Document&);
 
     void parseHTML(const String&, Element& contextElement, OptionSet<ParserContentPolicy> = { ParserContentPolicy::AllowScriptingContent });
-    bool parseXML(const String&, Element* contextElement, OptionSet<ParserContentPolicy> = { ParserContentPolicy::AllowScriptingContent });
+    WEBCORE_EXPORT bool parseXML(const String&, Element* contextElement, OptionSet<ParserContentPolicy> = { ParserContentPolicy::AllowScriptingContent });
 
     bool canContainRangeEndPoint() const final { return true; }
     virtual bool isTemplateContent() const { return false; }

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -505,7 +505,7 @@ public:
     WEBCORE_EXPORT unsigned short compareDocumentPosition(Node&);
 
     EventTargetInterface eventTargetInterface() const override;
-    ScriptExecutionContext* scriptExecutionContext() const final; // Implemented in Document.h
+    ScriptExecutionContext* scriptExecutionContext() const final; // Implemented in DocumentInlines.h.
 
     WEBCORE_EXPORT bool addEventListener(const AtomString& eventType, Ref<EventListener>&&, const AddEventListenerOptions&) override;
     bool removeEventListener(const AtomString& eventType, EventListener&, const EventListenerOptions&) override;

--- a/Source/WebCore/dom/XMLDocument.cpp
+++ b/Source/WebCore/dom/XMLDocument.cpp
@@ -32,5 +32,12 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(XMLDocument);
 
+Ref<XMLDocument> XMLDocument::createXHTML(LocalFrame* frame, const Settings& settings, const URL& url)
+{
+    auto document = adoptRef(*new XMLDocument(frame, settings, url, { DocumentClass::XML, DocumentClass::XHTML }));
+    document->addToContextsMap();
+    return document;
+}
+
 } // namespace WebCore
 

--- a/Source/WebCore/dom/XMLDocument.h
+++ b/Source/WebCore/dom/XMLDocument.h
@@ -39,12 +39,7 @@ public:
         return document;
     }
 
-    static Ref<XMLDocument> createXHTML(LocalFrame* frame, const Settings& settings, const URL& url)
-    {
-        auto document = adoptRef(*new XMLDocument(frame, settings, url, { DocumentClass::XML, DocumentClass::XHTML }));
-        document->addToContextsMap();
-        return document;
-    }
+    WEBCORE_EXPORT static Ref<XMLDocument> createXHTML(LocalFrame*, const Settings&, const URL&);
 
 protected:
     XMLDocument(LocalFrame* frame, const Settings& settings, const URL& url, DocumentClasses documentClasses = { })

--- a/Source/WebCore/testing/js/WebCoreTestSupport.cpp
+++ b/Source/WebCore/testing/js/WebCoreTestSupport.cpp
@@ -28,6 +28,7 @@
 #include "WebCoreTestSupport.h"
 
 #include "DeprecatedGlobalSettings.h"
+#include "DocumentFragment.h"
 #include "FrameDestructionObserverInlines.h"
 #include "InternalSettings.h"
 #include "Internals.h"
@@ -45,6 +46,7 @@
 #include "ServiceWorkerGlobalScope.h"
 #include "SincResampler.h"
 #include "WheelEventTestMonitor.h"
+#include "XMLDocument.h"
 #include <JavaScriptCore/APICast.h>
 #include <JavaScriptCore/CallFrame.h>
 #include <JavaScriptCore/IdentifierInlines.h>
@@ -123,7 +125,7 @@ void clearWheelEventTestMonitor(WebCore::LocalFrame& frame)
     Page* page = frame.page();
     if (!page)
         return;
-    
+
     page->clearWheelEventTestMonitor();
 }
 
@@ -289,5 +291,16 @@ void testSincResamplerProcessBuffer(std::span<const float> source, std::span<flo
     SincResampler::processBuffer(source, destination, scaleFactor);
 }
 #endif // ENABLE(WEB_AUDIO)
+
+bool testDocumentFragmentParseXML(const String& chunk, OptionSet<ParserContentPolicy> parserContentPolicy)
+{
+    ProcessWarming::prewarmGlobally();
+
+    auto settings = Settings::create(nullptr);
+    auto document = WebCore::XMLDocument::createXHTML(nullptr, settings, URL());
+    auto fragment = document->createDocumentFragment();
+
+    return fragment->parseXML(chunk, nullptr, parserContentPolicy);
+}
 
 } // namespace WebCoreTestSupport

--- a/Source/WebCore/testing/js/WebCoreTestSupport.h
+++ b/Source/WebCore/testing/js/WebCoreTestSupport.h
@@ -28,6 +28,7 @@
 
 #include <span>
 #include <wtf/Forward.h>
+#include <wtf/OptionSet.h>
 
 typedef const struct OpaqueJSContext* JSContextRef;
 typedef struct OpaqueJSString* JSStringRef;
@@ -41,6 +42,7 @@ typedef struct OpaqueJSValue* JSObjectRef;
 
 namespace WebCore {
 class LocalFrame;
+enum class ParserContentPolicy : uint8_t;
 }
 
 namespace WebCoreTestSupport {
@@ -87,6 +89,8 @@ inline void populateJITOperations() { populateDisassemblyLabels(); }
 #else
 inline void populateJITOperations() { }
 #endif // ENABLE(JIT_OPERATION_VALIDATION) || ENABLE(JIT_OPERATION_DISASSEMBLY)
+
+bool testDocumentFragmentParseXML(const String&, OptionSet<WebCore::ParserContentPolicy>) TEST_SUPPORT_EXPORT;
 
 #if ENABLE(WEB_AUDIO)
 void testSincResamplerProcessBuffer(std::span<const float> source, std::span<float> destination, double scaleFactor) TEST_SUPPORT_EXPORT;


### PR DESCRIPTION
#### 82a50675769ac8060258ee90f73cf08d8f1d2d32
<pre>
Add test function for WebCore::DocumentFragment::parseXML
<a href="https://bugs.webkit.org/show_bug.cgi?id=262426">https://bugs.webkit.org/show_bug.cgi?id=262426</a>
&lt;<a href="https://rdar.apple.com/116267317">rdar://116267317</a>&gt;

Reviewed by Darin Adler.

* Source/WebCore/dom/DocumentFragment.h:
(WebCore::DocumentFragment::parseXML):
- Export method for WebCoreTestSupport.
* Source/WebCore/dom/Node.h:
(WebCore::Node::eventTargetInterface):
- Drive-by fix to comment.
* Source/WebCore/dom/XMLDocument.cpp:
(WebCore::XMLDocument::createXHTML): Add.
- Move implementation into source file.
* Source/WebCore/dom/XMLDocument.h:
(WebCore::XMLDocument::createXHTML):
- Change to exported method declaration.
* Source/WebCore/testing/js/WebCoreTestSupport.cpp:
(WebCoreTestSupport::testDocumentFragmentParseXML): Add.
- Add test method.
* Source/WebCore/testing/js/WebCoreTestSupport.h:
(WebCoreTestSupport::testDocumentFragmentParseXML): Add.

Originally-landed-as: 267815.149@safari-7617-branch (9bc754a9deaf). <a href="https://rdar.apple.com/119593187">rdar://119593187</a>
Canonical link: <a href="https://commits.webkit.org/272327@main">https://commits.webkit.org/272327@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d8d91e609fdd95c20ffac7055407cd832deee27

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31316 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9985 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33009 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33813 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28397 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32083 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12328 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7237 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28037 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31652 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8409 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27963 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7223 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7394 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27863 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35154 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28473 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28327 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33528 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7456 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5494 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31370 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9130 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7359 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8154 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7978 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->