### PR TITLE
Reduce use of downcast<>() in WebCore/rendering/

### DIFF
--- a/Source/WebCore/rendering/svg/SVGRootInlineBox.cpp
+++ b/Source/WebCore/rendering/svg/SVGRootInlineBox.cpp
@@ -80,10 +80,10 @@ void SVGRootInlineBox::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffse
 
     if (hasSelection && shouldPaintSelectionHighlight) {
         for (auto* child = firstChild(); child; child = child->nextOnLine()) {
-            if (is<SVGInlineTextBox>(*child))
-                downcast<SVGInlineTextBox>(*child).paintSelectionBackground(childPaintInfo);
-            else if (is<SVGInlineFlowBox>(*child))
-                downcast<SVGInlineFlowBox>(*child).paintSelectionBackground(childPaintInfo);
+            if (auto* textBox = dynamicDowncast<SVGInlineTextBox>(*child))
+                textBox->paintSelectionBackground(childPaintInfo);
+            else if (auto* flowBox = dynamicDowncast<SVGInlineFlowBox>(*child))
+                flowBox->paintSelectionBackground(childPaintInfo);
         }
     }
 
@@ -133,9 +133,9 @@ void SVGRootInlineBox::computePerCharacterLayoutInformation()
 void SVGRootInlineBox::layoutCharactersInTextBoxes(LegacyInlineFlowBox* start, SVGTextLayoutEngine& characterLayout)
 {
     for (auto* child = start->firstChild(); child; child = child->nextOnLine()) {
-        if (is<SVGInlineTextBox>(*child)) {
-            ASSERT(is<RenderSVGInlineText>(child->renderer()));
-            characterLayout.layoutInlineTextBox(downcast<SVGInlineTextBox>(*child));
+        if (auto* textBox = dynamicDowncast<SVGInlineTextBox>(*child)) {
+            ASSERT(is<RenderSVGInlineText>(textBox->renderer()));
+            characterLayout.layoutInlineTextBox(*textBox);
         } else {
             // Skip generated content.
             Node* node = child->renderer().node();
@@ -165,15 +165,14 @@ void SVGRootInlineBox::layoutChildBoxes(LegacyInlineFlowBox* start, FloatRect* c
 {
     for (auto* child = start->firstChild(); child; child = child->nextOnLine()) {
         FloatRect boxRect;
-        if (is<SVGInlineTextBox>(*child)) {
-            ASSERT(is<RenderSVGInlineText>(child->renderer()));
+        if (auto* textBox = dynamicDowncast<SVGInlineTextBox>(*child)) {
+            ASSERT(is<RenderSVGInlineText>(textBox->renderer()));
 
-            auto& textBox = downcast<SVGInlineTextBox>(*child);
-            boxRect = textBox.calculateBoundaries();
-            textBox.setX(boxRect.x());
-            textBox.setY(boxRect.y());
-            textBox.setLogicalWidth(boxRect.width());
-            textBox.setLogicalHeight(boxRect.height());
+            boxRect = textBox->calculateBoundaries();
+            textBox->setX(boxRect.x());
+            textBox->setY(boxRect.y());
+            textBox->setLogicalWidth(boxRect.width());
+            textBox->setLogicalHeight(boxRect.height());
         } else {
             // Skip generated content.
             if (!child->renderer().node())

--- a/Source/WebCore/rendering/svg/SVGTextLayoutAttributesBuilder.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutAttributesBuilder.cpp
@@ -103,22 +103,22 @@ void SVGTextLayoutAttributesBuilder::collectTextPositioningElements(RenderBoxMod
     ASSERT(!is<RenderSVGText>(start) || m_textPositions.isEmpty());
 
     for (auto& child : childrenOfType<RenderObject>(start)) {
-        if (is<RenderSVGInlineText>(child)) {
-            processRenderSVGInlineText(downcast<RenderSVGInlineText>(child), m_textLength, lastCharacterWasSpace);
+        if (CheckedPtr inlineText = dynamicDowncast<RenderSVGInlineText>(child)) {
+            processRenderSVGInlineText(*inlineText, m_textLength, lastCharacterWasSpace);
             continue;
         }
 
-        if (!is<RenderSVGInline>(child))
+        CheckedPtr inlineChild = dynamicDowncast<RenderSVGInline>(child);
+        if (!inlineChild)
             continue;
 
-        auto& inlineChild = downcast<RenderSVGInline>(child);
-        SVGTextPositioningElement* element = SVGTextPositioningElement::elementFromRenderer(inlineChild);
+        auto* element = SVGTextPositioningElement::elementFromRenderer(*inlineChild);
 
         unsigned atPosition = m_textPositions.size();
         if (element)
             m_textPositions.append(TextPosition(element, m_textLength));
 
-        collectTextPositioningElements(inlineChild, lastCharacterWasSpace);
+        collectTextPositioningElements(*inlineChild, lastCharacterWasSpace);
 
         if (!element)
             continue;

--- a/Source/WebCore/rendering/svg/SVGTextQuery.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextQuery.cpp
@@ -56,24 +56,21 @@ static inline LegacyInlineFlowBox* flowBoxForRenderer(RenderObject* renderer)
     if (!renderer)
         return nullptr;
 
-    if (is<RenderBlockFlow>(*renderer)) {
+    if (auto* renderBlock = dynamicDowncast<RenderBlockFlow>(*renderer)) {
         // If we're given a block element, it has to be a RenderSVGText.
-        ASSERT(is<RenderSVGText>(*renderer));
-        RenderBlockFlow& renderBlock = downcast<RenderBlockFlow>(*renderer);
+        ASSERT(is<RenderSVGText>(*renderBlock));
 
         // RenderSVGText only ever contains a single line box.
-        auto flowBox = renderBlock.firstRootBox();
-        ASSERT(flowBox == renderBlock.lastRootBox());
+        auto* flowBox = renderBlock->firstRootBox();
+        ASSERT(flowBox == renderBlock->lastRootBox());
         return flowBox;
     }
 
-    if (is<RenderInline>(*renderer)) {
+    if (auto* renderInline = dynamicDowncast<RenderInline>(*renderer)) {
         // We're given a RenderSVGInline or objects that derive from it (RenderSVGTSpan / RenderSVGTextPath)
-        RenderInline& renderInline = downcast<RenderInline>(*renderer);
-
         // RenderSVGInline only ever contains a single line box.
-        LegacyInlineFlowBox* flowBox = renderInline.firstLineBox();
-        ASSERT(flowBox == renderInline.lastLineBox());
+        auto* flowBox = renderInline->firstLineBox();
+        ASSERT(flowBox == renderInline->lastLineBox());
         return flowBox;
     }
 
@@ -92,17 +89,17 @@ void SVGTextQuery::collectTextBoxesInFlowBox(LegacyInlineFlowBox* flowBox)
         return;
 
     for (auto* child = flowBox->firstChild(); child; child = child->nextOnLine()) {
-        if (is<LegacyInlineFlowBox>(*child)) {
+        if (auto* flowBox = dynamicDowncast<LegacyInlineFlowBox>(*child)) {
             // Skip generated content.
-            if (!child->renderer().node())
+            if (!flowBox->renderer().element())
                 continue;
 
-            collectTextBoxesInFlowBox(downcast<LegacyInlineFlowBox>(child));
+            collectTextBoxesInFlowBox(flowBox);
             continue;
         }
 
-        if (is<SVGInlineTextBox>(*child))
-            m_textBoxes.append(downcast<SVGInlineTextBox>(child));
+        if (auto* inlineTextBox = dynamicDowncast<SVGInlineTextBox>(*child))
+            m_textBoxes.append(inlineTextBox);
     }
 }
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
@@ -153,12 +153,11 @@ static void getElementCTM(SVGElement* element, AffineTransform& transform)
     AffineTransform localTransform;
     Node* current = element;
 
-    while (current && current->isSVGElement()) {
-        SVGElement& currentElement = downcast<SVGElement>(*current);
-        localTransform = currentElement.renderer()->localToParentTransform();
+    while (auto* currentElement = dynamicDowncast<SVGElement>(current)) {
+        localTransform = currentElement->renderer()->localToParentTransform();
         transform = localTransform.multiply(transform);
         // For getCTM() computation, stop at the nearest viewport element
-        if (&currentElement == stopAtElement)
+        if (currentElement == stopAtElement)
             break;
 
         current = current->parentOrShadowHostNode();

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResource.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResource.cpp
@@ -182,10 +182,9 @@ static void removeFromCacheAndInvalidateDependencies(RenderElement& renderer, bo
             clipper->removeClientFromCache(renderer);
     }
 
-    if (!is<SVGElement>(renderer.element()))
+    RefPtr svgElement = dynamicDowncast<SVGElement>(renderer.element());
+    if (!svgElement)
         return;
-
-    Ref svgElement = downcast<SVGElement>(*renderer.element());
 
     for (auto& element : svgElement->referencingElements()) {
         if (auto* renderer = element->renderer()) {
@@ -204,7 +203,7 @@ static void removeFromCacheAndInvalidateDependencies(RenderElement& renderer, bo
     for (auto& cssClient : svgElement->referencingCSSClients()) {
         if (!cssClient)
             continue;
-        cssClient->resourceChanged(svgElement.get());
+        cssClient->resourceChanged(*svgElement);
     }
 }
 
@@ -233,38 +232,37 @@ void LegacyRenderSVGResource::markForLayoutAndParentResourceInvalidationIfNeeded
     if (needsLayout && !object.renderTreeBeingDestroyed()) {
         // If we are inside the layout of an LegacyRenderSVGRoot, do not cross the SVG boundary to
         // invalidate the ancestor renderer because it may have finished its layout already.
-        if (is<LegacyRenderSVGRoot>(object) && downcast<LegacyRenderSVGRoot>(object).isInLayout())
-            object.setNeedsLayout(MarkOnlyThis);
+        if (CheckedPtr svgRoot = dynamicDowncast<LegacyRenderSVGRoot>(object); svgRoot && svgRoot->isInLayout())
+            svgRoot->setNeedsLayout(MarkOnlyThis);
         else {
-            if (!is<RenderElement>(object))
-                object.setNeedsLayout(MarkOnlyThis);
-            else {
-                auto svgRoot = SVGRenderSupport::findTreeRootObject(downcast<RenderElement>(object));
+            if (CheckedPtr element = dynamicDowncast<RenderElement>(object)) {
+                auto svgRoot = SVGRenderSupport::findTreeRootObject(*element);
                 if (!svgRoot || !svgRoot->isInLayout())
-                    object.setNeedsLayout(MarkContainingBlockChain);
+                    element->setNeedsLayout(MarkContainingBlockChain);
                 else {
                     // We just want to re-layout the ancestors up to the RenderSVGRoot.
-                    object.setNeedsLayout(MarkOnlyThis);
-                    for (auto current = object.parent(); current != svgRoot; current = current->parent())
+                    element->setNeedsLayout(MarkOnlyThis);
+                    for (auto current = element->parent(); current != svgRoot; current = current->parent())
                         current->setNeedsLayout(MarkOnlyThis);
                     svgRoot->setNeedsLayout(MarkOnlyThis);
                 }
-            }
+            } else
+                object.setNeedsLayout(MarkOnlyThis);
         }
     }
 
-    if (is<RenderElement>(object))
-        removeFromCacheAndInvalidateDependencies(downcast<RenderElement>(object), needsLayout, visitedRenderers);
+    if (CheckedPtr element = dynamicDowncast<RenderElement>(object))
+        removeFromCacheAndInvalidateDependencies(*element, needsLayout, visitedRenderers);
 
     // Invalidate resources in ancestor chain, if needed.
     auto current = object.parent();
     while (current) {
         removeFromCacheAndInvalidateDependencies(*current, needsLayout, visitedRenderers);
 
-        if (is<LegacyRenderSVGResourceContainer>(*current)) {
+        if (CheckedPtr container = dynamicDowncast<LegacyRenderSVGResourceContainer>(*current)) {
             // This will process the rest of the ancestors.
             bool markForInvalidation = true;
-            downcast<LegacyRenderSVGResourceContainer>(*current).removeAllClientsFromCacheIfNeeded(markForInvalidation, visitedRenderers);
+            container->removeAllClientsFromCacheIfNeeded(markForInvalidation, visitedRenderers);
             break;
         }
 
@@ -278,20 +276,20 @@ void LegacyRenderSVGResource::fillAndStrokePathOrShape(GraphicsContext& context,
         ASSERT(shape->isRenderOrLegacyRenderSVGShape());
 
         if (resourceMode.contains(RenderSVGResourceMode::ApplyToFill)) {
-            if (is<LegacyRenderSVGShape>(shape))
-                downcast<LegacyRenderSVGShape>(shape)->fillShape(context);
+            if (CheckedPtr svgShape = dynamicDowncast<LegacyRenderSVGShape>(shape))
+                svgShape->fillShape(context);
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
-            else if (is<RenderSVGShape>(shape))
-                downcast<RenderSVGShape>(shape)->fillShape(context);
+            else if (CheckedPtr svgShape = dynamicDowncast<RenderSVGShape>(shape))
+                svgShape->fillShape(context);
 #endif
         }
 
         if (resourceMode.contains(RenderSVGResourceMode::ApplyToStroke)) {
-            if (is<LegacyRenderSVGShape>(shape))
-                downcast<LegacyRenderSVGShape>(shape)->strokeShape(context);
+            if (CheckedPtr svgShape = dynamicDowncast<LegacyRenderSVGShape>(shape))
+                svgShape->strokeShape(context);
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
-            else if (is<RenderSVGShape>(shape))
-                downcast<RenderSVGShape>(shape)->strokeShape(context);
+            else if (CheckedPtr svgShape = dynamicDowncast<RenderSVGShape>(shape))
+                svgShape->strokeShape(context);
 #endif
         }
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp
@@ -259,13 +259,12 @@ bool LegacyRenderSVGResourceClipper::drawContentIntoMaskImage(ImageBuffer& maskI
             continue;
 
         WindRule newClipRule = style.svgStyle().clipRule();
-        bool isUseElement = child.hasTagName(SVGNames::useTag);
-        if (isUseElement) {
-            SVGUseElement& useElement = downcast<SVGUseElement>(child);
-            renderer = useElement.rendererClipChild();
+        RefPtr useElement = dynamicDowncast<SVGUseElement>(child);
+        if (useElement) {
+            renderer = useElement->rendererClipChild();
             if (!renderer)
                 continue;
-            if (!useElement.hasAttributeWithoutSynchronization(SVGNames::clip_ruleAttr))
+            if (!useElement->hasAttributeWithoutSynchronization(SVGNames::clip_ruleAttr))
                 newClipRule = renderer->style().svgStyle().clipRule();
         }
 
@@ -277,8 +276,8 @@ bool LegacyRenderSVGResourceClipper::drawContentIntoMaskImage(ImageBuffer& maskI
 
         // In the case of a <use> element, we obtained its renderere above, to retrieve its clipRule.
         // We have to pass the <use> renderer itself to renderSubtreeToContext() to apply it's x/y/transform/etc. values when rendering.
-        // So if isUseElement is true, refetch the childNode->renderer(), as renderer got overridden above.
-        SVGRenderingContext::renderSubtreeToContext(maskContext, isUseElement ? *child.renderer() : *renderer, maskContentTransformation);
+        // So if useElement is non-null, refetch the childNode->renderer(), as renderer got overridden above.
+        SVGRenderingContext::renderSubtreeToContext(maskContext, useElement ? *child.renderer() : *renderer, maskContentTransformation);
     }
 
     view().frameView().setPaintBehavior(oldBehavior);

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp
@@ -116,8 +116,8 @@ void LegacyRenderSVGResourceContainer::markAllClientsForInvalidationIfNeeded(Inv
         if (root != SVGRenderSupport::findTreeRootObject(client))
             continue;
 
-        if (is<LegacyRenderSVGResourceContainer>(client)) {
-            downcast<LegacyRenderSVGResourceContainer>(client).removeAllClientsFromCacheIfNeeded(markForInvalidation, visitedRenderers);
+        if (CheckedPtr container = dynamicDowncast<LegacyRenderSVGResourceContainer>(client)) {
+            container->removeAllClientsFromCacheIfNeeded(markForInvalidation, visitedRenderers);
             continue;
         }
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.h
@@ -94,10 +94,7 @@ Renderer* getRenderSVGResourceById(TreeScope& treeScope, const AtomString& id)
     // Using the LegacyRenderSVGResource type here avoids ambiguous casts for types that
     // descend from both RenderObject and LegacyRenderSVGResourceContainer.
     LegacyRenderSVGResource* container = getRenderSVGResourceContainerById(treeScope, id);
-    if (is<Renderer>(container))
-        return downcast<Renderer>(container);
-
-    return nullptr;
+    return dynamicDowncast<Renderer>(container);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilterPrimitive.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilterPrimitive.cpp
@@ -74,28 +74,24 @@ void LegacyRenderSVGResourceFilterPrimitive::styleDidChange(StyleDifference diff
 
 void LegacyRenderSVGResourceFilterPrimitive::markFilterEffectForRepaint(FilterEffect* effect)
 {
-    auto parent = this->parent();
-    if (!is<LegacyRenderSVGResourceFilter>(parent))
+    CheckedPtr parent = dynamicDowncast<LegacyRenderSVGResourceFilter>(this->parent());
+    if (!parent)
         return;
 
-    auto& filterRenderer = downcast<LegacyRenderSVGResourceFilter>(*parent);
-
     if (effect)
-        filterRenderer.markFilterForRepaint(*effect);
+        parent->markFilterForRepaint(*effect);
 
-    filterRenderer.markAllClientLayersForInvalidation();
+    parent->markAllClientLayersForInvalidation();
 }
 
 void LegacyRenderSVGResourceFilterPrimitive::markFilterEffectForRebuild()
 {
-    auto parent = this->parent();
-    if (!is<LegacyRenderSVGResourceFilter>(parent))
+    CheckedPtr parent = dynamicDowncast<LegacyRenderSVGResourceFilter>(this->parent());
+    if (!parent)
         return;
 
-    auto& filterRenderer = downcast<LegacyRenderSVGResourceFilter>(*parent);
-
-    filterRenderer.markFilterForRebuild();
-    filterRenderer.markAllClientLayersForInvalidation();
+    parent->markFilterForRebuild();
+    parent->markAllClientLayersForInvalidation();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGTransformableContainer.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGTransformableContainer.cpp
@@ -49,13 +49,10 @@ bool LegacyRenderSVGTransformableContainer::calculateLocalTransform()
     // If we're either the renderer for a <use> element, or for any <g> element inside the shadow
     // tree, that was created during the use/symbol/svg expansion in SVGUseElement. These containers
     // need to respect the translations induced by their corresponding use elements x/y attributes.
-    SVGUseElement* useElement = nullptr;
-    if (is<SVGUseElement>(element))
-        useElement = &downcast<SVGUseElement>(element);
-    else if (element.isInShadowTree() && is<SVGGElement>(element)) {
-        SVGElement* correspondingElement = element.correspondingElement();
-        if (is<SVGUseElement>(correspondingElement))
-            useElement = downcast<SVGUseElement>(correspondingElement);
+    auto* useElement = dynamicDowncast<SVGUseElement>(element);
+    if (!useElement && element.isInShadowTree() && is<SVGGElement>(element)) {
+        if (auto* correspondingElement = dynamicDowncast<SVGUseElement>(element.correspondingElement()))
+            useElement = correspondingElement;
     }
 
     if (useElement) {

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderInline.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderInline.cpp
@@ -49,8 +49,8 @@ static bool canUseAsParentForContinuation(const RenderObject* renderer)
 
 static RenderBoxModelObject* nextContinuation(RenderObject* renderer)
 {
-    if (is<RenderInline>(*renderer) && !renderer->isReplacedOrInlineBlock())
-        return downcast<RenderInline>(*renderer).continuation();
+    if (auto* renderInline = dynamicDowncast<RenderInline>(*renderer); renderInline && !renderInline->isReplacedOrInlineBlock())
+        return renderInline->continuation();
     return downcast<RenderBlock>(*renderer).inlineContinuation();
 }
 
@@ -215,8 +215,8 @@ void RenderTreeBuilder::Inline::splitFlow(RenderInline& parent, RenderObject* be
         // FIXME-BLOCKFLOW: The enclosing method should likely be switched over
         // to only work on RenderBlockFlow, in which case this conversion can be
         // removed.
-        if (is<RenderBlockFlow>(*pre))
-            downcast<RenderBlockFlow>(*pre).removeFloatingObjects();
+        if (auto* blockFlow = dynamicDowncast<RenderBlockFlow>(*pre))
+            blockFlow->removeFloatingObjects();
         block = block->containingBlock();
     } else {
         // No anonymous block available for use. Make one.
@@ -305,8 +305,8 @@ void RenderTreeBuilder::Inline::splitInlines(RenderInline& parent, RenderBlock* 
         auto childToMove = m_builder.detachFromRenderElement(*rendererToMove->parent(), *rendererToMove, WillBeDestroyed::No);
         m_builder.attachIgnoringContinuation(*cloneInline, WTFMove(childToMove));
         auto* newParent = rendererToMove->parent();
-        if (is<RenderBox>(newParent))
-            markBoxForRelayoutAfterSplit(downcast<RenderBox>(*newParent));
+        if (CheckedPtr newParentBox = dynamicDowncast<RenderBox>(newParent))
+            markBoxForRelayoutAfterSplit(*newParentBox);
         rendererToMove->setNeedsLayoutAndPrefWidthsRecalc();
         rendererToMove = nextSibling;
     }

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp
@@ -59,7 +59,7 @@ static RenderBlock* getParentOfFirstLineBox(RenderBlock& current, RenderObject& 
         if (!is<RenderBlock>(child) || is<RenderTable>(child) || is<RenderRubyAsBlock>(child))
             break;
 
-        if (is<RenderBox>(child) && downcast<RenderBox>(child).isWritingModeRoot())
+        if (auto* renderBox = dynamicDowncast<RenderBox>(child); renderBox && renderBox->isWritingModeRoot())
             break;
 
         if (is<RenderListItem>(current) && inQuirksMode && child.node() && isHTMLListElement(*child.node()))

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderMultiColumn.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderMultiColumn.cpp
@@ -252,7 +252,8 @@ RenderObject* RenderTreeBuilder::MultiColumn::resolveMovedChild(RenderFragmented
     if (!beforeChild)
         return nullptr;
 
-    if (!is<RenderBox>(*beforeChild))
+    auto* beforeChildRenderBox = dynamicDowncast<RenderBox>(*beforeChild);
+    if (!beforeChildRenderBox)
         return beforeChild;
 
     auto* renderMultiColumnFlow = dynamicDowncast<RenderMultiColumnFlow>(enclosingFragmentedFlow);
@@ -269,7 +270,7 @@ RenderObject* RenderTreeBuilder::MultiColumn::resolveMovedChild(RenderFragmented
     // create and insert a renderer for the sibling node immediately preceding the spanner, we need
     // to map that spanner renderer to the spanner's placeholder, which is where the new inserted
     // renderer belongs.
-    if (auto* placeholder = renderMultiColumnFlow->findColumnSpannerPlaceholder(downcast<RenderBox>(beforeChild)))
+    if (auto* placeholder = renderMultiColumnFlow->findColumnSpannerPlaceholder(beforeChildRenderBox))
         return placeholder;
 
     // This is an invalid spanner, or its placeholder hasn't been created yet. This happens when


### PR DESCRIPTION
#### 77c906c7f5cf802e4e7b3929718c715668c56e4f
<pre>
Reduce use of downcast&lt;&gt;() in WebCore/rendering/
<a href="https://bugs.webkit.org/show_bug.cgi?id=266729">https://bugs.webkit.org/show_bug.cgi?id=266729</a>

Reviewed by Darin Adler.

* Source/WebCore/rendering/svg/SVGRootInlineBox.cpp:
(WebCore::SVGRootInlineBox::paint):
(WebCore::SVGRootInlineBox::layoutCharactersInTextBoxes):
(WebCore::SVGRootInlineBox::layoutChildBoxes):
* Source/WebCore/rendering/svg/SVGTextLayoutAttributesBuilder.cpp:
(WebCore::SVGTextLayoutAttributesBuilder::collectTextPositioningElements):
* Source/WebCore/rendering/svg/SVGTextQuery.cpp:
(WebCore::flowBoxForRenderer):
(WebCore::SVGTextQuery::collectTextBoxesInFlowBox):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp:
(WebCore::getElementCTM):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResource.cpp:
(WebCore::removeFromCacheAndInvalidateDependencies):
(WebCore::LegacyRenderSVGResource::markForLayoutAndParentResourceInvalidationIfNeeded):
(WebCore::LegacyRenderSVGResource::fillAndStrokePathOrShape const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp:
(WebCore::LegacyRenderSVGResourceClipper::drawContentIntoMaskImage):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp:
(WebCore::LegacyRenderSVGResourceContainer::markAllClientsForInvalidationIfNeeded):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.h:
(WebCore::getRenderSVGResourceById):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilterPrimitive.cpp:
(WebCore::LegacyRenderSVGResourceFilterPrimitive::markFilterEffectForRepaint):
(WebCore::LegacyRenderSVGResourceFilterPrimitive::markFilterEffectForRebuild):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGTransformableContainer.cpp:
(WebCore::LegacyRenderSVGTransformableContainer::calculateLocalTransform):
* Source/WebCore/rendering/updating/RenderTreeBuilder.cpp:
(WebCore::RenderTreeBuilder::destroy):
(WebCore::RenderTreeBuilder::attachInternal):
(WebCore::RenderTreeBuilder::attachIgnoringContinuation):
(WebCore::RenderTreeBuilder::detach):
(WebCore::RenderTreeBuilder::attachToRenderElement):
(WebCore::RenderTreeBuilder::attachToRenderElementInternal):
(WebCore::RenderTreeBuilder::move):
(WebCore::RenderTreeBuilder::moveChildren):
(WebCore::RenderTreeBuilder::normalizeTreeAfterStyleChange):
(WebCore::RenderTreeBuilder::childFlowStateChangesAndAffectsParentBlock):
(WebCore::RenderTreeBuilder::removeAnonymousWrappersForInlineChildrenIfNeeded):
(WebCore::RenderTreeBuilder::destroyAndCleanUpAnonymousWrappers):
(WebCore::RenderTreeBuilder::detachFromRenderElement):
(WebCore::RenderTreeBuilder::reportVisuallyNonEmptyContent):
(WebCore::RenderTreeBuilder::markBoxForRelayoutAfterSplit):
(WebCore::RenderTreeBuilder::removeFloatingObjects):
* Source/WebCore/rendering/updating/RenderTreeBuilderInline.cpp:
(WebCore::nextContinuation):
(WebCore::RenderTreeBuilder::Inline::splitFlow):
(WebCore::RenderTreeBuilder::Inline::splitInlines):
* Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp:
(WebCore::getParentOfFirstLineBox):
* Source/WebCore/rendering/updating/RenderTreeBuilderMultiColumn.cpp:
(WebCore::RenderTreeBuilder::MultiColumn::resolveMovedChild):

Canonical link: <a href="https://commits.webkit.org/272401@main">https://commits.webkit.org/272401@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3159bf4c623ab55431b0c2bdb0f4e8e4c348d0ca

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31493 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10168 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33197 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33981 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28523 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32263 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12517 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7415 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28139 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31833 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8559 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28106 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7368 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7528 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28015 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35325 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28621 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28461 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33661 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7607 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5626 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31517 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9264 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8296 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4115 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8112 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->