### PR TITLE
[html] Port PredefinedColorSpace to the new IPC serialization format

### DIFF
--- a/Source/WebCore/html/canvas/PredefinedColorSpace.h
+++ b/Source/WebCore/html/canvas/PredefinedColorSpace.h
@@ -26,13 +26,12 @@
 #pragma once
 
 #include <optional>
-#include <wtf/EnumTraits.h>
 
 namespace WebCore {
 
 class DestinationColorSpace;
 
-enum class PredefinedColorSpace {
+enum class PredefinedColorSpace : uint8_t {
     SRGB
 #if ENABLE(PREDEFINED_COLOR_SPACE_DISPLAY_P3)
     , DisplayP3
@@ -43,17 +42,3 @@ DestinationColorSpace toDestinationColorSpace(PredefinedColorSpace);
 std::optional<PredefinedColorSpace> toPredefinedColorSpace(const DestinationColorSpace&);
 
 }
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::PredefinedColorSpace> {
-    using values = EnumValues<
-        WebCore::PredefinedColorSpace,
-        WebCore::PredefinedColorSpace::SRGB
-#if ENABLE(PREDEFINED_COLOR_SPACE_DISPLAY_P3)
-        , WebCore::PredefinedColorSpace::DisplayP3
-#endif
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/inspector/InspectorCanvasCallTracer.h
+++ b/Source/WebCore/inspector/InspectorCanvasCallTracer.h
@@ -78,7 +78,7 @@ enum class CanvasLineCap;
 enum class CanvasLineJoin;
 enum class CanvasTextAlign;
 enum class CanvasTextBaseline;
-enum class PredefinedColorSpace;
+enum class PredefinedColorSpace : uint8_t;
 enum ImageSmoothingQuality;
 
 #define FOR_EACH_INSPECTOR_CANVAS_CALL_TRACER_CSS_TYPED_OM_ARGUMENT(macro) \

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -7220,3 +7220,11 @@ enum class WebCore::ContextMenuItemType : uint8_t {
     Mini,
     Large,
 };
+
+header: <WebCore/PredefinedColorSpace.h>
+enum class WebCore::PredefinedColorSpace : uint8_t {
+    SRGB
+#if ENABLE(PREDEFINED_COLOR_SPACE_DISPLAY_P3)
+    , DisplayP3
+#endif
+};


### PR DESCRIPTION
#### 790be614997f866247b1b23d86f54a1813ae4cdc
<pre>
[html] Port PredefinedColorSpace to the new IPC serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=266769">https://bugs.webkit.org/show_bug.cgi?id=266769</a>

Reviewed by Tim Nguyen.

Remove the EnumTraits for this enum, make it inherit from uint_8 explicitly,
and port it to use the generator for serialization.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/html/canvas/PredefinedColorSpace.h:
* Source/WebCore/inspector/InspectorCanvasCallTracer.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/272492@main">https://commits.webkit.org/272492@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14fcc61cc245a34958543cd347983e24c770d651

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31572 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10250 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33285 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34066 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28599 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32349 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12604 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7500 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28210 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31918 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8633 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28179 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7442 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7603 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28086 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35410 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28698 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28536 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33734 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7687 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5703 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31585 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9343 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7455 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8374 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8193 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->