### PR TITLE
Generalize RenderElementType as TypeFlag and make it const

### DIFF
--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -304,14 +304,14 @@ private:
     bool m_hadVerticalLayoutOverflow;
 };
 
-RenderBlock::RenderBlock(Type type, Element& element, RenderStyle&& style, OptionSet<RenderElementType> baseTypeFlags)
-    : RenderBox(type, element, WTFMove(style), baseTypeFlags | RenderElementType::RenderBlockFlag)
+RenderBlock::RenderBlock(Type type, Element& element, RenderStyle&& style, OptionSet<TypeFlag> baseTypeFlags)
+    : RenderBox(type, element, WTFMove(style), baseTypeFlags | TypeFlag::IsRenderBlock)
 {
     ASSERT(isRenderBlock());
 }
 
-RenderBlock::RenderBlock(Type type, Document& document, RenderStyle&& style, OptionSet<RenderElementType> baseTypeFlags)
-    : RenderBox(type, document, WTFMove(style), baseTypeFlags | RenderElementType::RenderBlockFlag)
+RenderBlock::RenderBlock(Type type, Document& document, RenderStyle&& style, OptionSet<TypeFlag> baseTypeFlags)
+    : RenderBox(type, document, WTFMove(style), baseTypeFlags | TypeFlag::IsRenderBlock)
 {
     ASSERT(isRenderBlock());
 }

--- a/Source/WebCore/rendering/RenderBlock.h
+++ b/Source/WebCore/rendering/RenderBlock.h
@@ -59,8 +59,8 @@ public:
     virtual ~RenderBlock();
 
 protected:
-    RenderBlock(Type, Element&, RenderStyle&&, OptionSet<RenderElementType>);
-    RenderBlock(Type, Document&, RenderStyle&&, OptionSet<RenderElementType>);
+    RenderBlock(Type, Element&, RenderStyle&&, OptionSet<TypeFlag>);
+    RenderBlock(Type, Document&, RenderStyle&&, OptionSet<TypeFlag>);
 
 public:
     // These two functions are overridden for inline-block.

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -115,8 +115,8 @@ RenderBlockFlow::MarginInfo::MarginInfo(const RenderBlockFlow& block, LayoutUnit
     m_negativeMargin = m_canCollapseMarginBeforeWithChildren ? block.maxNegativeMarginBefore() : 0_lu;
 }
 
-RenderBlockFlow::RenderBlockFlow(Type type, Element& element, RenderStyle&& style, OptionSet<RenderElementType> baseTypeFlags)
-    : RenderBlock(type, element, WTFMove(style), baseTypeFlags | RenderElementType::RenderBlockFlowFlag)
+RenderBlockFlow::RenderBlockFlow(Type type, Element& element, RenderStyle&& style, OptionSet<TypeFlag> baseTypeFlags)
+    : RenderBlock(type, element, WTFMove(style), baseTypeFlags | TypeFlag::IsBlockFlow)
 #if ENABLE(TEXT_AUTOSIZING)
     , m_widthForTextAutosizing(-1)
     , m_lineCountForTextAutosizing(NOT_SET)
@@ -126,8 +126,8 @@ RenderBlockFlow::RenderBlockFlow(Type type, Element& element, RenderStyle&& styl
     setChildrenInline(true);
 }
 
-RenderBlockFlow::RenderBlockFlow(Type type, Document& document, RenderStyle&& style, OptionSet<RenderElementType> baseTypeFlags)
-    : RenderBlock(type, document, WTFMove(style), baseTypeFlags | RenderElementType::RenderBlockFlowFlag)
+RenderBlockFlow::RenderBlockFlow(Type type, Document& document, RenderStyle&& style, OptionSet<TypeFlag> baseTypeFlags)
+    : RenderBlock(type, document, WTFMove(style), baseTypeFlags | TypeFlag::IsBlockFlow)
 #if ENABLE(TEXT_AUTOSIZING)
     , m_widthForTextAutosizing(-1)
     , m_lineCountForTextAutosizing(NOT_SET)

--- a/Source/WebCore/rendering/RenderBlockFlow.h
+++ b/Source/WebCore/rendering/RenderBlockFlow.h
@@ -54,8 +54,8 @@ enum LineCount {
 class RenderBlockFlow : public RenderBlock {
     WTF_MAKE_ISO_ALLOCATED(RenderBlockFlow);
 public:
-    RenderBlockFlow(Type, Element&, RenderStyle&&, OptionSet<RenderElementType> = { });
-    RenderBlockFlow(Type, Document&, RenderStyle&&, OptionSet<RenderElementType> = { });
+    RenderBlockFlow(Type, Element&, RenderStyle&&, OptionSet<TypeFlag> = { });
+    RenderBlockFlow(Type, Document&, RenderStyle&&, OptionSet<TypeFlag> = { });
     virtual ~RenderBlockFlow();
         
     void layoutBlock(bool relayoutChildren, LayoutUnit pageLogicalHeight = 0_lu) override;

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -132,17 +132,15 @@ static const unsigned backgroundObscurationTestMaxDepth = 4;
 
 bool RenderBox::s_hadNonVisibleOverflow = false;
 
-RenderBox::RenderBox(Type type, Element& element, RenderStyle&& style, OptionSet<RenderElementType> baseTypeFlags)
-    : RenderBoxModelObject(type, element, WTFMove(style), baseTypeFlags)
+RenderBox::RenderBox(Type type, Element& element, RenderStyle&& style, OptionSet<TypeFlag> flags)
+    : RenderBoxModelObject(type, element, WTFMove(style), flags | TypeFlag::IsBox)
 {
-    setIsRenderBox();
     ASSERT(isRenderBox());
 }
 
-RenderBox::RenderBox(Type type, Document& document, RenderStyle&& style, OptionSet<RenderElementType> baseTypeFlags)
-    : RenderBoxModelObject(type, document, WTFMove(style), baseTypeFlags)
+RenderBox::RenderBox(Type type, Document& document, RenderStyle&& style, OptionSet<TypeFlag> flags)
+    : RenderBoxModelObject(type, document, WTFMove(style), flags | TypeFlag::IsBox)
 {
-    setIsRenderBox();
     ASSERT(isRenderBox());
 }
 

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -660,8 +660,8 @@ public:
     bool computeHasTransformRelatedProperty(const RenderStyle&) const;
 
 protected:
-    RenderBox(Type, Element&, RenderStyle&&, OptionSet<RenderElementType>);
-    RenderBox(Type, Document&, RenderStyle&&, OptionSet<RenderElementType>);
+    RenderBox(Type, Element&, RenderStyle&&, OptionSet<TypeFlag>);
+    RenderBox(Type, Document&, RenderStyle&&, OptionSet<TypeFlag>);
 
     void styleWillChange(StyleDifference, const RenderStyle& newStyle) override;
     void styleDidChange(StyleDifference, const RenderStyle* oldStyle) override;

--- a/Source/WebCore/rendering/RenderBoxModelObject.cpp
+++ b/Source/WebCore/rendering/RenderBoxModelObject.cpp
@@ -167,14 +167,14 @@ bool RenderBoxModelObject::hasAcceleratedCompositing() const
     return view().compositor().hasAcceleratedCompositing();
 }
 
-RenderBoxModelObject::RenderBoxModelObject(Type type, Element& element, RenderStyle&& style, OptionSet<RenderElementType> baseTypeFlags)
-    : RenderLayerModelObject(type, element, WTFMove(style), baseTypeFlags | RenderElementType::RenderBoxModelObjectFlag)
+RenderBoxModelObject::RenderBoxModelObject(Type type, Element& element, RenderStyle&& style, OptionSet<TypeFlag> baseTypeFlags)
+    : RenderLayerModelObject(type, element, WTFMove(style), baseTypeFlags | TypeFlag::IsBoxModelObject)
 {
     ASSERT(isRenderBoxModelObject());
 }
 
-RenderBoxModelObject::RenderBoxModelObject(Type type, Document& document, RenderStyle&& style, OptionSet<RenderElementType> baseTypeFlags)
-    : RenderLayerModelObject(type, document, WTFMove(style), baseTypeFlags | RenderElementType::RenderBoxModelObjectFlag)
+RenderBoxModelObject::RenderBoxModelObject(Type type, Document& document, RenderStyle&& style, OptionSet<TypeFlag> baseTypeFlags)
+    : RenderLayerModelObject(type, document, WTFMove(style), baseTypeFlags | TypeFlag::IsBoxModelObject)
 {
     ASSERT(isRenderBoxModelObject());
 }

--- a/Source/WebCore/rendering/RenderBoxModelObject.h
+++ b/Source/WebCore/rendering/RenderBoxModelObject.h
@@ -213,8 +213,8 @@ public:
     void applyTransform(TransformationMatrix&, const RenderStyle&, const FloatRect& boundingBox, OptionSet<RenderStyle::TransformOperationOption>) const override;
 
 protected:
-    RenderBoxModelObject(Type, Element&, RenderStyle&&, OptionSet<RenderElementType>);
-    RenderBoxModelObject(Type, Document&, RenderStyle&&, OptionSet<RenderElementType>);
+    RenderBoxModelObject(Type, Element&, RenderStyle&&, OptionSet<TypeFlag>);
+    RenderBoxModelObject(Type, Document&, RenderStyle&&, OptionSet<TypeFlag>);
 
     void willBeDestroyed() override;
 

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -117,7 +117,7 @@ struct SameSizeAsRenderElement : public RenderObject {
 
 static_assert(sizeof(RenderElement) == sizeof(SameSizeAsRenderElement), "RenderElement should stay small");
 
-inline RenderElement::RenderElement(Type type, ContainerNode& elementOrDocument, RenderStyle&& style, OptionSet<RenderElementType> flags)
+inline RenderElement::RenderElement(Type type, ContainerNode& elementOrDocument, RenderStyle&& style, OptionSet<TypeFlag> flags)
     : RenderObject(type, elementOrDocument, flags)
     , m_firstChild(nullptr)
     , m_ancestorLineBoxDirty(false)
@@ -141,12 +141,12 @@ inline RenderElement::RenderElement(Type type, ContainerNode& elementOrDocument,
     ASSERT(RenderObject::isRenderElement());
 }
 
-RenderElement::RenderElement(Type type, Element& element, RenderStyle&& style, OptionSet<RenderElementType> baseTypeFlags)
+RenderElement::RenderElement(Type type, Element& element, RenderStyle&& style, OptionSet<TypeFlag> baseTypeFlags)
     : RenderElement(type, static_cast<ContainerNode&>(element), WTFMove(style), baseTypeFlags)
 {
 }
 
-RenderElement::RenderElement(Type type, Document& document, RenderStyle&& style, OptionSet<RenderElementType> baseTypeFlags)
+RenderElement::RenderElement(Type type, Document& document, RenderStyle&& style, OptionSet<TypeFlag> baseTypeFlags)
     : RenderElement(type, static_cast<ContainerNode&>(document), WTFMove(style), baseTypeFlags)
 {
 }

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -294,8 +294,8 @@ public:
     void clearNeedsLayoutForDescendants();
 
 protected:
-    RenderElement(Type, Element&, RenderStyle&&, OptionSet<RenderElementType>);
-    RenderElement(Type, Document&, RenderStyle&&, OptionSet<RenderElementType>);
+    RenderElement(Type, Element&, RenderStyle&&, OptionSet<TypeFlag>);
+    RenderElement(Type, Document&, RenderStyle&&, OptionSet<TypeFlag>);
 
     bool layerCreationAllowedForSubtree() const;
 
@@ -338,7 +338,7 @@ protected:
     inline bool shouldApplySizeOrStyleContainment(bool) const;
 
 private:
-    RenderElement(Type, ContainerNode&, RenderStyle&&, OptionSet<RenderElementType>);
+    RenderElement(Type, ContainerNode&, RenderStyle&&, OptionSet<TypeFlag>);
     void node() const = delete;
     void nonPseudoNode() const = delete;
     void generatingNode() const = delete;

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -81,14 +81,14 @@ struct RenderFlexibleBox::LineState {
 };
 
 RenderFlexibleBox::RenderFlexibleBox(Type type, Element& element, RenderStyle&& style)
-    : RenderBlock(type, element, WTFMove(style), RenderElementType::RenderFlexibleBoxFlag)
+    : RenderBlock(type, element, WTFMove(style), TypeFlag::IsFlexibleBox)
 {
     ASSERT(isRenderFlexibleBox());
     setChildrenInline(false); // All of our children must be block-level.
 }
 
 RenderFlexibleBox::RenderFlexibleBox(Type type, Document& document, RenderStyle&& style)
-    : RenderBlock(type, document, WTFMove(style), RenderElementType::RenderFlexibleBoxFlag)
+    : RenderBlock(type, document, WTFMove(style), TypeFlag::IsFlexibleBox)
 {
     ASSERT(isRenderFlexibleBox());
     setChildrenInline(false); // All of our children must be block-level.

--- a/Source/WebCore/rendering/RenderFragmentContainer.cpp
+++ b/Source/WebCore/rendering/RenderFragmentContainer.cpp
@@ -55,13 +55,13 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderFragmentContainer);
 
 RenderFragmentContainer::RenderFragmentContainer(Type type, Element& element, RenderStyle&& style, RenderFragmentedFlow* fragmentedFlow)
-    : RenderBlockFlow(type, element, WTFMove(style))
+    : RenderBlockFlow(type, element, WTFMove(style), TypeFlag::IsFragmentContainer)
     , m_fragmentedFlow(fragmentedFlow)
 {
 }
 
 RenderFragmentContainer::RenderFragmentContainer(Type type, Document& document, RenderStyle&& style, RenderFragmentedFlow* fragmentedFlow)
-    : RenderBlockFlow(type, document, WTFMove(style))
+    : RenderBlockFlow(type, document, WTFMove(style), TypeFlag::IsFragmentContainer)
     , m_fragmentedFlow(fragmentedFlow)
 {
 }

--- a/Source/WebCore/rendering/RenderFragmentContainer.h
+++ b/Source/WebCore/rendering/RenderFragmentContainer.h
@@ -134,7 +134,6 @@ protected:
     LayoutRect fragmentedFlowContentRectangle(const LayoutRect&, const LayoutRect& fragmentedFlowPortionRect, const LayoutPoint& fragmentLocation, const LayoutRect* fragmentedFlowPortionClipRect = 0) const;
 
 private:
-    bool isRenderFragmentContainer() const final { return true; }
     ASCIILiteral renderName() const override { return "RenderFragmentContainer"_s; }
 
     void insertedIntoTree(IsInternalMove) override;

--- a/Source/WebCore/rendering/RenderFragmentedFlow.cpp
+++ b/Source/WebCore/rendering/RenderFragmentedFlow.cpp
@@ -56,14 +56,13 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderFragmentedFlow);
 
 RenderFragmentedFlow::RenderFragmentedFlow(Type type, Document& document, RenderStyle&& style)
-    : RenderBlockFlow(type, document, WTFMove(style))
+    : RenderBlockFlow(type, document, WTFMove(style), TypeFlag::IsFragmentedFlow)
     , m_currentFragmentMaintainer(nullptr)
     , m_fragmentsInvalidated(false)
     , m_fragmentsHaveUniformLogicalWidth(true)
     , m_fragmentsHaveUniformLogicalHeight(true)
     , m_pageLogicalSizeChanged(false)
 {
-    setIsRenderFragmentedFlow(true);
     ASSERT(isRenderFragmentedFlow());
 }
 

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -145,8 +145,8 @@ void RenderImage::collectSelectionGeometries(Vector<SelectionGeometry>& geometri
 
 using namespace HTMLNames;
 
-RenderImage::RenderImage(Type type, Element& element, RenderStyle&& style, OptionSet<RenderElementType> typeFlags, StyleImage* styleImage, const float imageDevicePixelRatio)
-    : RenderReplaced(type, element, WTFMove(style), IntSize(), typeFlags | RenderElementType::RenderImageFlag)
+RenderImage::RenderImage(Type type, Element& element, RenderStyle&& style, OptionSet<ReplacedFlag> flags, StyleImage* styleImage, const float imageDevicePixelRatio)
+    : RenderReplaced(type, element, WTFMove(style), IntSize(), flags | ReplacedFlag::IsImage)
     , m_imageResource(styleImage ? makeUnique<RenderImageResourceStyleImage>(*styleImage) : makeUnique<RenderImageResource>())
     , m_hasImageOverlay(is<HTMLElement>(element) && ImageOverlay::hasOverlay(downcast<HTMLElement>(element)))
     , m_imageDevicePixelRatio(imageDevicePixelRatio)
@@ -159,12 +159,12 @@ RenderImage::RenderImage(Type type, Element& element, RenderStyle&& style, Optio
 }
 
 RenderImage::RenderImage(Type type, Element& element, RenderStyle&& style, StyleImage* styleImage, const float imageDevicePixelRatio)
-    : RenderImage(type, element, WTFMove(style), RenderElementType::RenderImageFlag, styleImage, imageDevicePixelRatio)
+    : RenderImage(type, element, WTFMove(style), ReplacedFlag::IsImage, styleImage, imageDevicePixelRatio)
 {
 }
 
 RenderImage::RenderImage(Type type, Document& document, RenderStyle&& style, StyleImage* styleImage)
-    : RenderReplaced(type, document, WTFMove(style), IntSize(), RenderElementType::RenderImageFlag)
+    : RenderReplaced(type, document, WTFMove(style), IntSize(), ReplacedFlag::IsImage)
     , m_imageResource(styleImage ? makeUnique<RenderImageResourceStyleImage>(*styleImage) : makeUnique<RenderImageResource>())
 {
 }

--- a/Source/WebCore/rendering/RenderImage.h
+++ b/Source/WebCore/rendering/RenderImage.h
@@ -84,7 +84,7 @@ public:
     bool hasAnimatedImage() const;
 
 protected:
-    RenderImage(Type, Element&, RenderStyle&&, OptionSet<RenderElementType>, StyleImage* = nullptr, const float imageDevicePixelRatio = 1.0f);
+    RenderImage(Type, Element&, RenderStyle&&, OptionSet<ReplacedFlag>, StyleImage* = nullptr, const float imageDevicePixelRatio = 1.0f);
     void willBeDestroyed() override;
 
     bool needsPreferredWidthsRecalculation() const final;

--- a/Source/WebCore/rendering/RenderInline.cpp
+++ b/Source/WebCore/rendering/RenderInline.cpp
@@ -65,14 +65,14 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderInline);
 
 RenderInline::RenderInline(Type type, Element& element, RenderStyle&& style)
-    : RenderBoxModelObject(type, element, WTFMove(style), RenderElementType::RenderInlineFlag)
+    : RenderBoxModelObject(type, element, WTFMove(style), TypeFlag::IsRenderInline)
 {
     setChildrenInline(true);
     ASSERT(isRenderInline());
 }
 
 RenderInline::RenderInline(Type type, Document& document, RenderStyle&& style)
-    : RenderBoxModelObject(type, document, WTFMove(style), RenderElementType::RenderInlineFlag)
+    : RenderBoxModelObject(type, document, WTFMove(style), TypeFlag::IsRenderInline)
 {
     setChildrenInline(true);
     ASSERT(isRenderInline());

--- a/Source/WebCore/rendering/RenderLayerModelObject.cpp
+++ b/Source/WebCore/rendering/RenderLayerModelObject.cpp
@@ -63,14 +63,14 @@ bool RenderLayerModelObject::s_hadLayer = false;
 bool RenderLayerModelObject::s_wasTransformed = false;
 bool RenderLayerModelObject::s_layerWasSelfPainting = false;
 
-RenderLayerModelObject::RenderLayerModelObject(Type type, Element& element, RenderStyle&& style, OptionSet<RenderElementType> baseTypeFlags)
-    : RenderElement(type, element, WTFMove(style), baseTypeFlags | RenderElementType::RenderLayerModelObjectFlag)
+RenderLayerModelObject::RenderLayerModelObject(Type type, Element& element, RenderStyle&& style, OptionSet<TypeFlag> baseTypeFlags)
+    : RenderElement(type, element, WTFMove(style), baseTypeFlags | TypeFlag::IsLayerModelObject)
 {
     ASSERT(isRenderLayerModelObject());
 }
 
-RenderLayerModelObject::RenderLayerModelObject(Type type, Document& document, RenderStyle&& style, OptionSet<RenderElementType> baseTypeFlags)
-    : RenderElement(type, document, WTFMove(style), baseTypeFlags | RenderElementType::RenderLayerModelObjectFlag)
+RenderLayerModelObject::RenderLayerModelObject(Type type, Document& document, RenderStyle&& style, OptionSet<TypeFlag> baseTypeFlags)
+    : RenderElement(type, document, WTFMove(style), baseTypeFlags | TypeFlag::IsLayerModelObject)
 {
     ASSERT(isRenderLayerModelObject());
 }

--- a/Source/WebCore/rendering/RenderLayerModelObject.h
+++ b/Source/WebCore/rendering/RenderLayerModelObject.h
@@ -108,8 +108,8 @@ public:
     void applyTransform(TransformationMatrix&, const RenderStyle&, const FloatRect& boundingBox) const;
 
 protected:
-    RenderLayerModelObject(Type, Element&, RenderStyle&&, OptionSet<RenderElementType>);
-    RenderLayerModelObject(Type, Document&, RenderStyle&&, OptionSet<RenderElementType>);
+    RenderLayerModelObject(Type, Element&, RenderStyle&&, OptionSet<TypeFlag>);
+    RenderLayerModelObject(Type, Document&, RenderStyle&&, OptionSet<TypeFlag>);
 
     void createLayer();
     void willBeDestroyed() override;

--- a/Source/WebCore/rendering/RenderMedia.cpp
+++ b/Source/WebCore/rendering/RenderMedia.cpp
@@ -40,13 +40,13 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderMedia);
 
 RenderMedia::RenderMedia(Type type, HTMLMediaElement& element, RenderStyle&& style)
-    : RenderImage(type, element, WTFMove(style), RenderElementType::RenderMediaFlag)
+    : RenderImage(type, element, WTFMove(style), ReplacedFlag::IsMedia)
 {
     setHasShadowControls(true);
 }
 
 RenderMedia::RenderMedia(Type type, HTMLMediaElement& element, RenderStyle&& style, const IntSize& intrinsicSize)
-    : RenderImage(type, element, WTFMove(style), RenderElementType::RenderMediaFlag)
+    : RenderImage(type, element, WTFMove(style), ReplacedFlag::IsMedia)
 {
     setIntrinsicSize(intrinsicSize);
     setHasShadowControls(true);

--- a/Source/WebCore/rendering/RenderMultiColumnSpannerPlaceholder.cpp
+++ b/Source/WebCore/rendering/RenderMultiColumnSpannerPlaceholder.cpp
@@ -49,7 +49,7 @@ RenderPtr<RenderMultiColumnSpannerPlaceholder> RenderMultiColumnSpannerPlacehold
 }
 
 RenderMultiColumnSpannerPlaceholder::RenderMultiColumnSpannerPlaceholder(RenderMultiColumnFlow& fragmentedFlow, RenderBox& spanner, RenderStyle&& style)
-    : RenderBox(Type::MultiColumnSpannerPlaceholder, fragmentedFlow.document(), WTFMove(style), RenderElementType::RenderBoxModelObjectFlag)
+    : RenderBox(Type::MultiColumnSpannerPlaceholder, fragmentedFlow.document(), WTFMove(style), TypeFlag::IsBoxModelObject)
     , m_spanner(spanner)
     , m_fragmentedFlow(fragmentedFlow)
 {

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -222,26 +222,34 @@ public:
         LegacySVGViewportContainer
     };
 
-    enum class RenderElementType : uint16_t {
-        RenderLayerModelObjectFlag = 1 << 0,
-        RenderBoxModelObjectFlag = 1 << 1,
-        RenderInlineFlag = 1 << 2,
-        RenderReplacedFlag = 1 << 3,
-        RenderBlockFlag = 1 << 4,
-        RenderBlockFlowFlag = 1 << 5,
-        RenderFlexibleBoxFlag = 1 << 6,
-        RenderTextControlFlag = 1 << 7,
-        RenderImageFlag = 1 << 8,
-        RenderMediaFlag = 1 << 9,
-        RenderWidgetFlag = 1 << 10,
-        RenderSVGModelObjectFlag = 1 << 11,
-        RenderSVGBlockFlag = 1 << 12,
+    enum class TypeFlag : uint16_t {
+        IsAnonymous = 1 << 0,
+        IsText = 1 << 1,
+        IsBox = 1 << 2,
+        IsBoxModelObject = 1 << 3,
+        IsLayerModelObject = 1 << 4,
+        IsRenderInline = 1 << 5,
+        IsReplaced = 1 << 6,
+        IsRenderBlock = 1 << 7,
+        IsBlockFlow = 1 << 8,
+        IsFragmentContainer = 1 << 9,
+        IsFragmentedFlow = 1 << 10,
+        IsTextControl = 1 << 11,
+        IsFlexibleBox = 1 << 12,
+        IsSVGModelObject = 1 << 13,
+        IsSVGBlock = 1 << 14,
     };
 
     // Type Specific Flags
 
     enum class LineBreakFlag : uint8_t {
         IsWBR = 1 << 0,
+    };
+
+    enum class ReplacedFlag : uint8_t {
+        IsImage = 1 << 0,
+        IsMedia = 1 << 1,
+        IsWidget = 1 << 2,
     };
 
     enum class SVGModelObjectFlag : uint8_t {
@@ -254,7 +262,7 @@ public:
 
     // Anonymous objects should pass the document as their node, and they will then automatically be
     // marked as anonymous in the constructor.
-    RenderObject(Type, Node&, OptionSet<RenderElementType>);
+    RenderObject(Type, Node&, OptionSet<TypeFlag>);
     virtual ~RenderObject();
 
     Type type() const { return m_type; }
@@ -349,12 +357,12 @@ public:
     bool isPseudoElement() const { return node() && node()->isPseudoElement(); }
 
     bool isRenderElement() const { return !isRenderText(); }
-    bool isRenderReplaced() const { return m_renderElementTypeFlags.contains(RenderElementType::RenderReplacedFlag); }
-    bool isRenderBoxModelObject() const { return m_renderElementTypeFlags.contains(RenderElementType::RenderBoxModelObjectFlag); }
-    bool isRenderBlock() const { return m_renderElementTypeFlags.contains(RenderElementType::RenderBlockFlag); }
-    bool isRenderBlockFlow() const { return m_renderElementTypeFlags.contains(RenderElementType::RenderBlockFlowFlag); }
-    bool isRenderInline() const { return m_renderElementTypeFlags.contains(RenderElementType::RenderInlineFlag); }
-    bool isRenderLayerModelObject() const { return m_renderElementTypeFlags.contains(RenderElementType::RenderLayerModelObjectFlag); }
+    bool isRenderReplaced() const { return m_typeFlags.contains(TypeFlag::IsReplaced); }
+    bool isRenderBoxModelObject() const { return m_typeFlags.contains(TypeFlag::IsBoxModelObject); }
+    bool isRenderBlock() const { return m_typeFlags.contains(TypeFlag::IsRenderBlock); }
+    bool isRenderBlockFlow() const { return m_typeFlags.contains(TypeFlag::IsBlockFlow); }
+    bool isRenderInline() const { return m_typeFlags.contains(TypeFlag::IsRenderInline); }
+    bool isRenderLayerModelObject() const { return m_typeFlags.contains(TypeFlag::IsLayerModelObject); }
 
     inline bool isAtomicInlineLevelBox() const;
 
@@ -372,18 +380,18 @@ public:
     bool isRenderListBox() const { return type() == Type::ListBox; }
     bool isRenderListItem() const { return type() == Type::ListItem; }
     bool isRenderListMarker() const { return type() == Type::ListMarker; }
-    bool isRenderMedia() const { return m_renderElementTypeFlags.contains(RenderElementType::RenderMediaFlag); }
+    bool isRenderMedia() const { return isRenderReplaced() && replacedFlags().contains(ReplacedFlag::IsMedia); }
     bool isRenderMenuList() const { return type() == Type::MenuList; }
     bool isRenderMeter() const { return type() == Type::Meter; }
     bool isRenderProgress() const { return type() == Type::Progress; }
     bool isRenderButton() const { return type() == Type::Button; }
     bool isRenderIFrame() const { return type() == Type::IFrame; }
-    bool isRenderImage() const { return m_renderElementTypeFlags.contains(RenderElementType::RenderImageFlag); }
+    bool isRenderImage() const { return isRenderReplaced() && replacedFlags().contains(ReplacedFlag::IsImage); }
     bool isRenderTextFragment() const { return type() == Type::TextFragment; }
 #if ENABLE(MODEL_ELEMENT)
     bool isRenderModel() const { return type() == Type::Model; }
 #endif
-    virtual bool isRenderFragmentContainer() const { return false; }
+    bool isRenderFragmentContainer() const { return m_typeFlags.contains(TypeFlag::IsFragmentContainer); }
     bool isRenderReplica() const { return type() == Type::Replica; }
 
     bool isRenderRubyAsInline() const { return type() == Type::RubyAsInline; }
@@ -398,13 +406,13 @@ public:
     bool isRenderTableCol() const { return type() == Type::TableCol; }
     bool isRenderTableCaption() const { return type() == Type::TableCaption; }
     bool isRenderTableSection() const { return type() == Type::TableSection; }
-    bool isRenderTextControl() const { return m_renderElementTypeFlags.contains(RenderElementType::RenderTextControlFlag); }
+    bool isRenderTextControl() const { return m_typeFlags.contains(TypeFlag::IsTextControl); }
     bool isRenderTextControlMultiLine() const { return type() == Type::TextControlMultiLine; }
     bool isRenderTextControlSingleLine() const { return isRenderTextControl() && !isRenderTextControlMultiLine(); }
     bool isRenderSearchField() const { return type() == Type::SearchField; }
     bool isRenderTextControlInnerBlock() const { return type() == Type::TextControlInnerBlock; }
     bool isRenderVideo() const { return type() == Type::Video; }
-    bool isRenderWidget() const { return m_renderElementTypeFlags.contains(RenderElementType::RenderWidgetFlag); }
+    bool isRenderWidget() const { return isRenderReplaced() && replacedFlags().contains(ReplacedFlag::IsWidget); }
     bool isRenderHTMLCanvas() const { return type() == Type::HTMLCanvas; }
 #if ENABLE(ATTACHMENT_ELEMENT)
     bool isRenderAttachment() const { return type() == Type::Attachment; }
@@ -473,13 +481,11 @@ public:
     bool isRenderMathMLUnderOver() const { return type() == Type::MathMLUnderOver; }
 #endif // ENABLE(MATHML)
 
-    bool isLegacyRenderSVGModelObject() const { return m_renderElementTypeFlags.contains(RenderElementType::RenderSVGModelObjectFlag) && svgFlags().contains(SVGModelObjectFlag::IsLegacy); }
+    bool isLegacyRenderSVGModelObject() const { return m_typeFlags.contains(TypeFlag::IsSVGModelObject) && svgFlags().contains(SVGModelObjectFlag::IsLegacy); }
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
-    bool isRenderSVGModelObject() const { return m_renderElementTypeFlags.contains(RenderElementType::RenderSVGModelObjectFlag) && !svgFlags().contains(SVGModelObjectFlag::IsLegacy); }
+    bool isRenderSVGModelObject() const { return m_typeFlags.contains(TypeFlag::IsSVGModelObject) && !svgFlags().contains(SVGModelObjectFlag::IsLegacy); }
 #endif
-    OptionSet<SVGModelObjectFlag> svgFlags() const { ASSERT(m_renderElementTypeFlags.contains(RenderElementType::RenderSVGModelObjectFlag)); return OptionSet<SVGModelObjectFlag>::fromRaw(m_typeSpecificFlags); }
-    void setSVGFlags(OptionSet<SVGModelObjectFlag> flags) { ASSERT(m_renderElementTypeFlags.contains(RenderElementType::RenderSVGModelObjectFlag)); m_typeSpecificFlags = flags.toRaw(); }
-    bool isRenderSVGBlock() const { return m_renderElementTypeFlags.contains(RenderElementType::RenderSVGBlockFlag); }
+    bool isRenderSVGBlock() const { return m_typeFlags.contains(TypeFlag::IsSVGBlock); }
     bool isLegacyRenderSVGRoot() const { return type() == Type::LegacySVGRoot; }
     bool isRenderSVGRoot() const { return type() == Type::SVGRoot; }
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
@@ -575,7 +581,7 @@ public:
     virtual bool nodeAtFloatPoint(const HitTestRequest&, HitTestResult&, const FloatPoint& pointInParent, HitTestAction);
 
     virtual bool hasIntrinsicAspectRatio() const { return isReplacedOrInlineBlock() && (isImage() || isRenderVideo() || isRenderHTMLCanvas()); }
-    bool isAnonymous() const { return m_bitfields.hasFlag(RenderObjectFlag::IsAnonymous); }
+    bool isAnonymous() const { return m_typeFlags.contains(TypeFlag::IsAnonymous); }
     bool isAnonymousBlock() const;
     bool isBlockContainer() const;
 
@@ -590,13 +596,13 @@ public:
     bool isStickilyPositioned() const { return m_bitfields.isStickilyPositioned(); }
     bool shouldUsePositionedClipping() const { return isAbsolutelyPositioned() || isRenderSVGForeignObject(); }
 
-    bool isRenderText() const { return m_bitfields.hasFlag(RenderObjectFlag::IsRenderText); }
+    bool isRenderText() const { return m_typeFlags.contains(TypeFlag::IsText); }
     bool isRenderLineBreak() const { return type() == Type::LineBreak; }
     bool isBR() const { return isRenderLineBreak() && !isWBR(); }
     bool isWBR() const { return isRenderLineBreak() && lineBreakFlags().contains(LineBreakFlag::IsWBR); }
     bool isLineBreakOpportunity() const { return isRenderLineBreak() && isWBR(); }
     bool isRenderTextOrLineBreak() const { return isRenderText() || isRenderLineBreak(); }
-    bool isRenderBox() const { return m_bitfields.hasFlag(RenderObjectFlag::IsRenderBox); }
+    bool isRenderBox() const { return m_typeFlags.contains(TypeFlag::IsBox); }
     bool isRenderTableRow() const { return type() == Type::TableRow; }
     bool isRenderView() const  { return type() == Type::View; }
     bool isInline() const { return !m_bitfields.hasFlag(RenderObjectFlag::IsBlock); } // inline object
@@ -604,7 +610,7 @@ public:
     bool isHorizontalWritingMode() const { return !m_bitfields.hasFlag(RenderObjectFlag::VerticalWritingMode); }
 
     bool hasReflection() const { return hasRareData() && rareData().hasReflection(); }
-    bool isRenderFragmentedFlow() const { return hasRareData() && rareData().isRenderFragmentedFlow(); }
+    bool isRenderFragmentedFlow() const { return m_typeFlags.contains(TypeFlag::IsFragmentedFlow); }
     bool hasOutlineAutoAncestor() const { return hasRareData() && rareData().hasOutlineAutoAncestor(); }
     bool paintContainmentApplies() const { return hasRareData() && rareData().paintContainmentApplies(); }
 
@@ -710,8 +716,6 @@ public:
     void invalidateBackgroundObscurationStatus();
     virtual bool computeBackgroundIsKnownToBeObscured(const LayoutPoint&) { return false; }
 
-    void setIsRenderText() { ASSERT(!isRenderBox()); m_bitfields.setFlag(RenderObjectFlag::IsRenderText); }
-    void setIsRenderBox() { ASSERT(!isRenderText()); m_bitfields.setFlag(RenderObjectFlag::IsRenderBox); }
     void setReplacedOrInlineBlock(bool b = true) { m_bitfields.setFlag(RenderObjectFlag::IsReplacedOrInlineBlock, b); }
     void setHorizontalWritingMode(bool b = true) { m_bitfields.setFlag(RenderObjectFlag::VerticalWritingMode, !b); }
     void setHasNonVisibleOverflow(bool b = true) { m_bitfields.setFlag(RenderObjectFlag::HasNonVisibleOverflow, b); }
@@ -719,7 +723,6 @@ public:
     void setHasTransformRelatedProperty(bool b = true) { m_bitfields.setFlag(RenderObjectFlag::HasTransformRelatedProperty, b); }
 
     void setHasReflection(bool = true);
-    void setIsRenderFragmentedFlow(bool = true);
     void setHasOutlineAutoAncestor(bool = true);
     void setPaintContainmentApplies(bool = true);
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
@@ -1011,7 +1014,7 @@ public:
     // Virtual function helpers for the deprecated Flexible Box Layout (display: -webkit-box).
     bool isRenderDeprecatedFlexibleBox() const { return m_type == RenderObject::Type::DeprecatedFlexibleBox; }
     // Virtual function helper for the new FlexibleBox Layout (display: -webkit-flex).
-    inline bool isRenderFlexibleBox() const { return m_renderElementTypeFlags.contains(RenderElementType::RenderFlexibleBoxFlag); }
+    inline bool isRenderFlexibleBox() const { return m_typeFlags.contains(TypeFlag::IsFlexibleBox); }
     inline bool isFlexibleBoxIncludingDeprecated() const { return isRenderFlexibleBox() || isRenderDeprecatedFlexibleBox(); }
 
     bool isRenderCombineText() const { return type() == Type::CombineText; }
@@ -1076,6 +1079,12 @@ protected:
 
     OptionSet<LineBreakFlag> lineBreakFlags() const { ASSERT(isRenderLineBreak()); return OptionSet<LineBreakFlag>::fromRaw(m_typeSpecificFlags); }
     void setLineBreakFlags(OptionSet<LineBreakFlag> flags) { ASSERT(isRenderLineBreak()); m_typeSpecificFlags = flags.toRaw(); }
+
+    OptionSet<ReplacedFlag> replacedFlags() const { ASSERT(isRenderReplaced()); return OptionSet<ReplacedFlag>::fromRaw(m_typeSpecificFlags); }
+    void setReplacedFlags(OptionSet<ReplacedFlag> flags) { ASSERT(isRenderReplaced()); m_typeSpecificFlags = flags.toRaw(); }
+
+    OptionSet<SVGModelObjectFlag> svgFlags() const { ASSERT(m_typeFlags.contains(TypeFlag::IsSVGModelObject)); return OptionSet<SVGModelObjectFlag>::fromRaw(m_typeSpecificFlags); }
+    void setSVGFlags(OptionSet<SVGModelObjectFlag> flags) { ASSERT(m_typeFlags.contains(TypeFlag::IsSVGModelObject)); m_typeSpecificFlags = flags.toRaw(); }
 
     virtual void willBeDestroyed();
 
@@ -1144,27 +1153,24 @@ private:
         void set##Name(Type name) { m_##name = static_cast<unsigned>(name); }\
 
     enum class RenderObjectFlag : uint32_t {
-        IsAnonymous = 1 << 0,
-        IsRenderText = 1 << 1,
-        IsRenderBox = 1 << 2,
-        IsBlock = 1 << 3,
-        IsReplacedOrInlineBlock = 1 << 4,
-        BeingDestroyed = 1 << 5,
-        NeedsLayout = 1 << 6,
-        NeedsPositionedMovementLayout = 1 << 7,
-        NormalChildNeedsLayout = 1 << 8,
-        PosChildNeedsLayout = 1 << 9,
-        NeedsSimplifiedNormalFlowLayout = 1 << 10,
-        EverHadLayout = 1 << 11,
-        IsExcludedFromNormalLayout = 1 << 12,
-        Floating = 1 << 13,
-        VerticalWritingMode = 1 << 14,
-        PreferredLogicalWidthsDirty = 1 << 15,
-        HasRareData = 1 << 16,
-        HasLayer = 1 << 17,
-        HasNonVisibleOverflow = 1 << 18,
-        HasTransformRelatedProperty = 1 << 19,
-        ChildrenInline = 1 << 20,
+        IsBlock = 1 << 0,
+        IsReplacedOrInlineBlock = 1 << 1,
+        BeingDestroyed = 1 << 2,
+        NeedsLayout = 1 << 3,
+        NeedsPositionedMovementLayout = 1 << 4,
+        NormalChildNeedsLayout = 1 << 5,
+        PosChildNeedsLayout = 1 << 6,
+        NeedsSimplifiedNormalFlowLayout = 1 << 7,
+        EverHadLayout = 1 << 8,
+        IsExcludedFromNormalLayout = 1 << 9,
+        Floating = 1 << 10,
+        VerticalWritingMode = 1 << 11,
+        PreferredLogicalWidthsDirty = 1 << 12,
+        HasRareData = 1 << 13,
+        HasLayer = 1 << 14,
+        HasNonVisibleOverflow = 1 << 15,
+        HasTransformRelatedProperty = 1 << 16,
+        ChildrenInline = 1 << 17,
     };
 
     class RenderObjectBitfields {
@@ -1176,12 +1182,12 @@ private:
         };
 
     private:
-        uint32_t m_flags : 21 { 0 };
+        uint32_t m_flags : 18 { 0 };
         uint32_t m_positionedState : 2 { IsStaticallyPositioned }; // PositionedState
         uint32_t m_selectionState : 3 { HighlightState::None }; // HighlightState
         uint32_t m_fragmentedFlowState : 1 { NotInsideFragmentedFlow }; // FragmentedFlowState
         uint32_t m_boxDecorationState : 2 { NoBoxDecorations }; // BoxDecorationState
-        // 3 bits left
+        // 6 bits left
 
     public:
         OptionSet<RenderObjectFlag> flags() const { return OptionSet<RenderObjectFlag>::fromRaw(m_flags); }
@@ -1223,10 +1229,10 @@ private:
 
     SingleThreadWeakPtr<RenderElement> m_parent;
     SingleThreadPackedWeakPtr<RenderObject> m_previous;
-    OptionSet<RenderElementType> m_renderElementTypeFlags;
+    const OptionSet<TypeFlag> m_typeFlags;
     SingleThreadPackedWeakPtr<RenderObject> m_next;
-    Type m_type;
-    uint8_t m_typeSpecificFlags { 0 }; // Depends on values of m_type and/or m_renderElementTypeFlags
+    const Type m_type;
+    uint8_t m_typeSpecificFlags { 0 }; // Depends on values of m_type and/or m_typeFlags
 
     CheckedPtr<Layout::Box> m_layoutBox;
 
@@ -1238,7 +1244,6 @@ private:
         ~RenderObjectRareData();
 
         ADD_BOOLEAN_BITFIELD(hasReflection, HasReflection);
-        ADD_BOOLEAN_BITFIELD(isRenderFragmentedFlow, IsRenderFragmentedFlow);
         ADD_BOOLEAN_BITFIELD(hasOutlineAutoAncestor, HasOutlineAutoAncestor);
         ADD_BOOLEAN_BITFIELD(paintContainmentApplies, PaintContainmentApplies);
 #if ENABLE(LAYER_BASED_SVG_ENGINE)

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -64,26 +64,29 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderReplaced);
 const int cDefaultWidth = 300;
 const int cDefaultHeight = 150;
 
-RenderReplaced::RenderReplaced(Type type, Element& element, RenderStyle&& style, OptionSet<RenderElementType> typeFlags)
-    : RenderBox(type, element, WTFMove(style), typeFlags | RenderElementType::RenderReplacedFlag)
+RenderReplaced::RenderReplaced(Type type, Element& element, RenderStyle&& style, OptionSet<ReplacedFlag> flags)
+    : RenderBox(type, element, WTFMove(style), TypeFlag::IsReplaced)
     , m_intrinsicSize(cDefaultWidth, cDefaultHeight)
 {
+    setReplacedFlags(flags);
     setReplacedOrInlineBlock(true);
     ASSERT(isRenderReplaced());
 }
 
-RenderReplaced::RenderReplaced(Type type, Element& element, RenderStyle&& style, const LayoutSize& intrinsicSize, OptionSet<RenderElementType> typeFlags)
-    : RenderBox(type, element, WTFMove(style), typeFlags | RenderElementType::RenderReplacedFlag)
+RenderReplaced::RenderReplaced(Type type, Element& element, RenderStyle&& style, const LayoutSize& intrinsicSize, OptionSet<ReplacedFlag> flags)
+    : RenderBox(type, element, WTFMove(style), TypeFlag::IsReplaced)
     , m_intrinsicSize(intrinsicSize)
 {
+    setReplacedFlags(flags);
     setReplacedOrInlineBlock(true);
     ASSERT(isRenderReplaced());
 }
 
-RenderReplaced::RenderReplaced(Type type, Document& document, RenderStyle&& style, const LayoutSize& intrinsicSize, OptionSet<RenderElementType> typeFlags)
-    : RenderBox(type, document, WTFMove(style), typeFlags | RenderElementType::RenderReplacedFlag)
+RenderReplaced::RenderReplaced(Type type, Document& document, RenderStyle&& style, const LayoutSize& intrinsicSize, OptionSet<ReplacedFlag> flags)
+    : RenderBox(type, document, WTFMove(style), TypeFlag::IsReplaced)
     , m_intrinsicSize(intrinsicSize)
 {
+    setReplacedFlags(flags);
     setReplacedOrInlineBlock(true);
     ASSERT(isRenderReplaced());
 }

--- a/Source/WebCore/rendering/RenderReplaced.h
+++ b/Source/WebCore/rendering/RenderReplaced.h
@@ -50,9 +50,9 @@ public:
     void computeIntrinsicRatioInformation(FloatSize& intrinsicSize, FloatSize& intrinsicRatio) const override;
 
 protected:
-    RenderReplaced(Type, Element&, RenderStyle&&, OptionSet<RenderElementType> = { });
-    RenderReplaced(Type, Element&, RenderStyle&&, const LayoutSize& intrinsicSize, OptionSet<RenderElementType> = { });
-    RenderReplaced(Type, Document&, RenderStyle&&, const LayoutSize& intrinsicSize, OptionSet<RenderElementType> = { });
+    RenderReplaced(Type, Element&, RenderStyle&&, OptionSet<ReplacedFlag> = { });
+    RenderReplaced(Type, Element&, RenderStyle&&, const LayoutSize& intrinsicSize, OptionSet<ReplacedFlag> = { });
+    RenderReplaced(Type, Document&, RenderStyle&&, const LayoutSize& intrinsicSize, OptionSet<ReplacedFlag> = { });
 
     void layout() override;
 

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -251,12 +251,11 @@ static unsigned offsetForPositionInRun(const InlineIterator::TextBox& textBox, f
 }
 
 inline RenderText::RenderText(Type type, Node& node, const String& text)
-    : RenderObject(type, node, { })
+    : RenderObject(type, node, TypeFlag::IsText)
     , m_text(text)
     , m_containsOnlyASCII(text.impl()->containsOnlyASCII())
 {
     ASSERT(!m_text.isNull());
-    setIsRenderText();
     m_canUseSimpleFontCodePath = computeCanUseSimpleFontCodePath();
     ASSERT(isRenderText());
 }

--- a/Source/WebCore/rendering/RenderTextControl.cpp
+++ b/Source/WebCore/rendering/RenderTextControl.cpp
@@ -44,7 +44,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderTextControl);
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderTextControlInnerContainer);
 
 RenderTextControl::RenderTextControl(Type type, HTMLTextFormControlElement& element, RenderStyle&& style)
-    : RenderBlockFlow(type, element, WTFMove(style), RenderElementType::RenderTextControlFlag)
+    : RenderBlockFlow(type, element, WTFMove(style), TypeFlag::IsTextControl)
 {
     ASSERT(isRenderTextControl());
 }

--- a/Source/WebCore/rendering/RenderWidget.cpp
+++ b/Source/WebCore/rendering/RenderWidget.cpp
@@ -95,7 +95,7 @@ static void moveWidgetToParentSoon(Widget& child, LocalFrameView* parent)
 }
 
 RenderWidget::RenderWidget(Type type, HTMLFrameOwnerElement& element, RenderStyle&& style)
-    : RenderReplaced(type, element, WTFMove(style), RenderElementType::RenderWidgetFlag)
+    : RenderReplaced(type, element, WTFMove(style), ReplacedFlag::IsWidget)
 {
     relaxAdoptionRequirement();
     setInline(false);

--- a/Source/WebCore/rendering/svg/RenderSVGBlock.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGBlock.cpp
@@ -37,7 +37,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGBlock);
 
 RenderSVGBlock::RenderSVGBlock(Type type, SVGGraphicsElement& element, RenderStyle&& style)
-    : RenderBlockFlow(type, element, WTFMove(style), RenderElementType::RenderSVGBlockFlag)
+    : RenderBlockFlow(type, element, WTFMove(style), TypeFlag::IsSVGBlock)
 {
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
@@ -56,7 +56,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGModelObject);
 
 RenderSVGModelObject::RenderSVGModelObject(Type type, Document& document, RenderStyle&& style, OptionSet<SVGModelObjectFlag> typeFlags)
-    : RenderLayerModelObject(type, document, WTFMove(style), RenderElementType::RenderSVGModelObjectFlag)
+    : RenderLayerModelObject(type, document, WTFMove(style), TypeFlag::IsSVGModelObject)
 {
     setSVGFlags(typeFlags);
     ASSERT(!svgFlags().contains(SVGModelObjectFlag::IsLegacy));
@@ -64,7 +64,7 @@ RenderSVGModelObject::RenderSVGModelObject(Type type, Document& document, Render
 }
 
 RenderSVGModelObject::RenderSVGModelObject(Type type, SVGElement& element, RenderStyle&& style, OptionSet<SVGModelObjectFlag> typeFlags)
-    : RenderLayerModelObject(type, element, WTFMove(style), RenderElementType::RenderSVGModelObjectFlag)
+    : RenderLayerModelObject(type, element, WTFMove(style), TypeFlag::IsSVGModelObject)
 {
     setSVGFlags(typeFlags);
     ASSERT(!svgFlags().contains(SVGModelObjectFlag::IsLegacy));

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
@@ -47,7 +47,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(LegacyRenderSVGModelObject);
 
 LegacyRenderSVGModelObject::LegacyRenderSVGModelObject(Type type, SVGElement& element, RenderStyle&& style, OptionSet<SVGModelObjectFlag> typeFlags)
-    : RenderElement(type, element, WTFMove(style), { RenderElementType::RenderSVGModelObjectFlag })
+    : RenderElement(type, element, WTFMove(style), { TypeFlag::IsSVGModelObject })
 {
     setSVGFlags(typeFlags | SVGModelObjectFlag::IsLegacy);
     ASSERT(isLegacyRenderSVGModelObject());


### PR DESCRIPTION
#### 35c1f16c757919912b753c31234880400a5c6f25
<pre>
Generalize RenderElementType as TypeFlag and make it const
<a href="https://bugs.webkit.org/show_bug.cgi?id=266659">https://bugs.webkit.org/show_bug.cgi?id=266659</a>

Reviewed by Simon Fraser.

This PR generalizes RenderElementType as TypeFlag to be used with any RenderObject instead of
just RenderElement and moves IsAnonymous, IsText, and IsBox flags from RenderObjectFlag.

It also renames the member variable to m_typeFlags and makes it const so that its value doesn&apos;t
change once RenderObject is initialized. This PR also makes m_type const as well.

Finally, this PR also creates RenderReplaced specific type flags (ReplacedFlag) and moves
IsImage, IsMedia, IsWidget over there to free up more bits in TypeFlag.

* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::RenderBlock):
* Source/WebCore/rendering/RenderBlock.h:
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::RenderBlockFlow):
* Source/WebCore/rendering/RenderBlockFlow.h:
(WebCore::RenderBlockFlow::RenderBlockFlow):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::RenderBox):
* Source/WebCore/rendering/RenderBox.h:
* Source/WebCore/rendering/RenderBoxModelObject.cpp:
(WebCore::RenderBoxModelObject::RenderBoxModelObject):
* Source/WebCore/rendering/RenderBoxModelObject.h:
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::RenderElement):
* Source/WebCore/rendering/RenderElement.h:
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::RenderFlexibleBox):
* Source/WebCore/rendering/RenderFragmentContainer.cpp:
(WebCore::RenderFragmentContainer::RenderFragmentContainer):
* Source/WebCore/rendering/RenderFragmentContainer.h:
* Source/WebCore/rendering/RenderFragmentedFlow.cpp:
(WebCore::RenderFragmentedFlow::RenderFragmentedFlow):
* Source/WebCore/rendering/RenderImage.cpp:
(WebCore::RenderImage::RenderImage):
* Source/WebCore/rendering/RenderImage.h:
* Source/WebCore/rendering/RenderInline.cpp:
(WebCore::RenderInline::RenderInline):
* Source/WebCore/rendering/RenderLayerModelObject.cpp:
(WebCore::RenderLayerModelObject::RenderLayerModelObject):
* Source/WebCore/rendering/RenderLayerModelObject.h:
* Source/WebCore/rendering/RenderMedia.cpp:
(WebCore::RenderMedia::RenderMedia):
* Source/WebCore/rendering/RenderMultiColumnSpannerPlaceholder.cpp:
(WebCore::RenderMultiColumnSpannerPlaceholder::RenderMultiColumnSpannerPlaceholder):
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::RenderObject):
(WebCore::RenderObject::RenderObjectRareData::RenderObjectRareData):
(WebCore::RenderObject::setIsRenderFragmentedFlow): Deleted.
* Source/WebCore/rendering/RenderObject.h:
(WebCore::RenderObject::isRenderReplaced const):
(WebCore::RenderObject::isRenderBoxModelObject const):
(WebCore::RenderObject::isRenderBlock const):
(WebCore::RenderObject::isRenderBlockFlow const):
(WebCore::RenderObject::isRenderInline const):
(WebCore::RenderObject::isRenderLayerModelObject const):
(WebCore::RenderObject::isRenderMedia const):
(WebCore::RenderObject::isRenderImage const):
(WebCore::RenderObject::isRenderFragmentContainer const):
(WebCore::RenderObject::isRenderTextControl const):
(WebCore::RenderObject::isRenderWidget const):
(WebCore::RenderObject::isLegacyRenderSVGModelObject const):
(WebCore::RenderObject::isRenderSVGModelObject const):
(WebCore::RenderObject::isRenderSVGBlock const):
(WebCore::RenderObject::isAnonymous const):
(WebCore::RenderObject::isRenderText const):
(WebCore::RenderObject::isRenderBox const):
(WebCore::RenderObject::isRenderFragmentedFlow const):
(WebCore::RenderObject::isRenderFlexibleBox const):
(WebCore::RenderObject::replacedFlags const):
(WebCore::RenderObject::setReplacedFlags):
(WebCore::RenderObject::svgFlags const):
(WebCore::RenderObject::setSVGFlags):
(WebCore::RenderObject::setIsRenderText): Deleted.
(WebCore::RenderObject::setIsRenderBox): Deleted.
* Source/WebCore/rendering/RenderReplaced.cpp:
(WebCore::RenderReplaced::RenderReplaced):
* Source/WebCore/rendering/RenderReplaced.h:
(WebCore::RenderReplaced::RenderReplaced):
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::RenderText::RenderText):
(WebCore::m_containsOnlyASCII): Deleted.
* Source/WebCore/rendering/RenderTextControl.cpp:
(WebCore::RenderTextControl::RenderTextControl):
* Source/WebCore/rendering/RenderWidget.cpp:
(WebCore::RenderWidget::RenderWidget):
* Source/WebCore/rendering/svg/RenderSVGBlock.cpp:
(WebCore::RenderSVGBlock::RenderSVGBlock):
* Source/WebCore/rendering/svg/RenderSVGModelObject.cpp:
(WebCore::RenderSVGModelObject::RenderSVGModelObject):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp:
(WebCore::LegacyRenderSVGModelObject::LegacyRenderSVGModelObject):

Canonical link: <a href="https://commits.webkit.org/272311@main">https://commits.webkit.org/272311@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63ce4cc2d5c47875daa4b898802fdbbb9b50ed39

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31283 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9953 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32976 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33785 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/28375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32050 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12298 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7207 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/28022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31619 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8389 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27941 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7205 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/7377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27840 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35128 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28455 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28295 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/33509 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7432 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/5476 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/31348 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/9108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8131 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4076 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/7956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->