### PR TITLE
[content-visibility] Make content-visibility animatable

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-077-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-077-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Content-visibility is animatable assert_equals: expected "auto" but got "visible"
+PASS Content-visibility is animatable
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-interpolation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-interpolation-expected.txt
@@ -1,76 +1,76 @@
 
-FAIL CSS Transitions: property <content-visibility> from [visible] to [hidden] at (-1) should be [visible] assert_equals: expected "visible " but got "hidden "
-FAIL CSS Transitions: property <content-visibility> from [visible] to [hidden] at (0) should be [visible] assert_equals: expected "visible " but got "hidden "
-FAIL CSS Transitions: property <content-visibility> from [visible] to [hidden] at (0.1) should be [visible] assert_equals: expected "visible " but got "hidden "
-FAIL CSS Transitions: property <content-visibility> from [visible] to [hidden] at (0.9) should be [visible] assert_equals: expected "visible " but got "hidden "
+PASS CSS Transitions: property <content-visibility> from [visible] to [hidden] at (-1) should be [visible]
+PASS CSS Transitions: property <content-visibility> from [visible] to [hidden] at (0) should be [visible]
+PASS CSS Transitions: property <content-visibility> from [visible] to [hidden] at (0.1) should be [visible]
+PASS CSS Transitions: property <content-visibility> from [visible] to [hidden] at (0.9) should be [visible]
 PASS CSS Transitions: property <content-visibility> from [visible] to [hidden] at (1) should be [hidden]
 PASS CSS Transitions: property <content-visibility> from [visible] to [hidden] at (1.5) should be [hidden]
-FAIL CSS Transitions with transition: all: property <content-visibility> from [visible] to [hidden] at (-1) should be [visible] assert_equals: expected "visible " but got "hidden "
-FAIL CSS Transitions with transition: all: property <content-visibility> from [visible] to [hidden] at (0) should be [visible] assert_equals: expected "visible " but got "hidden "
-FAIL CSS Transitions with transition: all: property <content-visibility> from [visible] to [hidden] at (0.1) should be [visible] assert_equals: expected "visible " but got "hidden "
-FAIL CSS Transitions with transition: all: property <content-visibility> from [visible] to [hidden] at (0.9) should be [visible] assert_equals: expected "visible " but got "hidden "
+PASS CSS Transitions with transition: all: property <content-visibility> from [visible] to [hidden] at (-1) should be [visible]
+PASS CSS Transitions with transition: all: property <content-visibility> from [visible] to [hidden] at (0) should be [visible]
+PASS CSS Transitions with transition: all: property <content-visibility> from [visible] to [hidden] at (0.1) should be [visible]
+PASS CSS Transitions with transition: all: property <content-visibility> from [visible] to [hidden] at (0.9) should be [visible]
 PASS CSS Transitions with transition: all: property <content-visibility> from [visible] to [hidden] at (1) should be [hidden]
 PASS CSS Transitions with transition: all: property <content-visibility> from [visible] to [hidden] at (1.5) should be [hidden]
 PASS CSS Animations: property <content-visibility> from [visible] to [hidden] at (-1) should be [visible]
 PASS CSS Animations: property <content-visibility> from [visible] to [hidden] at (0) should be [visible]
 PASS CSS Animations: property <content-visibility> from [visible] to [hidden] at (0.1) should be [visible]
 PASS CSS Animations: property <content-visibility> from [visible] to [hidden] at (0.9) should be [visible]
-FAIL CSS Animations: property <content-visibility> from [visible] to [hidden] at (1) should be [hidden] assert_equals: expected "hidden " but got "visible "
-FAIL CSS Animations: property <content-visibility> from [visible] to [hidden] at (1.5) should be [hidden] assert_equals: expected "hidden " but got "visible "
+PASS CSS Animations: property <content-visibility> from [visible] to [hidden] at (1) should be [hidden]
+PASS CSS Animations: property <content-visibility> from [visible] to [hidden] at (1.5) should be [hidden]
 PASS Web Animations: property <content-visibility> from [visible] to [hidden] at (-1) should be [visible]
 PASS Web Animations: property <content-visibility> from [visible] to [hidden] at (0) should be [visible]
 PASS Web Animations: property <content-visibility> from [visible] to [hidden] at (0.1) should be [visible]
 PASS Web Animations: property <content-visibility> from [visible] to [hidden] at (0.9) should be [visible]
-FAIL Web Animations: property <content-visibility> from [visible] to [hidden] at (1) should be [hidden] assert_equals: expected "hidden " but got "visible "
-FAIL Web Animations: property <content-visibility> from [visible] to [hidden] at (1.5) should be [hidden] assert_equals: expected "hidden " but got "visible "
-FAIL CSS Transitions: property <content-visibility> from [hidden] to [visible] at (-1) should be [hidden] assert_equals: expected "hidden " but got "visible "
-FAIL CSS Transitions: property <content-visibility> from [hidden] to [visible] at (0) should be [hidden] assert_equals: expected "hidden " but got "visible "
+PASS Web Animations: property <content-visibility> from [visible] to [hidden] at (1) should be [hidden]
+PASS Web Animations: property <content-visibility> from [visible] to [hidden] at (1.5) should be [hidden]
+PASS CSS Transitions: property <content-visibility> from [hidden] to [visible] at (-1) should be [hidden]
+PASS CSS Transitions: property <content-visibility> from [hidden] to [visible] at (0) should be [hidden]
 PASS CSS Transitions: property <content-visibility> from [hidden] to [visible] at (0.1) should be [visible]
 PASS CSS Transitions: property <content-visibility> from [hidden] to [visible] at (0.9) should be [visible]
 PASS CSS Transitions: property <content-visibility> from [hidden] to [visible] at (1) should be [visible]
 PASS CSS Transitions: property <content-visibility> from [hidden] to [visible] at (1.5) should be [visible]
-FAIL CSS Transitions with transition: all: property <content-visibility> from [hidden] to [visible] at (-1) should be [hidden] assert_equals: expected "hidden " but got "visible "
-FAIL CSS Transitions with transition: all: property <content-visibility> from [hidden] to [visible] at (0) should be [hidden] assert_equals: expected "hidden " but got "visible "
+PASS CSS Transitions with transition: all: property <content-visibility> from [hidden] to [visible] at (-1) should be [hidden]
+PASS CSS Transitions with transition: all: property <content-visibility> from [hidden] to [visible] at (0) should be [hidden]
 PASS CSS Transitions with transition: all: property <content-visibility> from [hidden] to [visible] at (0.1) should be [visible]
 PASS CSS Transitions with transition: all: property <content-visibility> from [hidden] to [visible] at (0.9) should be [visible]
 PASS CSS Transitions with transition: all: property <content-visibility> from [hidden] to [visible] at (1) should be [visible]
 PASS CSS Transitions with transition: all: property <content-visibility> from [hidden] to [visible] at (1.5) should be [visible]
-FAIL CSS Animations: property <content-visibility> from [hidden] to [visible] at (-1) should be [hidden] assert_equals: expected "hidden " but got "visible "
-FAIL CSS Animations: property <content-visibility> from [hidden] to [visible] at (0) should be [hidden] assert_equals: expected "hidden " but got "visible "
+PASS CSS Animations: property <content-visibility> from [hidden] to [visible] at (-1) should be [hidden]
+PASS CSS Animations: property <content-visibility> from [hidden] to [visible] at (0) should be [hidden]
 PASS CSS Animations: property <content-visibility> from [hidden] to [visible] at (0.1) should be [visible]
 PASS CSS Animations: property <content-visibility> from [hidden] to [visible] at (0.9) should be [visible]
 PASS CSS Animations: property <content-visibility> from [hidden] to [visible] at (1) should be [visible]
 PASS CSS Animations: property <content-visibility> from [hidden] to [visible] at (1.5) should be [visible]
-FAIL Web Animations: property <content-visibility> from [hidden] to [visible] at (-1) should be [hidden] assert_equals: expected "hidden " but got "visible "
-FAIL Web Animations: property <content-visibility> from [hidden] to [visible] at (0) should be [hidden] assert_equals: expected "hidden " but got "visible "
+PASS Web Animations: property <content-visibility> from [hidden] to [visible] at (-1) should be [hidden]
+PASS Web Animations: property <content-visibility> from [hidden] to [visible] at (0) should be [hidden]
 PASS Web Animations: property <content-visibility> from [hidden] to [visible] at (0.1) should be [visible]
 PASS Web Animations: property <content-visibility> from [hidden] to [visible] at (0.9) should be [visible]
 PASS Web Animations: property <content-visibility> from [hidden] to [visible] at (1) should be [visible]
 PASS Web Animations: property <content-visibility> from [hidden] to [visible] at (1.5) should be [visible]
-PASS CSS Transitions: property <content-visibility> from [auto] to [visible] at (-0.3) should be [visible]
-PASS CSS Transitions: property <content-visibility> from [auto] to [visible] at (0) should be [visible]
-PASS CSS Transitions: property <content-visibility> from [auto] to [visible] at (0.3) should be [visible]
+FAIL CSS Transitions: property <content-visibility> from [auto] to [visible] at (-0.3) should be [visible] assert_equals: expected "visible " but got "auto "
+FAIL CSS Transitions: property <content-visibility> from [auto] to [visible] at (0) should be [visible] assert_equals: expected "visible " but got "auto "
+FAIL CSS Transitions: property <content-visibility> from [auto] to [visible] at (0.3) should be [visible] assert_equals: expected "visible " but got "auto "
 PASS CSS Transitions: property <content-visibility> from [auto] to [visible] at (0.5) should be [visible]
 PASS CSS Transitions: property <content-visibility> from [auto] to [visible] at (0.6) should be [visible]
 PASS CSS Transitions: property <content-visibility> from [auto] to [visible] at (1) should be [visible]
 PASS CSS Transitions: property <content-visibility> from [auto] to [visible] at (1.5) should be [visible]
-PASS CSS Transitions with transition: all: property <content-visibility> from [auto] to [visible] at (-0.3) should be [visible]
-PASS CSS Transitions with transition: all: property <content-visibility> from [auto] to [visible] at (0) should be [visible]
-PASS CSS Transitions with transition: all: property <content-visibility> from [auto] to [visible] at (0.3) should be [visible]
+FAIL CSS Transitions with transition: all: property <content-visibility> from [auto] to [visible] at (-0.3) should be [visible] assert_equals: expected "visible " but got "auto "
+FAIL CSS Transitions with transition: all: property <content-visibility> from [auto] to [visible] at (0) should be [visible] assert_equals: expected "visible " but got "auto "
+FAIL CSS Transitions with transition: all: property <content-visibility> from [auto] to [visible] at (0.3) should be [visible] assert_equals: expected "visible " but got "auto "
 PASS CSS Transitions with transition: all: property <content-visibility> from [auto] to [visible] at (0.5) should be [visible]
 PASS CSS Transitions with transition: all: property <content-visibility> from [auto] to [visible] at (0.6) should be [visible]
 PASS CSS Transitions with transition: all: property <content-visibility> from [auto] to [visible] at (1) should be [visible]
 PASS CSS Transitions with transition: all: property <content-visibility> from [auto] to [visible] at (1.5) should be [visible]
-FAIL CSS Animations: property <content-visibility> from [auto] to [visible] at (-0.3) should be [auto] assert_equals: expected "auto " but got "visible "
-FAIL CSS Animations: property <content-visibility> from [auto] to [visible] at (0) should be [auto] assert_equals: expected "auto " but got "visible "
-FAIL CSS Animations: property <content-visibility> from [auto] to [visible] at (0.3) should be [auto] assert_equals: expected "auto " but got "visible "
+PASS CSS Animations: property <content-visibility> from [auto] to [visible] at (-0.3) should be [auto]
+PASS CSS Animations: property <content-visibility> from [auto] to [visible] at (0) should be [auto]
+PASS CSS Animations: property <content-visibility> from [auto] to [visible] at (0.3) should be [auto]
 PASS CSS Animations: property <content-visibility> from [auto] to [visible] at (0.5) should be [visible]
 PASS CSS Animations: property <content-visibility> from [auto] to [visible] at (0.6) should be [visible]
 PASS CSS Animations: property <content-visibility> from [auto] to [visible] at (1) should be [visible]
 PASS CSS Animations: property <content-visibility> from [auto] to [visible] at (1.5) should be [visible]
-FAIL Web Animations: property <content-visibility> from [auto] to [visible] at (-0.3) should be [auto] assert_equals: expected "auto " but got "visible "
-FAIL Web Animations: property <content-visibility> from [auto] to [visible] at (0) should be [auto] assert_equals: expected "auto " but got "visible "
-FAIL Web Animations: property <content-visibility> from [auto] to [visible] at (0.3) should be [auto] assert_equals: expected "auto " but got "visible "
+PASS Web Animations: property <content-visibility> from [auto] to [visible] at (-0.3) should be [auto]
+PASS Web Animations: property <content-visibility> from [auto] to [visible] at (0) should be [auto]
+PASS Web Animations: property <content-visibility> from [auto] to [visible] at (0.3) should be [auto]
 PASS Web Animations: property <content-visibility> from [auto] to [visible] at (0.5) should be [visible]
 PASS Web Animations: property <content-visibility> from [auto] to [visible] at (0.6) should be [visible]
 PASS Web Animations: property <content-visibility> from [auto] to [visible] at (1) should be [visible]
@@ -105,14 +105,14 @@ PASS CSS Transitions with transition: all: property <content-visibility> from [h
 PASS CSS Transitions with transition: all: property <content-visibility> from [hidden] to [hidden] at (0.5) should be [hidden]
 PASS CSS Transitions with transition: all: property <content-visibility> from [hidden] to [hidden] at (1) should be [hidden]
 PASS CSS Transitions with transition: all: property <content-visibility> from [hidden] to [hidden] at (1.5) should be [hidden]
-FAIL CSS Animations: property <content-visibility> from [hidden] to [hidden] at (-1) should be [hidden] assert_equals: expected "hidden " but got "visible "
-FAIL CSS Animations: property <content-visibility> from [hidden] to [hidden] at (0) should be [hidden] assert_equals: expected "hidden " but got "visible "
-FAIL CSS Animations: property <content-visibility> from [hidden] to [hidden] at (0.5) should be [hidden] assert_equals: expected "hidden " but got "visible "
-FAIL CSS Animations: property <content-visibility> from [hidden] to [hidden] at (1) should be [hidden] assert_equals: expected "hidden " but got "visible "
-FAIL CSS Animations: property <content-visibility> from [hidden] to [hidden] at (1.5) should be [hidden] assert_equals: expected "hidden " but got "visible "
-FAIL Web Animations: property <content-visibility> from [hidden] to [hidden] at (-1) should be [hidden] assert_equals: expected "hidden " but got "visible "
-FAIL Web Animations: property <content-visibility> from [hidden] to [hidden] at (0) should be [hidden] assert_equals: expected "hidden " but got "visible "
-FAIL Web Animations: property <content-visibility> from [hidden] to [hidden] at (0.5) should be [hidden] assert_equals: expected "hidden " but got "visible "
-FAIL Web Animations: property <content-visibility> from [hidden] to [hidden] at (1) should be [hidden] assert_equals: expected "hidden " but got "visible "
-FAIL Web Animations: property <content-visibility> from [hidden] to [hidden] at (1.5) should be [hidden] assert_equals: expected "hidden " but got "visible "
+PASS CSS Animations: property <content-visibility> from [hidden] to [hidden] at (-1) should be [hidden]
+PASS CSS Animations: property <content-visibility> from [hidden] to [hidden] at (0) should be [hidden]
+PASS CSS Animations: property <content-visibility> from [hidden] to [hidden] at (0.5) should be [hidden]
+PASS CSS Animations: property <content-visibility> from [hidden] to [hidden] at (1) should be [hidden]
+PASS CSS Animations: property <content-visibility> from [hidden] to [hidden] at (1.5) should be [hidden]
+PASS Web Animations: property <content-visibility> from [hidden] to [hidden] at (-1) should be [hidden]
+PASS Web Animations: property <content-visibility> from [hidden] to [hidden] at (0) should be [hidden]
+PASS Web Animations: property <content-visibility> from [hidden] to [hidden] at (0.5) should be [hidden]
+PASS Web Animations: property <content-visibility> from [hidden] to [hidden] at (1) should be [hidden]
+PASS Web Animations: property <content-visibility> from [hidden] to [hidden] at (1.5) should be [hidden]
 

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -1912,6 +1912,8 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
             changingProperties.m_properties.set(CSSPropertyClip);
         if (first.viewTransitionName != second.viewTransitionName)
             changingProperties.m_properties.set(CSSPropertyViewTransitionName);
+        if (first.contentVisibility != second.contentVisibility)
+            changingProperties.m_properties.set(CSSPropertyContentVisibility);
 
         // Non animated styles are followings.
         // customProperties
@@ -1936,7 +1938,6 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
         // overscrollBehaviorY
         // applePayButtonStyle
         // applePayButtonType
-        // contentVisibility
         // inputSecurity
         // containerType
         // transformStyleForcedToFlat

--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -330,6 +330,16 @@ TextStream& operator<<(TextStream& ts, ContentPosition position)
     return ts;
 }
 
+TextStream& operator<<(TextStream& ts, ContentVisibility contentVisibility)
+{
+    switch (contentVisibility) {
+    case ContentVisibility::Visible: ts << "visible"; break;
+    case ContentVisibility::Auto: ts << "auto"; break;
+    case ContentVisibility::Hidden: ts << "hidden"; break;
+    }
+    return ts;
+}
+
 TextStream& operator<<(TextStream& ts, CursorType cursor)
 {
     switch (cursor) {

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -1215,6 +1215,7 @@ WTF::TextStream& operator<<(WTF::TextStream&, ColumnProgression);
 WTF::TextStream& operator<<(WTF::TextStream&, ColumnSpan);
 WTF::TextStream& operator<<(WTF::TextStream&, ContentDistribution);
 WTF::TextStream& operator<<(WTF::TextStream&, ContentPosition);
+WTF::TextStream& operator<<(WTF::TextStream&, ContentVisibility);
 WTF::TextStream& operator<<(WTF::TextStream&, CursorType);
 #if ENABLE(CURSOR_VISIBILITY)
 WTF::TextStream& operator<<(WTF::TextStream&, CursorVisibility);


### PR DESCRIPTION
#### 6fb45947f4f465d513debb81ecbf1e95a519b60d
<pre>
[content-visibility] Make content-visibility animatable
<a href="https://bugs.webkit.org/show_bug.cgi?id=266712">https://bugs.webkit.org/show_bug.cgi?id=266712</a>
<a href="https://rdar.apple.com/119940258">rdar://119940258</a>

Reviewed by Simon Fraser.

Make content-visibility animatable as specified by <a href="https://drafts.csswg.org/css-contain-3/#content-visibility-animation">https://drafts.csswg.org/css-contain-3/#content-visibility-animation</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-077-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-interpolation-expected.txt:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::blendFunc):
(WebCore::CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::conservativelyCollectChangedAnimatableProperties const):
* Source/WebCore/rendering/style/RenderStyleConstants.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/rendering/style/RenderStyleConstants.h:

Canonical link: <a href="https://commits.webkit.org/272364@main">https://commits.webkit.org/272364@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1889aba5e958389865a773613c80ad2202811388

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31436 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10107 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33134 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33934 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28488 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32207 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12457 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7357 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/28110 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31776 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8515 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28069 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7331 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7489 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27976 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35276 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28578 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28427 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33628 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7566 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5592 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31471 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9228 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8257 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4102 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8077 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->