### PR TITLE
jsc_fuz/wktr: null ptr deref in WebCore::GraphicsLayerAsyncContentsDisplayDelegateCocoa::tryCopyToLayer(WebCore::ImageBuffer&)

### DIFF
--- a/LayoutTests/fast/canvas/offscreen-giant-expected.html
+++ b/LayoutTests/fast/canvas/offscreen-giant-expected.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<body>
+<canvas id="onscreen" width="100" height="10""></canvas>
+<script>
+const canvas = document.getElementById('onscreen');
+
+const context = canvas.getContext('2d');
+
+const square = new Path2D();
+square.rect(0, 0, 100, 10);
+context.fillStyle = 'green';
+context.fill(square);
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/canvas/offscreen-giant.html
+++ b/LayoutTests/fast/canvas/offscreen-giant.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="fuzzy" content="maxDifference=0-64; totalPixels=0-10" />
+</head>
+<body style="overflow:hidden">
+<canvas id="offscreen"></canvas>
+<script>
+const canvas = document.getElementById('offscreen');
+
+const offscreenCanvas = canvas.transferControlToOffscreen();
+offscreenCanvas.width = 200000;
+offscreenCanvas.height = 10;
+
+const offscreenContext = offscreenCanvas.getContext('2d');
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+requestAnimationFrame(function() {
+    const square = new Path2D();
+    square.rect(0, 0, 100, 10);
+    offscreenContext.fillStyle = 'green';
+    offscreenContext.fill(square);
+    offscreenContext.commit();
+
+    requestAnimationFrame(function() {
+        if (window.testRunner)
+            testRunner.notifyDone();
+    });
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3757,6 +3757,8 @@ webkit.org/b/266636 fast/multicol/last-set-crash.html [ Skip ]
 
 webkit.org/b/266708 imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/loading-the-media-resource/resource-selection-currentSrc.html [ Pass Crash ]
 
+webkit.org/b/266719 fast/canvas/offscreen-giant.html [ ImageOnlyFailure ]
+
 # End: Common failures between GTK and WPE.
 
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/LayoutTests/platform/mac-monterey/TestExpectations
+++ b/LayoutTests/platform/mac-monterey/TestExpectations
@@ -7,3 +7,5 @@
 
 # Failing after OS migration rdar://112624778 (Migrate macOS Sonoma test expectations to OpenSource, add expectation files to Down-Levels (259373))
 http/tests/appcache/fail-on-update-2.html [ DumpJSConsoleLogInStdErr Timeout Failure ]
+
+fast/canvas/offscreen-giant.html [ ImageOnlyFailure ]

--- a/Source/WTF/wtf/unix/UnixFileDescriptor.h
+++ b/Source/WTF/wtf/unix/UnixFileDescriptor.h
@@ -34,7 +34,6 @@
 namespace WTF {
 
 class UnixFileDescriptor {
-    WTF_MAKE_NONCOPYABLE(UnixFileDescriptor);
 public:
     UnixFileDescriptor() = default;
 
@@ -53,6 +52,12 @@ public:
     UnixFileDescriptor(UnixFileDescriptor&& o)
     {
         m_value = o.release();
+    }
+
+    explicit UnixFileDescriptor(const UnixFileDescriptor& o)
+    {
+        if (o.m_value >= 0)
+            m_value = dupCloseOnExec(o.m_value);
     }
 
     UnixFileDescriptor& operator=(UnixFileDescriptor&& o)

--- a/Source/WebCore/platform/graphics/ca/cocoa/GraphicsLayerAsyncContentsDisplayDelegateCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/GraphicsLayerAsyncContentsDisplayDelegateCocoa.mm
@@ -43,6 +43,8 @@ GraphicsLayerAsyncContentsDisplayDelegateCocoa::GraphicsLayerAsyncContentsDispla
 bool GraphicsLayerAsyncContentsDisplayDelegateCocoa::tryCopyToLayer(ImageBuffer& image)
 {
     m_image = ImageBuffer::sinkIntoNativeImage(image.clone());
+    if (!m_image)
+        return false;
 
     [CATransaction begin];
     [CATransaction setDisableActions:YES];

--- a/Source/WebCore/platform/graphics/cocoa/DynamicContentScalingDisplayList.h
+++ b/Source/WebCore/platform/graphics/cocoa/DynamicContentScalingDisplayList.h
@@ -33,13 +33,13 @@
 namespace WebCore {
 
 class DynamicContentScalingDisplayList {
-    WTF_MAKE_NONCOPYABLE(DynamicContentScalingDisplayList);
 public:
     DynamicContentScalingDisplayList(Ref<WebCore::SharedBuffer> displayList, Vector<MachSendRight>&& surfaces)
         : m_displayList(WTFMove(displayList))
         , m_surfaces(WTFMove(surfaces))
     {
     }
+    explicit CGDisplayList(const CGDisplayList&) = default;
 
     DynamicContentScalingDisplayList(DynamicContentScalingDisplayList&&) = default;
     DynamicContentScalingDisplayList& operator=(DynamicContentScalingDisplayList&&) = default;

--- a/Source/WebKit/Platform/SharedMemory.h
+++ b/Source/WebKit/Platform/SharedMemory.h
@@ -60,7 +60,6 @@ namespace WebKit {
 enum class MemoryLedger { None, Default, Network, Media, Graphics, Neural };
 
 class SharedMemoryHandle {
-    WTF_MAKE_NONCOPYABLE(SharedMemoryHandle);
 public:
     using Type =
 #if USE(UNIX_DOMAIN_SOCKETS)
@@ -72,6 +71,7 @@ public:
 #endif
 
     SharedMemoryHandle(SharedMemoryHandle&&) = default;
+    explicit SharedMemoryHandle(const SharedMemoryHandle&) = default;
     SharedMemoryHandle(SharedMemoryHandle::Type&&, size_t);
 
     SharedMemoryHandle& operator=(SharedMemoryHandle&&) = default;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
@@ -54,6 +54,7 @@ class RemoteLayerBackingStoreCollection;
 class RemoteLayerTreeNode;
 class RemoteLayerTreeHost;
 enum class SwapBuffersDisplayRequirement : uint8_t;
+struct PlatformCALayerRemoteDelegatedContents;
 
 enum class BackingStoreNeedsDisplayReason : uint8_t {
     None,
@@ -102,7 +103,7 @@ public:
     void setNeedsDisplay(const WebCore::IntRect);
     void setNeedsDisplay();
 
-    void setDelegatedContents(const WebCore::PlatformCALayerDelegatedContents&);
+    void setDelegatedContents(const PlatformCALayerRemoteDelegatedContents&);
 
     // Returns true if we need to encode the buffer.
     bool layerWillBeDisplayed();
@@ -178,7 +179,7 @@ protected:
 
     // FIXME: This should be removed and m_bufferHandle should be used to ref the buffer once ShareableBitmap::Handle
     // can be encoded multiple times. http://webkit.org/b/234169
-    std::optional<MachSendRight> m_contentsBufferHandle;
+    std::optional<ImageBufferBackendHandle> m_contentsBufferHandle;
     std::optional<WebCore::RenderingResourceIdentifier> m_contentsRenderingResourceIdentifier;
 
     Vector<std::unique_ptr<WebCore::ThreadSafeImageBufferFlusher>> m_frontBufferFlushers;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm
@@ -71,7 +71,7 @@ static std::optional<ImageBufferBackendHandle> handleFromBuffer(ImageBuffer& buf
 {
     auto* sharing = buffer.toBackendSharing();
     if (is<ImageBufferBackendHandleSharing>(sharing))
-        return downcast<ImageBufferBackendHandleSharing>(*sharing).takeBackendHandle();
+        return downcast<ImageBufferBackendHandleSharing>(*sharing).takeBackendHandle(SharedMemory::Protection::ReadOnly);
 
     return std::nullopt;
 }

--- a/Source/WebKit/Shared/ShareableBitmap.h
+++ b/Source/WebKit/Shared/ShareableBitmap.h
@@ -95,9 +95,9 @@ private:
 };
 
 class ShareableBitmapHandle  {
-    WTF_MAKE_NONCOPYABLE(ShareableBitmapHandle);
 public:
     ShareableBitmapHandle(ShareableBitmapHandle&&) = default;
+    explicit ShareableBitmapHandle(const ShareableBitmapHandle&) = default;
     ShareableBitmapHandle(SharedMemory::Handle&&, const ShareableBitmapConfiguration&);
 
     ShareableBitmapHandle& operator=(ShareableBitmapHandle&&) = default;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
@@ -29,6 +29,7 @@
 #include "RemoteLayerTreeTransaction.h"
 #include <WebCore/HTMLMediaElementIdentifier.h>
 #include <WebCore/PlatformCALayer.h>
+#include <WebCore/PlatformCALayerDelegatedContents.h>
 #include <WebCore/PlatformLayer.h>
 #include <wtf/WeakPtr.h>
 
@@ -43,6 +44,12 @@ struct AcceleratedEffectValues;
 namespace WebKit {
 
 class RemoteLayerTreeContext;
+
+struct PlatformCALayerRemoteDelegatedContents {
+    ImageBufferBackendHandle surface;
+    RefPtr<WebCore::PlatformCALayerDelegatedContentsFence> finishedFence;
+    std::optional<WebCore::RenderingResourceIdentifier> surfaceIdentifier;
+};
 
 class PlatformCALayerRemote : public WebCore::PlatformCALayer, public CanMakeWeakPtr<PlatformCALayerRemote> {
 public:
@@ -146,6 +153,7 @@ public:
     CFTypeRef contents() const override;
     void setContents(CFTypeRef) override;
     void setDelegatedContents(const WebCore::PlatformCALayerDelegatedContents&) override;
+    void setRemoteDelegatedContents(const PlatformCALayerRemoteDelegatedContents&);
     void setContentsRect(const WebCore::FloatRect&) override;
 
     void setMinificationFilter(WebCore::PlatformCALayer::FilterType) override;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
@@ -743,6 +743,11 @@ void PlatformCALayerRemote::setContents(CFTypeRef value)
 
 void PlatformCALayerRemote::setDelegatedContents(const PlatformCALayerDelegatedContents& contents)
 {
+    setRemoteDelegatedContents({ ImageBufferBackendHandle { MachSendRight { contents.surface } }, contents.finishedFence, contents.surfaceIdentifier });
+}
+
+void PlatformCALayerRemote::setRemoteDelegatedContents(const PlatformCALayerRemoteDelegatedContents& contents)
+{
     ASSERT(m_acceleratesDrawing);
     ensureBackingStore();
     m_properties.backingStoreOrProperties.store->setDelegatedContents(contents);


### PR DESCRIPTION
#### bdc9ba2c424d1d7e95f86e454b3d08b0dd136ee7
<pre>
jsc_fuz/wktr: null ptr deref in WebCore::GraphicsLayerAsyncContentsDisplayDelegateCocoa::tryCopyToLayer(WebCore::ImageBuffer&amp;)
<a href="https://bugs.webkit.org/show_bug.cgi?id=262640">https://bugs.webkit.org/show_bug.cgi?id=262640</a>
&lt;<a href="https://rdar.apple.com/115497296">rdar://115497296</a>&gt;

Reviewed by Kimmo Kinnunen.

This adds support for setDelegatedContents on a PlatformCALayerRemote having a generic ImageBufferBackendHandle (which includes
shared memory), instead of only MachSendRight.

Adds an explicit copy constructor to SharedMemoryHandle, UnixFileDescriptor and CGDisplayList to match MachSendRight and make
this possible.

Also switches Protection::ReadWrite to Protection::ReadOnly for the RemoteLayerBackingStore callers, since we were already using
this for tryCopyToLayer, and we need the ::map() call in the UI process to not try ask for extra permissions.

* Source/WTF/wtf/unix/UnixFileDescriptor.h:
(WTF::UnixFileDescriptor::UnixFileDescriptor):
* Source/WebKit/Platform/SharedMemory.h:
* Source/WebKit/Shared/RemoteLayerTree/CGDisplayList.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm:
(WebKit::RemoteLayerBackingStore::encode const):
(WebKit::RemoteLayerBackingStore::setDelegatedContents):
(WebKit::RemoteLayerBackingStoreProperties::layerContentsBufferFromBackendHandle):
* Source/WebKit/Shared/ShareableBitmap.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm:
(WebKit::PlatformCALayerRemote::setDelegatedContents):
(WebKit::PlatformCALayerRemote::setRemoteDelegatedContents):

Originally-landed-as: 267815.262@safari-7617-branch (8ac19464ff91). <a href="https://rdar.apple.com/119570861">rdar://119570861</a>
Canonical link: <a href="https://commits.webkit.org/272365@main">https://commits.webkit.org/272365@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad2115d77d6a3a1b3153a42733c0d2d37e4e498c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31477 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10152 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33181 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/33965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/28509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32247 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12497 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7398 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/33965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31817 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/8540 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/28089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/33965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/7510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/27998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/35309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/27000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/28602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/28445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/35309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/31536 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/7591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/5611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/35309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/9249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/27803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/37991 "Built successfully") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/8280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8086 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4103 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/8098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->