### PR TITLE
rdar://110000099 (jsc_fuz/wktr: invalid message WebPasteboardProxy_GetPasteboardChangeCount)

### DIFF
--- a/LayoutTests/editing/pasteboard/copy-paste-crash-onbeforeunload-event-expected.txt
+++ b/LayoutTests/editing/pasteboard/copy-paste-crash-onbeforeunload-event-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it doesn't crash.

--- a/LayoutTests/editing/pasteboard/copy-paste-crash-onbeforeunload-event.html
+++ b/LayoutTests/editing/pasteboard/copy-paste-crash-onbeforeunload-event.html
@@ -1,0 +1,17 @@
+<p>This test passes if it doesn't crash.</p>
+<script>
+  if (window.testRunner)
+    testRunner.dumpAsText();
+  
+  onbeforeunload = () => {
+    for (let i = 0; i < 1000; i++)
+      document.execCommand('Copy');
+  };
+  onload = async () => {
+      document.execCommand('SelectAll');
+    location.host = '';
+    await caches.has('a');
+    window.open();
+    
+  };
+</script>


### PR DESCRIPTION
#### eae948cc319807613f9921d1babbcac374f57587
<pre>
<a href="https://rdar.apple.com/110000099">rdar://110000099</a> (jsc_fuz/wktr: invalid message WebPasteboardProxy_GetPasteboardChangeCount)
<a href="https://bugs.webkit.org/show_bug.cgi\?id\=262292">https://bugs.webkit.org/show_bug.cgi\?id\=262292</a>
<a href="https://rdar.apple.com/110000099">rdar://110000099</a>

Reviewed by Wenson Hsieh.

Disable copy paste for beforeunload event.

* LayoutTests/editing/pasteboard/copy-paste-crash-onbeforeunload-event-expected.txt: Added.
* LayoutTests/editing/pasteboard/copy-paste-crash-onbeforeunload-event.html: Added.
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::ForbidCopyPasteScope::ForbidCopyPasteScope):
(WebCore::ForbidCopyPasteScope::~ForbidCopyPasteScope):
(WebCore::FrameLoader::dispatchBeforeUnloadEvent):

Originally-landed-as: 267815.226@safari-7617-branch (20bb95c77d7c). <a href="https://rdar.apple.com/119592394">rdar://119592394</a>
Canonical link: <a href="https://commits.webkit.org/272314@main">https://commits.webkit.org/272314@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ea0fee89ef0dae3857a17ea5a38ff1bb5e90abe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31193 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9871 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32887 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33701 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28326 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31960 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12214 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7129 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27976 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31530 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8322 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27886 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7148 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7325 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27780 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35042 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28389 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28236 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33458 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7366 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5419 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31297 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9050 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/27569 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7349 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8067 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7899 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->