### PR TITLE
[iOS] WebM video does not display

### DIFF
--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
@@ -114,7 +114,7 @@ static VideoDecoder::Config createVideoDecoderConfig(const WebCodecsVideoDecoder
         description,
         config.codedWidth.value_or(0),
         config.codedHeight.value_or(0),
-        config.hardwareAcceleration == HardwareAcceleration::PreferSoftware
+        config.hardwareAcceleration == HardwareAcceleration::PreferSoftware ? VideoDecoder::HardwareAcceleration::No : VideoDecoder::HardwareAcceleration::Yes
     };
 }
 

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -448,6 +448,7 @@ platform/graphics/cocoa/WebActionDisablingCALayerDelegate.mm
 platform/graphics/cocoa/WebCoreCALayerExtras.mm
 platform/graphics/cocoa/WebCoreDecompressionSession.mm
 platform/graphics/cocoa/WebProcessGraphicsContextGLCocoa.mm
+platform/graphics/cocoa/VideoMediaSampleRenderer.mm
 platform/graphics/cocoa/VideoTrackPrivateWebM.cpp
 platform/graphics/cocoa/controls/ApplePayButtonCocoa.mm
 platform/graphics/cocoa/controls/ControlFactoryCocoa.mm

--- a/Source/WebCore/platform/PlatformMediaError.h
+++ b/Source/WebCore/platform/PlatformMediaError.h
@@ -40,6 +40,7 @@ enum class PlatformMediaError : uint8_t {
     MemoryError,
     Cancelled,
     LogicError,
+    DecoderCreationError,
 };
 
 using MediaPromise = NativePromise<void, PlatformMediaError>;

--- a/Source/WebCore/platform/VideoDecoder.cpp
+++ b/Source/WebCore/platform/VideoDecoder.cpp
@@ -26,8 +26,6 @@
 #include "config.h"
 #include "VideoDecoder.h"
 
-#if ENABLE(WEB_CODECS)
-
 #if USE(LIBWEBRTC) && PLATFORM(COCOA)
 #include "LibWebRTCVPXVideoDecoder.h"
 #endif
@@ -57,25 +55,36 @@ void VideoDecoder::create(const String& codecName, const Config& config, CreateC
     createLocalDecoder(codecName, config, WTFMove(callback), WTFMove(outputCallback), WTFMove(postCallback));
 }
 
+#define LE_CHR(a, b, c, d) (((a)<<24) | ((b)<<16) | ((c)<<8) | (d))
+
+String VideoDecoder::fourCCToCodecString(uint32_t fourCC)
+{
+    switch (fourCC) {
+    case LE_CHR('v', 'p', '0', '8'): return "vp8"_s;
+    case LE_CHR('v', 'p', '0', '9'): return "vp09.00"_s;
+    case LE_CHR('a', 'v', '0', '1'): return "av01."_s;
+    default:
+            return nullString();
+    }
+}
 
 void VideoDecoder::createLocalDecoder(const String& codecName, const Config& config, CreateCallback&& callback, OutputCallback&& outputCallback, PostTaskCallback&& postCallback)
 {
 #if USE(LIBWEBRTC) && PLATFORM(COCOA)
-    UNUSED_PARAM(config);
     if (codecName == "vp8"_s) {
-        LibWebRTCVPXVideoDecoder::create(LibWebRTCVPXVideoDecoder::Type::VP8, WTFMove(callback), WTFMove(outputCallback), WTFMove(postCallback));
+        LibWebRTCVPXVideoDecoder::create(LibWebRTCVPXVideoDecoder::Type::VP8, config, WTFMove(callback), WTFMove(outputCallback), WTFMove(postCallback));
         return;
     }
     if (codecName.startsWith("vp09.00"_s)) {
-        LibWebRTCVPXVideoDecoder::create(LibWebRTCVPXVideoDecoder::Type::VP9, WTFMove(callback), WTFMove(outputCallback), WTFMove(postCallback));
+        LibWebRTCVPXVideoDecoder::create(LibWebRTCVPXVideoDecoder::Type::VP9, config, WTFMove(callback), WTFMove(outputCallback), WTFMove(postCallback));
         return;
     }
     if (codecName.startsWith("vp09.02"_s)) {
-        LibWebRTCVPXVideoDecoder::create(LibWebRTCVPXVideoDecoder::Type::VP9_P2, WTFMove(callback), WTFMove(outputCallback), WTFMove(postCallback));
+        LibWebRTCVPXVideoDecoder::create(LibWebRTCVPXVideoDecoder::Type::VP9_P2, config, WTFMove(callback), WTFMove(outputCallback), WTFMove(postCallback));
         return;
     }
     if (codecName.startsWith("av01."_s)) {
-        LibWebRTCVPXVideoDecoder::create(LibWebRTCVPXVideoDecoder::Type::AV1, WTFMove(callback), WTFMove(outputCallback), WTFMove(postCallback));
+        LibWebRTCVPXVideoDecoder::create(LibWebRTCVPXVideoDecoder::Type::AV1, config, WTFMove(callback), WTFMove(outputCallback), WTFMove(postCallback));
         return;
     }
 #elif USE(GSTREAMER)
@@ -95,5 +104,3 @@ VideoDecoder::VideoDecoder() = default;
 VideoDecoder::~VideoDecoder() = default;
 
 }
-
-#endif // ENABLE(WEB_CODECS)

--- a/Source/WebCore/platform/VideoDecoder.h
+++ b/Source/WebCore/platform/VideoDecoder.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#if ENABLE(WEB_CODECS)
-
 #include <span>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Expected.h>
@@ -41,11 +39,14 @@ public:
     WEBCORE_EXPORT VideoDecoder();
     WEBCORE_EXPORT virtual ~VideoDecoder();
 
+    enum class HardwareAcceleration { Yes, No };
+    enum class HardwareBuffer { Yes, No };
     struct Config {
         std::span<const uint8_t> description;
         uint64_t width { 0 };
         uint64_t height { 0 };
-        bool prefersSoftware { false };
+        HardwareAcceleration decoding { HardwareAcceleration::No };
+        HardwareBuffer pixelBuffer { HardwareBuffer::No };
     };
 
     struct EncodedFrame {
@@ -78,9 +79,9 @@ public:
     virtual void reset() = 0;
     virtual void close() = 0;
 
+    static String fourCCToCodecString(uint32_t fourCC);
+
     static CreatorFunction s_customCreator;
 };
 
 }
-
-#endif // ENABLE(WEB_CODECS)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
@@ -68,6 +68,7 @@ class MediaPlayerPrivateMediaSourceAVFObjC;
 class MediaSourcePrivateAVFObjC;
 class TimeRanges;
 class AudioTrackPrivate;
+class VideoMediaSampleRenderer;
 class VideoTrackPrivate;
 class AudioTrackPrivateMediaSourceAVFObjC;
 class VideoTrackPrivateMediaSourceAVFObjC;
@@ -210,7 +211,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     Vector<Function<void()>> m_pendingTrackChangeTasks;
     Deque<std::pair<TrackID, Ref<MediaSampleAVFObjC>>> m_blockedSamples;
 
-    RetainPtr<AVSampleBufferDisplayLayer> m_displayLayer;
+    RefPtr<VideoMediaSampleRenderer> m_videoLayer;
 ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
     StdUnorderedMap<TrackID, RetainPtr<AVSampleBufferAudioRenderer>> m_audioRenderers;
 ALLOW_NEW_API_WITHOUT_GUARDS_END

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -64,6 +64,7 @@ class SharedBuffer;
 class TextTrackRepresentation;
 class TrackBuffer;
 class VideoFrame;
+class VideoMediaSampleRenderer;
 class VideoLayerManagerObjC;
 class VideoTrackPrivateWebM;
 class WebCoreDecompressionSession;
@@ -196,7 +197,6 @@ private:
     void reenqueueMediaForTime(TrackBuffer&, TrackID, const MediaTime&);
     void notifyClientWhenReadyForMoreSamples(TrackID);
 
-    bool canSetMinimumUpcomingPresentationTime(TrackID) const;
     void setMinimumUpcomingPresentationTime(TrackID, const MediaTime&);
     void clearMinimumUpcomingPresentationTime(TrackID);
 
@@ -270,7 +270,7 @@ private:
     StdUnorderedMap<TrackID, UniqueRef<TrackBuffer>> m_trackBufferMap;
     PlatformTimeRanges m_buffered;
 
-    RetainPtr<AVSampleBufferDisplayLayer> m_displayLayer;
+    RefPtr<VideoMediaSampleRenderer> m_videoLayer;
     StdUnorderedMap<TrackID, RetainPtr<AVSampleBufferAudioRenderer>> m_audioRenderers;
     Ref<SourceBufferParserWebM> m_parser;
     const Ref<WTF::WorkQueue> m_appendQueue;

--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+OBJC_CLASS AVSampleBufferDisplayLayer;
+
+#include "SampleMap.h"
+#include <wtf/Function.h>
+#include <wtf/Ref.h>
+#include <wtf/RetainPtr.h>
+#include <wtf/ThreadSafeWeakPtr.h>
+
+namespace WebCore {
+
+class WebCoreDecompressionSession;
+
+class VideoMediaSampleRenderer : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<VideoMediaSampleRenderer> {
+public:
+    static Ref<VideoMediaSampleRenderer> create(AVSampleBufferDisplayLayer* layer) { return adoptRef(*new VideoMediaSampleRenderer(layer)); }
+    ~VideoMediaSampleRenderer();
+
+    bool isReadyForMoreMediaData() const;
+    void requestMediaDataWhenReady(Function<void()>&&);
+    void enqueueSample(CMSampleBufferRef, bool displaying = true);
+    void stopRequestingMediaData();
+
+    void flush();
+
+    void expectMinimumUpcomingSampleBufferPresentationTime(const MediaTime&);
+    void resetUpcomingSampleBufferPresentationTimeExpectations();
+
+    AVSampleBufferDisplayLayer* displayLayer() const { return m_displayLayer.get(); }
+#if HAVE(AVSAMPLEBUFFERDISPLAYLAYER_COPYDISPLAYEDPIXELBUFFER)
+    RetainPtr<CVPixelBufferRef> copyDisplayedPixelBuffer() const;
+    CGRect bounds() const;
+#endif
+private:
+    VideoMediaSampleRenderer(AVSampleBufferDisplayLayer*);
+    void resetReadyForMoreSample();
+    void initializeDecompressionSession();
+
+    RetainPtr<AVSampleBufferDisplayLayer> m_displayLayer;
+    RefPtr<WebCoreDecompressionSession> m_decompressionSession;
+    bool m_displayLayerReadyForMoreSample { false };
+    bool m_decompressionSessionReadyForMoreSample { false };
+    Function<void()> m_readyForMoreSampleFunction;
+    uint32_t m_decodePending { 0 };
+    bool m_wasNotDisplaying { false };
+    bool m_requestMediaDataWhenReadySet { false };
+    std::optional<uint32_t> m_currentCodec;
+    std::optional<MediaTime> m_minimumUpcomingPresentationTime;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
@@ -1,0 +1,187 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "VideoMediaSampleRenderer.h"
+
+#import "WebCoreDecompressionSession.h"
+#import <AVFoundation/AVFoundation.h>
+#import <CoreMedia/CMFormatDescription.h>
+#import <pal/avfoundation/MediaTimeAVFoundation.h>
+#import <pal/spi/cocoa/AVFoundationSPI.h>
+
+#pragma mark - Soft Linking
+
+#import "VideoToolboxSoftLink.h"
+#import <pal/cf/CoreMediaSoftLink.h>
+#import <pal/cocoa/AVFoundationSoftLink.h>
+
+@interface AVSampleBufferDisplayLayer (WebCoreAVSampleBufferDisplayLayerQueueManagementPrivate)
+- (void)expectMinimumUpcomingSampleBufferPresentationTime:(CMTime)minimumUpcomingPresentationTime;
+- (void)resetUpcomingSampleBufferPresentationTimeExpectations;
+@end
+
+namespace WebCore {
+
+VideoMediaSampleRenderer::VideoMediaSampleRenderer(AVSampleBufferDisplayLayer* layer)
+    : m_displayLayer(layer)
+{
+}
+
+VideoMediaSampleRenderer::~VideoMediaSampleRenderer()
+{
+    [m_displayLayer flush];
+    [m_displayLayer stopRequestingMediaData];
+    if (m_decompressionSession)
+        m_decompressionSession->invalidate();
+}
+
+bool VideoMediaSampleRenderer::isReadyForMoreMediaData() const
+{
+    return (!m_decompressionSession || m_decompressionSession->isReadyForMoreMediaData()) && [m_displayLayer isReadyForMoreMediaData];
+}
+
+void VideoMediaSampleRenderer::stopRequestingMediaData()
+{
+    [m_displayLayer stopRequestingMediaData];
+}
+
+void VideoMediaSampleRenderer::enqueueSample(CMSampleBufferRef sample, bool displaying)
+{
+#if PLATFORM(IOS_FAMILY)
+    if (!m_decompressionSession && !m_currentCodec) {
+        // Only use a decompression session for vp8 or vp9 when software decoded.
+        CMVideoFormatDescriptionRef videoFormatDescription = PAL::CMSampleBufferGetFormatDescription(sample);
+        auto fourCC = PAL::CMFormatDescriptionGetMediaSubType(videoFormatDescription);
+        if (fourCC == 'vp08' || (fourCC == 'vp09' && !(canLoad_VideoToolbox_VTIsHardwareDecodeSupported() && VTIsHardwareDecodeSupported(kCMVideoCodecType_VP9))))
+            initializeDecompressionSession();
+        m_currentCodec = fourCC;
+    }
+#endif
+
+    if (!m_decompressionSession) {
+        [m_displayLayer enqueueSampleBuffer:sample];
+        return;
+    }
+    m_decompressionSession->enqueueSample(sample, displaying);
+    ++m_decodePending;
+    m_wasNotDisplaying |= !displaying;
+    if (m_requestMediaDataWhenReadySet)
+        return;
+    m_requestMediaDataWhenReadySet = true;
+    // We set requestMediaDataWhenReady only after calling enqueueSample once, to avoid having the callback
+    // being called immediately.
+    m_decompressionSession->requestMediaDataWhenReady([weakThis = ThreadSafeWeakPtr { *this }, this] {
+        if (RefPtr protectedThis = weakThis.get()) {
+            if (!--m_decodePending && m_minimumUpcomingPresentationTime) {
+                expectMinimumUpcomingSampleBufferPresentationTime(*m_minimumUpcomingPresentationTime);
+                m_minimumUpcomingPresentationTime.reset();
+            }
+            if (!m_wasNotDisplaying)
+                return;
+            m_wasNotDisplaying = false;
+            if (m_readyForMoreSampleFunction)
+                m_readyForMoreSampleFunction();
+        }
+    });
+}
+
+void VideoMediaSampleRenderer::initializeDecompressionSession()
+{
+    if (m_decompressionSession)
+        m_decompressionSession->invalidate();
+    m_decompressionSession = WebCoreDecompressionSession::createOpenGL();
+    m_decompressionSession->setTimebase([m_displayLayer timebase]);
+    m_decompressionSession->decodedFrameWhenAvailable([weakThis = ThreadSafeWeakPtr { *this }](RetainPtr<CMSampleBufferRef>&& sample) {
+        if (RefPtr protectedThis = weakThis.get())
+            [protectedThis->m_displayLayer enqueueSampleBuffer:sample.get()];
+    });
+    m_decompressionSession->setErrorListener([weakThis = ThreadSafeWeakPtr { *this }, this](OSStatus status) {
+        if (RefPtr protectedThis = weakThis.get()) {
+            // Simulate AVSBDL decoding error.
+            RetainPtr error = [NSError errorWithDomain:@"com.apple.WebKit" code:status userInfo:nil];
+            NSDictionary *userInfoDict = @{ (__bridge NSString *)AVSampleBufferDisplayLayerFailedToDecodeNotificationErrorKey: (__bridge NSError *)error.get() };
+            [NSNotificationCenter.defaultCenter postNotificationName:AVSampleBufferDisplayLayerFailedToDecodeNotification object:m_displayLayer.get() userInfo:userInfoDict];
+        }
+    });
+
+    resetReadyForMoreSample();
+}
+
+void VideoMediaSampleRenderer::flush()
+{
+    [m_displayLayer flush];
+    if (m_decompressionSession)
+        m_decompressionSession->flush();
+}
+
+void VideoMediaSampleRenderer::requestMediaDataWhenReady(Function<void()>&& function)
+{
+    m_readyForMoreSampleFunction = WTFMove(function);
+    resetReadyForMoreSample();
+}
+
+void VideoMediaSampleRenderer::resetReadyForMoreSample()
+{
+    ThreadSafeWeakPtr weakThis { *this };
+    [m_displayLayer requestMediaDataWhenReadyOnQueue:dispatch_get_main_queue() usingBlock:^{
+        if (RefPtr protectedThis = weakThis.get(); protectedThis && protectedThis->m_readyForMoreSampleFunction)
+            protectedThis->m_readyForMoreSampleFunction();
+    }];
+}
+
+void VideoMediaSampleRenderer::expectMinimumUpcomingSampleBufferPresentationTime(const MediaTime& time)
+{
+    if (![PAL::getAVSampleBufferDisplayLayerClass() instancesRespondToSelector:@selector(expectMinimumUpcomingSampleBufferPresentationTime:)])
+        return;
+    if (!m_decodePending)
+        [m_displayLayer expectMinimumUpcomingSampleBufferPresentationTime:PAL::toCMTime(time)];
+    else
+        m_minimumUpcomingPresentationTime = time;
+}
+
+void VideoMediaSampleRenderer::resetUpcomingSampleBufferPresentationTimeExpectations()
+{
+    if (![PAL::getAVSampleBufferDisplayLayerClass() instancesRespondToSelector:@selector(resetUpcomingSampleBufferPresentationTimeExpectations)])
+        return;
+    [m_displayLayer resetUpcomingSampleBufferPresentationTimeExpectations];
+    m_minimumUpcomingPresentationTime.reset();
+}
+
+#if HAVE(AVSAMPLEBUFFERDISPLAYLAYER_COPYDISPLAYEDPIXELBUFFER)
+
+RetainPtr<CVPixelBufferRef> VideoMediaSampleRenderer::copyDisplayedPixelBuffer() const
+{
+    return adoptCF([m_displayLayer copyDisplayedPixelBuffer]);
+}
+
+CGRect VideoMediaSampleRenderer::bounds() const
+{
+    return [m_displayLayer bounds];
+}
+
+#endif
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.mm
+++ b/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.mm
@@ -28,12 +28,14 @@
 
 #import "Logging.h"
 #import "PixelBufferConformerCV.h"
+#import "VideoDecoder.h"
+#import "VideoFrame.h"
 #import <CoreMedia/CMBufferQueue.h>
 #import <CoreMedia/CMFormatDescription.h>
 #import <pal/avfoundation/MediaTimeAVFoundation.h>
 #import <wtf/MainThread.h>
 #import <wtf/MediaTime.h>
-#import <wtf/MonotonicTime.h>
+#import <wtf/NativePromise.h>
 #import <wtf/RunLoop.h>
 #import <wtf/StringPrintStream.h>
 #import <wtf/Vector.h>
@@ -60,18 +62,37 @@ WebCoreDecompressionSession::WebCoreDecompressionSession(Mode mode)
 {
 }
 
+WebCoreDecompressionSession::~WebCoreDecompressionSession() = default;
+
 void WebCoreDecompressionSession::invalidate()
 {
+    assertIsMainThread();
     m_invalidated = true;
+    Locker lock { m_lock };
     m_notificationCallback = nullptr;
     m_hasAvailableFrameCallback = nullptr;
-    setTimebase(nullptr);
-    if (m_timerSource)
+    setTimebaseWithLockHeld(nullptr);
+    if (m_timerSource) {
         dispatch_source_cancel(m_timerSource.get());
+        m_timerSource = nullptr;
+    }
+    m_decompressionQueue->dispatch([decoder = WTFMove(m_videoDecoder)] {
+        if (decoder)
+            decoder->close();
+    });
+    removeErrorListener();
 }
 
 void WebCoreDecompressionSession::setTimebase(CMTimebaseRef timebase)
 {
+    Locker lock { m_lock };
+    setTimebaseWithLockHeld(timebase);
+}
+
+void WebCoreDecompressionSession::setTimebaseWithLockHeld(CMTimebaseRef timebase)
+{
+    assertIsHeld(m_lock);
+
     if (m_timebase == timebase)
         return;
 
@@ -92,16 +113,22 @@ void WebCoreDecompressionSession::setTimebase(CMTimebaseRef timebase)
     }
 }
 
+RetainPtr<CMTimebaseRef> WebCoreDecompressionSession::timebase() const
+{
+    Locker lock { m_lock };
+    return m_timebase;
+}
+
 void WebCoreDecompressionSession::maybeBecomeReadyForMoreMediaData()
 {
-    if (!isReadyForMoreMediaData() || !m_notificationCallback)
+    if (!isReadyForMoreMediaData())
         return;
 
-    LOG(Media, "WebCoreDecompressionSession::maybeBecomeReadyForMoreMediaData(%p) - isReadyForMoreMediaData(%d), hasCallback(%d)", this, isReadyForMoreMediaData(), !!m_notificationCallback);
-
-    ensureOnMainThread([protectedThis = Ref { *this }] {
-        if (protectedThis->m_notificationCallback)
-            protectedThis->m_notificationCallback();
+    ensureOnMainThread([protectedThis = Ref { *this }, this] {
+        assertIsMainThread();
+        LOG(Media, "WebCoreDecompressionSession::maybeBecomeReadyForMoreMediaData(%p) - isReadyForMoreMediaData(1), hasCallback(%d)", this, !!m_notificationCallback);
+        if (m_notificationCallback)
+            m_notificationCallback();
     });
 }
 
@@ -166,10 +193,10 @@ void WebCoreDecompressionSession::enqueueSample(CMSampleBufferRef sampleBuffer, 
 
     ++m_framesBeingDecoded;
 
-    LOG(Media, "WebCoreDecompressionSession::enqueueSample(%p) - framesBeingDecoded(%d)", this, m_framesBeingDecoded);
+    LOG(Media, "WebCoreDecompressionSession::enqueueSample(%p) - framesBeingDecoded(%d)", this, int(m_framesBeingDecoded));
 
     m_decompressionQueue->dispatch([protectedThis = Ref { *this }, strongBuffer = retainPtr(sampleBuffer), displaying] {
-        protectedThis->decodeSample(strongBuffer.get(), displaying);
+        protectedThis->enqueueCompressedSample(strongBuffer.get(), displaying);
     });
 }
 
@@ -178,10 +205,11 @@ bool WebCoreDecompressionSession::shouldDecodeSample(CMSampleBufferRef sample, b
     if (!displaying)
         return true;
 
-    if (!m_timebase)
+    RetainPtr timebase = this->timebase();
+    if (!timebase)
         return true;
 
-    auto currentTime = PAL::CMTimebaseGetTime(m_timebase.get());
+    auto currentTime = PAL::CMTimebaseGetTime(timebase.get());
     auto presentationStartTime = PAL::CMSampleBufferGetPresentationTimeStamp(sample);
     auto duration = PAL::CMSampleBufferGetDuration(sample);
     auto presentationEndTime = PAL::CMTimeAdd(presentationStartTime, duration);
@@ -201,10 +229,11 @@ bool WebCoreDecompressionSession::shouldDecodeSample(CMSampleBufferRef sample, b
     return true;
 }
 
-void WebCoreDecompressionSession::ensureDecompressionSessionForSample(CMSampleBufferRef sample)
+RetainPtr<VTDecompressionSessionRef> WebCoreDecompressionSession::ensureDecompressionSessionForSample(CMSampleBufferRef sample)
 {
-    if (isInvalidated())
-        return;
+    Locker lock { m_lock };
+    if (isInvalidated() || m_videoDecoder)
+        return nullptr;
 
     CMVideoFormatDescriptionRef videoFormatDescription = PAL::CMSampleBufferGetFormatDescription(sample);
     if (m_decompressionSession && !VTDecompressionSessionCanAcceptFormatDescription(m_decompressionSession.get(), videoFormatDescription)) {
@@ -213,8 +242,7 @@ void WebCoreDecompressionSession::ensureDecompressionSessionForSample(CMSampleBu
     }
 
     if (!m_decompressionSession) {
-        CMVideoFormatDescriptionRef videoFormatDescription = PAL::CMSampleBufferGetFormatDescription(sample);
-        auto videoDecoderSpecification = @{ (__bridge NSString *)kVTVideoDecoderSpecification_EnableHardwareAcceleratedVideoDecoder: @( m_hardwareDecoderEnabled ) };
+        auto videoDecoderSpecification = @{ (__bridge NSString *)kVTVideoDecoderSpecification_EnableHardwareAcceleratedVideoDecoder: @( bool(m_hardwareDecoderEnabled) ) };
 
         NSDictionary *attributes;
         if (m_mode == OpenGL)
@@ -227,23 +255,47 @@ void WebCoreDecompressionSession::ensureDecompressionSessionForSample(CMSampleBu
         }
 
         VTDecompressionSessionRef decompressionSessionOut = nullptr;
-        if (noErr == VTDecompressionSessionCreate(kCFAllocatorDefault, videoFormatDescription, (__bridge CFDictionaryRef)videoDecoderSpecification, (__bridge CFDictionaryRef)attributes, nullptr, &decompressionSessionOut)) {
+        auto result = VTDecompressionSessionCreate(kCFAllocatorDefault, videoFormatDescription, (__bridge CFDictionaryRef)videoDecoderSpecification, (__bridge CFDictionaryRef)attributes, nullptr, &decompressionSessionOut);
+        if (noErr == result) {
             m_decompressionSession = adoptCF(decompressionSessionOut);
             CFArrayRef rawSuggestedQualityOfServiceTiers = nullptr;
             VTSessionCopyProperty(decompressionSessionOut, kVTDecompressionPropertyKey_SuggestedQualityOfServiceTiers, kCFAllocatorDefault, &rawSuggestedQualityOfServiceTiers);
             m_qosTiers = adoptCF(rawSuggestedQualityOfServiceTiers);
             m_currentQosTier = 0;
             resetQosTier();
+            // Decoder creation succeeded, we'll never fallback to using a VideoDecoder.
+            m_isUsingVideoDecoder = false;
         }
     }
+
+    return m_decompressionSession;
+}
+
+void WebCoreDecompressionSession::enqueueCompressedSample(CMSampleBufferRef sample, bool displaying)
+{
+    assertIsCurrent(m_decompressionQueue.get());
+
+    m_pendingSamples.append(std::make_pair(sample, displaying));
+
+    maybeDecodeNextSample();
+}
+
+void WebCoreDecompressionSession::maybeDecodeNextSample()
+{
+    assertIsCurrent(m_decompressionQueue.get());
+
+    if (m_pendingSamples.isEmpty() || m_isDecodingSample)
+        return;
+
+    auto pair = m_pendingSamples.takeFirst();
+    decodeSample(pair.first.get(), pair.second);
 }
 
 void WebCoreDecompressionSession::decodeSample(CMSampleBufferRef sample, bool displaying)
 {
-    if (isInvalidated())
-        return;
+    assertIsCurrent(m_decompressionQueue.get());
 
-    ensureDecompressionSessionForSample(sample);
+    m_isDecodingSample = true;
 
     VTDecodeInfoFlags flags { kVTDecodeFrame_EnableTemporalProcessing };
     if (!displaying)
@@ -252,31 +304,136 @@ void WebCoreDecompressionSession::decodeSample(CMSampleBufferRef sample, bool di
     if (!shouldDecodeSample(sample, displaying)) {
         ++m_totalVideoFrames;
         ++m_droppedVideoFrames;
-        --m_framesBeingDecoded;
-        maybeBecomeReadyForMoreMediaData();
+        finishCurrentDecodingAndDecodeNextSample();
         return;
     }
 
-    MonotonicTime startTime = MonotonicTime::now();
-    VTDecompressionSessionDecodeFrameWithOutputHandler(m_decompressionSession.get(), sample, flags, nullptr, [protectedThis = Ref { *this }, this, displaying, startTime](OSStatus status, VTDecodeInfoFlags infoFlags, CVImageBufferRef imageBuffer, CMTime presentationTimeStamp, CMTime presentationDuration) {
-        double deltaRatio = (MonotonicTime::now() - startTime).seconds() / PAL::CMTimeGetSeconds(presentationDuration);
+    RetainPtr decompressionSession = ensureDecompressionSessionForSample(sample);
+    if (!decompressionSession && !m_videoDecoderCreationFailed) {
+        Locker lock { m_lock };
+        if (!m_videoDecoder) {
+            if (isInvalidated())
+                return;
+            CMVideoFormatDescriptionRef videoFormatDescription = PAL::CMSampleBufferGetFormatDescription(sample);
+            auto fourCC = PAL::CMFormatDescriptionGetMediaSubType(videoFormatDescription);
+            initializeVideoDecoder(fourCC)->whenSettled(m_decompressionQueue, [protectedThis = Ref { *this }, this, sample = RetainPtr { sample }, displaying](auto&& result) {
+                if (!result) {
+                    m_videoDecoderCreationFailed = true;
+                    finishCurrentDecodingAndReportError(kVTVideoDecoderNotAvailableNowErr);
+                    return;
+                }
+                decodeSample(sample.get(), displaying);
+            });
+            return;
+        }
+        MediaTime presentationTimestamp = PAL::toMediaTime(PAL::CMSampleBufferGetPresentationTimeStamp(sample));
+        MediaTime duration = PAL::toMediaTime(PAL::CMSampleBufferGetDuration(sample));
+        CMBlockBufferRef rawBuffer = PAL::CMSampleBufferGetDataBuffer(sample);
+        ASSERT(rawBuffer);
+        RetainPtr buffer = rawBuffer;
+        // Make sure block buffer is contiguous.
+        if (!PAL::CMBlockBufferIsRangeContiguous(rawBuffer, 0, 0)) {
+            CMBlockBufferRef contiguousBuffer;
+            if (auto status = PAL::CMBlockBufferCreateContiguous(nullptr, rawBuffer, nullptr, nullptr, 0, 0, 0, &contiguousBuffer); status != kCMBlockBufferNoErr) {
+                finishCurrentDecodingAndReportError(status);
+                return;
+            }
+            buffer = adoptCF(contiguousBuffer);
+        }
+        auto size = PAL::CMBlockBufferGetDataLength(buffer.get());
+        char* data = nullptr;
+        if (auto status = PAL::CMBlockBufferGetDataPointer(buffer.get(), 0, nullptr, nullptr, &data); status != noErr) {
+            finishCurrentDecodingAndReportError(status);
+            return;
+        }
+        m_pendingDecodeData = { MonotonicTime::now(), displaying };
+        auto presentationTimeInUs = presentationTimestamp.toTimeScale(1000000);
+        auto durationInUs = duration.toTimeScale(1000000);
+        m_videoDecoder->decode({ { reinterpret_cast<uint8_t*>(data), size }, true, presentationTimeInUs.timeValue(), durationInUs.timeValue() }, [weakThis = ThreadSafeWeakPtr { *this }, this, duration = PAL::toCMTime(duration)](String&&) {
+            if (RefPtr protectedThis = weakThis.get()) {
+                assertIsCurrent(m_decompressionQueue.get());
+                if (m_lastDecodingError != noErr)
+                    finishCurrentDecodingAndReportError(m_lastDecodingError);
+                else
+                    finishCurrentDecodingAndDecodeNextSample();
+                if (!m_pendingDecodeData)
+                    return;
+                double deltaRatio = (MonotonicTime::now() - m_pendingDecodeData->startTime).seconds() / PAL::CMTimeGetSeconds(duration);
+                updateQosWithDecodeTimeStatistics(deltaRatio);
+                m_pendingDecodeData.reset();
+            };
+        });
+        return;
+    }
 
-        updateQosWithDecodeTimeStatistics(deltaRatio);
-        handleDecompressionOutput(displaying, status, infoFlags, imageBuffer, presentationTimeStamp, presentationDuration);
+    if (!decompressionSession)
+        return;
+    MonotonicTime startTime = MonotonicTime::now();
+    VTDecompressionSessionDecodeFrameWithOutputHandler(decompressionSession.get(), sample, flags, nullptr, [weakThis = ThreadSafeWeakPtr { *this }, this, displaying, startTime](OSStatus status, VTDecodeInfoFlags infoFlags, CVImageBufferRef imageBuffer, CMTime presentationTimeStamp, CMTime presentationDuration) {
+        if (RefPtr protectedThis = weakThis.get()) {
+            m_decompressionQueue->dispatch([protectedThis = WTFMove(protectedThis), this, displaying, startTime, status, infoFlags, imageBuffer = RetainPtr { imageBuffer }, presentationTimeStamp, presentationDuration]() {
+                assertIsCurrent(m_decompressionQueue.get());
+                double deltaRatio = (MonotonicTime::now() - startTime).seconds() / PAL::CMTimeGetSeconds(presentationDuration);
+
+                updateQosWithDecodeTimeStatistics(deltaRatio);
+                handleDecompressionOutput(displaying, status, infoFlags, imageBuffer.get(), presentationTimeStamp, presentationDuration);
+                if (m_lastDecodingError != noErr)
+                    finishCurrentDecodingAndReportError(m_lastDecodingError);
+                else
+                    finishCurrentDecodingAndDecodeNextSample();
+            });
+        }
     });
+}
+
+void WebCoreDecompressionSession::setErrorListener(Function<void(OSStatus)>&& listener)
+{
+    assertIsMainThread();
+    m_errorListener = WTFMove(listener);
+}
+
+void WebCoreDecompressionSession::removeErrorListener()
+{
+    assertIsMainThread();
+    m_errorListener = { };
+}
+
+void WebCoreDecompressionSession::finishCurrentDecodingAndReportError(OSStatus status)
+{
+    assertIsCurrent(m_decompressionQueue.get());
+
+    --m_framesBeingDecoded;
+    m_isDecodingSample = false;
+    ensureOnMainThread([protectedThis = Ref { *this }, this, status] {
+        assertIsMainThread();
+        if (!m_errorListener)
+            return;
+        m_errorListener(status);
+    });
+}
+
+void WebCoreDecompressionSession::finishCurrentDecodingAndDecodeNextSample()
+{
+    assertIsCurrent(m_decompressionQueue.get());
+
+    --m_framesBeingDecoded;
+    m_isDecodingSample = false;
+    m_decompressionQueue->dispatch([protectedThis = Ref { *this }] {
+        protectedThis->maybeDecodeNextSample();
+    });
+    maybeBecomeReadyForMoreMediaData();
 }
 
 RetainPtr<CVPixelBufferRef> WebCoreDecompressionSession::decodeSampleSync(CMSampleBufferRef sample)
 {
-    if (isInvalidated())
+    RetainPtr decompressionSession = ensureDecompressionSessionForSample(sample);
+    if (!decompressionSession)
         return nullptr;
-
-    ensureDecompressionSessionForSample(sample);
 
     RetainPtr<CVPixelBufferRef> pixelBuffer;
     VTDecodeInfoFlags flags { 0 };
     WTF::Semaphore syncDecompressionOutputSemaphore { 0 };
-    VTDecompressionSessionDecodeFrameWithOutputHandler(m_decompressionSession.get(), sample, flags, nullptr, [&] (OSStatus, VTDecodeInfoFlags, CVImageBufferRef imageBuffer, CMTime, CMTime) mutable {
+    VTDecompressionSessionDecodeFrameWithOutputHandler(decompressionSession.get(), sample, flags, nullptr, [&] (OSStatus, VTDecodeInfoFlags, CVImageBufferRef imageBuffer, CMTime, CMTime) mutable {
         if (imageBuffer && CFGetTypeID(imageBuffer) == CVPixelBufferGetTypeID())
             pixelBuffer = (CVPixelBufferRef)imageBuffer;
         syncDecompressionOutputSemaphore.signal();
@@ -287,15 +444,27 @@ RetainPtr<CVPixelBufferRef> WebCoreDecompressionSession::decodeSampleSync(CMSamp
 
 void WebCoreDecompressionSession::handleDecompressionOutput(bool displaying, OSStatus status, VTDecodeInfoFlags infoFlags, CVImageBufferRef rawImageBuffer, CMTime presentationTimeStamp, CMTime presentationDuration)
 {
+    assertIsCurrent(m_decompressionQueue.get());
+
     ++m_totalVideoFrames;
-    if (infoFlags & kVTDecodeInfo_FrameDropped)
+    if (infoFlags & kVTDecodeInfo_FrameDropped) {
         ++m_droppedVideoFrames;
+        return;
+    }
+
+    if (status != noErr) {
+        ++m_corruptedVideoFrames;
+        m_lastDecodingError = status;
+        return;
+    }
+
+    if (!displaying)
+        return;
 
     CMVideoFormatDescriptionRef rawImageBufferDescription = nullptr;
-    if (status != noErr || noErr != PAL::CMVideoFormatDescriptionCreateForImageBuffer(kCFAllocatorDefault, rawImageBuffer, &rawImageBufferDescription)) {
+    if (auto status = PAL::CMVideoFormatDescriptionCreateForImageBuffer(kCFAllocatorDefault, rawImageBuffer, &rawImageBufferDescription); status != noErr) {
         ++m_corruptedVideoFrames;
-        --m_framesBeingDecoded;
-        maybeBecomeReadyForMoreMediaData();
+        m_lastDecodingError = status;
         return;
     }
     RetainPtr<CMVideoFormatDescriptionRef> imageBufferDescription = adoptCF(rawImageBufferDescription);
@@ -307,15 +476,24 @@ void WebCoreDecompressionSession::handleDecompressionOutput(bool displaying, OSS
     };
 
     CMSampleBufferRef rawImageSampleBuffer = nullptr;
-    if (noErr != PAL::CMSampleBufferCreateReadyWithImageBuffer(kCFAllocatorDefault, rawImageBuffer, imageBufferDescription.get(), &imageBufferTiming, &rawImageSampleBuffer)) {
+    if (auto status = PAL::CMSampleBufferCreateReadyWithImageBuffer(kCFAllocatorDefault, rawImageBuffer, imageBufferDescription.get(), &imageBufferTiming, &rawImageSampleBuffer); status != noErr) {
         ++m_corruptedVideoFrames;
-        --m_framesBeingDecoded;
-        maybeBecomeReadyForMoreMediaData();
+        m_lastDecodingError = status;
         return;
     }
 
-    m_enqueingQueue->dispatch([protectedThis = Ref { *this }, imageSampleBuffer = adoptCF(rawImageSampleBuffer), displaying] {
-        protectedThis->enqueueDecodedSample(imageSampleBuffer.get(), displaying);
+    if (!m_deliverDecodedFrames) {
+        m_enqueingQueue->dispatch([protectedThis = Ref { *this }, imageSampleBuffer = adoptCF(rawImageSampleBuffer)] {
+            protectedThis->enqueueDecodedSample(imageSampleBuffer.get());
+        });
+        return;
+    }
+
+    RunLoop::main().dispatch([protectedThis = Ref { *this }, this, imageSampleBuffer = adoptCF(rawImageSampleBuffer)]() mutable {
+        assertIsMainThread();
+        LOG(Media, "WebCoreDecompressionSession::handleDecompressionOutput(%p) - returning frame: presentationTime(%s)", this, toString(PAL::toMediaTime(PAL::CMSampleBufferGetPresentationTimeStamp(imageSampleBuffer.get()))).utf8().data());
+        if (m_newDecodedFrameCallback)
+            m_newDecodedFrameCallback(WTFMove(imageSampleBuffer));
     });
 }
 
@@ -335,10 +513,12 @@ RetainPtr<CVPixelBufferRef> WebCoreDecompressionSession::getFirstVideoFrame()
 
 void WebCoreDecompressionSession::automaticDequeue()
 {
-    if (!m_timebase)
+    assertIsMainThread();
+    RetainPtr timebase = this->timebase();
+    if (!timebase)
         return;
 
-    auto time = PAL::toMediaTime(PAL::CMTimebaseGetTime(m_timebase.get()));
+    auto time = PAL::toMediaTime(PAL::CMTimebaseGetTime(timebase.get()));
     LOG(Media, "WebCoreDecompressionSession::automaticDequeue(%p) - purging all samples before time(%s)", this, toString(time).utf8().data());
 
     MediaTime nextFireTime = MediaTime::positiveInfiniteTime();
@@ -368,26 +548,27 @@ void WebCoreDecompressionSession::automaticDequeue()
         maybeBecomeReadyForMoreMediaData();
 
     LOG(Media, "WebCoreDecompressionSession::automaticDequeue(%p) - queue empty", this);
+
+    Locker lock { m_lock };
+    if (isInvalidated())
+        return;
     PAL::CMTimebaseSetTimerDispatchSourceNextFireTime(m_timebase.get(), m_timerSource.get(), PAL::toCMTime(nextFireTime), 0);
 }
 
-void WebCoreDecompressionSession::enqueueDecodedSample(CMSampleBufferRef sample, bool displaying)
+void WebCoreDecompressionSession::enqueueDecodedSample(CMSampleBufferRef sample)
 {
+    assertIsCurrent(m_enqueingQueue);
+
     if (isInvalidated())
         return;
 
-    --m_framesBeingDecoded;
-
-    if (!displaying) {
-        maybeBecomeReadyForMoreMediaData();
-        return;
-    }
-
     bool shouldNotify = true;
 
-    if (displaying && m_timebase) {
-        auto currentRate = PAL::CMTimebaseGetRate(m_timebase.get());
-        auto currentTime = PAL::toMediaTime(PAL::CMTimebaseGetTime(m_timebase.get()));
+    RetainPtr timebase = this->timebase();
+
+    if (timebase) {
+        auto currentRate = PAL::CMTimebaseGetRate(timebase.get());
+        auto currentTime = PAL::toMediaTime(PAL::CMTimebaseGetTime(timebase.get()));
         auto presentationStartTime = PAL::toMediaTime(PAL::CMSampleBufferGetPresentationTimeStamp(sample));
         auto presentationEndTime = presentationStartTime + PAL::toMediaTime(PAL::CMSampleBufferGetDuration(sample));
         if (currentTime < presentationStartTime || currentTime >= presentationEndTime)
@@ -397,7 +578,7 @@ void WebCoreDecompressionSession::enqueueDecodedSample(CMSampleBufferRef sample,
 #if !LOG_DISABLED
             auto begin = PAL::toMediaTime(PAL::CMBufferQueueGetFirstPresentationTimeStamp(m_producerQueue.get()));
             auto end = PAL::toMediaTime(PAL::CMBufferQueueGetEndPresentationTimeStamp(m_producerQueue.get()));
-            LOG(Media, "WebCoreDecompressionSession::enqueueDecodedSample(%p) - dropping frame late by %s, framesBeingDecoded(%d), producerQueue(%s -> %s)", this, toString(presentationEndTime - currentTime).utf8().data(), m_framesBeingDecoded, toString(begin).utf8().data(), toString(end).utf8().data());
+            LOG(Media, "WebCoreDecompressionSession::enqueueDecodedSample(%p) - dropping frame late by %s, framesBeingDecoded(%d), producerQueue(%s -> %s)", this, toString(presentationEndTime - currentTime).utf8().data(), int(m_framesBeingDecoded), toString(begin).utf8().data(), toString(end).utf8().data());
 #endif
             ++m_droppedVideoFrames;
             return;
@@ -410,58 +591,71 @@ void WebCoreDecompressionSession::enqueueDecodedSample(CMSampleBufferRef sample,
     auto begin = PAL::toMediaTime(PAL::CMBufferQueueGetFirstPresentationTimeStamp(m_producerQueue.get()));
     auto end = PAL::toMediaTime(PAL::CMBufferQueueGetEndPresentationTimeStamp(m_producerQueue.get()));
     auto presentationTime = PAL::toMediaTime(PAL::CMSampleBufferGetPresentationTimeStamp(sample));
-    LOG(Media, "WebCoreDecompressionSession::enqueueDecodedSample(%p) - presentationTime(%s), framesBeingDecoded(%d), producerQueue(%s -> %s)", this, toString(presentationTime).utf8().data(), m_framesBeingDecoded, toString(begin).utf8().data(), toString(end).utf8().data());
+    LOG(Media, "WebCoreDecompressionSession::enqueueDecodedSample(%p) - presentationTime(%s), framesBeingDecoded(%d), producerQueue(%s -> %s)", this, toString(presentationTime).utf8().data(), int(m_framesBeingDecoded), toString(begin).utf8().data(), toString(end).utf8().data());
 #endif
 
-    if (m_timebase)
-        PAL::CMTimebaseSetTimerDispatchSourceToFireImmediately(m_timebase.get(), m_timerSource.get());
-
-    if (!m_hasAvailableFrameCallback)
-        return;
+    {
+        Locker lock { m_lock };
+        if (m_timebase)
+            PAL::CMTimebaseSetTimerDispatchSourceToFireImmediately(m_timebase.get(), m_timerSource.get());
+    }
 
     if (!shouldNotify)
         return;
 
-    RunLoop::main().dispatch([protectedThis = Ref { *this }, callback = WTFMove(m_hasAvailableFrameCallback)] {
-        callback();
+    RunLoop::main().dispatch([protectedThis = Ref { *this }] {
+        assertIsMainThread();
+        if (auto callback = std::exchange(protectedThis->m_hasAvailableFrameCallback, { }))
+            callback();
     });
 }
 
 bool WebCoreDecompressionSession::isReadyForMoreMediaData() const
 {
     CMItemCount producerCount = m_producerQueue ? PAL::CMBufferQueueGetBufferCount(m_producerQueue.get()) : 0;
-    return m_framesBeingDecoded + producerCount <= kHighWaterMark;
+    return (!m_isUsingVideoDecoder || !m_framesBeingDecoded) && (m_framesBeingDecoded + producerCount <= kHighWaterMark);
 }
 
-void WebCoreDecompressionSession::requestMediaDataWhenReady(std::function<void()> notificationCallback)
+void WebCoreDecompressionSession::requestMediaDataWhenReady(Function<void()>&& notificationCallback)
 {
+    assertIsMainThread();
     LOG(Media, "WebCoreDecompressionSession::requestMediaDataWhenReady(%p), hasNotificationCallback(%d)", this, !!notificationCallback);
-    m_notificationCallback = notificationCallback;
+    m_notificationCallback = WTFMove(notificationCallback);
 
-    if (notificationCallback && isReadyForMoreMediaData()) {
+    if (m_notificationCallback && isReadyForMoreMediaData()) {
         RefPtr<WebCoreDecompressionSession> protectedThis { this };
         RunLoop::main().dispatch([protectedThis] {
+            assertIsMainThread();
             if (protectedThis->m_notificationCallback)
                 protectedThis->m_notificationCallback();
         });
     }
 }
 
+void WebCoreDecompressionSession::decodedFrameWhenAvailable(Function<void(RetainPtr<CMSampleBufferRef>&&)>&& callback)
+{
+    assertIsMainThread();
+    LOG(Media, "WebCoreDecompressionSession::decodedFrameWhenAvailable(%p), hasDecodedFrameWhenAvailable(%d)", this, !!callback);
+    m_newDecodedFrameCallback = WTFMove(callback);
+
+    m_deliverDecodedFrames = !!m_newDecodedFrameCallback;
+}
+
 void WebCoreDecompressionSession::stopRequestingMediaData()
 {
+    assertIsMainThread();
     LOG(Media, "WebCoreDecompressionSession::stopRequestingMediaData(%p)", this);
     m_notificationCallback = nullptr;
 }
 
-void WebCoreDecompressionSession::notifyWhenHasAvailableVideoFrame(std::function<void()> callback)
+void WebCoreDecompressionSession::notifyWhenHasAvailableVideoFrame(Function<void()>&& callback)
 {
-    if (callback && m_producerQueue && !PAL::CMBufferQueueIsEmpty(m_producerQueue.get())) {
-        RunLoop::main().dispatch([callback] {
-            callback();
-        });
+    assertIsMainThread();
+    if (m_producerQueue && !PAL::CMBufferQueueIsEmpty(m_producerQueue.get())) {
+        RunLoop::main().dispatch(WTFMove(callback));
         return;
     }
-    m_hasAvailableFrameCallback = callback;
+    m_hasAvailableFrameCallback = WTFMove(callback);
 }
 
 RetainPtr<CVPixelBufferRef> WebCoreDecompressionSession::imageForTime(const MediaTime& time, ImageForTimeFlags flags)
@@ -501,18 +695,22 @@ RetainPtr<CVPixelBufferRef> WebCoreDecompressionSession::imageForTime(const Medi
         RetainPtr<CVPixelBufferRef> imageBuffer = (CVPixelBufferRef)PAL::CMSampleBufferGetImageBuffer(currentSample.get());
         ASSERT(CFGetTypeID(imageBuffer.get()) == CVPixelBufferGetTypeID());
 
-        if (m_timebase)
-            PAL::CMTimebaseSetTimerDispatchSourceToFireImmediately(m_timebase.get(), m_timerSource.get());
-
+        {
+            Locker lock { m_lock };
+            if (m_timebase)
+                PAL::CMTimebaseSetTimerDispatchSourceToFireImmediately(m_timebase.get(), m_timerSource.get());
+        }
         maybeBecomeReadyForMoreMediaData();
 
         LOG(Media, "WebCoreDecompressionSession::imageForTime(%p) - found sample for time(%s) in queue(%s -> %s)", this, toString(time).utf8().data(), toString(startTime).utf8().data(), toString(endTime).utf8().data());
         return imageBuffer;
     }
 
-    if (m_timebase)
-        PAL::CMTimebaseSetTimerDispatchSourceToFireImmediately(m_timebase.get(), m_timerSource.get());
-
+    {
+        Locker lock { m_lock };
+        if (m_timebase)
+            PAL::CMTimebaseSetTimerDispatchSourceToFireImmediately(m_timebase.get(), m_timerSource.get());
+    }
     if (releasedImageBuffers)
         maybeBecomeReadyForMoreMediaData();
 
@@ -526,6 +724,7 @@ void WebCoreDecompressionSession::flush()
         PAL::CMBufferQueueReset(protectedThis->m_producerQueue.get());
         m_enqueingQueue->dispatchSync([protectedThis = WTFMove(protectedThis)] {
             PAL::CMBufferQueueReset(protectedThis->m_consumerQueue.get());
+            Locker lock { protectedThis->m_lock };
             protectedThis->m_framesSinceLastQosCheck = 0;
             protectedThis->m_currentQosTier = 0;
             protectedThis->resetQosTier();
@@ -558,6 +757,8 @@ CFComparisonResult WebCoreDecompressionSession::compareBuffers(CMBufferRef buf1,
 
 void WebCoreDecompressionSession::resetQosTier()
 {
+    assertIsHeld(m_lock);
+
     if (!m_qosTiers || !m_decompressionSession)
         return;
 
@@ -573,6 +774,7 @@ void WebCoreDecompressionSession::resetQosTier()
 
 void WebCoreDecompressionSession::increaseQosTier()
 {
+    Locker lock { m_lock };
     if (!m_qosTiers)
         return;
 
@@ -585,6 +787,7 @@ void WebCoreDecompressionSession::increaseQosTier()
 
 void WebCoreDecompressionSession::decreaseQosTier()
 {
+    Locker lock { m_lock };
     if (!m_qosTiers)
         return;
 
@@ -597,23 +800,27 @@ void WebCoreDecompressionSession::decreaseQosTier()
 
 void WebCoreDecompressionSession::updateQosWithDecodeTimeStatistics(double ratio)
 {
+    assertIsCurrent(m_decompressionQueue.get());
+
     static const double kMovingAverageAlphaValue = 0.1;
     static const unsigned kNumberOfFramesBeforeSwitchingTiers = 60;
     static const double kHighWaterDecodeRatio = 1.;
     static const double kLowWaterDecodeRatio = 0.5;
 
-    if (!m_timebase)
+    auto timebase = this->timebase();
+    if (!timebase)
         return;
 
-    double rate = PAL::CMTimebaseGetRate(m_timebase.get());
+    double rate = PAL::CMTimebaseGetRate(timebase.get());
     if (!rate)
         rate = 1;
 
     m_decodeRatioMovingAverage += kMovingAverageAlphaValue * (ratio - m_decodeRatioMovingAverage) * rate;
-    if (++m_framesSinceLastQosCheck < kNumberOfFramesBeforeSwitchingTiers)
+    unsigned framesSinceLastQosCheck = ++m_framesSinceLastQosCheck;
+    if (framesSinceLastQosCheck < kNumberOfFramesBeforeSwitchingTiers)
         return;
 
-    LOG(Media, "WebCoreDecompressionSession::updateQosWithDecodeTimeStatistics(%p) - framesSinceLastQosCheck(%ld), decodeRatioMovingAverage(%g)", this, m_framesSinceLastQosCheck, m_decodeRatioMovingAverage);
+    LOG(Media, "WebCoreDecompressionSession::updateQosWithDecodeTimeStatistics(%p) - framesSinceLastQosCheck(%ld), decodeRatioMovingAverage(%g)", this, framesSinceLastQosCheck, m_decodeRatioMovingAverage);
     if (m_decodeRatioMovingAverage > kHighWaterDecodeRatio)
         increaseQosTier();
     else if (m_decodeRatioMovingAverage < kLowWaterDecodeRatio)
@@ -621,4 +828,39 @@ void WebCoreDecompressionSession::updateQosWithDecodeTimeStatistics(double ratio
     m_framesSinceLastQosCheck = 0;
 }
 
+Ref<MediaPromise> WebCoreDecompressionSession::initializeVideoDecoder(FourCharCode codec)
+{
+    VideoDecoder::Config config { { }, 0, 0, VideoDecoder::HardwareAcceleration::Yes, VideoDecoder::HardwareBuffer::Yes };
+    MediaPromise::Producer producer;
+    auto promise = producer.promise();
+    VideoDecoder::create(VideoDecoder::fourCCToCodecString(codec), config, [protectedThis = Ref { *this }, this, producer = WTFMove(producer)](VideoDecoder::CreateResult&& result) {
+        assertIsCurrent(m_decompressionQueue.get());
+        if (!result || isInvalidated()) {
+            producer.reject(PlatformMediaError::DecoderCreationError);
+            return;
+        }
+        Locker lock { m_lock };
+        m_videoDecoder = result.value().moveToUniquePtr();
+        producer.resolve();
+    }, [weakThis = ThreadSafeWeakPtr { *this }, this](Expected<VideoDecoder::DecodedFrame, String>&& result) {
+        if (RefPtr protectedThis = weakThis.get()) {
+            assertIsCurrent(m_decompressionQueue.get());
+            if (isInvalidated() || !m_pendingDecodeData)
+                return;
+
+            if (!result) {
+                handleDecompressionOutput(false, -1, 0, nullptr, PAL::kCMTimeInvalid, PAL::kCMTimeInvalid);
+                return;
+            }
+
+            auto presentationTime = PAL::toCMTime(MediaTime(result->timestamp, 1000000));
+            auto presentationDuration = PAL::toCMTime(MediaTime(result->duration.value_or(0), 1000000));
+            handleDecompressionOutput(m_pendingDecodeData->displaying, noErr, 0, result->frame->pixelBuffer(), presentationTime, presentationDuration);
+        }
+    }, [queue = m_decompressionQueue](Function<void()>&& function) {
+        queue->dispatch(WTFMove(function));
+    });
+    return promise;
 }
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp
@@ -20,7 +20,7 @@
 #include "config.h"
 #include "VideoDecoderGStreamer.h"
 
-#if ENABLE(WEB_CODECS) && USE(GSTREAMER)
+#if USE(GSTREAMER)
 
 #include "GStreamerCodecUtilities.h"
 #include "GStreamerCommon.h"

--- a/Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.h
@@ -19,7 +19,7 @@
 
 #pragma once
 
-#if ENABLE(WEB_CODECS) && USE(GSTREAMER)
+#if USE(GSTREAMER)
 
 #include "GRefPtrGStreamer.h"
 #include "VideoDecoder.h"
@@ -51,4 +51,4 @@ private:
 
 }
 
-#endif // ENABLE(WEB_CODECS) && USE(GSTREAMER)
+#endif // USE(GSTREAMER)

--- a/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.h
+++ b/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#if ENABLE(WEB_CODECS) && USE(LIBWEBRTC)
+#if USE(LIBWEBRTC)
 
 #include "VideoDecoder.h"
 #include <wtf/FastMalloc.h>
@@ -44,9 +44,9 @@ public:
         VP9_P2,
         AV1
     };
-    static void create(Type, CreateCallback&&, OutputCallback&&, PostTaskCallback&&);
+    static void create(Type, const Config&, CreateCallback&&, OutputCallback&&, PostTaskCallback&&);
 
-    LibWebRTCVPXVideoDecoder(Type, OutputCallback&&, PostTaskCallback&&);
+    LibWebRTCVPXVideoDecoder(Type, const Config&, OutputCallback&&, PostTaskCallback&&);
     ~LibWebRTCVPXVideoDecoder();
 
 private:
@@ -60,4 +60,4 @@ private:
 
 }
 
-#endif // ENABLE(WEB_CODECS) && USE(LIBWEBRTC)
+#endif // USE(LIBWEBRTC)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.cpp
@@ -130,7 +130,7 @@ static bool shouldUseLocalDecoder(std::optional<VideoCodecType> type, const Vide
         return true;
 
 #if PLATFORM(MAC) && CPU(X86_64)
-    if (*type == VideoCodecType::VP9 && config.prefersSoftware)
+    if (*type == VideoCodecType::VP9 && config.decoding == VideoDecoder::HardwareAcceleration::No)
         return true;
 #endif
 


### PR DESCRIPTION
#### 7096369deae13feb0406190c08315fb99d5ae28d
<pre>
[iOS] WebM video does not display
<a href="https://bugs.webkit.org/show_bug.cgi?id=266748">https://bugs.webkit.org/show_bug.cgi?id=266748</a>
<a href="https://rdar.apple.com/119493652">rdar://119493652</a>

Reviewed by Youenn Fablet.

We registered the VP8 decoder in both the content and GPU process but on iOS decoding was done
in mediaserverd.
So instead we decode in the GPU process before passing the decoded frames to the AVSBDL.
This is achieved with a new VideoMediaSampleRenderer AVSBDL wrapper which will first decode
as necessary.

For VP8 and VP9 (where hardware decoding isn&apos;t available), on iOS we use the WebCodec&apos;s VideoDecoder
as the decoders aren&apos;t available in mediaserverd process.
To not have to rely on WebCodec being conditionally enabled, we make VideoDecoder available
even when ENABLE_WEB_CODECS isn&apos;t set.

Add VideoDecoder config option to use a CVPixelBufferPool as CoreMedia requires the use of
IOSurface backed CVPixelBuffer. We don&apos;t make this option the default to prevent unexpected
regressions that would impact WebCodecs.

Manually tested on iOS as currently all webm tests are disabled on iOS.

* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp:
(WebCore::createVideoDecoderConfig):
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/PlatformMediaError.h:
* Source/WebCore/platform/VideoDecoder.cpp:
(WebCore::VideoDecoder::fourCCToCodecString):
(WebCore::VideoDecoder::createLocalDecoder):
* Source/WebCore/platform/VideoDecoder.h:
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(WebCore::SourceBufferPrivateAVFObjC::destroyRenderers):
(WebCore::SourceBufferPrivateAVFObjC::setCDMInstance):
(WebCore::SourceBufferPrivateAVFObjC::flushIfNeeded):
(WebCore::SourceBufferPrivateAVFObjC::outputObscuredDueToInsufficientExternalProtectionChanged):
(WebCore::SourceBufferPrivateAVFObjC::layerRequiresFlushToResumeDecodingChanged):
(WebCore::SourceBufferPrivateAVFObjC::layerReadyForDisplayChanged):
(WebCore::SourceBufferPrivateAVFObjC::flushVideo):
(WebCore::SourceBufferPrivateAVFObjC::canEnqueueSample):
(WebCore::SourceBufferPrivateAVFObjC::enqueueSample):
(WebCore::SourceBufferPrivateAVFObjC::enqueueSampleBuffer):
(WebCore::SourceBufferPrivateAVFObjC::isReadyForMoreSamples):
(WebCore::SourceBufferPrivateAVFObjC::didBecomeReadyForMoreSamples):
(WebCore::SourceBufferPrivateAVFObjC::notifyClientWhenReadyForMoreSamples):
(WebCore::SourceBufferPrivateAVFObjC::canSetMinimumUpcomingPresentationTime const):
(WebCore::SourceBufferPrivateAVFObjC::setMinimumUpcomingPresentationTime):
(WebCore::SourceBufferPrivateAVFObjC::clearMinimumUpcomingPresentationTime):
(WebCore::SourceBufferPrivateAVFObjC::setVideoLayer):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::platformLayer const):
(WebCore::MediaPlayerPrivateWebM::updateLastPixelBuffer):
(WebCore::MediaPlayerPrivateWebM::shouldEnsureLayer const):
(WebCore::MediaPlayerPrivateWebM::setPresentationSize):
(WebCore::MediaPlayerPrivateWebM::enqueueSample):
(WebCore::MediaPlayerPrivateWebM::notifyClientWhenReadyForMoreSamples):
(WebCore::MediaPlayerPrivateWebM::setMinimumUpcomingPresentationTime):
(WebCore::MediaPlayerPrivateWebM::clearMinimumUpcomingPresentationTime):
(WebCore::MediaPlayerPrivateWebM::isReadyForMoreSamples):
(WebCore::MediaPlayerPrivateWebM::didBecomeReadyForMoreSamples):
(WebCore::MediaPlayerPrivateWebM::provideMediaData):
(WebCore::MediaPlayerPrivateWebM::flushIfNeeded):
(WebCore::MediaPlayerPrivateWebM::flushTrack):
(WebCore::MediaPlayerPrivateWebM::flushVideo):
(WebCore::MediaPlayerPrivateWebM::ensureLayer):
(WebCore::MediaPlayerPrivateWebM::destroyLayer):
(WebCore::MediaPlayerPrivateWebM::canSetMinimumUpcomingPresentationTime const): Deleted.
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h: Added.
(WebCore::VideoMediaSampleRenderer::create):
(WebCore::VideoMediaSampleRenderer::displayLayer const):
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm: Added.
(WebCore::VideoMediaSampleRenderer::VideoMediaSampleRenderer):
(WebCore::VideoMediaSampleRenderer::~VideoMediaSampleRenderer):
(WebCore::VideoMediaSampleRenderer::isReadyForMoreMediaData const):
(WebCore::VideoMediaSampleRenderer::stopRequestingMediaData):
(WebCore::VideoMediaSampleRenderer::enqueueSample):
(WebCore::VideoMediaSampleRenderer::initializeDecompressionSession):
(WebCore::VideoMediaSampleRenderer::flush):
(WebCore::VideoMediaSampleRenderer::requestMediaDataWhenReady):
(WebCore::VideoMediaSampleRenderer::resetReadyForMoreSample):
(WebCore::VideoMediaSampleRenderer::expectMinimumUpcomingSampleBufferPresentationTime):
(WebCore::VideoMediaSampleRenderer::resetUpcomingSampleBufferPresentationTimeExpectations):
(WebCore::VideoMediaSampleRenderer::copyDisplayedPixelBuffer const):
(WebCore::VideoMediaSampleRenderer::bounds const):
* Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.h:
* Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.mm:
(WebCore::WebCoreDecompressionSession::invalidate):
(WebCore::WebCoreDecompressionSession::setTimebase):
(WebCore::WebCoreDecompressionSession::setTimebaseWithLockHeld):
(WebCore::WebCoreDecompressionSession::timebase const):
(WebCore::WebCoreDecompressionSession::maybeBecomeReadyForMoreMediaData):
(WebCore::WebCoreDecompressionSession::enqueueSample):
(WebCore::WebCoreDecompressionSession::shouldDecodeSample):
(WebCore::WebCoreDecompressionSession::ensureDecompressionSessionForSample):
(WebCore::WebCoreDecompressionSession::enqueueCompressedSample):
(WebCore::WebCoreDecompressionSession::maybeDecodeNextSample):
(WebCore::WebCoreDecompressionSession::decodeSample):
(WebCore::WebCoreDecompressionSession::setErrorListener):
(WebCore::WebCoreDecompressionSession::removeErrorListener):
(WebCore::WebCoreDecompressionSession::finishCurrentDecodingAndReportError):
(WebCore::WebCoreDecompressionSession::finishCurrentDecodingAndDecodeNextSample):
(WebCore::WebCoreDecompressionSession::decodeSampleSync):
(WebCore::WebCoreDecompressionSession::handleDecompressionOutput):
(WebCore::WebCoreDecompressionSession::automaticDequeue):
(WebCore::WebCoreDecompressionSession::enqueueDecodedSample):
(WebCore::WebCoreDecompressionSession::isReadyForMoreMediaData const):
(WebCore::WebCoreDecompressionSession::requestMediaDataWhenReady):
(WebCore::WebCoreDecompressionSession::decodedFrameWhenAvailable):
(WebCore::WebCoreDecompressionSession::stopRequestingMediaData):
(WebCore::WebCoreDecompressionSession::notifyWhenHasAvailableVideoFrame):
(WebCore::WebCoreDecompressionSession::imageForTime):
(WebCore::WebCoreDecompressionSession::flush):
(WebCore::WebCoreDecompressionSession::resetQosTier):
(WebCore::WebCoreDecompressionSession::increaseQosTier):
(WebCore::WebCoreDecompressionSession::decreaseQosTier):
(WebCore::WebCoreDecompressionSession::updateQosWithDecodeTimeStatistics):
(WebCore::WebCoreDecompressionSession::initializeVideoDecoder):
* Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp:
* Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.h:
* Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp:
(WebCore::LibWebRTCVPXInternalVideoDecoder::create):
(WebCore::LibWebRTCVPXVideoDecoder::create):
(WebCore::LibWebRTCVPXVideoDecoder::LibWebRTCVPXVideoDecoder):
(WebCore::LibWebRTCVPXInternalVideoDecoder::LibWebRTCVPXInternalVideoDecoder):
(WebCore::LibWebRTCVPXInternalVideoDecoder::pixelBufferPool):
(WebCore::LibWebRTCVPXInternalVideoDecoder::Decoded):
* Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.h:

Canonical link: <a href="https://commits.webkit.org/272760@main">https://commits.webkit.org/272760@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf845348d3d84098243c8ee942205f6d26e6a641

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32983 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11753 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34882 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35626 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29804 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33951 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/14112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8927 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/29243 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33455 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9902 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29467 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8638 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8784 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/29423 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36959 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29959 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29834 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/34920 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8924 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6869 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32775 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10615 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7648 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9517 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9553 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->