### PR TITLE
Split NodeFlag into TypeFlag and StateFlag

### DIFF
--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -118,7 +118,7 @@ public:
 #endif
 
 private:
-    static constexpr auto CreateHTMLModelElement = CreateHTMLElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    static constexpr auto CreateHTMLModelElement = CreateHTMLElement | TypeFlag::HasCustomStyleResolveCallbacks;
     HTMLModelElement(const QualifiedName&, Document&);
 
     URL selectModelSource() const;

--- a/Source/WebCore/dom/DocumentFragment.cpp
+++ b/Source/WebCore/dom/DocumentFragment.cpp
@@ -49,7 +49,7 @@ Ref<DocumentFragment> DocumentFragment::create(Document& document)
 
 Ref<DocumentFragment> DocumentFragment::createForInnerOuterHTML(Document& document)
 {
-    return adoptRef(*new DocumentFragment(document, Node::CreateDocumentFragment | NodeFlag::IsDocumentFragmentForInnerOuterHTML));
+    return adoptRef(*new DocumentFragment(document, Node::CreateDocumentFragment | TypeFlag::IsDocumentFragmentForInnerOuterHTML));
 }
 
 String DocumentFragment::nodeName() const

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2380,7 +2380,7 @@ void Element::setIsLink(bool flag)
         { CSSSelector::PseudoClassType::AnyLinkDeprecated, flag },
         { CSSSelector::PseudoClassType::Link, flag }
     });
-    setNodeFlag(NodeFlag::IsLink, flag);
+    setStateFlag(StateFlag::IsLink, flag);
 }
 
 #if ENABLE(TOUCH_EVENTS)
@@ -2481,7 +2481,7 @@ void Element::invalidateForQueryContainerSizeChange()
 {
     // FIXME: Ideally we would just recompute things that are actually affected by containers queries within the subtree.
     Node::invalidateStyle(Style::Validity::SubtreeInvalid);
-    setNodeFlag(NodeFlag::NeedsUpdateQueryContainerDependentStyle);
+    setStateFlag(StateFlag::NeedsUpdateQueryContainerDependentStyle);
 }
 
 void Element::invalidateForResumingQueryContainerResolution()
@@ -2491,12 +2491,12 @@ void Element::invalidateForResumingQueryContainerResolution()
 
 bool Element::needsUpdateQueryContainerDependentStyle() const
 {
-    return hasNodeFlag(NodeFlag::NeedsUpdateQueryContainerDependentStyle);
+    return hasStateFlag(StateFlag::NeedsUpdateQueryContainerDependentStyle);
 }
 
 void Element::clearNeedsUpdateQueryContainerDependentStyle()
 {
-    clearNodeFlag(NodeFlag::NeedsUpdateQueryContainerDependentStyle);
+    clearStateFlag(StateFlag::NeedsUpdateQueryContainerDependentStyle);
 }
 
 void Element::invalidateEventListenerRegions()
@@ -4068,13 +4068,13 @@ const RenderStyle* Element::resolveComputedStyle(ResolveComputedStyleMode mode)
         if (document->hasPendingFullStyleRebuild())
             return document->documentElement();
 
-        if (!document->documentElement() || document->documentElement()->hasNodeFlag(NodeFlag::IsComputedStyleInvalidFlag))
+        if (!document->documentElement() || document->documentElement()->hasStateFlag(StateFlag::IsComputedStyleInvalidFlag))
             return document->documentElement();
 
         RefPtr<const Element> rootmost;
 
         for (RefPtr element = this; element; element = element->parentElementInComposedTree()) {
-            if (element->hasNodeFlag(NodeFlag::IsComputedStyleInvalidFlag)) {
+            if (element->hasStateFlag(StateFlag::IsComputedStyleInvalidFlag)) {
                 rootmost = element;
                 continue;
             }
@@ -4126,12 +4126,12 @@ const RenderStyle* Element::resolveComputedStyle(ResolveComputedStyleMode mode)
             if (change > Style::Change::NonInherited) {
                 for (Ref child : composedTreeChildren(*element)) {
                     if (RefPtr childElement = dynamicDowncast<Element>(WTFMove(child)))
-                        childElement->setNodeFlag(NodeFlag::IsComputedStyleInvalidFlag);
+                        childElement->setStateFlag(StateFlag::IsComputedStyleInvalidFlag);
                 }
             }
         }
         rareData.setComputedStyle(WTFMove(style));
-        element->clearNodeFlag(NodeFlag::IsComputedStyleInvalidFlag);
+        element->clearStateFlag(StateFlag::IsComputedStyleInvalidFlag);
 
         if (mode == ResolveComputedStyleMode::RenderedOnly && computedStyle->display() == DisplayType::None)
             return nullptr;
@@ -4480,19 +4480,19 @@ void Element::setFullscreenFlag(bool flag)
 {
     Style::PseudoClassChangeInvalidation styleInvalidation(*this, { { CSSSelector::PseudoClassType::Fullscreen, flag }, { CSSSelector::PseudoClassType::Modal, flag } });
     if (flag)
-        setNodeFlag(NodeFlag::IsFullscreen);
+        setStateFlag(StateFlag::IsFullscreen);
     else
-        clearNodeFlag(NodeFlag::IsFullscreen);
+        clearStateFlag(StateFlag::IsFullscreen);
 
-    clearNodeFlag(NodeFlag::IsIFrameFullscreen);
+    clearStateFlag(StateFlag::IsIFrameFullscreen);
 }
 
 void Element::setIFrameFullscreenFlag(bool flag)
 {
     if (flag)
-        setNodeFlag(NodeFlag::IsIFrameFullscreen);
+        setStateFlag(StateFlag::IsIFrameFullscreen);
     else
-        clearNodeFlag(NodeFlag::IsIFrameFullscreen);
+        clearStateFlag(StateFlag::IsIFrameFullscreen);
 }
 
 #endif

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -592,7 +592,7 @@ public:
     bool hasPendingKeyframesUpdate(PseudoId) const;
     // FIXME: do we need a counter style didChange here? (rdar://103018993).
 
-    bool isLink() const { return hasNodeFlag(NodeFlag::IsLink); }
+    bool isLink() const { return hasStateFlag(StateFlag::IsLink); }
     void setIsLink(bool flag);
 
     bool isInTopLayer() const { return hasEventTargetFlag(EventTargetFlag::IsInTopLayer); }
@@ -600,8 +600,8 @@ public:
     void removeFromTopLayer();
 
 #if ENABLE(FULLSCREEN_API)
-    bool hasFullscreenFlag() const { return hasNodeFlag(NodeFlag::IsFullscreen); }
-    bool hasIFrameFullscreenFlag() const { return hasNodeFlag(NodeFlag::IsIFrameFullscreen); }
+    bool hasFullscreenFlag() const { return hasStateFlag(StateFlag::IsFullscreen); }
+    bool hasIFrameFullscreenFlag() const { return hasStateFlag(StateFlag::IsIFrameFullscreen); }
     void setFullscreenFlag(bool);
     void setIFrameFullscreenFlag(bool);
     WEBCORE_EXPORT void webkitRequestFullscreen();
@@ -906,14 +906,14 @@ private:
     bool hasXMLLangAttr() const { return hasEventTargetFlag(EventTargetFlag::HasXMLLangAttr); }
     void setHasXMLLangAttr(bool has) { setEventTargetFlag(EventTargetFlag::HasXMLLangAttr, has); }
 
-    bool effectiveLangKnownToMatchDocumentElement() const { return hasNodeFlag(NodeFlag::EffectiveLangKnownToMatchDocumentElement); }
-    void setEffectiveLangKnownToMatchDocumentElement(bool matches) { setNodeFlag(NodeFlag::EffectiveLangKnownToMatchDocumentElement, matches); }
+    bool effectiveLangKnownToMatchDocumentElement() const { return hasStateFlag(StateFlag::EffectiveLangKnownToMatchDocumentElement); }
+    void setEffectiveLangKnownToMatchDocumentElement(bool matches) { setStateFlag(StateFlag::EffectiveLangKnownToMatchDocumentElement, matches); }
 
     bool hasLanguageAttribute() const { return hasLangAttr() || hasXMLLangAttr(); }
     bool hasLangAttrKnownToMatchDocumentElement() const { return hasLanguageAttribute() && effectiveLangKnownToMatchDocumentElement(); }
 
-    bool hasEverHadSmoothScroll() const { return hasNodeFlag(NodeFlag::EverHadSmoothScroll); }
-    void setHasEverHadSmoothScroll(bool value) { return setNodeFlag(NodeFlag::EverHadSmoothScroll, value); }
+    bool hasEverHadSmoothScroll() const { return hasStateFlag(StateFlag::EverHadSmoothScroll); }
+    void setHasEverHadSmoothScroll(bool value) { return setStateFlag(StateFlag::EverHadSmoothScroll, value); }
 
     void parentOrShadowHostNode() const = delete; // Call parentNode() instead.
 

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -392,10 +392,9 @@ inline void NodeRareData::operator delete(NodeRareData* nodeRareData, std::destr
 
 Node::Node(Document& document, ConstructionType type)
     : EventTarget(ConstructNode)
-    , m_nodeFlags(type)
+    , m_typeFlags(type)
     , m_treeScope((isDocumentNode() || isShadowRoot()) ? nullptr : &document)
 {
-    ASSERT(type.toRaw() == (type.toRaw() & NodeFlagTypeMask));
     ASSERT(isMainThread());
 
     // Allow code to ref the Document while it is being constructed to make our life easier.
@@ -967,7 +966,7 @@ void Node::invalidateStyle(Style::Validity validity, Style::InvalidationMode mod
         return;
 
     if (validity != Style::Validity::Valid)
-        setNodeFlag(NodeFlag::IsComputedStyleInvalidFlag);
+        setStateFlag(StateFlag::IsComputedStyleInvalidFlag);
 
     bool markAncestors = styleValidity() == Style::Validity::Valid || mode == Style::InvalidationMode::InsertedIntoAncestor;
 

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -209,15 +209,15 @@ public:
 
     // Other methods (not part of DOM)
 
-    bool isElementNode() const { return hasNodeFlag(NodeFlag::IsElement); }
-    bool isContainerNode() const { return hasNodeFlag(NodeFlag::IsContainerNode); }
-    bool isCharacterData() const { return hasNodeFlag(NodeFlag::IsCharacterData); }
-    bool isTextNode() const { return hasNodeFlag(NodeFlag::IsText); }
-    bool isHTMLElement() const { return hasNodeFlag(NodeFlag::IsHTMLElement); }
-    bool isSVGElement() const { return hasNodeFlag(NodeFlag::IsSVGElement); }
-    bool isMathMLElement() const { return hasNodeFlag(NodeFlag::IsMathMLElement); }
+    bool isElementNode() const { return hasTypeFlag(TypeFlag::IsElement); }
+    bool isContainerNode() const { return hasTypeFlag(TypeFlag::IsContainerNode); }
+    bool isCharacterData() const { return hasTypeFlag(TypeFlag::IsCharacterData); }
+    bool isTextNode() const { return hasTypeFlag(TypeFlag::IsText); }
+    bool isHTMLElement() const { return hasTypeFlag(TypeFlag::IsHTMLElement); }
+    bool isSVGElement() const { return hasTypeFlag(TypeFlag::IsSVGElement); }
+    bool isMathMLElement() const { return hasTypeFlag(TypeFlag::IsMathMLElement); }
 
-    bool isUnknownElement() const { return hasNodeFlag(NodeFlag::IsUnknownElement); }
+    bool isUnknownElement() const { return hasTypeFlag(TypeFlag::IsUnknownElement); }
     bool isHTMLUnknownElement() const { return isHTMLElement() && isUnknownElement(); }
     bool isSVGUnknownElement() const { return isSVGElement() && isUnknownElement(); }
     bool isMathMLUnknownElement() const { return isMathMLElement() && isUnknownElement(); }
@@ -232,19 +232,19 @@ public:
     virtual bool isWebVTTRubyElement() const { return false; }
     virtual bool isWebVTTRubyTextElement() const { return false; }
 #endif
-    bool isStyledElement() const { return hasNodeFlag(NodeFlag::IsHTMLElement) || hasNodeFlag(NodeFlag::IsSVGElement) || hasNodeFlag(NodeFlag::IsMathMLElement); }
+    bool isStyledElement() const { return hasTypeFlag(TypeFlag::IsHTMLElement) || hasTypeFlag(TypeFlag::IsSVGElement) || hasTypeFlag(TypeFlag::IsMathMLElement); }
     virtual bool isAttributeNode() const { return false; }
-    bool isCharacterDataNode() const { return hasNodeFlag(NodeFlag::IsCharacterData); }
+    bool isCharacterDataNode() const { return hasTypeFlag(TypeFlag::IsCharacterData); }
     virtual bool isFrameOwnerElement() const { return false; }
     virtual bool isPluginElement() const { return false; }
 
-    bool isDocumentNode() const { return hasNodeFlag(NodeFlag::IsDocumentNode); }
-    bool isTreeScope() const { return hasNodeFlag(NodeFlag::IsDocumentNode) || hasNodeFlag(NodeFlag::IsShadowRoot); }
-    bool isDocumentFragment() const { return hasNodeFlag(NodeFlag::IsDocumentFragment); }
-    bool isShadowRoot() const { return hasNodeFlag(NodeFlag::IsShadowRoot); }
+    bool isDocumentNode() const { return hasTypeFlag(TypeFlag::IsDocumentNode); }
+    bool isTreeScope() const { return hasTypeFlag(TypeFlag::IsDocumentNode) || hasTypeFlag(TypeFlag::IsShadowRoot); }
+    bool isDocumentFragment() const { return hasTypeFlag(TypeFlag::IsDocumentFragment); }
+    bool isShadowRoot() const { return hasTypeFlag(TypeFlag::IsShadowRoot); }
     bool isUserAgentShadowRoot() const; // Defined in ShadowRoot.h
 
-    bool hasCustomStyleResolveCallbacks() const { return hasNodeFlag(NodeFlag::HasCustomStyleResolveCallbacks); }
+    bool hasCustomStyleResolveCallbacks() const { return hasTypeFlag(TypeFlag::HasCustomStyleResolveCallbacks); }
 
     bool hasSyntheticAttrChildNodes() const { return hasEventTargetFlag(EventTargetFlag::HasSyntheticAttrChildNodes); }
     void setHasSyntheticAttrChildNodes(bool flag) { setEventTargetFlag(EventTargetFlag::HasSyntheticAttrChildNodes, flag); }
@@ -252,8 +252,8 @@ public:
     bool hasShadowRootContainingSlots() const { return hasEventTargetFlag(EventTargetFlag::HasShadowRootContainingSlots); }
     void setHasShadowRootContainingSlots(bool flag) { setEventTargetFlag(EventTargetFlag::HasShadowRootContainingSlots, flag); }
 
-    bool needsSVGRendererUpdate() const { return hasNodeFlag(NodeFlag::NeedsSVGRendererUpdate); }
-    void setNeedsSVGRendererUpdate(bool flag) { setNodeFlag(NodeFlag::NeedsSVGRendererUpdate, flag); }
+    bool needsSVGRendererUpdate() const { return hasStateFlag(StateFlag::NeedsSVGRendererUpdate); }
+    void setNeedsSVGRendererUpdate(bool flag) { setStateFlag(StateFlag::NeedsSVGRendererUpdate, flag); }
 
     // If this node is in a shadow tree, returns its shadow host. Otherwise, returns null.
     WEBCORE_EXPORT Element* shadowHost() const;
@@ -307,8 +307,8 @@ public:
     // Returns the parent node, but null if the parent node is a ShadowRoot.
     ContainerNode* nonShadowBoundaryParentNode() const;
 
-    bool selfOrPrecedingNodesAffectDirAuto() const { return hasNodeFlag(NodeFlag::SelfOrPrecedingNodesAffectDirAuto); }
-    void setSelfOrPrecedingNodesAffectDirAuto(bool flag) { setNodeFlag(NodeFlag::SelfOrPrecedingNodesAffectDirAuto, flag); }
+    bool selfOrPrecedingNodesAffectDirAuto() const { return hasStateFlag(StateFlag::SelfOrPrecedingNodesAffectDirAuto); }
+    void setSelfOrPrecedingNodesAffectDirAuto(bool flag) { setStateFlag(StateFlag::SelfOrPrecedingNodesAffectDirAuto, flag); }
 
     TextDirection effectiveTextDirection() const;
     void setEffectiveTextDirection(TextDirection);
@@ -342,8 +342,8 @@ public:
     virtual void notifyLoadedSheetAndAllCriticalSubresources(bool /* error loading subresource */) { }
     virtual void startLoadingDynamicSheet() { ASSERT_NOT_REACHED(); }
 
-    bool isUserActionElement() const { return hasNodeFlag(NodeFlag::IsUserActionElement); }
-    void setUserActionElement(bool flag) { setNodeFlag(NodeFlag::IsUserActionElement, flag); }
+    bool isUserActionElement() const { return hasStateFlag(StateFlag::IsUserActionElement); }
+    void setUserActionElement(bool flag) { setStateFlag(StateFlag::IsUserActionElement, flag); }
 
     bool inRenderedDocument() const;
     bool needsStyleRecalc() const { return styleValidity() != Style::Validity::Valid || hasInvalidRenderer(); }
@@ -351,9 +351,9 @@ public:
     bool hasInvalidRenderer() const { return hasStyleFlag(NodeStyleFlag::HasInvalidRenderer); }
     bool styleResolutionShouldRecompositeLayer() const { return hasStyleFlag(NodeStyleFlag::StyleResolutionShouldRecompositeLayer); }
     bool childNeedsStyleRecalc() const { return hasStyleFlag(NodeStyleFlag::DescendantNeedsStyleResolution); }
-    bool isEditingText() const { return hasNodeFlag(NodeFlag::IsEditingText); }
+    bool isEditingText() const { return hasTypeFlag(TypeFlag::IsEditingText); }
 
-    bool isDocumentFragmentForInnerOuterHTML() const { return hasNodeFlag(NodeFlag::IsDocumentFragmentForInnerOuterHTML); }
+    bool isDocumentFragmentForInnerOuterHTML() const { return hasTypeFlag(TypeFlag::IsDocumentFragmentForInnerOuterHTML); }
 
     void setChildNeedsStyleRecalc() { setStyleFlag(NodeStyleFlag::DescendantNeedsStyleResolution); }
     void clearChildNeedsStyleRecalc();
@@ -558,25 +558,25 @@ public:
     void updateAncestorConnectedSubframeCountForInsertion() const;
 
 #if ENABLE(JIT)
-    static ptrdiff_t nodeFlagsMemoryOffset() { return OBJECT_OFFSETOF(Node, m_nodeFlags); }
+    static ptrdiff_t typeFlagsMemoryOffset() { return OBJECT_OFFSETOF(Node, m_typeFlags); }
+    static ptrdiff_t stateFlagsMemoryOffset() { return OBJECT_OFFSETOF(Node, m_stateFlags); }
     static ptrdiff_t rareDataMemoryOffset() { return OBJECT_OFFSETOF(Node, m_rareDataWithBitfields); }
 #if CPU(ADDRESS64)
     static uint64_t rareDataPointerMask() { return CompactPointerTuple<NodeRareData*, uint16_t>::pointerMask; }
 #else
     static uint32_t rareDataPointerMask() { return -1; }
 #endif
-    static auto flagIsText() { return enumToUnderlyingType(NodeFlag::IsText); }
-    static auto flagIsContainer() { return enumToUnderlyingType(NodeFlag::IsContainerNode); }
-    static auto flagIsElement() { return enumToUnderlyingType(NodeFlag::IsElement); }
-    static auto flagIsShadowRoot() { return enumToUnderlyingType(NodeFlag::IsShadowRoot); }
-    static auto flagIsHTML() { return enumToUnderlyingType(NodeFlag::IsHTMLElement); }
-    static auto flagIsLink() { return enumToUnderlyingType(NodeFlag::IsLink); }
-    static auto flagIsParsingChildren() { return enumToUnderlyingType(NodeFlag::IsParsingChildren); }
+    static auto flagIsText() { return enumToUnderlyingType(TypeFlag::IsText); }
+    static auto flagIsContainer() { return enumToUnderlyingType(TypeFlag::IsContainerNode); }
+    static auto flagIsElement() { return enumToUnderlyingType(TypeFlag::IsElement); }
+    static auto flagIsShadowRoot() { return enumToUnderlyingType(TypeFlag::IsShadowRoot); }
+    static auto flagIsHTML() { return enumToUnderlyingType(TypeFlag::IsHTMLElement); }
+    static auto flagIsLink() { return enumToUnderlyingType(StateFlag::IsLink); }
+    static auto flagIsParsingChildren() { return enumToUnderlyingType(StateFlag::IsParsingChildren); }
 #endif // ENABLE(JIT)
 
 protected:
-    enum class NodeFlag : uint32_t {
-        // Types
+    enum class TypeFlag : uint16_t {
         IsCharacterData = 1 << 0,
         IsText = 1 << 1,
         IsContainerNode = 1 << 2,
@@ -591,28 +591,23 @@ protected:
         IsDocumentFragmentForInnerOuterHTML = 1 << 11,
         IsEditingText = 1 << 12,
         HasCustomStyleResolveCallbacks = 1 << 13,
-        // 2 Free bits
-
-        // States
-        IsLink = 1 << 16, // Element
-        IsUserActionElement = 1 << 17,
-        IsParsingChildren = 1 << 18,
-        EverHadSmoothScroll = 1 << 19,
-        SelfOrPrecedingNodesAffectDirAuto = 1 << 20,
-        EffectiveLangKnownToMatchDocumentElement = 1 << 21,
-        // Free bit
-        IsComputedStyleInvalidFlag = 1 << 23,
-        // 2 Free bits
-        NeedsSVGRendererUpdate = 1 << 26,
-        NeedsUpdateQueryContainerDependentStyle = 1 << 27,
-        // Free bit
-#if ENABLE(FULLSCREEN_API)
-        IsFullscreen = 1 << 29,
-        IsIFrameFullscreen = 1 << 30,
-#endif
-        // Free bit
     };
-    static constexpr auto NodeFlagTypeMask = 0xffff;
+
+    enum class StateFlag : uint16_t {
+        IsLink = 1 << 0,
+        IsUserActionElement = 1 << 1,
+        IsParsingChildren = 1 << 2,
+        EverHadSmoothScroll = 1 << 3,
+        SelfOrPrecedingNodesAffectDirAuto = 1 << 4,
+        EffectiveLangKnownToMatchDocumentElement = 1 << 5,
+        IsComputedStyleInvalidFlag = 1 << 6,
+        NeedsSVGRendererUpdate = 1 << 7,
+        NeedsUpdateQueryContainerDependentStyle = 1 << 8,
+#if ENABLE(FULLSCREEN_API)
+        IsFullscreen = 1 << 9,
+        IsIFrameFullscreen = 1 << 10,
+#endif
+    };
 
     enum class TabIndexState : uint8_t {
         NotSet = 0,
@@ -636,9 +631,11 @@ protected:
         uint16_t effectiveTextDirection : 1;
     };
 
-    bool hasNodeFlag(NodeFlag flag) const { return m_nodeFlags.contains(flag); }
-    void setNodeFlag(NodeFlag flag, bool value = true) const { ASSERT(!(static_cast<uint32_t>(flag) & NodeFlagTypeMask)); m_nodeFlags.set(flag, value); }
-    void clearNodeFlag(NodeFlag flag) const { setNodeFlag(flag, false); }
+    bool hasTypeFlag(TypeFlag flag) const { return m_typeFlags.contains(flag); }
+
+    bool hasStateFlag(StateFlag flag) const { return m_stateFlags.contains(flag); }
+    void setStateFlag(StateFlag flag, bool value = true) const { m_stateFlags.set(flag, value); }
+    void clearStateFlag(StateFlag flag) const { setStateFlag(flag, false); }
 
     RareDataBitFields rareDataBitfields() const { return bitwise_cast<RareDataBitFields>(m_rareDataWithBitfields.type()); }
     void setRareDataBitfields(RareDataBitFields bitfields) { m_rareDataWithBitfields.setType(bitwise_cast<uint16_t>(bitfields)); }
@@ -649,26 +646,26 @@ protected:
     CustomElementState customElementState() const { return static_cast<CustomElementState>(rareDataBitfields().customElementState); }
     void setCustomElementState(CustomElementState);
 
-    bool isParsingChildrenFinished() const { return !hasNodeFlag(NodeFlag::IsParsingChildren); }
-    void setIsParsingChildrenFinished() { clearNodeFlag(NodeFlag::IsParsingChildren); }
-    void clearIsParsingChildrenFinished() { setNodeFlag(NodeFlag::IsParsingChildren); }
+    bool isParsingChildrenFinished() const { return !hasStateFlag(StateFlag::IsParsingChildren); }
+    void setIsParsingChildrenFinished() { clearStateFlag(StateFlag::IsParsingChildren); }
+    void clearIsParsingChildrenFinished() { setStateFlag(StateFlag::IsParsingChildren); }
 
-    static constexpr auto DefaultNodeFlags = OptionSet<NodeFlag> { };
-    static constexpr auto CreateAttr = DefaultNodeFlags;
-    static constexpr auto CreateDocumentType = DefaultNodeFlags;
-    static constexpr auto CreateCharacterData = DefaultNodeFlags | NodeFlag::IsCharacterData;
-    static constexpr auto CreateText = CreateCharacterData | NodeFlag::IsText;
-    static constexpr auto CreateContainer = DefaultNodeFlags | NodeFlag::IsContainerNode;
-    static constexpr auto CreateElement = CreateContainer | NodeFlag::IsElement;
-    static constexpr auto CreatePseudoElement = CreateElement | NodeFlag::HasCustomStyleResolveCallbacks;
-    static constexpr auto CreateDocumentFragment = CreateContainer | NodeFlag::IsDocumentFragment;
-    static constexpr auto CreateShadowRoot = CreateDocumentFragment | NodeFlag::IsShadowRoot;
-    static constexpr auto CreateHTMLElement = CreateElement | NodeFlag::IsHTMLElement;
-    static constexpr auto CreateSVGElement = CreateElement | NodeFlag::IsSVGElement | NodeFlag::HasCustomStyleResolveCallbacks;
-    static constexpr auto CreateMathMLElement = CreateElement | NodeFlag::IsMathMLElement;
-    static constexpr auto CreateDocument = CreateContainer | NodeFlag::IsDocumentNode;
-    static constexpr auto CreateEditingText = CreateText | NodeFlag::IsEditingText;
-    using ConstructionType = OptionSet<NodeFlag>;
+    static constexpr auto DefaultTypeFlags = OptionSet<TypeFlag> { };
+    static constexpr auto CreateAttr = DefaultTypeFlags;
+    static constexpr auto CreateDocumentType = DefaultTypeFlags;
+    static constexpr auto CreateCharacterData = DefaultTypeFlags | TypeFlag::IsCharacterData;
+    static constexpr auto CreateText = CreateCharacterData | TypeFlag::IsText;
+    static constexpr auto CreateContainer = DefaultTypeFlags | TypeFlag::IsContainerNode;
+    static constexpr auto CreateElement = CreateContainer | TypeFlag::IsElement;
+    static constexpr auto CreatePseudoElement = CreateElement | TypeFlag::HasCustomStyleResolveCallbacks;
+    static constexpr auto CreateDocumentFragment = CreateContainer | TypeFlag::IsDocumentFragment;
+    static constexpr auto CreateShadowRoot = CreateDocumentFragment | TypeFlag::IsShadowRoot;
+    static constexpr auto CreateHTMLElement = CreateElement | TypeFlag::IsHTMLElement;
+    static constexpr auto CreateSVGElement = CreateElement | TypeFlag::IsSVGElement | TypeFlag::HasCustomStyleResolveCallbacks;
+    static constexpr auto CreateMathMLElement = CreateElement | TypeFlag::IsMathMLElement;
+    static constexpr auto CreateDocument = CreateContainer | TypeFlag::IsDocumentNode;
+    static constexpr auto CreateEditingText = CreateText | TypeFlag::IsEditingText;
+    using ConstructionType = OptionSet<TypeFlag>;
     Node(Document&, ConstructionType);
 
     static constexpr uint32_t s_refCountIncrement = 2;
@@ -762,7 +759,8 @@ private:
     WEBCORE_EXPORT void notifyInspectorOfRendererChange();
     
     mutable uint32_t m_refCountAndParentBit { s_refCountIncrement };
-    mutable OptionSet<NodeFlag> m_nodeFlags;
+    const OptionSet<TypeFlag> m_typeFlags;
+    mutable OptionSet<StateFlag> m_stateFlags;
 
     CheckedPtr<ContainerNode> m_parentNode;
     CheckedPtr<TreeScope> m_treeScope;
@@ -886,7 +884,7 @@ inline void Node::setHasValidStyle()
     bitfields.setStyleValidity(Style::Validity::Valid);
     bitfields.clearFlags({ NodeStyleFlag::HasInvalidRenderer, NodeStyleFlag::StyleResolutionShouldRecompositeLayer });
     setStyleBitfields(bitfields);
-    clearNodeFlag(NodeFlag::IsComputedStyleInvalidFlag);
+    clearStateFlag(StateFlag::IsComputedStyleInvalidFlag);
 }
 
 inline void Node::setTreeScopeRecursively(TreeScope& newTreeScope)

--- a/Source/WebCore/domjit/DOMJITHelpers.h
+++ b/Source/WebCore/domjit/DOMJITHelpers.h
@@ -174,23 +174,23 @@ void loadDocumentElement(MacroAssembler&, GPRReg document, GPRReg output);
 
 inline CCallHelpers::Jump branchTestIsElementFlagOnNode(MacroAssembler& jit, CCallHelpers::ResultCondition condition, GPRReg nodeAddress)
 {
-    return jit.branchTest32(condition, CCallHelpers::Address(nodeAddress, Node::nodeFlagsMemoryOffset()), CCallHelpers::TrustedImm32(Node::flagIsElement()));
+    return jit.branchTest16(condition, CCallHelpers::Address(nodeAddress, Node::typeFlagsMemoryOffset()), CCallHelpers::TrustedImm32(Node::flagIsElement()));
 }
 
 inline CCallHelpers::Jump branchTestIsShadowRootFlagOnNode(MacroAssembler& jit, CCallHelpers::ResultCondition condition, GPRReg nodeAddress)
 {
-    return jit.branchTest32(condition, CCallHelpers::Address(nodeAddress, Node::nodeFlagsMemoryOffset()), CCallHelpers::TrustedImm32(Node::flagIsShadowRoot()));
+    return jit.branchTest16(condition, CCallHelpers::Address(nodeAddress, Node::typeFlagsMemoryOffset()), CCallHelpers::TrustedImm32(Node::flagIsShadowRoot()));
 }
 
 inline CCallHelpers::Jump branchTestIsElementOrShadowRootFlagOnNode(MacroAssembler& jit, CCallHelpers::ResultCondition condition, GPRReg nodeAddress)
 {
-    return jit.branchTest32(condition, CCallHelpers::Address(nodeAddress, Node::nodeFlagsMemoryOffset()),
+    return jit.branchTest16(condition, CCallHelpers::Address(nodeAddress, Node::typeFlagsMemoryOffset()),
         CCallHelpers::TrustedImm32(Node::flagIsShadowRoot() | Node::flagIsElement()));
 }
 
 inline CCallHelpers::Jump branchTestIsHTMLFlagOnNode(MacroAssembler& jit, CCallHelpers::ResultCondition condition, GPRReg nodeAddress)
 {
-    return jit.branchTest32(condition, CCallHelpers::Address(nodeAddress, Node::nodeFlagsMemoryOffset()), CCallHelpers::TrustedImm32(Node::flagIsHTML()));
+    return jit.branchTest16(condition, CCallHelpers::Address(nodeAddress, Node::typeFlagsMemoryOffset()), CCallHelpers::TrustedImm32(Node::flagIsHTML()));
 }
 
 JSC_DECLARE_JIT_OPERATION(operationToJSNode, JSC::EncodedJSValue, (JSC::JSGlobalObject*, void*));

--- a/Source/WebCore/domjit/JSNodeDOMJIT.cpp
+++ b/Source/WebCore/domjit/JSNodeDOMJIT.cpp
@@ -65,7 +65,7 @@ static Ref<JSC::DOMJIT::CallDOMGetterSnippet> createCallDOMGetterForOffsetAccess
         static_assert(!JSNode::hasCustomPtrTraits(), "Optimized JSNode wrapper access should not be using RawPtrTraits");
 
         if (isContainerGuardRequirement == IsContainerGuardRequirement::Required)
-            nullCases.append(jit.branchTest32(CCallHelpers::Zero, CCallHelpers::Address(scratch, Node::nodeFlagsMemoryOffset()), CCallHelpers::TrustedImm32(Node::flagIsContainer())));
+            nullCases.append(jit.branchTest16(CCallHelpers::Zero, CCallHelpers::Address(scratch, Node::typeFlagsMemoryOffset()), CCallHelpers::TrustedImm32(Node::flagIsContainer())));
 
         jit.loadPtr(CCallHelpers::Address(scratch, offset), scratch);
         nullCases.append(jit.branchTestPtr(CCallHelpers::Zero, scratch));

--- a/Source/WebCore/html/HTMLFormControlElement.h
+++ b/Source/WebCore/html/HTMLFormControlElement.h
@@ -110,7 +110,7 @@ public:
     using Node::deref;
 
 protected:
-    static constexpr auto CreateHTMLFormControlElement = CreateHTMLElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    static constexpr auto CreateHTMLFormControlElement = CreateHTMLElement | TypeFlag::HasCustomStyleResolveCallbacks;
     HTMLFormControlElement(const QualifiedName& tagName, Document&, HTMLFormElement*);
 
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) override;

--- a/Source/WebCore/html/HTMLFrameElementBase.h
+++ b/Source/WebCore/html/HTMLFrameElementBase.h
@@ -40,7 +40,7 @@ public:
     ScrollbarMode scrollingMode() const final;
 
 protected:
-    static constexpr auto CreateHTMLFrameElementBase = CreateHTMLFrameOwnerElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    static constexpr auto CreateHTMLFrameElementBase = CreateHTMLFrameOwnerElement | TypeFlag::HasCustomStyleResolveCallbacks;
     HTMLFrameElementBase(const QualifiedName&, Document&);
 
     bool canLoad() const;

--- a/Source/WebCore/html/HTMLFrameSetElement.h
+++ b/Source/WebCore/html/HTMLFrameSetElement.h
@@ -54,7 +54,7 @@ public:
     bool isSupportedPropertyName(const AtomString&);
 
 private:
-    static constexpr auto CreateHTMLFrameSetElement = CreateHTMLElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    static constexpr auto CreateHTMLFrameSetElement = CreateHTMLElement | TypeFlag::HasCustomStyleResolveCallbacks;
     HTMLFrameSetElement(const QualifiedName&, Document&);
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;

--- a/Source/WebCore/html/HTMLImageElement.h
+++ b/Source/WebCore/html/HTMLImageElement.h
@@ -178,7 +178,7 @@ public:
     void collectExtraStyleForPresentationalHints(MutableStyleProperties&);
 
 protected:
-    static constexpr auto CreateHTMLImageElement = CreateHTMLElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    static constexpr auto CreateHTMLImageElement = CreateHTMLElement | TypeFlag::HasCustomStyleResolveCallbacks;
     HTMLImageElement(const QualifiedName&, Document&, HTMLFormElement* = nullptr);
 
     void didMoveToNewDocument(Document& oldDocument, Document& newDocument) override;

--- a/Source/WebCore/html/HTMLLIElement.h
+++ b/Source/WebCore/html/HTMLLIElement.h
@@ -33,7 +33,7 @@ public:
     static Ref<HTMLLIElement> create(const QualifiedName&, Document&);
 
 private:
-    static constexpr auto CreateHTMLLIElement = CreateHTMLElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    static constexpr auto CreateHTMLLIElement = CreateHTMLElement | TypeFlag::HasCustomStyleResolveCallbacks;
     HTMLLIElement(const QualifiedName&, Document&);
 
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const final;

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -648,7 +648,7 @@ public:
     void updateMediaState();
 
 protected:
-    static constexpr auto CreateHTMLMediaElement = CreateHTMLElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    static constexpr auto CreateHTMLMediaElement = CreateHTMLElement | TypeFlag::HasCustomStyleResolveCallbacks;
     HTMLMediaElement(const QualifiedName&, Document&, bool createdByParser);
     virtual ~HTMLMediaElement();
 

--- a/Source/WebCore/html/HTMLOptionElement.h
+++ b/Source/WebCore/html/HTMLOptionElement.h
@@ -68,7 +68,7 @@ public:
     bool selectedWithoutUpdate() const { return m_isSelected; }
 
 private:
-    static constexpr auto CreateHTMLOptionElement = CreateHTMLElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    static constexpr auto CreateHTMLOptionElement = CreateHTMLElement | TypeFlag::HasCustomStyleResolveCallbacks;
     HTMLOptionElement(const QualifiedName&, Document&);
 
     bool isFocusable() const final;

--- a/Source/WebCore/html/HTMLPlugInElement.h
+++ b/Source/WebCore/html/HTMLPlugInElement.h
@@ -75,7 +75,7 @@ public:
     WEBCORE_EXPORT bool isReplacementObscured();
 
 protected:
-    static constexpr auto CreateHTMLPlugInElement = CreateHTMLFrameOwnerElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    static constexpr auto CreateHTMLPlugInElement = CreateHTMLFrameOwnerElement | TypeFlag::HasCustomStyleResolveCallbacks;
     HTMLPlugInElement(const QualifiedName& tagName, Document&);
 
     bool canContainRangeEndPoint() const override { return false; }

--- a/Source/WebCore/html/HTMLProgressElement.h
+++ b/Source/WebCore/html/HTMLProgressElement.h
@@ -44,7 +44,7 @@ public:
     double position() const;
 
 private:
-    static constexpr auto CreateHTMLProgressElement = CreateHTMLElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    static constexpr auto CreateHTMLProgressElement = CreateHTMLElement | TypeFlag::HasCustomStyleResolveCallbacks;
     HTMLProgressElement(const QualifiedName&, Document&);
     virtual ~HTMLProgressElement();
 

--- a/Source/WebCore/html/HTMLUnknownElement.h
+++ b/Source/WebCore/html/HTMLUnknownElement.h
@@ -43,7 +43,7 @@ public:
 
 private:
     HTMLUnknownElement(const QualifiedName& tagName, Document& document)
-        : HTMLElement(tagName, document, CreateHTMLElement | NodeFlag::IsUnknownElement)
+        : HTMLElement(tagName, document, CreateHTMLElement | TypeFlag::IsUnknownElement)
     {
     }
 };

--- a/Source/WebCore/html/shadow/DateTimeFieldElement.h
+++ b/Source/WebCore/html/shadow/DateTimeFieldElement.h
@@ -75,7 +75,7 @@ public:
     virtual String placeholderValue() const = 0;
 
 protected:
-    static constexpr auto CreateDateTimeFieldElement = CreateHTMLDivElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    static constexpr auto CreateDateTimeFieldElement = CreateHTMLDivElement | TypeFlag::HasCustomStyleResolveCallbacks;
     DateTimeFieldElement(Document&, FieldOwner&);
     void initialize(const AtomString& pseudo);
     Locale& localeForOwner() const;

--- a/Source/WebCore/html/shadow/SliderThumbElement.h
+++ b/Source/WebCore/html/shadow/SliderThumbElement.h
@@ -57,7 +57,7 @@ public:
     void hostDisabledStateChanged();
 
 private:
-    static constexpr auto CreateSliderThumbElement = CreateHTMLDivElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    static constexpr auto CreateSliderThumbElement = CreateHTMLDivElement | TypeFlag::HasCustomStyleResolveCallbacks;
     explicit SliderThumbElement(Document&);
     bool isSliderThumbElement() const final { return true; }
 
@@ -113,7 +113,7 @@ public:
     static Ref<SliderContainerElement> create(Document&);
 
 private:
-    static constexpr auto CreateSliderContainerElement = CreateHTMLDivElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    static constexpr auto CreateSliderContainerElement = CreateHTMLDivElement | TypeFlag::HasCustomStyleResolveCallbacks;
     explicit SliderContainerElement(Document&);
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;
     bool isSliderContainerElement() const final { return true; }

--- a/Source/WebCore/html/shadow/SpinButtonElement.h
+++ b/Source/WebCore/html/shadow/SpinButtonElement.h
@@ -68,7 +68,7 @@ public:
     void forwardEvent(Event&);
 
 private:
-    static constexpr auto CreateSpinButtonElement = CreateHTMLDivElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    static constexpr auto CreateSpinButtonElement = CreateHTMLDivElement | TypeFlag::HasCustomStyleResolveCallbacks;
     SpinButtonElement(Document&, SpinButtonOwner&);
 
     void willDetachRenderers() override;

--- a/Source/WebCore/html/shadow/SwitchThumbElement.h
+++ b/Source/WebCore/html/shadow/SwitchThumbElement.h
@@ -36,7 +36,7 @@ class SwitchThumbElement final : public HTMLDivElement {
 public:
     static Ref<SwitchThumbElement> create(Document&);
 private:
-    static constexpr auto CreateSwitchThumbElement = CreateHTMLDivElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    static constexpr auto CreateSwitchThumbElement = CreateHTMLDivElement | TypeFlag::HasCustomStyleResolveCallbacks;
     explicit SwitchThumbElement(Document&);
 };
 

--- a/Source/WebCore/html/shadow/SwitchTrackElement.h
+++ b/Source/WebCore/html/shadow/SwitchTrackElement.h
@@ -36,7 +36,7 @@ class SwitchTrackElement final : public HTMLDivElement {
 public:
     static Ref<SwitchTrackElement> create(Document&);
 private:
-    static constexpr auto CreateSwitchTrackElement = CreateHTMLDivElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    static constexpr auto CreateSwitchTrackElement = CreateHTMLDivElement | TypeFlag::HasCustomStyleResolveCallbacks;
     explicit SwitchTrackElement(Document&);
 };
 

--- a/Source/WebCore/html/shadow/TextControlInnerElements.h
+++ b/Source/WebCore/html/shadow/TextControlInnerElements.h
@@ -38,7 +38,7 @@ class TextControlInnerContainer final : public HTMLDivElement {
 public:
     static Ref<TextControlInnerContainer> create(Document&);
 private:
-    static constexpr auto CreateTextControlInnerContainer = CreateHTMLDivElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    static constexpr auto CreateTextControlInnerContainer = CreateHTMLDivElement | TypeFlag::HasCustomStyleResolveCallbacks;
     explicit TextControlInnerContainer(Document&);
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) override;
     std::optional<Style::ResolvedStyle> resolveCustomStyle(const Style::ResolutionContext&, const RenderStyle* shadowHostStyle) override;
@@ -50,7 +50,7 @@ public:
     static Ref<TextControlInnerElement> create(Document&);
 
 private:
-    static constexpr auto CreateTextControlInnerElement = CreateHTMLDivElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    static constexpr auto CreateTextControlInnerElement = CreateHTMLDivElement | TypeFlag::HasCustomStyleResolveCallbacks;
     explicit TextControlInnerElement(Document&);
     std::optional<Style::ResolvedStyle> resolveCustomStyle(const Style::ResolutionContext&, const RenderStyle* shadowHostStyle) override;
 
@@ -75,7 +75,7 @@ public:
 private:
     void updateInnerTextElementEditabilityImpl(bool isEditable, bool initialization);
 
-    static constexpr auto CreateTextControlInnerTextElement = CreateHTMLDivElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    static constexpr auto CreateTextControlInnerTextElement = CreateHTMLDivElement | TypeFlag::HasCustomStyleResolveCallbacks;
     explicit TextControlInnerTextElement(Document&);
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) override;
     std::optional<Style::ResolvedStyle> resolveCustomStyle(const Style::ResolutionContext&, const RenderStyle* shadowHostStyle) override;
@@ -89,7 +89,7 @@ public:
     static Ref<TextControlPlaceholderElement> create(Document&);
 
 private:
-    static constexpr auto CreateTextControlPlaceholderElement = CreateHTMLDivElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    static constexpr auto CreateTextControlPlaceholderElement = CreateHTMLDivElement | TypeFlag::HasCustomStyleResolveCallbacks;
     explicit TextControlPlaceholderElement(Document&);
     
     std::optional<Style::ResolvedStyle> resolveCustomStyle(const Style::ResolutionContext&, const RenderStyle* shadowHostStyle) override;
@@ -108,7 +108,7 @@ public:
     bool canAdjustStyleForAppearance() const { return m_canAdjustStyleForAppearance; }
 
 private:
-    static constexpr auto CreateSearchFieldResultsButtonElement = CreateHTMLDivElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    static constexpr auto CreateSearchFieldResultsButtonElement = CreateHTMLDivElement | TypeFlag::HasCustomStyleResolveCallbacks;
     explicit SearchFieldResultsButtonElement(Document&);
     bool isMouseFocusable() const override { return false; }
     std::optional<Style::ResolvedStyle> resolveCustomStyle(const Style::ResolutionContext&, const RenderStyle* shadowHostStyle) override;
@@ -128,7 +128,7 @@ public:
 #endif
 
 private:
-    static constexpr auto CreateSearchFieldCancelButtonElement = CreateHTMLDivElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    static constexpr auto CreateSearchFieldCancelButtonElement = CreateHTMLDivElement | TypeFlag::HasCustomStyleResolveCallbacks;
     explicit SearchFieldCancelButtonElement(Document&);
     bool isMouseFocusable() const override { return false; }
     std::optional<Style::ResolvedStyle> resolveCustomStyle(const Style::ResolutionContext&, const RenderStyle* shadowHostStyle) override;

--- a/Source/WebCore/html/track/TextTrackCue.h
+++ b/Source/WebCore/html/track/TextTrackCue.h
@@ -56,7 +56,7 @@ public:
 protected:
     void initialize();
 
-    static constexpr auto CreateTextTrackCueBox = CreateHTMLElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    static constexpr auto CreateTextTrackCueBox = CreateHTMLElement | TypeFlag::HasCustomStyleResolveCallbacks;
     TextTrackCueBox(Document&, TextTrackCue&);
     ~TextTrackCueBox() { }
 

--- a/Source/WebCore/mathml/MathMLMathElement.h
+++ b/Source/WebCore/mathml/MathMLMathElement.h
@@ -39,7 +39,7 @@ public:
     static Ref<MathMLMathElement> create(const QualifiedName& tagName, Document&);
 
 private:
-    static constexpr auto CreateMathMLMathElement = CreateMathMLRowElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    static constexpr auto CreateMathMLMathElement = CreateMathMLRowElement | TypeFlag::HasCustomStyleResolveCallbacks;
     MathMLMathElement(const QualifiedName& tagName, Document&);
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void didAttachRenderers() final;

--- a/Source/WebCore/mathml/MathMLTokenElement.h
+++ b/Source/WebCore/mathml/MathMLTokenElement.h
@@ -41,7 +41,7 @@ public:
     static std::optional<char32_t> convertToSingleCodePoint(StringView);
 
 protected:
-    static constexpr auto CreateMathMLTokenElement = CreateMathMLPresentationElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    static constexpr auto CreateMathMLTokenElement = CreateMathMLPresentationElement | TypeFlag::HasCustomStyleResolveCallbacks;
     MathMLTokenElement(const QualifiedName& tagName, Document&);
     void childrenChanged(const ChildChange&) override;
 

--- a/Source/WebCore/mathml/MathMLUnknownElement.h
+++ b/Source/WebCore/mathml/MathMLUnknownElement.h
@@ -41,7 +41,7 @@ public:
 
 private:
     MathMLUnknownElement(const QualifiedName& tagName, Document& document)
-        : MathMLElement(tagName, document, CreateMathMLElement | NodeFlag::IsUnknownElement)
+        : MathMLElement(tagName, document, CreateMathMLElement | TypeFlag::IsUnknownElement)
     {
     }
 

--- a/Source/WebCore/svg/SVGUnknownElement.h
+++ b/Source/WebCore/svg/SVGUnknownElement.h
@@ -45,7 +45,7 @@ public:
 
 private:
     SVGUnknownElement(const QualifiedName& tagName, Document& document)
-        : SVGElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this), CreateSVGElement | NodeFlag::IsUnknownElement)
+        : SVGElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this), CreateSVGElement | TypeFlag::IsUnknownElement)
     {
     }
 


### PR DESCRIPTION
#### 038b325a0082d69adbffc3404f6fc5951209f0f9
<pre>
Split NodeFlag into TypeFlag and StateFlag
<a href="https://bugs.webkit.org/show_bug.cgi?id=266778">https://bugs.webkit.org/show_bug.cgi?id=266778</a>

Reviewed by Antti Koivisto and Tim Nguyen.

This PR splits NodeFlag, which is currently a single 32-bit flag with some values representing types and others
denoting states, into two 16-bit flags: TypeFlag and StateFlag. TypeFlag is immutable once Node is initialized.

* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::SelectorCodeGenerator::generateSpecialFailureInQuirksModeForActiveAndHoverIfNeeded):
(WebCore::SelectorCompiler::SelectorCodeGenerator::generateElementIsLastChild):
(WebCore::SelectorCompiler::SelectorCodeGenerator::generateElementIsOnlyChild):
(WebCore::SelectorCompiler::SelectorCodeGenerator::generateElementIsLink):
(WebCore::SelectorCompiler::SelectorCodeGenerator::generateNthLastChildParentCheckAndRelationUpdate):
(WebCore::SelectorCompiler::SelectorCodeGenerator::generateElementIsFirstLink):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::setIsLink):
(WebCore::Element::invalidateForQueryContainerSizeChange):
(WebCore::Element::needsUpdateQueryContainerDependentStyle const):
(WebCore::Element::clearNeedsUpdateQueryContainerDependentStyle):
(WebCore::Element::resolveComputedStyle):
(WebCore::Element::setFullscreenFlag):
(WebCore::Element::setIFrameFullscreenFlag):
* Source/WebCore/dom/Element.h:
(WebCore::Element::isLink const):
(WebCore::Element::hasFullscreenFlag const):
(WebCore::Element::hasIFrameFullscreenFlag const):
(WebCore::Element::effectiveLangKnownToMatchDocumentElement const):
(WebCore::Element::setEffectiveLangKnownToMatchDocumentElement):
(WebCore::Element::hasEverHadSmoothScroll const):
(WebCore::Element::setHasEverHadSmoothScroll):
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::invalidateStyle):
* Source/WebCore/dom/Node.h:
(WebCore::Node::needsSVGRendererUpdate const):
(WebCore::Node::setNeedsSVGRendererUpdate):
(WebCore::Node::selfOrPrecedingNodesAffectDirAuto const):
(WebCore::Node::setSelfOrPrecedingNodesAffectDirAuto):
(WebCore::Node::isUserActionElement const):
(WebCore::Node::setUserActionElement):
(WebCore::Node::stateFlagsMemoryOffset):
(WebCore::Node::flagIsLink):
(WebCore::Node::flagIsParsingChildren):
(WebCore::Node::hasStateFlag const):
(WebCore::Node::setStateFlag const):
(WebCore::Node::clearStateFlag const):
(WebCore::Node::isParsingChildrenFinished const):
(WebCore::Node::setIsParsingChildrenFinished):
(WebCore::Node::clearIsParsingChildrenFinished):
(WebCore::Node::setHasValidStyle):
(WebCore::Node::setNodeFlag const): Deleted.
(WebCore::Node::clearNodeFlag const): Deleted.

Canonical link: <a href="https://commits.webkit.org/272446@main">https://commits.webkit.org/272446@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57e2359098435039da8e41ac7833420fd238f654

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31658 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10337 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33374 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34146 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28666 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32436 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12691 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7588 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/28261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32006 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8705 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28246 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7513 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7665 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28160 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35489 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28769 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/28606 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33796 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7764 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5770 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31647 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9421 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8447 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4138 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8277 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->