### PR TITLE
REGRESSION: Catalyst + WebKitLegacy crash at `com.apple.WebCore: WTF::WeakHashMap<WebCore::Page, WTF::MonotonicTime, WTF::DefaultWeakPtrImpl>::removeNullReferences`

### DIFF
--- a/Source/WebCore/page/OpportunisticTaskScheduler.cpp
+++ b/Source/WebCore/page/OpportunisticTaskScheduler.cpp
@@ -58,7 +58,8 @@ void OpportunisticTaskScheduler::rescheduleIfNeeded(MonotonicTime deadline)
     m_runloopCountAfterBeingScheduled = 0;
     m_currentDeadline = deadline;
     m_runLoopObserver->invalidate();
-    m_runLoopObserver->schedule();
+    if (!m_runLoopObserver->isScheduled())
+        m_runLoopObserver->schedule();
 }
 
 Ref<ImminentlyScheduledWorkScope> OpportunisticTaskScheduler::makeScheduledWorkScope()
@@ -72,6 +73,11 @@ void OpportunisticTaskScheduler::runLoopObserverFired()
 
     if (!m_currentDeadline)
         return;
+
+#if USE(WEB_THREAD)
+    if (WebThreadIsEnabled())
+        return;
+#endif
 
     if (UNLIKELY(!m_page))
         return;


### PR DESCRIPTION
#### 1522a457a5b4039f544a308e27abffd80a7f2c82
<pre>
REGRESSION: Catalyst + WebKitLegacy crash at `com.apple.WebCore: WTF::WeakHashMap&lt;WebCore::Page, WTF::MonotonicTime, WTF::DefaultWeakPtrImpl&gt;::removeNullReferences`
<a href="https://bugs.webkit.org/show_bug.cgi?id=263731">https://bugs.webkit.org/show_bug.cgi?id=263731</a>
<a href="https://rdar.apple.com/116431805">rdar://116431805</a>

Reviewed by Wenson Hsieh.

This crash happens in WebKitLegacy within the Opportunistic task scheduling of IdleCallback,
as the WebThread attempts to write to bad memory within `WindowEventLoop::opportunisticallyRunIdleCallbacks`.

Fix by disabling the Opportunistic Task Scheduler when using WebKitLegacy; specifically, if the
WebThread is enabled. Also, do not even schedule the runloop observer to begin with in this case.

* Source/WebCore/page/OpportunisticTaskScheduler.cpp:
(WebCore::OpportunisticTaskScheduler::reschedule):
(WebCore::OpportunisticTaskScheduler::runLoopObserverFired):

Originally-landed-as: 267815.467@safari-7617-branch (60c37687d046). <a href="https://rdar.apple.com/119595490">rdar://119595490</a>
Canonical link: <a href="https://commits.webkit.org/272371@main">https://commits.webkit.org/272371@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/512dd2aca147cccd7fec65bf3b2fb6b1c91c1d46

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31429 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10100 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33126 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33926 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28481 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32199 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12448 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7349 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28105 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31768 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8502 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28062 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7325 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7478 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27968 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35268 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28566 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28421 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33618 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7559 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5586 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31461 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9221 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7380 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8250 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8070 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->