### PR TITLE
J414s/23C25: 1Password extension does not work and keeps trying to open a blank new tab (Unhandled Promise Rejection: AbortError: IDBTransaction will abort due to uncaught exception in an event handler)

### DIFF
--- a/LayoutTests/fast/storage/serialized-script-value.html
+++ b/LayoutTests/fast/storage/serialized-script-value.html
@@ -6,7 +6,7 @@
     <body>
         <script>
 
-const currentVersion = 14;
+const currentVersion = 15;
 
 // Here's a little Q&D helper for future adventurers needing to rebaseline this.
 


### PR DESCRIPTION
#### 671344dba649d5d7627988374f7651e6a1db3f71
<pre>
J414s/23C25: 1Password extension does not work and keeps trying to open a blank new tab (Unhandled Promise Rejection: AbortError: IDBTransaction will abort due to uncaught exception in an event handler)
<a href="https://rdar.apple.com/117020274">rdar://117020274</a>

Reviewed by Mark Lam.

We updated serialization format of SerializedScriptValue in <a href="https://rdar.apple.com/117020274">rdar://117020274</a>, but we didn&apos;t change the version number.
This makes serialized values with old format stored in IndexedDB databases no longer readable, as we are looking for the
new format during deserialization.

* LayoutTests/fast/storage/serialized-script-value.html:
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneDeserializer::deserialize):

Originally-landed-as: 267815.465@safari-7617-branch (9a56d2bb940b). <a href="https://rdar.apple.com/119595569">rdar://119595569</a>
Canonical link: <a href="https://commits.webkit.org/272378@main">https://commits.webkit.org/272378@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21c1a2a3a07c589c99b03284b53b6421d66c7fcf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31426 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10097 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33123 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33923 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28478 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32196 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12445 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7346 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28101 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31765 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8508 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28055 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7320 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7483 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27961 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35265 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28572 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28414 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33614 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7556 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5584 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31457 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9218 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/27763 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7382 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8247 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8067 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->