### PR TITLE
[Buildstream SDK] Bump to GStreamer 1.22.8 and include a libsoup patch

### DIFF
--- a/Tools/buildstream/elements/freedesktop-sdk.bst
+++ b/Tools/buildstream/elements/freedesktop-sdk.bst
@@ -7,9 +7,11 @@ sources:
 - kind: patch
   path: patches/fdo-0001-gtk3-Include-changes-from-downstream-WebKit-SDK.patch
 - kind: patch
+  path: patches/fdo-0003-libsoup-Vendor-patch-needed-for-test-bots.patch
+- kind: patch
   path: patches/fdo-0004-gst-plugins-ugly-Enable-x264-encoder.patch
 - kind: patch
-  path: patches/fdo-0005-GStreamer-Bump-to-1.22.7.patch
+  path: patches/fdo-0005-GStreamer-Bump-to-1.22.8.patch
 - kind: patch
   path: patches/fdo-0006-gst-plugins-bad-Enable-soundtouch.patch
 - kind: patch

--- a/Tools/buildstream/patches/fdo-0003-libsoup-Vendor-patch-needed-for-test-bots.patch
+++ b/Tools/buildstream/patches/fdo-0003-libsoup-Vendor-patch-needed-for-test-bots.patch
@@ -1,0 +1,85 @@
+From 0699264013211ad778a1284ce7490d9acfb1c757 Mon Sep 17 00:00:00 2001
+From: Philippe Normand <philn@igalia.com>
+Date: Thu, 21 Dec 2023 10:19:01 +0000
+Subject: [PATCH] libsoup: Vendor patch needed for test bots
+
+I suppose that will ship in libsoup 3.4.5.
+---
+ elements/components/libsoup.bst               |  2 +
+ ...ef-of-the-item-when-calling-soup_mes.patch | 54 +++++++++++++++++++
+ 2 files changed, 56 insertions(+)
+ create mode 100644 patches/libsoup/0001-session-take-a-ref-of-the-item-when-calling-soup_mes.patch
+
+diff --git a/elements/components/libsoup.bst b/elements/components/libsoup.bst
+index d0351e4..c3ecd15 100644
+--- a/elements/components/libsoup.bst
++++ b/elements/components/libsoup.bst
+@@ -38,3 +38,5 @@ sources:
+   url: gnome:libsoup.git
+   track: 3.[02468].*
+   ref: 3.4.4-0-gd6133a8e116953dac824b835d4f788e21a3e6565
++- kind: patch
++  path: patches/libsoup/0001-session-take-a-ref-of-the-item-when-calling-soup_mes.patch
+diff --git a/patches/libsoup/0001-session-take-a-ref-of-the-item-when-calling-soup_mes.patch b/patches/libsoup/0001-session-take-a-ref-of-the-item-when-calling-soup_mes.patch
+new file mode 100644
+index 0000000..57a7ae4
+--- /dev/null
++++ b/patches/libsoup/0001-session-take-a-ref-of-the-item-when-calling-soup_mes.patch
+@@ -0,0 +1,54 @@
++From 2a592b114092b0105f9f27af17225a3b35c288f8 Mon Sep 17 00:00:00 2001
++From: Carlos Garcia Campos <cgarcia@igalia.com>
++Date: Thu, 21 Dec 2023 09:25:07 +0100
++Subject: [PATCH] session: take a ref of the item when calling
++ soup_message_io_run_until_read_async
++
++And release it in the callback. In case of cancellation the item can be
++finished by explicitly calling soup_session_process_queue_item()
++which can release the last reference before
++async_send_request_return_result() is called.
++---
++ libsoup/soup-session.c | 5 ++++-
++ 1 file changed, 4 insertions(+), 1 deletion(-)
++
++diff --git a/libsoup/soup-session.c b/libsoup/soup-session.c
++index 631bec01..18b9c0a0 100644
++--- a/libsoup/soup-session.c
+++++ b/libsoup/soup-session.c
++@@ -2801,6 +2801,7 @@ run_until_read_done (SoupMessage          *msg,
++ 	if (error && (!item->io_started || item->state == SOUP_MESSAGE_RESTARTING)) {
++ 		/* Message was restarted, we'll try again. */
++ 		g_error_free (error);
+++                soup_message_queue_item_unref (item);
++ 		return;
++ 	}
++ 
++@@ -2809,6 +2810,7 @@ run_until_read_done (SoupMessage          *msg,
++ 
++ 	if (stream) {
++ 		send_async_maybe_complete (item, stream);
+++                soup_message_queue_item_unref (item);
++ 	        return;
++ 	}
++ 
++@@ -2820,6 +2822,7 @@ run_until_read_done (SoupMessage          *msg,
++ 		soup_session_process_queue_item (item->session, item, FALSE);
++ 	}
++ 	async_send_request_return_result (item, NULL, error);
+++        soup_message_queue_item_unref (item);
++ }
++ 
++ static void
++@@ -2831,7 +2834,7 @@ async_send_request_running (SoupSession *session, SoupMessageQueueItem *item)
++ 						      item->io_priority,
++ 						      item->cancellable,
++ 						      (GAsyncReadyCallback)run_until_read_done,
++-						      item);
+++						      soup_message_queue_item_ref (item));
++ 		return;
++ 	}
++ 
++-- 
++2.43.0
++
+-- 
+2.43.0
+

--- a/Tools/buildstream/patches/fdo-0005-GStreamer-Bump-to-1.22.8.patch
+++ b/Tools/buildstream/patches/fdo-0005-GStreamer-Bump-to-1.22.8.patch
@@ -1,17 +1,16 @@
-From 297d68b30e6feeda0a399d697f112d31f5d75006 Mon Sep 17 00:00:00 2001
+From 627bd29a83425c1cf7a75be3e7ad2efce9605dc0 Mon Sep 17 00:00:00 2001
 From: Philippe Normand <philn@igalia.com>
-Date: Thu, 23 Nov 2023 17:29:44 +0000
-Subject: [PATCH] GStreamer: Bump to 1.22.7
+Date: Thu, 21 Dec 2023 10:42:51 +0000
+Subject: [PATCH] GStreamer: Bump to 1.22.8
 
-Also include an avviddec deadlock fix scheduled to ship in 1.22.8.
 ---
  .../components/gstreamer-plugins-good.bst     |  1 +
  elements/include/gstreamer-source.yml         |  2 +-
- ...stream-lock-while-waiting-for-decode.patch | 33 +++++++++++++++++
  .../gstreamer/graceful-error-noopenh264.patch | 35 -------------------
- 4 files changed, 35 insertions(+), 36 deletions(-)
- create mode 100644 patches/gstreamer/0001-avviddec-Unlock-stream-lock-while-waiting-for-decode.patch
+ ...ins-bad-Optional-LRDF-dep-for-ladspa.patch | 13 -------
+ 4 files changed, 2 insertions(+), 49 deletions(-)
  delete mode 100644 patches/gstreamer/graceful-error-noopenh264.patch
+ delete mode 100644 patches/gstreamer/gst-plugins-bad-Optional-LRDF-dep-for-ladspa.patch
 
 diff --git a/elements/components/gstreamer-plugins-good.bst b/elements/components/gstreamer-plugins-good.bst
 index cea2a32..5d5224a 100644
@@ -26,7 +25,7 @@ index cea2a32..5d5224a 100644
  public:
    cpe:
 diff --git a/elements/include/gstreamer-source.yml b/elements/include/gstreamer-source.yml
-index f36b91e..a5050cc 100644
+index f36b91e..8fdb4f6 100644
 --- a/elements/include/gstreamer-source.yml
 +++ b/elements/include/gstreamer-source.yml
 @@ -2,6 +2,6 @@ sources:
@@ -34,48 +33,9 @@ index f36b91e..a5050cc 100644
    url: freedesktop:gstreamer/gstreamer.git
    track: 1.*[02468].*
 -  ref: 1.22.5-0-gbf6ce1d64a0697e7910826147b48f8f658366a5a
-+  ref: 1.22.7-0-g4d13eddc8b6d3f42ba44682ba42048acf170547f
++  ref: 1.22.8-0-g4af14db10e8355f980bbf79733af004e59d255fc
  - kind: patch_queue
    path: patches/gstreamer
-diff --git a/patches/gstreamer/0001-avviddec-Unlock-stream-lock-while-waiting-for-decode.patch b/patches/gstreamer/0001-avviddec-Unlock-stream-lock-while-waiting-for-decode.patch
-new file mode 100644
-index 0000000..40ae478
---- /dev/null
-+++ b/patches/gstreamer/0001-avviddec-Unlock-stream-lock-while-waiting-for-decode.patch
-@@ -0,0 +1,33 @@
-+From f96d05bf52d2e7b97241ed29b019fc5ad573592a Mon Sep 17 00:00:00 2001
-+From: Seungha Yang <seungha@centricular.com>
-+Date: Fri, 17 Nov 2023 01:01:36 +0900
-+Subject: [PATCH] avviddec: Unlock stream lock while waiting for decoded frame
-+
-+FFmpeg might request buffer from other threads, it will result
-+in deadlock
-+
-+Fixes: https://gitlab.freedesktop.org/gstreamer/gstreamer/-/issues/2558
-+Part-of: <https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/5683>
-+---
-+ subprojects/gst-libav/ext/libav/gstavviddec.c | 4 ++++
-+ 1 file changed, 4 insertions(+)
-+
-+diff --git a/subprojects/gst-libav/ext/libav/gstavviddec.c b/subprojects/gst-libav/ext/libav/gstavviddec.c
-+index 1c10bb28ce..060b2f7dbe 100644
-+--- a/subprojects/gst-libav/ext/libav/gstavviddec.c
-++++ b/subprojects/gst-libav/ext/libav/gstavviddec.c
-+@@ -1779,7 +1779,11 @@ gst_ffmpegviddec_video_frame (GstFFMpegVidDec * ffmpegdec,
-+    * else we might skip a reference frame */
-+   gst_ffmpegviddec_do_qos (ffmpegdec, frame, &mode_switch);
-+ 
-++  /* FFmpeg might request new buffer from other threads.
-++   * Release lock here */
-++  GST_VIDEO_DECODER_STREAM_UNLOCK (ffmpegdec);
-+   res = avcodec_receive_frame (ffmpegdec->context, ffmpegdec->picture);
-++  GST_VIDEO_DECODER_STREAM_LOCK (ffmpegdec);
-+ 
-+   /* No frames available at this time */
-+   if (res == AVERROR (EAGAIN)) {
-+-- 
-+2.42.0
-+
 diff --git a/patches/gstreamer/graceful-error-noopenh264.patch b/patches/gstreamer/graceful-error-noopenh264.patch
 deleted file mode 100644
 index 8fbe833..0000000
@@ -117,6 +77,25 @@ index 8fbe833..0000000
 -   unsigned int uiTraceLevel = WELS_LOG_ERROR;
 -   openh264enc->encoder->SetOption (ENCODER_OPTION_TRACE_LEVEL, &uiTraceLevel);
 - 
+diff --git a/patches/gstreamer/gst-plugins-bad-Optional-LRDF-dep-for-ladspa.patch b/patches/gstreamer/gst-plugins-bad-Optional-LRDF-dep-for-ladspa.patch
+deleted file mode 100644
+index a91cf04..0000000
+--- a/patches/gstreamer/gst-plugins-bad-Optional-LRDF-dep-for-ladspa.patch
++++ /dev/null
+@@ -1,13 +0,0 @@
+-diff --git a/subprojects/gst-plugins-bad/ext/ladspa/meson.build b/subprojects/gst-plugins-bad/ext/ladspa/meson.build
+-index adfd3459e2..3e8060796d 100644
+---- a/subprojects/gst-plugins-bad/ext/ladspa/meson.build
+-+++ b/subprojects/gst-plugins-bad/ext/ladspa/meson.build
+-@@ -13,7 +13,7 @@ if get_option('ladspa').disabled()
+- endif
+- 
+- # This is an optional dep, but we make it optional only in auto mode
+--lrdf_dep = dependency('lrdf', required : get_option('ladspa'))
+-+lrdf_dep = dependency('lrdf', required: false)
+- if lrdf_dep.found()
+-   ladspa_cargs = ['-DHAVE_LRDF']
+- endif
 -- 
-2.42.0
+2.43.0
 


### PR DESCRIPTION
#### e769fe6c134e4f7d482d9784f8592ba2da606fd5
<pre>
[Buildstream SDK] Bump to GStreamer 1.22.8 and include a libsoup patch
<a href="https://bugs.webkit.org/show_bug.cgi?id=266757">https://bugs.webkit.org/show_bug.cgi?id=266757</a>

Reviewed by Carlos Garcia Campos.

* Tools/buildstream/elements/freedesktop-sdk.bst:
* Tools/buildstream/patches/fdo-0003-libsoup-Vendor-patch-needed-for-test-bots.patch: Added.
* Tools/buildstream/patches/fdo-0005-GStreamer-Bump-to-1.22.7.patch: Removed.
* Tools/buildstream/patches/fdo-0005-GStreamer-Bump-to-1.22.8.patch: Added.

Canonical link: <a href="https://commits.webkit.org/272413@main">https://commits.webkit.org/272413@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b24b66347c9d8595fe9c31d9806a9a4b0d434f1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31540 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10217 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33249 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34031 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28565 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32314 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12570 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7464 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28177 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31883 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8607 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28154 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7411 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7576 "Found 1 new test failure: imported/w3c/web-platform-tests/webrtc-extensions/RTCRtpSynchronizationSource-senderCaptureTimeOffset.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28061 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35375 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28671 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28508 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33702 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7654 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5672 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31553 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9309 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8342 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4119 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8159 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->