### PR TITLE
Use-after-free in FullscreenManager::requestFullscreenForElement

### DIFF
--- a/LayoutTests/fullscreen/fullscreen-cancel-after-request-crash-expected.txt
+++ b/LayoutTests/fullscreen/fullscreen-cancel-after-request-crash-expected.txt
@@ -1,0 +1,4 @@
+This test passes if it does not crash.
+
+END OF TEST
+

--- a/LayoutTests/fullscreen/fullscreen-cancel-after-request-crash.html
+++ b/LayoutTests/fullscreen/fullscreen-cancel-after-request-crash.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="full-screen-test.js"></script>    
+</head>
+<body>
+<p>This test passes if it does not crash.</p>
+<script>
+(() => {
+    const iframe = document.body.appendChild(document.createElement('iframe'));
+    const div = iframe.contentDocument.body.appendChild(document.createElement('div'));
+    runWithKeyDown(() => {
+        div.requestFullscreen().catch((error) => {
+            endTest();
+        });
+        const contentDocument = iframe.contentDocument;
+        document.body.removeChild(iframe);
+        setTimeout(() => {
+            contentDocument.webkitCancelFullScreen();
+            GCController.collect();
+        }, 0);
+    });
+})();
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/FullscreenManager.cpp
+++ b/Source/WebCore/dom/FullscreenManager.cpp
@@ -92,10 +92,11 @@ void FullscreenManager::requestFullscreenForElement(Ref<Element>&& element, RefP
     auto failedPreflights = [this, weakThis = WeakPtr { *this }](Ref<Element>&& element, RefPtr<DeferredPromise>&& promise) mutable {
         if (!weakThis)
             return;
+        Ref document { protectedDocument() };
         m_fullscreenErrorEventTargetQueue.append(WTFMove(element));
         if (promise)
             promise->reject(Exception { ExceptionCode::TypeError });
-        protectedDocument()->eventLoop().queueTask(TaskSource::MediaElement, [weakThis = WTFMove(weakThis)]() mutable {
+        document->eventLoop().queueTask(TaskSource::MediaElement, [weakThis = WTFMove(weakThis)]() mutable {
             if (weakThis)
                 weakThis->notifyAboutFullscreenChangeOrError();
         });


### PR DESCRIPTION
#### 633fbf1eab41bddec1989aadbb319a65200f6633
<pre>
Use-after-free in FullscreenManager::requestFullscreenForElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=263140">https://bugs.webkit.org/show_bug.cgi?id=263140</a>
<a href="https://rdar.apple.com/116736343">rdar://116736343</a>

Reviewed by Chris Dumez.

Calling DeferredPromise::reject from the failedPreflights lambda in
FullscreenManager::requestFullscreenForElement may cause the Document that owns the
FullscreenManager to be deallocated, resulting in a use-after-free when the document is accessed
again after rejecting the promise. Resolved this by keeping a Ref to m_document for the lifetime of
the failedPreflights lambda.

Added a layout test.

* LayoutTests/fullscreen/fullscreen-cancel-after-request-crash-expected.txt: Added.
* LayoutTests/fullscreen/fullscreen-cancel-after-request-crash.html: Added.
* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::requestFullscreenForElement):

Originally-landed-as: 267815.332@safari-7617-branch (dc44d44d42fd). <a href="https://rdar.apple.com/119594954">rdar://119594954</a>
Canonical link: <a href="https://commits.webkit.org/272320@main">https://commits.webkit.org/272320@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d58478b6e6f39b18f0d035d69944b34585a10b9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31262 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9933 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32956 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33765 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28360 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32029 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12278 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7188 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28011 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31598 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8375 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27927 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7188 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7366 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27823 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35107 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28442 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28280 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33497 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7417 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5465 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31346 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9093 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/27618 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7355 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8116 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7941 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->