### PR TITLE
Crash under WebCore::createMainThreadConnection(WebCore::WorkerGlobalScope&)

### DIFF
--- a/Source/WebCore/Modules/cache/WorkerCacheStorageConnection.cpp
+++ b/Source/WebCore/Modules/cache/WorkerCacheStorageConnection.cpp
@@ -70,8 +70,9 @@ static Ref<CacheStorageConnection> createMainThreadConnection(WorkerGlobalScope&
 {
     RefPtr<CacheStorageConnection> mainThreadConnection;
     callOnMainThreadAndWait([workerThread = Ref { scope.thread() }, &mainThreadConnection]() mutable {
-        if (!workerThread->runLoop().terminated())
-            mainThreadConnection = workerThread->workerLoaderProxy().createCacheStorageConnection();
+        auto* workerLoaderProxy = workerThread->workerLoaderProxy();
+        if (!workerThread->runLoop().terminated() && workerLoaderProxy)
+            mainThreadConnection = workerLoaderProxy->createCacheStorageConnection();
         if (!mainThreadConnection) {
             RELEASE_LOG_INFO(ServiceWorker, "Creating stopped WorkerCacheStorageConnection");
             mainThreadConnection = StoppedCacheStorageConnection::create();

--- a/Source/WebCore/Modules/cookie-store/CookieStore.cpp
+++ b/Source/WebCore/Modules/cookie-store/CookieStore.cpp
@@ -108,7 +108,7 @@ void CookieStore::MainThreadBridge::ensureOnMainThread(Function<void(ScriptExecu
         return;
     }
 
-    downcast<WorkerGlobalScope>(*context).thread().workerLoaderProxy().postTaskToLoader(WTFMove(task));
+    downcast<WorkerGlobalScope>(*context).thread().workerLoaderProxy()->postTaskToLoader(WTFMove(task));
 }
 
 void CookieStore::MainThreadBridge::ensureOnContextThread(Function<void(CookieStore&)>&& task)

--- a/Source/WebCore/Modules/permissions/Permissions.cpp
+++ b/Source/WebCore/Modules/permissions/Permissions.cpp
@@ -196,7 +196,8 @@ void Permissions::query(JSC::Strong<JSC::JSObject> permissionDescriptorValue, DO
         });
     };
 
-    workerGlobalScope.thread().workerLoaderProxy().postTaskToLoader(WTFMove(completionHandler));
+    if (auto* workerLoaderProxy = workerGlobalScope.thread().workerLoaderProxy())
+        workerLoaderProxy->postTaskToLoader(WTFMove(completionHandler));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/storage/WorkerStorageConnection.cpp
+++ b/Source/WebCore/Modules/storage/WorkerStorageConnection.cpp
@@ -64,10 +64,14 @@ void WorkerStorageConnection::getPersisted(ClientOrigin&& origin, StorageConnect
 {
     ASSERT(m_scope);
 
+    auto* workerLoaderProxy = m_scope->thread().workerLoaderProxy();
+    if (!workerLoaderProxy)
+        return completionHandler(false);
+
     auto callbackIdentifier = ++m_lastCallbackIdentifier;
     m_getPersistedCallbacks.add(callbackIdentifier, WTFMove(completionHandler));
 
-    m_scope->thread().workerLoaderProxy().postTaskToLoader([callbackIdentifier, contextIdentifier = m_scope->identifier(), origin = WTFMove(origin).isolatedCopy()](auto& context) mutable {
+    workerLoaderProxy->postTaskToLoader([callbackIdentifier, contextIdentifier = m_scope->identifier(), origin = WTFMove(origin).isolatedCopy()](auto& context) mutable {
         ASSERT(isMainThread());
 
         auto& document = downcast<Document>(context);
@@ -94,10 +98,14 @@ void WorkerStorageConnection::getEstimate(ClientOrigin&& origin, StorageConnecti
 {
     ASSERT(m_scope);
 
+    auto* workerLoaderProxy = m_scope->thread().workerLoaderProxy();
+    if (!workerLoaderProxy)
+        return completionHandler(Exception { ExceptionCode::InvalidStateError });
+
     auto callbackIdentifier = ++m_lastCallbackIdentifier;
     m_getEstimateCallbacks.add(callbackIdentifier, WTFMove(completionHandler));
 
-    m_scope->thread().workerLoaderProxy().postTaskToLoader([callbackIdentifier, contextIdentifier = m_scope->identifier(), origin = WTFMove(origin).isolatedCopy()](auto& context) mutable {
+    workerLoaderProxy->postTaskToLoader([callbackIdentifier, contextIdentifier = m_scope->identifier(), origin = WTFMove(origin).isolatedCopy()](auto& context) mutable {
         ASSERT(isMainThread());
 
         auto& document = downcast<Document>(context);
@@ -123,11 +131,15 @@ void WorkerStorageConnection::didGetEstimate(uint64_t callbackIdentifier, Except
 void WorkerStorageConnection::fileSystemGetDirectory(ClientOrigin&& origin, StorageConnection::GetDirectoryCallback&& completionHandler)
 {
     ASSERT(m_scope);
+
+    auto* workerLoaderProxy = m_scope->thread().workerLoaderProxy();
+    if (!workerLoaderProxy)
+        return completionHandler(Exception { ExceptionCode::InvalidStateError });
     
     auto callbackIdentifier = ++m_lastCallbackIdentifier;
     m_getDirectoryCallbacks.add(callbackIdentifier, WTFMove(completionHandler));
 
-    m_scope->thread().workerLoaderProxy().postTaskToLoader([callbackIdentifier, contextIdentifier = m_scope->identifier(), origin = WTFMove(origin).isolatedCopy()](auto& context) mutable {
+    workerLoaderProxy->postTaskToLoader([callbackIdentifier, contextIdentifier = m_scope->identifier(), origin = WTFMove(origin).isolatedCopy()](auto& context) mutable {
         ASSERT(isMainThread());
 
         auto& document = downcast<Document>(context);

--- a/Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.cpp
@@ -119,7 +119,11 @@ ExceptionOr<void> AudioWorkletGlobalScope::registerProcessor(String&& name, Ref<
     if (!addResult.isNewEntry)
         return Exception { ExceptionCode::NotSupportedError, "A processor was already registered with this name"_s };
 
-    thread().messagingProxy().postTaskToAudioWorklet([name = WTFMove(name).isolatedCopy(), parameterDescriptors = crossThreadCopy(WTFMove(parameterDescriptors))](AudioWorklet& worklet) mutable {
+    auto* messagingProxy = thread().messagingProxy();
+    if (!messagingProxy)
+        return Exception { ExceptionCode::InvalidStateError };
+
+    messagingProxy->postTaskToAudioWorklet([name = WTFMove(name).isolatedCopy(), parameterDescriptors = crossThreadCopy(WTFMove(parameterDescriptors))](AudioWorklet& worklet) mutable {
         ASSERT(isMainThread());
         if (RefPtr audioContext = worklet.audioContext())
             audioContext->addAudioParamDescriptors(name, WTFMove(parameterDescriptors));

--- a/Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.cpp
@@ -77,6 +77,7 @@ AudioWorkletMessagingProxy::AudioWorkletMessagingProxy(AudioWorklet& worklet)
 AudioWorkletMessagingProxy::~AudioWorkletMessagingProxy()
 {
     m_workletThread->stop();
+    m_workletThread->clearProxies();
 }
 
 bool AudioWorkletMessagingProxy::postTaskForModeToWorkletGlobalScope(ScriptExecutionContext::Task&& task, const String& mode)

--- a/Source/WebCore/Modules/webaudio/AudioWorkletThread.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletThread.cpp
@@ -39,7 +39,7 @@ namespace WebCore {
 
 AudioWorkletThread::AudioWorkletThread(AudioWorkletMessagingProxy& messagingProxy, WorkletParameters&& parameters)
     : WorkerOrWorkletThread(parameters.identifier.isolatedCopy())
-    , m_messagingProxy(messagingProxy)
+    , m_messagingProxy(&messagingProxy)
     , m_parameters(WTFMove(parameters).isolatedCopy())
 {
 }
@@ -51,7 +51,12 @@ RefPtr<WorkerOrWorkletGlobalScope> AudioWorkletThread::createGlobalScope()
     return AudioWorkletGlobalScope::tryCreate(*this, m_parameters);
 }
 
-WorkerLoaderProxy& AudioWorkletThread::workerLoaderProxy()
+void AudioWorkletThread::clearProxies()
+{
+    m_messagingProxy = nullptr;
+}
+
+WorkerLoaderProxy* AudioWorkletThread::workerLoaderProxy()
 {
     return m_messagingProxy;
 }

--- a/Source/WebCore/Modules/webaudio/AudioWorkletThread.h
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletThread.h
@@ -47,11 +47,13 @@ public:
 
     AudioWorkletGlobalScope* globalScope() const;
 
+    void clearProxies() final;
+
     // WorkerOrWorkletThread.
-    WorkerLoaderProxy& workerLoaderProxy() final;
+    WorkerLoaderProxy* workerLoaderProxy() final;
     WorkerDebuggerProxy* workerDebuggerProxy() const final;
 
-    AudioWorkletMessagingProxy& messagingProxy() { return m_messagingProxy; }
+    AudioWorkletMessagingProxy* messagingProxy() { return m_messagingProxy; }
 
 private:
     AudioWorkletThread(AudioWorkletMessagingProxy&, WorkletParameters&&);
@@ -60,7 +62,7 @@ private:
     Ref<Thread> createThread() final;
     RefPtr<WorkerOrWorkletGlobalScope> createGlobalScope() final;
 
-    AudioWorkletMessagingProxy& m_messagingProxy;
+    AudioWorkletMessagingProxy* m_messagingProxy; // FIXME: Adopt CheckedPtr.
     WorkletParameters m_parameters;
 };
 

--- a/Source/WebCore/Modules/websockets/WebSocket.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocket.cpp
@@ -335,8 +335,8 @@ ExceptionOr<void> WebSocket::connect(const String& url, const Vector<String>& pr
     };
     if (is<Document>(context))
         reportRegistrableDomain(context);
-    else
-        downcast<WorkerGlobalScope>(context).thread().workerLoaderProxy().postTaskToLoader(WTFMove(reportRegistrableDomain));
+    else if (auto* workerLoaderProxy = downcast<WorkerGlobalScope>(context).thread().workerLoaderProxy())
+        workerLoaderProxy->postTaskToLoader(WTFMove(reportRegistrableDomain));
 
     m_pendingActivity = makePendingActivity(*this);
 

--- a/Source/WebCore/dom/BroadcastChannel.cpp
+++ b/Source/WebCore/dom/BroadcastChannel.cpp
@@ -118,7 +118,11 @@ void BroadcastChannel::MainThreadBridge::ensureOnMainThread(Function<void(Page*)
         return;
     }
 
-    downcast<WorkerGlobalScope>(*context).thread().workerLoaderProxy().postTaskToLoader([protectedThis = WTFMove(protectedThis), task = WTFMove(task)](auto& context) {
+    auto* workerLoaderProxy = downcast<WorkerGlobalScope>(*context).thread().workerLoaderProxy();
+    if (!workerLoaderProxy)
+        return;
+
+    workerLoaderProxy->postTaskToLoader([protectedThis = WTFMove(protectedThis), task = WTFMove(task)](auto& context) {
         task(downcast<Document>(context).protectedPage().get());
     });
 }

--- a/Source/WebCore/dom/ScriptExecutionContext.cpp
+++ b/Source/WebCore/dom/ScriptExecutionContext.cpp
@@ -778,9 +778,11 @@ void ScriptExecutionContext::postTaskToResponsibleDocument(Function<void(Documen
         return;
 
     if (RefPtr thread = workerOrWorketGlobalScope->workerOrWorkletThread()) {
-        thread->workerLoaderProxy().postTaskToLoader([callback = WTFMove(callback)](auto&& context) {
-            callback(downcast<Document>(context));
-        });
+        if (auto* workerLoaderProxy = thread->workerLoaderProxy()) {
+            workerLoaderProxy->postTaskToLoader([callback = WTFMove(callback)](auto&& context) {
+                callback(downcast<Document>(context));
+            });
+        }
         return;
     }
 

--- a/Source/WebCore/loader/WorkerThreadableLoader.h
+++ b/Source/WebCore/loader/WorkerThreadableLoader.h
@@ -93,7 +93,7 @@ private:
     class MainThreadBridge : public ThreadableLoaderClient {
     public:
         // All executed on the worker context's thread.
-        MainThreadBridge(ThreadableLoaderClientWrapper&, WorkerLoaderProxy&, ScriptExecutionContextIdentifier, const String& taskMode, ResourceRequest&&, const ThreadableLoaderOptions&, const String& outgoingReferrer, WorkerOrWorkletGlobalScope&);
+        MainThreadBridge(ThreadableLoaderClientWrapper&, WorkerLoaderProxy*, ScriptExecutionContextIdentifier, const String& taskMode, ResourceRequest&&, const ThreadableLoaderOptions&, const String& outgoingReferrer, WorkerOrWorkletGlobalScope&);
         void cancel();
         void destroy();
         void computeIsDone();
@@ -120,7 +120,7 @@ private:
         RefPtr<ThreadableLoaderClientWrapper> m_workerClientWrapper;
 
         // May be used on either thread.
-        WorkerLoaderProxy& m_loaderProxy;
+        WorkerLoaderProxy* m_loaderProxy;
 
         // For use on the main thread.
         String m_taskMode;

--- a/Source/WebCore/loader/cache/MemoryCache.cpp
+++ b/Source/WebCore/loader/cache/MemoryCache.cpp
@@ -685,7 +685,10 @@ void MemoryCache::adjustSize(bool live, long long delta)
 void MemoryCache::removeRequestFromSessionCaches(ScriptExecutionContext& context, const ResourceRequest& request)
 {
     if (is<WorkerGlobalScope>(context)) {
-        downcast<WorkerGlobalScope>(context).thread().workerLoaderProxy().postTaskToLoader([request = request.isolatedCopy()] (ScriptExecutionContext& context) {
+        auto* workerLoaderProxy = downcast<WorkerGlobalScope>(context).thread().workerLoaderProxy();
+        if (!workerLoaderProxy)
+            return;
+        workerLoaderProxy->postTaskToLoader([request = request.isolatedCopy()] (ScriptExecutionContext& context) {
             MemoryCache::removeRequestFromSessionCaches(context, request);
         });
         return;

--- a/Source/WebCore/page/WorkerNavigator.cpp
+++ b/Source/WebCore/page/WorkerNavigator.cpp
@@ -107,7 +107,8 @@ void WorkerNavigator::setAppBadge(std::optional<unsigned long long> badge, Ref<D
         return;
     }
 
-    scope->thread().workerBadgeProxy().setAppBadge(badge);
+    if (auto* workerBadgeProxy = scope->thread().workerBadgeProxy())
+        workerBadgeProxy->setAppBadge(badge);
     promise->resolve();
 }
 

--- a/Source/WebCore/workers/WorkerNotificationClient.cpp
+++ b/Source/WebCore/workers/WorkerNotificationClient.cpp
@@ -111,7 +111,7 @@ auto WorkerNotificationClient::checkPermission(ScriptExecutionContext*) -> Permi
 
 void WorkerNotificationClient::postToMainThread(Function<void(NotificationClient*, ScriptExecutionContext& context)>&& task)
 {
-    m_workerScope.thread().workerLoaderProxy().postTaskToLoader([task = WTFMove(task)](auto& context) mutable {
+    m_workerScope.thread().workerLoaderProxy()->postTaskToLoader([task = WTFMove(task)](auto& context) mutable {
         task(context.notificationClient(), context);
     });
 }

--- a/Source/WebCore/workers/WorkerOrWorkletThread.h
+++ b/Source/WebCore/workers/WorkerOrWorkletThread.h
@@ -55,8 +55,10 @@ public:
 
     Thread* thread() const { return m_thread.get(); }
 
+    virtual void clearProxies() = 0;
+
     virtual WorkerDebuggerProxy* workerDebuggerProxy() const = 0;
-    virtual WorkerLoaderProxy& workerLoaderProxy() = 0;
+    virtual WorkerLoaderProxy* workerLoaderProxy() = 0;
 
     WorkerOrWorkletGlobalScope* globalScope() const { return m_globalScope.get(); }
     WorkerRunLoop& runLoop() { return m_runLoop; }

--- a/Source/WebCore/workers/WorkerThread.cpp
+++ b/Source/WebCore/workers/WorkerThread.cpp
@@ -94,10 +94,10 @@ WorkerThreadStartupData::WorkerThreadStartupData(const WorkerParameters& other, 
 
 WorkerThread::WorkerThread(const WorkerParameters& params, const ScriptBuffer& sourceCode, WorkerLoaderProxy& workerLoaderProxy, WorkerDebuggerProxy& workerDebuggerProxy, WorkerReportingProxy& workerReportingProxy, WorkerBadgeProxy& badgeProxy, WorkerThreadStartMode startMode, const SecurityOrigin& topOrigin, IDBClient::IDBConnectionProxy* connectionProxy, SocketProvider* socketProvider, JSC::RuntimeFlags runtimeFlags)
     : WorkerOrWorkletThread(params.inspectorIdentifier.isolatedCopy(), params.workerThreadMode)
-    , m_workerLoaderProxy(workerLoaderProxy)
-    , m_workerDebuggerProxy(workerDebuggerProxy)
-    , m_workerReportingProxy(workerReportingProxy)
-    , m_workerBadgeProxy(badgeProxy)
+    , m_workerLoaderProxy(&workerLoaderProxy)
+    , m_workerDebuggerProxy(&workerDebuggerProxy)
+    , m_workerReportingProxy(&workerReportingProxy)
+    , m_workerBadgeProxy(&badgeProxy)
     , m_runtimeFlags(runtimeFlags)
     , m_startupData(makeUnique<WorkerThreadStartupData>(params, sourceCode, startMode, topOrigin))
     , m_idbConnectionProxy(connectionProxy)
@@ -192,6 +192,14 @@ SocketProvider* WorkerThread::socketProvider()
 WorkerGlobalScope* WorkerThread::globalScope()
 {
     return downcast<WorkerGlobalScope>(WorkerOrWorkletThread::globalScope());
+}
+
+void WorkerThread::clearProxies()
+{
+    m_workerLoaderProxy = nullptr;
+    m_workerDebuggerProxy = nullptr;
+    m_workerReportingProxy = nullptr;
+    m_workerBadgeProxy = nullptr;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/workers/WorkerThread.h
+++ b/Source/WebCore/workers/WorkerThread.h
@@ -93,10 +93,11 @@ class WorkerThread : public WorkerOrWorkletThread {
 public:
     virtual ~WorkerThread();
 
-    WorkerBadgeProxy& workerBadgeProxy() const { return m_workerBadgeProxy; }
-    WorkerDebuggerProxy* workerDebuggerProxy() const final { return &m_workerDebuggerProxy; }
-    WorkerLoaderProxy& workerLoaderProxy() final { return m_workerLoaderProxy; }
-    WorkerReportingProxy& workerReportingProxy() const { return m_workerReportingProxy; }
+    WorkerBadgeProxy* workerBadgeProxy() const { return m_workerBadgeProxy; }
+    WorkerDebuggerProxy* workerDebuggerProxy() const final { return m_workerDebuggerProxy; }
+    WorkerLoaderProxy* workerLoaderProxy() final { return m_workerLoaderProxy; }
+    WorkerReportingProxy* workerReportingProxy() const { return m_workerReportingProxy; }
+
 
     // Number of active worker threads.
     WEBCORE_EXPORT static unsigned workerThreadCount();
@@ -108,6 +109,8 @@ public:
     
     JSC::RuntimeFlags runtimeFlags() const { return m_runtimeFlags; }
     bool isInStaticScriptEvaluation() const { return m_isInStaticScriptEvaluation; }
+
+    void clearProxies() override;
 
     void setWorkerClient(std::unique_ptr<WorkerClient>&& client) { m_workerClient = WTFMove(client); }
     WorkerClient* workerClient() { return m_workerClient.get(); }
@@ -134,10 +137,10 @@ private:
     void evaluateScriptIfNecessary(String& exceptionMessage) final;
     bool shouldWaitForWebInspectorOnStartup() const final;
 
-    WorkerLoaderProxy& m_workerLoaderProxy;
-    WorkerDebuggerProxy& m_workerDebuggerProxy;
-    WorkerReportingProxy& m_workerReportingProxy;
-    WorkerBadgeProxy& m_workerBadgeProxy;
+    WorkerLoaderProxy* m_workerLoaderProxy; // FIXME: Use CheckedPtr.
+    WorkerDebuggerProxy* m_workerDebuggerProxy; // FIXME: Use CheckedPtr.
+    WorkerReportingProxy* m_workerReportingProxy; // FIXME: Use CheckedPtr.
+    WorkerBadgeProxy* m_workerBadgeProxy; // FIXME: Use CheckedPtr.
     JSC::RuntimeFlags m_runtimeFlags;
 
     std::unique_ptr<WorkerThreadStartupData> m_startupData;

--- a/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp
@@ -96,6 +96,8 @@ ServiceWorkerThreadProxy::~ServiceWorkerThreadProxy()
     auto functionalEventTasks = WTFMove(m_ongoingFunctionalEventTasks);
     for (auto& callback : functionalEventTasks.values())
         callback(false);
+
+    m_serviceWorkerThread->clearProxies();
 }
 
 void ServiceWorkerThreadProxy::setLastNavigationWasAppInitiated(bool wasAppInitiated)

--- a/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp
+++ b/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp
@@ -120,6 +120,8 @@ SharedWorkerThreadProxy::~SharedWorkerThreadProxy()
 {
     ASSERT(allSharedWorkerThreadProxies().contains(m_contextIdentifier));
     allSharedWorkerThreadProxies().remove(m_contextIdentifier);
+
+    m_workerThread->clearProxies();
 }
 
 SharedWorkerIdentifier SharedWorkerThreadProxy::identifier() const


### PR DESCRIPTION
#### 926054f254028ee2cc29b0e96a50cca42592ce66
<pre>
Crash under WebCore::createMainThreadConnection(WebCore::WorkerGlobalScope&amp;)
<a href="https://bugs.webkit.org/show_bug.cgi?id=264222">https://bugs.webkit.org/show_bug.cgi?id=264222</a>
<a href="https://rdar.apple.com/117727810">rdar://117727810</a>

Reviewed by Darin Adler.

We&apos;re crashing when calling `createCacheStorageConnection()` on the WorkerLoaderProxy which
we got from the WorkerThread. I believe the WorkerLoaderProxy reference returned by the
WorkerThread is stale, which is possible since it keeps C++ references to its proxies.

To address the issue, I updated WorkerThread to keep raw pointers to its proxies instead of
C++ references. I am also adding a clearProxies() function to clear those raw pointers once
the proxies get destroyed. Finally, I added null checks are proxy use sites now that we null
them out.

In the future, we should convert this raw pointers into CheckedPtrs.

* Source/WebCore/Modules/badge/WorkerBadgeProxy.h:
* Source/WebCore/Modules/cache/WorkerCacheStorageConnection.cpp:
(WebCore::createMainThreadConnection):
* Source/WebCore/Modules/permissions/Permissions.cpp:
(WebCore::Permissions::query):
* Source/WebCore/Modules/storage/WorkerStorageConnection.cpp:
(WebCore::WorkerStorageConnection::getPersisted):
(WebCore::WorkerStorageConnection::getEstimate):
(WebCore::WorkerStorageConnection::fileSystemGetDirectory):
* Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.cpp:
(WebCore::AudioWorkletGlobalScope::registerProcessor):
* Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.cpp:
(WebCore::AudioWorkletMessagingProxy::~AudioWorkletMessagingProxy):
* Source/WebCore/Modules/webaudio/AudioWorkletThread.cpp:
(WebCore::AudioWorkletThread::clearProxies):
(WebCore::AudioWorkletThread::workerLoaderProxy):
(WebCore::AudioWorkletThread::messagingProxy):
* Source/WebCore/Modules/webaudio/AudioWorkletThread.h:
(WebCore::AudioWorkletThread::messagingProxy): Deleted.
* Source/WebCore/Modules/websockets/WebSocket.cpp:
(WebCore::WebSocket::connect):
* Source/WebCore/Modules/websockets/WorkerThreadableWebSocketChannel.cpp:
(WebCore::WorkerThreadableWebSocketChannel::Bridge::Bridge):
(WebCore::WorkerThreadableWebSocketChannel::Bridge::mainThreadInitialize):
* Source/WebCore/dom/BroadcastChannel.cpp:
(WebCore::BroadcastChannel::MainThreadBridge::ensureOnMainThread):
* Source/WebCore/dom/ScriptExecutionContext.cpp:
(WebCore::ScriptExecutionContext::postTaskToResponsibleDocument):
* Source/WebCore/loader/WorkerThreadableLoader.cpp:
(WebCore::WorkerThreadableLoader::WorkerThreadableLoader):
* Source/WebCore/loader/cache/MemoryCache.cpp:
(WebCore::MemoryCache::removeRequestFromSessionCaches):
* Source/WebCore/page/WorkerNavigator.cpp:
(WebCore::WorkerNavigator::setAppBadge):
* Source/WebCore/workers/WorkerDebuggerProxy.h:
* Source/WebCore/workers/WorkerGlobalScope.cpp:
(WebCore::WorkerGlobalScope::~WorkerGlobalScope):
(WebCore::WorkerGlobalScope::createRTCDataChannelRemoteHandlerConnection):
(WebCore::WorkerGlobalScope::close):
(WebCore::WorkerGlobalScope::logExceptionToConsole):
(WebCore::WorkerGlobalScope::wrapCryptoKey):
(WebCore::WorkerGlobalScope::unwrapCryptoKey):
(WebCore::WorkerGlobalScope::reportErrorToWorkerObject):
* Source/WebCore/workers/WorkerLoaderProxy.h:
* Source/WebCore/workers/WorkerMessagingProxy.cpp:
(WebCore::WorkerMessagingProxy::WorkerMessagingProxy):
(WebCore::WorkerMessagingProxy::~WorkerMessagingProxy):
(WebCore::WorkerMessagingProxy::workerGlobalScopeDestroyedInternal):
* Source/WebCore/workers/WorkerNotificationClient.cpp:
(WebCore::WorkerNotificationClient::postToMainThread):
* Source/WebCore/workers/WorkerOrWorkletThread.h:
* Source/WebCore/workers/WorkerReportingProxy.h:
* Source/WebCore/workers/WorkerThread.cpp:
(WebCore::WorkerThread::workerBadgeProxy const):
(WebCore::WorkerThread::workerDebuggerProxy const):
(WebCore::WorkerThread::workerLoaderProxy):
(WebCore::WorkerThread::workerReportingProxy const):
(WebCore::WorkerThread::clearProxies):
* Source/WebCore/workers/WorkerThread.h:
(WebCore::WorkerThread::workerBadgeProxy const): Deleted.
(WebCore::WorkerThread::workerReportingProxy const): Deleted.
* Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp:
(WebCore::ServiceWorkerThreadProxy::~ServiceWorkerThreadProxy):
* Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp:
(WebCore::SharedWorkerThreadProxy::~SharedWorkerThreadProxy):

Originally-landed-as: 267815.537@safari-7617-branch (4cae7c8ab138). <a href="https://rdar.apple.com/119598285">rdar://119598285</a>
Canonical link: <a href="https://commits.webkit.org/272389@main">https://commits.webkit.org/272389@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c066932de992102f4e48b7af0c8028c38311e351

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31469 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10143 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33172 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33961 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28505 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32239 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12519 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7392 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28124 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31809 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8562 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28085 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7348 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/7531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27993 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35305 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28624 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28442 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33648 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7587 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5608 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31491 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9245 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7396 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8276 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8094 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->