### PR TITLE
[UnifiedPDF] Scrollbars don't show

### DIFF
--- a/LayoutTests/compositing/plugins/pdf/pdf-scrolling-tree-dynamic-expected.txt
+++ b/LayoutTests/compositing/plugins/pdf/pdf-scrolling-tree-dynamic-expected.txt
@@ -33,7 +33,7 @@ After installing PDF:
   (min layout viewport origin (0,0))
   (max layout viewport origin (0,0))
   (synchronous event dispatch region for event wheel
-    at (8,23) size 300x300)
+    at (8,23) size 300x250)
   (behavior for fixed 1)
 )
 

--- a/LayoutTests/compositing/plugins/pdf/pdf-scrolling-tree-dynamic.html
+++ b/LayoutTests/compositing/plugins/pdf/pdf-scrolling-tree-dynamic.html
@@ -5,7 +5,7 @@
     <style>
         embed {
             width: 300px;
-            height: 300px;
+            height: 250px;
         }
     </style>
     <script src="../../../resources/ui-helper.js"></script>
@@ -21,20 +21,20 @@
             if (!window.internals)
                 return;
 
+            let testOutput = "Before installing PDF:\n" + internals.scrollingStateTreeAsText() + "\n";
+
             const pdf = document.getElementById("pdf");
-
-            document.getElementById('scrollingtree').textContent = "Before installing PDF:\n" + internals.scrollingStateTreeAsText() + "\n";
-
             pdf.src = "../../../fast/images/resources/green_rectangle.pdf";
 
-            shouldBecomeEqual("internals.numberOfScrollableAreas()", "1", function () {
-                document.getElementById('scrollingtree').textContent += "After installing PDF:\n" + internals.scrollingStateTreeAsText() + "\n";
+            shouldBecomeEqual("internals.numberOfScrollableAreas()", "1", () => {
+                testOutput += "After installing PDF:\n" + internals.scrollingStateTreeAsText() + "\n";
 
                 pdf.parentElement.removeChild(pdf);
 
-                shouldBecomeEqual("internals.numberOfScrollableAreas()", "0", function () {
+                shouldBecomeEqual("internals.numberOfScrollableAreas()", "0", () => {
 
-                    document.getElementById('scrollingtree').textContent += "After removing PDF:\n" + internals.scrollingStateTreeAsText() + "\n";
+                    testOutput += "After removing PDF:\n" + internals.scrollingStateTreeAsText() + "\n";
+                    document.getElementById('scrollingtree').textContent = testOutput
 
                     finishJSTest();
                 });

--- a/LayoutTests/compositing/plugins/pdf/pdf-scrolling-tree-expected.txt
+++ b/LayoutTests/compositing/plugins/pdf/pdf-scrolling-tree-expected.txt
@@ -12,7 +12,7 @@
   (min layout viewport origin (0,0))
   (max layout viewport origin (0,0))
   (synchronous event dispatch region for event wheel
-    at (8,8) size 300x300)
+    at (8,8) size 300x250)
   (behavior for fixed 1)
 )
 

--- a/LayoutTests/compositing/plugins/pdf/pdf-scrolling-tree.html
+++ b/LayoutTests/compositing/plugins/pdf/pdf-scrolling-tree.html
@@ -4,7 +4,7 @@
     <style>
         embed {
             width: 300px;
-            height: 300px;
+            height: 250px;
         }
     </style>
     <script src="../../../resources/ui-helper.js"></script>

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -211,13 +211,20 @@ protected:
     WebCore::IntSize visibleSize() const final { return m_size; }
     float deviceScaleFactor() const override;
     bool shouldSuspendScrollAnimations() const final { return false; } // If we return true, ScrollAnimatorMac will keep cycling a timer forever, waiting for a good time to animate.
-    void scrollbarStyleChanged(WebCore::ScrollbarStyle, bool forceUpdate) final;
+    void scrollbarStyleChanged(WebCore::ScrollbarStyle, bool forceUpdate) override;
+
     WebCore::IntRect convertFromScrollbarToContainingView(const WebCore::Scrollbar&, const WebCore::IntRect& scrollbarRect) const final;
     WebCore::IntRect convertFromContainingViewToScrollbar(const WebCore::Scrollbar&, const WebCore::IntRect& parentRect) const final;
     WebCore::IntPoint convertFromScrollbarToContainingView(const WebCore::Scrollbar&, const WebCore::IntPoint& scrollbarPoint) const final;
     WebCore::IntPoint convertFromContainingViewToScrollbar(const WebCore::Scrollbar&, const WebCore::IntPoint& parentPoint) const final;
+
     bool forceUpdateScrollbarsOnMainThreadForPerformanceTesting() const final;
     bool shouldPlaceVerticalScrollbarOnLeft() const final { return false; }
+
+    WebCore::IntRect viewRelativeVerticalScrollbarRect() const;
+    WebCore::IntRect viewRelativeHorizontalScrollbarRect() const;
+    WebCore::IntRect viewRelativeScrollCornerRect() const;
+
     String debugDescription() const final;
 
     // Scrolling, but not ScrollableArea:

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -440,6 +440,46 @@ void PDFPluginBase::willDetachRenderer()
         frameView->removeScrollableArea(this);
 }
 
+IntRect PDFPluginBase::viewRelativeVerticalScrollbarRect() const
+{
+    if (!m_verticalScrollbar)
+        return { };
+
+    auto scrollbarRect = IntRect({ }, size());
+    scrollbarRect.shiftXEdgeTo(scrollbarRect.maxX() - m_verticalScrollbar->width());
+
+    if (m_horizontalScrollbar)
+        scrollbarRect.contract(0, m_horizontalScrollbar->width());
+
+    return scrollbarRect;
+}
+
+IntRect PDFPluginBase::viewRelativeHorizontalScrollbarRect() const
+{
+    if (!m_horizontalScrollbar)
+        return { };
+
+    auto scrollbarRect = IntRect({ }, size());
+    scrollbarRect.shiftYEdgeTo(scrollbarRect.maxY() - m_horizontalScrollbar->height());
+
+    if (m_verticalScrollbar)
+        scrollbarRect.contract(m_verticalScrollbar->width(), 0);
+
+    return scrollbarRect;
+}
+
+IntRect PDFPluginBase::viewRelativeScrollCornerRect() const
+{
+    IntSize scrollbarSpace = scrollbarIntrusion();
+    if (scrollbarSpace.isEmpty())
+        return { };
+
+    auto cornerRect = IntRect({ }, size());
+    cornerRect.shiftXEdgeTo(cornerRect.maxX() - scrollbarSpace.width());
+    cornerRect.shiftYEdgeTo(cornerRect.maxY() - scrollbarSpace.height());
+    return cornerRect;
+}
+
 void PDFPluginBase::updateScrollbars()
 {
     if (m_hasBeenDestroyed)
@@ -460,24 +500,22 @@ void PDFPluginBase::updateScrollbars()
     } else if (m_size.height() < pdfDocumentSize.height())
         m_verticalScrollbar = createScrollbar(ScrollbarOrientation::Vertical);
 
-    IntSize scrollbarSpace = scrollbarIntrusion();
-
     if (m_horizontalScrollbar) {
-        m_horizontalScrollbar->setSteps(Scrollbar::pixelsPerLineStep(), firstPageHeight());
-        m_horizontalScrollbar->setProportion(m_size.width() - scrollbarSpace.width(), pdfDocumentSize.width());
-        IntRect scrollbarRect(m_view->x(), m_view->y() + m_size.height() - m_horizontalScrollbar->height(), m_size.width(), m_horizontalScrollbar->height());
-        if (m_verticalScrollbar)
-            scrollbarRect.contract(m_verticalScrollbar->width(), 0);
+        auto scrollbarRect = viewRelativeHorizontalScrollbarRect();
+        scrollbarRect.moveBy(m_view->location());
         m_horizontalScrollbar->setFrameRect(scrollbarRect);
+
+        m_horizontalScrollbar->setSteps(Scrollbar::pixelsPerLineStep(), firstPageHeight());
+        m_horizontalScrollbar->setProportion(scrollbarRect.width(), pdfDocumentSize.width());
     }
 
     if (m_verticalScrollbar) {
-        m_verticalScrollbar->setSteps(Scrollbar::pixelsPerLineStep(), firstPageHeight());
-        m_verticalScrollbar->setProportion(m_size.height() - scrollbarSpace.height(), pdfDocumentSize.height());
-        IntRect scrollbarRect(IntRect(m_view->x() + m_size.width() - m_verticalScrollbar->width(), m_view->y(), m_verticalScrollbar->width(), m_size.height()));
-        if (m_horizontalScrollbar)
-            scrollbarRect.contract(0, m_horizontalScrollbar->height());
+        auto scrollbarRect = viewRelativeVerticalScrollbarRect();
+        scrollbarRect.moveBy(m_view->location());
         m_verticalScrollbar->setFrameRect(scrollbarRect);
+
+        m_verticalScrollbar->setSteps(Scrollbar::pixelsPerLineStep(), firstPageHeight());
+        m_verticalScrollbar->setProportion(scrollbarRect.height(), pdfDocumentSize.height());
     }
 
     RefPtr frameView = m_frame ? m_frame->coreLocalFrame()->view() : nullptr;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -32,6 +32,10 @@
 #include <WebCore/GraphicsLayer.h>
 #include <wtf/OptionSet.h>
 
+namespace WebCore {
+enum class DelegatedScrollingMode : uint8_t;
+}
+
 namespace WebKit {
 
 struct PDFContextMenu;
@@ -100,6 +104,13 @@ private:
     void scheduleRenderingUpdate();
 
     void updateLayout();
+
+    WebCore::IntRect availableContentsRect() const;
+
+    WebCore::DelegatedScrollingMode scrollingMode() const;
+
+    void scrollbarStyleChanged(WebCore::ScrollbarStyle, bool forceUpdate) override;
+    void updateScrollbars() override;
     void geometryDidChange(const WebCore::IntSize&, const WebCore::AffineTransform&) override;
 
     RefPtr<WebCore::FragmentedSharedBuffer> liveResourceData() const override;
@@ -171,6 +182,7 @@ private:
     float deviceScaleFactor() const override;
     float pageScaleFactor() const override;
 
+    void ensureLayers();
     void updateLayerHierarchy();
 
     void didChangeScrollOffset() override;
@@ -183,7 +195,16 @@ private:
 
     void invalidateScrollbarRect(WebCore::Scrollbar&, const WebCore::IntRect&) override;
     void invalidateScrollCornerRect(const WebCore::IntRect&) override;
+
+    WebCore::GraphicsLayer* layerForHorizontalScrollbar() const override;
+    WebCore::GraphicsLayer* layerForVerticalScrollbar() const override;
+    WebCore::GraphicsLayer* layerForScrollCorner() const override;
+
     void updateScrollingExtents();
+
+    bool updateOverflowControlsLayers(bool needsHorizontalScrollbarLayer, bool needsVerticalScrollbarLayer, bool needsScrollCornerLayer);
+    void positionOverflowControlsLayers();
+
     WebCore::ScrollingCoordinator* scrollingCoordinator();
 
     // ScrollableArea
@@ -211,6 +232,11 @@ private:
     RefPtr<WebCore::GraphicsLayer> m_scrollContainerLayer;
     RefPtr<WebCore::GraphicsLayer> m_scrolledContentsLayer;
     RefPtr<WebCore::GraphicsLayer> m_contentsLayer;
+
+    RefPtr<WebCore::GraphicsLayer> m_overflowControlsContainer;
+    RefPtr<WebCore::GraphicsLayer> m_layerForHorizontalScrollbar;
+    RefPtr<WebCore::GraphicsLayer> m_layerForVerticalScrollbar;
+    RefPtr<WebCore::GraphicsLayer> m_layerForScrollCorner;
 
     WebCore::ScrollingNodeID m_scrollingNodeID { 0 };
 

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -477,12 +477,7 @@ Scrollbar* PluginView::horizontalScrollbar()
     if (!m_isInitialized)
         return nullptr;
 
-#if ENABLE(LEGACY_PDFKIT_PLUGIN)
-    if (is<PDFPlugin>(m_plugin))
-        return downcast<PDFPlugin>(m_plugin)->horizontalScrollbar();
-#endif
-
-    return nullptr;
+    return m_plugin->horizontalScrollbar();
 }
 
 Scrollbar* PluginView::verticalScrollbar()
@@ -490,12 +485,7 @@ Scrollbar* PluginView::verticalScrollbar()
     if (!m_isInitialized)
         return nullptr;
 
-#if ENABLE(LEGACY_PDFKIT_PLUGIN)
-    if (is<PDFPlugin>(m_plugin))
-        return downcast<PDFPlugin>(m_plugin)->verticalScrollbar();
-#endif
-
-    return nullptr;
+    return m_plugin->verticalScrollbar();
 }
 
 bool PluginView::wantsWheelEvents()


### PR DESCRIPTION
#### 55195d817a86c40943811d2e3dd5d3b7ca10c76c
<pre>
[UnifiedPDF] Scrollbars don&apos;t show
<a href="https://bugs.webkit.org/show_bug.cgi?id=266644">https://bugs.webkit.org/show_bug.cgi?id=266644</a>
<a href="https://rdar.apple.com/119848161">rdar://119848161</a>

Reviewed by Tim Horton.

Fix the UnifiedPDFPlugin to display scrollbars. This involves:

1. Making layers for scrollbars, via `layerForVerticalScrollbar()` and friends.
   Implement `viewRelativeVerticalScrollbarRect()` etc in the base class to share
   code related to scrollbar geometry. In the non-UI-side compositing configuration,
   those scrollbar layers are painted into via `UnifiedPDFPlugin::paintContents()`.

2. Make a m_overflowControlsContainer layer to host the overflow controls layers,
   which makes it easier to ensure that scrollbars are always above the content.

3. `UnifiedPDFPlugin::updateLayout()` takes scrollbars into account when
   doing layout, potentially doing two passes when they change as a result of layout.

4. Respond to changes between overlay and legacy scrollbars. This is handled
   by `UnifiedPDFPlugin::scrollbarStyleChanged()` which just updates layout,
   since scrollbars an affect the available space for the PDF content.

* LayoutTests/compositing/plugins/pdf/pdf-in-embed-expected.txt:
* LayoutTests/compositing/plugins/pdf/pdf-scrolling-tree-dynamic-expected.txt:
* LayoutTests/compositing/plugins/pdf/pdf-scrolling-tree-dynamic.html: The embed has to be small enough to trigger scrolling.
* LayoutTests/compositing/plugins/pdf/pdf-scrolling-tree-expected.txt:
* LayoutTests/compositing/plugins/pdf/pdf-scrolling-tree.html: The embed has to be small enough to trigger scrolling.
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::viewRelativeVerticalScrollbarRect const):
(WebKit::PDFPluginBase::viewRelativeHorizontalScrollbarRect const):
(WebKit::PDFPluginBase::viewRelativeScrollCornerRect const):
(WebKit::PDFPluginBase::updateScrollbars):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::ensureLayers):
(WebKit::UnifiedPDFPlugin::updateLayerHierarchy):
(WebKit::UnifiedPDFPlugin::didChangeSettings):
(WebKit::UnifiedPDFPlugin::paintContents):
(WebKit::UnifiedPDFPlugin::availableContentsRect const):
(WebKit::UnifiedPDFPlugin::updateLayout):
(WebKit::UnifiedPDFPlugin::updateOverflowControlsLayers):
(WebKit::UnifiedPDFPlugin::positionOverflowControlsLayers):
(WebKit::UnifiedPDFPlugin::invalidateScrollbarRect):
(WebKit::UnifiedPDFPlugin::invalidateScrollCornerRect):
(WebKit::UnifiedPDFPlugin::layerForHorizontalScrollbar const):
(WebKit::UnifiedPDFPlugin::layerForVerticalScrollbar const):
(WebKit::UnifiedPDFPlugin::layerForScrollCorner const):
(WebKit::UnifiedPDFPlugin::scrollingMode const):
(WebKit::UnifiedPDFPlugin::scrollbarStyleChanged):
(WebKit::UnifiedPDFPlugin::updateScrollbars):
(WebKit::UnifiedPDFPlugin::updateScrollingExtents):
* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::horizontalScrollbar):
(WebKit::PluginView::verticalScrollbar):

Canonical link: <a href="https://commits.webkit.org/272350@main">https://commits.webkit.org/272350@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b591787f69c84a9fa7dff50201f8d80bd0d90e4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31353 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10022 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33046 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33847 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28420 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12366 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7272 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28056 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31689 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8437 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27991 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7255 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7415 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27895 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35188 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28501 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28345 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33551 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7489 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5518 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31390 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9153 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/27698 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7370 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8182 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8001 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->