### PR TITLE
querySelector() throws exception for -webkit-prefixed pseudo elements

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/parsing/tree-abiding-pseudo-elements-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/parsing/tree-abiding-pseudo-elements-expected.txt
@@ -11,15 +11,15 @@ PASS "::marker" should be a valid selector
 PASS "*::marker" should be a valid selector
 PASS "foo.bar[baz]::marker" should be a valid selector
 PASS "::marker *" should be an invalid selector
-FAIL "::placeholder" should be a valid selector '::placeholder' is not a valid selector.
-FAIL "*::placeholder" should be a valid selector '*::placeholder' is not a valid selector.
-FAIL "foo.bar[baz]::placeholder" should be a valid selector 'foo.bar[baz]::placeholder' is not a valid selector.
+PASS "::placeholder" should be a valid selector
+PASS "*::placeholder" should be a valid selector
+PASS "foo.bar[baz]::placeholder" should be a valid selector
 PASS "::placeholder *" should be an invalid selector
-FAIL "::file-selector-button" should be a valid selector '::file-selector-button' is not a valid selector.
-FAIL "::file-selector-button:hover" should be a valid selector '::file-selector-button:hover' is not a valid selector.
-FAIL "::file-selector-button:focus" should be a valid selector '::file-selector-button:focus' is not a valid selector.
-FAIL "::file-selector-button:active" should be a valid selector '::file-selector-button:active' is not a valid selector.
-FAIL "::file-selector-button:is(:hover)" should be a valid selector '::file-selector-button:is(:hover)' is not a valid selector.
+PASS "::file-selector-button" should be a valid selector
+PASS "::file-selector-button:hover" should be a valid selector
+PASS "::file-selector-button:focus" should be a valid selector
+PASS "::file-selector-button:active" should be a valid selector
+PASS "::file-selector-button:is(:hover)" should be a valid selector
 PASS "::file-selector-button::before" should be an invalid selector
 PASS "::file-selector-button#id" should be an invalid selector
 PASS "::file-selector-button#class" should be an invalid selector

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-part-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-part-expected.txt
@@ -10,10 +10,10 @@ PASS "::part(foo):hover" should be a valid selector
 PASS "::part(foo):focus-within" should be a valid selector
 PASS "::part(foo)::before" should be a valid selector
 PASS "::part(foo)::after" should be a valid selector
-FAIL "::part(foo)::placeholder" should be a valid selector '::part(foo)::placeholder' is not a valid selector.
+PASS "::part(foo)::placeholder" should be a valid selector
 PASS "::part(foo)::first-line" should be a valid selector
 PASS "::part(foo)::first-letter" should be a valid selector
-FAIL "::part(foo)::file-selector-button" should be a valid selector '::part(foo)::file-selector-button' is not a valid selector.
+PASS "::part(foo)::file-selector-button" should be a valid selector
 PASS "::part(foo):is(:focus)" should be a valid selector
 PASS ":lang(en)::part(foo)" should be a valid selector
 PASS ":dir(ltr)::part(foo)" should be a valid selector

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/webkit-pseudo-element-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/webkit-pseudo-element-expected.txt
@@ -1,6 +1,6 @@
 
 FAIL rules include webkit-prefixed pseudo-element should be cascaded assert_equals: expected "rgb(0, 255, 0)" but got "rgb(255, 0, 0)"
 FAIL webkit-prefixed pseudo-element selectors should be accessible from CSSOM undefined is not an object (evaluating 'sheet.cssRules[1].selectorText')
-FAIL qS and qSA shouldn't throw exception 'span::-webkit-something-invalid' is not a valid selector.
+PASS qS and qSA shouldn't throw exception
 FAIL webkit-prefix without dash is invalid assert_equals: expected 2 but got 1
 

--- a/Source/WebCore/css/CSSSelectorList.cpp
+++ b/Source/WebCore/css/CSSSelectorList.cpp
@@ -175,7 +175,7 @@ class SelectorHasInvalidSelectorFunctor {
 public:
     bool operator()(const CSSSelector* selector)
     {
-        return selector->isUnknownPseudoElement() || selector->isCustomPseudoElement();
+        return selector->isUnknownPseudoElement();
     }
 };
 

--- a/Source/WebCore/css/parser/CSSParserSelector.h
+++ b/Source/WebCore/css/parser/CSSParserSelector.h
@@ -76,7 +76,6 @@ public:
     void setSelectorList(std::unique_ptr<CSSSelectorList>);
 
     CSSSelector::PseudoClassType pseudoClassType() const { return m_selector->pseudoClassType(); }
-    bool isCustomPseudoElement() const { return m_selector->isCustomPseudoElement(); }
 
     bool isPseudoElementCueFunction() const;
 

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -68,9 +68,9 @@ CSSParserSelectorList parseCSSParserSelectorList(CSSParserTokenRange& range, con
     return result;
 }
 
-std::optional<CSSSelectorList> parseCSSSelectorList(CSSParserTokenRange range, const CSSSelectorParserContext& context, StyleSheetContents* styleSheet, CSSParserEnum::IsNestedContext isNestedContext, CSSParserEnum::IsForgiving isForgiving)
+std::optional<CSSSelectorList> parseCSSSelectorList(CSSParserTokenRange range, const CSSSelectorParserContext& context, StyleSheetContents* styleSheet, CSSParserEnum::IsNestedContext isNestedContext)
 {
-    auto result = parseCSSParserSelectorList(range, context, styleSheet, isNestedContext, isForgiving);
+    auto result = parseCSSParserSelectorList(range, context, styleSheet, isNestedContext, CSSParserEnum::IsForgiving::No);
 
     if (result.isEmpty() || !range.atEnd())
         return { };

--- a/Source/WebCore/css/parser/CSSSelectorParser.h
+++ b/Source/WebCore/css/parser/CSSSelectorParser.h
@@ -110,7 +110,7 @@ private:
     std::optional<CSSSelector::PseudoElementType> m_precedingPseudoElement;
 };
 
-std::optional<CSSSelectorList> parseCSSSelectorList(CSSParserTokenRange, const CSSSelectorParserContext&, StyleSheetContents* = nullptr, CSSParserEnum::IsNestedContext = CSSParserEnum::IsNestedContext::No, CSSParserEnum::IsForgiving = CSSParserEnum::IsForgiving::No);
+std::optional<CSSSelectorList> parseCSSSelectorList(CSSParserTokenRange, const CSSSelectorParserContext&, StyleSheetContents* = nullptr, CSSParserEnum::IsNestedContext = CSSParserEnum::IsNestedContext::No);
 CSSParserSelectorList parseCSSParserSelectorList(CSSParserTokenRange&, const CSSSelectorParserContext&, StyleSheetContents*, CSSParserEnum::IsNestedContext, CSSParserEnum::IsForgiving);
 
 } // namespace WebCore

--- a/Source/WebCore/dom/SelectorQuery.cpp
+++ b/Source/WebCore/dom/SelectorQuery.cpp
@@ -613,7 +613,7 @@ SelectorQuery* SelectorQueryCache::add(const String& selectors, const Document& 
 
     return m_entries.ensure(key, [&]() -> std::unique_ptr<SelectorQuery> {
         auto tokenizer = CSSTokenizer { selectors };
-        auto selectorList = parseCSSSelectorList(tokenizer.tokenRange(), context, nullptr, CSSParserEnum::IsNestedContext::No);
+        auto selectorList = parseCSSSelectorList(tokenizer.tokenRange(), context);
 
         if (!selectorList || selectorList->hasInvalidSelector())
             return nullptr;


### PR DESCRIPTION
#### a23b77e8bca1e6a510f6b23e688695ac68ccdb98
<pre>
querySelector() throws exception for -webkit-prefixed pseudo elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=149160">https://bugs.webkit.org/show_bug.cgi?id=149160</a>
<a href="https://rdar.apple.com/99299129">rdar://99299129</a>

Reviewed by Antti Koivisto.

SelectorHasInvalidSelectorFunctor which is only used by querySelector()
and friends treated custom pseudo-elements as invalid. This is wrong.
querySelector(&quot;::placeholder&quot;) and querySelector(&quot;::-webkit-asdf&quot;) are
perfectly acceptable inputs, they are just supposed to return null.

Also do some minor code cleanup while in the general area.

Canonical link: <a href="https://commits.webkit.org/272337@main">https://commits.webkit.org/272337@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de86f5a4212a4b741fbd5b28103f3c63148fafae

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31362 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10031 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33055 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33856 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28428 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32129 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12376 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7281 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28064 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31698 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8447 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28000 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7266 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7424 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27904 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35197 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28511 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28355 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33561 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7498 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5528 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31401 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9161 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7364 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8191 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8009 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->