### PR TITLE
Reduce use of downcast<>() in WebCore

### DIFF
--- a/Source/WebCore/rendering/updating/RenderTreeBuilderRuby.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderRuby.cpp
@@ -369,19 +369,18 @@ RenderPtr<RenderObject> RenderTreeBuilder::Ruby::detach(RenderRubyRun& parent, R
     // If the child is a ruby text, then merge the ruby base with the base of
     // the right sibling run, if possible.
     if (!parent.beingDestroyed() && !parent.renderTreeBeingDestroyed() && child.isRenderRubyText()) {
-        RenderRubyBase* base = parent.rubyBase();
-        RenderObject* rightNeighbour = parent.nextSibling();
-        if (base && is<RenderRubyRun>(rightNeighbour)) {
-            // Ruby run without a base can happen only at the first run.
-            RenderRubyRun& rightRun = downcast<RenderRubyRun>(*rightNeighbour);
-            if (rightRun.hasRubyBase()) {
-                RenderRubyBase* rightBase = rightRun.rubyBase();
-                // Collect all children in a single base, then swap the bases.
-                moveChildren(*rightBase, *base);
-                m_builder.move(parent, rightRun, *base, RenderTreeBuilder::NormalizeAfterInsertion::No);
-                m_builder.move(rightRun, parent, *rightBase, RenderTreeBuilder::NormalizeAfterInsertion::No);
-                // The now empty ruby base will be removed below.
-                ASSERT(!parent.rubyBase()->firstChild());
+        if (auto* base = parent.rubyBase()) {
+            if (auto* rightRun = dynamicDowncast<RenderRubyRun>(parent.nextSibling())) {
+                // Ruby run without a base can happen only at the first run.
+                if (rightRun->hasRubyBase()) {
+                    RenderRubyBase* rightBase = rightRun->rubyBase();
+                    // Collect all children in a single base, then swap the bases.
+                    moveChildren(*rightBase, *base);
+                    m_builder.move(parent, *rightRun, *base, RenderTreeBuilder::NormalizeAfterInsertion::No);
+                    m_builder.move(*rightRun, parent, *rightBase, RenderTreeBuilder::NormalizeAfterInsertion::No);
+                    // The now empty ruby base will be removed below.
+                    ASSERT(!parent.rubyBase()->firstChild());
+                }
             }
         }
     }

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderTable.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderTable.cpp
@@ -46,9 +46,9 @@ RenderElement& RenderTreeBuilder::Table::findOrCreateParentForChild(RenderTableR
 
     if (beforeChild && !beforeChild->isAnonymous() && beforeChild->parent() == &parent) {
         auto* previousSibling = beforeChild->previousSibling();
-        if (is<RenderTableCell>(previousSibling) && previousSibling->isAnonymous()) {
+        if (auto* tableCell = dynamicDowncast<RenderTableCell>(previousSibling); tableCell && tableCell->isAnonymous()) {
             beforeChild = nullptr;
-            return downcast<RenderElement>(*previousSibling);
+            return *tableCell;
         }
     }
 
@@ -62,10 +62,10 @@ RenderElement& RenderTreeBuilder::Table::findOrCreateParentForChild(RenderTableR
 
     auto* lastChild = beforeChild ? beforeChild : parent.lastCell();
     if (lastChild) {
-        if (is<RenderTableCell>(*lastChild) && lastChild->isAnonymous() && !lastChild->isBeforeOrAfterContent()) {
+        if (auto* tableCell = dynamicDowncast<RenderTableCell>(*lastChild); tableCell && tableCell->isAnonymous() && !tableCell->isBeforeOrAfterContent()) {
             if (beforeChild == lastChild)
-                beforeChild = downcast<RenderElement>(*lastChild).firstChild();
-            return downcast<RenderElement>(*lastChild);
+                beforeChild = tableCell->firstChild();
+            return *tableCell;
         }
 
         // Try to find an anonymous container for the child.
@@ -78,8 +78,8 @@ RenderElement& RenderTreeBuilder::Table::findOrCreateParentForChild(RenderTableR
                 if (!is<RenderTableCell>(*lastChild))
                     return *lastChildParent;
                 // If beforeChild is inside an anonymous row, insert into the row.
-                if (is<RenderTableRow>(*lastChildParent))
-                    return createAnonymousTableCell(downcast<RenderTableRow>(*lastChildParent));
+                if (auto* tableRow = dynamicDowncast<RenderTableRow>(*lastChildParent))
+                    return createAnonymousTableCell(*tableRow);
             }
         }
     }
@@ -92,17 +92,17 @@ RenderElement& RenderTreeBuilder::Table::findOrCreateParentForChild(RenderTableS
         return parent;
 
     auto* lastChild = beforeChild ? beforeChild : parent.lastRow();
-    if (is<RenderTableRow>(lastChild) && lastChild->isAnonymous() && !lastChild->isBeforeOrAfterContent()) {
+    if (auto* tableRow = dynamicDowncast<RenderTableRow>(lastChild); tableRow && tableRow->isAnonymous() && !tableRow->isBeforeOrAfterContent()) {
         if (beforeChild == lastChild)
-            beforeChild = downcast<RenderTableRow>(*lastChild).firstCell();
-        return downcast<RenderElement>(*lastChild);
+            beforeChild = tableRow->firstCell();
+        return *tableRow;
     }
 
     if (beforeChild && !beforeChild->isAnonymous() && beforeChild->parent() == &parent) {
         auto* row = beforeChild->previousSibling();
-        if (is<RenderTableRow>(row) && row->isAnonymous()) {
+        if (auto* tableRow = dynamicDowncast<RenderTableRow>(row); tableRow && tableRow->isAnonymous()) {
             beforeChild = nullptr;
-            return downcast<RenderElement>(*row);
+            return *tableRow;
         }
     }
 
@@ -111,8 +111,8 @@ RenderElement& RenderTreeBuilder::Table::findOrCreateParentForChild(RenderTableS
     auto* parentCandidate = lastChild;
     while (parentCandidate && parentCandidate->parent() && parentCandidate->parent()->isAnonymous() && !is<RenderTableRow>(*parentCandidate))
         parentCandidate = parentCandidate->parent();
-    if (is<RenderTableRow>(parentCandidate) && parentCandidate->isAnonymous() && !parentCandidate->isBeforeOrAfterContent())
-        return downcast<RenderElement>(*parentCandidate);
+    if (auto* tableRow = dynamicDowncast<RenderTableRow>(parentCandidate); tableRow && tableRow->isAnonymous() && !tableRow->isBeforeOrAfterContent())
+        return *tableRow;
 
     auto newRow = RenderTableRow::createAnonymousWithParentRenderer(parent);
     auto& row = *newRow;
@@ -140,14 +140,14 @@ RenderElement& RenderTreeBuilder::Table::findOrCreateParentForChild(RenderTable&
     }
 
     auto* lastChild = parent.lastChild();
-    if (!beforeChild && is<RenderTableSection>(lastChild) && lastChild->isAnonymous() && !lastChild->isBeforeContent())
-        return downcast<RenderElement>(*lastChild);
+    if (auto* tableSection = dynamicDowncast<RenderTableSection>(lastChild); !beforeChild && tableSection && tableSection->isAnonymous() && !tableSection->isBeforeContent())
+        return *tableSection;
 
     if (beforeChild && !beforeChild->isAnonymous() && beforeChild->parent() == &parent) {
         auto* section = beforeChild->previousSibling();
-        if (is<RenderTableSection>(section) && section->isAnonymous()) {
+        if (auto* tableSection = dynamicDowncast<RenderTableSection>(section); tableSection && tableSection->isAnonymous()) {
             beforeChild = nullptr;
-            return downcast<RenderElement>(*section);
+            return *tableSection;
         }
     }
 
@@ -161,16 +161,16 @@ RenderElement& RenderTreeBuilder::Table::findOrCreateParentForChild(RenderTable&
     if (parentCandidate) {
         if (beforeChild && !beforeChild->isAnonymous() && parentCandidate->parent() == &parent) {
             auto* section = parentCandidate->previousSibling();
-            if (is<RenderTableSection>(section) && section->isAnonymous()) {
+            if (auto* tableSection = dynamicDowncast<RenderTableSection>(section); tableSection && tableSection->isAnonymous()) {
                 beforeChild = nullptr;
-                return downcast<RenderElement>(*section);
+                return *tableSection;
             }
         }
 
-        if (is<RenderTableSection>(*parentCandidate) && parentCandidate->isAnonymous() && !parent.isAfterContent(parentCandidate)) {
+        if (auto* parentTableSection = dynamicDowncast<RenderTableSection>(*parentCandidate); parentTableSection && parentTableSection->isAnonymous() && !parent.isAfterContent(parentTableSection)) {
             if (beforeChild == parentCandidate)
-                beforeChild = downcast<RenderTableSection>(*parentCandidate).firstRow();
-            return downcast<RenderElement>(*parentCandidate);
+                beforeChild = parentTableSection->firstRow();
+            return *parentTableSection;
         }
     }
 
@@ -195,8 +195,8 @@ void RenderTreeBuilder::Table::attach(RenderTableRow& parent, RenderPtr<RenderOb
     ASSERT(!beforeChild || is<RenderTableCell>(*beforeChild));
     m_builder.attachToRenderElement(parent, WTFMove(child), beforeChild);
     // FIXME: child should always be a RenderTableCell at this point.
-    if (is<RenderTableCell>(newChild))
-        parent.didInsertTableCell(downcast<RenderTableCell>(newChild), beforeChild);
+    if (auto* renderTableCell = dynamicDowncast<RenderTableCell>(newChild))
+        parent.didInsertTableCell(*renderTableCell, beforeChild);
 }
 
 void RenderTreeBuilder::Table::attach(RenderTableSection& parent, RenderPtr<RenderObject> child, RenderObject* beforeChild)
@@ -205,8 +205,8 @@ void RenderTreeBuilder::Table::attach(RenderTableSection& parent, RenderPtr<Rend
         beforeChild = m_builder.splitAnonymousBoxesAroundChild(parent, *beforeChild);
 
     // FIXME: child should always be a RenderTableRow at this point.
-    if (is<RenderTableRow>(child))
-        parent.willInsertTableRow(downcast<RenderTableRow>(*child.get()), beforeChild);
+    if (auto* renderTableRow = dynamicDowncast<RenderTableRow>(child.get()))
+        parent.willInsertTableRow(*renderTableRow, beforeChild);
     ASSERT(!beforeChild || is<RenderTableRow>(*beforeChild));
     m_builder.attachToRenderElement(parent, WTFMove(child), beforeChild);
 }
@@ -217,19 +217,18 @@ void RenderTreeBuilder::Table::attach(RenderTable& parent, RenderPtr<RenderObjec
         beforeChild = m_builder.splitAnonymousBoxesAroundChild(parent, *beforeChild);
 
     auto& newChild = *child.get();
-    if (is<RenderTableSection>(newChild))
-        parent.willInsertTableSection(downcast<RenderTableSection>(newChild), beforeChild);
-    else if (is<RenderTableCol>(newChild))
-        parent.willInsertTableColumn(downcast<RenderTableCol>(newChild), beforeChild);
+    if (auto* renderTableSection = dynamicDowncast<RenderTableSection>(newChild))
+        parent.willInsertTableSection(*renderTableSection, beforeChild);
+    else if (auto* renderTableCol = dynamicDowncast<RenderTableCol>(newChild))
+        parent.willInsertTableColumn(*renderTableCol, beforeChild);
 
     m_builder.attachToRenderElement(parent, WTFMove(child), beforeChild);
 }
 
 bool RenderTreeBuilder::Table::childRequiresTable(const RenderElement& parent, const RenderObject& child)
 {
-    if (is<RenderTableCol>(child)) {
-        const RenderTableCol& newTableColumn = downcast<RenderTableCol>(child);
-        bool isColumnInColumnGroup = newTableColumn.isTableColumn() && is<RenderTableCol>(parent);
+    if (auto* newTableColumn = dynamicDowncast<RenderTableCol>(child)) {
+        bool isColumnInColumnGroup = newTableColumn->isTableColumn() && is<RenderTableCol>(parent);
         return !is<RenderTable>(parent) && !isColumnInColumnGroup;
     }
     if (is<RenderTableCaption>(child))

--- a/Source/WebCore/rendering/updating/RenderTreePosition.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreePosition.cpp
@@ -84,8 +84,8 @@ RenderObject* RenderTreePosition::nextSiblingRenderer(const Node& node) const
     auto composedDescendants = composedTreeDescendants(*parentElement);
 
     auto initializeIteratorConsideringPseudoElements = [&] {
-        if (is<PseudoElement>(node)) {
-            auto* host = downcast<PseudoElement>(node).hostElement();
+        if (auto* pseudoElement = dynamicDowncast<PseudoElement>(node)) {
+            auto* host = pseudoElement->hostElement();
             if (node.isBeforePseudoElement()) {
                 if (host != parentElement)
                     return composedDescendants.at(*host).traverseNext();
@@ -131,10 +131,9 @@ RenderObject* RenderTreePosition::nextSiblingRenderer(const Node& node) const
         if (auto* renderer = it->renderer())
             return renderer;
 
-        if (is<Element>(*it)) {
-            auto& element = downcast<Element>(*it);
-            if (element.hasDisplayContents()) {
-                if (auto* renderer = pushCheckingForAfterPseudoElementRenderer(element))
+        if (auto* element = dynamicDowncast<Element>(*it)) {
+            if (element->hasDisplayContents()) {
+                if (auto* renderer = pushCheckingForAfterPseudoElementRenderer(*element))
                     return renderer;
                 it.traverseNext();
                 continue;

--- a/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
@@ -85,8 +85,8 @@ void RenderTreeUpdater::GeneratedContent::updateCounters()
 
 static bool elementIsTargetedByKeyframeEffectRequiringPseudoElement(const Element* element, PseudoId pseudoId)
 {
-    if (is<PseudoElement>(element))
-        return elementIsTargetedByKeyframeEffectRequiringPseudoElement(downcast<PseudoElement>(*element).hostElement(), pseudoId);
+    if (auto* pseudoElement = dynamicDowncast<PseudoElement>(element))
+        return elementIsTargetedByKeyframeEffectRequiringPseudoElement(pseudoElement->hostElement(), pseudoId);
 
     if (element) {
         if (auto* stack = element->keyframeEffectStack(pseudoId))

--- a/Source/WebCore/style/InlineTextBoxStyle.cpp
+++ b/Source/WebCore/style/InlineTextBoxStyle.cpp
@@ -65,7 +65,7 @@ static float minLogicalTopForTextDecorationLineUnder(const InlineIterator::LineB
         if (!run->style().textDecorationsInEffect().contains(TextDecorationLine::Underline))
             continue; // If the text decoration isn't in effect on the child, then it must be outside of |decoratingBoxRendererForUnderline|'s hierarchy.
 
-        if (decoratingBoxRendererForUnderline.isRenderInline() && !isAncestorAndWithinBlock(downcast<RenderInline>(decoratingBoxRendererForUnderline), &run->renderer()))
+        if (auto* renderInline = dynamicDowncast<RenderInline>(decoratingBoxRendererForUnderline); renderInline && !isAncestorAndWithinBlock(*renderInline, &run->renderer()))
             continue;
 
         if (run->isText() || run->style().textDecorationSkipInk() == TextDecorationSkipInk::None)
@@ -84,7 +84,7 @@ static float maxLogicalBottomForTextDecorationLineUnder(const InlineIterator::Li
         if (!run->style().textDecorationsInEffect().contains(TextDecorationLine::Underline))
             continue; // If the text decoration isn't in effect on the child, then it must be outside of |decoratingBoxRendererForUnderline|'s hierarchy.
 
-        if (decoratingBoxRendererForUnderline.isRenderInline() && !isAncestorAndWithinBlock(downcast<RenderInline>(decoratingBoxRendererForUnderline), &run->renderer()))
+        if (auto* renderInline = dynamicDowncast<RenderInline>(decoratingBoxRendererForUnderline); renderInline && !isAncestorAndWithinBlock(*renderInline, &run->renderer()))
             continue;
 
         if (run->isText() || run->style().textDecorationSkipInk() == TextDecorationSkipInk::None)

--- a/Source/WebCore/style/InspectorCSSOMWrappers.cpp
+++ b/Source/WebCore/style/InspectorCSSOMWrappers.cpp
@@ -65,25 +65,25 @@ void InspectorCSSOMWrappers::collect(ListType* listType)
         
         switch (cssRule->styleRuleType()) {
         case StyleRuleType::Container:
-            collect(downcast<CSSContainerRule>(cssRule));
+            collect(uncheckedDowncast<CSSContainerRule>(cssRule));
             break;
         case StyleRuleType::Import:
-            collect(downcast<CSSImportRule>(*cssRule).styleSheet());
+            collect(uncheckedDowncast<CSSImportRule>(*cssRule).styleSheet());
             break;
         case StyleRuleType::LayerBlock:
-            collect(downcast<CSSLayerBlockRule>(cssRule));
+            collect(uncheckedDowncast<CSSLayerBlockRule>(cssRule));
             break;
         case StyleRuleType::Media:
-            collect(downcast<CSSMediaRule>(cssRule));
+            collect(uncheckedDowncast<CSSMediaRule>(cssRule));
             break;
         case StyleRuleType::Supports:
-            collect(downcast<CSSSupportsRule>(cssRule));
+            collect(uncheckedDowncast<CSSSupportsRule>(cssRule));
             break;
         case StyleRuleType::Style:
-            m_styleRuleToCSSOMWrapperMap.add(&downcast<CSSStyleRule>(*cssRule).styleRule(), downcast<CSSStyleRule>(cssRule));
+            m_styleRuleToCSSOMWrapperMap.add(&uncheckedDowncast<CSSStyleRule>(*cssRule).styleRule(), uncheckedDowncast<CSSStyleRule>(cssRule));
 
             // Eagerly collect rules nested in this style rule.
-            collect(downcast<CSSStyleRule>(cssRule));
+            collect(uncheckedDowncast<CSSStyleRule>(cssRule));
             break;
         default:
             break;

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -337,10 +337,11 @@ OptionSet<EventListenerRegionType> Adjuster::computeEventListenerRegionTypes(con
 #endif
 
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-    if (document.page() && document.page()->shouldBuildInteractionRegions() && eventTarget.isNode()) {
-        const auto& node = downcast<Node>(eventTarget);
-        if (node.willRespondToMouseClickEventsWithEditability(node.computeEditabilityForMouseClickEvents(&style)))
-            types.add(EventListenerRegionType::MouseClick);
+    if (document.page() && document.page()->shouldBuildInteractionRegions()) {
+        if (const auto* node = dynamicDowncast<Node>(eventTarget)) {
+            if (node->willRespondToMouseClickEventsWithEditability(node->computeEditabilityForMouseClickEvents(&style)))
+                types.add(EventListenerRegionType::MouseClick);
+        }
     }
 #else
     UNUSED_PARAM(document);

--- a/Source/WebCore/style/StyleInvalidator.cpp
+++ b/Source/WebCore/style/StyleInvalidator.cpp
@@ -148,7 +148,7 @@ static void invalidateAssignedElements(HTMLSlotElement& slot)
             invalidateAssignedElements(*slotElement);
             continue;
         }
-        downcast<Element>(*node).invalidateStyleInternal();
+        element->invalidateStyleInternal();
     }
 }
 

--- a/Source/WebCore/style/StyleSharingResolver.cpp
+++ b/Source/WebCore/style/StyleSharingResolver.cpp
@@ -161,11 +161,11 @@ StyledElement* SharingResolver::findSibling(const Context& context, Node* node, 
         if (!styledElement)
             continue;
         if (canShareStyleWithElement(context, *styledElement))
-            break;
+            return styledElement;
         if (count++ >= cStyleSearchThreshold)
             return nullptr;
     }
-    return downcast<StyledElement>(node);
+    return nullptr;
 }
 
 Node* SharingResolver::locateCousinList(const Element* parent) const


### PR DESCRIPTION
#### b541bbcbd32a399a33f3a54b22e18f88ea307289
<pre>
Reduce use of downcast&lt;&gt;() in WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=266679">https://bugs.webkit.org/show_bug.cgi?id=266679</a>

Reviewed by Simon Fraser.

* Source/WebCore/rendering/updating/RenderTreeBuilderMultiColumn.cpp:
(WebCore::isValidColumnSpanner):
(WebCore::RenderTreeBuilder::MultiColumn::createFragmentedFlow):
(WebCore::RenderTreeBuilder::MultiColumn::resolveMovedChild):
(WebCore::RenderTreeBuilder::MultiColumn::multiColumnDescendantInserted):
(WebCore::RenderTreeBuilder::MultiColumn::processPossibleSpannerDescendant):
(WebCore::RenderTreeBuilder::MultiColumn::multiColumnRelativeWillBeRemoved):
(WebCore::RenderTreeBuilder::MultiColumn::adjustBeforeChildForMultiColumnSpannerIfNeeded):
* Source/WebCore/rendering/updating/RenderTreeBuilderRuby.cpp:
(WebCore::RenderTreeBuilder::Ruby::detach):
* Source/WebCore/rendering/updating/RenderTreeBuilderTable.cpp:
(WebCore::RenderTreeBuilder::Table::findOrCreateParentForChild):
(WebCore::RenderTreeBuilder::Table::attach):
(WebCore::RenderTreeBuilder::Table::childRequiresTable):
* Source/WebCore/rendering/updating/RenderTreePosition.cpp:
(WebCore::RenderTreePosition::nextSiblingRenderer const):
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(WebCore::RenderTreeUpdater::updateRebuildRoots):
(WebCore::RenderTreeUpdater::updateRenderTree):
(WebCore::RenderTreeUpdater::tearDownRenderers):
(WebCore::RenderTreeUpdater::tearDownLeftoverChildrenOfComposedTree):
* Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp:
(WebCore::elementIsTargetedByKeyframeEffectRequiringPseudoElement):
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::matchAllRules):
(WebCore::Style::ElementRuleCollector::addElementInlineStyleProperties):
* Source/WebCore/style/FilterOperationsBuilder.cpp:
(WebCore::Style::createFilterOperations):
* Source/WebCore/style/InlineTextBoxStyle.cpp:
(WebCore::minLogicalTopForTextDecorationLineUnder):
(WebCore::maxLogicalBottomForTextDecorationLineUnder):
* Source/WebCore/style/InspectorCSSOMWrappers.cpp:
(WebCore::Style::InspectorCSSOMWrappers::collect):
* Source/WebCore/style/RuleSetBuilder.cpp:
(WebCore::Style::RuleSetBuilder::addChildRule):
(WebCore::Style::RuleSetBuilder::addMutatingRulesToResolver):
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::computeEventListenerRegionTypes):
* Source/WebCore/style/StyleInvalidator.cpp:
(WebCore::Style::invalidateAssignedElements):
* Source/WebCore/style/StyleSharingResolver.cpp:
(WebCore::Style::SharingResolver::findSibling const):

Canonical link: <a href="https://commits.webkit.org/272366@main">https://commits.webkit.org/272366@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/681382deac32f20749f4c928472f0fa285463911

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31443 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10116 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33143 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33941 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28493 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32214 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12464 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7364 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/28112 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31783 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8519 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28071 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7334 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7492 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27978 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35283 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28582 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28428 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33631 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7572 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5596 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31474 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9233 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8263 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4104 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8082 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->