### PR TITLE
[WPE] WPE Platform: add API to set user data to WPEBuffer

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/WPEBuffer.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEBuffer.h
@@ -66,13 +66,17 @@ typedef enum {
 } WPEBufferError;
 
 WPE_API GQuark      wpe_buffer_error_quark         (void);
-WPE_API WPEDisplay *wpe_buffer_get_display         (WPEBuffer *buffer);
-WPE_API int         wpe_buffer_get_width           (WPEBuffer *buffer);
-WPE_API int         wpe_buffer_get_height          (WPEBuffer *buffer);
-WPE_API gpointer    wpe_buffer_import_to_egl_image (WPEBuffer *buffer,
-                                                    GError   **error);
-WPE_API GBytes     *wpe_buffer_import_to_pixels    (WPEBuffer *buffer,
-                                                    GError   **error);
+WPE_API WPEDisplay *wpe_buffer_get_display         (WPEBuffer     *buffer);
+WPE_API int         wpe_buffer_get_width           (WPEBuffer     *buffer);
+WPE_API int         wpe_buffer_get_height          (WPEBuffer     *buffer);
+WPE_API void        wpe_buffer_set_user_data       (WPEBuffer     *buffer,
+                                                    gpointer       user_data,
+                                                    GDestroyNotify destroy_func);
+WPE_API gpointer    wpe_buffer_get_user_data       (WPEBuffer     *buffer);
+WPE_API gpointer    wpe_buffer_import_to_egl_image (WPEBuffer     *buffer,
+                                                    GError       **error);
+WPE_API GBytes     *wpe_buffer_import_to_pixels    (WPEBuffer     *buffer,
+                                                    GError       **error);
 
 G_END_DECLS
 

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEViewDRM.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEViewDRM.cpp
@@ -208,7 +208,7 @@ static WPE::DRM::Buffer* drmBufferCreateDMABuf(WPEBuffer* buffer, bool modifiers
     }
 
     auto* drmBufferPtr = drmBuffer.get();
-    g_object_set_data_full(G_OBJECT(buffer), "wpe-drm-buffer", drmBuffer.release(), reinterpret_cast<GDestroyNotify>(+[](void* userData) {
+    wpe_buffer_set_user_data(buffer, drmBuffer.release(), reinterpret_cast<GDestroyNotify>(+[](void* userData) {
         delete static_cast<WPE::DRM::Buffer*>(userData);
     }));
     return drmBufferPtr;
@@ -402,7 +402,7 @@ static std::pair<uint32_t, uint64_t> wpeBufferFormat(WPEBuffer* buffer)
 static gboolean wpeViewDRMRequestUpdate(WPEViewDRM* view, GError** error)
 {
     auto* priv = view->priv;
-    auto* drmBuffer = priv->buffer ? static_cast<WPE::DRM::Buffer*>(g_object_get_data(G_OBJECT(priv->buffer.get()), "wpe-drm-buffer")) : nullptr;
+    auto* drmBuffer = priv->buffer ? static_cast<WPE::DRM::Buffer*>(wpe_buffer_get_user_data(WPE_BUFFER(priv->buffer.get()))) : nullptr;
     if (wpe_display_drm_supports_atomic(WPE_DISPLAY_DRM(wpe_view_get_display(WPE_VIEW(view)))))
         return wpeViewDRMCommitAtomic(WPE_VIEW_DRM(view), drmBuffer, error);
 
@@ -411,7 +411,7 @@ static gboolean wpeViewDRMRequestUpdate(WPEViewDRM* view, GError** error)
 
 static gboolean wpeViewDRMRenderBuffer(WPEView* view, WPEBuffer* buffer, GError** error)
 {
-    auto* drmBuffer = static_cast<WPE::DRM::Buffer*>(g_object_get_data(G_OBJECT(buffer), "wpe-drm-buffer"));
+    auto* drmBuffer = static_cast<WPE::DRM::Buffer*>(wpe_buffer_get_user_data(buffer));
     if (!drmBuffer) {
         auto* display = WPE_DISPLAY_DRM(wpe_view_get_display(view));
         auto& plane = wpeDisplayDRMGetPrimaryPlane(display);

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp
@@ -387,7 +387,7 @@ static struct wl_buffer* createWaylandBufferFromEGLImage(WPEBuffer* buffer, GErr
 
 static struct wl_buffer* createWaylandBufferFromDMABuf(WPEBuffer* buffer, GError** error)
 {
-    if (auto* wlBuffer = static_cast<struct wl_buffer*>(g_object_get_data(G_OBJECT(buffer), "wpe-wayland-buffer")))
+    if (auto* wlBuffer = static_cast<struct wl_buffer*>(wpe_buffer_get_user_data(buffer)))
         return wlBuffer;
 
     struct wl_buffer* wlBuffer = nullptr;
@@ -414,7 +414,7 @@ static struct wl_buffer* createWaylandBufferFromDMABuf(WPEBuffer* buffer, GError
             return nullptr;
     }
 
-    g_object_set_data_full(G_OBJECT(buffer), "wpe-wayland-buffer", wlBuffer, reinterpret_cast<GDestroyNotify>(wl_buffer_destroy));
+    wpe_buffer_set_user_data(buffer, wlBuffer, reinterpret_cast<GDestroyNotify>(wl_buffer_destroy));
     return wlBuffer;
 }
 
@@ -452,7 +452,7 @@ static SharedMemoryBuffer* sharedMemoryBufferCreate(WPEDisplayWayland* display, 
 
 static struct wl_buffer* createWaylandBufferSHM(WPEBuffer* buffer, GError** error)
 {
-    if (auto* sharedMemoryBuffer = static_cast<SharedMemoryBuffer*>(g_object_get_data(G_OBJECT(buffer), "wpe-wayland-buffer"))) {
+    if (auto* sharedMemoryBuffer = static_cast<SharedMemoryBuffer*>(wpe_buffer_get_user_data(buffer))) {
         GBytes* bytes = wpe_buffer_shm_get_data(WPE_BUFFER_SHM(buffer));
         memcpy(reinterpret_cast<char*>(sharedMemoryBuffer->wlPool->data()), g_bytes_get_data(bytes, nullptr), sharedMemoryBuffer->wlPool->size());
         return sharedMemoryBuffer->wlBuffer;
@@ -472,8 +472,7 @@ static struct wl_buffer* createWaylandBufferSHM(WPEBuffer* buffer, GError** erro
         return nullptr;
     }
 
-    g_object_set_data_full(G_OBJECT(buffer), "wpe-wayland-buffer", sharedMemoryBuffer, reinterpret_cast<GDestroyNotify>(sharedMemoryBufferDestroy));
-
+    wpe_buffer_set_user_data(buffer, sharedMemoryBuffer, reinterpret_cast<GDestroyNotify>(sharedMemoryBufferDestroy));
     return sharedMemoryBuffer->wlBuffer;
 }
 


### PR DESCRIPTION
#### 061466c843bb851a8a51aeb44c3674fe852fdfdc
<pre>
[WPE] WPE Platform: add API to set user data to WPEBuffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=266701">https://bugs.webkit.org/show_bug.cgi?id=266701</a>

Reviewed by Michael Catanzaro.

It&apos;s common to associate a platform buffer to a WPEBuffer. We currently
use g_object_set_data_full for that, but it&apos;s more covenient with the
API provides a specific API for it.

* Source/WebKit/WPEPlatform/wpe/WPEBuffer.cpp:
(wpeBufferDispose):
(wpe_buffer_class_init):
(wpe_buffer_set_user_data):
(wpe_buffer_get_user_data):
* Source/WebKit/WPEPlatform/wpe/WPEBuffer.h:
* Source/WebKit/WPEPlatform/wpe/drm/WPEViewDRM.cpp:
(drmBufferCreateDMABuf):
(wpeViewDRMRequestUpdate):
(wpeViewDRMRenderBuffer):
* Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp:
(createWaylandBufferFromDMABuf):
(createWaylandBufferSHM):

Canonical link: <a href="https://commits.webkit.org/272344@main">https://commits.webkit.org/272344@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34b3306a0230195a4fe746e40c57bd52feada22a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31407 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10077 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33102 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/33901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28460 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12424 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7325 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/28089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31744 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/8486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/28040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/7306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/7463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35243 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/28550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/28399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/33601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7537 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/5566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/31442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9200 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8229 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4089 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8049 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->