### PR TITLE
REGRESSION (270071@main): [ Sonoma wk2  ] 2 tests in imported/w3c/web-platform-tests/css/ are consistent failures

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overscroll-behavior/overscroll-behavior-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overscroll-behavior/overscroll-behavior-expected.txt
@@ -8,5 +8,5 @@ Repeat the same scrolls as in step 1 and then tap on DONE.
 Repeat the same scrolls as in step 1 and then tap on DONE.
 Make two separate scrolls on GREEN, in this order: scroll UP (or drag down), then scroll LEFT (or drag right). Scroll (or drag) until nothing is scrolling. Then tap on DONE.
 
-FAIL overscroll-behavior prevents scroll-propagation in the area and direction as specified assert_equals: expected 0 but got 100
+PASS overscroll-behavior prevents scroll-propagation in the area and direction as specified
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/input/snap-area-overflow-boundary-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/input/snap-area-overflow-boundary-expected.txt
@@ -1,6 +1,6 @@
 Header 1Footer 1
 Header 2Footer 2
 
-FAIL Keyboard scrolling with vertical snap-area overflow assert_equals: End boundary of snap-area is valid snap target expected 39 but got 449
+FAIL Keyboard scrolling with vertical snap-area overflow assert_equals: Verify snap on relayout expected 0 but got 40
 FAIL Mouse-wheel scrolling with vertical snap-area overflow assert_equals: End boundary of snap-area is valid snap target expected 100 but got 101
 

--- a/LayoutTests/platform/mac-ventura-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-ventura-wk2/TestExpectations
@@ -40,3 +40,14 @@ imported/w3c/web-platform-tests/css/cssom-view/scroll-behavior-smooth-positions.
 
 # This feature was introduced in macOS Sonoma.
 http/tests/paymentrequest/paymentrequest-applePayLaterAvailability.https.html [ Skip ]
+
+# webkit.org/b/263476 [ mac-wk2 ] Some WPTs exercising wheel actions interface timing out on pre-Sonoma macOS after 269632@main
+imported/w3c/web-platform-tests/css/css-overscroll-behavior/overscroll-behavior.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-scroll-snap/input/snap-area-overflow-boundary.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-transforms/scroll-preserve-3d.html [ Skip ]
+imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-mousewheel-event-listener-on-div.html [ Skip ]
+imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-wheel-event-listener-on-div.html [ Skip ]
+imported/w3c/web-platform-tests/dom/events/scrolling/iframe-chains.html [ Skip ]
+imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-for-user-scroll.html [ Skip ]
+imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss.html [ Skip ]
+imported/w3c/web-platform-tests/pointerevents/pointerevent_touch-action-mouse.html [ Skip ]

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2735,3 +2735,14 @@ webkit.org/b/266184 compositing/images/truncated-direct-png-image.html [ ImageOn
 # webkit.org/b/266345 [Test Gardening] css-contain/contain-size-block-003.html and css-contain/contain-size-inline-block-003.html only fail on GTK
 imported/w3c/web-platform-tests/css/css-contain/contain-size-block-003.html [ Failure ]
 imported/w3c/web-platform-tests/css/css-contain/contain-size-inline-block-003.html [ Failure ]
+
+# webkit.org/b/263441 [ mac-wk1 ] Several WPTs using wheel actions are timing out after 269632@main
+imported/w3c/web-platform-tests/css/css-overscroll-behavior/overscroll-behavior.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-scroll-snap/input/snap-area-overflow-boundary.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-transforms/scroll-preserve-3d.html [ Skip ]
+imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-mousewheel-event-listener-on-div.html [ Skip ]
+imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-wheel-event-listener-on-div.html [ Skip ]
+imported/w3c/web-platform-tests/dom/events/scrolling/iframe-chains.html [ Skip ]
+imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-for-user-scroll.html [ Skip ]
+imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss.html [ Skip ]
+imported/w3c/web-platform-tests/pointerevents/pointerevent_touch-action-mouse.html [ Skip ]

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2542,17 +2542,7 @@ imported/w3c/web-platform-tests/media-source/mediasource-redundant-seek.html [ P
 imported/w3c/web-platform-tests/media-source/mediasource-remove-preserves-currentTime.html [ Pass Failure ]
 imported/w3c/web-platform-tests/media-source/mediasource-remove.html [ Pass Failure ]
 
-# webkit.org/b/263441 [ mac-wk1 ] Several WPTs using wheel actions are timing out after b243272
-# webkit.org/b/263476 [ mac-wk2 ] Some WPTs exercising wheel actions interface timing out on pre-Sonoma MacOS after b243272
-imported/w3c/web-platform-tests/css/css-overscroll-behavior/overscroll-behavior.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-scroll-snap/input/snap-area-overflow-boundary.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-transforms/scroll-preserve-3d.html [ Skip ]
-imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-mousewheel-event-listener-on-div.html [ Skip ]
-imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-wheel-event-listener-on-div.html [ Skip ]
-imported/w3c/web-platform-tests/dom/events/scrolling/iframe-chains.html [ Skip ]
-imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-for-user-scroll.html [ Skip ]
-imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss.html [ Skip ]
-imported/w3c/web-platform-tests/pointerevents/pointerevent_touch-action-mouse.html [ Skip ]
+webkit.org/b/266683 imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss.html [ Failure ]
 
 # Failing word-break: auto-phrase tests.
 webkit.org/b/257698 [ Sonoma+ ] imported/w3c/web-platform-tests/css/css-text/word-break/auto-phrase/word-break-auto-phrase-004.html [ ImageOnlyFailure ]


### PR DESCRIPTION
#### 7e9e2cfbdd0e993f8ddde4cc193c18b485f0988a
<pre>
REGRESSION (270071@main): [ Sonoma wk2  ] 2 tests in imported/w3c/web-platform-tests/css/ are consistent failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=266684">https://bugs.webkit.org/show_bug.cgi?id=266684</a>
<a href="https://rdar.apple.com/119902392">rdar://119902392</a>

Unreviewed test expectations gardening.

The following CSS WPTs were always behaving differently with async
overflow scrolling enabled:
- css-overscroll-behavior/overscroll-behavior.html
- css-scroll-snap/input/snap-area-overflow-boundary.html

Unfortunately, this failure never surfaced in open source EWS since I
simply skipped over these tests for any macOS target. Instead, this
commit skips these tests in more specific platform configurations (where
it is necessary), and adjust the test output accordingly.

This test also adds a drive-by expectation adjustment to reflect that
the html/semantics/popovers/popover-light-dismiss.html WPT no longer
behaves as expected after enabling async overflow scrolling.

* LayoutTests/imported/w3c/web-platform-tests/css/css-overscroll-behavior/overscroll-behavior-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/input/snap-area-overflow-boundary-expected.txt:
* LayoutTests/platform/mac-ventura-wk2/TestExpectations:
* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/272340@main">https://commits.webkit.org/272340@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1cc4204acf201e7fb9aabf4ffa3310057e36a97b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31371 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10041 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33065 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33865 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28431 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12388 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7290 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28066 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31707 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8454 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28005 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7273 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7431 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/readwrite-readonly.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27909 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35207 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28518 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28361 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33569 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7506 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5533 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31409 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9169 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7365 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8199 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8017 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->