### PR TITLE
Remove PseudoElementUnknown and PseudoClassType::Unknown

### DIFF
--- a/Source/WebCore/animation/WebAnimationUtilities.cpp
+++ b/Source/WebCore/animation/WebAnimationUtilities.cpp
@@ -357,9 +357,10 @@ ExceptionOr<PseudoId> pseudoIdFromString(const String& pseudoElement)
     // FIXME: This parserContext should include a document to get the proper settings.
     CSSSelectorParserContext parserContext { CSSParserContext { HTMLStandardMode } };
     auto pseudoType = CSSSelector::parsePseudoElementType(StringView(pseudoElement).substring(isLegacy ? 1 : 2), parserContext);
-    if (pseudoType == CSSSelector::PseudoElementUnknown || pseudoType == CSSSelector::PseudoElementWebKitCustom)
+    // FIXME: Excluding CSSSelector::PseudoElementWebKitCustom is almost certainly a bug.
+    if (!pseudoType || pseudoType == CSSSelector::PseudoElementWebKitCustom)
         return Exception { ExceptionCode::SyntaxError };
-    return CSSSelector::pseudoId(pseudoType);
+    return CSSSelector::pseudoId(*pseudoType);
 }
 
 AtomString animatablePropertyAsString(AnimatableCSSProperty property)

--- a/Source/WebCore/css/CSSComputedStyleDeclaration.cpp
+++ b/Source/WebCore/css/CSSComputedStyleDeclaration.cpp
@@ -56,7 +56,8 @@ CSSComputedStyleDeclaration::CSSComputedStyleDeclaration(Element& element, bool 
         name = name.substring(1);
     if (name.startsWith(':'))
         name = name.substring(1);
-    m_pseudoElementSpecifier = CSSSelector::pseudoId(CSSSelector::parsePseudoElementType(name, CSSSelectorParserContext { element.document() }));
+    auto pseudoType = CSSSelector::parsePseudoElementType(name, CSSSelectorParserContext { element.document() });
+    m_pseudoElementSpecifier = pseudoType ? CSSSelector::pseudoId(*pseudoType) : PseudoId::None;
 }
 
 CSSComputedStyleDeclaration::~CSSComputedStyleDeclaration() = default;

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -103,7 +103,6 @@ struct PossiblyQuotedIdentifier {
         };
 
         enum class PseudoClassType : uint8_t {
-            Unknown = 0,
             Empty,
             FirstChild,
             FirstOfType,
@@ -203,7 +202,6 @@ struct PossiblyQuotedIdentifier {
         };
 
         enum PseudoElementType {
-            PseudoElementUnknown = 0,
             PseudoElementAfter,
             PseudoElementBackdrop,
             PseudoElementBefore,
@@ -263,7 +261,7 @@ struct PossiblyQuotedIdentifier {
             RightBottomMarginBox,
         };
 
-        static PseudoElementType parsePseudoElementType(StringView, const CSSSelectorParserContext&);
+        static std::optional<PseudoElementType> parsePseudoElementType(StringView, const CSSSelectorParserContext&);
         static PseudoId pseudoId(PseudoElementType);
 
         // Selectors are kept in an array by CSSSelectorList.

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -1127,10 +1127,6 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, const LocalCont
 
         case CSSSelector::PseudoClassType::UserValid:
             return matchesUserValidPseudoClass(element);
-
-        case CSSSelector::PseudoClassType::Unknown:
-            ASSERT_NOT_REACHED();
-            break;
         }
         return false;
     }

--- a/Source/WebCore/css/SelectorPseudoClassAndCompatibilityElementMap.in
+++ b/Source/WebCore/css/SelectorPseudoClassAndCompatibilityElementMap.in
@@ -1,7 +1,7 @@
 -khtml-drag
 -internal-html-document
 -webkit-any
--webkit-any-link, PseudoClassType::AnyLinkDeprecated, PseudoElementUnknown
+-webkit-any-link, PseudoClassType::AnyLinkDeprecated
 -webkit-autofill
 -webkit-autofill-and-obscured
 -webkit-autofill-strong-password
@@ -9,10 +9,10 @@
 -webkit-drag
 -webkit-full-page-media
 active
-after, PseudoClassType::Unknown, PseudoElementAfter
+after, std::nullopt, PseudoElementAfter
 any-link
 autofill
-before, PseudoClassType::Unknown, PseudoElementBefore
+before, std::nullopt, PseudoElementBefore
 checked
 corner-present
 decrement
@@ -25,8 +25,8 @@ empty
 enabled
 end
 first-child
-first-letter, PseudoClassType::Unknown, PseudoElementFirstLetter
-first-line, PseudoClassType::Unknown, PseudoElementFirstLine
+first-letter, std::nullopt, PseudoElementFirstLetter
+first-line, std::nullopt, PseudoElementFirstLine
 first-of-type
 focus
 focus-visible
@@ -36,7 +36,7 @@ has
 has-attachment
 #endif
 horizontal
-host, PseudoClassType::Host, PseudoElementUnknown
+host, PseudoClassType::Host
 hover
 in-range
 increment
@@ -81,7 +81,7 @@ window-inactive
 #if ENABLE(FULLSCREEN_API)
 fullscreen
 -webkit-animating-full-screen-transition
--webkit-full-screen, PseudoClassType::WebkitFullScreen, PseudoElementUnknown
+-webkit-full-screen, PseudoClassType::WebkitFullScreen
 -webkit-full-screen-ancestor
 -webkit-full-screen-document
 -webkit-full-screen-controls-hidden

--- a/Source/WebCore/css/SelectorPseudoTypeMap.h
+++ b/Source/WebCore/css/SelectorPseudoTypeMap.h
@@ -30,11 +30,11 @@
 namespace WebCore {
 
 struct PseudoClassOrCompatibilityPseudoElement {
-    CSSSelector::PseudoClassType pseudoClass;
-    CSSSelector::PseudoElementType compatibilityPseudoElement;
+    std::optional<CSSSelector::PseudoClassType> pseudoClass;
+    std::optional<CSSSelector::PseudoElementType> compatibilityPseudoElement;
 };
 
 PseudoClassOrCompatibilityPseudoElement parsePseudoClassAndCompatibilityElementString(StringView pseudoTypeString);
-CSSSelector::PseudoElementType parsePseudoElementString(StringView pseudoTypeString);
+std::optional<CSSSelector::PseudoElementType> parsePseudoElementString(StringView pseudoTypeString);
 
 } // namespace WebCore

--- a/Source/WebCore/css/makeSelectorPseudoClassAndCompatibilityElementMap.py
+++ b/Source/WebCore/css/makeSelectorPseudoClassAndCompatibilityElementMap.py
@@ -112,7 +112,7 @@ struct SelectorPseudoClassOrCompatibilityPseudoElementEntry {
 
 %}
 %struct-type
-%define initializer-suffix ,{CSSSelector::PseudoClassType::Unknown,CSSSelector::PseudoElementUnknown}
+%define initializer-suffix ,{std::nullopt,std::nullopt}
 %define class-name SelectorPseudoClassAndCompatibilityElementMapHash
 %omit-struct-type
 %language=C++
@@ -152,11 +152,18 @@ for line in input_file:
         continue
 
     keyword_definition = line.split(',')
-    if len(keyword_definition) == 1:
+    if len(keyword_definition):
         keyword = keyword_definition[0].strip()
-        output_file.write('"%s", {%s, CSSSelector::PseudoElementUnknown}\n' % (keyword, enumerablePseudoType(keyword)))
-    else:
-        output_file.write('"%s", {CSSSelector::%s, CSSSelector::%s}\n' % (keyword_definition[0].strip(), keyword_definition[1].strip(), keyword_definition[2].strip()))
+        pseudo_class = "std::nullopt"
+        pseudo_element = "std::nullopt"
+        if len(keyword_definition) == 1:
+            pseudo_class = enumerablePseudoType(keyword)
+        else:
+            if keyword_definition[1].strip() != "std::nullopt":
+                pseudo_class = 'CSSSelector::%s' % keyword_definition[1].strip()
+            if len(keyword_definition) == 3:
+                pseudo_element = 'CSSSelector::%s' % keyword_definition[2].strip()
+        output_file.write('"%s", {%s, %s}\n' % (keyword, pseudo_class, pseudo_element))
 
     longest_keyword = max(longest_keyword, len(keyword))
 
@@ -198,7 +205,7 @@ PseudoClassOrCompatibilityPseudoElement parsePseudoClassAndCompatibilityElementS
 
     if (entry)
         return entry->pseudoTypes;
-    return { CSSSelector::PseudoClassType::Unknown, CSSSelector::PseudoElementUnknown };
+    return { std::nullopt, std::nullopt };
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/makeSelectorPseudoElementsMap.py
+++ b/Source/WebCore/css/makeSelectorPseudoElementsMap.py
@@ -101,12 +101,12 @@ namespace WebCore {
 
 struct SelectorPseudoTypeEntry {
     const char* name;
-    CSSSelector::PseudoElementType type;
+    std::optional<CSSSelector::PseudoElementType> type;
 };
 
 %}
 %struct-type
-%define initializer-suffix ,CSSSelector::PseudoElementUnknown
+%define initializer-suffix ,std::nullopt
 %define class-name SelectorPseudoElementTypeMapHash
 %omit-struct-type
 %language=C++
@@ -158,26 +158,26 @@ for line in input_file:
 
 output_file.write("""%%
 
-static inline CSSSelector::PseudoElementType parsePseudoElementString(const LChar* characters, unsigned length)
+static inline std::optional<CSSSelector::PseudoElementType> parsePseudoElementString(const LChar* characters, unsigned length)
 {
     if (const SelectorPseudoTypeEntry* entry = SelectorPseudoElementTypeMapHash::in_word_set(reinterpret_cast<const char*>(characters), length))
         return entry->type;
-    return CSSSelector::PseudoElementUnknown;
+    return std::nullopt;
 }""")
 
 output_file.write("""
 
-static inline CSSSelector::PseudoElementType parsePseudoElementString(const UChar* characters, unsigned length)
+static inline std::optional<CSSSelector::PseudoElementType> parsePseudoElementString(const UChar* characters, unsigned length)
 {
     const unsigned maxKeywordLength = %s;
     LChar buffer[maxKeywordLength];
     if (length > maxKeywordLength)
-        return CSSSelector::PseudoElementUnknown;
+        return std::nullopt;
 
     for (unsigned i = 0; i < length; ++i) {
         UChar character = characters[i];
         if (!isLatin1(character))
-            return CSSSelector::PseudoElementUnknown;
+            return std::nullopt;
 
         buffer[i] = static_cast<LChar>(character);
     }
@@ -186,7 +186,7 @@ static inline CSSSelector::PseudoElementType parsePseudoElementString(const UCha
 """ % longest_keyword)
 
 output_file.write("""
-CSSSelector::PseudoElementType parsePseudoElementString(StringView pseudoTypeString)
+std::optional<CSSSelector::PseudoElementType> parsePseudoElementString(StringView pseudoTypeString)
 {
     if (pseudoTypeString.is8Bit())
         return parsePseudoElementString(pseudoTypeString.characters8(), pseudoTypeString.length());

--- a/Source/WebCore/css/parser/CSSParserSelector.cpp
+++ b/Source/WebCore/css/parser/CSSParserSelector.cpp
@@ -53,14 +53,14 @@ std::unique_ptr<CSSParserSelector> CSSParserSelector::parsePagePseudoSelector(St
 std::unique_ptr<CSSParserSelector> CSSParserSelector::parsePseudoElementSelector(StringView pseudoTypeString, const CSSSelectorParserContext& context)
 {
     auto pseudoType = CSSSelector::parsePseudoElementType(pseudoTypeString, context);
-    if (pseudoType == CSSSelector::PseudoElementUnknown)
+    if (!pseudoType)
         return nullptr;
 
     auto selector = makeUnique<CSSParserSelector>();
     selector->m_selector->setMatch(CSSSelector::Match::PseudoElement);
-    selector->m_selector->setPseudoElementType(pseudoType);
+    selector->m_selector->setPseudoElementType(*pseudoType);
     AtomString name;
-    if (pseudoType != CSSSelector::PseudoElementWebKitCustomLegacyPrefixed)
+    if (*pseudoType != CSSSelector::PseudoElementWebKitCustomLegacyPrefixed)
         name = pseudoTypeString.convertToASCIILowercaseAtom();
     else {
         if (equalLettersIgnoringASCIICase(pseudoTypeString, "-webkit-input-placeholder"_s))
@@ -79,16 +79,16 @@ std::unique_ptr<CSSParserSelector> CSSParserSelector::parsePseudoElementSelector
 std::unique_ptr<CSSParserSelector> CSSParserSelector::parsePseudoClassSelector(StringView pseudoTypeString)
 {
     auto pseudoType = parsePseudoClassAndCompatibilityElementString(pseudoTypeString);
-    if (pseudoType.pseudoClass != CSSSelector::PseudoClassType::Unknown) {
+    if (pseudoType.pseudoClass) {
         auto selector = makeUnique<CSSParserSelector>();
         selector->m_selector->setMatch(CSSSelector::Match::PseudoClass);
-        selector->m_selector->setPseudoClassType(pseudoType.pseudoClass);
+        selector->m_selector->setPseudoClassType(*pseudoType.pseudoClass);
         return selector;
     }
-    if (pseudoType.compatibilityPseudoElement != CSSSelector::PseudoElementUnknown) {
+    if (pseudoType.compatibilityPseudoElement) {
         auto selector = makeUnique<CSSParserSelector>();
         selector->m_selector->setMatch(CSSSelector::Match::PseudoElement);
-        selector->m_selector->setPseudoElementType(pseudoType.compatibilityPseudoElement);
+        selector->m_selector->setPseudoElementType(*pseudoType.compatibilityPseudoElement);
         selector->m_selector->setValue(pseudoTypeString.convertToASCIILowercaseAtom());
         return selector;
     }

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -475,8 +475,6 @@ static bool isTreeAbidingPseudoElement(CSSSelector::PseudoElementType pseudoElem
 
 static bool isSimpleSelectorValidAfterPseudoElement(const CSSParserSelector& simpleSelector, CSSSelector::PseudoElementType compoundPseudoElement)
 {
-    ASSERT(compoundPseudoElement != CSSSelector::PseudoElementUnknown);
-    
     if (compoundPseudoElement == CSSSelector::PseudoElementPart) {
         if (simpleSelector.match() == CSSSelector::Match::PseudoElement && simpleSelector.pseudoElementType() != CSSSelector::PseudoElementPart)
             return true;
@@ -806,8 +804,8 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumePseudo(CSSParserTok
 
     if (token.type() == IdentToken) {
         range.consume();
-        if ((selector->match() == CSSSelector::Match::PseudoElement && (selector->pseudoElementType() == CSSSelector::PseudoElementUnknown || isOnlyPseudoElementFunction(selector->pseudoElementType())))
-            || (selector->match() == CSSSelector::Match::PseudoClass && (selector->pseudoClassType() == CSSSelector::PseudoClassType::Unknown || isOnlyPseudoClassFunction(selector->pseudoClassType()))))
+        if ((selector->match() == CSSSelector::Match::PseudoElement && isOnlyPseudoElementFunction(selector->pseudoElementType()))
+            || (selector->match() == CSSSelector::Match::PseudoClass && isOnlyPseudoClassFunction(selector->pseudoClassType())))
             return nullptr;
         return selector;
     }
@@ -1247,7 +1245,7 @@ bool CSSSelectorParser::containsUnknownWebKitPseudoElements(const CSSSelector& c
             if (current->pseudoElementType() != CSSSelector::PseudoElementWebKitCustom)
                 continue;
 
-            if (parsePseudoElementString(StringView(current->value())) == CSSSelector::PseudoElementUnknown)
+            if (!parsePseudoElementString(StringView(current->value())))
                 return true;
         }
     }

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -1383,9 +1383,6 @@ static inline FunctionType addPseudoClassType(const CSSSelector& selector, Selec
         }
     case CSSSelector::PseudoClassType::Host:
         return FunctionType::CannotCompile;
-    case CSSSelector::PseudoClassType::Unknown:
-        ASSERT_NOT_REACHED();
-        return FunctionType::CannotMatchAnything;
     }
 
     ASSERT_NOT_REACHED();
@@ -1497,9 +1494,6 @@ static FunctionType constructFragmentsInternal(const CSSSelector* rootSelector, 
                 ASSERT(!fragment->pseudoElementSelector);
                 fragment->pseudoElementSelector = selector;
                 break;
-            case CSSSelector::PseudoElementUnknown:
-                ASSERT_NOT_REACHED();
-                return FunctionType::CannotMatchAnything;
 #if ENABLE(VIDEO)
             case CSSSelector::PseudoElementCue:
 #endif

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -1669,7 +1669,7 @@ RefPtr<CSSRuleList> LocalDOMWindow::getMatchedCSSRules(Element* element, const S
     // FIXME: This parser context won't get the right settings without a document.
     auto parserContext = document() ? CSSSelectorParserContext { *document() } : CSSSelectorParserContext { CSSParserContext { HTMLStandardMode } };
     auto pseudoType = CSSSelector::parsePseudoElementType(StringView { pseudoElement }.substring(colonStart), parserContext);
-    if (pseudoType == CSSSelector::PseudoElementUnknown && !pseudoElement.isEmpty())
+    if (!pseudoType && !pseudoElement.isEmpty())
         return nullptr;
 
     RefPtr frame = this->frame();
@@ -1679,7 +1679,7 @@ RefPtr<CSSRuleList> LocalDOMWindow::getMatchedCSSRules(Element* element, const S
     if (!authorOnly)
         rulesToInclude |= Style::Resolver::UAAndUserCSSRules;
 
-    PseudoId pseudoId = CSSSelector::pseudoId(pseudoType);
+    PseudoId pseudoId = CSSSelector::pseudoId(*pseudoType);
 
     auto matchedRules = frame->document()->styleScope().resolver().pseudoStyleRulesForElement(element, pseudoId, rulesToInclude);
     if (matchedRules.isEmpty())


### PR DESCRIPTION
#### d56482629f2d93c96d6bac4e038e15c8c9008a8e
<pre>
Remove PseudoElementUnknown and PseudoClassType::Unknown
<a href="https://bugs.webkit.org/show_bug.cgi?id=266767">https://bugs.webkit.org/show_bug.cgi?id=266767</a>

Reviewed by Antti Koivisto.

By removing these enum values we can be much more certain about when we
have selector and when we don&apos;t.

* Source/WebCore/animation/WebAnimationUtilities.cpp:
(WebCore::pseudoIdFromString):
* Source/WebCore/css/CSSComputedStyleDeclaration.cpp:
(WebCore::CSSComputedStyleDeclaration::CSSComputedStyleDeclaration):
* Source/WebCore/css/CSSSelector.cpp:
(WebCore::CSSSelector::pseudoId):
(WebCore::CSSSelector::parsePseudoElementType):
(WebCore::CSSSelector::selectorText const):
* Source/WebCore/css/CSSSelector.h:
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::checkOne const):
* Source/WebCore/css/SelectorPseudoClassAndCompatibilityElementMap.in:
* Source/WebCore/css/SelectorPseudoTypeMap.h:
* Source/WebCore/css/makeSelectorPseudoClassAndCompatibilityElementMap.py:
* Source/WebCore/css/makeSelectorPseudoElementsMap.py:
* Source/WebCore/css/parser/CSSParserSelector.cpp:
(WebCore::CSSParserSelector::parsePseudoElementSelector):
(WebCore::CSSParserSelector::parsePseudoClassSelector):
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::isSimpleSelectorValidAfterPseudoElement):
(WebCore::CSSSelectorParser::consumePseudo):
(WebCore::CSSSelectorParser::containsUnknownWebKitPseudoElements):
* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::addPseudoClassType):
(WebCore::SelectorCompiler::constructFragmentsInternal):
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::getMatchedCSSRules const):

Canonical link: <a href="https://commits.webkit.org/272429@main">https://commits.webkit.org/272429@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8004b4ab5cb030d887654beddff87ca06e5bfe77

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31556 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10233 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33267 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34048 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28582 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32331 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12587 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7481 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28195 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31900 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8618 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28166 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7427 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7588 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28073 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35392 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28683 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28522 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33718 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7671 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5687 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31569 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9327 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7418 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8359 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8176 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->