### PR TITLE
Reduce use of downcast<>() in SVG code

### DIFF
--- a/Source/WebCore/svg/DocumentSVG.cpp
+++ b/Source/WebCore/svg/DocumentSVG.cpp
@@ -34,10 +34,7 @@ namespace WebCore {
 
 RefPtr<SVGSVGElement> DocumentSVG::rootElement(const Document& document)
 {
-    auto* element = document.documentElement();
-    if (!is<SVGSVGElement>(element))
-        return nullptr;
-    return downcast<SVGSVGElement>(element);
+    return dynamicDowncast<SVGSVGElement>(document.documentElement());
 }
 
 }

--- a/Source/WebCore/svg/SVGAElement.cpp
+++ b/Source/WebCore/svg/SVGAElement.cpp
@@ -105,7 +105,8 @@ void SVGAElement::svgAttributeChanged(const QualifiedName& attrName)
 
 RenderPtr<RenderElement> SVGAElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)
 {
-    if (is<SVGElement>(parentNode()) && downcast<SVGElement>(*parentNode()).isTextContent())
+    auto* svgParent = dynamicDowncast<SVGElement>(parentNode());
+    if (svgParent && svgParent->isTextContent())
         return createRenderer<RenderSVGInline>(RenderObject::Type::SVGInline, *this, WTFMove(style));
 
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
@@ -128,9 +129,8 @@ void SVGAElement::defaultEventHandler(Event& event)
             auto url = href().trim(isASCIIWhitespace);
 
             if (url[0] == '#') {
-                RefPtr targetElement = treeScope().getElementById(url.substringSharingImpl(1));
-                if (is<SVGSMILElement>(targetElement)) {
-                    downcast<SVGSMILElement>(*targetElement).beginByLinkActivation();
+                if (RefPtr targetElement = dynamicDowncast<SVGSMILElement>(treeScope().getElementById(url.substringSharingImpl(1)))) {
+                    targetElement->beginByLinkActivation();
                     event.setDefaultHandled();
                     return;
                 }

--- a/Source/WebCore/svg/SVGAltGlyphDefElement.cpp
+++ b/Source/WebCore/svg/SVGAltGlyphDefElement.cpp
@@ -106,13 +106,15 @@ bool SVGAltGlyphDefElement::hasValidGlyphElements(Vector<String>& glyphNames) co
                 glyphNames.clear();
                 return false;
             }
-        } else if (!fountFirstGlyphRef && is<SVGAltGlyphItemElement>(child)) {
-            foundFirstAltGlyphItem = true;
+        } else if (!fountFirstGlyphRef) {
+            if (auto* altGlyphItem = dynamicDowncast<SVGAltGlyphItemElement>(child)) {
+                foundFirstAltGlyphItem = true;
 
-            // As the spec says "The first 'altGlyphItem' in which all referenced glyphs
-            // are available is chosen."
-            if (downcast<SVGAltGlyphItemElement>(child).hasValidGlyphElements(glyphNames) && !glyphNames.isEmpty())
-                return true;
+                // As the spec says "The first 'altGlyphItem' in which all referenced glyphs
+                // are available is chosen."
+                if (altGlyphItem->hasValidGlyphElements(glyphNames) && !glyphNames.isEmpty())
+                    return true;
+            }
         }
     }
     return !glyphNames.isEmpty();

--- a/Source/WebCore/svg/SVGAltGlyphElement.cpp
+++ b/Source/WebCore/svg/SVGAltGlyphElement.cpp
@@ -89,10 +89,8 @@ bool SVGAltGlyphElement::hasValidGlyphElements(Vector<String>& glyphNames) const
         return true;
     }
     
-    if (!is<SVGAltGlyphDefElement>(target.element))
-        return false;
-
-    return downcast<SVGAltGlyphDefElement>(*target.element).hasValidGlyphElements(glyphNames);
+    auto* altGlyphDefElement = downcast<SVGAltGlyphDefElement>(target.element.get());
+    return altGlyphDefElement && altGlyphDefElement->hasValidGlyphElements(glyphNames);
 }
 
 }

--- a/Source/WebCore/svg/SVGClipPathElement.cpp
+++ b/Source/WebCore/svg/SVGClipPathElement.cpp
@@ -142,7 +142,7 @@ SVGGraphicsElement* SVGClipPathElement::shouldApplyPathClipping() const
                 return nullptr;
         }
 
-        useGraphicsElement = downcast<SVGGraphicsElement>(childNode);
+        useGraphicsElement = graphicsElement;
     }
 
     return useGraphicsElement;

--- a/Source/WebCore/svg/SVGComponentTransferFunctionElement.cpp
+++ b/Source/WebCore/svg/SVGComponentTransferFunctionElement.cpp
@@ -85,13 +85,10 @@ void SVGComponentTransferFunctionElement::attributeChanged(const QualifiedName& 
 void SVGComponentTransferFunctionElement::svgAttributeChanged(const QualifiedName& attrName)
 {
     if (PropertyRegistry::isKnownAttribute(attrName)) {
-        RefPtr parent = parentElement();
-
-        if (parent && is<SVGFEComponentTransferElement>(*parent)) {
+        if (RefPtr transferElement = dynamicDowncast<SVGFEComponentTransferElement>(parentElement())) {
             InstanceInvalidationGuard guard(*this);
-            downcast<SVGFEComponentTransferElement>(*parent).transferFunctionAttributeChanged(*this, attrName);
+            transferElement->transferFunctionAttributeChanged(*this, attrName);
         }
-
         return;
     }
 

--- a/Source/WebCore/svg/SVGFEImageElement.cpp
+++ b/Source/WebCore/svg/SVGFEImageElement.cpp
@@ -108,8 +108,8 @@ void SVGFEImageElement::buildPendingResource()
             treeScopeForSVGReferences().addPendingSVGResource(target.identifier, *this);
             ASSERT(hasPendingResources());
         }
-    } else if (is<SVGElement>(*target.element))
-        downcast<SVGElement>(*target.element).addReferencingElement(*this);
+    } else if (RefPtr element = dynamicDowncast<SVGElement>(*target.element))
+        element->addReferencingElement(*this);
 
     updateSVGRendererForElementChange();
 }

--- a/Source/WebCore/svg/SVGFELightElement.cpp
+++ b/Source/WebCore/svg/SVGFELightElement.cpp
@@ -115,6 +115,7 @@ void SVGFELightElement::svgAttributeChanged(const QualifiedName& attrName)
         ASSERT(attrName == SVGNames::azimuthAttr || attrName == SVGNames::elevationAttr || attrName == SVGNames::xAttr || attrName == SVGNames::yAttr
             || attrName == SVGNames::zAttr || attrName == SVGNames::pointsAtXAttr || attrName == SVGNames::pointsAtYAttr || attrName == SVGNames::pointsAtZAttr
             || attrName == SVGNames::specularExponentAttr || attrName == SVGNames::limitingConeAngleAttr);
+
         RefPtr parent = parentElement();
         if (!parent)
             return;
@@ -123,12 +124,12 @@ void SVGFELightElement::svgAttributeChanged(const QualifiedName& attrName)
         if (!renderer || !renderer->isRenderSVGResourceFilterPrimitive())
             return;
 
-        if (is<SVGFEDiffuseLightingElement>(*parent)) {
+        if (auto* lightingElement = dynamicDowncast<SVGFEDiffuseLightingElement>(*parent)) {
             InstanceInvalidationGuard guard(*this);
-            downcast<SVGFEDiffuseLightingElement>(*parent).lightElementAttributeChanged(this, attrName);
-        } else if (is<SVGFESpecularLightingElement>(*parent)) {
+            lightingElement->lightElementAttributeChanged(this, attrName);
+        } else if (auto* lightingElement = dynamicDowncast<SVGFESpecularLightingElement>(*parent)) {
             InstanceInvalidationGuard guard(*this);
-            downcast<SVGFESpecularLightingElement>(*parent).lightElementAttributeChanged(this, attrName);
+            lightingElement->lightElementAttributeChanged(this, attrName);
         }
 
         return;

--- a/Source/WebCore/svg/SVGFilterElement.cpp
+++ b/Source/WebCore/svg/SVGFilterElement.cpp
@@ -136,10 +136,11 @@ bool SVGFilterElement::childShouldCreateRenderer(const Node& child) const
 {
     using namespace ElementNames;
 
-    if (!child.isSVGElement())
+    auto* childElement = dynamicDowncast<SVGElement>(child);
+    if (!childElement)
         return false;
 
-    switch (downcast<SVGElement>(child).elementName()) {
+    switch (childElement->elementName()) {
     case SVG::feBlend:
     case SVG::feColorMatrix:
     case SVG::feComponentTransfer:

--- a/Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.h
+++ b/Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.h
@@ -97,5 +97,9 @@ private:
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SVGFilterPrimitiveStandardAttributes)
     static bool isType(const WebCore::SVGElement& element) { return element.isFilterEffect(); }
-    static bool isType(const WebCore::Node& node) { return is<WebCore::SVGElement>(node) && isType(downcast<WebCore::SVGElement>(node)); }
+    static bool isType(const WebCore::Node& node)
+    {
+        auto* svgElement = dynamicDowncast<WebCore::SVGElement>(node);
+        return svgElement && isType(*svgElement);
+    }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/svg/SVGFontFaceElement.cpp
+++ b/Source/WebCore/svg/SVGFontFaceElement.cpp
@@ -269,17 +269,14 @@ void SVGFontFaceElement::rebuildFontFace()
     // we currently ignore all but the first src element, alternatively we could concat them
     auto srcElement = childrenOfType<SVGFontFaceSrcElement>(*this).first();
 
-    bool describesParentFont = is<SVGFontElement>(*parentNode());
-    RefPtr<CSSValueList> list;
+    m_fontElement = dynamicDowncast<SVGFontElement>(*parentNode());
+    bool describesParentFont = !!m_fontElement;
 
-    if (describesParentFont) {
-        m_fontElement = downcast<SVGFontElement>(parentNode());
+    RefPtr<CSSValueList> list;
+    if (m_fontElement)
         list = CSSValueList::createCommaSeparated(CSSFontFaceSrcLocalValue::create(AtomString { fontFamily() }));
-    } else {
-        m_fontElement = nullptr;
-        if (srcElement)
-            list = srcElement->createSrcValue();
-    }
+    else if (srcElement)
+        list = srcElement->createSrcValue();
 
     if (!list || !list->length())
         return;
@@ -287,7 +284,7 @@ void SVGFontFaceElement::rebuildFontFace()
     // Parse in-memory CSS rules
     m_fontFaceRule->mutableProperties().addParsedProperty(CSSProperty(CSSPropertySrc, list));
 
-    if (describesParentFont) {    
+    if (describesParentFont) {
         // Traverse parsed CSS values and associate CSSFontFaceSrcLocalValue elements with ourselves.
         if (auto* srcList = downcast<CSSValueList>(m_fontFaceRule->properties().getPropertyCSSValue(CSSPropertySrc).get())) {
             for (auto& item : *srcList)

--- a/Source/WebCore/svg/SVGFontFaceFormatElement.cpp
+++ b/Source/WebCore/svg/SVGFontFaceFormatElement.cpp
@@ -54,8 +54,8 @@ void SVGFontFaceFormatElement::childrenChanged(const ChildChange& change)
         return;
     
     ancestor = ancestor->parentNode();
-    if (ancestor && ancestor->hasTagName(font_faceTag))
-        downcast<SVGFontFaceElement>(*ancestor).rebuildFontFace();
+    if (RefPtr fontFaceElement = dynamicDowncast<SVGFontFaceElement>(ancestor))
+        fontFaceElement->rebuildFontFace();
 }
 
 }

--- a/Source/WebCore/svg/SVGFontFaceSrcElement.cpp
+++ b/Source/WebCore/svg/SVGFontFaceSrcElement.cpp
@@ -65,8 +65,8 @@ Ref<CSSValueList> SVGFontFaceSrcElement::createSrcValue() const
 void SVGFontFaceSrcElement::childrenChanged(const ChildChange& change)
 {
     SVGElement::childrenChanged(change);
-    if (is<SVGFontFaceElement>(parentNode()))
-        downcast<SVGFontFaceElement>(*parentNode()).rebuildFontFace();
+    if (RefPtr parent = dynamicDowncast<SVGFontFaceElement>(parentNode()))
+        parent->rebuildFontFace();
 }
 
 }

--- a/Source/WebCore/svg/SVGFontFaceUriElement.cpp
+++ b/Source/WebCore/svg/SVGFontFaceUriElement.cpp
@@ -81,9 +81,8 @@ void SVGFontFaceUriElement::childrenChanged(const ChildChange& change)
     if (!parentNode() || !parentNode()->hasTagName(font_face_srcTag))
         return;
     
-    RefPtr grandParent = parentNode()->parentNode();
-    if (grandParent && grandParent->hasTagName(font_faceTag))
-        downcast<SVGFontFaceElement>(*grandParent).rebuildFontFace();
+    if (RefPtr grandParent = dynamicDowncast<SVGFontFaceElement>(parentNode()->parentNode()))
+        grandParent->rebuildFontFace();
 }
 
 Node::InsertedIntoAncestorResult SVGFontFaceUriElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)

--- a/Source/WebCore/svg/SVGGeometryElement.cpp
+++ b/Source/WebCore/svg/SVGGeometryElement.cpp
@@ -53,12 +53,12 @@ float SVGGeometryElement::getTotalLength() const
     if (!renderer)
         return 0;
 
-    if (is<LegacyRenderSVGShape>(renderer))
-        return downcast<LegacyRenderSVGShape>(renderer)->getTotalLength();
+    if (auto* renderSVGShape = dynamicDowncast<LegacyRenderSVGShape>(renderer))
+        return renderSVGShape->getTotalLength();
 
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
-    if (is<RenderSVGShape>(renderer))
-        return downcast<RenderSVGShape>(renderer)->getTotalLength();
+    if (auto* renderSVGShape = dynamicDowncast<RenderSVGShape>(renderer))
+        return renderSVGShape->getTotalLength();
 #endif
 
     ASSERT_NOT_REACHED();
@@ -79,12 +79,12 @@ ExceptionOr<Ref<SVGPoint>> SVGGeometryElement::getPointAtLength(float distance) 
         return Exception { ExceptionCode::InvalidStateError };
 
     // Spec: Return a newly created, detached SVGPoint object.
-    if (is<LegacyRenderSVGShape>(renderer))
-        return SVGPoint::create(downcast<LegacyRenderSVGShape>(renderer)->getPointAtLength(distance));
+    if (auto* renderSVGShape = dynamicDowncast<LegacyRenderSVGShape>(renderer))
+        return SVGPoint::create(renderSVGShape->getPointAtLength(distance));
 
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
-    if (is<RenderSVGShape>(renderer))
-        return SVGPoint::create(downcast<RenderSVGShape>(renderer)->getPointAtLength(distance));
+    if (auto* renderSVGShape = dynamicDowncast<RenderSVGShape>(renderer))
+        return SVGPoint::create(renderSVGShape->getPointAtLength(distance));
 #endif
 
     ASSERT_NOT_REACHED();
@@ -100,12 +100,12 @@ bool SVGGeometryElement::isPointInFill(DOMPointInit&& pointInit)
         return false;
 
     FloatPoint point {static_cast<float>(pointInit.x), static_cast<float>(pointInit.y)};
-    if (is<LegacyRenderSVGShape>(renderer))
-        return downcast<LegacyRenderSVGShape>(renderer)->isPointInFill(point);
+    if (auto* renderSVGShape = dynamicDowncast<LegacyRenderSVGShape>(renderer))
+        return renderSVGShape->isPointInFill(point);
 
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
-    if (is<RenderSVGShape>(renderer))
-        return downcast<RenderSVGShape>(renderer)->isPointInFill(point);
+    if (auto* renderSVGShape = dynamicDowncast<RenderSVGShape>(renderer))
+        return renderSVGShape->isPointInFill(point);
 #endif
 
     ASSERT_NOT_REACHED();
@@ -121,12 +121,12 @@ bool SVGGeometryElement::isPointInStroke(DOMPointInit&& pointInit)
         return false;
 
     FloatPoint point {static_cast<float>(pointInit.x), static_cast<float>(pointInit.y)};
-    if (is<LegacyRenderSVGShape>(renderer))
-        return downcast<LegacyRenderSVGShape>(renderer)->isPointInStroke(point);
+    if (auto* renderSVGShape = dynamicDowncast<LegacyRenderSVGShape>(renderer))
+        return renderSVGShape->isPointInStroke(point);
 
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
-    if (is<RenderSVGShape>(renderer))
-        return downcast<RenderSVGShape>(renderer)->isPointInStroke(point);
+    if (auto* renderSVGShape = dynamicDowncast<RenderSVGShape>(renderer))
+        return renderSVGShape->isPointInStroke(point);
 #endif
 
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/svg/SVGLocatable.cpp
+++ b/Source/WebCore/svg/SVGLocatable.cpp
@@ -34,20 +34,26 @@
 
 namespace WebCore {
 
-static bool isViewportElement(Node* node)
+// FIXME: This doesn't match SVGElement::viewportElement() as it has an extra check for
+// foreign object.
+static bool isViewportElement(const SVGElement* element)
 {
-    return (node->hasTagName(SVGNames::svgTag)
-        || node->hasTagName(SVGNames::symbolTag)
-        || node->hasTagName(SVGNames::foreignObjectTag)
-        || is<SVGImageElement>(*node));
+    if (!element)
+        return false;
+
+    return element->hasTagName(SVGNames::svgTag)
+        || element->hasTagName(SVGNames::symbolTag)
+        || element->hasTagName(SVGNames::foreignObjectTag)
+        || is<SVGImageElement>(*element);
 }
 
 SVGElement* SVGLocatable::nearestViewportElement(const SVGElement* element)
 {
     ASSERT(element);
     for (Element* current = element->parentOrShadowHostElement(); current; current = current->parentOrShadowHostElement()) {
-        if (isViewportElement(current))
-            return downcast<SVGElement>(current);
+        auto* svgElement = dynamicDowncast<SVGElement>(*current);
+        if (isViewportElement(svgElement))
+            return svgElement;
     }
 
     return nullptr;
@@ -58,8 +64,9 @@ SVGElement* SVGLocatable::farthestViewportElement(const SVGElement* element)
     ASSERT(element);
     SVGElement* farthest = nullptr;
     for (Element* current = element->parentOrShadowHostElement(); current; current = current->parentOrShadowHostElement()) {
-        if (isViewportElement(current))
-            farthest = downcast<SVGElement>(current);
+        auto* svgElement = dynamicDowncast<SVGElement>(*current);
+        if (isViewportElement(svgElement))
+            farthest = svgElement;
     }
     return farthest;
 }

--- a/Source/WebCore/svg/SVGTextPathElement.cpp
+++ b/Source/WebCore/svg/SVGTextPathElement.cpp
@@ -28,6 +28,7 @@
 #include "SVGDocumentExtensions.h"
 #include "SVGElementInlines.h"
 #include "SVGNames.h"
+#include "SVGPathElement.h"
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/NeverDestroyed.h>
 
@@ -157,8 +158,8 @@ void SVGTextPathElement::buildPendingResource()
             treeScope.addPendingSVGResource(target.identifier, *this);
             ASSERT(hasPendingResources());
         }
-    } else if (target.element->hasTagName(SVGNames::pathTag))
-        downcast<SVGElement>(*target.element).addReferencingElement(*this);
+    } else if (RefPtr pathElement = dynamicDowncast<SVGPathElement>(*target.element))
+        pathElement->addReferencingElement(*this);
 }
 
 Node::InsertedIntoAncestorResult SVGTextPathElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)


### PR DESCRIPTION
#### b17ef60d82a20024e5e3ad6a1e71e1100222f6ab
<pre>
Reduce use of downcast&lt;&gt;() in SVG code
<a href="https://bugs.webkit.org/show_bug.cgi?id=266678">https://bugs.webkit.org/show_bug.cgi?id=266678</a>

Reviewed by Simon Fraser.

Reduce use of downcast&lt;&gt;() in SVG code. Use dynamicDowncast&lt;&gt;() instead.

* Source/WebCore/svg/DocumentSVG.cpp:
(WebCore::DocumentSVG::rootElement):
* Source/WebCore/svg/SVGAElement.cpp:
(WebCore::SVGAElement::createElementRenderer):
(WebCore::SVGAElement::defaultEventHandler):
* Source/WebCore/svg/SVGAltGlyphDefElement.cpp:
(WebCore::SVGAltGlyphDefElement::hasValidGlyphElements const):
* Source/WebCore/svg/SVGAltGlyphElement.cpp:
(WebCore::SVGAltGlyphElement::hasValidGlyphElements const):
* Source/WebCore/svg/SVGClipPathElement.cpp:
(WebCore::SVGClipPathElement::shouldApplyPathClipping const):
* Source/WebCore/svg/SVGComponentTransferFunctionElement.cpp:
(WebCore::SVGComponentTransferFunctionElement::svgAttributeChanged):
* Source/WebCore/svg/SVGElement.cpp:
(WebCore::SVGElement::correspondingUseElement const):
(WebCore::SVGElement::childShouldCreateRenderer const):
(WebCore::SVGElement::svgAttributeChanged):
* Source/WebCore/svg/SVGFEImageElement.cpp:
(WebCore::SVGFEImageElement::buildPendingResource):
* Source/WebCore/svg/SVGFELightElement.cpp:
(WebCore::SVGFELightElement::svgAttributeChanged):
* Source/WebCore/svg/SVGFilterElement.cpp:
(WebCore::SVGFilterElement::childShouldCreateRenderer const):
* Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.h:
(isType):
* Source/WebCore/svg/SVGFontFaceElement.cpp:
(WebCore::SVGFontFaceElement::rebuildFontFace):
* Source/WebCore/svg/SVGFontFaceFormatElement.cpp:
(WebCore::SVGFontFaceFormatElement::childrenChanged):
* Source/WebCore/svg/SVGFontFaceSrcElement.cpp:
(WebCore::SVGFontFaceSrcElement::childrenChanged):
* Source/WebCore/svg/SVGFontFaceUriElement.cpp:
(WebCore::SVGFontFaceUriElement::childrenChanged):
* Source/WebCore/svg/SVGGeometryElement.cpp:
(WebCore::SVGGeometryElement::getTotalLength const):
(WebCore::SVGGeometryElement::getPointAtLength const):
(WebCore::SVGGeometryElement::isPointInFill):
(WebCore::SVGGeometryElement::isPointInStroke):
* Source/WebCore/svg/SVGLocatable.cpp:
(WebCore::toViewportElement):
(WebCore::SVGLocatable::nearestViewportElement):
(WebCore::SVGLocatable::farthestViewportElement):
(WebCore::isViewportElement): Deleted.
* Source/WebCore/svg/SVGTextPathElement.cpp:
(WebCore::SVGTextPathElement::buildPendingResource):

Canonical link: <a href="https://commits.webkit.org/272374@main">https://commits.webkit.org/272374@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/257b5c024e1ae92237e196df294687c834b7ae1a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31454 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10128 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33157 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33947 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/28497 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32224 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12475 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7377 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/28118 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31794 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8526 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28079 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7340 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7498 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27986 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35290 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28588 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28436 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33634 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7576 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5601 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31477 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9237 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8267 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4108 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8086 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->