### PR TITLE
[GTK][WPE] Add an option to build unified for distcheck

### DIFF
--- a/Tools/Scripts/make-dist
+++ b/Tools/Scripts/make-dist
@@ -233,7 +233,7 @@ class Distcheck(object):
         with closing(tarfile.open(tarball_path, 'r')) as tarball:
             tarball.extractall(self.build_root)
 
-    def configure(self, dist_dir, build_dir, install_dir, port):
+    def configure(self, dist_dir, build_dir, install_dir, port, build_unified):
         def create_dir(directory, directory_type):
             try:
                 os.mkdir(directory)
@@ -244,7 +244,9 @@ class Distcheck(object):
         create_dir(build_dir, "build")
         create_dir(install_dir, "install")
 
-        command = ['cmake', '-DPORT=%s' % port, '-DCMAKE_INSTALL_PREFIX=%s' % install_dir, '-DCMAKE_BUILD_TYPE=Release', dist_dir, '-DENABLE_UNIFIED_BUILDS=OFF']
+        command = ['cmake', '-DPORT=%s' % port, '-DCMAKE_INSTALL_PREFIX=%s' % install_dir, '-DCMAKE_BUILD_TYPE=Release', dist_dir]
+        if not build_unified:
+            command.append('-DENABLE_UNIFIED_BUILDS=OFF')
         subprocess.check_call(command, cwd=build_dir)
 
     def build(self, build_dir):
@@ -272,14 +274,14 @@ class Distcheck(object):
     def clean(self, dist_dir):
         shutil.rmtree(dist_dir)
 
-    def check(self, tarball, port):
+    def check(self, tarball, port, build_unified):
         tarball_name, ext = os.path.splitext(os.path.basename(tarball))
         dist_dir = os.path.join(self.build_root, tarball_name)
         build_dir = os.path.join(dist_dir, self.BUILD_DIRECTORY_NAME)
         install_dir = os.path.join(dist_dir, self.INSTALL_DIRECTORY_NAME)
 
         self.extract_tarball(tarball)
-        self.configure(dist_dir, build_dir, install_dir, port)
+        self.configure(dist_dir, build_dir, install_dir, port, build_unified)
         self.build(build_dir)
         if port == 'GTK':
             self.check_symbols(build_dir)
@@ -314,6 +316,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Build a distribution bundle.')
     parser.add_argument('-c', '--check', action='store_true',
                         help='Check the tarball')
+    parser.add_argument('-u', '--unified', action='store_true',
+                        help='Build unified when checking the tarball')
     parser.add_argument('-s', '--source-dir', type=str, action=FilePathAction, default=os.getcwd(),
                         help='The top-level directory of the source distribution. ' + \
                               'Directory for relative paths. Defaults to current directory.')
@@ -342,4 +346,4 @@ if __name__ == "__main__":
     manifest.create_tarfile(output_filename)
 
     if arguments.check:
-        Distcheck(arguments.source_dir, arguments.build_dir).check(output_filename, arguments.port)
+        Distcheck(arguments.source_dir, arguments.build_dir).check(output_filename, arguments.port, arguments.unified)


### PR DESCRIPTION
#### fd785b7f04f7ecf74ffb81f6bc28a6d339075583
<pre>
[GTK][WPE] Add an option to build unified for distcheck
<a href="https://bugs.webkit.org/show_bug.cgi?id=266755">https://bugs.webkit.org/show_bug.cgi?id=266755</a>

Reviewed by Adrian Perez de Castro.

* Tools/Scripts/make-dist:
(Distcheck.extract_tarball):
(Distcheck.configure):
(Distcheck.clean):
(Distcheck.check):

Canonical link: <a href="https://commits.webkit.org/272404@main">https://commits.webkit.org/272404@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6315de97ab870fecba0aeb848e1e61bdbe72a865

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31523 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10198 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33228 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34012 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28549 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32294 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12550 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7446 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/28162 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31864 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/8589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/28132 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7391 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/7558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/28039 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35355 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/28651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/28486 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/33683 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7638 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/5653 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31530 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9295 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8326 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4117 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8142 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->