### PR TITLE
Move Node flags for ownerships and relationships to EventTargetFlag

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -650,7 +650,7 @@ Document::Document(LocalFrame* frame, const Settings& settings, const URL& url, 
     , m_isNonRenderedPlaceholder(constructionFlags.contains(ConstructionFlag::NonRenderedPlaceholder))
     , m_frameIdentifier(frame ? std::optional(frame->frameID()) : std::nullopt)
 {
-    setNodeFlag(NodeFlag::IsConnected);
+    setEventTargetFlag(EventTargetFlag::IsConnected);
     addToDocumentsMap();
 
     // We depend on the url getting immediately set in subframes, but we

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3954,7 +3954,7 @@ void Element::addToTopLayer()
 
     Ref document = this->document();
     document->addTopLayerElement(*this);
-    setNodeFlag(NodeFlag::IsInTopLayer);
+    setEventTargetFlag(EventTargetFlag::IsInTopLayer);
 
     document->scheduleContentRelevancyUpdate(ContentRelevancy::IsInTopLayer);
 
@@ -3989,7 +3989,7 @@ void Element::removeFromTopLayer()
 
     // Unable to protect the document as it may have started destruction.
     document().removeTopLayerElement(*this);
-    clearNodeFlag(NodeFlag::IsInTopLayer);
+    clearEventTargetFlag(EventTargetFlag::IsInTopLayer);
 
     document().scheduleContentRelevancyUpdate(ContentRelevancy::IsInTopLayer);
 

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -595,7 +595,7 @@ public:
     bool isLink() const { return hasNodeFlag(NodeFlag::IsLink); }
     void setIsLink(bool flag);
 
-    bool isInTopLayer() const { return hasNodeFlag(NodeFlag::IsInTopLayer); }
+    bool isInTopLayer() const { return hasEventTargetFlag(EventTargetFlag::IsInTopLayer); }
     void addToTopLayer();
     void removeFromTopLayer();
 
@@ -906,14 +906,14 @@ private:
     bool hasXMLLangAttr() const { return hasEventTargetFlag(EventTargetFlag::HasXMLLangAttr); }
     void setHasXMLLangAttr(bool has) { setEventTargetFlag(EventTargetFlag::HasXMLLangAttr, has); }
 
-    bool effectiveLangKnownToMatchDocumentElement() const { return hasEventTargetFlag(EventTargetFlag::EffectiveLangKnownToMatchDocumentElement); }
-    void setEffectiveLangKnownToMatchDocumentElement(bool matches) { setEventTargetFlag(EventTargetFlag::EffectiveLangKnownToMatchDocumentElement, matches); }
+    bool effectiveLangKnownToMatchDocumentElement() const { return hasNodeFlag(NodeFlag::EffectiveLangKnownToMatchDocumentElement); }
+    void setEffectiveLangKnownToMatchDocumentElement(bool matches) { setNodeFlag(NodeFlag::EffectiveLangKnownToMatchDocumentElement, matches); }
 
     bool hasLanguageAttribute() const { return hasLangAttr() || hasXMLLangAttr(); }
     bool hasLangAttrKnownToMatchDocumentElement() const { return hasLanguageAttribute() && effectiveLangKnownToMatchDocumentElement(); }
 
-    bool hasEverHadSmoothScroll() const { return hasEventTargetFlag(EventTargetFlag::EverHadSmoothScroll); }
-    void setHasEverHadSmoothScroll(bool value) { return setEventTargetFlag(EventTargetFlag::EverHadSmoothScroll, value); }
+    bool hasEverHadSmoothScroll() const { return hasNodeFlag(NodeFlag::EverHadSmoothScroll); }
+    void setHasEverHadSmoothScroll(bool value) { return setNodeFlag(NodeFlag::EverHadSmoothScroll, value); }
 
     void parentOrShadowHostNode() const = delete; // Call parentNode() instead.
 

--- a/Source/WebCore/dom/EventTarget.h
+++ b/Source/WebCore/dom/EventTarget.h
@@ -151,6 +151,9 @@ public:
     bool hasEventTargetData() const { return hasEventTargetFlag(EventTargetFlag::HasEventTargetData); }
     bool isNode() const { return hasEventTargetFlag(EventTargetFlag::IsNode); }
 
+    bool isInGCReacheableRefMap() const { return hasEventTargetFlag(EventTargetFlag::IsInGCReachableRefMap); }
+    void setIsInGCReacheableRefMap(bool flag) { setEventTargetFlag(EventTargetFlag::IsInGCReachableRefMap, flag); }
+
 protected:
     enum ConstructNodeTag { ConstructNode };
     EventTarget() = default;
@@ -161,15 +164,26 @@ protected:
 
     WEBCORE_EXPORT virtual ~EventTarget();
 
+    // Flags for ownership & relationship.
     enum class EventTargetFlag : uint16_t {
-        HasEventTargetData                          = 1 << 0,
-        IsNode                                      = 1 << 1,
+        HasEventTargetData = 1 << 0,
+        IsNode = 1 << 1,
+        IsInGCReachableRefMap = 1 << 2,
+        // Node bits
+        IsConnected = 1 << 3,
+        IsInShadowTree = 1 << 4,
+        HasBeenInUserAgentShadowTree = 1 << 5,
         // Element bits
-        HasDuplicateAttribute                       = 1 << 2,
-        HasLangAttr                                 = 1 << 3,
-        HasXMLLangAttr                              = 1 << 4,
-        EffectiveLangKnownToMatchDocumentElement    = 1 << 5,
-        EverHadSmoothScroll                         = 1 << 6,
+        HasSyntheticAttrChildNodes = 1 << 6,
+        HasDuplicateAttribute = 1 << 7,
+        HasLangAttr = 1 << 8,
+        HasXMLLangAttr = 1 << 9,
+        HasFormAssociatedCustomElementInterface = 1 << 10,
+        HasShadowRootContainingSlots = 1 << 11,
+        IsInTopLayer = 1 << 12,
+        // SVGElement bits
+        HasPendingResources = 1 << 13,
+        // 2 Free bits
     };
 
     EventTargetData& ensureEventTargetData()
@@ -185,7 +199,8 @@ protected:
     virtual void eventListenersDidChange() { }
 
     bool hasEventTargetFlag(EventTargetFlag flag) const { return weakPtrFactory().bitfield() & enumToUnderlyingType(flag); }
-    void setEventTargetFlag(EventTargetFlag, bool);
+    void setEventTargetFlag(EventTargetFlag, bool = true);
+    void clearEventTargetFlag(EventTargetFlag flag) { setEventTargetFlag(flag, false); }
 
 private:
     virtual void refEventTarget() = 0;
@@ -222,12 +237,9 @@ void EventTarget::visitJSEventListeners(Visitor& visitor)
 
 inline void EventTarget::setEventTargetFlag(EventTargetFlag flag, bool value)
 {
-    uint16_t bitfield = weakPtrFactory().bitfield();
-    if (value)
-        bitfield |= enumToUnderlyingType(flag);
-    else
-        bitfield &= ~enumToUnderlyingType(flag);
-    weakPtrFactory().setBitfield(bitfield);
+    auto flags = OptionSet<EventTargetFlag>::fromRaw(weakPtrFactory().bitfield());
+    flags.set(flag, value);
+    weakPtrFactory().setBitfield(flags.toRaw());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/GCReachableRef.cpp
+++ b/Source/WebCore/dom/GCReachableRef.cpp
@@ -30,9 +30,9 @@
 
 namespace WebCore {
 
-HashCountedSet<Node*>& GCReachableRefMap::map()
+HashCountedSet<EventTarget*>& GCReachableRefMap::map()
 {
-    static NeverDestroyed<HashCountedSet<Node*>> map;
+    static NeverDestroyed<HashCountedSet<EventTarget*>> map;
     return map;
 }
 

--- a/Source/WebCore/dom/GCReachableRef.h
+++ b/Source/WebCore/dom/GCReachableRef.h
@@ -36,20 +36,20 @@ class Node;
 
 class GCReachableRefMap {
 public:
-    static inline bool contains(Node& node) { return node.isInGCReacheableRefMap(); }
-    static inline void add(Node& node)
+    static inline bool contains(EventTarget& target) { return target.isInGCReacheableRefMap(); }
+    static inline void add(EventTarget& target)
     {
-        if (map().add(&node).isNewEntry)
-            node.setIsInGCReacheableRefMap(true);
+        if (map().add(&target).isNewEntry)
+            target.setIsInGCReacheableRefMap(true);
     }
-    static inline void remove(Node& node)
+    static inline void remove(EventTarget& target)
     {
-        if (map().remove(&node))
-            node.setIsInGCReacheableRefMap(false);
+        if (map().remove(&target))
+            target.setIsInGCReacheableRefMap(false);
     }
 
 private:
-    static HashCountedSet<Node*>& map();
+    static HashCountedSet<EventTarget*>& map();
 };
 
 template <typename T, typename = std::enable_if_t<std::is_same<T, typename std::remove_const<T>::type>::value>>

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -1427,9 +1427,9 @@ void Node::queueTaskToDispatchEvent(TaskSource source, Ref<Event>&& event)
 Node::InsertedIntoAncestorResult Node::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
     if (insertionType.connectedToDocument)
-        setNodeFlag(NodeFlag::IsConnected);
+        setEventTargetFlag(EventTargetFlag::IsConnected);
     if (parentOfInsertedTree.isInShadowTree())
-        setNodeFlag(NodeFlag::IsInShadowTree);
+        setEventTargetFlag(EventTargetFlag::IsInShadowTree);
 
     invalidateStyle(Style::Validity::SubtreeInvalid, Style::InvalidationMode::InsertedIntoAncestor);
 
@@ -1439,9 +1439,9 @@ Node::InsertedIntoAncestorResult Node::insertedIntoAncestor(InsertionType insert
 void Node::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
     if (removalType.disconnectedFromDocument)
-        clearNodeFlag(NodeFlag::IsConnected);
+        clearEventTargetFlag(EventTargetFlag::IsConnected);
     if (isInShadowTree() && !treeScope().rootNode().isShadowRoot())
-        clearNodeFlag(NodeFlag::IsInShadowTree);
+        clearEventTargetFlag(EventTargetFlag::IsInShadowTree);
     if (removalType.disconnectedFromDocument) {
         if (auto* cache = oldParentOfRemovedTree.document().existingAXObjectCache())
             cache->remove(*this);
@@ -2151,7 +2151,7 @@ void Node::moveTreeToNewScope(Node& root, TreeScope& oldScope, TreeScope& newSco
             ASSERT(!node.isTreeScope());
             RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(&node.treeScope() == &oldScope);
             if (newScopeIsUAShadowTree)
-                node.setNodeFlag(NodeFlag::HasBeenInUserAgentShadowTree);
+                node.setEventTargetFlag(EventTargetFlag::HasBeenInUserAgentShadowTree);
             node.setTreeScope(newScope);
             node.moveNodeToNewDocument(oldDocument, newDocument);
         }, [&](ShadowRoot& shadowRoot) {
@@ -2166,7 +2166,7 @@ void Node::moveTreeToNewScope(Node& root, TreeScope& oldScope, TreeScope& newSco
             ASSERT(!node.isTreeScope());
             RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(&node.treeScope() == &oldScope);
             if (newScopeIsUAShadowTree)
-                node.setNodeFlag(NodeFlag::HasBeenInUserAgentShadowTree);
+                node.setEventTargetFlag(EventTargetFlag::HasBeenInUserAgentShadowTree);
             node.setTreeScope(newScope);
             if (UNLIKELY(!node.hasRareData()))
                 return;

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -246,11 +246,11 @@ public:
 
     bool hasCustomStyleResolveCallbacks() const { return hasNodeFlag(NodeFlag::HasCustomStyleResolveCallbacks); }
 
-    bool hasSyntheticAttrChildNodes() const { return hasNodeFlag(NodeFlag::HasSyntheticAttrChildNodes); }
-    void setHasSyntheticAttrChildNodes(bool flag) { setNodeFlag(NodeFlag::HasSyntheticAttrChildNodes, flag); }
+    bool hasSyntheticAttrChildNodes() const { return hasEventTargetFlag(EventTargetFlag::HasSyntheticAttrChildNodes); }
+    void setHasSyntheticAttrChildNodes(bool flag) { setEventTargetFlag(EventTargetFlag::HasSyntheticAttrChildNodes, flag); }
 
-    bool hasShadowRootContainingSlots() const { return hasNodeFlag(NodeFlag::HasShadowRootContainingSlots); }
-    void setHasShadowRootContainingSlots(bool flag) { setNodeFlag(NodeFlag::HasShadowRootContainingSlots, flag); }
+    bool hasShadowRootContainingSlots() const { return hasEventTargetFlag(EventTargetFlag::HasShadowRootContainingSlots); }
+    void setHasShadowRootContainingSlots(bool flag) { setEventTargetFlag(EventTargetFlag::HasShadowRootContainingSlots, flag); }
 
     bool needsSVGRendererUpdate() const { return hasNodeFlag(NodeFlag::NeedsSVGRendererUpdate); }
     void setNeedsSVGRendererUpdate(bool flag) { setNodeFlag(NodeFlag::NeedsSVGRendererUpdate, flag); }
@@ -360,9 +360,6 @@ public:
 
     void setHasValidStyle();
 
-    bool isInGCReacheableRefMap() const { return hasNodeFlag(NodeFlag::IsInGCReachableRefMap); }
-    void setIsInGCReacheableRefMap(bool flag) { setNodeFlag(NodeFlag::IsInGCReachableRefMap, flag); }
-
     WEBCORE_EXPORT bool isContentEditable() const;
     bool isContentRichlyEditable() const;
 
@@ -410,11 +407,11 @@ public:
 
     // Returns true if this node is associated with a document and is in its associated document's
     // node tree, false otherwise (https://dom.spec.whatwg.org/#connected).
-    bool isConnected() const { return hasNodeFlag(NodeFlag::IsConnected); }
+    bool isConnected() const { return hasEventTargetFlag(EventTargetFlag::IsConnected); }
     bool isInUserAgentShadowTree() const;
-    bool isInShadowTree() const { return hasNodeFlag(NodeFlag::IsInShadowTree); }
-    bool isInTreeScope() const { return hasNodeFlag(NodeFlag::IsConnected) || hasNodeFlag(NodeFlag::IsInShadowTree); }
-    bool hasBeenInUserAgentShadowTree() const { return hasNodeFlag(NodeFlag::HasBeenInUserAgentShadowTree); }
+    bool isInShadowTree() const { return hasEventTargetFlag(EventTargetFlag::IsInShadowTree); }
+    bool isInTreeScope() const { return isConnected() || isInShadowTree(); }
+    bool hasBeenInUserAgentShadowTree() const { return hasEventTargetFlag(EventTargetFlag::HasBeenInUserAgentShadowTree); }
 
     // https://dom.spec.whatwg.org/#in-a-document-tree
     bool isInDocumentTree() const { return isConnected() && !isInShadowTree(); }
@@ -594,31 +591,28 @@ protected:
         IsDocumentFragmentForInnerOuterHTML = 1 << 11,
         IsEditingText = 1 << 12,
         HasCustomStyleResolveCallbacks = 1 << 13,
+        // 2 Free bits
 
         // States
-        IsConnected = 1 << 14,
-        IsInShadowTree = 1 << 15,
         IsLink = 1 << 16, // Element
         IsUserActionElement = 1 << 17,
         IsParsingChildren = 1 << 18,
-        HasSyntheticAttrChildNodes = 1 << 19,
+        EverHadSmoothScroll = 1 << 19,
         SelfOrPrecedingNodesAffectDirAuto = 1 << 20,
-
-        HasPendingResources = 1 << 21,
-        IsInGCReachableRefMap = 1 << 22,
+        EffectiveLangKnownToMatchDocumentElement = 1 << 21,
+        // Free bit
         IsComputedStyleInvalidFlag = 1 << 23,
-        HasShadowRootContainingSlots = 1 << 24,
-        IsInTopLayer = 1 << 25,
+        // 2 Free bits
         NeedsSVGRendererUpdate = 1 << 26,
         NeedsUpdateQueryContainerDependentStyle = 1 << 27,
-        HasBeenInUserAgentShadowTree = 1 << 28,
+        // Free bit
 #if ENABLE(FULLSCREEN_API)
         IsFullscreen = 1 << 29,
         IsIFrameFullscreen = 1 << 30,
 #endif
-        HasFormAssociatedCustomElementInterface = 1U << 31,
+        // Free bit
     };
-    static constexpr auto NodeFlagTypeMask = static_cast<uint32_t>(NodeFlag::IsConnected) - 1;
+    static constexpr auto NodeFlagTypeMask = 0xffff;
 
     enum class TabIndexState : uint8_t {
         NotSet = 0,

--- a/Source/WebCore/dom/PseudoElement.cpp
+++ b/Source/WebCore/dom/PseudoElement.cpp
@@ -53,7 +53,7 @@ PseudoElement::PseudoElement(Element& host, PseudoId pseudoId)
     , m_hostElement(host)
     , m_pseudoId(pseudoId)
 {
-    setNodeFlag(NodeFlag::IsConnected);
+    setEventTargetFlag(EventTargetFlag::IsConnected);
     ASSERT(pseudoId == PseudoId::Before || pseudoId == PseudoId::After);
 }
 

--- a/Source/WebCore/dom/ShadowRoot.cpp
+++ b/Source/WebCore/dom/ShadowRoot.cpp
@@ -73,9 +73,9 @@ ShadowRoot::ShadowRoot(Document& document, ShadowRootMode mode, SlotAssignmentMo
     , m_slotAssignmentMode(assignmentMode)
     , m_styleScope(makeUnique<Style::Scope>(*this))
 {
-    setNodeFlag(NodeFlag::IsInShadowTree);
+    setEventTargetFlag(EventTargetFlag::IsInShadowTree);
     if (m_mode == ShadowRootMode::UserAgent)
-        setNodeFlag(NodeFlag::HasBeenInUserAgentShadowTree);
+        setEventTargetFlag(EventTargetFlag::HasBeenInUserAgentShadowTree);
 }
 
 
@@ -86,8 +86,8 @@ ShadowRoot::ShadowRoot(Document& document, std::unique_ptr<SlotAssignment>&& slo
     , m_styleScope(makeUnique<Style::Scope>(*this))
     , m_slotAssignment(WTFMove(slotAssignment))
 {
-    setNodeFlag(NodeFlag::IsInShadowTree);
-    setNodeFlag(NodeFlag::HasBeenInUserAgentShadowTree);
+    setEventTargetFlag(EventTargetFlag::IsInShadowTree);
+    setEventTargetFlag(EventTargetFlag::HasBeenInUserAgentShadowTree);
 }
 
 

--- a/Source/WebCore/html/HTMLMaybeFormAssociatedCustomElement.cpp
+++ b/Source/WebCore/html/HTMLMaybeFormAssociatedCustomElement.cpp
@@ -166,7 +166,7 @@ void HTMLMaybeFormAssociatedCustomElement::finishParsingChildren()
 
 void HTMLMaybeFormAssociatedCustomElement::setInterfaceIsFormAssociated()
 {
-    setNodeFlag(NodeFlag::HasFormAssociatedCustomElementInterface);
+    setEventTargetFlag(EventTargetFlag::HasFormAssociatedCustomElementInterface, true);
     ensureFormAssociatedCustomElement();
 }
 

--- a/Source/WebCore/html/HTMLMaybeFormAssociatedCustomElement.h
+++ b/Source/WebCore/html/HTMLMaybeFormAssociatedCustomElement.h
@@ -59,7 +59,7 @@ public:
     bool isDisabledFormControl() const final;
 
     void setInterfaceIsFormAssociated();
-    bool hasFormAssociatedInterface() const { return hasNodeFlag(NodeFlag::HasFormAssociatedCustomElementInterface); }
+    bool hasFormAssociatedInterface() const { return hasEventTargetFlag(EventTargetFlag::HasFormAssociatedCustomElementInterface); }
 
     void willUpgradeFormAssociated();
     void didUpgradeFormAssociated();

--- a/Source/WebCore/svg/SVGElement.h
+++ b/Source/WebCore/svg/SVGElement.h
@@ -64,9 +64,9 @@ public:
     void setInstanceUpdatesBlocked(bool);
     virtual AffineTransform localCoordinateSpaceTransform(SVGLocatable::CTMScope) const;
 
-    bool hasPendingResources() const { return hasNodeFlag(NodeFlag::HasPendingResources); }
-    void setHasPendingResources() { setNodeFlag(NodeFlag::HasPendingResources); }
-    void clearHasPendingResources() { clearNodeFlag(NodeFlag::HasPendingResources); }
+    bool hasPendingResources() const { return hasEventTargetFlag(EventTargetFlag::HasPendingResources); }
+    void setHasPendingResources() { setEventTargetFlag(EventTargetFlag::HasPendingResources, true); }
+    void clearHasPendingResources() { setEventTargetFlag(EventTargetFlag::HasPendingResources, false); }
     virtual void buildPendingResource() { }
 
     virtual bool isSVGGraphicsElement() const { return false; }


### PR DESCRIPTION
#### ea5e30e46342b0e755281a1ffb2f23c37a2b9bcd
<pre>
Move Node flags for ownerships and relationships to EventTargetFlag
<a href="https://bugs.webkit.org/show_bug.cgi?id=266754">https://bugs.webkit.org/show_bug.cgi?id=266754</a>

Reviewed by Tim Nguyen.

This PR consolidates NodeFlag flags that express ownership and relationships with other objects
to EventTargetFlag. NodeFlag now represents Node&apos;s types and its own state.

The lower 16-bit of NodeFlag is now reserved for type information, and only upper 16-bits can be
used to express Node&apos;s states.

It also generalizes GCReachableRefMap so that it works with any EventTarget instead of just Node.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::Document):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::addToTopLayer):
(WebCore::Element::removeFromTopLayer):
* Source/WebCore/dom/Element.h:
(WebCore::Element::isInTopLayer const):
(WebCore::Element::effectiveLangKnownToMatchDocumentElement const):
(WebCore::Element::setEffectiveLangKnownToMatchDocumentElement):
(WebCore::Element::hasEverHadSmoothScroll const):
(WebCore::Element::setHasEverHadSmoothScroll):
* Source/WebCore/dom/EventTarget.h:
(WebCore::EventTarget::isInGCReacheableRefMap const): Moved from Node.
(WebCore::EventTarget::setIsInGCReacheableRefMap): Ditto.
(WebCore::EventTarget::clearEventTargetFlag): Added.
(WebCore::EventTarget::setEventTargetFlag): Use OptionSet to manipulate bitfields for clarity
and simplicity.
* Source/WebCore/dom/GCReachableRef.cpp:
(WebCore::GCReachableRefMap::map):
* Source/WebCore/dom/GCReachableRef.h:
(WebCore::GCReachableRefMap::contains): Now works with any EventTarget, not just Node.
(WebCore::GCReachableRefMap::add): Ditto.
(WebCore::GCReachableRefMap::remove): Ditto.
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::insertedIntoAncestor):
(WebCore::Node::removedFromAncestor):
(WebCore::Node::moveTreeToNewScope):
* Source/WebCore/dom/Node.h:
(WebCore::Node::hasSyntheticAttrChildNodes const):
(WebCore::Node::setHasSyntheticAttrChildNodes):
(WebCore::Node::hasShadowRootContainingSlots const):
(WebCore::Node::setHasShadowRootContainingSlots):
(WebCore::Node::isConnected const):
(WebCore::Node::isInShadowTree const):
(WebCore::Node::isInTreeScope const):
(WebCore::Node::hasBeenInUserAgentShadowTree const):
(WebCore::Node::isInGCReacheableRefMap const): Deleted.
(WebCore::Node::setIsInGCReacheableRefMap): Deleted.
* Source/WebCore/dom/PseudoElement.cpp:
(WebCore::PseudoElement::PseudoElement):
* Source/WebCore/dom/ShadowRoot.cpp:
(WebCore::ShadowRoot::ShadowRoot):
* Source/WebCore/html/HTMLMaybeFormAssociatedCustomElement.cpp:
(WebCore::HTMLMaybeFormAssociatedCustomElement::setInterfaceIsFormAssociated):
* Source/WebCore/html/HTMLMaybeFormAssociatedCustomElement.h:
* Source/WebCore/svg/SVGElement.h:
(WebCore::SVGElement::hasPendingResources const):
(WebCore::SVGElement::setHasPendingResources):
(WebCore::SVGElement::clearHasPendingResources):

Canonical link: <a href="https://commits.webkit.org/272421@main">https://commits.webkit.org/272421@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f7944256f4ac58964f1af5d421244b9b89981425

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31522 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10197 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33227 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34011 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28548 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32293 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12549 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7445 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28163 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31863 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8588 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28133 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7392 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7571 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28040 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35354 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28650 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28487 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33689 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7637 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5654 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31536 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9294 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8325 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4123 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8141 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->