### PR TITLE
[web-animations] refactor animation code related to size-dependent transforms

### DIFF
--- a/Source/WebCore/animation/BlendingKeyframes.h
+++ b/Source/WebCore/animation/BlendingKeyframes.h
@@ -94,7 +94,7 @@ public:
     bool operator==(const BlendingKeyframes&) const;
 
     const AtomString& animationName() const { return m_animationName; }
-    
+
     void insert(BlendingKeyframe&&);
 
     void addProperty(const AnimatableCSSProperty&);
@@ -125,14 +125,21 @@ public:
 
     void updatePropertiesMetadata(const StyleProperties&);
 
+    bool hasWidthDependentTransform() const { return m_hasWidthDependentTransform; }
+    bool hasHeightDependentTransform() const { return m_hasHeightDependentTransform; }
+
 private:
+    void analyzeKeyframe(const BlendingKeyframe&);
+
     AtomString m_animationName;
     Vector<BlendingKeyframe> m_keyframes; // Kept sorted by key.
     HashSet<AnimatableCSSProperty> m_properties; // The properties being animated.
-    bool m_usesRelativeFontWeight { false };
-    bool m_containsCSSVariableReferences { false };
     HashSet<AnimatableCSSProperty> m_propertiesSetToInherit;
     HashSet<AnimatableCSSProperty> m_propertiesSetToCurrentColor;
+    bool m_usesRelativeFontWeight { false };
+    bool m_containsCSSVariableReferences { false };
+    bool m_hasWidthDependentTransform { false };
+    bool m_hasHeightDependentTransform { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -1115,28 +1115,11 @@ void KeyframeEffect::computeCSSTransitionBlendingKeyframes(const RenderStyle& ol
 
 void KeyframeEffect::computedNeedsForcedLayout()
 {
-    m_needsForcedLayout = false;
-    if (is<CSSTransition>(animation()) || !m_blendingKeyframes.containsProperty(CSSPropertyTransform))
-        return;
-
-    for (auto& keyframe : m_blendingKeyframes) {
-        auto* keyframeStyle = keyframe.style();
-        if (!keyframeStyle) {
-            ASSERT_NOT_REACHED();
-            continue;
-        }
-        if (keyframeStyle->hasTransform()) {
-            auto& transformOperations = keyframeStyle->transform();
-            for (const auto& operation : transformOperations.operations()) {
-                if (auto* translation = dynamicDowncast<TranslateTransformOperation>(operation.get())) {
-                    if (translation->x().isPercent() || translation->y().isPercent()) {
-                        m_needsForcedLayout = true;
-                        return;
-                    }
-                }
-            }
-        }
-    }
+    m_needsForcedLayout = [&]() {
+        if (is<CSSTransition>(animation()))
+            return false;
+        return m_blendingKeyframes.hasWidthDependentTransform() || m_blendingKeyframes.hasHeightDependentTransform();
+    }();
 }
 
 void KeyframeEffect::computeStackingContextImpact()
@@ -1969,8 +1952,8 @@ void KeyframeEffect::applyPendingAcceleratedActions()
         auto* effectStack = m_target->keyframeEffectStack(m_pseudoId);
         ASSERT(effectStack);
 
-        if ((m_hasWidthDependentTransform && effectStack->containsProperty(CSSPropertyWidth))
-            || (m_hasHeightDependentTransform && effectStack->containsProperty(CSSPropertyHeight)))
+        if ((m_blendingKeyframes.hasWidthDependentTransform() && effectStack->containsProperty(CSSPropertyWidth))
+            || (m_blendingKeyframes.hasHeightDependentTransform() && effectStack->containsProperty(CSSPropertyHeight)))
             return RunningAccelerated::Prevented;
 
         if (!effectStack->allowsAcceleration())
@@ -2557,46 +2540,8 @@ void KeyframeEffect::computeHasReferenceFilter()
 
 void KeyframeEffect::computeHasSizeDependentTransform()
 {
-    m_hasWidthDependentTransform = false;
-    m_hasHeightDependentTransform = false;
-    m_animatesSizeAndSizeDependentTransform = false;
-
-    if (m_blendingKeyframes.isEmpty())
-        return;
-
-    auto animatesTransform = m_blendingKeyframes.containsProperty(CSSPropertyTransform);
-    auto animatesTranslate = m_blendingKeyframes.containsProperty(CSSPropertyTranslate);
-
-    if (!animatesTransform && !animatesTranslate)
-        return;
-
-    for (auto& keyframe : m_blendingKeyframes) {
-        if (auto* style = keyframe.style()) {
-            if (animatesTranslate) {
-                if (auto* translate = style->translate()) {
-                    if (translate->x().isPercent())
-                        m_hasWidthDependentTransform = true;
-                    if (translate->y().isPercent())
-                        m_hasHeightDependentTransform = true;
-                }
-            }
-            if (animatesTransform) {
-                for (auto& operation : style->transform().operations()) {
-                    if (auto* translate = dynamicDowncast<TranslateTransformOperation>(operation.get())) {
-                        if (translate->x().isPercent())
-                            m_hasWidthDependentTransform = true;
-                        if (translate->y().isPercent())
-                            m_hasHeightDependentTransform = true;
-                    }
-                }
-            }
-        }
-        if (m_hasWidthDependentTransform && m_hasHeightDependentTransform)
-            break;
-    }
-
-    m_animatesSizeAndSizeDependentTransform = (m_hasWidthDependentTransform && m_blendingKeyframes.containsProperty(CSSPropertyWidth))
-        || (m_hasHeightDependentTransform && m_blendingKeyframes.containsProperty(CSSPropertyHeight));
+    m_animatesSizeAndSizeDependentTransform = (m_blendingKeyframes.hasWidthDependentTransform() && m_blendingKeyframes.containsProperty(CSSPropertyWidth))
+        || (m_blendingKeyframes.hasHeightDependentTransform() && m_blendingKeyframes.containsProperty(CSSPropertyHeight));
 }
 
 void KeyframeEffect::effectStackNoLongerPreventsAcceleration()

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -303,8 +303,6 @@ private:
     bool m_hasExplicitlyInheritedKeyframeProperty { false };
     bool m_hasAcceleratedPropertyOverriddenByCascadeProperty { false };
     bool m_hasReferenceFilter { false };
-    bool m_hasWidthDependentTransform { false };
-    bool m_hasHeightDependentTransform { false };
     bool m_animatesSizeAndSizeDependentTransform { false };
 };
 


### PR DESCRIPTION
#### 89f7f09d29636e18884c6d74eb2790a0c3db2325
<pre>
[web-animations] refactor animation code related to size-dependent transforms
<a href="https://bugs.webkit.org/show_bug.cgi?id=266643">https://bugs.webkit.org/show_bug.cgi?id=266643</a>
<a href="https://rdar.apple.com/119876112">rdar://119876112</a>

Reviewed by Simon Fraser.

We have recently (272022@main) started accounting for whether a keyframe effect is targeting
a transform-related property that is size-dependent. We already had some code that relied
on a similar analysis to determine whether applying a keyframe effect required a forced layout
prior to initiating an accelerated animation.

We move the bits tracking that information from `KeyframeEffect` to `BlendingKeyframes`, which
really is the best place to analyze keyframe data, and use the same bits to determine both
cases described above.

We will add more code to `BlendingKeyframes::analyzeKeyframe()` in the future, removing more code
from `KeyframeEffect` and making the various keyframe iterations we do under `KeyframeEffect::setBlendingKeyframes()`
more efficient.

Finally, note that the code under `KeyframeEffect::computedNeedsForcedLayout()` did not account for
the `translate` property while the code under `KeyframeEffect::computeHasSizeDependentTransform`
did. The logic from the latter is now being used in both cases, meaning we also account for `translate`
to determine whether a forced layout is required. This is the only behavioral change.

* Source/WebCore/animation/BlendingKeyframes.cpp:
(WebCore::BlendingKeyframes::insert):
(WebCore::BlendingKeyframes::analyzeKeyframe):
* Source/WebCore/animation/BlendingKeyframes.h:
(WebCore::BlendingKeyframes::BlendingKeyframes):
(WebCore::BlendingKeyframes::hasWidthDependentTransform const):
(WebCore::BlendingKeyframes::hasHeightDependentTransform const):
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::computedNeedsForcedLayout):
(WebCore::KeyframeEffect::applyPendingAcceleratedActions):
(WebCore::KeyframeEffect::computeHasSizeDependentTransform):
* Source/WebCore/animation/KeyframeEffect.h:

Canonical link: <a href="https://commits.webkit.org/272325@main">https://commits.webkit.org/272325@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa652c6836de606985449f0e07642ba8468cead1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31258 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9929 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32952 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33761 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28356 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32025 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12274 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7184 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28010 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31594 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8372 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27930 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7187 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7363 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27826 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35103 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28439 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28283 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33490 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7413 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5460 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31327 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9089 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8112 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4079 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7936 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->