### PR TITLE
Remove no-op code from SelectorQuery

### DIFF
--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -310,8 +310,6 @@ struct PossiblyQuotedIdentifier {
         void setPagePseudoType(PagePseudoClassType);
 
         bool matchesPseudoElement() const;
-        bool isUnknownPseudoElement() const;
-        bool isCustomPseudoElement() const;
         bool isWebKitCustomPseudoElement() const;
         bool isSiblingSelector() const;
         bool isAttributeSelector() const;
@@ -412,18 +410,6 @@ inline const QualifiedName& CSSSelector::attribute() const
 inline bool CSSSelector::matchesPseudoElement() const
 {
     return match() == Match::PseudoElement;
-}
-
-inline bool CSSSelector::isUnknownPseudoElement() const
-{
-    return match() == Match::PseudoElement && pseudoElementType() == PseudoElementUnknown;
-}
-
-inline bool CSSSelector::isCustomPseudoElement() const
-{
-    return match() == Match::PseudoElement
-        && (pseudoElementType() == PseudoElementWebKitCustom
-            || pseudoElementType() == PseudoElementWebKitCustomLegacyPrefixed);
 }
 
 inline bool CSSSelector::isWebKitCustomPseudoElement() const

--- a/Source/WebCore/css/CSSSelectorList.cpp
+++ b/Source/WebCore/css/CSSSelectorList.cpp
@@ -153,38 +153,6 @@ static bool forEachSelector(Functor& functor, const CSSSelectorList* selectorLis
     return false;
 }
 
-class SelectorNeedsNamespaceResolutionFunctor {
-public:
-    bool operator()(const CSSSelector* selector)
-    {
-        if (selector->match() == CSSSelector::Match::Tag && !selector->tagQName().prefix().isEmpty() && selector->tagQName().prefix() != starAtom())
-            return true;
-        if (selector->isAttributeSelector() && !selector->attribute().prefix().isEmpty() && selector->attribute().prefix() != starAtom())
-            return true;
-        return false;
-    }
-};
-
-bool CSSSelectorList::selectorsNeedNamespaceResolution()
-{
-    SelectorNeedsNamespaceResolutionFunctor functor;
-    return forEachSelector(functor, this);
-}
-
-class SelectorHasInvalidSelectorFunctor {
-public:
-    bool operator()(const CSSSelector* selector)
-    {
-        return selector->isUnknownPseudoElement();
-    }
-};
-
-bool CSSSelectorList::hasInvalidSelector() const
-{
-    SelectorHasInvalidSelectorFunctor functor;
-    return forEachSelector(functor, this);
-}
-
 bool CSSSelectorList::hasExplicitNestingParent() const
 {
     auto functor = [](auto* selector) {

--- a/Source/WebCore/css/CSSSelectorList.h
+++ b/Source/WebCore/css/CSSSelectorList.h
@@ -57,8 +57,6 @@ public:
         return current - m_selectorArray.get();
     }
 
-    bool selectorsNeedNamespaceResolution();
-    bool hasInvalidSelector() const;
     bool hasExplicitNestingParent() const;
     bool hasOnlyNestingSelector() const;
 

--- a/Source/WebCore/dom/SelectorQuery.cpp
+++ b/Source/WebCore/dom/SelectorQuery.cpp
@@ -615,10 +615,7 @@ SelectorQuery* SelectorQueryCache::add(const String& selectors, const Document& 
         auto tokenizer = CSSTokenizer { selectors };
         auto selectorList = parseCSSSelectorList(tokenizer.tokenRange(), context);
 
-        if (!selectorList || selectorList->hasInvalidSelector())
-            return nullptr;
-
-        if (selectorList->selectorsNeedNamespaceResolution())
+        if (!selectorList)
             return nullptr;
 
         if (selectorList->hasExplicitNestingParent())


### PR DESCRIPTION
#### 72335ee184004bbb0eb8a90504108bb5cc0bfb4b
<pre>
Remove no-op code from SelectorQuery
<a href="https://bugs.webkit.org/show_bug.cgi?id=266698">https://bugs.webkit.org/show_bug.cgi?id=266698</a>

Reviewed by Antti Koivisto.

I discovered that no other code was using hasInvalidSelector() and
selectorsNeedNamespaceResolution() and they seemed somewhat suspect as
the selector parser ought to have taken care of them. And as far as I
can tell it has.

The removal of CSSSelector::isCustomPseudoElement() is a follow-up to
272337@main and 272339@main.

* Source/WebCore/css/CSSSelector.h:
(WebCore::CSSSelector::isUnknownPseudoElement const): Deleted.
(WebCore::CSSSelector::isCustomPseudoElement const): Deleted.
* Source/WebCore/css/CSSSelectorList.cpp:
(WebCore::SelectorNeedsNamespaceResolutionFunctor::operator()): Deleted.
(WebCore::CSSSelectorList::selectorsNeedNamespaceResolution): Deleted.
(WebCore::SelectorHasInvalidSelectorFunctor::operator()): Deleted.
(WebCore::CSSSelectorList::hasInvalidSelector const): Deleted.
* Source/WebCore/css/CSSSelectorList.h:
* Source/WebCore/dom/SelectorQuery.cpp:
(WebCore::SelectorQueryCache::add):

Canonical link: <a href="https://commits.webkit.org/272408@main">https://commits.webkit.org/272408@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c9cfe68674f06e91697ccfec09f54235a8bc5881

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31392 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10062 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33086 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33886 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28448 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32159 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12408 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7311 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28083 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31728 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8470 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28021 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7297 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7447 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27925 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35228 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28534 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28379 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33589 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7525 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5551 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31429 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9188 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7406 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8218 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8038 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->