### PR TITLE
Don't error out if we successfully loaded an image

### DIFF
--- a/LayoutTests/http/tests/misc/image-error-expected.html
+++ b/LayoutTests/http/tests/misc/image-error-expected.html
@@ -1,0 +1,6 @@
+<div id="target">
+    This test is making sure that even though the image returns a 404, it still gets loaded and displayed.  This is done for legacy compat reasons,
+    and is the opposite of how the object element behaves.<br>
+    <img id="result" src="resources/compass.jpg">
+</div>
+<div id="console"></div>

--- a/LayoutTests/http/tests/misc/image-error-expected.txt
+++ b/LayoutTests/http/tests/misc/image-error-expected.txt
@@ -1,3 +1,0 @@
-This test is making sure that even though the image returns a 404, it still gets loaded and displayed. This is done for legacy compat reasons, and is the opposite of how the object element behaves.
-
-The image size is: 128x128

--- a/LayoutTests/http/tests/misc/image-error.html
+++ b/LayoutTests/http/tests/misc/image-error.html
@@ -1,12 +1,10 @@
 <script>
     if (window.testRunner) {
-        testRunner.dumpAsText()
         testRunner.waitUntilDone();
     }
 
     function finished()
     {
-        document.getElementById('console').innerHTML = "The image size is: " + document.getElementById('result').width + "x" + document.getElementById('result').height;
         if (window.testRunner)
             testRunner.notifyDone();
     }

--- a/Source/WebCore/html/HTMLImageLoader.cpp
+++ b/Source/WebCore/html/HTMLImageLoader.cpp
@@ -1,7 +1,8 @@
 /*
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
- * Copyright (C) 2004, 2005, 2006, 2007, 2010, 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2015 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -80,7 +81,7 @@ void HTMLImageLoader::notifyFinished(CachedResource&, const NetworkLoadMetrics& 
     Ref<Element> protect(element());
     ImageLoader::notifyFinished(cachedImage, metrics);
 
-    bool loadError = cachedImage.errorOccurred() || cachedImage.response().httpStatusCode() >= 400;
+    bool loadError = cachedImage.errorOccurred();
     if (!loadError) {
         if (!element().isConnected()) {
             JSC::VM& vm = commonVM();
@@ -91,7 +92,7 @@ void HTMLImageLoader::notifyFinished(CachedResource&, const NetworkLoadMetrics& 
         }
     }
 
-    if (loadError) {
+    if (loadError || cachedImage.response().httpStatusCode() >= 400) {
         if (RefPtr objectElement = dynamicDowncast<HTMLObjectElement>(element()))
             objectElement->renderFallbackContent();
     }


### PR DESCRIPTION
<pre>
Don't error out if we successfully loaded an image
<a href="https://bugs.webkit.org/show_bug.cgi?id=266676">https://bugs.webkit.org/show_bug.cgi?id=266676</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://chromium.googlesource.com/chromium/blink/+/c1fdb4cd2099a27ae10dba405fe2869121c50545">https://chromium.googlesource.com/chromium/blink/+/c1fdb4cd2099a27ae10dba405fe2869121c50545</a>

Our current behavior was to show 'fallback' image for http response code being > 400.
While the spec shows that this behavior is OK for the `object` element but not for `img`
element, where the spec is silent and implies that the browser should load and display
image even if the http response was a 404.

* Source/WebCore/html/HTMLImageLoader.cpp:
(HTMLImageLoader::notifyFinished):
* LayoutTests/http/tests/misc/image-error.html: Rebaselined
* LayoutTests/http/tests/misc/image-error-expected.txt: Deleted to make 'ref' test
* LayoutTests/http/tests/misc/image-error-expected.html: New Test Expectation
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a8cde1cdbf14cbd56e5a1872ae76d31c73b24dcb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31408 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10078 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33103 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33902 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28461 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32176 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12449 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7326 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28090 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31745 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8504 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28039 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7307 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7479 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27945 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35244 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28568 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28398 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33602 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7538 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5567 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31443 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9201 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/27747 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8230 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8050 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->