### PR TITLE
Correct parsing and serialization of -webkit-prefixed pseudo elements

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/webkit-pseudo-element-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/webkit-pseudo-element-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL rules include webkit-prefixed pseudo-element should be cascaded assert_equals: expected "rgb(0, 255, 0)" but got "rgb(255, 0, 0)"
-FAIL webkit-prefixed pseudo-element selectors should be accessible from CSSOM undefined is not an object (evaluating 'sheet.cssRules[1].selectorText')
+PASS rules include webkit-prefixed pseudo-element should be cascaded
+PASS webkit-prefixed pseudo-element selectors should be accessible from CSSOM
 PASS qS and qSA shouldn't throw exception
-FAIL webkit-prefix without dash is invalid assert_equals: expected 2 but got 1
+PASS webkit-prefix without dash is invalid
 

--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -329,7 +329,8 @@ CSSSelector::PseudoElementType CSSSelector::parsePseudoElementType(StringView na
             return PseudoElementUnknown;
         break;
     case PseudoElementUnknown:
-        if (name.startsWith("-webkit-"_s) || name.startsWith("-apple-"_s))
+        // FIXME: Investigate removing -apple- as it's non-standard.
+        if (name.startsWithIgnoringASCIICase("-webkit-"_s) || name.startsWithIgnoringASCIICase("-apple-"_s))
             return PseudoElementWebKitCustom;
         break;
     case PseudoElementHighlight:
@@ -838,7 +839,8 @@ String CSSSelector::selectorText(StringView separator, StringView rightSide) con
             }
 #endif
             default:
-                builder.append("::", cs->serializingValue());
+                builder.append("::");
+                serializeIdentifier(cs->serializingValue(), builder);
             }
         } else if (cs->isAttributeSelector()) {
             builder.append('[');


### PR DESCRIPTION
#### 1a1341a4dec7b50d2778a3100bb30f59c1710343
<pre>
Correct parsing and serialization of -webkit-prefixed pseudo elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=266759">https://bugs.webkit.org/show_bug.cgi?id=266759</a>
<a href="https://rdar.apple.com/118081134">rdar://118081134</a>

Reviewed by Antti Koivisto.

We were not matching the prefix case-insensitively and when serializing
we forgot about the potential for identifier escapes.

* LayoutTests/imported/w3c/web-platform-tests/css/selectors/webkit-pseudo-element-expected.txt:
* Source/WebCore/css/CSSSelector.cpp:
(WebCore::CSSSelector::parsePseudoElementType):
(WebCore::CSSSelector::selectorText const):

Canonical link: <a href="https://commits.webkit.org/272411@main">https://commits.webkit.org/272411@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7337d5d7f61160c19b47aabbeb6c5c4e6e4be13

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31544 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10221 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33253 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34035 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28569 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32318 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12574 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7468 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28181 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31887 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8610 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28157 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7416 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7579 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28064 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35379 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28674 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28511 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33709 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7658 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5674 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31560 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9313 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7409 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8346 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8163 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->