### PR TITLE
[GTK][WPE] Show display link information in webkit://gpu

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitURISchemeRequest.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitURISchemeRequest.cpp
@@ -93,6 +93,11 @@ void webkitURISchemeRequestCancel(WebKitURISchemeRequest* request)
     g_cancellable_cancel(request->priv->cancellable.get());
 }
 
+WebPageProxy& webkitURISchemeRequestGetWebPage(WebKitURISchemeRequest* request)
+{
+    return *request->priv->initiatingPage;
+}
+
 /**
  * webkit_uri_scheme_request_get_scheme:
  * @request: a #WebKitURISchemeRequest

--- a/Source/WebKit/UIProcess/API/glib/WebKitURISchemeRequestPrivate.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitURISchemeRequestPrivate.h
@@ -27,3 +27,4 @@
 
 WebKitURISchemeRequest* webkitURISchemeRequestCreate(WebKitWebContext*, WebKit::WebPageProxy&, WebKit::WebURLSchemeTask&);
 void webkitURISchemeRequestCancel(WebKitURISchemeRequest*);
+WebKit::WebPageProxy& webkitURISchemeRequestGetWebPage(WebKitURISchemeRequest*);

--- a/Source/WebKit/UIProcess/DisplayLink.h
+++ b/Source/WebKit/UIProcess/DisplayLink.h
@@ -76,6 +76,10 @@ public:
 
     void setObserverPreferredFramesPerSecond(Client&, DisplayLinkObserverID, WebCore::FramesPerSecond);
 
+#if PLATFORM(GTK) || PLATFORM(WPE)
+    DisplayVBlankMonitor& vblankMonitor() const { return *m_vblankMonitor; }
+#endif
+
 private:
 #if PLATFORM(MAC)
     static CVReturn displayLinkCallback(CVDisplayLinkRef, const CVTimeStamp*, const CVTimeStamp*, CVOptionFlags, CVOptionFlags*, void* data);

--- a/Source/WebKit/UIProcess/glib/DisplayVBlankMonitor.h
+++ b/Source/WebKit/UIProcess/glib/DisplayVBlankMonitor.h
@@ -41,6 +41,9 @@ public:
     static std::unique_ptr<DisplayVBlankMonitor> create(PlatformDisplayID);
     virtual ~DisplayVBlankMonitor();
 
+    enum class Type { Drm, Timer };
+    virtual Type type() const = 0;
+
     unsigned refreshRate() const { return m_refreshRate; }
 
     void start();

--- a/Source/WebKit/UIProcess/glib/DisplayVBlankMonitorDRM.h
+++ b/Source/WebKit/UIProcess/glib/DisplayVBlankMonitorDRM.h
@@ -39,6 +39,7 @@ public:
     ~DisplayVBlankMonitorDRM() = default;
 
 private:
+    Type type() const override { return Type::Drm; }
     bool waitForVBlank() const override;
 
     WTF::UnixFileDescriptor m_fd;

--- a/Source/WebKit/UIProcess/glib/DisplayVBlankMonitorTimer.h
+++ b/Source/WebKit/UIProcess/glib/DisplayVBlankMonitorTimer.h
@@ -36,6 +36,7 @@ public:
     ~DisplayVBlankMonitorTimer() = default;
 
 private:
+    Type type() const override { return Type::Timer; }
     bool waitForVBlank() const override;
 };
 


### PR DESCRIPTION
#### 34d16618308e16f40991351ab5038b3b1ced6956
<pre>
[GTK][WPE] Show display link information in webkit://gpu
<a href="https://bugs.webkit.org/show_bug.cgi?id=266685">https://bugs.webkit.org/show_bug.cgi?id=266685</a>

Reviewed by Adrian Perez de Castro.

Show the display ID, vblank monitor type and refresh rate.

* Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp:
(WebKit::WebKitProtocolHandler::handleGPU):
* Source/WebKit/UIProcess/API/glib/WebKitURISchemeRequest.cpp:
(webkitURISchemeRequestGetWebPage):
* Source/WebKit/UIProcess/API/glib/WebKitURISchemeRequestPrivate.h:
* Source/WebKit/UIProcess/DisplayLink.h:
(WebKit::DisplayLink::vblankMonitor const):
* Source/WebKit/UIProcess/glib/DisplayVBlankMonitor.h:
* Source/WebKit/UIProcess/glib/DisplayVBlankMonitorDRM.h:
* Source/WebKit/UIProcess/glib/DisplayVBlankMonitorTimer.h:

Canonical link: <a href="https://commits.webkit.org/272332@main">https://commits.webkit.org/272332@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd4fb383f040e39407df6ad926b4b4ecfff3199c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31375 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10045 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33069 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33869 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/28434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12392 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7294 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/28068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31711 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8458 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28009 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7279 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/7435 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35211 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28522 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28365 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/33574 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7510 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/5537 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31414 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9173 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8203 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4082 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8021 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->