### PR TITLE
Stop using CheckedPtr with GraphicsLayer

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -265,7 +265,7 @@ protected:
 // GraphicsLayer is an abstraction for a rendering surface with backing store,
 // which may have associated transformation and animations.
 
-class GraphicsLayer : public RefCounted<GraphicsLayer>, public CanMakeCheckedPtr {
+class GraphicsLayer : public RefCounted<GraphicsLayer> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     enum class Type : uint8_t {

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.h
@@ -33,7 +33,7 @@ namespace WebKit {
 
 class RemoteLayerTreeContext;
 
-class GraphicsLayerCARemote final : public WebCore::GraphicsLayerCA {
+class GraphicsLayerCARemote final : public WebCore::GraphicsLayerCA, public CanMakeWeakPtr<GraphicsLayerCARemote> {
 public:
     GraphicsLayerCARemote(Type layerType, WebCore::GraphicsLayerClient&, RemoteLayerTreeContext&);
     virtual ~GraphicsLayerCARemote();

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h
@@ -115,7 +115,7 @@ private:
     HashMap<WebCore::PlatformLayerIdentifier, PlaybackSessionContextIdentifier> m_videoLayers;
 #endif
 
-    HashSet<CheckedPtr<GraphicsLayerCARemote>> m_liveGraphicsLayers;
+    HashSet<WeakRef<GraphicsLayerCARemote>> m_liveGraphicsLayers;
 
     std::unique_ptr<RemoteLayerBackingStoreCollection> m_backingStoreCollection;
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
@@ -60,7 +60,7 @@ RemoteLayerTreeContext::~RemoteLayerTreeContext()
 
     auto graphicsLayers = m_liveGraphicsLayers;
     for (auto& layer : graphicsLayers)
-        RefPtr { layer.get() }->clearContext();
+        Ref { layer.get() }->clearContext();
 
     // Make sure containers are empty before destruction to avoid hitting the assertion in CanMakeCheckedPtr.
     m_livePlatformLayers.clear();
@@ -76,7 +76,7 @@ void RemoteLayerTreeContext::adoptLayersFromContext(RemoteLayerTreeContext& oldC
 
     auto& graphicsLayers = oldContext.m_liveGraphicsLayers;
     while (!graphicsLayers.isEmpty())
-        RefPtr { (*graphicsLayers.begin()).get() }->moveToContext(*this);
+        Ref { (*graphicsLayers.begin()).get() }->moveToContext(*this);
 }
 
 float RemoteLayerTreeContext::deviceScaleFactor() const
@@ -168,12 +168,12 @@ void RemoteLayerTreeContext::layerWillLeaveContext(PlatformCALayerRemote& layer)
 
 void RemoteLayerTreeContext::graphicsLayerDidEnterContext(GraphicsLayerCARemote& layer)
 {
-    m_liveGraphicsLayers.add(&layer);
+    m_liveGraphicsLayers.add(layer);
 }
 
 void RemoteLayerTreeContext::graphicsLayerWillLeaveContext(GraphicsLayerCARemote& layer)
 {
-    m_liveGraphicsLayers.remove(&layer);
+    m_liveGraphicsLayers.remove(layer);
 }
 
 Ref<GraphicsLayer> RemoteLayerTreeContext::createGraphicsLayer(WebCore::GraphicsLayer::Type layerType, GraphicsLayerClient& client)


### PR DESCRIPTION
#### c94e713f78c210dbe7bff46e9711267812bf7766
<pre>
Stop using CheckedPtr with GraphicsLayer
<a href="https://bugs.webkit.org/show_bug.cgi?id=266663">https://bugs.webkit.org/show_bug.cgi?id=266663</a>

Reviewed by Ryosuke Niwa.

Stop using CheckedPtr with GraphicsLayer. Use WeakPtr instead to generate more
actionable crashes in case of problem.

* Source/WebCore/platform/graphics/GraphicsLayer.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm:
(WebKit::RemoteLayerTreeContext::~RemoteLayerTreeContext):
(WebKit::RemoteLayerTreeContext::adoptLayersFromContext):
(WebKit::RemoteLayerTreeContext::graphicsLayerDidEnterContext):
(WebKit::RemoteLayerTreeContext::graphicsLayerWillLeaveContext):

Canonical link: <a href="https://commits.webkit.org/272319@main">https://commits.webkit.org/272319@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/13cc13d413d4465779be2ff499f38cc3dcb1619d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31298 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9968 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32991 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33798 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/28387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32065 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12311 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7220 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/28030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31634 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8396 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27953 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7214 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7384 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27877 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35141 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28462 "Found 1 new API test failure: TestWebKitAPI.WebKit.ScrollToFoundRangeRepeated (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28307 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33521 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7445 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5485 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31362 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/9120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7354 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8144 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/7968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->