### PR TITLE
REGRESSION(267786@main): Crash under RenderBlock::isSelectionRoot() with query container

### DIFF
--- a/LayoutTests/fast/css/container-style-editability-crash-expected.txt
+++ b/LayoutTests/fast/css/container-style-editability-crash-expected.txt
@@ -1,0 +1,1 @@
+ This test passes if it doesn't crash.

--- a/LayoutTests/fast/css/container-style-editability-crash.html
+++ b/LayoutTests/fast/css/container-style-editability-crash.html
@@ -1,0 +1,23 @@
+<style>
+    body {
+        container-type: size;
+    }
+
+    div {
+        padding-block-start: 1px;
+    }
+</style>
+<script>
+  if (window.testRunner)
+    testRunner.dumpAsText();
+  onload = () => {
+    document.execCommand('SelectAll');
+  };
+  onbeforeunload = () => {
+    d.hidden = true;
+    d.remove();
+  };
+</script>
+<div id="d"></div>
+<input>
+This test passes if it doesn't crash.

--- a/LayoutTests/platform/ios-wk2/fast/dom/focus-dialog-blur-input-type-change-crash-expected.txt
+++ b/LayoutTests/platform/ios-wk2/fast/dom/focus-dialog-blur-input-type-change-crash-expected.txt
@@ -1,3 +1,2 @@
 CONSOLE MESSAGE: RangeError: Maximum call stack size exceeded.
-CONSOLE MESSAGE: RangeError: Maximum call stack size exceeded.
 PASS

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -4062,7 +4062,7 @@ const RenderStyle* Element::resolveComputedStyle(ResolveComputedStyleMode mode)
     // Traverse the ancestor chain to find the rootmost element that has invalid computed style.
     RefPtr rootmostInvalidElement = [&]() -> RefPtr<const Element> {
         // In ResolveComputedStyleMode::RenderedOnly case we check for display:none ancestors.
-        if (mode == ResolveComputedStyleMode::Normal && !document->hasPendingStyleRecalc() && existingComputedStyle())
+        if (mode != ResolveComputedStyleMode::RenderedOnly && !document->hasPendingStyleRecalc() && existingComputedStyle())
             return nullptr;
 
         if (document->hasPendingFullStyleRebuild())
@@ -4113,7 +4113,7 @@ const RenderStyle* Element::resolveComputedStyle(ResolveComputedStyleMode mode)
     // FIXME: This is not as efficient as it could be. For example if an ancestor has a non-inherited style change but
     // the styles are otherwise clean we would not need to re-resolve descendants.
     for (auto& element : makeReversedRange(elementsRequiringComputedStyle)) {
-        if (computedStyle && computedStyle->containerType() != ContainerType::Normal) {
+        if (computedStyle && computedStyle->containerType() != ContainerType::Normal && mode != ResolveComputedStyleMode::Editability) {
             // If we find a query container we need to bail out and do full style update to resolve it.
             if (document->updateStyleIfNeeded())
                 return this->computedStyle();
@@ -4191,7 +4191,7 @@ const RenderStyle* Element::computedStyleForEditability()
     if (!isConnected())
         return nullptr;
 
-    return resolveComputedStyle();
+    return resolveComputedStyle(ResolveComputedStyleMode::Editability);
 }
 
 bool Element::needsStyleInvalidation() const

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -866,7 +866,7 @@ private:
     inline void removeShadowRoot(); // Defined in ElementRareData.h.
     void removeShadowRootSlow(ShadowRoot&);
 
-    enum class ResolveComputedStyleMode : bool { Normal, RenderedOnly };
+    enum class ResolveComputedStyleMode : uint8_t { Normal, RenderedOnly, Editability };
     const RenderStyle* resolveComputedStyle(ResolveComputedStyleMode = ResolveComputedStyleMode::Normal);
     const RenderStyle& resolvePseudoElementStyle(PseudoId);
 


### PR DESCRIPTION
#### 6c89c10cbe633ca89d115925817694c1742e8ece
<pre>
REGRESSION(267786@main): Crash under RenderBlock::isSelectionRoot() with query container
<a href="https://bugs.webkit.org/show_bug.cgi?id=263522">https://bugs.webkit.org/show_bug.cgi?id=263522</a>
<a href="https://rdar.apple.com/115777188">rdar://115777188</a>

Reviewed by Alan Baradlay.

* LayoutTests/fast/css/container-style-editability-crash-expected.txt: Added.
* LayoutTests/fast/css/container-style-editability-crash.html: Added.
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::resolveComputedStyle):
(WebCore::Element::computedStyleForEditability):

Avoid triggering style resolution when computing editability.

* Source/WebCore/dom/Element.h:

Originally-landed-as: 267815.436@safari-7617-branch (699e9669a530). <a href="https://rdar.apple.com/119596409">rdar://119596409</a>
Canonical link: <a href="https://commits.webkit.org/272334@main">https://commits.webkit.org/272334@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84e17cc80a60e10797fe9de2c44570e725ff4964

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31330 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9999 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33023 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33825 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28407 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32097 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12341 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7249 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28048 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31666 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8421 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27974 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7238 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7403 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27874 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35166 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28485 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28328 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33534 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7469 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5505 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31376 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9140 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/27678 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7363 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8164 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7988 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->