### PR TITLE
[GStreamer] Fix delayed dispatch of async task post MediaPlayer destruction

### DIFF
--- a/Source/WebCore/platform/AbortableTaskQueue.h
+++ b/Source/WebCore/platform/AbortableTaskQueue.h
@@ -75,6 +75,7 @@ public:
         ASSERT(isMainThread());
         ASSERT(!m_lock.isHeld());
         ASSERT(m_channel.isEmpty());
+        startAborting();
     }
 
     // ===========================

--- a/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp
@@ -170,8 +170,10 @@ GstObject* TrackPrivateBaseGStreamer::objectForLogging() const
 
 void TrackPrivateBaseGStreamer::disconnect()
 {
-    if (m_stream)
+    if (m_stream) {
         g_signal_handlers_disconnect_matched(m_stream.get(), G_SIGNAL_MATCH_DATA, 0, 0, nullptr, nullptr, this);
+        ASSERT(!g_signal_handler_find(m_stream.get(), G_SIGNAL_MATCH_UNBLOCKED, 0, 0, nullptr, nullptr, nullptr));
+    }
 
     m_tags.clear();
 
@@ -183,8 +185,11 @@ void TrackPrivateBaseGStreamer::disconnect()
         m_bestUpstreamPad.clear();
     }
 
-    if (m_pad)
+    if (m_pad) {
+        g_signal_handlers_disconnect_matched(m_pad.get(), G_SIGNAL_MATCH_DATA, 0, 0, nullptr, nullptr, this);
+        ASSERT(!g_signal_handler_find(m_pad.get(), G_SIGNAL_MATCH_UNBLOCKED, 0, 0, nullptr, nullptr, nullptr));
         m_pad.clear();
+    }
 }
 
 void TrackPrivateBaseGStreamer::tagsChanged()


### PR DESCRIPTION
#### b1393655168baaef5595d59edb774c0ba12bc8cd
<pre>
[GStreamer] Fix delayed dispatch of async task post MediaPlayer destruction
<a href="https://bugs.webkit.org/show_bug.cgi?id=266715">https://bugs.webkit.org/show_bug.cgi?id=266715</a>

Reviewed by Xabier Rodriguez-Calvar.

When the media player is destroyed, there can still be async tasks (from AbortableTaskQueue)
ongoing, some of them related to tracks. Those tasks should be aborted, because they depend
on objects that are no longer there.

This patch aborts all pending tasks on AbortableTaskQueue destruction and also unregisters
all pending callbacks from TrackPrivateBaseGStreamer (and asserts that they&apos;re no longer
there).

See: <a href="https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1231">https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1231</a>

Original author: &quot;Vivek.A&quot; &lt;Vivek_Arumugam@comcast.com&gt;

* Source/WebCore/platform/AbortableTaskQueue.h: Abort tasks on destruction.
* Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp:
(WebCore::TrackPrivateBaseGStreamer::disconnect): Disconnect handlers and assert.

Canonical link: <a href="https://commits.webkit.org/272410@main">https://commits.webkit.org/272410@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cae98934fb855d6f2fb72916c36bb4f7dd801a06

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31444 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10117 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33144 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33942 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28494 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32215 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12507 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7365 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28113 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31784 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8550 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28077 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7335 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7519 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27984 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35284 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28612 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28434 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33629 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7573 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5598 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31472 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9234 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7408 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8264 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8083 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->