### PR TITLE
[Debug] ASSERTION FAILED: m_activeConnections.contains(connection)

### DIFF
--- a/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
@@ -255,14 +255,29 @@ CacheStorageManager::CacheStorageManager(const String& path, CacheStorageRegistr
 
 CacheStorageManager::~CacheStorageManager()
 {
-    for (auto& request : m_pendingSpaceRequests)
+    reset();
+}
+
+void CacheStorageManager::reset()
+{
+    while (!m_pendingSpaceRequests.isEmpty()) {
+        auto request = m_pendingSpaceRequests.takeFirst();
         request.second(false);
+    }
 
     for (auto& cache : m_caches)
         m_registry.unregisterCache(cache->identifier());
+    m_caches.clear();
 
     for (auto& identifier : m_removedCaches.keys())
         m_registry.unregisterCache(identifier);
+    m_removedCaches.clear();
+
+    m_cacheRefConnections.clear();
+    m_size = std::nullopt;
+    m_pendingSize = { 0, { } };
+    m_isInitialized = false;
+    makeDirty();
 }
 
 bool CacheStorageManager::initializeCaches()
@@ -342,12 +357,15 @@ void CacheStorageManager::allCaches(uint64_t updateCounter, WebCore::DOMCacheEng
 
 void CacheStorageManager::initializeCacheSize(CacheStorageCache& cache)
 {
-    cache.getSize([this, weakThis = WeakPtr { *this }](auto size) mutable {
+    cache.getSize([this, weakThis = WeakPtr { *this }, cacheIdentifier = cache.identifier()](auto size) mutable {
         if (!weakThis)
             return;
 
+        if (!m_pendingSize.second.remove(cacheIdentifier))
+            return;
+
         m_pendingSize.first += size;
-        if (!--m_pendingSize.second)
+        if (m_pendingSize.second.isEmpty())
             finishInitializingSize();
     });
 }
@@ -372,7 +390,13 @@ void CacheStorageManager::requestSpaceAfterInitializingSize(uint64_t spaceReques
     if (m_pendingSpaceRequests.size() > 1)
         return;
 
-    m_pendingSize = { 0, m_caches.size() + m_removedCaches.size() };
+    m_pendingSize = { 0, { } };
+    for (auto& cache : m_caches)
+        m_pendingSize.second.add(cache->identifier());
+
+    for (auto& identifier : m_removedCaches.keys())
+        m_pendingSize.second.add(identifier);
+
     for (auto& cache : m_caches)
         initializeCacheSize(*cache);
 

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageManager.h
@@ -69,6 +69,7 @@ public:
     void requestSpace(uint64_t size, CompletionHandler<void(bool)>&&);
     void sizeIncreased(uint64_t amount);
     void sizeDecreased(uint64_t amount);
+    void reset();
 
 private:
     void makeDirty();
@@ -81,7 +82,7 @@ private:
     bool m_isInitialized { false };
     uint64_t m_updateCounter;
     std::optional<uint64_t> m_size;
-    std::pair<uint64_t, size_t> m_pendingSize;
+    std::pair<uint64_t, HashSet<WebCore::DOMCacheIdentifier>> m_pendingSize;
     String m_path;
     FileSystem::Salt m_salt;
     CacheStorageRegistry& m_registry;

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -1673,7 +1673,8 @@ void NetworkStorageManager::lockCacheStorage(IPC::Connection& connection, const 
 
 void NetworkStorageManager::unlockCacheStorage(IPC::Connection& connection, const WebCore::ClientOrigin& origin)
 {
-    originStorageManager(origin).cacheStorageManager(*m_cacheStorageRegistry, origin, m_queue.copyRef()).unlockStorage(connection.uniqueID());
+    if (auto cacheStorageManager = originStorageManager(origin).existingCacheStorageManager())
+        cacheStorageManager->unlockStorage(connection.uniqueID());
 }
 
 void NetworkStorageManager::cacheStorageRetrieveRecords(WebCore::DOMCacheIdentifier cacheIdentifier, WebCore::RetrieveRecordsOptions&& options, WebCore::DOMCacheEngine::CrossThreadRecordsCallback&& callback)

--- a/Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp
@@ -452,7 +452,7 @@ void OriginStorageManager::StorageBucket::deleteIDBStorageData(WallTime time)
 void OriginStorageManager::StorageBucket::deleteCacheStorageData(WallTime time)
 {
     if (m_cacheStorageManager)
-        m_cacheStorageManager = nullptr;
+        m_cacheStorageManager->reset();
 
     FileSystem::deleteAllFilesModifiedSince(resolvedCacheStoragePath(), time);
 }


### PR DESCRIPTION
#### f93a6655d71b97847a7d3855c023229e5ac6e67b
<pre>
[Debug] ASSERTION FAILED: m_activeConnections.contains(connection)
<a href="https://bugs.webkit.org/show_bug.cgi?id=266732">https://bugs.webkit.org/show_bug.cgi?id=266732</a>
<a href="https://rdar.apple.com/119363590">rdar://119363590</a>

Reviewed by Youenn Fablet.

CacheStorageManager is active when it has active connections, i.e. its m_activeConnections is not empty. In existing
impelementation, an active CacheStorageManager can be removed during website data deletion (see
OriginStorageManager::StorageBucket::deleteCacheStorageData). Later on, a new CacheStorageManager is created on
demand for handling CacheStorage related tasks. For the new CacheStorageManager, it does not have information about
active connections. If a NetworkStorageManager::UnlockCacheStorage is received at this time, the message will be passed
to the new CacheStorageManager, and the assertion in CacheStorageManager::unlockStorage will fail.

To fix this, this patch makes three changes:
1. Instead of removing existing CacheStorageManager on data deletion and creating a new one later, we just uninitialize
the states of existing CacheStorageManager and let it initialize from disk storage again later. Note m_activeConnections
is not cleared, so the existing CacheStorageManager is still marked active and can handle UnlockCacheStorage message.
2. When receiving UnlockCacheStorage message, if CacheStorageManager for origin does not exist, we will not create a
new CacheStorageManager to handle it (since the newly created CacheStorageManager will not know active connections).
3. m_pendingSize now keeps track of pending requests by cache identifier instead of count, so for size requests
initiated before reset() and finished after reset(), their result will not be used to updated m_size.

* Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp:
(WebKit::CacheStorageManager::~CacheStorageManager):
(WebKit::CacheStorageManager::reset):
(WebKit::CacheStorageManager::initializeCacheSize):
(WebKit::CacheStorageManager::requestSpaceAfterInitializingSize):
* Source/WebKit/NetworkProcess/storage/CacheStorageManager.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::unlockCacheStorage):
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp:
(WebKit::OriginStorageManager::StorageBucket::deleteCacheStorageData):

Canonical link: <a href="https://commits.webkit.org/272585@main">https://commits.webkit.org/272585@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/948b991d111297bc2e19246db2033c7a54917fc3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32202 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10936 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34016 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34764 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29185 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13291 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8148 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28755 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32620 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9219 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28793 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8027 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8180 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36109 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29278 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29161 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34309 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8306 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6246 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32174 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9947 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7523 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8938 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8843 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->