### PR TITLE
Null deref under DynamicContentScalingImageBufferBackend::createBackendHandle

### DIFF
--- a/Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingImageBufferBackend.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingImageBufferBackend.mm
@@ -91,7 +91,8 @@ DynamicContentScalingImageBufferBackend::DynamicContentScalingImageBufferBackend
 
 std::optional<ImageBufferBackendHandle> DynamicContentScalingImageBufferBackend::createBackendHandle(SharedMemory::Protection) const
 {
-    ASSERT(m_context);
+    if (!m_context)
+        return std::nullopt;
 
     RetainPtr<NSDictionary> options;
     RetainPtr<NSMutableArray> ports;


### PR DESCRIPTION
#### 35b5d996abd860f1985f009634c683ce47c28798
<pre>
Null deref under DynamicContentScalingImageBufferBackend::createBackendHandle
<a href="https://bugs.webkit.org/show_bug.cgi?id=266723">https://bugs.webkit.org/show_bug.cgi?id=266723</a>
<a href="https://rdar.apple.com/119854411">rdar://119854411</a>

Reviewed by Aditya Keerthi.

* Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingImageBufferBackend.mm:
(WebKit::DynamicContentScalingImageBufferBackend::createBackendHandle const):
Add a null check, since we have evidence that we can be asked to make a backend
handle when nobody has painted into the layer. I&apos;m not sure why, but it&apos;s certainly
preferable to just not have a display list than to crash.

Canonical link: <a href="https://commits.webkit.org/272380@main">https://commits.webkit.org/272380@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6791b368e595b581ff49e064902b4d0f9af7f2db

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31484 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10159 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33188 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33972 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/28514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12505 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7406 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/28135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31824 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8549 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28094 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7364 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/7518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35316 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28611 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28450 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/33653 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7598 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5617 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/31496 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9255 "Built successfully") | | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7386 "Found 1 new test failure: imported/w3c/web-platform-tests/preload/preload-in-data-doc.html (failure)") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8287 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4110 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8103 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->