### PR TITLE
ImageBitmap and ImageBitmapBacking have unused functions

### DIFF
--- a/Source/WebCore/html/ImageBitmap.cpp
+++ b/Source/WebCore/html/ImageBitmap.cpp
@@ -125,14 +125,12 @@ RefPtr<ImageBuffer> ImageBitmap::createImageBuffer(ScriptExecutionContext& scrip
     return createImageBuffer(scriptExecutionContext, size, bufferRenderingMode, colorSpace, resolutionScale);
 }
 
-Vector<std::optional<ImageBitmapBacking>> ImageBitmap::detachBitmaps(Vector<RefPtr<ImageBitmap>>&& bitmaps)
+std::optional<ImageBitmapBacking> ImageBitmap::detach()
 {
-    return WTF::map(WTFMove(bitmaps), [](auto&& bitmap) {
-        std::optional<ImageBitmapBacking> backing = bitmap->takeImageBitmapBacking();
-        if (backing)
-            backing->disconnect();
-        return backing;
-    });
+    std::optional<ImageBitmapBacking> backing = takeImageBitmapBacking();
+    if (backing)
+        backing->disconnect();
+    return backing;
 }
 
 void ImageBitmap::createPromise(ScriptExecutionContext& scriptExecutionContext, ImageBitmap::Source&& source, ImageBitmapOptions&& options, int sx, int sy, int sw, int sh, ImageBitmap::Promise&& promise)

--- a/Source/WebCore/html/ImageBitmap.h
+++ b/Source/WebCore/html/ImageBitmap.h
@@ -118,10 +118,9 @@ public:
     bool forciblyPremultiplyAlpha() const { return m_backingStore && m_backingStore->forciblyPremultiplyAlpha(); }
 
     std::optional<ImageBitmapBacking> takeImageBitmapBacking();
+    std::optional<ImageBitmapBacking> detach();
     bool isDetached() const { return !m_backingStore; }
     void close() { takeImageBitmapBacking(); }
-
-    static Vector<std::optional<ImageBitmapBacking>> detachBitmaps(Vector<RefPtr<ImageBitmap>>&&);
 
     size_t memoryCost() const;
 private:

--- a/Source/WebCore/html/ImageBitmapBacking.cpp
+++ b/Source/WebCore/html/ImageBitmapBacking.cpp
@@ -50,11 +50,6 @@ RefPtr<ImageBuffer> ImageBitmapBacking::takeImageBuffer()
     return WTFMove(m_bitmapData);
 }
 
-RefPtr<ImageBuffer> ImageBitmapBacking::takeImageBufferForDifferentThread()
-{
-    return ImageBuffer::sinkIntoBufferForDifferentThread(WTFMove(m_bitmapData));
-}
-
 unsigned ImageBitmapBacking::width() const
 {
     // FIXME: Is this the right width?

--- a/Source/WebCore/html/ImageBitmapBacking.h
+++ b/Source/WebCore/html/ImageBitmapBacking.h
@@ -42,7 +42,6 @@ public:
 
     ImageBuffer* buffer() const;
     RefPtr<ImageBuffer> takeImageBuffer();
-    RefPtr<ImageBuffer> takeImageBufferForDifferentThread();
 
     unsigned width() const;
     unsigned height() const;


### PR DESCRIPTION
#### d1390b5d012f1d3c1fbfc886e883773e6bdfc240
<pre>
ImageBitmap and ImageBitmapBacking have unused functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=266760">https://bugs.webkit.org/show_bug.cgi?id=266760</a>
<a href="https://rdar.apple.com/119983961">rdar://119983961</a>

Reviewed by Antti Koivisto.

Remove the unused takeImageBufferForDifferentThread.

Make ImageBitmaps::detachBitmaps() to detach(),
similar to other detach() functions.

* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::SerializedScriptValue::create):
* Source/WebCore/html/ImageBitmap.cpp:
(WebCore::ImageBitmap::detach):
(WebCore::ImageBitmap::detachBitmaps): Deleted.
* Source/WebCore/html/ImageBitmap.h:
* Source/WebCore/html/ImageBitmapBacking.cpp:
(WebCore::ImageBitmapBacking::takeImageBufferForDifferentThread): Deleted.
* Source/WebCore/html/ImageBitmapBacking.h:

Canonical link: <a href="https://commits.webkit.org/272412@main">https://commits.webkit.org/272412@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77abc85848994b42da12298e70d74476c4151653

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31543 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10220 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33252 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34034 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28568 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32317 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12573 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7467 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28182 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31886 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8611 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28158 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7417 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7580 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28065 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35378 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28675 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28512 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33708 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7657 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5676 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31559 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9312 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7411 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8345 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8162 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->