### PR TITLE
[GStreamer] Crash after 10 seconds on watchdog thread due to hang in gst_deinit()

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -94,6 +94,7 @@ bool GStreamerMediaEndpoint::initializePipeline()
     static uint32_t nPipeline = 0;
     auto pipelineName = makeString("webkit-webrtc-pipeline-", nPipeline);
     m_pipeline = gst_pipeline_new(pipelineName.ascii().data());
+    registerActivePipeline(m_pipeline);
 
     connectSimpleBusMessageCallback(m_pipeline.get(), [this](GstMessage* message) {
         handleMessage(message);
@@ -186,6 +187,7 @@ void GStreamerMediaEndpoint::teardownPipeline()
 {
     ASSERT(m_pipeline);
     GST_DEBUG_OBJECT(m_pipeline.get(), "Tearing down.");
+    unregisterPipeline(m_pipeline);
 #if !RELEASE_LOG_DISABLED
     stopLoggingStats();
 #endif

--- a/Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp
@@ -116,6 +116,7 @@ AudioDestinationGStreamer::AudioDestinationGStreamer(AudioIOCallback& callback, 
 {
     static Atomic<uint32_t> pipelineId;
     m_pipeline = gst_pipeline_new(makeString("audio-destination-", pipelineId.exchangeAdd(1)).ascii().data());
+    registerActivePipeline(m_pipeline);
     connectSimpleBusMessageCallback(m_pipeline.get(), [this](GstMessage* message) {
         this->handleMessage(message);
     });
@@ -178,6 +179,7 @@ AudioDestinationGStreamer::AudioDestinationGStreamer(AudioIOCallback& callback, 
 AudioDestinationGStreamer::~AudioDestinationGStreamer()
 {
     GST_DEBUG_OBJECT(m_pipeline.get(), "Disposing");
+    unregisterPipeline(m_pipeline);
     disconnectSimpleBusMessageCallback(m_pipeline.get());
     gst_element_set_state(m_pipeline.get(), GST_STATE_NULL);
     notifyStopResult(true);

--- a/Source/WebCore/platform/audio/gstreamer/AudioFileReaderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioFileReaderGStreamer.cpp
@@ -154,6 +154,8 @@ AudioFileReader::AudioFileReader(const void* data, size_t dataSize)
 AudioFileReader::~AudioFileReader()
 {
     if (m_pipeline) {
+        unregisterPipeline(m_pipeline);
+
         GRefPtr<GstBus> bus = adoptGRef(gst_pipeline_get_bus(GST_PIPELINE(m_pipeline.get())));
         ASSERT(bus);
         gst_bus_set_sync_handler(bus.get(), nullptr, nullptr, nullptr);
@@ -395,6 +397,7 @@ void AudioFileReader::decodeAudioForBusCreation()
     // A deinterleave element is added once a src pad becomes available in decodebin.
     static Atomic<uint32_t> pipelineId;
     m_pipeline = gst_pipeline_new(makeString("audio-file-reader-", pipelineId.exchangeAdd(1)).ascii().data());
+    registerActivePipeline(m_pipeline);
 
     GRefPtr<GstBus> bus = adoptGRef(gst_pipeline_get_bus(GST_PIPELINE(m_pipeline.get())));
     ASSERT(bus);

--- a/Source/WebCore/platform/audio/gstreamer/AudioSourceProviderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioSourceProviderGStreamer.cpp
@@ -103,6 +103,7 @@ AudioSourceProviderGStreamer::AudioSourceProviderGStreamer(MediaStreamTrackPriva
 #endif
     auto pipelineName = makeString(pipelineNamePrefix, "WebAudioProvider_MediaStreamTrack_", source.id());
     m_pipeline = gst_element_factory_make("pipeline", pipelineName.utf8().data());
+    registerActivePipeline(m_pipeline);
     GST_DEBUG_OBJECT(m_pipeline.get(), "MediaStream WebAudio provider created");
 
     m_streamPrivate = MediaStreamPrivate::create(Logger::create(this), { source });
@@ -189,8 +190,10 @@ AudioSourceProviderGStreamer::~AudioSourceProviderGStreamer()
 
     setClient(nullptr);
 #if ENABLE(MEDIA_STREAM)
-    if (m_pipeline)
+    if (m_pipeline) {
+        unregisterPipeline(m_pipeline);
         gst_element_set_state(m_pipeline.get(), GST_STATE_NULL);
+    }
     GST_DEBUG_OBJECT(m_pipeline.get(), "Disposing DONE");
 #endif
 }

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerAudioMixer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerAudioMixer.cpp
@@ -45,6 +45,7 @@ GStreamerAudioMixer::GStreamerAudioMixer()
 {
     GST_DEBUG_CATEGORY_INIT(webkit_media_gst_audio_mixer_debug, "webkitaudiomixer", 0, "WebKit GStreamer audio mixer");
     m_pipeline = gst_element_factory_make("pipeline", "webkitaudiomixer");
+    registerActivePipeline(m_pipeline);
     connectSimpleBusMessageCallback(m_pipeline.get());
 
     m_mixer = makeGStreamerElement("audiomixer", nullptr);
@@ -75,8 +76,10 @@ void GStreamerAudioMixer::ensureState(GstStateChange stateChange)
             gst_element_set_state(m_pipeline.get(), GST_STATE_READY);
         break;
     case GST_STATE_CHANGE_READY_TO_NULL:
-        if (m_mixer->numsinkpads == 1)
+        if (m_mixer->numsinkpads == 1) {
+            unregisterPipeline(m_pipeline);
             gst_element_set_state(m_pipeline.get(), GST_STATE_NULL);
+        }
         break;
     default:
         break;

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -40,10 +40,13 @@
 #include <gst/gst.h>
 #include <mutex>
 #include <wtf/FileSystem.h>
+#include <wtf/HashMap.h>
+#include <wtf/NeverDestroyed.h>
 #include <wtf/PrintStream.h>
 #include <wtf/Scope.h>
 #include <wtf/glib/GUniquePtr.h>
 #include <wtf/glib/RunLoopSourcePriority.h>
+#include <wtf/text/StringHash.h>
 
 #if USE(GSTREAMER_MPEGTS)
 #define GST_USE_UNSTABLE_API
@@ -443,6 +446,27 @@ void registerWebKitGStreamerVideoEncoder()
         GStreamerRegistryScanner::singleton().refresh();
 }
 
+static Lock s_activePipelinesMapLock;
+static HashMap<String, GRefPtr<GstElement>>& activePipelinesMap()
+{
+    static NeverDestroyed<HashMap<String, GRefPtr<GstElement>>> activePipelines;
+    return activePipelines.get();
+}
+
+void registerActivePipeline(const GRefPtr<GstElement>& pipeline)
+{
+    GUniquePtr<gchar> name(gst_object_get_name(GST_OBJECT_CAST(pipeline.get())));
+    Locker locker { s_activePipelinesMapLock };
+    activePipelinesMap().add(makeString(name.get()), GRefPtr<GstElement>(pipeline));
+}
+
+void unregisterPipeline(const GRefPtr<GstElement>& pipeline)
+{
+    GUniquePtr<gchar> name(gst_object_get_name(GST_OBJECT_CAST(pipeline.get())));
+    Locker locker { s_activePipelinesMapLock };
+    activePipelinesMap().remove(makeString(name.get()));
+}
+
 void deinitializeGStreamer()
 {
 #if USE(GSTREAMER_GL)
@@ -459,6 +483,18 @@ void deinitializeGStreamer()
 #if ENABLE(VIDEO)
     teardownVideoEncoderSingleton();
 #endif
+
+    // Make sure there is no active pipeline left. Those might trigger deadlocks during gst_deinit().
+    {
+        Locker locker { s_activePipelinesMapLock };
+        for (auto& pipeline : activePipelinesMap().values()) {
+            GST_DEBUG("Pipeline %" GST_PTR_FORMAT " was left running. Forcing clean-up.", pipeline.get());
+            disconnectSimpleBusMessageCallback(pipeline.get());
+            gst_element_set_state(pipeline.get(), GST_STATE_NULL);
+        }
+        activePipelinesMap().clear();
+    }
+
     gst_deinit();
 }
 
@@ -485,8 +521,17 @@ uint64_t toGstUnsigned64Time(const MediaTime& mediaTime)
     return time.timeValue();
 }
 
+static GQuark customMessageHandlerQuark()
+{
+    static GQuark quark = g_quark_from_static_string("pipeline-custom-message-handler");
+    return quark;
+}
+
 void disconnectSimpleBusMessageCallback(GstElement* pipeline)
 {
+    if (!g_object_get_qdata(G_OBJECT(pipeline), customMessageHandlerQuark()))
+        return;
+
     auto bus = adoptGRef(gst_pipeline_get_bus(GST_PIPELINE(pipeline)));
     g_signal_handlers_disconnect_by_data(bus.get(), pipeline);
     gst_bus_remove_signal_watch(bus.get());
@@ -505,9 +550,7 @@ void connectSimpleBusMessageCallback(GstElement* pipeline, Function<void(GstMess
     auto bus = adoptGRef(gst_pipeline_get_bus(GST_PIPELINE(pipeline)));
     gst_bus_add_signal_watch_full(bus.get(), RunLoopSourcePriority::RunLoopDispatcher);
 
-    auto* holder = new CustomMessageHandlerHolder(WTFMove(customHandler));
-    GQuark quark = g_quark_from_static_string("pipeline-custom-message-handler");
-    g_object_set_qdata_full(G_OBJECT(pipeline), quark, holder, [](gpointer data) {
+    g_object_set_qdata_full(G_OBJECT(pipeline), customMessageHandlerQuark(), new CustomMessageHandlerHolder(WTFMove(customHandler)), [](gpointer data) {
         delete reinterpret_cast<CustomMessageHandlerHolder*>(data);
     });
 
@@ -542,8 +585,7 @@ void connectSimpleBusMessageCallback(GstElement* pipeline, Function<void(GstMess
             break;
         }
 
-        GQuark quark = g_quark_from_static_string("pipeline-custom-message-handler");
-        auto* holder = reinterpret_cast<CustomMessageHandlerHolder*>(g_object_get_qdata(G_OBJECT(pipeline), quark));
+        auto* holder = reinterpret_cast<CustomMessageHandlerHolder*>(g_object_get_qdata(G_OBJECT(pipeline), customMessageHandlerQuark()));
         if (!holder)
             return;
 

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -396,6 +396,9 @@ bool gstObjectHasProperty(GstPad*, const char* name);
 
 GRefPtr<GstBuffer> wrapSpanData(const std::span<const uint8_t>&);
 
+void registerActivePipeline(const GRefPtr<GstElement>&);
+void unregisterPipeline(const GRefPtr<GstElement>&);
+
 } // namespace WebCore
 
 #ifndef GST_BUFFER_DTS_OR_PTS

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.h
@@ -121,7 +121,6 @@ private:
     void handleEndOfAppend();
     void didReceiveInitializationSegment();
 
-    GstBus* bus() { return m_bus.get(); }
     GstElement* pipeline() { return m_pipeline.get(); }
     GstElement* appsrc() { return m_appsrc.get(); }
 
@@ -155,7 +154,6 @@ private:
 
     MediaTime m_initialDuration;
     GRefPtr<GstElement> m_pipeline;
-    GRefPtr<GstBus> m_bus;
     GRefPtr<GstElement> m_appsrc;
     // To simplify the code, mtypefind and m_demux can be a GstIdentity when not needed.
     GRefPtr<GstElement> m_typefind;

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
@@ -73,7 +73,7 @@ SourceBufferPrivateGStreamer::SourceBufferPrivateGStreamer(MediaSourcePrivateGSt
     : SourceBufferPrivate(mediaSource)
     , m_type(contentType)
     , m_playerPrivate(playerPrivate)
-    , m_appendPipeline(makeUniqueRef<AppendPipeline>(*this, playerPrivate))
+    , m_appendPipeline(makeUnique<AppendPipeline>(*this, playerPrivate))
 #if !RELEASE_LOG_DISABLED
     , m_logger(mediaSource.logger())
     , m_logIdentifier(mediaSource.nextSourceBufferLogIdentifier())
@@ -113,6 +113,9 @@ Ref<MediaPromise> SourceBufferPrivateGStreamer::appendInternal(Ref<SharedBuffer>
 void SourceBufferPrivateGStreamer::resetParserStateInternal()
 {
     ASSERT(isMainThread());
+    if (!m_appendPipeline)
+        return;
+
     GST_DEBUG_OBJECT(m_playerPrivate.pipeline(), "resetting parser state");
     m_appendPipeline->resetParserState();
 }
@@ -126,6 +129,12 @@ void SourceBufferPrivateGStreamer::removedFromMediaSource()
     m_hasBeenRemovedFromMediaSource = true;
 
     m_appendPipeline->stopParser();
+
+    // Release the resources used by the AppendPipeline. This effectively makes the
+    // SourceBufferPrivate useless. Ideally the entire instance should be destroyed. For now we
+    // explicitely release the AppendPipeline because that's the biggest resource user. In case the
+    // process remains alive, GC might kick in later on and release the SourceBufferPrivate.
+    m_appendPipeline = nullptr;
 
     SourceBufferPrivate::removedFromMediaSource();
 }

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h
@@ -103,7 +103,7 @@ private:
     bool m_hasBeenRemovedFromMediaSource { false };
     ContentType m_type;
     MediaPlayerPrivateGStreamerMSE& m_playerPrivate;
-    UniqueRef<AppendPipeline> m_appendPipeline;
+    std::unique_ptr<AppendPipeline> m_appendPipeline;
     StdUnorderedMap<TrackID, RefPtr<MediaSourceTrackGStreamer>> m_tracks;
     std::optional<MediaPromise::Producer> m_appendPromise;
 

--- a/Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp
@@ -96,6 +96,8 @@ GStreamerElementHarness::GStreamerElementHarness(GRefPtr<GstElement>&& element, 
         GST_DEBUG_CATEGORY_INIT(webkit_element_harness_debug, "webkitelementharness", 0, "WebKit Element Harness");
     });
 
+    registerActivePipeline(m_element);
+
     auto clock = adoptGRef(gst_system_clock_obtain());
     gst_element_set_clock(m_element.get(), clock.get());
 
@@ -160,6 +162,7 @@ GStreamerElementHarness::GStreamerElementHarness(GRefPtr<GstElement>&& element, 
 GStreamerElementHarness::~GStreamerElementHarness()
 {
     GST_DEBUG_OBJECT(m_element.get(), "Stopping harness");
+    unregisterPipeline(m_element);
     gst_pad_set_active(m_srcPad.get(), FALSE);
     {
         auto streamLock = GstPadStreamLocker(m_srcPad.get());

--- a/Source/WebCore/platform/gstreamer/PlatformSpeechSynthesizerGStreamer.cpp
+++ b/Source/WebCore/platform/gstreamer/PlatformSpeechSynthesizerGStreamer.cpp
@@ -70,6 +70,7 @@ GstSpeechSynthesisWrapper::GstSpeechSynthesisWrapper(const PlatformSpeechSynthes
 
     static Atomic<uint32_t> pipelineId;
     m_pipeline = gst_pipeline_new(makeString("speech-synthesizer-", pipelineId.exchangeAdd(1)).ascii().data());
+    registerActivePipeline(m_pipeline);
     connectSimpleBusMessageCallback(m_pipeline.get(), [this](GstMessage* message) {
         this->handleMessage(message);
     });
@@ -122,6 +123,7 @@ GstSpeechSynthesisWrapper::GstSpeechSynthesisWrapper(const PlatformSpeechSynthes
 
 GstSpeechSynthesisWrapper::~GstSpeechSynthesisWrapper()
 {
+    unregisterPipeline(m_pipeline);
     disconnectSimpleBusMessageCallback(m_pipeline.get());
     gst_element_set_state(m_pipeline.get(), GST_STATE_NULL);
 }

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp
@@ -117,6 +117,7 @@ MediaRecorderPrivateBackend::~MediaRecorderPrivateBackend()
     if (m_src)
         webkitMediaStreamSrcSignalEndOfStream(WEBKIT_MEDIA_STREAM_SRC(m_src.get()));
     if (m_transcoder) {
+        unregisterPipeline(m_pipeline);
         m_pipeline.clear();
         m_transcoder.clear();
     }
@@ -364,6 +365,7 @@ bool MediaRecorderPrivateBackend::preparePipeline()
     m_transcoder = adoptGRef(gst_transcoder_new_full("mediastream://", "appsink://", GST_ENCODING_PROFILE(profile.get())));
     gst_transcoder_set_avoid_reencoding(m_transcoder.get(), true);
     m_pipeline = gst_transcoder_get_pipeline(m_transcoder.get());
+    registerActivePipeline(m_pipeline);
 
     g_signal_connect_swapped(m_pipeline.get(), "source-setup", G_CALLBACK(+[](MediaRecorderPrivateBackend* recorder, GstElement* sourceElement) {
         recorder->setSource(sourceElement);

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp
@@ -74,6 +74,7 @@ GStreamerCapturer::~GStreamerCapturer()
     if (!m_pipeline)
         return;
 
+    unregisterPipeline(m_pipeline);
     disconnectSimpleBusMessageCallback(pipeline());
     gst_element_set_state(pipeline(), GST_STATE_NULL);
 }
@@ -169,6 +170,7 @@ void GStreamerCapturer::setupPipeline()
         disconnectSimpleBusMessageCallback(pipeline());
 
     m_pipeline = makeElement("pipeline");
+    registerActivePipeline(m_pipeline);
 
     GRefPtr<GstElement> source = createSource();
     GRefPtr<GstElement> converter = createConverter();
@@ -208,6 +210,7 @@ void GStreamerCapturer::stop()
 {
     ASSERT(m_pipeline);
     GST_INFO_OBJECT(pipeline(), "Stopping");
+    unregisterPipeline(m_pipeline);
     gst_element_set_state(pipeline(), GST_STATE_NULL);
 }
 


### PR DESCRIPTION
#### 6c5b045e794c3917520ab419400d51db47d74b8c
<pre>
[GStreamer] Crash after 10 seconds on watchdog thread due to hang in gst_deinit()
<a href="https://bugs.webkit.org/show_bug.cgi?id=257551">https://bugs.webkit.org/show_bug.cgi?id=257551</a>

Reviewed by Xabier Rodriguez-Calvar.

Keep track of every GStreamer pipeline during the life-time of the WebProcess and make sure no
active pipeline processing is left before calling gst_deinit().

Also, driving-by, the AppendPipeline is now explicitely cleared when the SourceBuffer has been
removed from the MediaSource, as an attempt to reduce memory pressure and keep open file descriptors
under control...

* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::initializePipeline):
(WebCore::GStreamerMediaEndpoint::teardownPipeline):
* Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp:
(WebCore::AudioDestinationGStreamer::AudioDestinationGStreamer):
(WebCore::AudioDestinationGStreamer::~AudioDestinationGStreamer):
* Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.cpp:
(WebCore::GStreamerInternalAudioEncoder::GStreamerInternalAudioEncoder):
(WebCore::GStreamerInternalAudioEncoder::initialize):
* Source/WebCore/platform/audio/gstreamer/AudioFileReaderGStreamer.cpp:
(WebCore::AudioFileReader::~AudioFileReader):
(WebCore::AudioFileReader::decodeAudioForBusCreation):
* Source/WebCore/platform/audio/gstreamer/AudioSourceProviderGStreamer.cpp:
(WebCore::AudioSourceProviderGStreamer::AudioSourceProviderGStreamer):
(WebCore::AudioSourceProviderGStreamer::~AudioSourceProviderGStreamer):
* Source/WebCore/platform/graphics/gstreamer/GStreamerAudioMixer.cpp:
(WebCore::GStreamerAudioMixer::GStreamerAudioMixer):
(WebCore::GStreamerAudioMixer::ensureState):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::activePipelinesMap):
(WebCore::registerActivePipeline):
(WebCore::unregisterPipeline):
(WebCore::deinitializeGStreamer):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h:
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::~MediaPlayerPrivateGStreamer):
(WebCore::MediaPlayerPrivateGStreamer::createGSTPlayBin):
* Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp:
(WebCore::AppendPipeline::AppendPipeline):
(WebCore::AppendPipeline::~AppendPipeline):
* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp:
(WebCore::SourceBufferPrivateGStreamer::SourceBufferPrivateGStreamer):
(WebCore::SourceBufferPrivateGStreamer::removedFromMediaSource):
* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h:
* Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp:
(WebCore::GStreamerElementHarness::GStreamerElementHarness):
(WebCore::GStreamerElementHarness::~GStreamerElementHarness):
* Source/WebCore/platform/gstreamer/PlatformSpeechSynthesizerGStreamer.cpp:
(WebCore::GstSpeechSynthesisWrapper::GstSpeechSynthesisWrapper):
(WebCore::GstSpeechSynthesisWrapper::~GstSpeechSynthesisWrapper):
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp:
(WebCore::MediaRecorderPrivateBackend::~MediaRecorderPrivateBackend):
(WebCore::MediaRecorderPrivateBackend::preparePipeline):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp:
(WebCore::GStreamerCapturer::~GStreamerCapturer):
(WebCore::GStreamerCapturer::setupPipeline):
(WebCore::GStreamerCapturer::stop):

Canonical link: <a href="https://commits.webkit.org/272552@main">https://commits.webkit.org/272552@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/552f35566109ee1d637c6e7c1bd6b0834e424765

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32083 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10801 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33870 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34626 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29077 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32912 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13158 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8024 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28659 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32482 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9120 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28675 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7911 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8084 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28590 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35970 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29179 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29045 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34191 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8194 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6150 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32049 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9835 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7493 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8840 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8721 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->