### PR TITLE
Wikipedia video control icon backgrounds flicker.

### DIFF
--- a/LayoutTests/compositing/repaint/copy-forward-clear-rect-expected.html
+++ b/LayoutTests/compositing/repaint/copy-forward-clear-rect-expected.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+
+<html>
+<head>
+    <style>
+        #first {
+            width: 500px;
+            height: 500px;
+            transform: translate3d(0, 0, 0);
+            background: rgba(222, 0, 0, 0.4);
+        }
+        #inner {
+            left: 50px;
+            top: 50px;
+            width: 50px;
+            height: 50px;
+            position: absolute;
+            background: rgba(0, 40, 40, 0.5);
+        }
+    </style>
+</head>
+<body>
+    <div id="first"><div id="inner"></div></div>
+</body>
+</html>

--- a/LayoutTests/compositing/repaint/copy-forward-clear-rect.html
+++ b/LayoutTests/compositing/repaint/copy-forward-clear-rect.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+
+<html>
+<head>
+    <script src="../../resources/ui-helper.js"></script>
+    <style>
+        #first {
+            width: 500px;
+            height: 500px;
+            transform: translate3d(0, 0, 0);
+            background: rgba(222, 0, 0, 0.4);
+        }
+        #inner {
+            width: 50px;
+            height: 50px;
+            position: absolute;
+            background: rgba(0, 40, 40, 0.5);
+        }
+    </style>
+    <script>
+        if (window.testRunner) {
+            testRunner.waitUntilDone();
+            if (testRunner.dontForceRepaint)
+                testRunner.dontForceRepaint();
+        }
+        async function doTest()
+        {
+            await UIHelper.renderingUpdate();
+
+            inner.style.left = "50px";
+            inner.style.top = "50px";
+            
+            await UIHelper.renderingUpdate();
+            await UIHelper.renderingUpdate();
+
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }
+        window.addEventListener('load', doTest, false);
+    </script>
+</head>
+<body>
+    <div id="first"><div id="inner"></div></div>
+</body>
+</html>


### PR DESCRIPTION
#### 5ce41d80d50760401a9399bc7cb3d3be7b97b58e
<pre>
Wikipedia video control icon backgrounds flicker.
<a href="https://bugs.webkit.org/show_bug.cgi?id=266726">https://bugs.webkit.org/show_bug.cgi?id=266726</a>
&lt;<a href="https://rdar.apple.com/119868478">rdar://119868478</a>&gt;

Reviewed by Simon Fraser.

The previous code always required a full repaint of the layer whenever a buffer was allocated,
so the copy-forward code didn&apos;t run on the second paint of a layer. This meant the copy-forward
code, and the &apos;buffer is already clear&apos; optimization were mutually exclusive.

The new code uses copy-forward and partial repaints whenever possible, even if the front buffer
was newly allocated (or existing, but purged).

The copy-forward code tries to only copy pixels that won&apos;t be re-drawn this frame, but is rounded
out to a single rectangle, not a complex region.

If the copy-forwards ends up copying pixels that we&apos;ll also drawn this frame, we can no longer
consider the buffer to be &apos;clear&apos; and have to manually clear the paint region.

* LayoutTests/compositing/repaint/copy-forward-clear-rect-expected.html: Added.
* LayoutTests/compositing/repaint/copy-forward-clear-rect.html: Added.
* Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp:
(WebKit::RemoteImageBufferSet::prepareBufferForDisplay):

Canonical link: <a href="https://commits.webkit.org/272394@main">https://commits.webkit.org/272394@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/236099a56afda70e8f9cc82414a255090f27936f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31487 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10162 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33191 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33975 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28517 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12510 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7409 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28134 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31827 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8553 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28101 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7363 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7522 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28010 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35319 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28615 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28456 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33657 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7601 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5619 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31500 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9258 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/27815 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7400 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8290 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8106 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->