### PR TITLE
Stop using CheckedPtr / CheckedRef with refcounted classes in WebKit2

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -124,8 +124,6 @@ class NetworkConnectionToWebProcess
 #endif
 #if HAVE(COOKIE_CHANGE_LISTENER_API)
     , public WebCore::CookieChangeObserver
-#else
-    , public CanMakeCheckedPtr
 #endif
     , public IPC::Connection::Client {
 public:

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.cpp
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.cpp
@@ -28,17 +28,17 @@
 
 #include "WebSharedWorkerServer.h"
 #include "WebSharedWorkerServerToContextConnection.h"
-#include <wtf/CheckedPtr.h>
 #include <wtf/HashMap.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/RunLoop.h>
+#include <wtf/WeakRef.h>
 
 namespace WebKit {
 
-static HashMap<WebCore::SharedWorkerIdentifier, CheckedPtr<WebSharedWorker>>& allWorkers()
+static HashMap<WebCore::SharedWorkerIdentifier, WeakRef<WebSharedWorker>>& allWorkers()
 {
     ASSERT(RunLoop::isMain());
-    static NeverDestroyed<HashMap<WebCore::SharedWorkerIdentifier, CheckedPtr<WebSharedWorker>>> allWorkers;
+    static NeverDestroyed<HashMap<WebCore::SharedWorkerIdentifier, WeakRef<WebSharedWorker>>> allWorkers;
     return allWorkers;
 }
 
@@ -49,7 +49,7 @@ WebSharedWorker::WebSharedWorker(WebSharedWorkerServer& server, const WebCore::S
     , m_workerOptions(workerOptions)
 {
     ASSERT(!allWorkers().contains(m_identifier));
-    allWorkers().add(m_identifier, this);
+    allWorkers().add(m_identifier, *this);
 }
 
 WebSharedWorker::~WebSharedWorker()

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.h
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.h
@@ -45,7 +45,7 @@ namespace WebKit {
 class WebSharedWorkerServer;
 class WebSharedWorkerServerToContextConnection;
 
-class WebSharedWorker : public CanMakeWeakPtr<WebSharedWorker>, public CanMakeCheckedPtr {
+class WebSharedWorker : public CanMakeWeakPtr<WebSharedWorker> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     WebSharedWorker(WebSharedWorkerServer&, const WebCore::SharedWorkerKey&, const WebCore::WorkerOptions&);

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.cpp
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.cpp
@@ -171,7 +171,7 @@ void WebSharedWorkerServer::addContextConnection(WebSharedWorkerServerToContextC
 
     ASSERT(!m_contextConnections.contains(contextConnection.registrableDomain()));
 
-    m_contextConnections.add(contextConnection.registrableDomain(), &contextConnection);
+    m_contextConnections.add(contextConnection.registrableDomain(), contextConnection);
 
     contextConnectionCreated(contextConnection);
 }

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.h
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.h
@@ -85,7 +85,7 @@ private:
 
     NetworkSession& m_session;
     HashMap<WebCore::ProcessIdentifier, std::unique_ptr<WebSharedWorkerServerConnection>> m_connections;
-    HashMap<WebCore::RegistrableDomain, CheckedPtr<WebSharedWorkerServerToContextConnection>> m_contextConnections;
+    HashMap<WebCore::RegistrableDomain, WeakRef<WebSharedWorkerServerToContextConnection>> m_contextConnections;
     HashSet<WebCore::RegistrableDomain> m_pendingContextConnectionDomains;
     HashMap<WebCore::SharedWorkerKey, std::unique_ptr<WebSharedWorker>> m_sharedWorkers;
 };

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.h
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.h
@@ -49,7 +49,7 @@ class NetworkConnectionToWebProcess;
 class WebSharedWorker;
 class WebSharedWorkerServer;
 
-class WebSharedWorkerServerToContextConnection final : public IPC::MessageSender, public IPC::MessageReceiver, public CanMakeCheckedPtr {
+class WebSharedWorkerServerToContextConnection final : public IPC::MessageSender, public IPC::MessageReceiver {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     WebSharedWorkerServerToContextConnection(NetworkConnectionToWebProcess&, const WebCore::RegistrableDomain&, WebSharedWorkerServer&);

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.cpp
@@ -135,7 +135,7 @@ void NetworkMDNSRegister::registerMDNSName(WebCore::ScriptExecutionContextIdenti
     }
 
     auto identifier = PendingRegistrationRequestIdentifier::generate();
-    CheckedRef connection = m_connection;
+    Ref connection = m_connection.get();
     auto pendingRequest = makeUnique<PendingRegistrationRequest>(connection.get(), WTFMove(name), sessionID(), WTFMove(completionHandler));
     auto addResult = pendingRegistrationRequestMap().add(identifier, WTFMove(pendingRequest));
     DNSRecordRef record { nullptr };

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.h
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.h
@@ -79,7 +79,7 @@ private:
 
     PAL::SessionID sessionID() const;
 
-    CheckedRef<NetworkConnectionToWebProcess> m_connection;
+    WeakRef<NetworkConnectionToWebProcess> m_connection;
 #if ENABLE_MDNS
     struct DNSServiceDeallocator;
     HashMap<WebCore::ScriptExecutionContextIdentifier, std::unique_ptr<_DNSServiceRef_t, DNSServiceDeallocator>> m_services;

--- a/Source/WebKit/Shared/WebBackForwardListItem.cpp
+++ b/Source/WebKit/Shared/WebBackForwardListItem.cpp
@@ -60,10 +60,10 @@ WebBackForwardListItem::~WebBackForwardListItem()
     removeFromBackForwardCache();
 }
 
-HashMap<BackForwardItemIdentifier, CheckedRef<WebBackForwardListItem>>& WebBackForwardListItem::allItems()
+HashMap<BackForwardItemIdentifier, WeakRef<WebBackForwardListItem>>& WebBackForwardListItem::allItems()
 {
     RELEASE_ASSERT(RunLoop::isMain());
-    static NeverDestroyed<HashMap<BackForwardItemIdentifier, CheckedRef<WebBackForwardListItem>>> items;
+    static NeverDestroyed<HashMap<BackForwardItemIdentifier, WeakRef<WebBackForwardListItem>>> items;
     return items;
 }
 

--- a/Source/WebKit/Shared/WebBackForwardListItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListItem.h
@@ -48,13 +48,13 @@ class SuspendedPageProxy;
 class WebBackForwardCache;
 class WebBackForwardCacheEntry;
 
-class WebBackForwardListItem : public API::ObjectImpl<API::Object::Type::BackForwardListItem>, public CanMakeWeakPtr<WebBackForwardListItem>, public CanMakeCheckedPtr {
+class WebBackForwardListItem : public API::ObjectImpl<API::Object::Type::BackForwardListItem>, public CanMakeWeakPtr<WebBackForwardListItem> {
 public:
     static Ref<WebBackForwardListItem> create(BackForwardListItemState&&, WebPageProxyIdentifier);
     virtual ~WebBackForwardListItem();
 
     static WebBackForwardListItem* itemForID(const WebCore::BackForwardItemIdentifier&);
-    static HashMap<WebCore::BackForwardItemIdentifier, CheckedRef<WebBackForwardListItem>>& allItems();
+    static HashMap<WebCore::BackForwardItemIdentifier, WeakRef<WebBackForwardListItem>>& allItems();
 
     const WebCore::BackForwardItemIdentifier& itemID() const { return m_itemState.identifier; }
     const BackForwardListItemState& itemState() { return m_itemState; }

--- a/Source/WebKit/UIProcess/API/APIContentWorld.h
+++ b/Source/WebKit/UIProcess/API/APIContentWorld.h
@@ -27,8 +27,8 @@
 
 #include "APIObject.h"
 #include "ContentWorldShared.h"
-#include <wtf/CheckedRef.h>
 #include <wtf/WeakHashSet.h>
+#include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebKit {
@@ -37,7 +37,7 @@ class WebUserContentControllerProxy;
 
 namespace API {
 
-class ContentWorld final : public API::ObjectImpl<API::Object::Type::ContentWorld>, public CanMakeCheckedPtr {
+class ContentWorld final : public API::ObjectImpl<API::Object::Type::ContentWorld>, public CanMakeWeakPtr<ContentWorld> {
 public:
     static ContentWorld* worldForIdentifier(WebKit::ContentWorldIdentifier);
     static Ref<ContentWorld> sharedWorldWithName(const WTF::String&);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKBrowsingContextController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKBrowsingContextController.mm
@@ -87,9 +87,9 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 }
 
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-static HashMap<CheckedPtr<WebKit::WebPageProxy>, __unsafe_unretained WKBrowsingContextController *>& browsingContextControllerMap()
+static HashMap<WeakRef<WebKit::WebPageProxy>, __unsafe_unretained WKBrowsingContextController *>& browsingContextControllerMap()
 {
-    static NeverDestroyed<HashMap<CheckedPtr<WebKit::WebPageProxy>, __unsafe_unretained WKBrowsingContextController *>> browsingContextControllerMap;
+    static NeverDestroyed<HashMap<WeakRef<WebKit::WebPageProxy>, __unsafe_unretained WKBrowsingContextController *>> browsingContextControllerMap;
     return browsingContextControllerMap;
 }
 ALLOW_DEPRECATED_DECLARATIONS_END
@@ -99,8 +99,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (WebCoreObjCScheduleDeallocateOnMainRunLoop(WKBrowsingContextController.class, self))
         return;
 
-    ASSERT(browsingContextControllerMap().get(_page.get()) == self);
-    browsingContextControllerMap().remove(_page.get());
+    ASSERT(browsingContextControllerMap().get(*_page) == self);
+    browsingContextControllerMap().remove(*_page);
 
     _page->pageLoadState().removeObserver(*_pageLoadStateObserver);
 
@@ -626,8 +626,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     _pageLoadStateObserver = makeUnique<WebKit::PageLoadStateObserver>(self);
     _page->pageLoadState().addObserver(*_pageLoadStateObserver);
 
-    ASSERT(!browsingContextControllerMap().contains(_page.get()));
-    browsingContextControllerMap().set(_page.get(), self);
+    ASSERT(!browsingContextControllerMap().contains(*_page));
+    browsingContextControllerMap().set(*_page, self);
 
     return self;
 }

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
@@ -298,7 +298,7 @@ private:
     std::optional<unichar> charCodeIgnoringModifiersForVirtualKey(Inspector::Protocol::Automation::VirtualKey) const;
 #endif
 
-    CheckedPtr<WebProcessPool> m_processPool;
+    WeakPtr<WebProcessPool> m_processPool;
 
     std::unique_ptr<API::AutomationSessionClient> m_client;
     String m_sessionIdentifier { "Untitled Session"_s };

--- a/Source/WebKit/UIProcess/Cocoa/UIRemoteObjectRegistry.h
+++ b/Source/WebKit/UIProcess/Cocoa/UIRemoteObjectRegistry.h
@@ -26,7 +26,7 @@
 #pragma once
 
 #include "RemoteObjectRegistry.h"
-#include <wtf/CheckedRef.h>
+#include <wtf/WeakRef.h>
 
 namespace WebKit {
 
@@ -45,7 +45,7 @@ private:
     uint64_t messageDestinationID() final;
     std::unique_ptr<ProcessThrottler::BackgroundActivity> backgroundActivity(ASCIILiteral) final;
 
-    CheckedRef<WebPageProxy> m_page;
+    WeakRef<WebPageProxy> m_page;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/DrawingAreaProxy.cpp
+++ b/Source/WebKit/UIProcess/DrawingAreaProxy.cpp
@@ -113,6 +113,11 @@ bool DrawingAreaProxy::setSize(const IntSize& size, const IntSize& scrollDelta)
     return true;
 }
 
+WebPageProxy& DrawingAreaProxy::page() const
+{
+    return m_webPageProxy;
+}
+
 #if PLATFORM(COCOA)
 MachSendRight DrawingAreaProxy::createFence()
 {

--- a/Source/WebKit/UIProcess/DrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/DrawingAreaProxy.h
@@ -34,10 +34,10 @@
 #include <WebCore/IntRect.h>
 #include <WebCore/IntSize.h>
 #include <stdint.h>
-#include <wtf/CheckedRef.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RunLoop.h>
 #include <wtf/TypeCasts.h>
+#include <wtf/WeakRef.h>
 
 #if PLATFORM(COCOA)
 namespace WTF {
@@ -124,7 +124,7 @@ public:
     virtual bool shouldCoalesceVisualEditorStateUpdates() const { return false; }
     virtual bool shouldSendWheelEventsToEventDispatcher() const { return false; }
 
-    WebPageProxy& page() const { return m_webPageProxy; }
+    WebPageProxy& page() const;
     virtual void viewWillStartLiveResize() { };
     virtual void viewWillEndLiveResize() { };
 
@@ -147,7 +147,7 @@ protected:
 
     DrawingAreaType m_type;
     DrawingAreaIdentifier m_identifier;
-    CheckedRef<WebPageProxy> m_webPageProxy;
+    WeakRef<WebPageProxy> m_webPageProxy;
     Ref<WebProcessProxy> m_webProcessProxy;
 
     WebCore::IntSize m_size;

--- a/Source/WebKit/UIProcess/Inspector/Agents/InspectorBrowserAgent.h
+++ b/Source/WebKit/UIProcess/Inspector/Agents/InspectorBrowserAgent.h
@@ -28,8 +28,8 @@
 #include "WebPageInspectorAgentBase.h"
 #include <JavaScriptCore/InspectorBackendDispatchers.h>
 #include <JavaScriptCore/InspectorFrontendDispatchers.h>
-#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
+#include <wtf/WeakRef.h>
 
 namespace WebKit {
 
@@ -57,7 +57,7 @@ public:
 private:
     std::unique_ptr<Inspector::BrowserFrontendDispatcher> m_frontendDispatcher;
     RefPtr<Inspector::BrowserBackendDispatcher> m_backendDispatcher;
-    CheckedRef<WebPageProxy> m_inspectedPage;
+    WeakRef<WebPageProxy> m_inspectedPage;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.h
@@ -30,10 +30,10 @@
 #include <WebCore/Color.h>
 #include <WebCore/FloatRect.h>
 #include <WebCore/InspectorFrontendClient.h>
-#include <wtf/CheckedPtr.h>
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
 #if PLATFORM(MAC)
@@ -167,7 +167,7 @@ private:
     void platformShowCertificate(const WebCore::CertificateInfo&);
 
     CheckedPtr<RemoteWebInspectorUIProxyClient> m_client;
-    CheckedPtr<WebPageProxy> m_inspectorPage;
+    WeakPtr<WebPageProxy> m_inspectorPage;
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
     RefPtr<WebInspectorUIExtensionControllerProxy> m_extensionController;

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp
@@ -66,7 +66,7 @@ const unsigned WebInspectorUIProxy::initialWindowWidth = 1000;
 const unsigned WebInspectorUIProxy::initialWindowHeight = 650;
 
 WebInspectorUIProxy::WebInspectorUIProxy(WebPageProxy& inspectedPage)
-    : m_inspectedPage(&inspectedPage)
+    : m_inspectedPage(inspectedPage)
     , m_inspectorClient(makeUnique<API::InspectorClient>())
     , m_inspectedPageIdentifier(inspectedPage.identifier())
 #if PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h
@@ -302,8 +302,8 @@ private:
     void windowReceivedMessage(HWND, UINT, WPARAM, LPARAM) override;
 #endif
 
-    CheckedPtr<WebPageProxy> m_inspectedPage;
-    CheckedPtr<WebPageProxy> m_inspectorPage;
+    WeakPtr<WebPageProxy> m_inspectedPage;
+    WeakPtr<WebPageProxy> m_inspectorPage;
     std::unique_ptr<API::InspectorClient> m_inspectorClient;
     WebPageProxyIdentifier m_inspectedPageIdentifier;
 

--- a/Source/WebKit/UIProcess/Inspector/WebPageInspectorAgentBase.h
+++ b/Source/WebKit/UIProcess/Inspector/WebPageInspectorAgentBase.h
@@ -26,7 +26,7 @@
 #pragma once
 
 #include <JavaScriptCore/InspectorAgentBase.h>
-#include <wtf/CheckedPtr.h>
+#include <wtf/WeakRef.h>
 #include <wtf/text/WTFString.h>
 
 namespace Inspector {
@@ -42,7 +42,7 @@ class WebPageProxy;
 struct WebPageAgentContext {
     Inspector::FrontendRouter& frontendRouter;
     Inspector::BackendDispatcher& backendDispatcher;
-    CheckedRef<WebPageProxy> inspectedPage;
+    WeakRef<WebPageProxy> inspectedPage;
 };
 
 class InspectorAgentBase : public Inspector::InspectorAgentBase {

--- a/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h
+++ b/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h
@@ -94,7 +94,7 @@ private:
     Ref<Inspector::BackendDispatcher> m_backendDispatcher;
     Inspector::AgentRegistry m_agents;
 
-    CheckedRef<WebPageProxy> m_inspectedPage;
+    WeakRef<WebPageProxy> m_inspectedPage;
 
     Inspector::InspectorTargetAgent* m_targetAgent { nullptr };
     HashMap<String, std::unique_ptr<InspectorTargetProxy>> m_targets;

--- a/Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.mm
@@ -54,7 +54,7 @@ static NSString * const WKInspectorResourceScheme = @"inspector-resource";
 @end
 
 @implementation WKInspectorViewController {
-    CheckedPtr<WebKit::WebPageProxy> _inspectedPage;
+    WeakPtr<WebKit::WebPageProxy> _inspectedPage;
     RetainPtr<WKInspectorWKWebView> _webView;
     WeakObjCPtr<id <WKInspectorViewControllerDelegate>> _delegate;
     RetainPtr<_WKInspectorConfiguration> _configuration;
@@ -68,7 +68,7 @@ static NSString * const WKInspectorResourceScheme = @"inspector-resource";
     _configuration = adoptNS([configuration copy]);
 
     // The (local) inspected page is nil if the controller is hosting a Remote Web Inspector view.
-    _inspectedPage = inspectedPage;
+    _inspectedPage = inspectedPage.get();
 
     return self;
 }

--- a/Source/WebKit/UIProcess/ProvisionalFrameProxy.h
+++ b/Source/WebKit/UIProcess/ProvisionalFrameProxy.h
@@ -28,7 +28,6 @@
 #include "WebPageProxyIdentifier.h"
 #include <WebCore/LayerHostingContextIdentifier.h>
 #include <WebCore/PageIdentifier.h>
-#include <wtf/CheckedRef.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -51,7 +50,7 @@ public:
     WebCore::LayerHostingContextIdentifier layerHostingContextIdentifier() const { return m_layerHostingContextIdentifier; }
 
 private:
-    CheckedRef<WebFrameProxy> m_frame;
+    WeakRef<WebFrameProxy> m_frame;
     Ref<WebProcessProxy> m_process;
     RefPtr<RemotePageProxy> m_remotePageProxy;
     Ref<VisitedLinkStore> m_visitedLinkStore;

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -126,7 +126,7 @@ ProvisionalPageProxy::~ProvisionalPageProxy()
 
         auto dataStore = m_process->websiteDataStore();
         if (dataStore && dataStore!= &m_page->websiteDataStore())
-            m_process->processPool().pageEndUsingWebsiteDataStore(CheckedRef { m_page }, *dataStore);
+            m_process->processPool().pageEndUsingWebsiteDataStore(Ref { m_page.get() }, *dataStore);
 
         if (m_process->hasConnection())
             send(Messages::WebPage::Close());

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.h
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.h
@@ -182,7 +182,7 @@ private:
     void initializeWebPage(RefPtr<API::WebsitePolicies>&&);
     bool validateInput(WebCore::FrameIdentifier, const std::optional<uint64_t>& navigationID = std::nullopt);
 
-    CheckedRef<WebPageProxy> m_page;
+    WeakRef<WebPageProxy> m_page;
     WebCore::PageIdentifier m_webPageID;
     Ref<WebProcessProxy> m_process;
     // Keep WebsiteDataStore alive for provisional page load.

--- a/Source/WebKit/UIProcess/SpeechRecognitionPermissionManager.h
+++ b/Source/WebKit/UIProcess/SpeechRecognitionPermissionManager.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "SpeechRecognitionPermissionRequest.h"
-#include <wtf/CheckedRef.h>
 #include <wtf/Deque.h>
 #include <wtf/WeakPtr.h>
 
@@ -56,7 +55,7 @@ private:
     void requestSpeechRecognitionServiceAccess();
     void requestUserPermission(WebCore::SpeechRecognitionRequest& request);
 
-    CheckedRef<WebPageProxy> m_page;
+    WeakRef<WebPageProxy> m_page;
     Deque<Ref<SpeechRecognitionPermissionRequest>> m_requests;
     CheckResult m_microphoneCheck { CheckResult::Unknown };
     CheckResult m_speechRecognitionServiceCheck { CheckResult::Unknown };

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
@@ -268,6 +268,11 @@ void SuspendedPageProxy::suspensionTimedOut()
     backForwardCache().removeEntry(*this); // Will destroy |this|.
 }
 
+WebPageProxy& SuspendedPageProxy::page() const
+{
+    return m_page.get();
+}
+
 void SuspendedPageProxy::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
     ASSERT(decoder.messageReceiverName() == Messages::WebPageProxy::messageReceiverName());

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.h
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.h
@@ -32,7 +32,6 @@
 #include "WebPageProxyMessageReceiverRegistration.h"
 #include "WebProcessProxy.h"
 #include <WebCore/FrameIdentifier.h>
-#include <wtf/CheckedRef.h>
 #include <wtf/RefCounted.h>
 #include <wtf/WeakPtr.h>
 
@@ -63,7 +62,7 @@ public:
 
     static RefPtr<WebProcessProxy> findReusableSuspendedPageProcess(WebProcessPool&, const WebCore::RegistrableDomain&, WebsiteDataStore&, WebProcessProxy::LockdownMode, const API::PageConfiguration&);
 
-    WebPageProxy& page() const { return m_page.get(); }
+    WebPageProxy& page() const;
     WebCore::PageIdentifier webPageID() const { return m_webPageID; }
     WebProcessProxy& process() const { return m_process.get(); }
     WebFrameProxy& mainFrame() { return m_mainFrame.get(); }
@@ -107,7 +106,7 @@ private:
 
     template<typename T> void sendToAllProcesses(T&&);
 
-    CheckedRef<WebPageProxy> m_page;
+    WeakRef<WebPageProxy> m_page;
     WebCore::PageIdentifier m_webPageID;
     Ref<WebProcessProxy> m_process;
     Ref<WebFrameProxy> m_mainFrame;

--- a/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp
+++ b/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp
@@ -53,9 +53,9 @@ namespace WebKit {
 
 using namespace WebCore;
 
-static HashMap<UserContentControllerIdentifier, CheckedPtr<WebUserContentControllerProxy>>& webUserContentControllerProxies()
+static HashMap<UserContentControllerIdentifier, WeakRef<WebUserContentControllerProxy>>& webUserContentControllerProxies()
 {
-    static NeverDestroyed<HashMap<UserContentControllerIdentifier, CheckedPtr<WebUserContentControllerProxy>>> proxies;
+    static NeverDestroyed<HashMap<UserContentControllerIdentifier, WeakRef<WebUserContentControllerProxy>>> proxies;
     return proxies;
 }
 
@@ -69,7 +69,7 @@ WebUserContentControllerProxy::WebUserContentControllerProxy()
     , m_userScripts(API::Array::create())
     , m_userStyleSheets(API::Array::create())
 {
-    webUserContentControllerProxies().add(m_identifier, this);
+    webUserContentControllerProxies().add(m_identifier, *this);
 }
 
 WebUserContentControllerProxy::~WebUserContentControllerProxy()

--- a/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h
+++ b/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h
@@ -67,7 +67,7 @@ struct WebPageCreationParameters;
 struct UserContentControllerParameters;
 enum class InjectUserScriptImmediately : bool;
 
-class WebUserContentControllerProxy : public API::ObjectImpl<API::Object::Type::UserContentController>, public IPC::MessageReceiver, public CanMakeCheckedPtr {
+class WebUserContentControllerProxy : public API::ObjectImpl<API::Object::Type::UserContentController>, public IPC::MessageReceiver {
 public:
     static Ref<WebUserContentControllerProxy> create()
     { 

--- a/Source/WebKit/UIProcess/ViewSnapshotStore.cpp
+++ b/Source/WebKit/UIProcess/ViewSnapshotStore.cpp
@@ -56,14 +56,14 @@ ViewSnapshotStore& ViewSnapshotStore::singleton()
 
 void ViewSnapshotStore::didAddImageToSnapshot(ViewSnapshot& snapshot)
 {
-    bool isNewEntry = m_snapshotsWithImages.add(&snapshot).isNewEntry;
+    bool isNewEntry = m_snapshotsWithImages.add(snapshot).isNewEntry;
     ASSERT_UNUSED(isNewEntry, isNewEntry);
     m_snapshotCacheSize += snapshot.estimatedImageSizeInBytes();
 }
 
 void ViewSnapshotStore::willRemoveImageFromSnapshot(ViewSnapshot& snapshot)
 {
-    bool removed = m_snapshotsWithImages.remove(&snapshot);
+    bool removed = m_snapshotsWithImages.remove(snapshot);
     ASSERT_UNUSED(removed, removed);
     m_snapshotCacheSize -= snapshot.estimatedImageSizeInBytes();
 }

--- a/Source/WebKit/UIProcess/ViewSnapshotStore.h
+++ b/Source/WebKit/UIProcess/ViewSnapshotStore.h
@@ -28,9 +28,9 @@
 #include <WebCore/Color.h>
 #include <WebCore/IntPoint.h>
 #include <WebCore/SecurityOriginData.h>
-#include <wtf/CheckedPtr.h>
 #include <wtf/ListHashSet.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
 #if HAVE(IOSURFACE)
@@ -50,7 +50,7 @@ namespace WebKit {
 class WebBackForwardListItem;
 class WebPageProxy;
 
-class ViewSnapshot : public RefCounted<ViewSnapshot>, public CanMakeCheckedPtr {
+class ViewSnapshot : public RefCounted<ViewSnapshot>, public CanMakeWeakPtr<ViewSnapshot> {
 public:
 #if HAVE(IOSURFACE)
     static Ref<ViewSnapshot> create(std::unique_ptr<WebCore::IOSurface>);
@@ -160,7 +160,7 @@ private:
 
     size_t m_snapshotCacheSize { 0 };
 
-    ListHashSet<CheckedPtr<ViewSnapshot>> m_snapshotsWithImages;
+    ListHashSet<WeakRef<ViewSnapshot>> m_snapshotsWithImages;
     bool m_disableSnapshotVolatility { false };
 };
 

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -54,6 +54,7 @@
 #include <stdio.h>
 #include <wtf/CheckedPtr.h>
 #include <wtf/RunLoop.h>
+#include <wtf/WeakRef.h>
 #include <wtf/text/WTFString.h>
 
 #define MESSAGE_CHECK(process, assertion) MESSAGE_CHECK_BASE(assertion, process->connection())
@@ -63,10 +64,10 @@ using namespace WebCore;
 
 class WebPageProxy;
 
-static HashMap<FrameIdentifier, CheckedPtr<WebFrameProxy>>& allFrames()
+static HashMap<FrameIdentifier, WeakRef<WebFrameProxy>>& allFrames()
 {
     ASSERT(RunLoop::isMain());
-    static NeverDestroyed<HashMap<FrameIdentifier, CheckedPtr<WebFrameProxy>>> map;
+    static NeverDestroyed<HashMap<FrameIdentifier, WeakRef<WebFrameProxy>>> map;
     return map.get();
 }
 
@@ -90,7 +91,7 @@ WebFrameProxy::WebFrameProxy(WebPageProxy& page, WebProcessProxy& process, Frame
     , m_frameID(frameID)
 {
     ASSERT(!allFrames().contains(frameID));
-    allFrames().set(frameID, this);
+    allFrames().set(frameID, *this);
     WebProcessPool::statistics().wkFrameCount++;
 }
 

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -71,7 +71,7 @@ struct FrameTreeCreationParameters;
 struct FrameTreeNodeData;
 struct WebsitePoliciesData;
 
-class WebFrameProxy : public API::ObjectImpl<API::Object::Type::Frame>, public CanMakeWeakPtr<WebFrameProxy>, public CanMakeCheckedPtr {
+class WebFrameProxy : public API::ObjectImpl<API::Object::Type::Frame>, public CanMakeWeakPtr<WebFrameProxy> {
 public:
     static Ref<WebFrameProxy> create(WebPageProxy& page, WebProcessProxy& process, WebCore::FrameIdentifier frameID)
     {

--- a/Source/WebKit/UIProcess/WebPageGroup.cpp
+++ b/Source/WebKit/UIProcess/WebPageGroup.cpp
@@ -41,7 +41,7 @@
 
 namespace WebKit {
 
-using WebPageGroupMap = HashMap<PageGroupIdentifier, CheckedPtr<WebPageGroup>>;
+using WebPageGroupMap = HashMap<PageGroupIdentifier, WeakRef<WebPageGroup>>;
 
 static WebPageGroupMap& webPageGroupMap()
 {
@@ -62,7 +62,7 @@ WebPageGroup* WebPageGroup::get(PageGroupIdentifier pageGroupID)
 void WebPageGroup::forEach(Function<void(WebPageGroup&)>&& function)
 {
     auto allGroups = WTF::map(webPageGroupMap().values(), [](auto&& group) -> Ref<WebPageGroup> {
-        return *group;
+        return group.get();
     });
     for (auto& group : allGroups)
         function(group);
@@ -95,7 +95,7 @@ WebPageGroup::WebPageGroup(const String& identifier)
     , m_preferences(WebPreferences::createWithLegacyDefaults(m_data.identifier, ".WebKit2"_s, "WebKit2."_s))
     , m_userContentController(WebUserContentControllerProxy::create())
 {
-    webPageGroupMap().set(m_data.pageGroupID, this);
+    webPageGroupMap().set(m_data.pageGroupID, *this);
 }
 
 WebPageGroup::~WebPageGroup()

--- a/Source/WebKit/UIProcess/WebPageGroup.h
+++ b/Source/WebKit/UIProcess/WebPageGroup.h
@@ -40,7 +40,7 @@ class WebPreferences;
 class WebPageProxy;
 class WebUserContentControllerProxy;
 
-class WebPageGroup : public API::ObjectImpl<API::Object::Type::PageGroup>, public CanMakeCheckedPtr {
+class WebPageGroup : public API::ObjectImpl<API::Object::Type::PageGroup>, public CanMakeWeakPtr<WebPageGroup> {
 public:
     explicit WebPageGroup(const String& identifier = { });
     static Ref<WebPageGroup> create(const String& identifier = { });

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -516,7 +516,7 @@ using WebPageProxyIdentifier = ObjectIdentifier<WebPageProxyIdentifierType>;
 using WebURLSchemeHandlerIdentifier = ObjectIdentifier<WebURLSchemeHandler>;
 using WebUndoStepID = uint64_t;
 
-class WebPageProxy final : public API::ObjectImpl<API::Object::Type::Page>, public IPC::MessageReceiver, public IPC::MessageSender, public CanMakeCheckedPtr {
+class WebPageProxy final : public API::ObjectImpl<API::Object::Type::Page>, public IPC::MessageReceiver, public IPC::MessageSender {
 public:
     static Ref<WebPageProxy> create(PageClient&, WebProcessProxy&, Ref<API::PageConfiguration>&&);
     virtual ~WebPageProxy();

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -175,9 +175,9 @@ Ref<WebProcessPool> WebProcessPool::create(API::ProcessPoolConfiguration& config
     return adoptRef(*new WebProcessPool(configuration));
 }
 
-static Vector<CheckedRef<WebProcessPool>>& processPools()
+static Vector<WeakRef<WebProcessPool>>& processPools()
 {
-    static NeverDestroyed<Vector<CheckedRef<WebProcessPool>>> processPools;
+    static NeverDestroyed<Vector<WeakRef<WebProcessPool>>> processPools;
     return processPools;
 }
 

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -151,8 +151,6 @@ class WebProcessPool final
 #endif
 #if ENABLE(EXTENSION_CAPABILITIES)
     , public ExtensionCapabilityGranter::Client
-#else
-    , public CanMakeCheckedPtr
 #endif
 {
 public:

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -144,7 +144,7 @@ enum class CheckBackForwardList : bool { No, Yes };
 
 class WebProcessProxy : public AuxiliaryProcessProxy {
 public:
-    using WebPageProxyMap = HashMap<WebPageProxyIdentifier, CheckedRef<WebPageProxy>>;
+    using WebPageProxyMap = HashMap<WebPageProxyIdentifier, WeakRef<WebPageProxy>>;
     using UserInitiatedActionByAuthorizationTokenMap = HashMap<WTF::UUID, RefPtr<API::UserInitiatedAction>>;
     typedef HashMap<uint64_t, RefPtr<API::UserInitiatedAction>> UserInitiatedActionMap;
 

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -109,10 +109,10 @@ static HashMap<String, PAL::SessionID>& activeGeneralStorageDirectories()
     return directoryToSessionMap;
 }
 
-static HashMap<PAL::SessionID, CheckedRef<WebsiteDataStore>>& allDataStores()
+static HashMap<PAL::SessionID, WeakRef<WebsiteDataStore>>& allDataStores()
 {
     RELEASE_ASSERT(isUIThread());
-    static NeverDestroyed<HashMap<PAL::SessionID, CheckedRef<WebsiteDataStore>>> map;
+    static NeverDestroyed<HashMap<PAL::SessionID, WeakRef<WebsiteDataStore>>> map;
     return map;
 }
 

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -117,7 +117,7 @@ struct WebPushMessage;
 struct WebsiteDataRecord;
 struct WebsiteDataStoreParameters;
 
-class WebsiteDataStore : public API::ObjectImpl<API::Object::Type::WebsiteDataStore>, public Identified<WebsiteDataStore>, public CanMakeWeakPtr<WebsiteDataStore>, public CanMakeCheckedPtr {
+class WebsiteDataStore : public API::ObjectImpl<API::Object::Type::WebsiteDataStore>, public Identified<WebsiteDataStore>, public CanMakeWeakPtr<WebsiteDataStore> {
 public:
     static Ref<WebsiteDataStore> defaultDataStore();
     static bool defaultDataStoreExists();

--- a/Source/WebKit/UIProcess/mac/WKImmediateActionController.h
+++ b/Source/WebKit/UIProcess/mac/WKImmediateActionController.h
@@ -57,7 +57,7 @@ enum class ImmediateActionState {
 
 @interface WKImmediateActionController : NSObject <NSImmediateActionGestureRecognizerDelegate> {
 @private
-    CheckedPtr<WebKit::WebPageProxy> _page;
+    WeakPtr<WebKit::WebPageProxy> _page;
     NSView *_view;
     CheckedPtr<WebKit::WebViewImpl> _viewImpl;
 

--- a/Source/WebKit/UIProcess/mac/WKTextFinderClient.mm
+++ b/Source/WebKit/UIProcess/mac/WKTextFinderClient.mm
@@ -157,7 +157,7 @@ private:
 @end
 
 @implementation WKTextFinderClient {
-    CheckedPtr<WebKit::WebPageProxy> _page;
+    WeakPtr<WebKit::WebPageProxy> _page;
     NSView *_view;
     Deque<WTF::Function<void(NSArray *, bool didWrap)>> _findReplyCallbacks;
     Deque<WTF::Function<void(NSImage *)>> _imageReplyCallbacks;

--- a/Source/WebKit/WebProcess/Databases/WebDatabaseProvider.h
+++ b/Source/WebKit/WebProcess/Databases/WebDatabaseProvider.h
@@ -27,12 +27,12 @@
 
 #include "IdentifierTypes.h"
 #include <WebCore/DatabaseProvider.h>
-#include <wtf/CheckedRef.h>
 #include <wtf/HashMap.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebKit {
 
-class WebDatabaseProvider final : public WebCore::DatabaseProvider, public CanMakeCheckedPtr {
+class WebDatabaseProvider final : public WebCore::DatabaseProvider, public CanMakeWeakPtr<WebDatabaseProvider> {
 public:
     static Ref<WebDatabaseProvider> getOrCreate(PageGroupIdentifier);
     virtual ~WebDatabaseProvider();

--- a/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleCSSStyleDeclarationHandle.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleCSSStyleDeclarationHandle.h
@@ -28,9 +28,9 @@
 
 #include "APIObject.h"
 #include <JavaScriptCore/JSBase.h>
-#include <wtf/CheckedRef.h>
 #include <wtf/Ref.h>
 #include <wtf/RefPtr.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 class CSSStyleDeclaration;
@@ -38,7 +38,7 @@ class CSSStyleDeclaration;
 
 namespace WebKit {
 
-class InjectedBundleCSSStyleDeclarationHandle : public API::ObjectImpl<API::Object::Type::BundleCSSStyleDeclarationHandle>, public CanMakeCheckedPtr {
+class InjectedBundleCSSStyleDeclarationHandle : public API::ObjectImpl<API::Object::Type::BundleCSSStyleDeclarationHandle>, public CanMakeWeakPtr<InjectedBundleCSSStyleDeclarationHandle> {
 public:
     static RefPtr<InjectedBundleCSSStyleDeclarationHandle> getOrCreate(JSContextRef, JSObjectRef);
     static RefPtr<InjectedBundleCSSStyleDeclarationHandle> getOrCreate(WebCore::CSSStyleDeclaration*);

--- a/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp
@@ -54,17 +54,17 @@
 #include <WebCore/SimpleRange.h>
 #include <WebCore/Text.h>
 #include <WebCore/VisiblePosition.h>
-#include <wtf/CheckedPtr.h>
 #include <wtf/HashMap.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/WeakHashMap.h>
+#include <wtf/WeakRef.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebKit {
 using namespace WebCore;
 using namespace HTMLNames;
 
-using DOMNodeHandleCache = WeakHashMap<Node, CheckedPtr<InjectedBundleNodeHandle>, WeakPtrImplWithEventTargetData>;
+using DOMNodeHandleCache = WeakHashMap<Node, WeakRef<InjectedBundleNodeHandle>, WeakPtrImplWithEventTargetData>;
 
 static DOMNodeHandleCache& domNodeHandleCache()
 {
@@ -93,7 +93,7 @@ Ref<InjectedBundleNodeHandle> InjectedBundleNodeHandle::getOrCreate(Node& node)
 
     auto nodeHandle = InjectedBundleNodeHandle::create(node);
     if (nodeHandle->coreNode())
-        domNodeHandleCache().add(*nodeHandle->coreNode(), nodeHandle.ptr());
+        domNodeHandleCache().add(*nodeHandle->coreNode(), nodeHandle.get());
     return nodeHandle;
 }
 

--- a/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.h
@@ -29,9 +29,9 @@
 #include "ImageOptions.h"
 #include <JavaScriptCore/JSBase.h>
 #include <WebCore/ActiveDOMObject.h>
-#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/RefPtr.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 class IntRect;
@@ -46,7 +46,7 @@ class InjectedBundleScriptWorld;
 class WebFrame;
 class WebImage;
 
-class InjectedBundleNodeHandle : public API::ObjectImpl<API::Object::Type::BundleNodeHandle>, public WebCore::ActiveDOMObject, public CanMakeCheckedPtr {
+class InjectedBundleNodeHandle : public API::ObjectImpl<API::Object::Type::BundleNodeHandle>, public WebCore::ActiveDOMObject, public CanMakeWeakPtr<InjectedBundleNodeHandle> {
 public:
     static RefPtr<InjectedBundleNodeHandle> getOrCreate(JSContextRef, JSObjectRef);
     static RefPtr<InjectedBundleNodeHandle> getOrCreate(WebCore::Node*);

--- a/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleRangeHandle.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleRangeHandle.h
@@ -28,9 +28,9 @@
 #include "APIObject.h"
 #include "ImageOptions.h"
 #include <JavaScriptCore/JSBase.h>
-#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/RefPtr.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 class IntRect;
@@ -44,7 +44,7 @@ class InjectedBundleNodeHandle;
 class InjectedBundleScriptWorld;
 class WebImage;
 
-class InjectedBundleRangeHandle : public API::ObjectImpl<API::Object::Type::BundleRangeHandle>, public CanMakeCheckedPtr {
+class InjectedBundleRangeHandle : public API::ObjectImpl<API::Object::Type::BundleRangeHandle>, public CanMakeWeakPtr<InjectedBundleRangeHandle> {
 public:
     static RefPtr<InjectedBundleRangeHandle> getOrCreate(JSContextRef, JSObjectRef);
     static RefPtr<InjectedBundleRangeHandle> getOrCreate(WebCore::Range*);

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp
@@ -37,7 +37,7 @@
 namespace WebKit {
 using namespace WebCore;
 
-using WorldMap = HashMap<SingleThreadWeakRef<DOMWrapperWorld>, CheckedPtr<InjectedBundleScriptWorld>>;
+using WorldMap = HashMap<SingleThreadWeakRef<DOMWrapperWorld>, WeakRef<InjectedBundleScriptWorld>>;
 
 static WorldMap& allWorlds()
 {
@@ -66,7 +66,7 @@ Ref<InjectedBundleScriptWorld> InjectedBundleScriptWorld::getOrCreate(DOMWrapper
     if (&world == &mainThreadNormalWorld())
         return normalWorld();
 
-    if (auto existingWorld = allWorlds().get(&world))
+    if (auto existingWorld = allWorlds().get(world))
         return *existingWorld;
 
     return adoptRef(*new InjectedBundleScriptWorld(world, uniqueWorldName()));
@@ -76,7 +76,7 @@ InjectedBundleScriptWorld* InjectedBundleScriptWorld::find(const String& name)
 {
     for (auto& world : allWorlds().values()) {
         if (world->name() == name)
-            return world.get();
+            return world.ptr();
     }
     return nullptr;
 }
@@ -91,8 +91,8 @@ InjectedBundleScriptWorld::InjectedBundleScriptWorld(DOMWrapperWorld& world, con
     : m_world(world)
     , m_name(name)
 {
-    ASSERT(!allWorlds().contains(m_world.get()));
-    allWorlds().add(m_world.get(), this);
+    ASSERT(!allWorlds().contains(world));
+    allWorlds().add(world, *this);
 }
 
 InjectedBundleScriptWorld::~InjectedBundleScriptWorld()

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.h
@@ -27,9 +27,9 @@
 #define InjectedBundleScriptWorld_h
 
 #include "APIObject.h"
-#include <wtf/CheckedRef.h>
 #include <wtf/Ref.h>
 #include <wtf/RefPtr.h>
+#include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -38,7 +38,7 @@ namespace WebCore {
 
 namespace WebKit {
 
-class InjectedBundleScriptWorld : public API::ObjectImpl<API::Object::Type::BundleScriptWorld>, public CanMakeCheckedPtr {
+class InjectedBundleScriptWorld : public API::ObjectImpl<API::Object::Type::BundleScriptWorld>, public CanMakeWeakPtr<InjectedBundleScriptWorld> {
 public:
     enum class Type { User, Internal };
     static Ref<InjectedBundleScriptWorld> create(Type = Type::Internal);

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -563,7 +563,7 @@ void WebLoaderStrategy::startLocalLoad(WebCore::ResourceLoader& resourceLoader)
 
 void WebLoaderStrategy::addURLSchemeTaskProxy(WebURLSchemeTaskProxy& task)
 {
-    auto result = m_urlSchemeTasks.add(task.identifier(), &task);
+    auto result = m_urlSchemeTasks.add(task.identifier(), task);
     ASSERT_UNUSED(result, result.isNewEntry);
 }
 

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.h
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.h
@@ -135,7 +135,7 @@ private:
     RunLoop::Timer m_internallyFailedLoadTimer;
     
     HashMap<WebCore::ResourceLoaderIdentifier, RefPtr<WebResourceLoader>> m_webResourceLoaders;
-    HashMap<WebCore::ResourceLoaderIdentifier, CheckedPtr<WebURLSchemeTaskProxy>> m_urlSchemeTasks;
+    HashMap<WebCore::ResourceLoaderIdentifier, WeakRef<WebURLSchemeTaskProxy>> m_urlSchemeTasks;
     HashMap<WebCore::ResourceLoaderIdentifier, PingLoadCompletionHandler> m_pingLoadCompletionHandlers;
     HashMap<WebCore::ResourceLoaderIdentifier, PreconnectCompletionHandler> m_preconnectCompletionHandlers;
     Vector<Function<void(bool)>> m_onlineStateChangeListeners;

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.h
@@ -33,7 +33,7 @@
 
 #if USE(LIBWEBRTC)
 
-#include <wtf/CheckedRef.h>
+#include <wtf/WeakRef.h>
 
 #if PLATFORM(COCOA)
 #include <WebCore/LibWebRTCProviderCocoa.h>
@@ -77,7 +77,7 @@ private:
 
     void willCreatePeerConnectionFactory() final;
 
-    CheckedRef<WebPage> m_webPage;
+    WeakRef<WebPage> m_webPage;
 };
 
 inline UniqueRef<LibWebRTCProvider> createLibWebRTCProvider(WebPage& page)

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.h
@@ -29,8 +29,8 @@
 
 #include <WebCore/LibWebRTCProvider.h>
 #include <WebCore/LibWebRTCSocketIdentifier.h>
-#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
+#include <wtf/WeakPtr.h>
 
 ALLOW_COMMA_BEGIN
 
@@ -47,7 +47,7 @@ namespace WebKit {
 
 class LibWebRTCSocketFactory;
 
-class LibWebRTCSocket final : public rtc::AsyncPacketSocket, public CanMakeCheckedPtr {
+class LibWebRTCSocket final : public rtc::AsyncPacketSocket, public CanMakeWeakPtr<LibWebRTCSocket> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     enum class Type { UDP, ClientTCP, ServerConnectionTCP };

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocketFactory.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocketFactory.cpp
@@ -129,7 +129,7 @@ void LibWebRTCSocketFactory::addSocket(LibWebRTCSocket& socket)
 {
     ASSERT(!WTF::isMainRunLoop());
     ASSERT(!m_sockets.contains(socket.identifier()));
-    m_sockets.add(socket.identifier(), &socket);
+    m_sockets.add(socket.identifier(), socket);
 }
 
 void LibWebRTCSocketFactory::removeSocket(LibWebRTCSocket& socket)
@@ -144,7 +144,7 @@ void LibWebRTCSocketFactory::forSocketInGroup(ScriptExecutionContextIdentifier c
     ASSERT(!WTF::isMainRunLoop());
     for (auto& socket : m_sockets.values()) {
         if (socket->contextIdentifier() == contextIdentifier)
-            callback(*socket);
+            callback(socket);
     }
 }
 
@@ -153,7 +153,7 @@ std::unique_ptr<LibWebRTCResolver> LibWebRTCSocketFactory::createAsyncDnsResolve
     auto resolver = makeUnique<LibWebRTCResolver>();
 
     ASSERT(!m_resolvers.contains(resolver->identifier()));
-    m_resolvers.add(resolver->identifier(), resolver.get());
+    m_resolvers.add(resolver->identifier(), *resolver);
 
     return resolver;
 }

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocketFactory.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocketFactory.h
@@ -32,10 +32,10 @@
 #include "WebPageProxyIdentifier.h"
 #include <WebCore/LibWebRTCMacros.h>
 #include <WebCore/LibWebRTCSocketIdentifier.h>
-#include <wtf/CheckedPtr.h>
 #include <wtf/Deque.h>
 #include <wtf/Function.h>
 #include <wtf/HashMap.h>
+#include <wtf/WeakRef.h>
 
 ALLOW_COMMA_BEGIN
 
@@ -74,9 +74,9 @@ public:
 
 private:
     // We cannot own sockets, clients of the factory are responsible to free them.
-    HashMap<WebCore::LibWebRTCSocketIdentifier, CheckedPtr<LibWebRTCSocket>> m_sockets;
+    HashMap<WebCore::LibWebRTCSocketIdentifier, WeakRef<LibWebRTCSocket>> m_sockets;
 
-    HashMap<LibWebRTCResolverIdentifier, WeakPtr<LibWebRTCResolver>> m_resolvers;
+    HashMap<LibWebRTCResolverIdentifier, WeakRef<LibWebRTCResolver>> m_resolvers;
     bool m_disableNonLocalhostConnections { false };
 
     RefPtr<IPC::Connection> m_connection;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -162,7 +162,7 @@ using namespace WebCore;
 using namespace HTMLNames;
 
 AXRelayProcessSuspendedNotification::AXRelayProcessSuspendedNotification(Ref<WebPage> page, AutomaticallySend automaticallySend)
-    : m_page(page)
+    : m_page(page.get())
     , m_automaticallySend(automaticallySend)
 {
     if (m_automaticallySend == AutomaticallySend::Yes)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -27,7 +27,7 @@
 #pragma once
 
 #include <WebCore/ChromeClient.h>
-#include <wtf/CheckedRef.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore {
 class HTMLImageElement;
@@ -502,7 +502,7 @@ private:
     mutable bool m_cachedMainFrameHasHorizontalScrollbar { false };
     mutable bool m_cachedMainFrameHasVerticalScrollbar { false };
 
-    CheckedRef<WebPage> m_page;
+    WeakRef<WebPage> m_page;
 };
 
 class AXRelayProcessSuspendedNotification {
@@ -514,7 +514,7 @@ public:
 
     void sendProcessSuspendMessage(bool suspended);
 private:
-    CheckedRef<WebPage> m_page;
+    WeakRef<WebPage> m_page;
     AutomaticallySend m_automaticallySend;
 };
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebDataListSuggestionPicker.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDataListSuggestionPicker.h
@@ -28,7 +28,7 @@
 #if ENABLE(DATALIST_ELEMENT)
 
 #include <WebCore/DataListSuggestionPicker.h>
-#include <wtf/CheckedRef.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore {
 class DataListSuggestionsClient;
@@ -51,7 +51,7 @@ private:
     void close() final;
 
     WebCore::DataListSuggestionsClient& m_client;
-    CheckedRef<WebPage> m_page;
+    WeakRef<WebPage> m_page;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebDateTimeChooser.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDateTimeChooser.h
@@ -28,7 +28,7 @@
 #if ENABLE(DATE_AND_TIME_INPUT_TYPES)
 
 #include <WebCore/DateTimeChooser.h>
-#include <wtf/CheckedRef.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore {
 class DateTimeChooserClient;
@@ -51,7 +51,7 @@ private:
     void showChooser(const WebCore::DateTimeChooserParameters&) final;
 
     WebCore::DateTimeChooserClient& m_client;
-    CheckedRef<WebPage> m_page;
+    WeakRef<WebPage> m_page;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebGeolocationClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebGeolocationClient.h
@@ -27,7 +27,7 @@
 
 #include "WebPage.h"
 #include <WebCore/GeolocationClient.h>
-#include <wtf/CheckedRef.h>
+#include <wtf/WeakRef.h>
 
 namespace WebKit {
 
@@ -54,7 +54,7 @@ private:
     void requestPermission(WebCore::Geolocation&) final;
     void cancelPermissionRequest(WebCore::Geolocation&) final;
 
-    CheckedRef<WebPage> m_page;
+    WeakRef<WebPage> m_page;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebRemoteObjectRegistry.h
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebRemoteObjectRegistry.h
@@ -26,7 +26,7 @@
 #pragma once
 
 #include "RemoteObjectRegistry.h"
-#include <wtf/CheckedRef.h>
+#include <wtf/WeakRef.h>
 
 namespace WebKit {
 
@@ -43,7 +43,7 @@ private:
     IPC::MessageSender& messageSender() final;
     uint64_t messageDestinationID() final;
 
-    CheckedRef<WebPage> m_page;
+    WeakRef<WebPage> m_page;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.h
@@ -193,7 +193,7 @@ protected:
 
     const DrawingAreaType m_type;
     DrawingAreaIdentifier m_identifier;
-    CheckedRef<WebPage> m_webPage;
+    WeakRef<WebPage> m_webPage;
     WebCore::IntSize m_lastViewSizeForScaleToFit;
     WebCore::IntSize m_lastDocumentSizeForScaleToFit;
     bool m_isScalingViewToFitDocument { false };

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -7761,7 +7761,7 @@ void WebPage::registerURLSchemeHandler(WebURLSchemeHandlerIdentifier handlerIden
     WebCore::LegacySchemeRegistry::registerURLSchemeAsHandledBySchemeHandler(scheme);
     WebCore::LegacySchemeRegistry::registerURLSchemeAsCORSEnabled(scheme);
     auto schemeResult = m_schemeToURLSchemeHandlerProxyMap.add(scheme, WebURLSchemeHandlerProxy::create(*this, handlerIdentifier));
-    m_identifierToURLSchemeHandlerProxyMap.add(handlerIdentifier, schemeResult.iterator->value.get());
+    m_identifierToURLSchemeHandlerProxyMap.add(handlerIdentifier, *schemeResult.iterator->value);
 }
 
 void WebPage::urlSchemeTaskWillPerformRedirection(WebURLSchemeHandlerIdentifier handlerIdentifier, WebCore::ResourceLoaderIdentifier taskIdentifier, ResourceResponse&& response, ResourceRequest&& request, CompletionHandler<void(WebCore::ResourceRequest&&)>&& completionHandler)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -415,7 +415,7 @@ class PlatformXRSystemProxy;
 using SnapshotOptions = uint32_t;
 using WKEventModifiers = uint32_t;
 
-class WebPage : public API::ObjectImpl<API::Object::Type::BundlePage>, public IPC::MessageReceiver, public IPC::MessageSender, public CanMakeCheckedPtr {
+class WebPage : public API::ObjectImpl<API::Object::Type::BundlePage>, public IPC::MessageReceiver, public IPC::MessageSender {
 public:
     static Ref<WebPage> create(WebCore::PageIdentifier, WebPageCreationParameters&&);
 
@@ -2566,7 +2566,7 @@ private:
 #endif
 
     HashMap<String, RefPtr<WebURLSchemeHandlerProxy>> m_schemeToURLSchemeHandlerProxyMap;
-    HashMap<WebURLSchemeHandlerIdentifier, CheckedPtr<WebURLSchemeHandlerProxy>> m_identifierToURLSchemeHandlerProxyMap;
+    HashMap<WebURLSchemeHandlerIdentifier, WeakRef<WebURLSchemeHandlerProxy>> m_identifierToURLSchemeHandlerProxyMap;
 
     HashMap<uint64_t, Function<void(bool granted)>> m_storageAccessResponseCallbackMap;
 

--- a/Source/WebKit/WebProcess/WebPage/WebURLSchemeHandlerProxy.h
+++ b/Source/WebKit/WebProcess/WebPage/WebURLSchemeHandlerProxy.h
@@ -43,7 +43,7 @@ namespace WebKit {
 
 class WebPage;
 
-class WebURLSchemeHandlerProxy : public RefCounted<WebURLSchemeHandlerProxy>, public CanMakeCheckedPtr {
+class WebURLSchemeHandlerProxy : public RefCounted<WebURLSchemeHandlerProxy>, public CanMakeWeakPtr<WebURLSchemeHandlerProxy> {
 public:
     static Ref<WebURLSchemeHandlerProxy> create(WebPage& page, WebURLSchemeHandlerIdentifier identifier)
     {

--- a/Source/WebKit/WebProcess/WebPage/WebURLSchemeTaskProxy.h
+++ b/Source/WebKit/WebProcess/WebPage/WebURLSchemeTaskProxy.h
@@ -27,9 +27,9 @@
 
 #include <WebCore/ResourceLoaderIdentifier.h>
 #include <WebCore/ResourceRequest.h>
-#include <wtf/CheckedRef.h>
 #include <wtf/Deque.h>
 #include <wtf/RefCounted.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 class ResourceError;
@@ -43,7 +43,7 @@ namespace WebKit {
 class WebFrame;
 class WebURLSchemeHandlerProxy;
 
-class WebURLSchemeTaskProxy : public RefCounted<WebURLSchemeTaskProxy>, public CanMakeCheckedPtr {
+class WebURLSchemeTaskProxy : public RefCounted<WebURLSchemeTaskProxy>, public CanMakeWeakPtr<WebURLSchemeTaskProxy> {
 public:
     static Ref<WebURLSchemeTaskProxy> create(WebURLSchemeHandlerProxy& handler, WebCore::ResourceLoader& loader, WebFrame& webFrame)
     {


### PR DESCRIPTION
#### 1d60d452f8d3162ff0a40f6db74c65cd9ec8de8b
<pre>
Stop using CheckedPtr / CheckedRef with refcounted classes in WebKit2
<a href="https://bugs.webkit.org/show_bug.cgi?id=266637">https://bugs.webkit.org/show_bug.cgi?id=266637</a>

Reviewed by Brent Fulgham.

Stop using CheckedPtr / CheckedRef with refcounted classes in WebKit2. Using RefPtr/Ref
or WeakPtr/WeakRef instead.

* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.cpp:
(WebKit::allWorkers):
(WebKit::WebSharedWorker::WebSharedWorker):
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.h:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.cpp:
(WebKit::WebSharedWorkerServer::addContextConnection):
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.h:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.h:
* Source/WebKit/Shared/WebBackForwardListItem.cpp:
(WebKit::WebBackForwardListItem::allItems):
* Source/WebKit/Shared/WebBackForwardListItem.h:
* Source/WebKit/UIProcess/API/APIContentWorld.cpp:
(API::sharedWorldNameMap):
(API::sharedWorldIdentifierMap):
(API::ContentWorld::ContentWorld):
(API::ContentWorld::sharedWorldWithName):
* Source/WebKit/UIProcess/API/APIContentWorld.h:
* Source/WebKit/UIProcess/API/Cocoa/WKBrowsingContextController.mm:
(-[WKBrowsingContextController dealloc]):
(-[WKBrowsingContextController _initWithPageRef:]):
* Source/WebKit/UIProcess/Automation/WebAutomationSession.h:
* Source/WebKit/UIProcess/Cocoa/UIRemoteObjectRegistry.h:
* Source/WebKit/UIProcess/DrawingAreaProxy.cpp:
(WebKit::DrawingAreaProxy::page const):
* Source/WebKit/UIProcess/DrawingAreaProxy.h:
(WebKit::DrawingAreaProxy::page const): Deleted.
* Source/WebKit/UIProcess/Inspector/Agents/InspectorBrowserAgent.h:
* Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.h:
* Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp:
(WebKit::WebInspectorUIProxy::WebInspectorUIProxy):
* Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h:
* Source/WebKit/UIProcess/Inspector/WebPageInspectorAgentBase.h:
* Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h:
* Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.mm:
(-[WKInspectorViewController initWithConfiguration:inspectedPage:]):
* Source/WebKit/UIProcess/ProvisionalFrameProxy.h:
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::~ProvisionalPageProxy):
* Source/WebKit/UIProcess/ProvisionalPageProxy.h:
* Source/WebKit/UIProcess/SpeechRecognitionPermissionManager.h:
* Source/WebKit/UIProcess/SuspendedPageProxy.cpp:
(WebKit::SuspendedPageProxy::page const):
* Source/WebKit/UIProcess/SuspendedPageProxy.h:
* Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp:
(WebKit::webUserContentControllerProxies):
(WebKit::WebUserContentControllerProxy::WebUserContentControllerProxy):
* Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h:
* Source/WebKit/UIProcess/ViewSnapshotStore.cpp:
(WebKit::ViewSnapshotStore::didAddImageToSnapshot):
(WebKit::ViewSnapshotStore::willRemoveImageFromSnapshot):
* Source/WebKit/UIProcess/ViewSnapshotStore.h:
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::allFrames):
(WebKit::WebFrameProxy::WebFrameProxy):
* Source/WebKit/UIProcess/WebFrameProxy.h:
* Source/WebKit/UIProcess/WebPageGroup.cpp:
(WebKit::WebPageGroup::forEach):
(WebKit::WebPageGroup::WebPageGroup):
* Source/WebKit/UIProcess/WebPageGroup.h:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::processPools):
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::allDataStores):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
* Source/WebKit/UIProcess/mac/WKImmediateActionController.h:
* Source/WebKit/UIProcess/mac/WKImmediateActionController.mm:
(-[WKImmediateActionController _clearImmediateActionState]):
(-[WKImmediateActionController dismissContentRelativeChildWindows]):
(-[WKImmediateActionController immediateActionRecognizerWillPrepare:]):
(-[WKImmediateActionController immediateActionRecognizerWillBeginAnimation:]):
(-[WKImmediateActionController immediateActionRecognizerDidUpdateAnimation:]):
(-[WKImmediateActionController immediateActionRecognizerDidCancelAnimation:]):
(-[WKImmediateActionController immediateActionRecognizerDidCompleteAnimation:]):
(-[WKImmediateActionController _webHitTestResult]):
(-[WKImmediateActionController _defaultAnimationController]):
(-[WKImmediateActionController _updateImmediateActionItem]):
* Source/WebKit/UIProcess/mac/WKTextFinderClient.mm:
* Source/WebKit/WebProcess/Databases/WebDatabaseProvider.cpp:
(WebKit::databaseProviders):
(WebKit::WebDatabaseProvider::getOrCreate):
* Source/WebKit/WebProcess/Databases/WebDatabaseProvider.h:
* Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleCSSStyleDeclarationHandle.cpp:
(WebKit::InjectedBundleCSSStyleDeclarationHandle::getOrCreate):
* Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleCSSStyleDeclarationHandle.h:
* Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp:
(WebKit::InjectedBundleNodeHandle::getOrCreate):
* Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.h:
* Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleRangeHandle.cpp:
(WebKit::InjectedBundleRangeHandle::getOrCreate):
* Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleRangeHandle.h:
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp:
(WebKit::InjectedBundleScriptWorld::getOrCreate):
(WebKit::InjectedBundleScriptWorld::find):
(WebKit::InjectedBundleScriptWorld::InjectedBundleScriptWorld):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.h:
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::addURLSchemeTaskProxy):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.h:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.h:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.h:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocketFactory.cpp:
(WebKit::LibWebRTCSocketFactory::addSocket):
(WebKit::LibWebRTCSocketFactory::forSocketInGroup):
(WebKit::LibWebRTCSocketFactory::createAsyncDnsResolver):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocketFactory.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::AXRelayProcessSuspendedNotification::AXRelayProcessSuspendedNotification):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebDataListSuggestionPicker.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebDateTimeChooser.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebGeolocationClient.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebRemoteObjectRegistry.h:
* Source/WebKit/WebProcess/WebPage/DrawingArea.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::registerURLSchemeHandler):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebURLSchemeHandlerProxy.h:
* Source/WebKit/WebProcess/WebPage/WebURLSchemeTaskProxy.h:

Canonical link: <a href="https://commits.webkit.org/272284@main">https://commits.webkit.org/272284@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0831e86dc2251c56a83080a26d4f73c6232e71f3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31202 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9880 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32896 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33710 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/28332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12225 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7138 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/27982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31539 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8334 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27894 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7154 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7334 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35051 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28401 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28245 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33464 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7375 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5428 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/31302 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9058 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8075 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4057 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7905 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->