### PR TITLE
Adding preference for controlling font fallback for PUA characters

### DIFF
--- a/LayoutTests/fast/css/font-fallback-private-use-area-characters-allow-system-fallback-expected.html
+++ b/LayoutTests/fast/css/font-fallback-private-use-area-characters-allow-system-fallback-expected.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+p {
+    font-family: 'Times';
+}
+</style>
+</head>
+<body>
+    <p>&#xF8FF;</p>
+</body>
+</html>

--- a/LayoutTests/fast/css/font-fallback-private-use-area-characters-allow-system-fallback.html
+++ b/LayoutTests/fast/css/font-fallback-private-use-area-characters-allow-system-fallback.html
@@ -1,0 +1,14 @@
+<!-- webkit-test-runner [ DisallowSystemFontFallbackForPrivateUseAreaCharacters=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+p {
+    font-family: 'Times New Roman';
+}
+</style>
+</head>
+<body>
+    <p>&#xF8FF;</p>
+</body>
+</html>

--- a/LayoutTests/fast/css/font-fallback-private-use-area-characters-disallow-system-fallback-expected-mismatch.html
+++ b/LayoutTests/fast/css/font-fallback-private-use-area-characters-disallow-system-fallback-expected-mismatch.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+p {
+    font-family: 'Times';
+    line-height: 20px;
+    font-size: 16px;
+    height: 20px;
+}
+</style>
+</head>
+<body>
+    <p>&#xF8FF;</p>
+</body>
+</html>

--- a/LayoutTests/fast/css/font-fallback-private-use-area-characters-disallow-system-fallback.html
+++ b/LayoutTests/fast/css/font-fallback-private-use-area-characters-disallow-system-fallback.html
@@ -1,0 +1,14 @@
+<!-- webkit-test-runner [ DisallowSystemFontFallbackForPrivateUseAreaCharacters=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+p {
+    font-family: 'Times New Roman';
+}
+</style>
+</head>
+<body>
+    <p>&#xF8FF;</p>
+</body>
+</html>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2373,6 +2373,20 @@ DisallowSyncXHRDuringPageDismissalEnabled:
     WebCore:
       default: true
 
+DisallowSystemFontFallbackForPrivateUseAreaCharacters:
+  type: bool
+  status: stable
+  category: css
+  humanReadableName: "Disallow system font fallback for Private Use Area (PUA) characters"
+  humanReadableDescription: "Disallow font fallback using system fonts for charactes that are within the Private Use Area (PUA) block"
+  defaultValue:
+    WebKitLegacy:
+      default: WebKit::defaultDisallowSystemFontFallbackForPrivateUseAreaCharacters()
+    WebKit:
+      default: WebKit::defaultDisallowSystemFontFallbackForPrivateUseAreaCharacters()
+    WebCore:
+      default: true
+
 # FIXME: This is on by default in WebKit2. Perhaps we should consider turning it on for WebKitLegacy as well.
 DownloadAttributeEnabled:
   type: bool

--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.cpp
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.cpp
@@ -202,8 +202,10 @@ static SDKAlignedBehaviors computeSDKAlignedBehaviors()
         disableBehavior(SDKAlignedBehavior::ResettingTransitionCancelsRunningTransitionQuirk);
     }
 
-    if (linkedBefore(dyld_2023_SU_C_os_versions, DYLD_IOS_VERSION_17_2, DYLD_MACOSX_VERSION_14_2))
+    if (linkedBefore(dyld_2023_SU_C_os_versions, DYLD_IOS_VERSION_17_2, DYLD_MACOSX_VERSION_14_2)) {
         disableBehavior(SDKAlignedBehavior::OnlyLoadWellKnownAboutURLs);
+        disableBehavior(SDKAlignedBehavior::DisallowSystemFontFallbackForPrivateUseAreaCharacters);
+    }
 
     disableAdditionalSDKAlignedBehaviors(behaviors);
 

--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -114,6 +114,7 @@ enum class SDKAlignedBehavior {
     ResettingTransitionCancelsRunningTransitionQuirk,
     OnlyLoadWellKnownAboutURLs,
     AsyncFragmentNavigationPolicyDecision,
+    DisallowSystemFontFallbackForPrivateUseAreaCharacters,
 
     NumberOfBehaviors
 };

--- a/Source/WebCore/platform/graphics/FontCascadeDescription.h
+++ b/Source/WebCore/platform/graphics/FontCascadeDescription.h
@@ -69,6 +69,8 @@ public:
     FontSelectionValue bolderWeight() const { return bolderWeight(weight()); }
     static FontSelectionValue lighterWeight(FontSelectionValue);
     static FontSelectionValue bolderWeight(FontSelectionValue);
+    bool disallowSystemFontFallbackForPrivateUseAreaCharacters() const { return m_disallowSystemFontFallbackForPrivateUseAreaCharacters; }
+
 
     // only use fixed default size when there is only one font family, and that family is "monospace"
     bool useFixedDefaultSize() const { return familyCount() == 1 && firstFamily() == monospaceFamily; }
@@ -105,6 +107,8 @@ public:
     }
     void setFontSmoothing(FontSmoothingMode smoothing) { m_fontSmoothing = static_cast<unsigned>(smoothing); }
     void setIsSpecifiedFont(bool isSpecifiedFont) { m_isSpecifiedFont = isSpecifiedFont; }
+    void setDisallowSystemFontFallbackForPrivateUseAreaCharacters(bool value) { m_disallowSystemFontFallbackForPrivateUseAreaCharacters = value; }
+
 
 #if ENABLE(TEXT_AUTOSIZING)
     bool familiesEqualForTextAutoSizing(const FontCascadeDescription& other) const;
@@ -140,6 +144,7 @@ public:
     static FontSizeAdjust initialFontSizeAdjust() { return { FontSizeAdjust::Metric::ExHeight }; }
     static TextSpacingTrim initialTextSpacingTrim() { return { }; }
     static TextAutospace initialTextAutospace() { return { }; }
+    static bool initialDisallowSystemFontFallbackForPrivateUseAreaCharacters() { return true; }
 
 private:
     Ref<RefCountedFixedVector<AtomString>> m_families;
@@ -156,6 +161,7 @@ private:
     unsigned m_fontSmoothing : 2; // FontSmoothingMode
     // True if a web page specifies a non-generic font family as the first font family.
     unsigned m_isSpecifiedFont : 1;
+    unsigned m_disallowSystemFontFallbackForPrivateUseAreaCharacters : 1;
 };
 
 inline bool FontCascadeDescription::operator==(const FontCascadeDescription& other) const
@@ -167,7 +173,8 @@ inline bool FontCascadeDescription::operator==(const FontCascadeDescription& oth
         && m_kerning == other.m_kerning
         && m_keywordSize == other.m_keywordSize
         && m_fontSmoothing == other.m_fontSmoothing
-        && m_isSpecifiedFont == other.m_isSpecifiedFont;
+        && m_isSpecifiedFont == other.m_isSpecifiedFont
+        && m_disallowSystemFontFallbackForPrivateUseAreaCharacters == other.m_disallowSystemFontFallbackForPrivateUseAreaCharacters;
 }
 
 }

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
@@ -476,9 +476,10 @@ GlyphData FontCascadeFonts::glyphDataForVariant(char32_t character, const FontCa
 
     if (loadingResult.isValid())
         return loadingResult;
+    // We allow applications to decide if they want or not to comply to the following spec. This is because not falling back to system fonts for PUA characters can cause characters traditionally rendered with certain glyphs by certain fonts to not work anymore:
     // https://drafts.csswg.org/css-fonts-4/#char-handling-issues
     // "If a given character is a Private-Use Area Unicode codepoint, user agents must only match font families named in the font-family list that are not generic families. If none of the families named in the font-family list contain a glyph for that codepoint, user agents must display some form of missing glyph symbol for that character rather than attempting installed font fallback for that codepoint."
-    if (isPrivateUseAreaCharacter(character)) {
+    if (description.disallowSystemFontFallbackForPrivateUseAreaCharacters() &&isPrivateUseAreaCharacter(character)) {
         auto font = FontCache::forCurrentThread().lastResortFallbackFont(description);
         GlyphData glyphData(0, font.ptr());
         m_systemFallbackFontSet.add(WTFMove(font));

--- a/Source/WebCore/style/StyleResolveForDocument.cpp
+++ b/Source/WebCore/style/StyleResolveForDocument.cpp
@@ -86,6 +86,7 @@ RenderStyle resolveForDocument(const Document& document)
     fontDescription.setSpecifiedLocale(document.contentLanguage());
     fontDescription.setOneFamily(standardFamily);
     fontDescription.setShouldAllowUserInstalledFonts(settings.shouldAllowUserInstalledFonts() ? AllowUserInstalledFonts::Yes : AllowUserInstalledFonts::No);
+    fontDescription.setDisallowSystemFontFallbackForPrivateUseAreaCharacters(settings.disallowSystemFontFallbackForPrivateUseAreaCharacters());
 
     fontDescription.setKeywordSizeFromIdentifier(CSSValueMedium);
     int size = fontSizeForKeyword(CSSValueMedium, false, document);

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -532,6 +532,7 @@ std::unique_ptr<RenderStyle> Resolver::defaultStyleForElement(const Element* ele
     fontDescription.setComputedSize(computedFontSizeFromSpecifiedSize(size, fontDescription.isAbsoluteSize(), is<SVGElement>(element), style.get(), document()));
 
     fontDescription.setShouldAllowUserInstalledFonts(settings().shouldAllowUserInstalledFonts() ? AllowUserInstalledFonts::Yes : AllowUserInstalledFonts::No);
+    fontDescription.setDisallowSystemFontFallbackForPrivateUseAreaCharacters(settings().disallowSystemFontFallbackForPrivateUseAreaCharacters());
     style->setFontDescription(WTFMove(fontDescription));
 
     style->fontCascade().update(&document().fontSelector());

--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
@@ -321,4 +321,14 @@ bool defaultSearchInputIncrementalAttributeAndSearchEventEnabled()
 #endif
 }
 
+bool defaultDisallowSystemFontFallbackForPrivateUseAreaCharacters()
+{
+#if PLATFORM(COCOA)
+    static bool newSDK = linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::DisallowSystemFontFallbackForPrivateUseAreaCharacters);
+    return newSDK;
+#else
+    return true;
+#endif
+}
+
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.h
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.h
@@ -103,6 +103,7 @@ bool defaultRunningBoardThrottlingEnabled();
 bool defaultShouldDropNearSuspendedAssertionAfterDelay();
 bool defaultShowModalDialogEnabled();
 bool defaultLiveRangeSelectionEnabled();
+bool defaultDisallowSystemFontFallbackForPrivateUseAreaCharacters();
 
 bool defaultShouldEnableScreenOrientationAPI();
 bool defaultPopoverAttributeEnabled();

--- a/Source/WebKitLegacy/mac/WebView/WebPreferencesDefaultValues.h
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferencesDefaultValues.h
@@ -67,6 +67,7 @@ bool defaultAllowRunningOfInsecureContent();
 bool defaultShouldConvertInvalidURLsToBlank();
 bool defaultPopoverAttributeEnabled();
 bool defaultSearchInputIncrementalAttributeAndSearchEventEnabled();
+bool defaultDisallowSystemFontFallbackForPrivateUseAreaCharacters();
 
 #if PLATFORM(MAC)
 bool defaultPassiveWheelListenersAsDefaultOnDocument();

--- a/Source/WebKitLegacy/mac/WebView/WebPreferencesDefaultValues.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferencesDefaultValues.mm
@@ -219,6 +219,16 @@ bool defaultSearchInputIncrementalAttributeAndSearchEventEnabled()
     return !newSDK;
 }
 
+bool defaultDisallowSystemFontFallbackForPrivateUseAreaCharacters()
+{
+#if PLATFORM(COCOA)
+    static bool newSDK = linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::DisallowSystemFontFallbackForPrivateUseAreaCharacters);
+    return newSDK;
+#else
+    return true;
+#endif
+}
+
 #if PLATFORM(MAC)
 
 bool defaultPassiveWheelListenersAsDefaultOnDocument()

--- a/Tools/WebKitTestRunner/TestOptions.cpp
+++ b/Tools/WebKitTestRunner/TestOptions.cpp
@@ -92,6 +92,7 @@ const TestFeatures& TestOptions::defaults()
             { "DataTransferItemsEnabled", true },
             { "DeveloperExtrasEnabled", true },
             { "DirectoryUploadEnabled", true },
+            { "DisallowSystemFontFallbackForPrivateUseAreaCharacters", true },
             { "EventHandlerDrivenSmoothKeyboardScrollingEnabled", eventHandlerDrivenSmoothKeyboardScrollingEnabledValue },
             { "ExposeSpeakersEnabled", true },
             { "FullScreenEnabled", true },


### PR DESCRIPTION
#### 7f053c3147c2d030ba968fb2d2386c9b92bfaccf
<pre>
Adding preference for controlling font fallback for PUA characters
<a href="https://bugs.webkit.org/show_bug.cgi?id=266664">https://bugs.webkit.org/show_bug.cgi?id=266664</a>
<a href="https://rdar.apple.com/119517735">rdar://119517735</a>

Reviewed by NOBODY (OOPS!).

WebKit currently complies to CSS fonts specification <a href="https://drafts.csswg.org/css-fonts-4/#char-handling-issues">https://drafts.csswg.org/css-fonts-4/#char-handling-issues</a>
on the fallback behavior for PUA characters. This was implemented at <a href="https://bugs.webkit.org/show_bug.cgi?id=263261">https://bugs.webkit.org/show_bug.cgi?id=263261</a>

The specification requires that the engine doesn&apos;t fallback to
system fonts if a character belongs to the Private Use Area (PUA) block.
If the author specifies a font that can render such character, we, of course
keep resolving that glyph accordingly, but if no font specified cover can do that
we won&apos;t fallback to a system font.

This behavior breaks the render of certain code points for applications
that have traditionally relied on it. For example, the codepoint
U+F8FF, which is in the PUA block, is mapped to the Apple logo in some fonts
like &apos;Times&apos; and &apos;Helvetica&apos; on Apple platforms. Some authors then  might expect
that this works for &apos;Times New Roman&apos;, although the font doesn&apos;t support it,
since they are not aware that under the hood WebKit would fallback to a system
font for rendering such a glyph.

For that reason, we are creating a prefererence &quot;DisallowSystemFontFallbackForPrivateUseAreaCharacters&quot;
that allows the application to choose if they want or not to comply to
such CSS Font specification.

When &quot;DisallowSystemFontFallbackForPrivateUseAreaCharacters&quot; is true,
as the name suggests, we won&apos;t allow PUA characters to fallback
to system fonts.

* LayoutTests/fast/css/font-fallback-private-use-area-characters-allow-system-fallback-expected.html: Added.
* LayoutTests/fast/css/font-fallback-private-use-area-characters-allow-system-fallback.html: Added.
* LayoutTests/fast/css/font-fallback-private-use-area-characters-disallow-system-fallback-expected-mismatch.html: Added.
* LayoutTests/fast/css/font-fallback-private-use-area-characters-disallow-system-fallback.html: Added.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.cpp:
(WTF::computeSDKAlignedBehaviors):
* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h:
* Source/WebCore/platform/graphics/FontCascadeDescription.h:
(WebCore::FontCascadeDescription::disallowSystemFontFallbackForPrivateUseAreaCharacters const):
(WebCore::FontCascadeDescription::setDisallowSystemFontFallbackForPrivateUseAreaCharacters):
(WebCore::FontCascadeDescription::initialDisallowSystemFontFallbackForPrivateUseAreaCharacters):
(WebCore::FontCascadeDescription::operator== const):
* Source/WebCore/platform/graphics/FontCascadeFonts.cpp:
(WebCore::FontCascadeFonts::glyphDataForVariant):
* Source/WebCore/style/StyleResolveForDocument.cpp:
(WebCore::Style::resolveForDocument):
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::defaultStyleForElement):
* Source/WebKit/Shared/WebPreferencesDefaultValues.cpp:
(WebKit::defaultDisallowSystemFontFallbackForPrivateUseAreaCharacters):
* Source/WebKit/Shared/WebPreferencesDefaultValues.h:
* Source/WebKitLegacy/mac/WebView/WebPreferencesDefaultValues.h:
* Source/WebKitLegacy/mac/WebView/WebPreferencesDefaultValues.mm:
(WebKit::defaultDisallowSystemFontFallbackForPrivateUseAreaCharacters):
* Tools/WebKitTestRunner/TestOptions.cpp:
(WTR::TestOptions::defaults):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f053c3147c2d030ba968fb2d2386c9b92bfaccf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31302 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9972 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32995 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33800 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28389 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32069 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12315 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7224 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28033 "Found 1 new test failure: fast/css/font-fallback-private-use-area-characters-disallow-system-fallback.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31638 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8401 "Found 2 new test failures: fast/css/font-fallback-private-use-area-characters-allow-system-fallback.html, fast/css/font-fallback-private-use-area-characters-disallow-system-fallback.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27955 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7219 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7387 "6 flakes 5 failures") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27855 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35143 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/26865 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28465 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28310 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33522 "Found 1 new test failure: fast/css/font-fallback-private-use-area-characters-disallow-system-fallback.html (failure)") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/31366 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7447 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5486 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31363 "Found 1 new API test failure: /TestWebCore:RenderStyleChangeTest.None (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9122 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/27653 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/37817 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8146 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8073 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7970 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->