### PR TITLE
[build.webkit.org] Improve support for required changes for uat/dev instance - part 2

### DIFF
--- a/Tools/CISupport/Shared/transfer-archive-to-s3
+++ b/Tools/CISupport/Shared/transfer-archive-to-s3
@@ -2,27 +2,35 @@
 import argparse
 import boto3
 import os
+import socket
 import sys
 
-S3_DEFAULT_BUCKET = 'archives.webkit.org'
-S3_EWS_BUCKET = 'ews-archives.webkit.org'
-S3_MINIFIED_BUCKET = 'minified-archives.webkit.org'
-S3_REGION_PREFIX = 'https://s3-us-west-2.amazonaws.com'
+custom_suffix = ''
+hostname = socket.gethostname().strip()
+if 'dev' in hostname:
+    custom_suffix = '-dev'
+if 'uat' in hostname:
+    custom_suffix = '-uat'
+
+S3_DEFAULT_BUCKET = f'archives{custom_suffix}.webkit.org'
+S3_EWS_BUCKET = f'ews-archives{custom_suffix}.webkit.org'
+S3_MINIFIED_BUCKET = f'minified-archives{custom_suffix}.webkit.org'
+S3_REGION_PREFIX = f'https://s3-us-west-2.amazonaws.com'
 
 def uploadToS3(archive_path, bucket, identifier, revision):
-    print('Transferring {} to S3...'.format(archive_path))
+    print(f'Transferring {archive_path} to S3...')
     key = '/'.join([identifier, revision + '.zip'])
-    print('\tS3 Bucket: {}\n\tS3 Key: {}'.format(bucket, key))
+    print(f'\tS3 Bucket: {bucket}\n\tS3 Key: {key}')
     s3 = boto3.client('s3')
     s3.upload_file(archive_path, bucket, key)
-    print('\tS3 URL: {}/{}/{}'.format(S3_REGION_PREFIX, bucket, key))
+    print(f'\tS3 URL: {S3_REGION_PREFIX}/{bucket}/{key}')
 
 def archiveExists(archive):
     if archive:
         if os.path.exists(archive):
             return True
         else:
-            print('WARNING: Archive does not exist: {}'.format(archive))
+            print(f'WARNING: Archive does not exist: {archive}')
             return False
 
 def main():


### PR DESCRIPTION
#### 0f607be029bf0deefdc9f4e4edc27b9aa2a5ddd6
<pre>
[build.webkit.org] Improve support for required changes for uat/dev instance - part 2
<a href="https://bugs.webkit.org/show_bug.cgi?id=266654">https://bugs.webkit.org/show_bug.cgi?id=266654</a>

Reviewed by Ryan Haddad.

Auto-detect the uat/dev instance and make changes accordingly.
Also change print statements to use f-strings.

* Tools/CISupport/Shared/transfer-archive-to-s3:
(uploadToS3):
(archiveExists):

Canonical link: <a href="https://commits.webkit.org/272290@main">https://commits.webkit.org/272290@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b9dd6996dce9b6b4b20d862ee06863beb2629b88

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31260 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/9931 "Build was cancelled. Recent messages:OS: Sonoma (14.0), Xcode: 15.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/32954 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33763 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/28358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32027 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12276 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7186 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/28009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31596 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/8373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/32954 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7186 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/7364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/32954 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35105 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/28440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/32954 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/33494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/7415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/5462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/31331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/31067 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/9091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/32954 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/8114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4061 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/7938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->