### PR TITLE
[CSS] Remove invalid scoping roots when outside the <scope-end>

### DIFF
--- a/LayoutTests/fast/css/scope-at-rule-expected.html
+++ b/LayoutTests/fast/css/scope-at-rule-expected.html
@@ -72,3 +72,9 @@
 <div>
   <span>should not be green</span>
 </div>
+<div>
+  <span class="green">should be green</span>
+</div>
+<div>
+  <span>should not be green</span>
+</div>

--- a/LayoutTests/fast/css/scope-at-rule.html
+++ b/LayoutTests/fast/css/scope-at-rule.html
@@ -84,6 +84,13 @@ div {
   }
 }
 
+@scope (.root) to (.limit) {
+  :scope.outer .green-17 {
+      color: green;
+    }
+  }
+}
+
 </style>
 
 <div class="a">
@@ -187,4 +194,13 @@ div {
    should be green
   </div>
   should not be green
+</div>
+
+<div class="root outer">
+  <span class="green-17">should be green</span>
+  <div class="limit">
+    <div class="root inner">
+      <span class="green-17">should not be green</span>
+    </div>
+  </div>
 </div>

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -665,13 +665,14 @@ std::pair<bool, std::optional<Vector<ElementRuleCollector::ScopingRootWithDistan
                 return false;
             };
 
-            for (auto [scopingRoot, _] : scopingRoots) {
+            Vector<ScopingRootWithDistance> scopingRootsWithinScope;
+            for (auto scopingRootWithDistance : scopingRoots) {
                 for (const auto* selector = selectorList.first(); selector; selector = CSSSelectorList::next(selector)) {
-                    if (!match(scopingRoot, selector))
-                        return true;
+                    if (!match(scopingRootWithDistance.scopingRoot, selector))
+                        scopingRootsWithinScope.append(scopingRootWithDistance);
                 }
             }
-            return false;
+            return scopingRootsWithinScope;
         };
 
         const auto& scopeStart = rule->scopeStart();
@@ -718,8 +719,10 @@ std::pair<bool, std::optional<Vector<ElementRuleCollector::ScopingRootWithDistan
 
         const auto& scopeEnd = rule->scopeEnd();
         if (!scopeEnd.isEmpty()) {
-            if (!isWithinScopingRootsAndScopeEnd(scopeEnd))
+            auto scopingRootsWithinScope = isWithinScopingRootsAndScopeEnd(scopeEnd);
+            if (scopingRootsWithinScope.isEmpty())
                 return false;
+            scopingRoots = WTFMove(scopingRootsWithinScope);
         }
         // element is in the @scope donut
         return true;


### PR DESCRIPTION
#### e84a617b4b4d0088df770ae59385090500d8c5f6
<pre>
[CSS] Remove invalid scoping roots when outside the &lt;scope-end&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=266771">https://bugs.webkit.org/show_bug.cgi?id=266771</a>
<a href="https://rdar.apple.com/119998989">rdar://119998989</a>

Reviewed by Antti Koivisto.

When there are multiple scoping roots identified from the &lt;scope-start&gt;,
only keep the relevant ones to the &lt;scope-end&gt; if it exists.

* LayoutTests/fast/css/scope-at-rule-expected.html:
* LayoutTests/fast/css/scope-at-rule.html:
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::scopeRulesMatch):

Canonical link: <a href="https://commits.webkit.org/272463@main">https://commits.webkit.org/272463@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f74ec6d09cc9c30b23fbeb8aa650939c008e55c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31692 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10374 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33430 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34182 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28697 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32473 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12731 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7623 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28289 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32041 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8741 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28299 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7539 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7701 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28213 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35526 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28805 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28660 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33822 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7795 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5801 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31675 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9451 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/28019 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7436 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8476 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8311 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->