### PR TITLE
jsc_fuz/wktr: ASSERT_WITH_SECURITY_IMPLICATION(position <= size()); in CSSStyleSheet::insertRule(...) CSSStyleSheet.cpp:365

### DIFF
--- a/LayoutTests/fast/css/delete-namespace-rule-when-child-rule-exists-expected.txt
+++ b/LayoutTests/fast/css/delete-namespace-rule-when-child-rule-exists-expected.txt
@@ -1,0 +1,10 @@
+Tests that deleting a @namespace rule when list contains anything other than @import or @namespace rules should throw InvalidStateError.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS styleSheet.deleteRule(0) threw exception InvalidStateError: The object is in an invalid state..
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/css/delete-namespace-rule-when-child-rule-exists.html
+++ b/LayoutTests/fast/css/delete-namespace-rule-when-child-rule-exists.html
@@ -1,0 +1,12 @@
+<style>
+  @namespace a url();
+</style>
+<script src="../../resources/js-test.js"></script>
+<script>
+  description("Tests that deleting a @namespace rule when list contains anything other than @import or @namespace rules should throw InvalidStateError.");
+
+  let styleSheet = document.styleSheets[0];
+  styleSheet.cssRules[0];
+  styleSheet.insertRule(`b {}`, 1);
+  shouldThrowErrorName("styleSheet.deleteRule(0)", "InvalidStateError");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/delete-namespace-rule-when-child-rule-exists-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/delete-namespace-rule-when-child-rule-exists-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Deleting a @namespace rule when list contains anything other than @import or @namespace rules should throw InvalidStateError. assert_throws_dom: function "() => styleSheet.deleteRule(0)" did not throw
+PASS Deleting a @namespace rule when list contains anything other than @import or @namespace rules should throw InvalidStateError.
 

--- a/Source/WebCore/css/CSSStyleSheet.cpp
+++ b/Source/WebCore/css/CSSStyleSheet.cpp
@@ -377,8 +377,9 @@ ExceptionOr<void> CSSStyleSheet::deleteRule(unsigned index)
         return Exception { ExceptionCode::IndexSizeError };
     RuleMutationScope mutationScope(this);
 
-    m_contents->wrapperDeleteRule(index);
-
+    bool success = m_contents->wrapperDeleteRule(index);
+    if (!success)
+        return Exception { ExceptionCode::InvalidStateError };
     if (!m_childRuleCSSOMWrappers.isEmpty()) {
         if (m_childRuleCSSOMWrappers[index])
             m_childRuleCSSOMWrappers[index]->setParentStyleSheet(nullptr);

--- a/Source/WebCore/css/StyleSheetContents.h
+++ b/Source/WebCore/css/StyleSheetContents.h
@@ -128,7 +128,7 @@ public:
     unsigned estimatedSizeInBytes() const;
     
     bool wrapperInsertRule(Ref<StyleRuleBase>&&, unsigned index);
-    void wrapperDeleteRule(unsigned index);
+    bool wrapperDeleteRule(unsigned index);
 
     Ref<StyleSheetContents> copy() const { return adoptRef(*new StyleSheetContents(*this)); }
 


### PR DESCRIPTION
#### 15b690620471d2779fb7c994a689178d3db1dc68
<pre>
jsc_fuz/wktr: ASSERT_WITH_SECURITY_IMPLICATION(position &lt;= size()); in CSSStyleSheet::insertRule(...) CSSStyleSheet.cpp:365
<a href="https://bugs.webkit.org/show_bug.cgi?id=263950">https://bugs.webkit.org/show_bug.cgi?id=263950</a>
<a href="https://rdar.apple.com/117469266">rdar://117469266</a>

Reviewed by Antti Koivisto and Darin Adler.

Based on specification, we should return early and throw InvalidStateError exception when attempting to delete @namespace rule, and list contains anything other than @import or @namespace rules.

* LayoutTests/fast/css/delete-namespace-rule-when-child-rule-exists-expected.txt: Added.
* LayoutTests/fast/css/delete-namespace-rule-when-child-rule-exists.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/delete-namespace-rule-when-child-rule-exists-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/delete-namespace-rule-when-child-rule-exists.html: Added.
* Source/WebCore/css/CSSStyleSheet.cpp:
(WebCore::CSSStyleSheet::deleteRule):
* Source/WebCore/css/StyleSheetContents.cpp:
(WebCore::StyleSheetContents::wrapperDeleteRule):
* Source/WebCore/css/StyleSheetContents.h:

Originally-landed-as: 267815.506@safari-7617-branch (40098636b478). <a href="https://rdar.apple.com/119598025">rdar://119598025</a>
Canonical link: <a href="https://commits.webkit.org/272384@main">https://commits.webkit.org/272384@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db0ee053e73fbc6a05ec970a921f8752a4289cf4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31449 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10122 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33149 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33944 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28495 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32219 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12469 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7370 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28117 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31789 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8523 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28076 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7339 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7496 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27983 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35287 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28586 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28433 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33636 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7574 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5600 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31479 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9235 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/27787 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7392 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8265 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8084 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->