### PR TITLE
jsc_fuz/wktr: heap-buffer-overflow in  WebCore::WebCodecsVideoFrame::copyTo(...) WebCodecsVideoFrame.cpp:488

### DIFF
--- a/LayoutTests/http/wpt/webcodecs/videoFrame-rect-expected.txt
+++ b/LayoutTests/http/wpt/webcodecs/videoFrame-rect-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Checking invalid rect
+

--- a/LayoutTests/http/wpt/webcodecs/videoFrame-rect.html
+++ b/LayoutTests/http/wpt/webcodecs/videoFrame-rect.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+    </head>
+    <body>
+<img id=myImage></img>
+<script>
+promise_test(async (t) => {
+    myImage.src = 'data:';
+    await new Promise(resolve => myImage.onerror = resolve);
+    const videoFrame = new VideoFrame(myImage, {timestamp: 0});
+    return promise_rejects_js(t, TypeError,
+        videoFrame.copyTo(new ArrayBuffer(72), { rect: {
+            y: -2,
+            width: 1,
+            height: 18
+        }})
+     );
+  }, "Checking invalid rect");
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -1714,3 +1714,5 @@ webkit.org/b/266577 webgl/2.0.0/conformance2/textures/video/tex-3d-srgb8_alpha8-
 webkit.org/b/266624 fast/events/wheel/wheel-event-destroys-overflow.html [ Timeout Pass Crash ]
 webkit.org/b/266624 fast/events/wheel/wheelevent-basic.html [ Failure Timeout Crash ]
 webkit.org/b/266624 fast/scrolling/sync-scroll-overscroll-behavior-iframe.html [ Pass Crash ]
+
+webkit.org/b/266671 http/wpt/webcodecs/videoFrame-rect.html [ Failure ]

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameAlgorithms.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameAlgorithms.cpp
@@ -111,7 +111,7 @@ ExceptionOr<DOMRectInit> parseVisibleRect(const DOMRectInit& defaultRect, const 
 {
     auto sourceRect = defaultRect;
     if (overrideRect) {
-        if (!overrideRect->width || !overrideRect->height)
+        if (overrideRect->width <= 0 || overrideRect->height <= 0 || overrideRect->x < 0 || overrideRect->y < 0)
             return Exception { ExceptionCode::TypeError, "overrideRect is not valid"_s };
         if (overrideRect->x + overrideRect->width > codedWidth)
             return Exception { ExceptionCode::TypeError, "overrideRect is not valid"_s };


### PR DESCRIPTION
#### c1787ccc4e9191a754f0ccfd07ad2d2f74a52b78
<pre>
jsc_fuz/wktr: heap-buffer-overflow in  WebCore::WebCodecsVideoFrame::copyTo(...) WebCodecsVideoFrame.cpp:488
<a href="https://bugs.webkit.org/show_bug.cgi?id=262955">https://bugs.webkit.org/show_bug.cgi?id=262955</a>
<a href="https://rdar.apple.com/115835656">rdar://115835656</a>

Reviewed by Eric Carlson.

We add a check that x and y are positive or zero.
Otherwise, we might still pass the check that the total width or height is below the codedWidth/codedHeight, while it is not.

* LayoutTests/http/wpt/webcodecs/videoFrame-rect-expected.txt: Added.
* LayoutTests/http/wpt/webcodecs/videoFrame-rect.html: Added.
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameAlgorithms.cpp:
(WebCore::parseVisibleRect):

Originally-landed-as: 267815.265@safari-7617-branch (aa715fb68472). <a href="https://rdar.apple.com/119565892">rdar://119565892</a>
Canonical link: <a href="https://commits.webkit.org/272352@main">https://commits.webkit.org/272352@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/813ffce11a21eac0673bdc3c0c319a385aeb2912

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31415 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10085 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33111 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33911 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28468 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32184 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12434 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7334 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/28096 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31753 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8496 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28048 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7313 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7473 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27954 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35253 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28560 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/28407 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/33608 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7545 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/5575 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31451 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9208 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/27756 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7369 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8237 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8057 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->