### PR TITLE
Add a way to test RemoteLayerBackingStore's copy-forward code.

### DIFF
--- a/LayoutTests/compositing/repaint/copy-forward-dirty-region-expected.html
+++ b/LayoutTests/compositing/repaint/copy-forward-dirty-region-expected.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        div {
+            width: 100px;
+            height: 100px;
+            position: absolute;
+            background-color: green;
+        }
+        #second {
+            left: 200px;
+        }
+    </style>
+</head>
+<body>
+    <div id="first"></div>
+    <div id="second"></div>
+</body>
+</html>

--- a/LayoutTests/compositing/repaint/copy-forward-dirty-region-purged-backbuffer-expected.html
+++ b/LayoutTests/compositing/repaint/copy-forward-dirty-region-purged-backbuffer-expected.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+
+<html>
+<head>
+    <style>
+        #first {
+            width: 200px;
+            height: 200px;
+            position: absolute;
+            background-color: green;
+        }
+    </style>
+</head>
+<body>
+    <div id="first"></div>
+</body>
+</html>

--- a/LayoutTests/compositing/repaint/copy-forward-dirty-region-purged-backbuffer.html
+++ b/LayoutTests/compositing/repaint/copy-forward-dirty-region-purged-backbuffer.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+
+<html>
+<head>
+    <script src="../../resources/ui-helper.js"></script>
+    <style>
+        #first {
+            width: 200px;
+            height: 200px;
+            position: absolute;
+            background-color: green;
+            transform: translateZ(0px);
+        }
+        #inner {
+            width: 50px;
+            height: 50px;
+            background-color: red;
+        }
+    </style>
+    <script>
+        if (window.testRunner) {
+            testRunner.waitUntilDone();
+            if (testRunner.dontForceRepaint)
+                testRunner.dontForceRepaint();
+        }
+        async function doTest()
+        {
+            await UIHelper.renderingUpdate();
+            document.getElementById('inner').style.backgroundColor = "blue";
+            await UIHelper.renderingUpdate();
+
+            window.internals.purgeBackBuffer(document.getElementById('first'));
+            document.getElementById('inner').style.backgroundColor = "green";
+            
+            await UIHelper.renderingUpdate();
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }
+        window.addEventListener('load', doTest, false);
+    </script>
+</head>
+<body>
+    <div id="first"><div id="inner"></div></div>
+</body>
+</html>

--- a/LayoutTests/compositing/repaint/copy-forward-dirty-region-purged-expected.html
+++ b/LayoutTests/compositing/repaint/copy-forward-dirty-region-purged-expected.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+
+<html>
+<head>
+    <style>
+        #first {
+            width: 200px;
+            height: 200px;
+            position: absolute;
+            background-color: green;
+        }
+    </style>
+</head>
+<body>
+    <div id="first"></div>
+</body>
+</html>

--- a/LayoutTests/compositing/repaint/copy-forward-dirty-region-purged.html
+++ b/LayoutTests/compositing/repaint/copy-forward-dirty-region-purged.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+
+<html>
+<head>
+    <script src="../../resources/ui-helper.js"></script>
+    <style>
+        #first {
+            width: 200px;
+            height: 200px;
+            position: absolute;
+            background-color: green;
+            transform: translateZ(0px);
+        }
+        #inner {
+            width: 50px;
+            height: 50px;
+            background-color: red;
+        }
+    </style>
+    <script>
+        if (window.testRunner) {
+            testRunner.waitUntilDone();
+            if (testRunner.dontForceRepaint)
+                testRunner.dontForceRepaint();
+        }
+        async function doTest()
+        {
+            await UIHelper.renderingUpdate();
+
+            window.internals.purgeFrontBuffer(document.getElementById('first'));
+            document.getElementById('inner').style.backgroundColor = "green";
+            
+            await UIHelper.renderingUpdate();
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }
+        window.addEventListener('load', doTest, false);
+    </script>
+</head>
+<body>
+    <div id="first"><div id="inner"></div></div>
+</body>
+</html>

--- a/LayoutTests/compositing/repaint/copy-forward-dirty-region.html
+++ b/LayoutTests/compositing/repaint/copy-forward-dirty-region.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+
+<html>
+<head>
+    <script src="../../resources/ui-helper.js"></script>
+    <style>
+        div {
+            width: 100px;
+            height: 100px;
+            position: absolute;
+        }
+        #second {
+            left: 200px;
+        }
+        #inner {
+            width: 50px;
+            height: 50px;
+        }
+    </style>
+    <script>
+        if (window.testRunner) {
+            testRunner.waitUntilDone();
+            if (testRunner.dontForceRepaint)
+                testRunner.dontForceRepaint();
+        }
+        async function doTest()
+        {
+            await UIHelper.renderingUpdate();
+            document.getElementById('second').style.backgroundColor = "red";
+            
+            await UIHelper.renderingUpdate();
+            document.getElementById('first').style.backgroundColor = "green";
+
+            await UIHelper.renderingUpdate();
+            document.getElementById('second').style.backgroundColor = "green";
+            document.getElementById('inner').style.backgroundColor = "green";
+            
+            await UIHelper.renderingUpdate();
+
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }
+        window.addEventListener('load', doTest, false);
+    </script>
+</head>
+<body>
+    <div id="first"><div id="inner"></div></div>
+    <div id="second"></div>
+</body>
+</html>

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -2598,3 +2598,4 @@ webkit.org/b/266204 [ Debug ] imported/w3c/web-platform-tests/scroll-animations/
 imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/mask-and-nested-clip-path.svg [ Failure ]
 
 fast/dom/no-scroll-when-command-click-fragment-URL.html [ Skip ]
+compositing/repaint/copy-forward-dirty-region-purged-backbuffer.html [ ImageOnlyFailure ]

--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -684,6 +684,9 @@ public:
     WEBCORE_EXPORT virtual void setAcceleratedEffectsAndBaseValues(AcceleratedEffects&&, AcceleratedEffectValues&&);
 #endif
 
+    virtual void purgeFrontBufferForTesting() { }
+    virtual void purgeBackBufferForTesting() { }
+
 protected:
     WEBCORE_EXPORT explicit GraphicsLayer(Type, GraphicsLayerClient&);
 

--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -482,9 +482,16 @@ bool ImageBuffer::setVolatile()
 
 SetNonVolatileResult ImageBuffer::setNonVolatile()
 {
+    auto result = SetNonVolatileResult::Valid;
     if (auto* backend = ensureBackend())
-        return backend->setNonVolatile();
-    return SetNonVolatileResult::Valid;
+        result = backend->setNonVolatile();
+
+    if (m_hasForcedPurgeForTesting) {
+        result = SetNonVolatileResult::Empty;
+        m_hasForcedPurgeForTesting = false;
+    }
+
+    return result;
 }
 
 VolatilityState ImageBuffer::volatilityState() const
@@ -498,6 +505,15 @@ void ImageBuffer::setVolatilityState(VolatilityState volatilityState)
 {
     if (auto* backend = ensureBackend())
         backend->setVolatilityState(volatilityState);
+}
+
+void ImageBuffer::setVolatileAndPurgeForTesting()
+{
+    releaseGraphicsContext();
+    context().clearRect(FloatRect(FloatPoint::zero(), logicalSize()));
+    releaseGraphicsContext();
+    setVolatile();
+    m_hasForcedPurgeForTesting = true;
 }
 
 std::unique_ptr<ThreadSafeImageBufferFlusher> ImageBuffer::createFlusher()

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -210,6 +210,7 @@ public:
     WEBCORE_EXPORT SetNonVolatileResult setNonVolatile();
     WEBCORE_EXPORT VolatilityState volatilityState() const;
     WEBCORE_EXPORT void setVolatilityState(VolatilityState);
+    WEBCORE_EXPORT void setVolatileAndPurgeForTesting();
     WEBCORE_EXPORT virtual std::unique_ptr<ThreadSafeImageBufferFlusher> createFlusher();
 
     // This value increments when the ImageBuffer gets a new backend, which can happen if, for example, the GPU Process exits.
@@ -235,6 +236,7 @@ protected:
     std::unique_ptr<ImageBufferBackend> m_backend;
     RenderingResourceIdentifier m_renderingResourceIdentifier;
     unsigned m_backendGeneration { 0 };
+    bool m_hasForcedPurgeForTesting { false };
 };
 
 class SerializedImageBuffer {

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -5066,6 +5066,18 @@ void GraphicsLayerCA::setAcceleratedEffectsAndBaseValues(AcceleratedEffects&& ef
 }
 #endif
 
+void GraphicsLayerCA::purgeFrontBufferForTesting()
+{
+    if (primaryLayer())
+        primaryLayer()->purgeFrontBufferForTesting();
+}
+
+void GraphicsLayerCA::purgeBackBufferForTesting()
+{
+    if (primaryLayer())
+        primaryLayer()->purgeBackBufferForTesting();
+}
+
 } // namespace WebCore
 
 #endif

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -208,6 +208,9 @@ public:
     WEBCORE_EXPORT void setAcceleratedEffectsAndBaseValues(AcceleratedEffects&&, AcceleratedEffectValues&&) override;
 #endif
 
+    WEBCORE_EXPORT void purgeFrontBufferForTesting() override;
+    WEBCORE_EXPORT void purgeBackBufferForTesting() override;
+
 private:
     bool isGraphicsLayerCA() const override { return true; }
 

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayer.h
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayer.h
@@ -332,6 +332,9 @@ public:
 
     virtual void dumpAdditionalProperties(TextStream&, OptionSet<PlatformLayerTreeAsTextFlags>);
 
+    virtual void purgeFrontBufferForTesting() { }
+    virtual void purgeBackBufferForTesting() { }
+
 protected:
     PlatformCALayer(LayerType, PlatformCALayerClient* owner);
 

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -5791,6 +5791,18 @@ void RenderLayer::simulateFrequentPaint()
     m_paintFrequencyTracker.track(page().lastRenderingUpdateTimestamp());
 }
 
+void RenderLayer::purgeFrontBufferForTesting()
+{
+    if (backing())
+        backing()->purgeFrontBufferForTesting();
+}
+
+void RenderLayer::purgeBackBufferForTesting()
+{
+    if (backing())
+        backing()->purgeBackBufferForTesting();
+}
+
 RenderLayerScrollableArea* RenderLayer::scrollableArea() const
 {
     return m_scrollableArea.get();

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -865,6 +865,8 @@ public:
 
     WEBCORE_EXPORT void simulateFrequentPaint();
     bool paintingFrequently() const { return m_paintFrequencyTracker.paintingFrequently(); }
+    WEBCORE_EXPORT void purgeFrontBufferForTesting();
+    WEBCORE_EXPORT void purgeBackBufferForTesting();
 
     WEBCORE_EXPORT bool isTransparentRespectingParentFrames() const;
 

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -4314,4 +4314,16 @@ TransformationMatrix RenderLayerBacking::transformMatrixForProperty(AnimatedProp
     return matrix;
 }
 
+void RenderLayerBacking::purgeFrontBufferForTesting()
+{
+    if (m_graphicsLayer)
+        m_graphicsLayer->purgeFrontBufferForTesting();
+}
+
+void RenderLayerBacking::purgeBackBufferForTesting()
+{
+    if (m_graphicsLayer)
+        m_graphicsLayer->purgeBackBufferForTesting();
+}
+
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderLayerBacking.h
+++ b/Source/WebCore/rendering/RenderLayerBacking.h
@@ -289,6 +289,9 @@ public:
     WEBCORE_EXPORT String replayDisplayListAsText(OptionSet<DisplayList::AsTextFlag>) const;
 
     bool shouldPaintUsingCompositeCopy() const { return m_shouldPaintUsingCompositeCopy; }
+
+    void purgeFrontBufferForTesting();
+    void purgeBackBufferForTesting();
 private:
     friend class PaintedContentsInfo;
 

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1383,6 +1383,18 @@ void Internals::incrementFrequentPaintCounter(Element& element)
         element.renderer()->enclosingLayer()->simulateFrequentPaint();
 }
 
+void Internals::purgeFrontBuffer(Element& element)
+{
+    if (element.renderer() && element.renderer()->enclosingLayer())
+        element.renderer()->enclosingLayer()->purgeFrontBufferForTesting();
+}
+
+void Internals::purgeBackBuffer(Element& element)
+{
+    if (element.renderer() && element.renderer()->enclosingLayer())
+        element.renderer()->enclosingLayer()->purgeBackBufferForTesting();
+}
+
 Ref<CSSComputedStyleDeclaration> Internals::computedStyleIncludingVisitedInfo(Element& element) const
 {
     bool allowVisitedStyle = true;

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -199,6 +199,8 @@ public:
     bool isFullyActive(Document&);
     bool isPaintingFrequently(Element&);
     void incrementFrequentPaintCounter(Element&);
+    void purgeFrontBuffer(Element&);
+    void purgeBackBuffer(Element&);
 
     String address(Node&);
     bool nodeNeedsStyleRecalc(Node&);

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -436,6 +436,8 @@ typedef (FetchRequest or FetchResponse) FetchObject;
     // Must be called on an element whose enclosingLayer() is self-painting.
     boolean isPaintingFrequently(Element element);
     undefined incrementFrequentPaintCounter(Element element);
+    undefined purgeFrontBuffer(Element element);
+    undefined purgeBackBuffer(Element element);
 
     DOMString elementRenderTreeAsText(Element element);
     boolean isPreloaded(DOMString url);

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp
@@ -255,11 +255,15 @@ void RemoteImageBufferSet::prepareBufferForDisplay(const WebCore::Region& dirtyR
     m_frontBufferIsCleared = false;
 }
 
-bool RemoteImageBufferSet::makeBuffersVolatile(OptionSet<BufferInSetType> requestedBuffers, OptionSet<BufferInSetType>& volatileBuffers)
+bool RemoteImageBufferSet::makeBuffersVolatile(OptionSet<BufferInSetType> requestedBuffers, OptionSet<BufferInSetType>& volatileBuffers, bool forcePurge)
 {
     bool allSucceeded = true;
 
-    auto makeVolatile = [](WebCore::ImageBuffer& imageBuffer) {
+    auto makeVolatile = [&](WebCore::ImageBuffer& imageBuffer) {
+        if (forcePurge) {
+            imageBuffer.setVolatileAndPurgeForTesting();
+            return true;
+        }
         imageBuffer.releaseGraphicsContext();
         return imageBuffer.setVolatile();
     };

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.h
@@ -57,7 +57,7 @@ public:
     // to be drawn (unless drawing will be opaque).
     void prepareBufferForDisplay(const WebCore::Region& dirtyRegion, bool requiresClearedPixels);
 
-    bool makeBuffersVolatile(OptionSet<BufferInSetType> requestedBuffers, OptionSet<BufferInSetType>& volatileBuffers);
+    bool makeBuffersVolatile(OptionSet<BufferInSetType> requestedBuffers, OptionSet<BufferInSetType>& volatileBuffers, bool forcePurge);
 
 private:
     RemoteImageBufferSet(RemoteImageBufferSetIdentifier, WebCore::RenderingResourceIdentifier, RemoteRenderingBackend&);

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -439,7 +439,7 @@ void RemoteRenderingBackend::prepareImageBufferSetsForDisplay(Vector<ImageBuffer
 }
 #endif
 
-void RemoteRenderingBackend::markSurfacesVolatile(MarkSurfacesAsVolatileRequestIdentifier requestIdentifier, const Vector<std::pair<RemoteImageBufferSetIdentifier, OptionSet<BufferInSetType>>>& identifiers)
+void RemoteRenderingBackend::markSurfacesVolatile(MarkSurfacesAsVolatileRequestIdentifier requestIdentifier, const Vector<std::pair<RemoteImageBufferSetIdentifier, OptionSet<BufferInSetType>>>& identifiers, bool forcePurge)
 {
     assertIsCurrent(workQueue());
     LOG_WITH_STREAM(RemoteLayerBuffers, stream << "GPU Process: RemoteRenderingBackend::markSurfacesVolatile " << identifiers);
@@ -453,7 +453,7 @@ void RemoteRenderingBackend::markSurfacesVolatile(MarkSurfacesAsVolatileRequestI
         MESSAGE_CHECK(remoteImageBufferSet, "BufferSet is being marked volatile before being created"_s);
 
         OptionSet<BufferInSetType> volatileBuffers;
-        if (!remoteImageBufferSet->makeBuffersVolatile(identifier.second, volatileBuffers))
+        if (!remoteImageBufferSet->makeBuffersVolatile(identifier.second, volatileBuffers, forcePurge))
             allSucceeded = false;
 
         if (!volatileBuffers.isEmpty())

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
@@ -151,7 +151,7 @@ private:
     void releaseAllImageResources();
     void releaseRenderingResource(WebCore::RenderingResourceIdentifier);
     void finalizeRenderingUpdate(RenderingUpdateID);
-    void markSurfacesVolatile(MarkSurfacesAsVolatileRequestIdentifier, const Vector<std::pair<RemoteImageBufferSetIdentifier, OptionSet<BufferInSetType>>>&);
+    void markSurfacesVolatile(MarkSurfacesAsVolatileRequestIdentifier, const Vector<std::pair<RemoteImageBufferSetIdentifier, OptionSet<BufferInSetType>>>&, bool forcePurge);
     void createRemoteImageBufferSet(WebKit::RemoteImageBufferSetIdentifier, WebCore::RenderingResourceIdentifier displayListIdentifier);
     void releaseRemoteImageBufferSet(WebKit::RemoteImageBufferSetIdentifier);
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
@@ -43,7 +43,7 @@ messages -> RemoteRenderingBackend NotRefCounted Stream {
     PrepareImageBufferSetsForDisplay(Vector<WebKit::ImageBufferSetPrepareBufferForDisplayInputData> swapBuffersInput)  -> (Vector<WebKit::ImageBufferSetPrepareBufferForDisplayOutputData> swapBuffersOutput) NotStreamEncodableReply ReplyCanDispatchOutOfOrder
 #endif
 
-    MarkSurfacesVolatile(WebKit::MarkSurfacesAsVolatileRequestIdentifier requestIdentifier, Vector<std::pair<WebKit::RemoteImageBufferSetIdentifier, OptionSet<WebKit::BufferInSetType>>> renderingResourceIdentifiers)
+    MarkSurfacesVolatile(WebKit::MarkSurfacesAsVolatileRequestIdentifier requestIdentifier, Vector<std::pair<WebKit::RemoteImageBufferSetIdentifier, OptionSet<WebKit::BufferInSetType>>> renderingResourceIdentifiers, bool forcePurge)
     FinalizeRenderingUpdate(WebKit::RenderingUpdateID renderingUpdateID)
 
 #if USE(GRAPHICS_LAYER_WC)

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
@@ -161,6 +161,9 @@ public:
 
     virtual void dump(WTF::TextStream&) const = 0;
 
+    void purgeFrontBufferForTesting();
+    void purgeBackBufferForTesting();
+
 protected:
     RemoteLayerBackingStoreCollection* backingStoreCollection() const;
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
@@ -607,6 +607,18 @@ Vector<std::unique_ptr<ThreadSafeImageBufferFlusher>> RemoteLayerBackingStore::t
     return std::exchange(m_frontBufferFlushers, { });
 }
 
+void RemoteLayerBackingStore::purgeFrontBufferForTesting()
+{
+    if (auto* collection = backingStoreCollection())
+        collection->purgeFrontBufferForTesting(*this);
+}
+
+void RemoteLayerBackingStore::purgeBackBufferForTesting()
+{
+    if (auto* collection = backingStoreCollection())
+        collection->purgeBackBufferForTesting(*this);
+}
+
 TextStream& operator<<(TextStream& ts, const RemoteLayerBackingStore& backingStore)
 {
     backingStore.dump(ts);

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.h
@@ -60,6 +60,9 @@ public:
     virtual void backingStoreWillBeDestroyed(RemoteLayerBackingStore&);
     void backingStoreWillBeEncoded(const RemoteLayerBackingStore&);
 
+    void purgeFrontBufferForTesting(RemoteLayerBackingStore&);
+    void purgeBackBufferForTesting(RemoteLayerBackingStore&);
+
     // Return value indicates whether the backing store needs to be included in the transaction.
     bool backingStoreWillBeDisplayed(RemoteLayerBackingStore&);
     void backingStoreBecameUnreachable(RemoteLayerBackingStore&);
@@ -105,7 +108,7 @@ private:
     void volatilityTimerFired();
 
 protected:
-    void sendMarkBuffersVolatile(Vector<std::pair<Ref<RemoteImageBufferSetProxy>, OptionSet<BufferInSetType>>>&&, CompletionHandler<void(bool)>&&);
+    void sendMarkBuffersVolatile(Vector<std::pair<Ref<RemoteImageBufferSetProxy>, OptionSet<BufferInSetType>>>&&, CompletionHandler<void(bool)>&&, bool forcePurge = false);
 
     static constexpr auto volatileBackingStoreAgeThreshold = 1_s;
     static constexpr auto volatileSecondaryBackingStoreAgeThreshold = 200_ms;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.h
@@ -41,7 +41,7 @@ public:
 
     void clearBackingStore() final;
 
-    bool setBufferVolatile(BufferType);
+    bool setBufferVolatile(BufferType, bool forcePurge = false);
 
     std::optional<ImageBufferBackendHandle> frontBufferHandle() const final;
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
@@ -73,7 +73,7 @@ private:
     };
 
     // Returns true if it was able to fulfill the request. This can fail when trying to mark an in-use surface as volatile.
-    bool setBufferVolatile(Buffer&);
+    bool setBufferVolatile(Buffer&, bool forcePurge = false);
 
     WebCore::SetNonVolatileResult setBufferNonVolatile(Buffer&);
     WebCore::SetNonVolatileResult setFrontBufferNonVolatile();

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -409,7 +409,7 @@ void RemoteRenderingBackendProxy::ensurePrepareCompleted()
 }
 #endif
 
-void RemoteRenderingBackendProxy::markSurfacesVolatile(Vector<std::pair<Ref<RemoteImageBufferSetProxy>, OptionSet<BufferInSetType>>>&& bufferSets, CompletionHandler<void(bool)>&& completionHandler)
+void RemoteRenderingBackendProxy::markSurfacesVolatile(Vector<std::pair<Ref<RemoteImageBufferSetProxy>, OptionSet<BufferInSetType>>>&& bufferSets, CompletionHandler<void(bool)>&& completionHandler, bool forcePurge)
 {
     Vector<std::pair<RemoteImageBufferSetIdentifier, OptionSet<BufferInSetType>>> identifiers;
     for (auto& pair : bufferSets) {
@@ -419,7 +419,7 @@ void RemoteRenderingBackendProxy::markSurfacesVolatile(Vector<std::pair<Ref<Remo
     m_currentVolatilityRequest = MarkSurfacesAsVolatileRequestIdentifier::generate();
     m_markAsVolatileRequests.add(m_currentVolatilityRequest, WTFMove(completionHandler));
 
-    send(Messages::RemoteRenderingBackend::MarkSurfacesVolatile(m_currentVolatilityRequest, identifiers));
+    send(Messages::RemoteRenderingBackend::MarkSurfacesVolatile(m_currentVolatilityRequest, identifiers, forcePurge));
 }
 
 void RemoteRenderingBackendProxy::didMarkLayersAsVolatile(MarkSurfacesAsVolatileRequestIdentifier requestIdentifier, Vector<std::pair<RemoteImageBufferSetIdentifier, OptionSet<BufferInSetType>>> markedBufferSets, bool didMarkAllLayersAsVolatile)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
@@ -110,7 +110,7 @@ public:
     void releaseAllDrawingResources();
     void releaseAllImageResources();
     void releaseRenderingResource(WebCore::RenderingResourceIdentifier);
-    void markSurfacesVolatile(Vector<std::pair<Ref<RemoteImageBufferSetProxy>, OptionSet<BufferInSetType>>>&&, CompletionHandler<void(bool madeAllVolatile)>&&);
+    void markSurfacesVolatile(Vector<std::pair<Ref<RemoteImageBufferSetProxy>, OptionSet<BufferInSetType>>>&&, CompletionHandler<void(bool madeAllVolatile)>&&, bool forcePurge);
     RefPtr<RemoteImageBufferSetProxy> createRemoteImageBufferSet();
     void releaseRemoteImageBufferSet(RemoteImageBufferSetProxy&);
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
@@ -251,6 +251,9 @@ public:
 
     bool containsBitmapOnly() const;
 
+    void purgeFrontBufferForTesting() override;
+    void purgeBackBufferForTesting() override;
+
 protected:
     PlatformCALayerRemote(WebCore::PlatformCALayer::LayerType, WebCore::PlatformCALayerClient* owner, RemoteLayerTreeContext&);
     PlatformCALayerRemote(const PlatformCALayerRemote&, WebCore::PlatformCALayerClient*, RemoteLayerTreeContext&);

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
@@ -1089,4 +1089,17 @@ void PlatformCALayerRemote::setAcceleratedEffectsAndBaseValues(const Accelerated
 }
 #endif
 
+void PlatformCALayerRemote::purgeFrontBufferForTesting()
+{
+    if (m_properties.backingStoreOrProperties.store)
+        return m_properties.backingStoreOrProperties.store->purgeFrontBufferForTesting();
+}
+
+void PlatformCALayerRemote::purgeBackBufferForTesting()
+{
+    if (m_properties.backingStoreOrProperties.store)
+        return m_properties.backingStoreOrProperties.store->purgeBackBufferForTesting();
+}
+
+
 } // namespace WebKit

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -122,6 +122,7 @@ interface TestRunner {
     undefined display();
     undefined displayAndTrackRepaints();
     undefined displayOnLoadFinish();
+    undefined dontForceRepaint();
 
     // Failed load condition testing
     undefined forceImmediateCompletion();

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
@@ -446,7 +446,7 @@ void InjectedBundle::didReceiveMessageToPage(WKBundlePageRef page, WKStringRef m
     }
 
     if (WKStringIsEqualToUTF8CString(messageName, "NotifyDone")) {
-        InjectedBundle::page()->dump();
+        InjectedBundle::page()->dump(m_testRunner->shouldForceRepaint());
         return;
     }
 
@@ -460,7 +460,7 @@ void InjectedBundle::didReceiveMessageToPage(WKBundlePageRef page, WKStringRef m
 
     if (WKStringIsEqualToUTF8CString(messageName, "WorkQueueProcessedCallback")) {
         if (!topLoadingFrame() && !m_testRunner->shouldWaitUntilDone())
-            InjectedBundle::page()->dump();
+            InjectedBundle::page()->dump(m_testRunner->shouldForceRepaint());
         return;
     }
 
@@ -596,7 +596,7 @@ void InjectedBundle::beginTesting(WKDictionaryRef settings, BegingTestingMode te
     // WKBundleSetDatabaseQuota(m_bundle.get(), 5 * 1024 * 1024);
 }
 
-void InjectedBundle::done()
+void InjectedBundle::done(bool forceRepaint)
 {
     m_state = Stopping;
 
@@ -617,6 +617,7 @@ void InjectedBundle::done()
         setValue(body, "PixelResult", m_pixelResult);
     setValue(body, "RepaintRects", m_repaintRects);
     setValue(body, "AudioResult", m_audioResult);
+    setValue(body, "ForceRepaint", forceRepaint);
 
     WKBundlePagePostMessageIgnoringFullySynchronousMode(page()->page(), toWK("Done").get(), body.get());
 

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h
@@ -63,7 +63,7 @@ public:
 
     void dumpBackForwardListsForAllPages(StringBuilder&);
 
-    void done();
+    void done(bool forceRepaint);
     void setAudioResult(WKDataRef audioData) { m_audioResult = audioData; }
     void setPixelResult(WKImageRef image) { m_pixelResult = image; m_pixelResultIsPending = false; }
     void setPixelResultIsPending(bool isPending) { m_pixelResultIsPending = isPending; }

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.h
@@ -41,7 +41,7 @@ public:
 
     WKBundlePageRef page() const { return m_page; }
 
-    void dump();
+    void dump(bool forceRepaint);
 
     void stopLoading();
 

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -257,7 +257,7 @@ void TestRunner::notifyDone()
         return;
 
     if (shouldWaitUntilDone() && !injectedBundle.topLoadingFrame())
-        injectedBundle.page()->dump();
+        injectedBundle.page()->dump(m_forceRepaint);
 
     // We don't call invalidateWaitToDumpWatchdogTimer() here, even if we continue to wait for a load to finish.
     // The test is still subject to timeout checking - it is better to detect an async timeout inside WebKitTestRunner
@@ -273,7 +273,7 @@ void TestRunner::forceImmediateCompletion()
         return;
 
     if (shouldWaitUntilDone() && injectedBundle.page())
-        injectedBundle.page()->dump();
+        injectedBundle.page()->dump(m_forceRepaint);
 
     setWaitUntilDone(false);
 }

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -149,6 +149,8 @@ public:
     void displayAndTrackRepaints();
     void displayOnLoadFinish() { m_displayOnLoadFinish = true; }
     bool shouldDisplayOnLoadFinish() { return m_displayOnLoadFinish; }
+    void dontForceRepaint() { m_forceRepaint = false; }
+    bool shouldForceRepaint() { return m_forceRepaint; }
 
     // UserContent testing.
     void addUserScript(JSStringRef source, bool runAtStart, bool allFrames);
@@ -640,6 +642,7 @@ private:
     bool m_testRepaint { false };
     bool m_testRepaintSweepHorizontally { false };
     bool m_displayOnLoadFinish { false };
+    bool m_forceRepaint { true };
     bool m_isPrinting { false };
     bool m_willSendRequestReturnsNull { false };
     bool m_willSendRequestReturnsNullOnRedirect { false };

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -272,9 +272,11 @@ void TestInvocation::dumpResults()
         if (m_pixelResult)
             dumpPixelsAndCompareWithExpected(SnapshotResultType::WebContents, m_repaintRects.get(), m_pixelResult.get());
         else if (m_pixelResultIsPending) {
-            m_gotRepaint = false;
-            WKPageForceRepaint(TestController::singleton().mainWebView()->page(), this, TestInvocation::forceRepaintDoneCallback);
-            TestController::singleton().runUntil(m_gotRepaint, TestController::noTimeout);
+            if (m_forceRepaint) {
+                m_gotRepaint = false;
+                WKPageForceRepaint(TestController::singleton().mainWebView()->page(), this, TestInvocation::forceRepaintDoneCallback);
+                TestController::singleton().runUntil(m_gotRepaint, TestController::noTimeout);
+            }
             dumpPixelsAndCompareWithExpected(SnapshotResultType::WebView, m_repaintRects.get());
         }
     }
@@ -344,6 +346,7 @@ void TestInvocation::didReceiveMessageFromInjectedBundle(WKStringRef messageName
         }
         m_repaintRects = static_cast<WKArrayRef>(value(messageBodyDictionary, "RepaintRects"));
         m_audioResult = static_cast<WKDataRef>(value(messageBodyDictionary, "AudioResult"));
+        m_forceRepaint = booleanValue(messageBodyDictionary, "ForceRepaint");
         done();
         return;
     }

--- a/Tools/WebKitTestRunner/TestInvocation.h
+++ b/Tools/WebKitTestRunner/TestInvocation.h
@@ -169,6 +169,7 @@ private:
     bool m_dumpPixels { false };
     bool m_forceDumpPixels { false };
     bool m_pixelResultIsPending { false };
+    bool m_forceRepaint { true };
     bool m_shouldDumpResourceLoadStatistics { false };
     bool m_canOpenWindows { true };
     bool m_shouldDumpPrivateClickMeasurement { false };


### PR DESCRIPTION
#### f57f00ab6a22c7b846e9dda0fa296da77aa48e23
<pre>
Add a way to test RemoteLayerBackingStore&apos;s copy-forward code.
<a href="https://bugs.webkit.org/show_bug.cgi?id=266674">https://bugs.webkit.org/show_bug.cgi?id=266674</a>
&lt;<a href="https://rdar.apple.com/problem/119905421">rdar://problem/119905421</a>&gt;

Reviewed by Kimmo Kinnunen.

We can&apos;t currently test this, because WKTR always forces a full repaint.

This adds a &apos;dontForceRepaint()&apos; option to the test runner, to request that no repaint is done
at the end of the test, and for it to just capture whatever pixel contents are currently available.

It also adds a purgeFrontBuffer/purgeBackBuffer method to the Internals interface, which try to
purge (faked via clearing the buffer contents) the relevant layer buffer for the element.

It adds three new tests, which would have caught each of the recent bugs (271908@main, 272069@main,
272304@main) in this area.

* LayoutTests/compositing/repaint/copy-forward-dirty-region-expected.html: Added.
* LayoutTests/compositing/repaint/copy-forward-dirty-region-purged-backbuffer-expected.html: Added.
* LayoutTests/compositing/repaint/copy-forward-dirty-region-purged-backbuffer.html: Added.
* LayoutTests/compositing/repaint/copy-forward-dirty-region-purged-expected.html: Added.
* LayoutTests/compositing/repaint/copy-forward-dirty-region-purged.html: Added.
* LayoutTests/compositing/repaint/copy-forward-dirty-region.html: Added.
* Source/WebCore/platform/graphics/GraphicsLayer.h:
(WebCore::GraphicsLayer::purgeFrontBufferForTesting):
(WebCore::GraphicsLayer::purgeBackBufferForTesting):
* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::forcePurgeForTesting):
* Source/WebCore/platform/graphics/ImageBuffer.h:
* Source/WebCore/platform/graphics/ImageBufferBackend.h:
(WebCore::ImageBufferBackend::forcePurgeForTesting):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::purgeFrontBufferForTesting):
(WebCore::GraphicsLayerCA::purgeBackBufferForTesting):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:
* Source/WebCore/platform/graphics/ca/PlatformCALayer.h:
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp:
(WebCore::ImageBufferIOSurfaceBackend::setNonVolatile):
(WebCore::ImageBufferIOSurfaceBackend::forcePurgeForTesting):
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h:
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::purgeFrontBufferForTesting):
(WebCore::RenderLayerBacking::purgeBackBufferForTesting):
* Source/WebCore/rendering/RenderLayerBacking.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::purgeFrontBuffer):
(WebCore::Internals::purgeBackBuffer):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp:
(WebKit::RemoteImageBufferSet::makeBuffersVolatile):
* Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.h:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::markSurfacesVolatile):
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm:
(WebKit::RemoteLayerBackingStore::purgeFrontBufferForTesting):
(WebKit::RemoteLayerBackingStore::purgeBackBufferForTesting):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm:
(WebKit::RemoteLayerBackingStoreCollection::purgeFrontBufferForTesting):
(WebKit::RemoteLayerBackingStoreCollection::purgeBackBufferForTesting):
(WebKit::RemoteLayerBackingStoreCollection::sendMarkBuffersVolatile):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm:
(WebKit::RemoteLayerWithInProcessRenderingBackingStore::setBufferVolatile):
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::markSurfacesVolatile):
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.cpp:
(WebKit::ImageBufferShareableMappedIOSurfaceBitmapBackend::setNonVolatile):
(WebKit::ImageBufferShareableMappedIOSurfaceBitmapBackend::forcePurgeForTesting):
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm:
(WebKit::PlatformCALayerRemote::purgeFrontBufferForTesting):
(WebKit::PlatformCALayerRemote::purgeBackBufferForTesting):
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp:
(WTR::InjectedBundle::didReceiveMessageToPage):
(WTR::InjectedBundle::done):
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h:
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp:
(WTR::InjectedBundlePage::dump):
(WTR::dumpAfterWaitAttributeIsRemoved):
(WTR::InjectedBundlePage::frameDidChangeLocation):
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.h:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::notifyDone):
(WTR::TestRunner::forceImmediateCompletion):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
(WTR::TestRunner::dontForceRepaint):
(WTR::TestRunner::shouldForceRepaint):
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::dumpResults):
(WTR::TestInvocation::didReceiveMessageFromInjectedBundle):
* Tools/WebKitTestRunner/TestInvocation.h:

Canonical link: <a href="https://commits.webkit.org/273169@main">https://commits.webkit.org/273169@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af8e1c7f9af9b7fe5355926700001e01747d15b2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34521 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13340 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36523 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37206 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31202 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35659 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15732 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10447 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30179 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35042 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11276 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30760 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9854 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9933 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30821 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38484 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31338 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31136 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36003 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10059 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7944 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33953 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11879 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/30446 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7935 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10615 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10924 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->