### PR TITLE
[IFC] Empty inline item range (no inline content) should not trigger line building

### DIFF
--- a/LayoutTests/fast/text/empty-shrink-to-fit-content-crash-expected.txt
+++ b/LayoutTests/fast/text/empty-shrink-to-fit-content-crash-expected.txt
@@ -1,0 +1,2 @@
+
+PASS if no crash or assert

--- a/LayoutTests/fast/text/empty-shrink-to-fit-content-crash.html
+++ b/LayoutTests/fast/text/empty-shrink-to-fit-content-crash.html
@@ -1,0 +1,6 @@
+<div style="float: left"><br style="position: absolute;"></div>
+PASS if no crash or assert
+<script>
+if (window.testRunner)
+  testRunner.dumpAsText();
+</script>

--- a/Source/WebCore/layout/formattingContexts/inline/IntrinsicWidthHandler.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/IntrinsicWidthHandler.cpp
@@ -115,6 +115,9 @@ InlineLayoutUnit IntrinsicWidthHandler::computedIntrinsicWidthForConstraint(Intr
     if (intrinsicWidthMode == IntrinsicWidthMode::Maximum)
         horizontalConstraints.logicalWidth = maxInlineLayoutUnit();
     auto layoutRange = InlineItemRange { 0 , m_inlineItemList.size() };
+    if (layoutRange.isEmpty())
+        return { };
+
     auto maximumContentWidth = InlineLayoutUnit { };
     auto previousLineEnd = std::optional<InlineItemPosition> { };
     auto previousLine = std::optional<PreviousLine> { };

--- a/Source/WebCore/layout/formattingContexts/inline/TextOnlySimpleLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/TextOnlySimpleLineBuilder.cpp
@@ -446,6 +446,8 @@ bool TextOnlySimpleLineBuilder::isEligibleForSimplifiedTextOnlyInlineLayout(cons
 {
     if (placedFloats && !placedFloats->isEmpty())
         return false;
+    if (inlineContentCache.inlineItems().isEmpty())
+        return false;
     if (!inlineContentCache.inlineItems().isNonBidiTextAndForcedLineBreakOnlyContent())
         return false;
 


### PR DESCRIPTION
#### 46e0dbab2a78dbde3c52666ca0e89c1adf73ccc4
<pre>
[IFC] Empty inline item range (no inline content) should not trigger line building
<a href="https://bugs.webkit.org/show_bug.cgi?id=263776">https://bugs.webkit.org/show_bug.cgi?id=263776</a>
&lt;<a href="https://rdar.apple.com/117540112">rdar://117540112</a>&gt;

Reviewed by Antti Koivisto.

* LayoutTests/fast/text/empty-shrink-to-fit-content-crash-expected.txt: Added.
* LayoutTests/fast/text/empty-shrink-to-fit-content-crash.html: Added.
* Source/WebCore/layout/formattingContexts/inline/IntrinsicWidthHandler.cpp:
(WebCore::Layout::IntrinsicWidthHandler::computedIntrinsicWidthForConstraint): do not run line building on empty inline content.
* Source/WebCore/layout/formattingContexts/inline/TextOnlySimpleLineBuilder.cpp: empty content should not be considered as text only.
(WebCore::Layout::TextOnlySimpleLineBuilder::isEligibleForSimplifiedTextOnlyInlineLayout):

Originally-landed-as: 267815.445@safari-7617-branch (0a8a8cb63d95). <a href="https://rdar.apple.com/119595875">rdar://119595875</a>
Canonical link: <a href="https://commits.webkit.org/272359@main">https://commits.webkit.org/272359@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a48ce9e241e0d0612aecdc43e925adc1b96e1c23

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31419 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10090 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33116 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33916 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28472 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32189 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12438 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7339 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28099 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31758 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8498 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28054 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7317 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7474 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27960 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35258 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28562 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28413 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33612 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7549 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5580 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31455 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9212 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/27762 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7376 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8241 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8061 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->