### PR TITLE
BBQJIT if conditions are very wrong

### DIFF
--- a/JSTests/wasm/stress/bbq-parallel-move.js
+++ b/JSTests/wasm/stress/bbq-parallel-move.js
@@ -1,0 +1,69 @@
+//@ skip if !$isSIMDPlatform
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (func $log_value (import "a" "log_value") (param i32))
+
+    (func (export "test") (param $p0 i32) (param $p1 i32) (param $p2 i32)
+        (local.get $p1)
+        (local.get $p1)
+        (local.get $p1)
+        (local.get $p1)
+        (local.get $p1)
+        (local.get $p1)
+        (local.get $p1)
+        (local.get $p1)
+        (local.get $p1)
+
+        (if (result i32)
+        (local.get $p0)
+        (then
+            (local.set $p2
+                (local.get $p0))
+            (i32.const 0))
+        (else
+            (i32.const 0)))
+
+        (local.get $p2)
+        (call $f)
+
+    )
+
+    (func $f (param i32) (param i32) (param i32) (param i32) (param i32) (param i32) (param i32) (param i32) (param i32) (param i32) (param $pl i32)
+        (call $log_value
+            (local.get $pl))
+    )
+)
+`
+
+async function test() {
+    let log = []
+    const instance = await instantiate(wat, { a: {
+        log_value: function(i) { log.push("value: " + i); },
+    } }, { simd: true })
+    const { test, test2 } = instance.exports
+
+    let lastLog = []
+    for (let i = 0; i < 10000; ++i) {
+        assert.eq(test(0, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21), undefined)
+
+        if (i > 0 && JSON.stringify(lastLog) != JSON.stringify(log)) {
+            print(lastLog)
+            print(log)
+            throw ""
+        }
+
+        lastLog = log
+        log = []
+    }
+
+    print(lastLog)
+    if (lastLog != "value: 3")
+        throw ""
+
+    ;; print("Success")
+}
+
+assert.asyncTest(test())


### PR DESCRIPTION
#### 470e562ed7b830ee06b73b892c6ae243e48b9af2
<pre>
BBQJIT if conditions are very wrong
<a href="https://bugs.webkit.org/show_bug.cgi?id=262222">https://bugs.webkit.org/show_bug.cgi?id=262222</a>
<a href="https://rdar.apple.com/problem/116145012">rdar://problem/116145012</a>

Reviewed by Keith Miller.

BBQJIT if conditions are very wrong. By random chance, the condition value
happens to be allocated in nonPreservedNonArgumentGPR1, but if you use
more than 8 registers, we end up just reading a completely random value.

Let&apos;s not do that.

We also add some extra debugging assertions for parallel move. These shouldn&apos;t ever actually
be hit, but they help us avoid a potential problem in the future if we
make BBQ register allocation smarter.

Finally, we allow allocating eax on x86, and fix some bugs surrounding if/else as a result.

* JSTests/wasm/stress/bbq-parallel-move.js: Added.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.func.log_value.import.string_appeared_here.string_appeared_here.param.i32.func.export.string_appeared_here.param.p0.i32.param.p1.i32.param.p2.i32.local.p1.local.p1.local.p1.local.p1.local.p1.local.p1.local.p1.local.p1.local.p1.result.i32.local.p0.then.local.p2.local.p0.i32.const.0.else.i32.const.0.local.p2.call.f.func.f.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.param.pl.i32.call.log_value.local.pl.async test.):
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.func.log_value.import.string_appeared_here.string_appeared_here.param.i32.func.export.string_appeared_here.param.p0.i32.param.p1.i32.param.p2.i32.local.p1.local.p1.local.p1.local.p1.local.p1.local.p1.local.p1.local.p1.local.p1.result.i32.local.p0.then.local.p2.local.p0.i32.const.0.else.i32.const.0.local.p2.call.f.func.f.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.param.i32.param.pl.i32.call.log_value.local.pl.async test):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJIT::ControlData::ControlData):
(JSC::Wasm::BBQJIT::addIf):
(JSC::Wasm::BBQJIT::emitIndirectCall):
(JSC::Wasm::BBQJIT::emitShuffle):

Originally-landed-as: 267815.223@safari-7617-branch (3c476842d24c). <a href="https://rdar.apple.com/119592377">rdar://119592377</a>
Canonical link: <a href="https://commits.webkit.org/272297@main">https://commits.webkit.org/272297@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f9eed47f8e63c58b95cdd4909de29092e7efdad

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31182 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9860 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32876 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33690 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28320 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12202 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7118 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27970 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31519 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8316 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27880 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7141 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7319 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27774 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35032 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/26781 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28383 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28230 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33450 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/31267 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7356 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5414 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31289 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9040 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/37702 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7343 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8057 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8056 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7889 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->