### PR TITLE
Stop using CheckedPtr / CheckedRef with NetworkProcess

### DIFF
--- a/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.cpp
+++ b/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.cpp
@@ -58,6 +58,7 @@ WebCookieManager::~WebCookieManager() = default;
 
 Ref<NetworkProcess> WebCookieManager::protectedProcess()
 {
+    ASSERT(RunLoop::isMain());
     return m_process.get();
 }
 
@@ -156,7 +157,7 @@ void WebCookieManager::stopObservingCookieChanges(PAL::SessionID sessionID)
 
 void WebCookieManager::setHTTPCookieAcceptPolicy(PAL::SessionID sessionID, HTTPCookieAcceptPolicy policy, CompletionHandler<void()>&& completionHandler)
 {
-    platformSetHTTPCookieAcceptPolicy(sessionID, policy, [policy, process = Ref { m_process.get() }, completionHandler = WTFMove(completionHandler)] () mutable {
+    platformSetHTTPCookieAcceptPolicy(sessionID, policy, [policy, process = protectedProcess(), completionHandler = WTFMove(completionHandler)] () mutable {
         process->cookieAcceptPolicyChanged(policy);
         completionHandler();
     });

--- a/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.h
+++ b/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.h
@@ -29,10 +29,10 @@
 #include "NetworkProcessSupplement.h"
 #include <pal/SessionID.h>
 #include <stdint.h>
-#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/WallTime.h>
+#include <wtf/WeakRef.h>
 
 #if USE(SOUP)
 #include "SoupCookiePersistentStorageType.h"
@@ -94,7 +94,7 @@ private:
     void startObservingCookieChanges(PAL::SessionID);
     void stopObservingCookieChanges(PAL::SessionID);
 
-    CheckedRef<NetworkProcess> m_process;
+    WeakRef<NetworkProcess> m_process;
 };
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.cpp
+++ b/Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.cpp
@@ -47,6 +47,12 @@ LegacyCustomProtocolManager::LegacyCustomProtocolManager(NetworkProcess& network
     m_networkProcess->addMessageReceiver(Messages::LegacyCustomProtocolManager::messageReceiverName(), *this);
 }
 
+Ref<NetworkProcess> LegacyCustomProtocolManager::protectedNetworkProcess() const
+{
+    ASSERT(RunLoop::isMain());
+    return m_networkProcess.get();
+}
+
 void LegacyCustomProtocolManager::initialize(const NetworkProcessCreationParameters& parameters)
 {
     registerProtocolClass();
@@ -71,12 +77,12 @@ void LegacyCustomProtocolManager::removeCustomProtocol(LegacyCustomProtocolID cu
 
 void LegacyCustomProtocolManager::startLoading(LegacyCustomProtocolID customProtocolID, const WebCore::ResourceRequest& request)
 {
-    m_networkProcess->send(Messages::LegacyCustomProtocolManagerProxy::StartLoading(customProtocolID, request));
+    protectedNetworkProcess()->send(Messages::LegacyCustomProtocolManagerProxy::StartLoading(customProtocolID, request));
 }
 
 void LegacyCustomProtocolManager::stopLoading(LegacyCustomProtocolID customProtocolID)
 {
-    m_networkProcess->send(Messages::LegacyCustomProtocolManagerProxy::StopLoading(customProtocolID), 0);
+    protectedNetworkProcess()->send(Messages::LegacyCustomProtocolManagerProxy::StopLoading(customProtocolID), 0);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.h
+++ b/Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.h
@@ -29,10 +29,10 @@
 #include "LegacyCustomProtocolID.h"
 #include "MessageReceiver.h"
 #include "NetworkProcessSupplement.h"
-#include <wtf/CheckedRef.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/Lock.h>
+#include <wtf/WeakRef.h>
 #include <wtf/text/StringHash.h>
 #include <wtf/text/WTFString.h>
 
@@ -94,8 +94,9 @@ private:
     void wasRedirectedToRequest(LegacyCustomProtocolID, const WebCore::ResourceRequest&, const WebCore::ResourceResponse& redirectResponse);
 
     void registerProtocolClass();
+    Ref<NetworkProcess> protectedNetworkProcess() const;
 
-    CheckedRef<NetworkProcess> m_networkProcess;
+    WeakRef<NetworkProcess> m_networkProcess;
 
     typedef HashMap<LegacyCustomProtocolID, CustomProtocol> CustomProtocolMap;
     CustomProtocolMap m_customProtocolMap WTF_GUARDED_BY_LOCK(m_customProtocolMapLock);

--- a/Source/WebKit/NetworkProcess/NetworkContentRuleListManager.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkContentRuleListManager.cpp
@@ -53,6 +53,12 @@ NetworkContentRuleListManager::~NetworkContentRuleListManager()
     }
 }
 
+Ref<NetworkProcess> NetworkContentRuleListManager::protectedNetworkProcess() const
+{
+    ASSERT(RunLoop::isMain());
+    return m_networkProcess.get();
+}
+
 void NetworkContentRuleListManager::contentExtensionsBackend(UserContentControllerIdentifier identifier, BackendCallback&& callback)
 {
     auto iterator = m_contentExtensionBackends.find(identifier);
@@ -63,7 +69,7 @@ void NetworkContentRuleListManager::contentExtensionsBackend(UserContentControll
     m_pendingCallbacks.ensure(identifier, [] {
         return Vector<BackendCallback> { };
     }).iterator->value.append(WTFMove(callback));
-    m_networkProcess->parentProcessConnection()->send(Messages::NetworkProcessProxy::ContentExtensionRules { identifier }, 0);
+    protectedNetworkProcess()->parentProcessConnection()->send(Messages::NetworkProcessProxy::ContentExtensionRules { identifier }, 0);
 }
 
 void NetworkContentRuleListManager::addContentRuleLists(UserContentControllerIdentifier identifier, Vector<std::pair<WebCompiledContentRuleListData, URL>>&& contentRuleLists)

--- a/Source/WebKit/NetworkProcess/NetworkContentRuleListManager.h
+++ b/Source/WebKit/NetworkProcess/NetworkContentRuleListManager.h
@@ -30,7 +30,7 @@
 #include "UserContentControllerIdentifier.h"
 #include "WebCompiledContentRuleListData.h"
 #include <WebCore/ContentExtensionsBackend.h>
-#include <wtf/CheckedRef.h>
+#include <wtf/WeakRef.h>
 
 namespace IPC {
 class Connection;
@@ -57,9 +57,11 @@ private:
     void removeAllContentRuleLists(UserContentControllerIdentifier);
     void remove(UserContentControllerIdentifier);
 
+    Ref<NetworkProcess> protectedNetworkProcess() const;
+
     HashMap<UserContentControllerIdentifier, std::unique_ptr<WebCore::ContentExtensions::ContentExtensionsBackend>> m_contentExtensionBackends;
     HashMap<UserContentControllerIdentifier, Vector<BackendCallback>> m_pendingCallbacks;
-    CheckedRef<NetworkProcess> m_networkProcess;
+    WeakRef<NetworkProcess> m_networkProcess;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -133,7 +133,7 @@ class Cache;
 enum class CacheOption : uint8_t;
 }
 
-class NetworkProcess : public AuxiliaryProcess, private DownloadManager::Client, public ThreadSafeRefCounted<NetworkProcess>, public CanMakeThreadSafeCheckedPtr
+class NetworkProcess : public AuxiliaryProcess, private DownloadManager::Client, public ThreadSafeRefCounted<NetworkProcess>
 {
     WTF_MAKE_NONCOPYABLE(NetworkProcess);
 public:
@@ -148,16 +148,6 @@ public:
     using NavigatedToDomain = WebCore::RegistrableDomain;
     using DomainInNeedOfStorageAccess = WebCore::RegistrableDomain;
     using OpenerDomain = WebCore::RegistrableDomain;
-
-    using CanMakeThreadSafeCheckedPtr::incrementPtrCount;
-    using CanMakeThreadSafeCheckedPtr::decrementPtrCount;
-#if CHECKED_POINTER_DEBUG
-    using CanMakeThreadSafeCheckedPtr::registerCheckedPtr;
-    using CanMakeThreadSafeCheckedPtr::copyCheckedPtr;
-    using CanMakeThreadSafeCheckedPtr::moveCheckedPtr;
-    using CanMakeThreadSafeCheckedPtr::unregisterCheckedPtr;
-#endif // CHECKED_POINTER_DEBUG
-
 
     NetworkProcess(AuxiliaryProcessInitializationParameters&&);
     ~NetworkProcess();

--- a/Source/WebKit/Shared/Authentication/AuthenticationManager.cpp
+++ b/Source/WebKit/Shared/Authentication/AuthenticationManager.cpp
@@ -62,9 +62,10 @@ AuthenticationManager::AuthenticationManager(NetworkProcess& process)
 
 AuthenticationManager::~AuthenticationManager() = default;
 
-inline CheckedRef<NetworkProcess> AuthenticationManager::checkedProcess() const
+inline Ref<NetworkProcess> AuthenticationManager::protectedProcess() const
 {
-    return m_process;
+    ASSERT(RunLoop::isMain());
+    return m_process.get();
 }
 
 AuthenticationChallengeIdentifier AuthenticationManager::addChallengeToChallengeMap(UniqueRef<Challenge>&& challenge)
@@ -124,7 +125,7 @@ void AuthenticationManager::didReceiveAuthenticationChallenge(PAL::SessionID ses
     std::optional<SecurityOriginData> topOriginData;
     if (topOrigin)
         topOriginData = *topOrigin;
-    checkedProcess()->send(Messages::NetworkProcessProxy::DidReceiveAuthenticationChallenge(sessionID, pageID, topOriginData, authenticationChallenge, negotiatedLegacyTLS == NegotiatedLegacyTLS::Yes, challengeID));
+    protectedProcess()->send(Messages::NetworkProcessProxy::DidReceiveAuthenticationChallenge(sessionID, pageID, topOriginData, authenticationChallenge, negotiatedLegacyTLS == NegotiatedLegacyTLS::Yes, challengeID));
 }
 
 void AuthenticationManager::didReceiveAuthenticationChallenge(IPC::MessageSender& download, const WebCore::AuthenticationChallenge& authenticationChallenge, ChallengeCompletionHandler&& completionHandler)
@@ -152,7 +153,7 @@ void AuthenticationManager::completeAuthenticationChallenge(AuthenticationChalle
 
 void AuthenticationManager::negotiatedLegacyTLS(WebPageProxyIdentifier pageID) const
 {
-    checkedProcess()->send(Messages::NetworkProcessProxy::NegotiatedLegacyTLS(pageID));
+    protectedProcess()->send(Messages::NetworkProcessProxy::NegotiatedLegacyTLS(pageID));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/Authentication/AuthenticationManager.h
+++ b/Source/WebKit/Shared/Authentication/AuthenticationManager.h
@@ -34,7 +34,6 @@
 #include <WebCore/AuthenticationChallenge.h>
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/PageIdentifier.h>
-#include <wtf/CheckedRef.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
@@ -81,7 +80,7 @@ public:
     void negotiatedLegacyTLS(WebPageProxyIdentifier) const;
 
 private:
-    CheckedRef<NetworkProcess> checkedProcess() const;
+    Ref<NetworkProcess> protectedProcess() const;
     struct Challenge {
         WTF_MAKE_STRUCT_FAST_ALLOCATED;
         Challenge(WebPageProxyIdentifier pageID, const WebCore::AuthenticationChallenge& challenge, ChallengeCompletionHandler&& completionHandler)
@@ -107,7 +106,7 @@ private:
 
     Vector<AuthenticationChallengeIdentifier> coalesceChallengesMatching(AuthenticationChallengeIdentifier) const;
 
-    CheckedRef<NetworkProcess> m_process;
+    WeakRef<NetworkProcess> m_process;
 
     HashMap<AuthenticationChallengeIdentifier, UniqueRef<Challenge>> m_challenges;
 };


### PR DESCRIPTION
#### b3886f3ddafc152b3a1e3d89ea0a392f0bdae35a
<pre>
Stop using CheckedPtr / CheckedRef with NetworkProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=266731">https://bugs.webkit.org/show_bug.cgi?id=266731</a>

Reviewed by Darin Adler.

Stop using CheckedPtr / CheckedRef with NetworkProcess. Use
WeakPtr / WeakRef instead to generate more actionable crashes.

* Source/WebKit/NetworkProcess/Cookies/WebCookieManager.cpp:
(WebKit::WebCookieManager::protectedProcess):
(WebKit::WebCookieManager::setHTTPCookieAcceptPolicy):
* Source/WebKit/NetworkProcess/Cookies/WebCookieManager.h:
* Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.cpp:
(WebKit::LegacyCustomProtocolManager::protectedNetworkProcess const):
(WebKit::LegacyCustomProtocolManager::startLoading):
(WebKit::LegacyCustomProtocolManager::stopLoading):
* Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.h:
* Source/WebKit/NetworkProcess/NetworkContentRuleListManager.cpp:
(WebKit::NetworkContentRuleListManager::protectedNetworkProcess const):
(WebKit::NetworkContentRuleListManager::contentExtensionsBackend):
* Source/WebKit/NetworkProcess/NetworkContentRuleListManager.h:
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/Shared/Authentication/AuthenticationManager.cpp:
(WebKit::AuthenticationManager::protectedProcess const):
(WebKit::AuthenticationManager::didReceiveAuthenticationChallenge):
(WebKit::AuthenticationManager::negotiatedLegacyTLS const):
(WebKit::AuthenticationManager::checkedProcess const): Deleted.
* Source/WebKit/Shared/Authentication/AuthenticationManager.h:

Canonical link: <a href="https://commits.webkit.org/272402@main">https://commits.webkit.org/272402@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b6e32ea4790290823011227eb4e3a5a8f589bf2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31498 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10173 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33202 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33986 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28527 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12523 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7420 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28146 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31838 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8565 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28108 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7375 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7534 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35330 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28627 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28463 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33665 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7612 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5627 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31509 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9269 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8301 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4116 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8117 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->