### PR TITLE
Crash under PAL::newTextCodec(PAL::TextEncoding const&)

### DIFF
--- a/Source/WebCore/loader/SubresourceLoader.cpp
+++ b/Source/WebCore/loader/SubresourceLoader.cpp
@@ -731,15 +731,19 @@ void SubresourceLoader::didFinishLoading(const NetworkLoadMetrics& networkLoadMe
 
     if (m_state != Initialized)
         return;
+
+    Ref protectedThis { *this };
+
     ASSERT(!reachedTerminalState());
     CachedResourceHandle resource = m_resource.get();
+    if (!resource)
+        return;
+
     ASSERT(!resource->resourceToRevalidate());
     // FIXME (129394): We should cancel the load when a decode error occurs instead of continuing the load to completion.
     ASSERT(!resource->errorOccurred() || resource->status() == CachedResource::DecodeError || !resource->isLoading());
     LOG(ResourceLoading, "Received '%s'.", resource->url().string().latin1().data());
     logResourceLoaded(m_frame.get(), resource->type());
-
-    Ref<SubresourceLoader> protectedThis(*this);
 
     m_loadTiming.markEndTime();
 

--- a/Source/WebCore/loader/cache/CachedCSSStyleSheet.cpp
+++ b/Source/WebCore/loader/cache/CachedCSSStyleSheet.cpp
@@ -111,7 +111,7 @@ void CachedCSSStyleSheet::finishLoading(const FragmentedSharedBuffer* data, cons
         auto contiguousData = data->makeContiguous();
         setEncodedSize(data->size());
         // Decode the data to find out the encoding and keep the sheet text around during checkNotify()
-        m_decodedSheetText = m_decoder->decodeAndFlush(contiguousData->data(), data->size());
+        m_decodedSheetText = protectedDecoder()->decodeAndFlush(contiguousData->data(), data->size());
         m_data = WTFMove(contiguousData);
     } else {
         m_data = nullptr;
@@ -121,6 +121,11 @@ void CachedCSSStyleSheet::finishLoading(const FragmentedSharedBuffer* data, cons
     checkNotify(metrics);
     // Clear the decoded text as it is unlikely to be needed immediately again and is cheap to regenerate.
     m_decodedSheetText = String();
+}
+
+Ref<TextResourceDecoder> CachedCSSStyleSheet::protectedDecoder() const
+{
+    return m_decoder;
 }
 
 void CachedCSSStyleSheet::checkNotify(const NetworkLoadMetrics&)

--- a/Source/WebCore/loader/cache/CachedCSSStyleSheet.h
+++ b/Source/WebCore/loader/cache/CachedCSSStyleSheet.h
@@ -49,12 +49,13 @@ private:
     String responseMIMEType() const;
     bool canUseSheet(MIMETypeCheckHint, bool* hasValidMIMEType, bool* hasHTTPStatusOK) const;
     bool mayTryReplaceEncodedData() const final { return true; }
+    Ref<TextResourceDecoder> protectedDecoder() const;
 
     void didAddClient(CachedResourceClient&) final;
 
     void setEncoding(const String&) final;
     String encoding() const final;
-    const TextResourceDecoder* textResourceDecoder() const final { return m_decoder.get(); }
+    const TextResourceDecoder* textResourceDecoder() const final { return m_decoder.ptr(); }
     void finishLoading(const FragmentedSharedBuffer*, const NetworkLoadMetrics&) final;
     void destroyDecodedData() final;
 
@@ -62,7 +63,7 @@ private:
 
     void checkNotify(const NetworkLoadMetrics&) final;
 
-    RefPtr<TextResourceDecoder> m_decoder;
+    Ref<TextResourceDecoder> m_decoder;
     String m_decodedSheetText;
 
     RefPtr<StyleSheetContents> m_parsedStyleSheetCache;


### PR DESCRIPTION
#### 795c0f6d648c62b60ce3b98f25414a420b155bb1
<pre>
Crash under PAL::newTextCodec(PAL::TextEncoding const&amp;)
<a href="https://bugs.webkit.org/show_bug.cgi?id=264979">https://bugs.webkit.org/show_bug.cgi?id=264979</a>
<a href="https://rdar.apple.com/118267012">rdar://118267012</a>

Reviewed by Brent Fulgham.

There is evidence for crashes in the wild that the CachedCSSStyleSheet or
the TextResourceDecoder are being used after getting freed. To prevent this,
protect both these objects in the code path identified by the crashes.

This is a speculative fix but it should be very safe.

* Source/WebCore/loader/SubresourceLoader.cpp:
(WebCore::SubresourceLoader::didFinishLoading):
* Source/WebCore/loader/cache/CachedCSSStyleSheet.cpp:
(WebCore::CachedCSSStyleSheet::finishLoading):
(WebCore::CachedCSSStyleSheet::protectedDecoder const):
* Source/WebCore/loader/cache/CachedCSSStyleSheet.h:

Originally-landed-as: 267815.575@safari-7617-branch (4c3430842100). <a href="https://rdar.apple.com/119598663">rdar://119598663</a>
Canonical link: <a href="https://commits.webkit.org/272391@main">https://commits.webkit.org/272391@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e877c7ac16162994dfc46135a09cd6f635c786ee

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31472 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10147 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33176 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33962 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28506 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32242 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12493 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7394 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28126 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31812 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8539 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28087 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7351 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7509 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27995 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35306 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28601 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28443 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33645 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7588 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5609 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31488 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9246 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7399 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8277 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8095 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->