### PR TITLE
Adopt dynamicDowncast<>() further in WebCore

### DIFF
--- a/Source/WebCore/animation/AcceleratedTimeline.cpp
+++ b/Source/WebCore/animation/AcceleratedTimeline.cpp
@@ -62,11 +62,11 @@ void AcceleratedTimeline::updateEffectStacks()
         auto pseudoId = static_cast<PseudoId>(hashedStyleable.second);
         Styleable target { *element, pseudoId };
 
-        auto* renderer = target.renderer();
-        if (!renderer || !renderer->isComposited() || !is<RenderLayerModelObject>(renderer))
+        auto* renderer = dynamicDowncast<RenderLayerModelObject>(target.renderer());
+        if (!renderer || !renderer->isComposited())
             continue;
 
-        auto* renderLayer = downcast<RenderLayerModelObject>(*renderer).layer();
+        auto* renderLayer = renderer->layer();
         ASSERT(renderLayer && renderLayer->backing());
         renderLayer->backing()->updateAcceleratedEffectsAndBaseValues();
     }

--- a/Source/WebCore/animation/AnimationEffect.cpp
+++ b/Source/WebCore/animation/AnimationEffect.cpp
@@ -135,8 +135,10 @@ ComputedEffectTiming AnimationEffect::getComputedTiming(std::optional<Seconds> s
 ExceptionOr<void> AnimationEffect::bindingsUpdateTiming(std::optional<OptionalEffectTiming> timing)
 {
     auto retVal = updateTiming(timing);
-    if (!retVal.hasException() && timing && is<CSSAnimation>(animation()))
-        downcast<CSSAnimation>(*animation()).effectTimingWasUpdatedUsingBindings(*timing);
+    if (!retVal.hasException() && timing) {
+        if (auto* cssAnimation = dynamicDowncast<CSSAnimation>(animation()))
+            cssAnimation->effectTimingWasUpdatedUsingBindings(*timing);
+    }
     return retVal;
 }
 
@@ -306,10 +308,11 @@ void AnimationEffect::setTimingFunction(const RefPtr<TimingFunction>& timingFunc
 
 std::optional<double> AnimationEffect::progressUntilNextStep(double iterationProgress) const
 {
-    if (!is<StepsTimingFunction>(m_timing.timingFunction))
+    RefPtr stepsTimingFunction = dynamicDowncast<StepsTimingFunction>(m_timing.timingFunction);
+    if (!stepsTimingFunction)
         return std::nullopt;
 
-    auto numberOfSteps = downcast<StepsTimingFunction>(*m_timing.timingFunction).numberOfSteps();
+    auto numberOfSteps = stepsTimingFunction->numberOfSteps();
     auto nextStepProgress = ceil(iterationProgress * numberOfSteps) / numberOfSteps;
     return nextStepProgress - iterationProgress;
 }

--- a/Source/WebCore/animation/AnimationTimeline.cpp
+++ b/Source/WebCore/animation/AnimationTimeline.cpp
@@ -46,9 +46,11 @@ void AnimationTimeline::animationTimingDidChange(WebAnimation& animation)
         auto* timeline = animation.timeline();
         if (timeline && timeline != this)
             timeline->removeAnimation(animation);
-        else if (timeline == this && is<KeyframeEffect>(animation.effect())) {
-            if (auto styleable = downcast<KeyframeEffect>(animation.effect())->targetStyleable())
-                styleable->animationWasAdded(animation);
+        else if (timeline == this) {
+            if (auto* keyframeEffect = dynamicDowncast<KeyframeEffect>(animation.effect())) {
+                if (auto styleable = keyframeEffect->targetStyleable())
+                    styleable->animationWasAdded(animation);
+            }
         }
     }
 }

--- a/Source/WebCore/animation/CSSAnimation.cpp
+++ b/Source/WebCore/animation/CSSAnimation.cpp
@@ -260,25 +260,32 @@ void CSSAnimation::effectCompositeOperationWasSetUsingBindings()
 
 void CSSAnimation::keyframesRuleDidChange()
 {
-    if (m_overriddenProperties.contains(Property::Keyframes) || !is<KeyframeEffect>(effect()))
+    if (m_overriddenProperties.contains(Property::Keyframes))
+        return;
+
+    auto* keyframeEffect = dynamicDowncast<KeyframeEffect>(effect());
+    if (!keyframeEffect)
         return;
 
     auto owningElement = this->owningElement();
     if (!owningElement)
         return;
 
-    downcast<KeyframeEffect>(*effect()).keyframesRuleDidChange();
+    keyframeEffect->keyframesRuleDidChange();
     owningElement->keyframesRuleDidChange();
 }
 
 void CSSAnimation::updateKeyframesIfNeeded(const RenderStyle* oldStyle, const RenderStyle& newStyle, const Style::ResolutionContext& resolutionContext)
 {
-    if (m_overriddenProperties.contains(Property::Keyframes) || !is<KeyframeEffect>(effect()))
+    if (m_overriddenProperties.contains(Property::Keyframes))
         return;
 
-    auto& keyframeEffect = downcast<KeyframeEffect>(*effect());
-    if (keyframeEffect.blendingKeyframes().isEmpty())
-        keyframeEffect.computeDeclarativeAnimationBlendingKeyframes(oldStyle, newStyle, resolutionContext);
+    auto* keyframeEffect = dynamicDowncast<KeyframeEffect>(effect());
+    if (!keyframeEffect)
+        return;
+
+    if (keyframeEffect->blendingKeyframes().isEmpty())
+        keyframeEffect->computeDeclarativeAnimationBlendingKeyframes(oldStyle, newStyle, resolutionContext);
 }
 
 Ref<DeclarativeAnimationEvent> CSSAnimation::createEvent(const AtomString& eventType, std::optional<Seconds> scheduledTime, double elapsedTime, PseudoId pseudoId)

--- a/Source/WebCore/animation/DocumentTimeline.cpp
+++ b/Source/WebCore/animation/DocumentTimeline.cpp
@@ -228,12 +228,11 @@ bool DocumentTimeline::animationCanBeRemoved(WebAnimation& animation)
         return false;
 
     // - has an associated animation effect whose target element is a descendant of doc, and
-    auto* effect = animation.effect();
-    if (!is<KeyframeEffect>(effect))
+    auto* keyframeEffect = dynamicDowncast<KeyframeEffect>(animation.effect());
+    if (!keyframeEffect)
         return false;
 
-    auto& keyframeEffect = downcast<KeyframeEffect>(*effect);
-    auto target = keyframeEffect.targetStyleable();
+    auto target = keyframeEffect->targetStyleable();
     if (!target || !target->element.isDescendantOf(*m_document))
         return false;
 
@@ -252,7 +251,7 @@ IGNORE_GCC_WARNINGS_END
     };
 
     HashSet<AnimatableCSSProperty> propertiesToMatch;
-    for (auto property : keyframeEffect.animatedProperties())
+    for (auto property : keyframeEffect->animatedProperties())
         propertiesToMatch.add(resolvedProperty(property));
 
     auto protectedAnimations = [&]() -> Vector<RefPtr<WebAnimation>> {

--- a/Source/WebCore/animation/ViewTimeline.cpp
+++ b/Source/WebCore/animation/ViewTimeline.cpp
@@ -57,7 +57,6 @@ Ref<ViewTimeline> ViewTimeline::createFromCSSValue(const CSSViewValue& cssViewVa
         if (value->valueID() == CSSValueAuto)
             return Length();
 
-        ASSERT(value->isPrimitiveValue());
         auto& primitiveValue = downcast<CSSPrimitiveValue>(*value);
         if (primitiveValue.isPercentage())
             return Length(primitiveValue.doubleValue(CSSUnitType::CSS_PERCENTAGE), LengthType::Percent);

--- a/Source/WebCore/css/TransformFunctions.cpp
+++ b/Source/WebCore/css/TransformFunctions.cpp
@@ -122,16 +122,16 @@ std::optional<TransformOperations> transformsForValue(const CSSValue& value, con
 
 RefPtr<TransformOperation> transformForValue(const CSSValue& value, const CSSToLengthConversionData& conversionData)
 {
-    if (!is<CSSFunctionValue>(value))
+    auto* transformValue = dynamicDowncast<CSSFunctionValue>(value);
+    if (!transformValue)
         return nullptr;
 
-    auto& transformValue = downcast<CSSFunctionValue>(value);
-    if (!transformValue.length())
+    if (!transformValue->length())
         return nullptr;
 
     bool haveNonPrimitiveValue = false;
-    for (unsigned j = 0; j < transformValue.length(); ++j) {
-        if (!is<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(j))) {
+    for (unsigned j = 0; j < transformValue->length(); ++j) {
+        if (!is<CSSPrimitiveValue>(*transformValue->itemWithoutBoundsCheck(j))) {
             haveNonPrimitiveValue = true;
             break;
         }
@@ -139,30 +139,30 @@ RefPtr<TransformOperation> transformForValue(const CSSValue& value, const CSSToL
     if (haveNonPrimitiveValue)
         return nullptr;
 
-    auto& firstValue = downcast<CSSPrimitiveValue>(transformValue[0]);
+    auto& firstValue = downcast<CSSPrimitiveValue>((*transformValue)[0]);
     auto doubleValue = [&](unsigned index) {
-        return downcast<CSSPrimitiveValue>(transformValue[index]).doubleValue();
+        return downcast<CSSPrimitiveValue>((*transformValue)[index]).doubleValue();
     };
 
-    switch (transformValue.name()) {
+    switch (transformValue->name()) {
     case CSSValueScale:
     case CSSValueScaleX:
     case CSSValueScaleY: {
         double sx = 1.0;
         double sy = 1.0;
-        if (transformValue.name() == CSSValueScaleY)
+        if (transformValue->name() == CSSValueScaleY)
             sy = firstValue.doubleValueDividingBy100IfPercentage();
         else {
             sx = firstValue.doubleValueDividingBy100IfPercentage();
-            if (transformValue.name() != CSSValueScaleX) {
-                if (transformValue.length() > 1) {
-                    auto& secondValue = downcast<CSSPrimitiveValue>(transformValue[1]);
+            if (transformValue->name() != CSSValueScaleX) {
+                if (transformValue->length() > 1) {
+                    auto& secondValue = downcast<CSSPrimitiveValue>((*transformValue)[1]);
                     sy = secondValue.doubleValueDividingBy100IfPercentage();
                 } else
                     sy = sx;
             }
         }
-        return ScaleTransformOperation::create(sx, sy, 1.0, transformOperationType(transformValue.name()));
+        return ScaleTransformOperation::create(sx, sy, 1.0, transformOperationType(transformValue->name()));
     }
 
     case CSSValueScaleZ:
@@ -170,25 +170,25 @@ RefPtr<TransformOperation> transformForValue(const CSSValue& value, const CSSToL
         double sx = 1.0;
         double sy = 1.0;
         double sz = 1.0;
-        if (transformValue.name() == CSSValueScaleZ)
+        if (transformValue->name() == CSSValueScaleZ)
             sz = firstValue.doubleValueDividingBy100IfPercentage();
-        else if (transformValue.name() == CSSValueScaleY)
+        else if (transformValue->name() == CSSValueScaleY)
             sy = firstValue.doubleValueDividingBy100IfPercentage();
         else {
             sx = firstValue.doubleValueDividingBy100IfPercentage();
-            if (transformValue.name() != CSSValueScaleX) {
-                if (transformValue.length() > 2) {
-                    auto& thirdValue = downcast<CSSPrimitiveValue>(transformValue[2]);
+            if (transformValue->name() != CSSValueScaleX) {
+                if (transformValue->length() > 2) {
+                    auto& thirdValue = downcast<CSSPrimitiveValue>((*transformValue)[2]);
                     sz = thirdValue.doubleValueDividingBy100IfPercentage();
                 }
-                if (transformValue.length() > 1) {
-                    auto& secondValue = downcast<CSSPrimitiveValue>(transformValue[1]);
+                if (transformValue->length() > 1) {
+                    auto& secondValue = downcast<CSSPrimitiveValue>((*transformValue)[1]);
                     sy = secondValue.doubleValueDividingBy100IfPercentage();
                 } else
                     sy = sx;
             }
         }
-        return ScaleTransformOperation::create(sx, sy, sz, transformOperationType(transformValue.name()));
+        return ScaleTransformOperation::create(sx, sy, sz, transformOperationType(transformValue->name()));
     }
 
     case CSSValueTranslate:
@@ -196,13 +196,13 @@ RefPtr<TransformOperation> transformForValue(const CSSValue& value, const CSSToL
     case CSSValueTranslateY: {
         Length tx = Length(0, LengthType::Fixed);
         Length ty = Length(0, LengthType::Fixed);
-        if (transformValue.name() == CSSValueTranslateY)
+        if (transformValue->name() == CSSValueTranslateY)
             ty = convertToFloatLength(&firstValue, conversionData);
         else {
             tx = convertToFloatLength(&firstValue, conversionData);
-            if (transformValue.name() != CSSValueTranslateX) {
-                if (transformValue.length() > 1) {
-                    auto& secondValue = downcast<CSSPrimitiveValue>(transformValue[1]);
+            if (transformValue->name() != CSSValueTranslateX) {
+                if (transformValue->length() > 1) {
+                    auto& secondValue = downcast<CSSPrimitiveValue>((*transformValue)[1]);
                     ty = convertToFloatLength(&secondValue, conversionData);
                 }
             }
@@ -211,7 +211,7 @@ RefPtr<TransformOperation> transformForValue(const CSSValue& value, const CSSToL
         if (tx.isUndefined() || ty.isUndefined())
             return nullptr;
 
-        return TranslateTransformOperation::create(tx, ty, Length(0, LengthType::Fixed), transformOperationType(transformValue.name()));
+        return TranslateTransformOperation::create(tx, ty, Length(0, LengthType::Fixed), transformOperationType(transformValue->name()));
     }
 
     case CSSValueTranslateZ:
@@ -219,19 +219,19 @@ RefPtr<TransformOperation> transformForValue(const CSSValue& value, const CSSToL
         Length tx = Length(0, LengthType::Fixed);
         Length ty = Length(0, LengthType::Fixed);
         Length tz = Length(0, LengthType::Fixed);
-        if (transformValue.name() == CSSValueTranslateZ)
+        if (transformValue->name() == CSSValueTranslateZ)
             tz = convertToFloatLength(&firstValue, conversionData);
-        else if (transformValue.name() == CSSValueTranslateY)
+        else if (transformValue->name() == CSSValueTranslateY)
             ty = convertToFloatLength(&firstValue, conversionData);
         else {
             tx = convertToFloatLength(&firstValue, conversionData);
-            if (transformValue.name() != CSSValueTranslateX) {
-                if (transformValue.length() > 2) {
-                    auto& thirdValue = downcast<CSSPrimitiveValue>(transformValue[2]);
+            if (transformValue->name() != CSSValueTranslateX) {
+                if (transformValue->length() > 2) {
+                    auto& thirdValue = downcast<CSSPrimitiveValue>((*transformValue)[2]);
                     tz = convertToFloatLength(&thirdValue, conversionData);
                 }
-                if (transformValue.length() > 1) {
-                    auto& secondValue = downcast<CSSPrimitiveValue>(transformValue[1]);
+                if (transformValue->length() > 1) {
+                    auto& secondValue = downcast<CSSPrimitiveValue>((*transformValue)[1]);
                     ty = convertToFloatLength(&secondValue, conversionData);
                 }
             }
@@ -240,12 +240,12 @@ RefPtr<TransformOperation> transformForValue(const CSSValue& value, const CSSToL
         if (tx.isUndefined() || ty.isUndefined() || tz.isUndefined())
             return nullptr;
 
-        return TranslateTransformOperation::create(tx, ty, tz, transformOperationType(transformValue.name()));
+        return TranslateTransformOperation::create(tx, ty, tz, transformOperationType(transformValue->name()));
     }
 
     case CSSValueRotate: {
         double angle = firstValue.computeDegrees();
-        return RotateTransformOperation::create(0, 0, 1, angle, transformOperationType(transformValue.name()));
+        return RotateTransformOperation::create(0, 0, 1, angle, transformOperationType(transformValue->name()));
     }
 
     case CSSValueRotateX:
@@ -255,20 +255,20 @@ RefPtr<TransformOperation> transformForValue(const CSSValue& value, const CSSToL
         double y = 0;
         double z = 0;
         double angle = firstValue.computeDegrees();
-        if (transformValue.name() == CSSValueRotateX)
+        if (transformValue->name() == CSSValueRotateX)
             x = 1;
-        else if (transformValue.name() == CSSValueRotateY)
+        else if (transformValue->name() == CSSValueRotateY)
             y = 1;
         else
             z = 1;
-        return RotateTransformOperation::create(x, y, z, angle, transformOperationType(transformValue.name()));
+        return RotateTransformOperation::create(x, y, z, angle, transformOperationType(transformValue->name()));
     }
 
     case CSSValueRotate3d: {
-        if (transformValue.length() < 4)
+        if (transformValue->length() < 4)
             break;
-        double angle = downcast<CSSPrimitiveValue>(transformValue[3]).computeDegrees();
-        return RotateTransformOperation::create(doubleValue(0), doubleValue(1), doubleValue(2), angle, transformOperationType(transformValue.name()));
+        double angle = downcast<CSSPrimitiveValue>((*transformValue)[3]).computeDegrees();
+        return RotateTransformOperation::create(doubleValue(0), doubleValue(1), doubleValue(2), angle, transformOperationType(transformValue->name()));
     }
 
     case CSSValueSkew:
@@ -277,22 +277,22 @@ RefPtr<TransformOperation> transformForValue(const CSSValue& value, const CSSToL
         double angleX = 0;
         double angleY = 0;
         double angle = firstValue.computeDegrees();
-        if (transformValue.name() == CSSValueSkewY)
+        if (transformValue->name() == CSSValueSkewY)
             angleY = angle;
         else {
             angleX = angle;
-            if (transformValue.name() == CSSValueSkew) {
-                if (transformValue.length() > 1) {
-                    auto& secondValue = downcast<CSSPrimitiveValue>(transformValue[1]);
+            if (transformValue->name() == CSSValueSkew) {
+                if (transformValue->length() > 1) {
+                    auto& secondValue = downcast<CSSPrimitiveValue>((*transformValue)[1]);
                     angleY = secondValue.computeDegrees();
                 }
             }
         }
-        return SkewTransformOperation::create(angleX, angleY, transformOperationType(transformValue.name()));
+        return SkewTransformOperation::create(angleX, angleY, transformOperationType(transformValue->name()));
     }
 
     case CSSValueMatrix: {
-        if (transformValue.length() < 6)
+        if (transformValue->length() < 6)
             break;
         auto zoom = conversionData.zoom();
         return MatrixTransformOperation::create(doubleValue(0), doubleValue(1), doubleValue(2), doubleValue(3),
@@ -300,7 +300,7 @@ RefPtr<TransformOperation> transformForValue(const CSSValue& value, const CSSToL
     }
 
     case CSSValueMatrix3d: {
-        if (transformValue.length() < 16)
+        if (transformValue->length() < 16)
             break;
         TransformationMatrix matrix(doubleValue(0), doubleValue(1), doubleValue(2), doubleValue(3),
             doubleValue(4), doubleValue(5), doubleValue(6), doubleValue(7),

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -837,10 +837,8 @@ RefPtr<StyleRuleFontFeatureValues> CSSParserImpl::consumeFontFeatureValuesRule(C
     auto fontFeatureValues = FontFeatureValues::create();
 
     for (auto& block : rules) {
-        if (!block->isFontFeatureValuesBlockRule())
-            continue;
-        const auto& fontFeatureValuesBlockRule = downcast<StyleRuleFontFeatureValuesBlock>(block.get());
-        fontFeatureValues->updateOrInsertForType(fontFeatureValuesBlockRule.fontFeatureValuesType(), fontFeatureValuesBlockRule.tags());
+        if (auto* fontFeatureValuesBlockRule = dynamicDowncast<StyleRuleFontFeatureValuesBlock>(block.get()))
+            fontFeatureValues->updateOrInsertForType(fontFeatureValuesBlockRule->fontFeatureValuesType(), fontFeatureValuesBlockRule->tags());
     }
 
     return StyleRuleFontFeatureValues::create(fontFamilies, WTFMove(fontFeatureValues));

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -353,8 +353,8 @@ void Builder::applyProperty(CSSPropertyID id, CSSValue& value, SelectorChecker::
         style.setHasExplicitlyInheritedProperties();
 
 #if ENABLE(CSS_PAINTING_API)
-    if (is<CSSPaintImageValue>(valueToApply)) {
-        auto& name = downcast<CSSPaintImageValue>(valueToApply.get()).name();
+    if (auto* paintImageValue = dynamicDowncast<CSSPaintImageValue>(valueToApply.get())) {
+        auto& name = paintImageValue->name();
         if (auto* paintWorklet = const_cast<Document&>(m_state.document()).paintWorkletGlobalScopeForName(name)) {
             Locker locker { paintWorklet->paintDefinitionLock() };
             if (auto* registration = paintWorklet->paintDefinitionMap().get(name)) {
@@ -374,10 +374,8 @@ Ref<CSSValue> Builder::resolveVariableReferences(CSSPropertyID propertyID, CSSVa
         return value;
 
     auto variableValue = [&]() -> RefPtr<CSSValue> {
-        if (is<CSSPendingSubstitutionValue>(value)) {
-            auto& substitution = downcast<CSSPendingSubstitutionValue>(value);
-            return substitution.resolveValue(m_state, propertyID);
-        }
+        if (auto* substitution = dynamicDowncast<CSSPendingSubstitutionValue>(value))
+            return substitution->resolveValue(m_state, propertyID);
 
         auto& variableReferenceValue = downcast<CSSVariableReferenceValue>(value);
         return variableReferenceValue.resolveSingleValue(m_state, propertyID);

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -342,51 +342,51 @@ inline void BuilderCustom::applyValueSize(BuilderState& builderState, CSSValue& 
 {
     builderState.style().resetPageSizeType();
 
-    if (!is<CSSValueList>(value))
+    auto* valueList = dynamicDowncast<CSSValueList>(value);
+    if (!valueList)
         return;
 
     Length width;
     Length height;
     PageSizeType pageSizeType = PAGE_SIZE_AUTO;
 
-    auto& valueList = downcast<CSSValueList>(value);
-    switch (valueList.length()) {
+    switch (valueList->length()) {
     case 2: {
-        auto firstValue = valueList.itemWithoutBoundsCheck(0);
-        auto secondValue = valueList.itemWithoutBoundsCheck(1);
+        auto firstValue = valueList->itemWithoutBoundsCheck(0);
+        auto secondValue = valueList->itemWithoutBoundsCheck(1);
         // <length>{2} | <page-size> <orientation>
-        if (!is<CSSPrimitiveValue>(*firstValue) || !is<CSSPrimitiveValue>(*secondValue))
+        auto* firstPrimitiveValue = dynamicDowncast<CSSPrimitiveValue>(*firstValue);
+        auto* secondPrimitiveValue = dynamicDowncast<CSSPrimitiveValue>(*secondValue);
+        if (!firstPrimitiveValue || !secondPrimitiveValue)
             return;
-        auto& firstPrimitiveValue = downcast<CSSPrimitiveValue>(*firstValue);
-        auto& secondPrimitiveValue = downcast<CSSPrimitiveValue>(*secondValue);
-        if (firstPrimitiveValue.isLength()) {
+        if (firstPrimitiveValue->isLength()) {
             // <length>{2}
-            if (!secondPrimitiveValue.isLength())
+            if (!secondPrimitiveValue->isLength())
                 return;
             CSSToLengthConversionData conversionData = builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f);
-            width = firstPrimitiveValue.computeLength<Length>(conversionData);
-            height = secondPrimitiveValue.computeLength<Length>(conversionData);
+            width = firstPrimitiveValue->computeLength<Length>(conversionData);
+            height = secondPrimitiveValue->computeLength<Length>(conversionData);
         } else {
             // <page-size> <orientation>
             // The value order is guaranteed. See CSSParser::parseSizeParameter.
-            if (!getPageSizeFromName(firstPrimitiveValue, &secondPrimitiveValue, width, height))
+            if (!getPageSizeFromName(*firstPrimitiveValue, secondPrimitiveValue, width, height))
                 return;
         }
         pageSizeType = PAGE_SIZE_RESOLVED;
         break;
     }
     case 1: {
-        auto value = valueList.itemWithoutBoundsCheck(0);
+        auto value = valueList->itemWithoutBoundsCheck(0);
         // <length> | auto | <page-size> | [ portrait | landscape]
-        if (!is<CSSPrimitiveValue>(*value))
+        auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(*value);
+        if (!primitiveValue)
             return;
-        auto& primitiveValue = downcast<CSSPrimitiveValue>(*value);
-        if (primitiveValue.isLength()) {
+        if (primitiveValue->isLength()) {
             // <length>
             pageSizeType = PAGE_SIZE_RESOLVED;
-            width = height = primitiveValue.computeLength<Length>(builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f));
+            width = height = primitiveValue->computeLength<Length>(builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f));
         } else {
-            switch (primitiveValue.valueID()) {
+            switch (primitiveValue->valueID()) {
             case 0:
                 return;
             case CSSValueAuto:
@@ -401,7 +401,7 @@ inline void BuilderCustom::applyValueSize(BuilderState& builderState, CSSValue& 
             default:
                 // <page-size>
                 pageSizeType = PAGE_SIZE_RESOLVED;
-                if (!getPageSizeFromName(primitiveValue, nullptr, width, height))
+                if (!getPageSizeFromName(*primitiveValue, nullptr, width, height))
                     return;
             }
         }
@@ -603,9 +603,8 @@ void maybeUpdateFontForLetterSpacing(BuilderState& builderState, CSSValue& value
     // actually a font-relative unit passed to letter-spacing, and 2. updateFont() internally has logic
     // to only do work if the font is actually dirty.
 
-    if (is<CSSPrimitiveValue>(value)) {
-        auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
-        if (primitiveValue.isFontRelativeLength() || primitiveValue.isCalculated())
+    if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
+        if (primitiveValue->isFontRelativeLength() || primitiveValue->isCalculated())
             builderState.updateFont();
     }
 }
@@ -1154,21 +1153,20 @@ inline void BuilderCustom::applyValueAspectRatio(BuilderState& builderState, CSS
     if (value.valueID() == CSSValueAuto)
         return builderState.style().setAspectRatioType(AspectRatioType::Auto);
 
-    if (!is<CSSValueList>(value))
+    auto* list = dynamicDowncast<CSSValueList>(value);
+    if (!list)
         return;
 
-    auto& list = downcast<CSSValueList>(value);
-    if (list.item(1)->isValueList()) {
+    if (auto* ratioList = dynamicDowncast<CSSValueList>(*list->item(1))) {
         builderState.style().setAspectRatioType(AspectRatioType::AutoAndRatio);
-        auto ratioList = downcast<CSSValueList>(list.item(1));
         ASSERT(ratioList->length() == 2);
         builderState.style().setAspectRatio(downcast<CSSPrimitiveValue>(ratioList->item(0))->doubleValue(), downcast<CSSPrimitiveValue>(ratioList->item(1))->doubleValue());
         return;
     }
 
-    ASSERT(list.length() == 2);
-    auto width = downcast<CSSPrimitiveValue>(list.item(0))->doubleValue();
-    auto height = downcast<CSSPrimitiveValue>(list.item(1))->doubleValue();
+    ASSERT(list->length() == 2);
+    auto width = downcast<CSSPrimitiveValue>(list->item(0))->doubleValue();
+    auto height = downcast<CSSPrimitiveValue>(list->item(1))->doubleValue();
     if (!width || !height)
         builderState.style().setAspectRatioType(AspectRatioType::AutoZero);
     else
@@ -1178,11 +1176,10 @@ inline void BuilderCustom::applyValueAspectRatio(BuilderState& builderState, CSS
 
 inline void BuilderCustom::applyValueTextEmphasisStyle(BuilderState& builderState, CSSValue& value)
 {
-    if (is<CSSValueList>(value)) {
-        auto& list = downcast<CSSValueList>(value);
-        ASSERT(list.length() == 2);
+    if (auto* list = dynamicDowncast<CSSValueList>(value)) {
+        ASSERT(list->length() == 2);
 
-        for (auto& item : list) {
+        for (auto& item : *list) {
             auto valueID = item.valueID();
             if (valueID == CSSValueFilled || valueID == CSSValueOpen)
                 builderState.style().setTextEmphasisFill(fromCSSValueID<TextEmphasisFill>(valueID));
@@ -1328,9 +1325,8 @@ inline void BuilderCustom::applyValueCursor(BuilderState& builderState, CSSValue
     builderState.style().setCursor(CursorType::Auto);
     auto& list = downcast<CSSValueList>(value);
     for (auto& item : list) {
-        if (is<CSSCursorImageValue>(item)) {
-            auto& image = downcast<CSSCursorImageValue>(item);
-            builderState.style().addCursor(builderState.createStyleImage(image), image.hotSpot());
+        if (auto* image = dynamicDowncast<CSSCursorImageValue>(item)) {
+            builderState.style().addCursor(builderState.createStyleImage(*image), image->hotSpot());
             continue;
         }
 
@@ -1376,12 +1372,11 @@ inline void BuilderCustom::applyInheritFill(BuilderState& builderState)
 inline void BuilderCustom::applyValueFill(BuilderState& builderState, CSSValue& value)
 {
     auto& svgStyle = builderState.style().accessSVGStyle();
-    const auto* localValue = value.isPrimitiveValue() ? &downcast<CSSPrimitiveValue>(value) : nullptr;
+    const auto* localValue = dynamicDowncast<CSSPrimitiveValue>(value);
     String url;
-    if (value.isValueList()) {
-        const CSSValueList& list = downcast<CSSValueList>(value);
-        url = downcast<CSSPrimitiveValue>(list.item(0))->stringValue();
-        localValue = downcast<CSSPrimitiveValue>(list.item(1));
+    if (auto* list = dynamicDowncast<CSSValueList>(value)) {
+        url = downcast<CSSPrimitiveValue>(list->item(0))->stringValue();
+        localValue = downcast<CSSPrimitiveValue>(list->item(1));
     }
 
     if (!localValue)
@@ -1409,10 +1404,9 @@ inline void BuilderCustom::applyValueStroke(BuilderState& builderState, CSSValue
     auto& svgStyle = builderState.style().accessSVGStyle();
     const auto* localValue = value.isPrimitiveValue() ? &downcast<CSSPrimitiveValue>(value) : nullptr;
     String url;
-    if (value.isValueList()) {
-        const CSSValueList& list = downcast<CSSValueList>(value);
-        url = downcast<CSSPrimitiveValue>(list.item(0))->stringValue();
-        localValue = downcast<CSSPrimitiveValue>(list.item(1));
+    if (auto* list = dynamicDowncast<CSSValueList>(value)) {
+        url = downcast<CSSPrimitiveValue>(list->item(0))->stringValue();
+        localValue = downcast<CSSPrimitiveValue>(list->item(1));
     }
 
     if (!localValue)
@@ -1465,12 +1459,11 @@ inline void BuilderCustom::applyValueContent(BuilderState& builderState, CSSValu
             didSet = true;
             // Register the fact that the attribute value affects the style.
             builderState.registerContentAttribute(attr.localName());
-        } else if (item.isCounter()) {
-            auto& counter = downcast<CSSCounterValue>(item);
+        } else if (auto* counter = dynamicDowncast<CSSCounterValue>(item)) {
             ListStyleType listStyleType;
-            if (counter.counterStyle())
-                listStyleType = BuilderConverter::convertListStyleType(builderState, *counter.counterStyle());
-            builderState.style().setContent(makeUnique<CounterContent>(counter.identifier(), listStyleType, counter.separator()), didSet);
+            if (counter->counterStyle())
+                listStyleType = BuilderConverter::convertListStyleType(builderState, *counter->counterStyle());
+            builderState.style().setContent(makeUnique<CounterContent>(counter->identifier(), listStyleType, counter->separator()), didSet);
             didSet = true;
         } else {
             switch (item.valueID()) {
@@ -2030,32 +2023,31 @@ inline void BuilderCustom::applyInheritContainIntrinsicWidth(BuilderState& build
 inline void BuilderCustom::applyValueContainIntrinsicWidth(BuilderState& builderState, CSSValue& value)
 {
     auto& style = builderState.style();
-    if (is<CSSPrimitiveValue>(value)) {
-        auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
-        if (primitiveValue.valueID() == CSSValueNone) {
+    if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
+        if (primitiveValue->valueID() == CSSValueNone) {
             style.setContainIntrinsicWidth(RenderStyle::initialContainIntrinsicWidth());
             return style.setContainIntrinsicWidthType(ContainIntrinsicSizeType::None);
         }
 
-        if (primitiveValue.isLength()) {
+        if (primitiveValue->isLength()) {
             style.setContainIntrinsicWidthType(ContainIntrinsicSizeType::Length);
-            auto width = primitiveValue.computeLength<Length>(builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f));
+            auto width = primitiveValue->computeLength<Length>(builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f));
             style.setContainIntrinsicWidth(width);
         }
         return;
     }
 
-    if (!is<CSSValuePair>(value))
+    auto* pair = dynamicDowncast<CSSValuePair>(value);
+    if (!pair)
         return;
 
-    auto& pair = downcast<CSSValuePair>(value);
-    ASSERT(downcast<CSSPrimitiveValue>(pair.first()).valueID() == CSSValueAuto);
-    if (downcast<CSSPrimitiveValue>(pair.second()).valueID() == CSSValueNone)
+    ASSERT(downcast<CSSPrimitiveValue>(pair->first()).valueID() == CSSValueAuto);
+    if (downcast<CSSPrimitiveValue>(pair->second()).valueID() == CSSValueNone)
         style.setContainIntrinsicWidthType(ContainIntrinsicSizeType::AutoAndNone);
     else {
-        ASSERT(downcast<CSSPrimitiveValue>(pair.second()).isLength());
+        ASSERT(downcast<CSSPrimitiveValue>(pair->second()).isLength());
         style.setContainIntrinsicWidthType(ContainIntrinsicSizeType::AutoAndLength);
-        auto lengthValue = downcast<CSSPrimitiveValue>(pair.second()).computeLength<Length>(builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f));
+        auto lengthValue = downcast<CSSPrimitiveValue>(pair->second()).computeLength<Length>(builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f));
         style.setContainIntrinsicWidth(lengthValue);
     }
 }
@@ -2075,32 +2067,31 @@ inline void BuilderCustom::applyInheritContainIntrinsicHeight(BuilderState& buil
 inline void BuilderCustom::applyValueContainIntrinsicHeight(BuilderState& builderState, CSSValue& value)
 {
     auto& style = builderState.style();
-    if (is<CSSPrimitiveValue>(value)) {
-        auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
-        if (primitiveValue.valueID() == CSSValueNone) {
+    if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
+        if (primitiveValue->valueID() == CSSValueNone) {
             style.setContainIntrinsicHeight(RenderStyle::initialContainIntrinsicHeight());
             return style.setContainIntrinsicHeightType(ContainIntrinsicSizeType::None);
         }
 
-        if (primitiveValue.isLength()) {
+        if (primitiveValue->isLength()) {
             style.setContainIntrinsicHeightType(ContainIntrinsicSizeType::Length);
-            auto height = primitiveValue.computeLength<Length>(builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f));
+            auto height = primitiveValue->computeLength<Length>(builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f));
             style.setContainIntrinsicHeight(height);
         }
         return;
     }
 
-    if (!is<CSSValuePair>(value))
+    auto* pair = dynamicDowncast<CSSValuePair>(value);
+    if (!pair)
         return;
 
-    auto& pair = downcast<CSSValuePair>(value);
-    ASSERT(downcast<CSSPrimitiveValue>(pair.first()).valueID() == CSSValueAuto);
-    if (downcast<CSSPrimitiveValue>(pair.second()).valueID() == CSSValueNone)
+    ASSERT(downcast<CSSPrimitiveValue>(pair->first()).valueID() == CSSValueAuto);
+    if (downcast<CSSPrimitiveValue>(pair->second()).valueID() == CSSValueNone)
         style.setContainIntrinsicHeightType(ContainIntrinsicSizeType::AutoAndNone);
     else {
-        ASSERT(downcast<CSSPrimitiveValue>(pair.second()).isLength());
+        ASSERT(downcast<CSSPrimitiveValue>(pair->second()).isLength());
         style.setContainIntrinsicHeightType(ContainIntrinsicSizeType::AutoAndLength);
-        auto lengthValue = downcast<CSSPrimitiveValue>(pair.second()).computeLength<Length>(builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f));
+        auto lengthValue = downcast<CSSPrimitiveValue>(pair->second()).computeLength<Length>(builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f));
         style.setContainIntrinsicHeight(lengthValue);
     }
 }

--- a/Source/WebCore/style/StyleBuilderState.cpp
+++ b/Source/WebCore/style/StyleBuilderState.cpp
@@ -99,37 +99,37 @@ bool BuilderState::useSVGZoomRulesForLength() const
 
 RefPtr<StyleImage> BuilderState::createStyleImage(const CSSValue& value)
 {
-    if (is<CSSImageValue>(value))
-        return downcast<CSSImageValue>(value).createStyleImage(*this);
-    if (is<CSSImageSetValue>(value))
-        return downcast<CSSImageSetValue>(value).createStyleImage(*this);
-    if (is<CSSCursorImageValue>(value))
-        return downcast<CSSCursorImageValue>(value).createStyleImage(*this);
-    if (is<CSSNamedImageValue>(value))
-        return downcast<CSSNamedImageValue>(value).createStyleImage(*this);
-    if (is<CSSCanvasValue>(value))
-        return downcast<CSSCanvasValue>(value).createStyleImage(*this);
-    if (is<CSSCrossfadeValue>(value))
-        return downcast<CSSCrossfadeValue>(value).createStyleImage(*this);
-    if (is<CSSFilterImageValue>(value))
-        return downcast<CSSFilterImageValue>(value).createStyleImage(*this);
-    if (is<CSSLinearGradientValue>(value))
-        return downcast<CSSLinearGradientValue>(value).createStyleImage(*this);
-    if (is<CSSPrefixedLinearGradientValue>(value))
-        return downcast<CSSPrefixedLinearGradientValue>(value).createStyleImage(*this);
-    if (is<CSSDeprecatedLinearGradientValue>(value))
-        return downcast<CSSDeprecatedLinearGradientValue>(value).createStyleImage(*this);
-    if (is<CSSRadialGradientValue>(value))
-        return downcast<CSSRadialGradientValue>(value).createStyleImage(*this);
-    if (is<CSSPrefixedRadialGradientValue>(value))
-        return downcast<CSSPrefixedRadialGradientValue>(value).createStyleImage(*this);
-    if (is<CSSDeprecatedRadialGradientValue>(value))
-        return downcast<CSSDeprecatedRadialGradientValue>(value).createStyleImage(*this);
-    if (is<CSSConicGradientValue>(value))
-        return downcast<CSSConicGradientValue>(value).createStyleImage(*this);
+    if (auto* imageValue = dynamicDowncast<CSSImageValue>(value))
+        return imageValue->createStyleImage(*this);
+    if (auto* imageSetValue = dynamicDowncast<CSSImageSetValue>(value))
+        return imageSetValue->createStyleImage(*this);
+    if (auto* imageValue = dynamicDowncast<CSSCursorImageValue>(value))
+        return imageValue->createStyleImage(*this);
+    if (auto* imageValue = dynamicDowncast<CSSNamedImageValue>(value))
+        return imageValue->createStyleImage(*this);
+    if (auto* cssCanvasValue = dynamicDowncast<CSSCanvasValue>(value))
+        return cssCanvasValue->createStyleImage(*this);
+    if (auto* crossfadeValue = dynamicDowncast<CSSCrossfadeValue>(value))
+        return crossfadeValue->createStyleImage(*this);
+    if (auto* filterImageValue = dynamicDowncast<CSSFilterImageValue>(value))
+        return filterImageValue->createStyleImage(*this);
+    if (auto* linearGradientValue = dynamicDowncast<CSSLinearGradientValue>(value))
+        return linearGradientValue->createStyleImage(*this);
+    if (auto* linearGradientValue = dynamicDowncast<CSSPrefixedLinearGradientValue>(value))
+        return linearGradientValue->createStyleImage(*this);
+    if (auto* linearGradientValue = dynamicDowncast<CSSDeprecatedLinearGradientValue>(value))
+        return linearGradientValue->createStyleImage(*this);
+    if (auto* radialGradientvalue = dynamicDowncast<CSSRadialGradientValue>(value))
+        return radialGradientvalue->createStyleImage(*this);
+    if (auto* radialGradientvalue = dynamicDowncast<CSSPrefixedRadialGradientValue>(value))
+        return radialGradientvalue->createStyleImage(*this);
+    if (auto* radialGradientvalue = dynamicDowncast<CSSDeprecatedRadialGradientValue>(value))
+        return radialGradientvalue->createStyleImage(*this);
+    if (auto conicGradientValue = dynamicDowncast<CSSConicGradientValue>(value))
+        return conicGradientValue->createStyleImage(*this);
 #if ENABLE(CSS_PAINTING_API)
-    if (is<CSSPaintImageValue>(value))
-        return downcast<CSSPaintImageValue>(value).createStyleImage(*this);
+    if (auto* paintImageValue = dynamicDowncast<CSSPaintImageValue>(value))
+        return paintImageValue->createStyleImage(*this);
 #endif
     return nullptr;
 }

--- a/Source/WebCore/style/StylePendingResources.cpp
+++ b/Source/WebCore/style/StylePendingResources.cpp
@@ -79,8 +79,8 @@ void loadPendingResources(RenderStyle& style, Document& document, const Element*
         loadPendingImage(document, backgroundLayer->image(), element);
 
     for (auto* contentData = style.contentData(); contentData; contentData = contentData->next()) {
-        if (is<ImageContentData>(*contentData)) {
-            auto& styleImage = downcast<ImageContentData>(*contentData).image();
+        if (auto* imageContentData = dynamicDowncast<ImageContentData>(*contentData)) {
+            auto& styleImage = imageContentData->image();
             loadPendingImage(document, &styleImage, element);
         }
     }

--- a/Source/WebCore/style/StyleResolveForFontRaw.cpp
+++ b/Source/WebCore/style/StyleResolveForFontRaw.cpp
@@ -212,7 +212,8 @@ std::optional<FontCascade> resolveForFontRaw(const FontRaw& fontRaw, FontCascade
             //        that it's off-screen and therefore doesn't strictly have an associated viewport.
             //        This needs clarification and possibly fixing.
             // FIXME: How should root font units work in OffscreenCanvas?
-            return static_cast<float>(CSSPrimitiveValue::computeUnzoomedNonCalcLengthDouble(length.type, length.value, CSSPropertyFontSize, &fontCascade, is<Document>(context) ? downcast<Document>(context).renderView() : nullptr));
+            auto* document = dynamicDowncast<Document>(context);
+            return static_cast<float>(CSSPrimitiveValue::computeUnzoomedNonCalcLengthDouble(length.type, length.value, CSSPropertyFontSize, &fontCascade, document ? document->renderView() : nullptr));
         }, [&] (const CSSPropertyParserHelpers::PercentRaw& percentage) {
             return static_cast<float>((parentSize * percentage.value) / 100.0);
         });

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -306,8 +306,8 @@ std::unique_ptr<RenderStyle> Resolver::styleForKeyframe(const Element& element, 
         if (auto* value = propertyReference.value()) {
             auto resolvedProperty = CSSProperty::resolveDirectionAwareProperty(unresolvedProperty, elementStyle.direction(), elementStyle.writingMode());
             if (resolvedProperty != CSSPropertyAnimationTimingFunction && resolvedProperty != CSSPropertyAnimationComposition) {
-                if (value->isCustomPropertyValue())
-                    blendingKeyframe.addProperty(downcast<CSSCustomPropertyValue>(*value).name());
+                if (auto customValue = dynamicDowncast<CSSCustomPropertyValue>(*value))
+                    blendingKeyframe.addProperty(customValue->name());
                 else
                     blendingKeyframe.addProperty(resolvedProperty);
             }

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -68,7 +68,8 @@ const std::optional<const Styleable> Styleable::fromRenderer(const RenderElement
     case PseudoId::Marker: {
         auto* ancestor = renderer.parent();
         while (ancestor) {
-            if (is<RenderListItem>(ancestor) && ancestor->element() && downcast<RenderListItem>(ancestor)->markerRenderer() == &renderer)
+            auto* renderListItem = dynamicDowncast<RenderListItem>(ancestor);
+            if (renderListItem && ancestor->element() && renderListItem->markerRenderer() == &renderer)
                 return Styleable(*ancestor->element(), PseudoId::Marker);
             ancestor = ancestor->parent();
         }
@@ -103,8 +104,8 @@ RenderElement* Styleable::renderer() const
             return beforePseudoElement->renderer();
         break;
     case PseudoId::Marker:
-        if (is<RenderListItem>(element.renderer())) {
-            auto* markerRenderer = downcast<RenderListItem>(*element.renderer()).markerRenderer();
+        if (auto* renderListItem = dynamicDowncast<RenderListItem>(element.renderer())) {
+            auto* markerRenderer = renderListItem->markerRenderer();
             if (markerRenderer && !markerRenderer->style().hasEffectiveContentNone())
                 return markerRenderer;
         }
@@ -526,8 +527,9 @@ static void updateCSSTransitionsForStyleableAndProperty(const Styleable& styleab
                     if (!effectTargetsProperty(*effect))
                         continue;
                     auto* effectAnimation = effect->animation();
-                    bool shouldUseTimelineTimeAtCreation = is<CSSTransition>(effectAnimation) && (!effectAnimation->startTime() || *effectAnimation->startTime() == document.timeline().currentTime());
-                    effectAnimation->resolve(style, { nullptr }, shouldUseTimelineTimeAtCreation ? downcast<CSSTransition>(*effectAnimation).timelineTimeAtCreation() : std::nullopt);
+                    auto* cssTransition = dynamicDowncast<CSSTransition>(effectAnimation);
+                    bool shouldUseTimelineTimeAtCreation = cssTransition && (!effectAnimation->startTime() || *effectAnimation->startTime() == document.timeline().currentTime());
+                    effectAnimation->resolve(style, { nullptr }, shouldUseTimelineTimeAtCreation ? cssTransition->timelineTimeAtCreation() : std::nullopt);
                 }
             }
             return style;

--- a/Source/WebCore/style/Styleable.h
+++ b/Source/WebCore/style/Styleable.h
@@ -51,8 +51,8 @@ struct Styleable {
 
     static const Styleable fromElement(Element& element)
     {
-        if (is<PseudoElement>(element))
-            return Styleable(*downcast<PseudoElement>(element).hostElement(), element.pseudoId());
+        if (auto* pseudoElement = dynamicDowncast<PseudoElement>(element))
+            return Styleable(*pseudoElement->hostElement(), element.pseudoId());
         return Styleable(element, element.pseudoId());
     }
 

--- a/Source/WebCore/svg/SVGAnimateElementBase.h
+++ b/Source/WebCore/svg/SVGAnimateElementBase.h
@@ -73,5 +73,9 @@ SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SVGAnimateElementBase)
         return element.hasTagName(WebCore::SVGNames::animateTag) || element.hasTagName(WebCore::SVGNames::animateColorTag)
             || element.hasTagName(WebCore::SVGNames::animateTransformTag) || element.hasTagName(WebCore::SVGNames::setTag);
     }
-    static bool isType(const WebCore::Node& node) { return is<WebCore::SVGElement>(node) && isType(downcast<WebCore::SVGElement>(node)); }
+    static bool isType(const WebCore::Node& node)
+    {
+        auto* svgElement = dynamicDowncast<WebCore::SVGElement>(node);
+        return svgElement && isType(*svgElement);
+    }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/svg/SVGComponentTransferFunctionElementInlines.h
+++ b/Source/WebCore/svg/SVGComponentTransferFunctionElementInlines.h
@@ -33,5 +33,9 @@
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SVGComponentTransferFunctionElement)
     static bool isType(const WebCore::Element& element) { return is<WebCore::SVGFEFuncRElement>(element) || is<WebCore::SVGFEFuncGElement>(element) || is<WebCore::SVGFEFuncBElement>(element) || is<WebCore::SVGFEFuncAElement>(element); }
-    static bool isType(const WebCore::Node& node) { return is<WebCore::Element>(node) && isType(downcast<WebCore::Element>(node)); }
+    static bool isType(const WebCore::Node& node)
+    {
+        auto* element = dynamicDowncast<WebCore::Element>(node);
+        return element && isType(*element);
+    }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/svg/SVGDocument.h
+++ b/Source/WebCore/svg/SVGDocument.h
@@ -55,5 +55,9 @@ inline Ref<SVGDocument> SVGDocument::create(LocalFrame* frame, const Settings& s
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SVGDocument)
     static bool isType(const WebCore::Document& document) { return document.isSVGDocument(); }
-    static bool isType(const WebCore::Node& node) { return is<WebCore::Document>(node) && isType(downcast<WebCore::Document>(node)); }
+    static bool isType(const WebCore::Node& node)
+    {
+        auto* document = dynamicDowncast<WebCore::Document>(node);
+        return document && isType(*document);
+    }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/svg/SVGElementInlines.h
+++ b/Source/WebCore/svg/SVGElementInlines.h
@@ -48,7 +48,8 @@ inline bool Element::hasTagName(const SVGQualifiedName& tagName) const
 
 inline bool Node::hasTagName(const SVGQualifiedName& name) const
 {
-    return isSVGElement() && downcast<SVGElement>(*this).hasTagName(name);
+    auto* svgElement = dynamicDowncast<SVGElement>(*this);
+    return svgElement && svgElement->hasTagName(name);
 }
 
 }

--- a/Source/WebCore/svg/SVGGeometryElement.h
+++ b/Source/WebCore/svg/SVGGeometryElement.h
@@ -61,5 +61,9 @@ private:
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SVGGeometryElement)
     static bool isType(const WebCore::SVGElement& element) { return element.isSVGGeometryElement(); }
-    static bool isType(const WebCore::Node& node) { return is<WebCore::SVGElement>(node) && isType(downcast<WebCore::SVGElement>(node)); }
+    static bool isType(const WebCore::Node& node)
+    {
+        auto* svgElement = dynamicDowncast<WebCore::SVGElement>(node);
+        return svgElement && isType(*svgElement);
+    }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/svg/SVGGradientElement.h
+++ b/Source/WebCore/svg/SVGGradientElement.h
@@ -115,6 +115,7 @@ static bool isType(const WebCore::SVGElement& element)
 }
 static bool isType(const WebCore::Node& node)
 {
-    return is<WebCore::SVGElement>(node) && isType(downcast<WebCore::SVGElement>(node));
+    auto* svgElement = dynamicDowncast<WebCore::SVGElement>(node);
+    return svgElement && isType(*svgElement);
 }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/svg/SVGGraphicsElement.h
+++ b/Source/WebCore/svg/SVGGraphicsElement.h
@@ -93,5 +93,9 @@ private:
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SVGGraphicsElement)
     static bool isType(const WebCore::SVGElement& element) { return element.isSVGGraphicsElement(); }
-    static bool isType(const WebCore::Node& node) { return is<WebCore::SVGElement>(node) && isType(downcast<WebCore::SVGElement>(node)); }
+    static bool isType(const WebCore::Node& node)
+    {
+        auto* svgElement = dynamicDowncast<WebCore::SVGElement>(node);
+        return svgElement && isType(*svgElement);
+    }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/svg/SVGLengthContext.cpp
+++ b/Source/WebCore/svg/SVGLengthContext.cpp
@@ -319,14 +319,13 @@ std::optional<FloatSize> SVGLengthContext::computeViewportSize() const
         return downcast<SVGSVGElement>(*m_context).currentViewportSizeExcludingZoom();
 
     // Take size from nearest viewport element.
-    RefPtr viewportElement = m_context->viewportElement();
-    if (!is<SVGSVGElement>(viewportElement))
+    RefPtr svg = dynamicDowncast<SVGSVGElement>(m_context->viewportElement());
+    if (!svg)
         return std::nullopt;
 
-    const SVGSVGElement& svg = downcast<SVGSVGElement>(*viewportElement);
-    auto viewportSize = svg.currentViewBoxRect().size();
+    auto viewportSize = svg->currentViewBoxRect().size();
     if (viewportSize.isEmpty())
-        viewportSize = svg.currentViewportSizeExcludingZoom();
+        viewportSize = svg->currentViewportSizeExcludingZoom();
 
     return viewportSize;
 }

--- a/Source/WebCore/svg/SVGLengthValue.cpp
+++ b/Source/WebCore/svg/SVGLengthValue.cpp
@@ -259,8 +259,8 @@ SVGLengthValue SVGLengthValue::fromCSSPrimitiveValue(const CSSPrimitiveValue& va
 
 Ref<CSSPrimitiveValue> SVGLengthValue::toCSSPrimitiveValue(const Element* element) const
 {
-    if (is<SVGElement>(element)) {
-        SVGLengthContext context { downcast<SVGElement>(element) };
+    if (auto* svgElement = dynamicDowncast<SVGElement>(element)) {
+        SVGLengthContext context { svgElement };
         auto computedValue = context.convertValueToUserUnits(valueInSpecifiedUnits(), lengthType(), lengthMode());
         if (!computedValue.hasException())
             return CSSPrimitiveValue::create(computedValue.releaseReturnValue(), CSSUnitType::CSS_PX);

--- a/Source/WebCore/svg/SVGLinearGradientElement.cpp
+++ b/Source/WebCore/svg/SVGLinearGradientElement.cpp
@@ -148,8 +148,8 @@ bool SVGLinearGradientElement::collectGradientAttributes(LinearGradientAttribute
     while (true) {
         // Respect xlink:href, take attributes from referenced element
         auto target = SVGURIReference::targetElementFromIRIString(current->href(), treeScopeForSVGReferences());
-        if (is<SVGGradientElement>(target.element)) {
-            current = downcast<SVGGradientElement>(*target.element);
+        if (auto* gradientElement = dynamicDowncast<SVGGradientElement>(target.element.get())) {
+            current = *gradientElement;
 
             // Cycle detection
             if (processedGradients.contains(current))

--- a/Source/WebCore/svg/SVGLocatable.cpp
+++ b/Source/WebCore/svg/SVGLocatable.cpp
@@ -101,10 +101,11 @@ AffineTransform SVGLocatable::computeCTM(SVGElement* element, CTMScope mode, Sty
     AffineTransform ctm;
 
     for (Element* currentElement = element; currentElement; currentElement = currentElement->parentOrShadowHostElement()) {
-        if (!currentElement->isSVGElement())
+        auto* svgElement = dynamicDowncast<SVGElement>(*currentElement);
+        if (!svgElement)
             break;
 
-        ctm = downcast<SVGElement>(*currentElement).localCoordinateSpaceTransform(mode).multiply(ctm);
+        ctm = svgElement->localCoordinateSpaceTransform(mode).multiply(ctm);
 
         // For getCTM() computation, stop at the nearest viewport element
         if (currentElement == stopAtElement)
@@ -118,8 +119,8 @@ ExceptionOr<Ref<SVGMatrix>> SVGLocatable::getTransformToElement(SVGElement* targ
 {
     AffineTransform ctm = getCTM(styleUpdateStrategy);
 
-    if (is<SVGGraphicsElement>(target)) {
-        AffineTransform targetCTM = downcast<SVGGraphicsElement>(*target).getCTM(styleUpdateStrategy);
+    if (auto* graphicsElement = dynamicDowncast<SVGGraphicsElement>(target)) {
+        AffineTransform targetCTM = graphicsElement->getCTM(styleUpdateStrategy);
         if (auto inverse = targetCTM.inverse())
             ctm = inverse.value() * ctm;
         else

--- a/Source/WebCore/svg/SVGMPathElement.cpp
+++ b/Source/WebCore/svg/SVGMPathElement.cpp
@@ -67,8 +67,8 @@ void SVGMPathElement::buildPendingResource()
             treeScope.addPendingSVGResource(target.identifier, *this);
             ASSERT(hasPendingResources());
         }
-    } else if (is<SVGElement>(*target.element))
-        downcast<SVGElement>(*target.element).addReferencingElement(*this);
+    } else if (auto* svgElement = dynamicDowncast<SVGElement>(*target.element))
+        svgElement->addReferencingElement(*this);
 
     targetPathChanged();
 }
@@ -120,9 +120,7 @@ void SVGMPathElement::svgAttributeChanged(const QualifiedName& attrName)
 RefPtr<SVGPathElement> SVGMPathElement::pathElement()
 {
     auto target = targetElementFromIRIString(href(), treeScopeForSVGReferences());
-    if (is<SVGPathElement>(target.element))
-        return downcast<SVGPathElement>(target.element.get());
-    return nullptr;
+    return dynamicDowncast<SVGPathElement>(target.element);
 }
 
 void SVGMPathElement::targetPathChanged()
@@ -132,8 +130,8 @@ void SVGMPathElement::targetPathChanged()
 
 void SVGMPathElement::notifyParentOfPathChange(ContainerNode* parent)
 {
-    if (is<SVGAnimateMotionElement>(parent))
-        downcast<SVGAnimateMotionElement>(*parent).updateAnimationPath();
+    if (auto* animateMotionElement = dynamicDowncast<SVGAnimateMotionElement>(parent))
+        animateMotionElement->updateAnimationPath();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/svg/SVGPathElement.cpp
+++ b/Source/WebCore/svg/SVGPathElement.cpp
@@ -155,8 +155,8 @@ void SVGPathElement::invalidateMPathDependencies()
     // <mpath> can only reference <path> but this dependency is not handled in
     // markForLayoutAndParentResourceInvalidation so we update any mpath dependencies manually.
     for (auto& element : referencingElements()) {
-        if (is<SVGMPathElement>(element))
-            downcast<SVGMPathElement>(element.get()).targetPathChanged();
+        if (auto* mpathElement = dynamicDowncast<SVGMPathElement>(element.get()))
+            mpathElement->targetPathChanged();
     }
 }
 

--- a/Source/WebCore/svg/SVGPolyElement.h
+++ b/Source/WebCore/svg/SVGPolyElement.h
@@ -55,5 +55,9 @@ private:
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SVGPolyElement)
     static bool isType(const WebCore::SVGElement& element) { return element.hasTagName(WebCore::SVGNames::polygonTag) || element.hasTagName(WebCore::SVGNames::polylineTag); }
-    static bool isType(const WebCore::Node& node) { return is<WebCore::SVGElement>(node) && isType(downcast<WebCore::SVGElement>(node)); }
+    static bool isType(const WebCore::Node& node)
+    {
+        auto* svgElement = dynamicDowncast<WebCore::SVGElement>(node);
+        return svgElement && isType(*svgElement);
+    }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/svg/SVGRadialGradientElement.cpp
+++ b/Source/WebCore/svg/SVGRadialGradientElement.cpp
@@ -161,8 +161,8 @@ bool SVGRadialGradientElement::collectGradientAttributes(RadialGradientAttribute
     while (true) {
         // Respect xlink:href, take attributes from referenced element
         auto target = SVGURIReference::targetElementFromIRIString(current->href(), treeScopeForSVGReferences());
-        if (is<SVGGradientElement>(target.element)) {
-            current = downcast<SVGGradientElement>(target.element.get());
+        if (auto* gradientElement = dynamicDowncast<SVGGradientElement>(target.element.get())) {
+            current = gradientElement;
 
             // Cycle detection
             if (processedGradients.contains(current))

--- a/Source/WebCore/svg/SVGSVGElement.cpp
+++ b/Source/WebCore/svg/SVGSVGElement.cpp
@@ -435,8 +435,8 @@ AffineTransform SVGSVGElement::localCoordinateSpaceTransform(SVGLocatable::CTMSc
             // to map an element from SVG viewport coordinates to CSS box coordinates.
             // LegacyRenderSVGRoot's localToAbsolute method expects CSS box coordinates.
             // We also need to adjust for the zoom level factored into CSS coordinates (bug #96361).
-            if (is<LegacyRenderSVGRoot>(*renderer)) {
-                location = downcast<LegacyRenderSVGRoot>(*renderer).localToBorderBoxTransform().mapPoint(location);
+            if (auto* legacyRenderSVGRoot = dynamicDowncast<LegacyRenderSVGRoot>(*renderer)) {
+                location = legacyRenderSVGRoot->localToBorderBoxTransform().mapPoint(location);
                 zoomFactor = 1 / renderer->style().effectiveZoom();
             }
 

--- a/Source/WebCore/svg/SVGTextContentElement.cpp
+++ b/Source/WebCore/svg/SVGTextContentElement.cpp
@@ -217,13 +217,9 @@ SVGTextContentElement* SVGTextContentElement::elementFromRenderer(RenderObject* 
     if (!renderer->isRenderSVGText() && !renderer->isRenderSVGInline())
         return nullptr;
 
-    SVGElement* element = downcast<SVGElement>(renderer->node());
+    auto* element = downcast<SVGElement>(renderer->node());
     ASSERT(element);
-
-    if (!is<SVGTextContentElement>(element))
-        return nullptr;
-
-    return downcast<SVGTextContentElement>(element);
+    return dynamicDowncast<SVGTextContentElement>(element);
 }
 
 }

--- a/Source/WebCore/svg/SVGTextContentElement.h
+++ b/Source/WebCore/svg/SVGTextContentElement.h
@@ -115,5 +115,9 @@ private:
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SVGTextContentElement)
     static bool isType(const WebCore::SVGElement& element) { return element.isTextContent(); }
-    static bool isType(const WebCore::Node& node) { return is<WebCore::SVGElement>(node) && isType(downcast<WebCore::SVGElement>(node)); }
+    static bool isType(const WebCore::Node& node)
+    {
+        auto* svgElement = dynamicDowncast<WebCore::SVGElement>(node);
+        return svgElement && isType(*svgElement);
+    }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/svg/animation/SVGSMILElement.cpp
+++ b/Source/WebCore/svg/animation/SVGSMILElement.cpp
@@ -195,7 +195,7 @@ void SVGSMILElement::buildPendingResource()
         target = WTFMove(result.element);
         id = WTFMove(result.identifier);
     }
-    RefPtr svgTarget = is<SVGElement>(target) && target->isConnected() ? downcast<SVGElement>(target.get()) : nullptr;
+    RefPtr svgTarget = target && target->isConnected() ? dynamicDowncast<SVGElement>(*target) : nullptr;
 
     if (svgTarget != targetElement())
         setTargetElement(svgTarget.get());
@@ -583,11 +583,12 @@ void SVGSMILElement::connectConditions()
             condition.m_syncbase = treeScope().getElementById(condition.m_baseID);
             if (!condition.m_syncbase)
                 continue;
-            if (!is<SVGSMILElement>(*condition.m_syncbase)) {
+            auto* svgSMILElement = dynamicDowncast<SVGSMILElement>(*condition.m_syncbase);
+            if (!svgSMILElement) {
                 condition.m_syncbase = nullptr;
                 continue;
             }
-            downcast<SVGSMILElement>(*condition.m_syncbase).addTimeDependent(this);
+            svgSMILElement->addTimeDependent(this);
         }
     }
 }

--- a/Source/WebCore/svg/animation/SVGSMILElement.h
+++ b/Source/WebCore/svg/animation/SVGSMILElement.h
@@ -226,5 +226,9 @@ private:
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SVGSMILElement)
     static bool isType(const WebCore::SVGElement& element) { return element.isSMILElement(); }
-    static bool isType(const WebCore::Node& node) { return is<WebCore::SVGElement>(node) && isType(downcast<WebCore::SVGElement>(node)); }
+    static bool isType(const WebCore::Node& node)
+    {
+        auto* svgElement = dynamicDowncast<WebCore::SVGElement>(node);
+        return svgElement && isType(*svgElement);
+    }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/svg/graphics/SVGImage.cpp
+++ b/Source/WebCore/svg/graphics/SVGImage.cpp
@@ -107,11 +107,11 @@ bool SVGImage::renderingTaintsOrigin() const
     for (auto& element : descendantsOfType<SVGElement>(*rootElement)) {
         if (is<SVGForeignObjectElement>(element))
             return true;
-        if (is<SVGImageElement>(element)) {
-            if (downcast<SVGImageElement>(element).renderingTaintsOrigin())
+        if (auto* svgImage = dynamicDowncast<SVGImageElement>(element)) {
+            if (svgImage->renderingTaintsOrigin())
                 return true;
-        } else if (is<SVGFEImageElement>(element)) {
-            if (downcast<SVGFEImageElement>(element).renderingTaintsOrigin())
+        } else if (auto* svgFEImage = dynamicDowncast<SVGFEImageElement>(element)) {
+            if (svgFEImage->renderingTaintsOrigin())
                 return true;
         }
     }

--- a/Source/WebCore/svg/properties/SVGPropertyAnimator.h
+++ b/Source/WebCore/svg/properties/SVGPropertyAnimator.h
@@ -89,12 +89,10 @@ protected:
 
     String computeInheritedCSSPropertyValue(SVGElement& targetElement) const
     {
-        RefPtr<Element> parent = targetElement.parentElement();
-        if (!parent || !parent->isSVGElement())
+        RefPtr svgParent = dynamicDowncast<SVGElement>(targetElement.parentElement());
+        if (!svgParent)
             return emptyString();
-        
-        SVGElement& svgParent = downcast<SVGElement>(*parent);
-        return computeCSSPropertyValue(svgParent, cssPropertyID(m_attributeName.localName()));
+        return computeCSSPropertyValue(*svgParent, cssPropertyID(m_attributeName.localName()));
     }
 
     AnimationFunction m_function;


### PR DESCRIPTION
#### b77e480dcfa67013da8a5302a103095074f2f0cf
<pre>
Adopt dynamicDowncast&lt;&gt;() further in WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=266640">https://bugs.webkit.org/show_bug.cgi?id=266640</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/animation/AcceleratedTimeline.cpp:
(WebCore::AcceleratedTimeline::updateEffectStacks):
* Source/WebCore/animation/AnimationEffect.cpp:
(WebCore::AnimationEffect::bindingsUpdateTiming):
(WebCore::AnimationEffect::progressUntilNextStep const):
* Source/WebCore/animation/AnimationTimeline.cpp:
(WebCore::AnimationTimeline::animationTimingDidChange):
* Source/WebCore/animation/CSSAnimation.cpp:
(WebCore::CSSAnimation::keyframesRuleDidChange):
(WebCore::CSSAnimation::updateKeyframesIfNeeded):
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::blendFunc):
* Source/WebCore/animation/DocumentTimeline.cpp:
(WebCore::DocumentTimeline::animationCanBeRemoved):
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::getKeyframes):
(WebCore::KeyframeEffect::setBindingsKeyframes):
(WebCore::KeyframeEffect::computeCSSAnimationBlendingKeyframes):
(WebCore::KeyframeEffect::computeCSSTransitionBlendingKeyframes):
(WebCore::isLinearTimingFunctionWithPoints):
(WebCore::KeyframeEffect::computeSomeKeyframesUseStepsOrLinearTimingFunctionWithPoints):
(WebCore::KeyframeEffect::setAnimatedPropertiesInStyle):
(WebCore::KeyframeEffect::computeExtentOfTransformAnimation const):
(WebCore::KeyframeEffect::progressUntilNextStep const):
(WebCore::KeyframeEffect::timingFunctionForKeyframe const):
* Source/WebCore/animation/ViewTimeline.cpp:
(WebCore::ViewTimeline::createFromCSSValue):
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::setEffectInternal):
(WebCore::WebAnimation::setTimeline):
(WebCore::WebAnimation::acceleratedStateDidChange):
(WebCore::WebAnimation::updateRelevance):
(WebCore::WebAnimation::isReplaceable const):
(WebCore::WebAnimation::commitStyles):
* Source/WebCore/animation/WebAnimationUtilities.cpp:
(WebCore::compareAnimationsByCompositeOrder):
(WebCore::compareDeclarativeAnimationEvents):
* Source/WebCore/css/TransformFunctions.cpp:
(WebCore::transformForValue):
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::consumeFontFeatureValuesRule):
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::applyProperty):
(WebCore::Style::Builder::resolveVariableReferences):
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertTextDecorationLine):
(WebCore::Style::BuilderConverter::convertTextTransform):
(WebCore::Style::BuilderConverter::convertColorScheme):
(WebCore::Style::BuilderConverter::convertTextEmphasisPosition):
(WebCore::Style::BuilderConverter::convertPathOperation):
(WebCore::Style::BuilderConverter::convertQuotes):
(WebCore::Style::BuilderConverter::convertShapeValue):
(WebCore::Style::BuilderConverter::convertScrollbarGutter):
(WebCore::Style::BuilderConverter::createGridTrackSize):
(WebCore::Style::BuilderConverter::createGridTrackList):
(WebCore::Style::BuilderConverter::createGridPosition):
(WebCore::Style::BuilderConverter::convertGridTrackSizeList):
(WebCore::Style::BuilderConverter::convertGridAutoFlow):
(WebCore::Style::BuilderConverter::convertFontSizeAdjust):
(WebCore::Style::BuilderConverter::convertTouchAction):
(WebCore::Style::BuilderConverter::convertContentAlignmentData):
(WebCore::Style::BuilderConverter::convertSpeakAs):
(WebCore::Style::BuilderConverter::convertHangingPunctuation):
(WebCore::Style::BuilderConverter::convertContainerName):
(WebCore::Style::BuilderConverter::convertViewTransitionName):
(WebCore::Style::BuilderConverter::convertWillChange):
(WebCore::Style::BuilderConverter::convertScrollTimelineName):
(WebCore::Style::BuilderConverter::convertScrollTimelineAxis):
(WebCore::Style::BuilderConverter::convertViewTimelineInset):
* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::BuilderCustom::applyValueSize):
(WebCore::Style::maybeUpdateFontForLetterSpacing):
(WebCore::Style::BuilderCustom::applyValueAspectRatio):
(WebCore::Style::BuilderCustom::applyValueTextEmphasisStyle):
(WebCore::Style::BuilderCustom::applyValueCursor):
(WebCore::Style::BuilderCustom::applyValueFill):
(WebCore::Style::BuilderCustom::applyValueStroke):
(WebCore::Style::BuilderCustom::applyValueContent):
(WebCore::Style::BuilderCustom::applyValueContainIntrinsicWidth):
(WebCore::Style::BuilderCustom::applyValueContainIntrinsicHeight):
* Source/WebCore/style/StyleBuilderState.cpp:
(WebCore::Style::BuilderState::createStyleImage):
* Source/WebCore/style/StyleInvalidator.cpp:
(WebCore::Style::shouldDirtyAllStyle):
(WebCore::Style::invalidateAssignedElements):
(WebCore::Style::Invalidator::invalidateIfNeeded):
* Source/WebCore/style/StylePendingResources.cpp:
(WebCore::Style::loadPendingResources):
* Source/WebCore/style/StyleResolveForFontRaw.cpp:
(WebCore::Style::resolveForFontRaw):
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::styleForKeyframe):
* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::releaseMemory):
(WebCore::Style::Scope::collectXSLTransforms):
(WebCore::Style::Scope::collectActiveStyleSheets):
(WebCore::Style::filterEnabledNonemptyCSSStyleSheets):
(WebCore::Style::Scope::activeStyleSheetsForInspector):
* Source/WebCore/style/StyleSharingResolver.cpp:
(WebCore::Style::elementHasDirectionAuto):
(WebCore::Style::SharingResolver::resolve):
(WebCore::Style::SharingResolver::findSibling const):
(WebCore::Style::SharingResolver::canShareStyleWithElement const):
* Source/WebCore/style/Styleable.cpp:
(WebCore::Styleable::fromRenderer):
(WebCore::Styleable::renderer const):
(WebCore::updateCSSTransitionsForStyleableAndProperty):
* Source/WebCore/style/Styleable.h:
(WebCore::Styleable::fromElement):
* Source/WebCore/svg/SVGAnimateElementBase.h:
(isType):
* Source/WebCore/svg/SVGComponentTransferFunctionElementInlines.h:
(isType):
* Source/WebCore/svg/SVGDocument.h:
(isType):
* Source/WebCore/svg/SVGElementInlines.h:
(WebCore::Node::hasTagName const):
* Source/WebCore/svg/SVGGeometryElement.h:
(isType):
* Source/WebCore/svg/SVGGradientElement.h:
(isType):
* Source/WebCore/svg/SVGGraphicsElement.h:
(isType):
* Source/WebCore/svg/SVGLengthContext.cpp:
(WebCore::SVGLengthContext::computeViewportSize const):
* Source/WebCore/svg/SVGLengthValue.cpp:
(WebCore::SVGLengthValue::toCSSPrimitiveValue const):
* Source/WebCore/svg/SVGLinearGradientElement.cpp:
(WebCore::SVGLinearGradientElement::collectGradientAttributes):
* Source/WebCore/svg/SVGLocatable.cpp:
(WebCore::SVGLocatable::computeCTM):
(WebCore::SVGLocatable::getTransformToElement):
* Source/WebCore/svg/SVGMPathElement.cpp:
(WebCore::SVGMPathElement::buildPendingResource):
(WebCore::SVGMPathElement::pathElement):
(WebCore::SVGMPathElement::notifyParentOfPathChange):
* Source/WebCore/svg/SVGPathElement.cpp:
(WebCore::SVGPathElement::invalidateMPathDependencies):
* Source/WebCore/svg/SVGPolyElement.h:
(isType):
* Source/WebCore/svg/SVGRadialGradientElement.cpp:
(WebCore::SVGRadialGradientElement::collectGradientAttributes):
* Source/WebCore/svg/SVGSVGElement.cpp:
(WebCore::SVGSVGElement::localCoordinateSpaceTransform const):
* Source/WebCore/svg/SVGTextContentElement.cpp:
(WebCore::SVGTextContentElement::elementFromRenderer):
* Source/WebCore/svg/SVGTextContentElement.h:
(isType):
* Source/WebCore/svg/SVGUseElement.cpp:
(WebCore::isDisallowedElement):
(WebCore::SVGUseElement::toClipPath):
(WebCore::disassociateAndRemoveClones):
(WebCore::SVGUseElement::findTarget const):
* Source/WebCore/svg/animation/SVGSMILElement.cpp:
(WebCore::SVGSMILElement::buildPendingResource):
(WebCore::SVGSMILElement::connectConditions):
* Source/WebCore/svg/animation/SVGSMILElement.h:
(isType):
* Source/WebCore/svg/graphics/SVGImage.cpp:
(WebCore::SVGImage::renderingTaintsOrigin const):
* Source/WebCore/svg/properties/SVGPropertyAnimator.h:
(WebCore::SVGPropertyAnimator::computeInheritedCSSPropertyValue const):

Canonical link: <a href="https://commits.webkit.org/272280@main">https://commits.webkit.org/272280@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5fb2a39d9eb9d7dc4ad3f22177460ec6a0c4b9bc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31207 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9885 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32901 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33715 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/28335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/31974 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12230 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7143 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/27993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31544 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8340 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27898 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/7166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/7337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27792 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35056 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28407 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28249 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/33471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7379 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5436 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/31309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/9061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/7334 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8079 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4052 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/7908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->