### PR TITLE
[JHBuild] Fix build for Ubuntu 20.04, follow-up 272173@main

### DIFF
--- a/Tools/Scripts/webkitpy/binary_bundling/bundle.py
+++ b/Tools/Scripts/webkitpy/binary_bundling/bundle.py
@@ -189,8 +189,9 @@ class BinaryBundler:
                         xkb_bundled = True
                         break
                 if xkb_bundled:
-                    assert os.path.isdir(os.path.join(share_dir, 'xkb'))
-                    script_handle.write('[ -d /usr/share/X11/xkb ] || export XKB_CONFIG_ROOT="${%s}/sys/share/xkb"\n' % self.VAR_MYDIR)
+                    # FIXME: the xkb directory is only copied when --syslibs=bundle-all but not with --syslibs=generate-script and we may be including libxkbcommon.so in that case (jhbuild for example)
+                    if os.path.isdir(os.path.join(share_dir, 'xkb')):
+                        script_handle.write('[ -d /usr/share/X11/xkb ] || export XKB_CONFIG_ROOT="${%s}/sys/share/xkb"\n' % self.VAR_MYDIR)
 
             ld_library_path = '${%s}/lib' % self.VAR_MYDIR
             if os.path.isdir(syslib_dir):

--- a/Tools/glib/dependencies/apt
+++ b/Tools/glib/dependencies/apt
@@ -94,18 +94,24 @@ PACKAGES=(
     libglib2.0-bin
 
     # These are dependencies necessary for building the jhbuild.
+    bison
+    flex
     git
+    gobject-introspection
     gsettings-desktop-schemas-dev
     gyp
     libegl1-mesa-dev
     libexpat1-dev
     $(aptIfExists libfdk-aac-dev)
+    libgirepository1.0-dev
     libgles2-mesa-dev
     liborc-0.4-dev
     libproxy-dev
     libpsl-dev
+    libssl-dev
     libtool-bin
     libxml-libxml-perl
+    nasm
     python3-setuptools
     uuid-dev
     yasm

--- a/Tools/gstreamer/jhbuild.modules
+++ b/Tools/gstreamer/jhbuild.modules
@@ -77,7 +77,7 @@
   <!-- GStreamer plugins have been moved with the base code to a monorepo.
   Is not longer needed to fetch different tarballs when using the main repository.
   See: https://gstreamer.freedesktop.org/documentation/frequently-asked-questions/mono-repository.html -->
-  <meson id="gstreamer" mesonargs="-Dlibnice=enabled -Dpython=enabled -Dintrospection=enabled -Dgst-plugins-bad:microdns=disabled -Dgst-plugins-bad:avtp=disabled -Dexamples=disabled -Dtests=disabled -Ddoc=disabled">
+  <meson id="gstreamer" mesonargs="-Dlibnice=enabled -Dpython=enabled -Dintrospection=enabled -Dgst-plugins-bad:microdns=disabled -Dgst-plugins-bad:avtp=disabled -Dgst-examples=disabled -Dexamples=disabled -Dtests=disabled -Ddoc=disabled">
     <dependencies>
       <dep package="aom"/>
       <dep package="ffmpeg"/>

--- a/Tools/gtk/dependencies/apt
+++ b/Tools/gtk/dependencies/apt
@@ -9,7 +9,6 @@ PACKAGES+=(
     libedit-dev
     libfaad-dev
     libffi-dev
-    libgirepository1.0-dev
     libgl1-mesa-dev
     $(aptIfExists libgl1-mesa-glx)
     $(aptIfExists libgtk-4-dev)
@@ -32,7 +31,6 @@ PACKAGES+=(
     libxcomposite-dev
     libxt-dev
     libxtst-dev
-    nasm
     unifdef
     xfonts-utils
 
@@ -48,9 +46,6 @@ PACKAGES+=(
     $(aptIfExists python-yaml)
 
     # These are dependencies necessary for building the jhbuild.
-    bison
-    flex
-    gobject-introspection
     icon-naming-utils
     libcups2-dev
     libevdev-dev
@@ -61,7 +56,6 @@ PACKAGES+=(
     libmtdev-dev
     libp11-kit-dev
     libpciaccess-dev
-    libssl-dev
     libtiff5-dev
     libudev-dev
     libunistring-dev


### PR DESCRIPTION
#### 03f82a2cffe10d07cc8a99526c5a46bc099d7ccf
<pre>
[JHBuild] Fix build for Ubuntu 20.04, follow-up 272173@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=266229">https://bugs.webkit.org/show_bug.cgi?id=266229</a>

Reviewed by Carlos Alberto Lopez Perez.

* Tools/Scripts/webkitpy/binary_bundling/bundle.py: Fix assertion in
  generate-bundle introduced after including &apos;libxkbcommon&apos;.
(BinaryBundler.generate_wrapper_script):
* Tools/glib/dependencies/apt: Update system dependencies neeeded to
  build GTK and WPE.
* Tools/gstreamer/jhbuild.modules: Disable &apos;gst-examples&apos;, it was
  causing a conflict with library &apos;sysprof&apos;.
* Tools/gtk/dependencies/apt: Move system dependencies to GLIB.

Canonical link: <a href="https://commits.webkit.org/272409@main">https://commits.webkit.org/272409@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/621d7d76d8855f5895cf73d03b53a81d77c92217

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31535 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10212 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33244 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34026 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28560 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32309 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12565 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7459 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/28172 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31878 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8601 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28149 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7406 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/31695 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7569 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28056 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35370 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28665 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28503 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/33697 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7649 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5667 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31546 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9304 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7407 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8337 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8154 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->