### PR TITLE
[IFC] Demote partial invalidation to full damage when computed damage extent is inconsistent

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6375,6 +6375,7 @@ fast/text/text-box-edge-no-half-leading-simple.html [ Skip ]
 fast/text/text-box-edge-no-half-leading-with-line-height-simple.html [ Skip ]
 
 webkit.org/b/249010 [ Debug ] fast/text/line-clamp-truncation-assert.html [ Skip ]
+webkit.org/b/263205 [ Debug ] fast/text/zero-height-first-line-assert.html [ Skip ]
 
 webkit.org/b/245905 imported/w3c/web-platform-tests/css/css-text/line-breaking/line-breaking-019.html [ ImageOnlyFailure ]
 

--- a/LayoutTests/fast/text/zero-height-first-line-assert-expected.txt
+++ b/LayoutTests/fast/text/zero-height-first-line-assert-expected.txt
@@ -1,0 +1,1 @@
+ Pass if no crash or assert 

--- a/LayoutTests/fast/text/zero-height-first-line-assert.html
+++ b/LayoutTests/fast/text/zero-height-first-line-assert.html
@@ -1,0 +1,16 @@
+<style>
+.child::first-line {
+  font-size-adjust: 0;
+}
+.child {
+  overflow-wrap: anywhere;
+  text-indent: 10000px;
+}
+</style><div><div class=child>X</div><div>Y</div></div><script>
+if (window.testRunner)
+  testRunner.dumpAsText();
+document.body.offsetHeight;
+document.designMode = "on";
+document.execCommand("selectAll",false, null);
+document.execCommand("insertHTML",false, " Pass if no crash or assert ");
+</script>

--- a/Source/WebCore/layout/formattingContexts/inline/invalidation/InlineInvalidation.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/invalidation/InlineInvalidation.cpp
@@ -318,6 +318,19 @@ void InlineInvalidation::updateInlineDamage(InlineDamage::Type type, std::option
 {
     if (type == InlineDamage::Type::Invalid || !damagedLine)
         return m_inlineDamage.reset();
+    auto isValidDamage = [&] {
+        // Check for consistency.
+        if (!damagedLine->leadingInlineItemPosition) {
+            // We have to start at the first line if damage points to the leading inline item.
+            return !damagedLine->index;
+        }
+        return true;
+    };
+    if (!isValidDamage()) {
+        ASSERT_NOT_REACHED();
+        m_inlineDamage.reset();
+        return;
+    }
 
     m_inlineDamage.setDamageType(type);
     m_inlineDamage.setDamageReason(*reason);

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentBuilder.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentBuilder.cpp
@@ -87,6 +87,11 @@ FloatRect InlineContentBuilder::build(Layout::InlineLayoutResult&& layoutResult,
                 ASSERT_NOT_REACHED();
                 return { };
             }
+            if (layoutResult.displayContent.boxes.size() && canidateLineIndex > layoutResult.displayContent.boxes[0].lineIndex()) {
+                // We should never generate lines _before_ the damaged line.
+                ASSERT_NOT_REACHED();
+                return { };
+            }
             return { canidateLineIndex };
         }();
 


### PR DESCRIPTION
#### ca41cc3271e4306589b9bc21822a5ce0f1404d8b
<pre>
[IFC] Demote partial invalidation to full damage when computed damage extent is inconsistent
<a href="https://bugs.webkit.org/show_bug.cgi?id=263222">https://bugs.webkit.org/show_bug.cgi?id=263222</a>
&lt;<a href="https://rdar.apple.com/117017324">rdar://117017324</a>&gt;

Reviewed by Antti Koivisto.

Fall back to full layout when we computed inconsistent damage extent.
(It could happen when previous layouts produced corrupt line content e.g. line with no boxes other than the root inline box).

* LayoutTests/fast/text/zero-height-first-line-assert-expected.txt: Added.
* LayoutTests/fast/text/zero-height-first-line-assert.html: Added.
* Source/WebCore/layout/formattingContexts/inline/invalidation/InlineInvalidation.cpp:
(WebCore::Layout::leadingContentDisplayForLineIndex):
(WebCore::Layout::InlineInvalidation::updateInlineDamage):
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentBuilder.cpp:
(WebCore::LayoutIntegration::InlineContentBuilder::build const):

Originally-landed-as: 267815.333@safari-7617-branch (c1a2b21f2532). <a href="https://rdar.apple.com/119594845">rdar://119594845</a>
Canonical link: <a href="https://commits.webkit.org/272347@main">https://commits.webkit.org/272347@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f833b40d58cb76a5b313fd6c97bd2c1768cb9679

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31270 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9941 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32964 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33773 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28366 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32037 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12345 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7196 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28014 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31606 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8423 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27931 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7192 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7411 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27827 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35115 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28487 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28284 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33500 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7423 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5470 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31337 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9099 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/27622 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7367 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8122 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7947 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->