### PR TITLE
[CoreIPC] The pasteboard may perform image conversion in UIProcess

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/FoundationSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/FoundationSPI.h
@@ -28,7 +28,10 @@
 
 #if USE(APPLE_INTERNAL_SDK)
 #import <Foundation/NSGeometry.h>
-#elif !PLATFORM(MAC) && !PLATFORM(MACCATALYST)
+#import <Foundation/NSPrivateDecls.h>
+#else // USE(APPLE_INTERNAL_SDK)
+
+#if !PLATFORM(MAC) && !PLATFORM(MACCATALYST)
 #define NSEDGEINSETS_DEFINED 1
 typedef struct NS_SWIFT_SENDABLE NSEdgeInsets {
     CGFloat top;
@@ -37,6 +40,12 @@ typedef struct NS_SWIFT_SENDABLE NSEdgeInsets {
     CGFloat right;
 } NSEdgeInsets;
 #endif
+
+@interface NSArray ()
+- (NSArray *)arrayByExcludingObjectsInArray:(NSArray *)otherArray;
+@end
+
+#endif // USE(APPLE_INTERNAL_SDK)
 
 @interface NSTextCheckingResult ()
 - (NSDictionary *)detail;

--- a/Source/WebCore/PAL/pal/spi/mac/NSPasteboardSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSPasteboardSPI.h
@@ -29,3 +29,7 @@
 // but that file won't compile as C++.
 
 extern NSString *_NXSmartPaste;
+
+@interface NSPasteboard ()
+- (NSData *)_dataWithoutConversionForType:(NSString *)type securityScoped:(BOOL)securityScoped;
+@end

--- a/Source/WebCore/platform/Pasteboard.cpp
+++ b/Source/WebCore/platform/Pasteboard.cpp
@@ -30,7 +30,6 @@
 #include "PasteboardStrategy.h"
 #include "PlatformStrategies.h"
 #include "Settings.h"
-#include "SharedBuffer.h"
 #include <wtf/text/StringHash.h>
 
 namespace WebCore {

--- a/Source/WebCore/platform/Pasteboard.h
+++ b/Source/WebCore/platform/Pasteboard.h
@@ -29,6 +29,7 @@
 #include "PasteboardContext.h"
 #include "PasteboardCustomData.h"
 #include "PasteboardItemInfo.h"
+#include "SharedBuffer.h"
 #include <wtf/HashMap.h>
 #include <wtf/ListHashSet.h>
 #include <wtf/Noncopyable.h>
@@ -61,7 +62,6 @@ typedef struct HWND__* HWND;
 
 namespace WebCore {
 
-class SharedBuffer;
 class DocumentFragment;
 class DragData;
 class Element;
@@ -294,6 +294,12 @@ public:
     const String& name() const { return m_name; }
 #else
     const String& name() const { return emptyString(); }
+#endif
+
+#if PLATFORM(MAC)
+    WEBCORE_EXPORT static RefPtr<SharedBuffer> bufferConvertedToPasteboardType(const PasteboardBuffer&, const String& pasteboardType);
+#else
+    static RefPtr<SharedBuffer> bufferConvertedToPasteboardType(const PasteboardBuffer& pasteboardBuffer, const String&) { return pasteboardBuffer.data; };
 #endif
 
 #if PLATFORM(WIN)

--- a/Source/WebCore/platform/PlatformPasteboard.h
+++ b/Source/WebCore/platform/PlatformPasteboard.h
@@ -50,6 +50,7 @@ class Color;
 class SharedBuffer;
 class PasteboardCustomData;
 class SelectionData;
+struct PasteboardBuffer;
 struct PasteboardImage;
 struct PasteboardItemInfo;
 struct PasteboardURL;
@@ -72,7 +73,7 @@ public:
     static String platformPasteboardTypeForSafeTypeForDOMToReadAndWrite(const String& domType, IncludeImageTypes = IncludeImageTypes::No);
 
     WEBCORE_EXPORT void getTypes(Vector<String>& types) const;
-    WEBCORE_EXPORT RefPtr<SharedBuffer> bufferForType(const String& pasteboardType) const;
+    WEBCORE_EXPORT PasteboardBuffer bufferForType(const String& pasteboardType) const;
     WEBCORE_EXPORT void getPathnamesForType(Vector<String>& pathnames, const String& pasteboardType) const;
     WEBCORE_EXPORT String stringForType(const String& pasteboardType) const;
     WEBCORE_EXPORT Vector<String> allStringsForType(const String& pasteboardType) const;

--- a/Source/WebCore/platform/ios/PlatformPasteboardIOS.mm
+++ b/Source/WebCore/platform/ios/PlatformPasteboardIOS.mm
@@ -79,9 +79,12 @@ void PlatformPasteboard::getTypes(Vector<String>& types) const
     types = makeVector<String>([m_pasteboard pasteboardTypes]);
 }
 
-RefPtr<SharedBuffer> PlatformPasteboard::bufferForType(const String& type) const
+PasteboardBuffer PlatformPasteboard::bufferForType(const String& type) const
 {
-    return readBuffer(0, type);
+    PasteboardBuffer pasteboardBuffer;
+    pasteboardBuffer.data = readBuffer(0, type);
+    pasteboardBuffer.type = type;
+    return pasteboardBuffer;
 }
 
 void PlatformPasteboard::performAsDataOwner(DataOwnerType type, Function<void()>&& actions)

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -825,6 +825,7 @@ def headers_for_type(type):
         'WebCore::NetworkTransactionInformation': ['<WebCore/NetworkLoadInformation.h>'],
         'WebCore::OpaqueOriginIdentifier': ['<WebCore/SecurityOriginData.h>'],
         'WebCore::PasteboardCustomData': ['<WebCore/Pasteboard.h>'],
+        'WebCore::PasteboardBuffer': ['<WebCore/Pasteboard.h>'],
         'WebCore::PasteboardImage': ['<WebCore/Pasteboard.h>'],
         'WebCore::PasteboardURL': ['<WebCore/Pasteboard.h>'],
         'WebCore::PasteboardWebContent': ['<WebCore/Pasteboard.h>'],

--- a/Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm
@@ -219,7 +219,7 @@ void WebPasteboardProxy::getPasteboardStringsForType(IPC::Connection& connection
     });
 }
 
-void WebPasteboardProxy::getPasteboardBufferForType(IPC::Connection& connection, const String& pasteboardName, const String& pasteboardType, std::optional<PageIdentifier> pageID, CompletionHandler<void(RefPtr<WebCore::SharedBuffer>&&)>&& completionHandler)
+void WebPasteboardProxy::getPasteboardBufferForType(IPC::Connection& connection, const String& pasteboardName, const String& pasteboardType, std::optional<PageIdentifier> pageID, CompletionHandler<void(WebCore::PasteboardBuffer&&)>&& completionHandler)
 {
     MESSAGE_CHECK_COMPLETION(!pasteboardType.isEmpty(), completionHandler({ }));
 
@@ -230,7 +230,8 @@ void WebPasteboardProxy::getPasteboardBufferForType(IPC::Connection& connection,
     MESSAGE_CHECK_COMPLETION(dataOwner, completionHandler({ }));
 
     PlatformPasteboard::performAsDataOwner(*dataOwner, [&] {
-        completionHandler(PlatformPasteboard(pasteboardName).bufferForType(pasteboardType));
+        auto pasteboardBuffer = PlatformPasteboard(pasteboardName).bufferForType(pasteboardType);
+        completionHandler(WTFMove(pasteboardBuffer));
     });
 }
 

--- a/Source/WebKit/UIProcess/WebPasteboardProxy.h
+++ b/Source/WebKit/UIProcess/WebPasteboardProxy.h
@@ -41,6 +41,7 @@ enum class DataOwnerType : uint8_t;
 class Color;
 class PasteboardCustomData;
 class SelectionData;
+struct PasteboardBuffer;
 struct PasteboardImage;
 struct PasteboardItemInfo;
 struct PasteboardURL;
@@ -96,7 +97,7 @@ private:
     void getPasteboardPathnamesForType(IPC::Connection&, const String& pasteboardName, const String& pasteboardType, std::optional<WebCore::PageIdentifier>, CompletionHandler<void(Vector<String>&& pathnames, Vector<SandboxExtension::Handle>&&)>&&);
     void getPasteboardStringForType(IPC::Connection&, const String& pasteboardName, const String& pasteboardType, std::optional<WebCore::PageIdentifier>, CompletionHandler<void(String&&)>&&);
     void getPasteboardStringsForType(IPC::Connection&, const String& pasteboardName, const String& pasteboardType, std::optional<WebCore::PageIdentifier>, CompletionHandler<void(Vector<String>&&)>&&);
-    void getPasteboardBufferForType(IPC::Connection&, const String& pasteboardName, const String& pasteboardType, std::optional<WebCore::PageIdentifier>, CompletionHandler<void(RefPtr<WebCore::SharedBuffer>&&)>&&);
+    void getPasteboardBufferForType(IPC::Connection&, const String& pasteboardName, const String& pasteboardType, std::optional<WebCore::PageIdentifier>, CompletionHandler<void(WebCore::PasteboardBuffer&&)>&&);
     void getPasteboardChangeCount(IPC::Connection&, const String& pasteboardName, std::optional<WebCore::PageIdentifier>, CompletionHandler<void(int64_t)>&&);
     void getPasteboardColor(IPC::Connection&, const String& pasteboardName, std::optional<WebCore::PageIdentifier>, CompletionHandler<void(WebCore::Color&&)>&&);
     void getPasteboardURL(IPC::Connection&, const String& pasteboardName, std::optional<WebCore::PageIdentifier>, CompletionHandler<void(const String&)>&&);

--- a/Source/WebKit/UIProcess/WebPasteboardProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPasteboardProxy.messages.in
@@ -46,7 +46,7 @@ messages -> WebPasteboardProxy NotRefCounted {
     GetPasteboardPathnamesForType(String pasteboardName, String pasteboardType, std::optional<WebCore::PageIdentifier> pageID) -> (Vector<String> pathnames, Vector<WebKit::SandboxExtension::Handle> sandboxExtensions) Synchronous
     GetPasteboardStringForType(String pasteboardName, String pasteboardType, std::optional<WebCore::PageIdentifier> pageID) -> (String string) Synchronous
     GetPasteboardStringsForType(String pasteboardName, String pasteboardType, std::optional<WebCore::PageIdentifier> pageID) -> (Vector<String> strings) Synchronous
-    GetPasteboardBufferForType(String pasteboardName, String pasteboardType, std::optional<WebCore::PageIdentifier> pageID) -> (RefPtr<WebCore::SharedBuffer> buffer) Synchronous
+    GetPasteboardBufferForType(String pasteboardName, String pasteboardType, std::optional<WebCore::PageIdentifier> pageID) -> (struct WebCore::PasteboardBuffer pasteboardBuffer) Synchronous
     GetPasteboardChangeCount(String pasteboardName, std::optional<WebCore::PageIdentifier> pageID) -> (int64_t changeCount) Synchronous
     GetPasteboardColor(String pasteboardName, std::optional<WebCore::PageIdentifier> pageID) -> (WebCore::Color color) Synchronous
     GetPasteboardURL(String pasteboardName, std::optional<WebCore::PageIdentifier> pageID) -> (String urlString) Synchronous

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp
@@ -150,8 +150,9 @@ RefPtr<WebCore::SharedBuffer> WebPlatformStrategies::bufferForType(const String&
 
     // Fallback to messaging the UI process for native pasteboard content.
     auto sendResult = WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPasteboardProxy::GetPasteboardBufferForType(pasteboardName, pasteboardType, pageIdentifier(context)), 0);
-    auto [buffer] = sendResult.takeReplyOr(nullptr);
-    return buffer;
+    auto [pasteboardBuffer] = sendResult.takeReplyOr(WebCore::PasteboardBuffer { });
+
+    return Pasteboard::bufferConvertedToPasteboardType(pasteboardBuffer, pasteboardType);
 }
 
 void WebPlatformStrategies::getPathnamesForType(Vector<String>& pathnames, const String& pasteboardType, const String& pasteboardName, const PasteboardContext* context)

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebPlatformStrategies.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebPlatformStrategies.mm
@@ -35,6 +35,7 @@
 #import <WebCore/LocalFrame.h>
 #import <WebCore/MediaStrategy.h>
 #import <WebCore/NetworkStorageSession.h>
+#import <WebCore/Pasteboard.h>
 #import <WebCore/PasteboardItemInfo.h>
 #import <WebCore/PlatformPasteboard.h>
 #import <WebCore/SharedBuffer.h>
@@ -109,9 +110,10 @@ void WebPlatformStrategies::getTypes(Vector<String>& types, const String& pasteb
     PlatformPasteboard(pasteboardName).getTypes(types);
 }
 
-RefPtr<SharedBuffer> WebPlatformStrategies::bufferForType(const String& pasteboardType, const String& pasteboardName, const PasteboardContext*)
+RefPtr<WebCore::SharedBuffer> WebPlatformStrategies::bufferForType(const String& pasteboardType, const String& pasteboardName, const PasteboardContext*)
 {
-    return PlatformPasteboard(pasteboardName).bufferForType(pasteboardType);
+    auto pasteboardBuffer = PlatformPasteboard(pasteboardName).bufferForType(pasteboardType);
+    return Pasteboard::bufferConvertedToPasteboardType(pasteboardBuffer, pasteboardType);
 }
 
 void WebPlatformStrategies::getPathnamesForType(Vector<String>& pathnames, const String& pasteboardType, const String& pasteboardName, const PasteboardContext*)

--- a/Tools/WebKitTestRunner/mac/WebKitTestRunnerPasteboard.mm
+++ b/Tools/WebKitTestRunner/mac/WebKitTestRunnerPasteboard.mm
@@ -30,6 +30,7 @@
 
 #import "NSPasteboardAdditions.h"
 #import <objc/runtime.h>
+#import <pal/spi/mac/NSPasteboardSPI.h>
 #import <wtf/Lock.h>
 #import <wtf/RetainPtr.h>
 
@@ -196,6 +197,11 @@ static RetainPtr<NSMutableDictionary> localPasteboards WTF_GUARDED_BY_LOCK(local
 - (NSData *)dataForType:(NSString *)dataType
 {
     return [_dataByType objectForKey:dataType];
+}
+
+- (NSData *)_dataWithoutConversionForType:(NSString *)type securityScoped:(BOOL)securityScoped
+{
+    return [self dataForType:type];
 }
 
 - (BOOL)setPropertyList:(id)propertyList forType:(NSString *)dataType


### PR DESCRIPTION
#### a2b978878b87687dffe753c836b7181e7a0f9276
<pre>
[CoreIPC] The pasteboard may perform image conversion in UIProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=263622">https://bugs.webkit.org/show_bug.cgi?id=263622</a>
<a href="https://rdar.apple.com/98996437">rdar://98996437</a>

Reviewed by Wenson Hsieh.

When reading data from the pasteboard, image conversion may be performed
when using `NSTIFFPboardType` as the requested type. This is a system feature,
where a PNG can be written to the pasteboard, and a TIFF can be read out.
However, this is undesirable from a WebKit perspective, as it allows for
arbitrary image conversion across the process boundary.

Fix by ensuring that the UI process always returns the original data, and
perform the image conversion in the Web process.

* Source/WebCore/PAL/pal/spi/cocoa/FoundationSPI.h:
* Source/WebCore/PAL/pal/spi/mac/NSPasteboardSPI.h:

Declare an internal `NSPasteboard` method to obtain the unconverted data.

* Source/WebCore/platform/Pasteboard.cpp:
* Source/WebCore/platform/Pasteboard.h:
(WebCore::Pasteboard::bufferConvertedToPasteboardType):
* Source/WebCore/platform/PlatformPasteboard.h:
* Source/WebCore/platform/ios/PlatformPasteboardIOS.mm:
(WebCore::PlatformPasteboard::bufferForType const):
* Source/WebCore/platform/mac/PasteboardMac.mm:
(WebCore::Pasteboard::bufferConvertedToPasteboardType):

Perform the conversion to TIFF using CoreGraphics in the Web process.

* Source/WebCore/platform/mac/PlatformPasteboardMac.mm:
(WebCore::PlatformPasteboard::bufferForType const):

When requesting `NSTIFFPboardType`, and an image source is available on the
pasteboard, return the original data and the original type, rather than
performing image conversion.

(WebCore::PlatformPasteboard::readBuffer const):
* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm:
(WebKit::WebPasteboardProxy::getPasteboardBufferForType):
* Source/WebKit/UIProcess/WebPasteboardProxy.h:
* Source/WebKit/UIProcess/WebPasteboardProxy.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp:
(WebKit::WebPlatformStrategies::bufferForType):
* Source/WebKitLegacy/mac/WebCoreSupport/WebPlatformStrategies.mm:
(WebPlatformStrategies::bufferForType):
* Tools/WebKitTestRunner/mac/WebKitTestRunnerPasteboard.mm:
(-[LocalPasteboard _dataWithoutConversionForType:securityScoped:]):

Override `_dataWithoutConversionForType:securityScoped:` since the custom
subclass used for testing does not account for pasteboard generation and
simply overrides `dataForType:`.

Without this implementation, the change would result in a call to the base
class and crash in `CFPasteboardGetGenerationCount`.

Originally-landed-as: 267815.441@safari-7617-branch (d4645ae84721). <a href="https://rdar.apple.com/119596032">rdar://119596032</a>
Canonical link: <a href="https://commits.webkit.org/272348@main">https://commits.webkit.org/272348@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a350e3e04db620a88fec38214f2f7af84d17896

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31350 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10019 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33043 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33844 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28417 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32117 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12384 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7269 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28055 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31686 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8451 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27988 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7254 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/31511 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7427 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27892 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35185 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28515 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28342 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33549 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7486 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5516 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31400 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9150 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7368 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8179 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7998 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->