### PR TITLE
[web-animations] refactor animation code related to explicitly inherited properties in keyframes

### DIFF
--- a/Source/WebCore/animation/BlendingKeyframes.cpp
+++ b/Source/WebCore/animation/BlendingKeyframes.cpp
@@ -317,12 +317,12 @@ void BlendingKeyframes::updatePropertiesMetadata(const StyleProperties& properti
 
 void BlendingKeyframes::analyzeKeyframe(const BlendingKeyframe& keyframe)
 {
-    auto analyzeSizeDependentTransform = [&]() {
-        if (m_hasWidthDependentTransform && m_hasHeightDependentTransform)
-            return;
+    auto* style = keyframe.style();
+    if (!style)
+        return;
 
-        auto* style = keyframe.style();
-        if (!style)
+    auto analyzeSizeDependentTransform = [&] {
+        if (m_hasWidthDependentTransform && m_hasHeightDependentTransform)
             return;
 
         if (keyframe.animatesProperty(CSSPropertyTransform)) {
@@ -346,7 +346,13 @@ void BlendingKeyframes::analyzeKeyframe(const BlendingKeyframe& keyframe)
         }
     };
 
+    auto analyzeExplicitlyInheritedKeyframeProperty = [&] {
+        if (!m_hasExplicitlyInheritedKeyframeProperty)
+            m_hasExplicitlyInheritedKeyframeProperty = style->hasExplicitlyInheritedProperties();
+    };
+
     analyzeSizeDependentTransform();
+    analyzeExplicitlyInheritedKeyframeProperty();
 }
 
 void BlendingKeyframe::addProperty(const AnimatableCSSProperty& property)

--- a/Source/WebCore/animation/BlendingKeyframes.h
+++ b/Source/WebCore/animation/BlendingKeyframes.h
@@ -127,6 +127,7 @@ public:
 
     bool hasWidthDependentTransform() const { return m_hasWidthDependentTransform; }
     bool hasHeightDependentTransform() const { return m_hasHeightDependentTransform; }
+    bool hasExplicitlyInheritedKeyframeProperty() const { return m_hasExplicitlyInheritedKeyframeProperty; }
 
 private:
     void analyzeKeyframe(const BlendingKeyframe&);
@@ -140,6 +141,7 @@ private:
     bool m_containsCSSVariableReferences { false };
     bool m_hasWidthDependentTransform { false };
     bool m_hasHeightDependentTransform { false };
+    bool m_hasExplicitlyInheritedKeyframeProperty { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -1010,7 +1010,6 @@ void KeyframeEffect::setBlendingKeyframes(BlendingKeyframes&& blendingKeyframes)
     computeSomeKeyframesUseStepsOrLinearTimingFunctionWithPoints();
     computeHasImplicitKeyframeForAcceleratedProperty();
     computeHasKeyframeComposingAcceleratedProperty();
-    computeHasExplicitlyInheritedKeyframeProperty();
     computeHasAcceleratedPropertyOverriddenByCascadeProperty();
     computeHasReferenceFilter();
     computeHasSizeDependentTransform();
@@ -1541,7 +1540,7 @@ void KeyframeEffect::setAnimatedPropertiesInStyle(RenderStyle& targetStyle, doub
     // In case one of the animated properties has its value set to "inherit" in one of the keyframes,
     // let's mark the resulting animated style as having an explicitly inherited property such that
     // a future style update accounts for this in a future call to TreeResolver::determineResolutionType().
-    if (m_hasExplicitlyInheritedKeyframeProperty)
+    if (m_blendingKeyframes.hasExplicitlyInheritedKeyframeProperty())
         targetStyle.setHasExplicitlyInheritedProperties();
 }
 
@@ -2465,20 +2464,6 @@ void KeyframeEffect::computeHasKeyframeComposingAcceleratedProperty()
         }
         return false;
     }();
-}
-
-void KeyframeEffect::computeHasExplicitlyInheritedKeyframeProperty()
-{
-    m_hasExplicitlyInheritedKeyframeProperty = false;
-
-    for (auto& keyframe : m_blendingKeyframes) {
-        if (auto* keyframeStyle = keyframe.style()) {
-            if (keyframeStyle->hasExplicitlyInheritedProperties()) {
-                m_hasExplicitlyInheritedKeyframeProperty = true;
-                return;
-            }
-        }
-    }
 }
 
 void KeyframeEffect::computeHasAcceleratedPropertyOverriddenByCascadeProperty()

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -229,7 +229,6 @@ private:
     void checkForMatchingTransformFunctionLists();
     void computeHasImplicitKeyframeForAcceleratedProperty();
     void computeHasKeyframeComposingAcceleratedProperty();
-    void computeHasExplicitlyInheritedKeyframeProperty();
     void computeHasAcceleratedPropertyOverriddenByCascadeProperty();
     void computeHasReferenceFilter();
     void computeHasSizeDependentTransform();
@@ -300,7 +299,6 @@ private:
     bool m_someKeyframesUseStepsTimingFunction { false };
     bool m_hasImplicitKeyframeForAcceleratedProperty { false };
     bool m_hasKeyframeComposingAcceleratedProperty { false };
-    bool m_hasExplicitlyInheritedKeyframeProperty { false };
     bool m_hasAcceleratedPropertyOverriddenByCascadeProperty { false };
     bool m_hasReferenceFilter { false };
     bool m_animatesSizeAndSizeDependentTransform { false };


### PR DESCRIPTION
#### 7e5538996fd3d99a2cf32c081881e9e8778d461a
<pre>
[web-animations] refactor animation code related to explicitly inherited properties in keyframes
<a href="https://bugs.webkit.org/show_bug.cgi?id=266687">https://bugs.webkit.org/show_bug.cgi?id=266687</a>
<a href="https://rdar.apple.com/119921171">rdar://119921171</a>

Reviewed by Antti Koivisto.

We still have several functions called under `KeyframeEffect::setBlendingKeyframes()` that iterate
over blending keyframes to determine various conditions. We need to refactor more of those in the
way we have in 272325@main so that we have fewer iterations and also move code over to `BlendingKeyframes`
for better encapsulation.

One such function is `Keyframe::computeHasExplicitlyInheritedKeyframeProperty()` which does nothing
but check styles on the blending keyframes. We move that logic over to `BlendingKeyframes::analyzeKeyframe()`.

* Source/WebCore/animation/BlendingKeyframes.cpp:
(WebCore::BlendingKeyframes::analyzeKeyframe):
* Source/WebCore/animation/BlendingKeyframes.h:
(WebCore::BlendingKeyframes::BlendingKeyframes):
(WebCore::BlendingKeyframes::hasExplicitlyInheritedKeyframeProperty const):
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::setBlendingKeyframes):
(WebCore::KeyframeEffect::setAnimatedPropertiesInStyle):
(WebCore::KeyframeEffect::computeHasKeyframeComposingAcceleratedProperty):
(WebCore::KeyframeEffect::computeHasExplicitlyInheritedKeyframeProperty): Deleted.
* Source/WebCore/animation/KeyframeEffect.h:

Canonical link: <a href="https://commits.webkit.org/272338@main">https://commits.webkit.org/272338@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/817f731df4aee38484c87f6e033ff6107ab98e9c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31388 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10058 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33082 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33882 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/28446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32155 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12405 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7307 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/28078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31724 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/8469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/28019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/7291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/7446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/27923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35224 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/28533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/28376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/33585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7523 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/5549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/31425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9185 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8216 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4085 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8034 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->