### PR TITLE
Making exception for Apple logo (U+F8FF) on PUA characters font fallback

### DIFF
--- a/LayoutTests/fast/css/font-fallback-private-use-area-apple-logo-exception-expected.html
+++ b/LayoutTests/fast/css/font-fallback-private-use-area-apple-logo-exception-expected.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+ <html>
+ <head>
+ <style>
+ p {
+     font-family: 'Times Roman';
+ }
+ </style>
+ </head>
+ <body>
+    <p>&#xF8FF;</p>
+ </body>
+ </html>
+ 

--- a/LayoutTests/fast/css/font-fallback-private-use-area-apple-logo-exception.html
+++ b/LayoutTests/fast/css/font-fallback-private-use-area-apple-logo-exception.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+ <html>
+ <head>
+ <style>
+ p {
+     font-family: 'Times New Roman';
+ }
+ </style>
+ </head>
+ <body>
+    <!-- Times New Roman has no support for U+F8FF, it should fallback to Times Roman on Apple platform -->
+    <p>&#xF8FF;</p>
+ </body>
+ </html>
+ 

--- a/LayoutTests/platform/gtk/fast/css/font-fallback-private-use-area-apple-logo-exception-expected.html
+++ b/LayoutTests/platform/gtk/fast/css/font-fallback-private-use-area-apple-logo-exception-expected.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+ <html>
+ <head>
+ <style>
+ </style>
+ </head>
+ <body>
+ </body>
+ </html>

--- a/LayoutTests/platform/wpe/fast/css/font-fallback-private-use-area-apple-logo-exception-expected.html
+++ b/LayoutTests/platform/wpe/fast/css/font-fallback-private-use-area-apple-logo-exception-expected.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+ <html>
+ <head>
+ <style>
+ </style>
+ </head>
+ <body>
+ </body>
+ </html>

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
@@ -478,7 +478,13 @@ GlyphData FontCascadeFonts::glyphDataForVariant(char32_t character, const FontCa
         return loadingResult;
     // https://drafts.csswg.org/css-fonts-4/#char-handling-issues
     // "If a given character is a Private-Use Area Unicode codepoint, user agents must only match font families named in the font-family list that are not generic families. If none of the families named in the font-family list contain a glyph for that codepoint, user agents must display some form of missing glyph symbol for that character rather than attempting installed font fallback for that codepoint."
-    if (isPrivateUseAreaCharacter(character)) {
+    bool shouldCheckForPrivateUseAreaCharacters = true;
+#if PLATFORM(COCOA)
+    // We make an exception for 0xF8FF in Apple platforms for compatibility with other browsers. This has traditionally being mapped on Apple platforms to the Apple logo glyph by some fonts like Times Roman.
+    // http://www.unicode.org/Public/MAPPINGS/VENDORS/APPLE/CORPCHAR.TXT
+    shouldCheckForPrivateUseAreaCharacters = character != 0xF8FF;
+#endif
+    if (shouldCheckForPrivateUseAreaCharacters && isPrivateUseAreaCharacter(character)) {
         auto font = FontCache::forCurrentThread().lastResortFallbackFont(description);
         GlyphData glyphData(0, font.ptr());
         m_systemFallbackFontSet.add(WTFMove(font));


### PR DESCRIPTION
#### 17737ef944ac199ac06b48ead10be64069cb90e0
<pre>
Making exception for Apple logo (U+F8FF) on PUA characters font fallback
<a href="https://bugs.webkit.org/show_bug.cgi?id=266664">https://bugs.webkit.org/show_bug.cgi?id=266664</a>
<a href="https://rdar.apple.com/119517735">rdar://119517735</a>

Reviewed by Brent Fulgham.

WebKit currently complies to CSS fonts specification <a href="https://drafts.csswg.org/css-fonts-4/#char-handling-issues">https://drafts.csswg.org/css-fonts-4/#char-handling-issues</a>
on the fallback behavior for PUA characters.
This was implemented at <a href="https://bugs.webkit.org/show_bug.cgi?id=263261">https://bugs.webkit.org/show_bug.cgi?id=263261</a>

The specification requires that the engine doesn&apos;t fallback to
system fonts if a character belongs to the Private Use Area (PUA) block.
If the author specifies a font that can render such character, we still resolve
that glyph accordingly, but if no font specified can do that we won&apos;t fallback
to a system font.

The problem:
The codepoint U+F8FF, which is in the PUA block, is traditionally mapped to the Apple logo
in some system fonts like &apos;Times Roman&apos; on Apple platforms.
Since we have always falled back to system fonts (before the patch mentioned before),
some authors might expect that U+F8FF is supported, for example, by &quot;Verdana&quot;
since they are not aware that under the hood WebKit would fallback to a system
font for rendering such a glyph.

For that reason, we are creating an exception for the U+F8FF codepoint:
<a href="http://www.unicode.org/Public/MAPPINGS/VENDORS/APPLE/CORPCHAR.TXT">http://www.unicode.org/Public/MAPPINGS/VENDORS/APPLE/CORPCHAR.TXT</a>

This seems to be compatible with other engines. Blink, for example,
handled this at:
&quot;Add support for PUA unicode codepoint for Apple Logo on Mac&quot;:
<a href="https://chromium-review.googlesource.com/c/chromium/src/+/2785423">https://chromium-review.googlesource.com/c/chromium/src/+/2785423</a>

Note that, browsers on other non-Apple platforms will most likely still render
.notdef for this codepoint, since system fonts there won&apos;t be mapping
it to the Apple logo.

* LayoutTests/fast/css/font-fallback-private-use-area-apple-logo-exception-expected.html: Added.
* LayoutTests/fast/css/font-fallback-private-use-area-apple-logo-exception.html: Added.
* LayoutTests/platform/gtk/fast/css/font-fallback-private-use-area-apple-logo-exception-expected.html: Added.
* LayoutTests/platform/wpe/fast/css/font-fallback-private-use-area-apple-logo-exception-expected.html: Added.
* Source/WebCore/platform/graphics/FontCascadeFonts.cpp:
(WebCore::FontCascadeFonts::glyphDataForVariant):

Canonical link: <a href="https://commits.webkit.org/272417@main">https://commits.webkit.org/272417@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0272479ee6ec2533b96834f40f08eb926bd599b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31562 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10240 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33274 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34055 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28588 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32338 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12594 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7488 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/28199 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31907 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8624 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28171 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7431 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7594 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28078 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35399 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28689 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28527 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/33724 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7677 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5694 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/31575 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9333 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/27883 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7413 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8364 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8183 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->