### PR TITLE
Deduplicate the correctionIndicatorType method.

### DIFF
--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -234,6 +234,7 @@ page/ios/EventHandlerIOS.mm
 page/ios/FrameIOS.mm
 page/ios/WebEventRegion.mm
 page/mac/ChromeMac.mm
+page/mac/CorrectionIndicator.mm
 page/mac/DragControllerMac.mm
 page/mac/EventHandlerMac.mm
 page/mac/ImageOverlayControllerMac.mm

--- a/Source/WebCore/page/ios/FrameIOS.mm
+++ b/Source/WebCore/page/ios/FrameIOS.mm
@@ -30,6 +30,7 @@
 #import "CommonVM.h"
 #import "ComposedTreeIterator.h"
 #import "Document.h"
+#import "DocumentInlines.h"
 #import "DocumentMarkerController.h"
 #import "Editor.h"
 #import "EditorClient.h"

--- a/Source/WebCore/page/mac/CorrectionIndicator.h
+++ b/Source/WebCore/page/mac/CorrectionIndicator.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(MAC)
+
+namespace WebCore {
+
+enum class AlternativeTextType : uint8_t;
+
+WEBCORE_EXPORT NSCorrectionIndicatorType correctionIndicatorType(WebCore::AlternativeTextType);
+
+}
+
+#endif

--- a/Source/WebCore/page/mac/CorrectionIndicator.mm
+++ b/Source/WebCore/page/mac/CorrectionIndicator.mm
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CorrectionIndicator.h"
+
+#if PLATFORM(MAC)
+
+#include "AlternativeTextClient.h"
+
+namespace WebCore {
+
+NSCorrectionIndicatorType correctionIndicatorType(AlternativeTextType alternativeTextType)
+{
+    switch (alternativeTextType) {
+    case AlternativeTextType::Correction:
+        return NSCorrectionIndicatorTypeDefault;
+    case AlternativeTextType::Reversion:
+        return NSCorrectionIndicatorTypeReversion;
+    case AlternativeTextType::SpellingSuggestions:
+    case AlternativeTextType::GrammarSuggestions:
+        return NSCorrectionIndicatorTypeGuesses;
+    case AlternativeTextType::DictationAlternatives:
+        ASSERT_NOT_REACHED();
+        return NSCorrectionIndicatorTypeDefault;
+    }
+}
+
+}
+
+#endif

--- a/Source/WebKit/UIProcess/mac/CorrectionPanel.mm
+++ b/Source/WebKit/UIProcess/mac/CorrectionPanel.mm
@@ -30,24 +30,9 @@
 
 #import "WebPageProxy.h"
 #import "WebViewImpl.h"
+#import <WebCore/CorrectionIndicator.h>
 #import <pal/SessionID.h>
 #import <wtf/cocoa/VectorCocoa.h>
-
-static inline NSCorrectionIndicatorType correctionIndicatorType(WebCore::AlternativeTextType alternativeTextType)
-{
-    switch (alternativeTextType) {
-    case WebCore::AlternativeTextType::Correction:
-        return NSCorrectionIndicatorTypeDefault;
-    case WebCore::AlternativeTextType::Reversion:
-        return NSCorrectionIndicatorTypeReversion;
-    case WebCore::AlternativeTextType::SpellingSuggestions:
-    case WebCore::AlternativeTextType::GrammarSuggestions:
-        return NSCorrectionIndicatorTypeGuesses;
-    case WebCore::AlternativeTextType::DictationAlternatives:
-        ASSERT_NOT_REACHED();
-        return NSCorrectionIndicatorTypeDefault;
-    }
-}
 
 namespace WebKit {
 using namespace WebCore;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/CorrectionPanel.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/CorrectionPanel.mm
@@ -26,28 +26,12 @@
 #import "CorrectionPanel.h"
 
 #import "WebViewInternal.h"
+#import <WebCore/CorrectionIndicator.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
 #if USE(AUTOCORRECTION_PANEL)
 
 using namespace WebCore;
-
-static inline NSCorrectionIndicatorType correctionIndicatorType(AlternativeTextType alternativeTextType)
-{
-    switch (alternativeTextType) {
-    case AlternativeTextType::Correction:
-        return NSCorrectionIndicatorTypeDefault;
-    case AlternativeTextType::Reversion:
-        return NSCorrectionIndicatorTypeReversion;
-    case AlternativeTextType::SpellingSuggestions:
-    case AlternativeTextType::GrammarSuggestions:
-        return NSCorrectionIndicatorTypeGuesses;
-    case AlternativeTextType::DictationAlternatives:
-        ASSERT_NOT_REACHED();
-        return NSCorrectionIndicatorTypeDefault;
-    }
-    
-}
 
 CorrectionPanel::CorrectionPanel()
     : m_wasDismissedExternally(false)


### PR DESCRIPTION
#### c213889156180d79d3d01c5108e2152c2b318c40
<pre>
Deduplicate the correctionIndicatorType method.
<a href="https://bugs.webkit.org/show_bug.cgi?id=248216">https://bugs.webkit.org/show_bug.cgi?id=248216</a>
<a href="https://rdar.apple.com/102760220">rdar://102760220</a>

Reviewed by Alex Christensen.

Move the correctionIndicatorType into WebCore and use that
instead in WebKit/WebKitLegacy. Earlier, they both had the exact same function individually.

* Source/WebCore/page/mac/CorrectionIndicator.h: Added.
* Source/WebCore/page/mac/CorrectionIndicator.mm: Added.
(WebCore::correctionIndicatorType):

* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/page/mac/CorrectionIndicator.h:
* Source/WebCore/page/mac/CorrectionIndicator.mm:
(WebCore::correctionIndicatorType):
* Source/WebKit/UIProcess/mac/CorrectionPanel.mm:
(correctionIndicatorType): Deleted.
* Source/WebKitLegacy/mac/WebCoreSupport/CorrectionPanel.mm:
(correctionIndicatorType): Deleted.
* Source/WebCore/page/ios/FrameIOS.mm:

Canonical link: <a href="https://commits.webkit.org/272388@main">https://commits.webkit.org/272388@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d30facbaefb286224b2e33d128a3bb79eb2cf71

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31489 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10164 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33193 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33977 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/28519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32259 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12512 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7411 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/28133 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31829 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8555 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28100 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7362 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/7523 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28009 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35321 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28617 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28455 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33656 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7603 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5621 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31499 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9260 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7394 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8292 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8108 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->