### PR TITLE
[content-visibility] Remove scroll anchor workaround

### DIFF
--- a/Source/WebCore/dom/ContentVisibilityDocumentState.cpp
+++ b/Source/WebCore/dom/ContentVisibilityDocumentState.cpp
@@ -216,13 +216,9 @@ void ContentVisibilityDocumentState::updateContentRelevancyForScrollIfNeeded(con
     };
 
     if (RefPtr scrollAnchorRoot = findSkippedContentRoot(scrollAnchor)) {
-        for (auto& weakTarget : m_observer->observationTargets()) {
-            if (RefPtr target = weakTarget.get()) {
-                ASSERT(target->renderer() && target->renderStyle()->contentVisibility() == ContentVisibility::Auto);
-                updateViewportProximity(*target, ViewportProximity::Far);
-            }
-        }
         updateViewportProximity(*scrollAnchorRoot, ViewportProximity::Near);
+        // Since we may not have determined initial visibility yet, force scheduling the content relevancy update.
+        scrollAnchorRoot->protectedDocument()->scheduleContentRelevancyUpdate(ContentRelevancy::OnScreen);
         scrollAnchorRoot->protectedDocument()->updateRelevancyOfContentVisibilityElements();
     }
 }

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3601,8 +3601,6 @@ void Element::focus(const FocusOptions& options)
         return;
     }
 
-    document->updateContentRelevancyForScrollIfNeeded(*this);
-
     RefPtr newTarget { this };
 
     // If we don't have renderer yet, isFocusable will compute it without style update.


### PR DESCRIPTION
#### a723510f30d7af0c3f94542d50a1a55ff455a171
<pre>
[content-visibility] Remove scroll anchor workaround
<a href="https://bugs.webkit.org/show_bug.cgi?id=259269">https://bugs.webkit.org/show_bug.cgi?id=259269</a>
<a href="https://rdar.apple.com/112759490">rdar://112759490</a>

Reviewed by NOBODY (OOPS!).

Now that scroll anchoring is enabled, remove the hack of resetting all c-v: auto elements to offscreen status on scrolling.

* Source/WebCore/dom/ContentVisibilityDocumentState.cpp:
(WebCore::ContentVisibilityDocumentState::updateContentRelevancyForScrollIfNeeded):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::focus):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a723510f30d7af0c3f94542d50a1a55ff455a171

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31553 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10230 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33263 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34045 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28578 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32328 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12583 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7478 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28187 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31897 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8617 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28164 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7425 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7585 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28071 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35389 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28682 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28519 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33716 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7667 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5686 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31567 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9322 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8355 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8172 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->