### PR TITLE
Use-after-free in RTCPeerConnection::processIceTransportStateChange

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3759,6 +3759,8 @@ webkit.org/b/266708 imported/w3c/web-platform-tests/html/semantics/embedded-cont
 
 webkit.org/b/266719 fast/canvas/offscreen-giant.html [ ImageOnlyFailure ]
 
+webkit.org/b/266713 webrtc/processIceTransportStateChange-gc.html [ Skip ]
+
 # End: Common failures between GTK and WPE.
 
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/LayoutTests/webrtc/processIceTransportStateChange-gc-expected.txt
+++ b/LayoutTests/webrtc/processIceTransportStateChange-gc-expected.txt
@@ -1,0 +1,1 @@
+This test passes if not crashing

--- a/LayoutTests/webrtc/processIceTransportStateChange-gc.html
+++ b/LayoutTests/webrtc/processIceTransportStateChange-gc.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>ICETransport statechangeEvent</title>
+<script src="../resources/gc.js"></script>
+</head>
+<body>
+<div>This test passes if not crashing</div>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+async function doTest()
+{
+    let value = window.localStorage.getItem("test-done");
+    if (value && value.length === 5) {
+        window.localStorage.removeItem("test-done");
+        if (window.testRunner)
+            testRunner.notifyDone();
+        return;
+    }
+
+    const iframe = document.body.appendChild(document.createElement('iframe'));
+    const local_connection = new iframe.contentWindow.RTCPeerConnection();
+    const remote_connection = new iframe.contentWindow.RTCPeerConnection();
+
+    local_connection.onicecandidate = event => {
+        remote_connection.addIceCandidate(event.candidate);
+    };
+
+    local_connection.createDataChannel('test');
+
+    const offer = await local_connection.createOffer();
+    await local_connection.setLocalDescription(offer);
+    await remote_connection.setRemoteDescription(offer);
+
+    const answer = await remote_connection.createAnswer();
+    await remote_connection.setLocalDescription(answer);
+
+    local_connection.sctp.transport.iceTransport.onstatechange = () => {
+        iframe.remove();
+        gc();
+
+        window.localStorage.setItem("test-done", (value ? value : "") + "a");
+
+        location.reload();
+    };
+}
+doTest();
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/mediastream/RTCIceTransport.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCIceTransport.cpp
@@ -78,8 +78,8 @@ void RTCIceTransport::onStateChanged(RTCIceTransportState state)
             return;
 
         m_transportState = state;
-        if (m_connection)
-            m_connection->processIceTransportStateChange(*this);
+        if (auto connection = this->connection())
+            connection->processIceTransportStateChange(*this);
     });
 }
 

--- a/Source/WebCore/Modules/mediastream/RTCIceTransport.h
+++ b/Source/WebCore/Modules/mediastream/RTCIceTransport.h
@@ -57,7 +57,7 @@ public:
     RTCIceGatheringState gatheringState() const { return m_gatheringState; }
 
     const RTCIceTransportBackend& backend() const { return m_backend.get(); }
-    RTCPeerConnection* connection() const { return m_connection.get(); }
+    RefPtr<RTCPeerConnection> connection() const { return m_connection.get(); }
 
     using RefCounted<RTCIceTransport>::ref;
     using RefCounted<RTCIceTransport>::deref;


### PR DESCRIPTION
#### c6a8bc14421a84ab750428015a97cac14185e36a
<pre>
Use-after-free in RTCPeerConnection::processIceTransportStateChange
<a href="https://rdar.apple.com/117526483">rdar://117526483</a>

Reviewed by Jean-Yves Avenard.

RTCIceTransport is calling RTCPeerConnection::processIceTransportStateChange without protecting its RTCPeerConnection.
processIceTransportStateChange can trigger JS execution so we need to protect the RTCPeerConnection.
Make RTCIceTransport do so, and update RTCIceTransport connection getter to return a RefPtr instead of a raw pointer.

* LayoutTests/webrtc/processIceTransportStateChange-gc-expected.txt: Added.
* LayoutTests/webrtc/processIceTransportStateChange-gc.html: Added.
* Source/WebCore/Modules/mediastream/RTCDtlsTransport.cpp:
(WebCore::RTCDtlsTransport::onStateChanged):
* Source/WebCore/Modules/mediastream/RTCIceTransport.cpp:
(WebCore::RTCIceTransport::onStateChanged):
* Source/WebCore/Modules/mediastream/RTCIceTransport.h:
(WebCore::RTCIceTransport::connection const):

Originally-landed-as: 267815.446@safari-7617-branch (8be2b8b167a1). <a href="https://rdar.apple.com/119595786">rdar://119595786</a>
Canonical link: <a href="https://commits.webkit.org/272392@main">https://commits.webkit.org/272392@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d02b939b15538f6e2617cd648865cb40cc03830

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31497 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10172 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33201 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33985 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/28526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32267 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12522 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7419 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/28141 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31837 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8563 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28107 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7370 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7532 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/28016 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35329 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28625 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28462 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/33667 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7611 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5629 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31511 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9268 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/27821 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7397 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8300 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8116 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->