### PR TITLE
[CSS] @scope can have orphan declarations with an implicit enclosing style rule

### DIFF
--- a/LayoutTests/fast/css/scope-at-rule-expected.html
+++ b/LayoutTests/fast/css/scope-at-rule-expected.html
@@ -60,3 +60,15 @@
 <div>
   <span>should not be green</span>
 </div>
+<div>
+  <span class="green">should be green</span>
+</div>
+<div>
+  <span>should not be green</span>
+</div>
+<div>
+  <span class="green">should be green</span>
+</div>
+<div>
+  <span>should not be green</span>
+</div>

--- a/LayoutTests/fast/css/scope-at-rule.html
+++ b/LayoutTests/fast/css/scope-at-rule.html
@@ -70,6 +70,20 @@ div {
   }
 }
 
+#green-15 {
+  @scope (#b) {
+    & {
+      color: green;
+    }
+  }
+}
+
+#green-16 {
+  @scope (#b) {
+    color: green;
+  }
+}
+
 </style>
 
 <div class="a">
@@ -159,4 +173,18 @@ div {
     <span class="green-14">should be green</div>
   </div>
   <span class="green-14">should not be green</div>
+</div>
+
+<div id="green-15">
+  <div id="b">
+    should be green
+  </div>
+  should not be green
+</div>
+
+<div id="green-16">
+  <div id="b">
+   should be green
+  </div>
+  should not be green
 </div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-nesting-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-nesting-expected.txt
@@ -9,6 +9,6 @@ PASS @scope nested within style rule
 PASS Parent pseudo class within scope-start
 PASS Parent pseudo class within scope-end
 PASS Parent pseudo class within body of nested @scope
-FAIL Implicit rule within nested @scope  assert_equals: expected "1" but got "auto"
-FAIL Implicit rule within nested @scope (proximity) assert_equals: expected "1" but got "2"
+PASS Implicit rule within nested @scope
+PASS Implicit rule within nested @scope (proximity)
 

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -624,7 +624,7 @@ Ref<StyleRuleBase> CSSParserImpl::createNestingParentRule()
     return StyleRuleWithNesting::create(WTFMove(properties), m_context.hasDocumentSecurityOrigin, CSSSelectorList { WTFMove(selectorList) }, { });
 }
 
-Vector<Ref<StyleRuleBase>> CSSParserImpl::consumeRegularRuleList(CSSParserTokenRange block)
+Vector<Ref<StyleRuleBase>> CSSParserImpl::consumeNestedGroupRules(CSSParserTokenRange block)
 {
     NestingLevelIncrementer incrementer { m_ruleListNestingLevel };
 
@@ -668,7 +668,7 @@ RefPtr<StyleRuleMedia> CSSParserImpl::consumeMediaRule(CSSParserTokenRange prelu
         m_observerWrapper->observer().startRuleBody(m_observerWrapper->previousTokenStartOffset(block));
     }
 
-    auto rules = consumeRegularRuleList(block);
+    auto rules = consumeNestedGroupRules(block);
 
     if (m_observerWrapper)
         m_observerWrapper->observer().endRuleBody(m_observerWrapper->endOffset(block));
@@ -688,7 +688,7 @@ RefPtr<StyleRuleSupports> CSSParserImpl::consumeSupportsRule(CSSParserTokenRange
         m_observerWrapper->observer().startRuleBody(m_observerWrapper->previousTokenStartOffset(block));
     }
 
-    auto rules = consumeRegularRuleList(block);
+    auto rules = consumeNestedGroupRules(block);
 
     if (m_observerWrapper)
         m_observerWrapper->observer().endRuleBody(m_observerWrapper->endOffset(block));
@@ -1062,10 +1062,7 @@ RefPtr<StyleRuleScope> CSSParserImpl::consumeScopeRule(CSSParserTokenRange prelu
 
     NestingLevelIncrementer incrementer { m_scopeRuleNestingLevel };
     m_ancestorRuleTypeStack.append(AncestorRuleType::Scope);
-    Vector<Ref<StyleRuleBase>> rules;
-    consumeRuleList(block, RegularRuleList, [&rules](Ref<StyleRuleBase> rule) {
-        rules.append(rule);
-    });
+    auto rules = consumeNestedGroupRules(block);
     m_ancestorRuleTypeStack.removeLast();
     auto rule = StyleRuleScope::create(WTFMove(scopeStart), WTFMove(scopeEnd), WTFMove(rules));
     if (m_styleSheet)
@@ -1122,7 +1119,7 @@ RefPtr<StyleRuleLayer> CSSParserImpl::consumeLayerRule(CSSParserTokenRange prelu
         m_observerWrapper->observer().startRuleBody(m_observerWrapper->previousTokenStartOffset(*block));
     }
 
-    auto rules = consumeRegularRuleList(*block);
+    auto rules = consumeNestedGroupRules(*block);
 
     if (m_observerWrapper)
         m_observerWrapper->observer().endRuleBody(m_observerWrapper->endOffset(*block));
@@ -1154,7 +1151,7 @@ RefPtr<StyleRuleContainer> CSSParserImpl::consumeContainerRule(CSSParserTokenRan
         m_observerWrapper->observer().startRuleBody(m_observerWrapper->previousTokenStartOffset(block));
     }
 
-    auto rules = consumeRegularRuleList(block);
+    auto rules = consumeNestedGroupRules(block);
 
     if (m_observerWrapper)
         m_observerWrapper->observer().endRuleBody(m_observerWrapper->endOffset(block));

--- a/Source/WebCore/css/parser/CSSParserImpl.h
+++ b/Source/WebCore/css/parser/CSSParserImpl.h
@@ -134,8 +134,10 @@ private:
     // This function updates the range it's given.
     RefPtr<StyleRuleBase> consumeQualifiedRule(CSSParserTokenRange&, AllowedRulesType);
 
-    // This function is used for all the nested group rules (@media, @supports,..etc)
-    Vector<Ref<StyleRuleBase>> consumeRegularRuleList(CSSParserTokenRange block);
+    // This function is used for all the nested group rules (@media, @layer, @supports, @scope, @container,..etc)
+    // It handles potentially orphaned declarations (in the context of style nesting)
+    // https://drafts.csswg.org/css-nesting/#conditionals
+    Vector<Ref<StyleRuleBase>> consumeNestedGroupRules(CSSParserTokenRange block);
 
     static RefPtr<StyleRuleCharset> consumeCharsetRule(CSSParserTokenRange prelude);
     RefPtr<StyleRuleImport> consumeImportRule(CSSParserTokenRange prelude);


### PR DESCRIPTION
#### e80242bc95b6dd3197e2ecfb88a4634f6fc2c7bf
<pre>
[CSS] @scope can have orphan declarations with an implicit enclosing style rule
<a href="https://bugs.webkit.org/show_bug.cgi?id=266710">https://bugs.webkit.org/show_bug.cgi?id=266710</a>
<a href="https://rdar.apple.com/119937025">rdar://119937025</a>

Reviewed by Antti Koivisto.

* LayoutTests/fast/css/scope-at-rule-expected.html:
* LayoutTests/fast/css/scope-at-rule.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-nesting-expected.txt:
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::consumeNestedGroupRules):

Rename the method to use a name closer to the spec

(WebCore::CSSParserImpl::consumeMediaRule):
(WebCore::CSSParserImpl::consumeSupportsRule):
(WebCore::CSSParserImpl::consumeScopeRule):

Allow declarations inside @scope, not just rules

(WebCore::CSSParserImpl::consumeLayerRule):
(WebCore::CSSParserImpl::consumeContainerRule):
(WebCore::CSSParserImpl::consumeRegularRuleList): Deleted.
* Source/WebCore/css/parser/CSSParserImpl.h:

Canonical link: <a href="https://commits.webkit.org/272407@main">https://commits.webkit.org/272407@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1be41ec9a9ad0d2141ee3886e8e0679ffea0c6ca

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31521 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10196 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33226 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34010 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28547 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32292 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12548 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7444 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28161 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31862 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8587 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28131 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7390 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7556 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28038 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35353 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28649 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28485 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/33685 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7636 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5652 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31532 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9293 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/27843 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7404 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8324 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8140 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->