### PR TITLE
[WebRTC] Fix logic when parsing H264 packets to make sure the buffer isn't exceeded

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_h264.h
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_h264.h
@@ -91,7 +91,11 @@ class RtpPacketizerH264 : public RtpPacketizer {
 #endif
   bool PacketizeSingleNalu(size_t fragment_index);
 
+#ifdef WEBRTC_WEBKIT_BUILD
+  bool NextAggregatePacket(RtpPacketToSend* rtp_packet);
+#else
   void NextAggregatePacket(RtpPacketToSend* rtp_packet);
+#endif
   void NextFragmentPacket(RtpPacketToSend* rtp_packet);
 
   const PayloadSizeLimits limits_;

--- a/Source/ThirdParty/libwebrtc/WebKit/0001-WebRTC-Fix-NextPacket-Payload-Overflow.patch
+++ b/Source/ThirdParty/libwebrtc/WebKit/0001-WebRTC-Fix-NextPacket-Payload-Overflow.patch
@@ -1,0 +1,88 @@
+diff --git a/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_h264.cc b/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_h264.cc
+index 3ab7ff9181fa..f7bd7cdf5f3b 100644
+--- a/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_h264.cc
++++ b/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_h264.cc
+@@ -257,6 +257,9 @@ bool RtpPacketizerH264::NextPacket(RtpPacketToSend* rtp_packet) {
+   }
+ 
+   PacketUnit packet = packets_.front();
++#ifdef WEBRTC_WEBKIT_BUILD
++  bool next_packet_result = true;
++#endif
+   if (packet.first_fragment && packet.last_fragment) {
+     // Single NAL unit packet.
+     size_t bytes_to_send = packet.source_fragment.size();
+@@ -265,18 +268,34 @@ bool RtpPacketizerH264::NextPacket(RtpPacketToSend* rtp_packet) {
+     packets_.pop();
+     input_fragments_.pop_front();
+   } else if (packet.aggregated) {
++#ifdef WEBRTC_WEBKIT_BUILD
++    next_packet_result = NextAggregatePacket(rtp_packet);
++#else
+     NextAggregatePacket(rtp_packet);
++#endif
+   } else {
+     NextFragmentPacket(rtp_packet);
+   }
+   rtp_packet->SetMarker(packets_.empty());
+   --num_packets_left_;
++#ifdef WEBRTC_WEBKIT_BUILD
++  return next_packet_result;
++#else
+   return true;
++#endif
+ }
+ 
++#ifdef WEBRTC_WEBKIT_BUILD
++bool RtpPacketizerH264::NextAggregatePacket(RtpPacketToSend* rtp_packet) {
++#else
+ void RtpPacketizerH264::NextAggregatePacket(RtpPacketToSend* rtp_packet) {
++#endif
+   // Reserve maximum available payload, set actual payload size later.
+   size_t payload_capacity = rtp_packet->FreeCapacity();
++#ifdef WEBRTC_WEBKIT_BUILD
++  if (rtp_packet->payload_size() > payload_capacity)
++      return false;
++#endif
+   RTC_CHECK_GE(payload_capacity, kNalHeaderSize);
+   uint8_t* buffer = rtp_packet->AllocatePayload(payload_capacity);
+   RTC_DCHECK(buffer);
+@@ -289,7 +308,12 @@ void RtpPacketizerH264::NextAggregatePacket(RtpPacketToSend* rtp_packet) {
+   bool is_last_fragment = packet->last_fragment;
+   while (packet->aggregated) {
+     rtc::ArrayView<const uint8_t> fragment = packet->source_fragment;
++#ifdef WEBRTC_WEBKIT_BUILD
++  if (index + kLengthFieldSize + fragment.size() > payload_capacity)
++      return false;
++#else
+     RTC_CHECK_LE(index + kLengthFieldSize + fragment.size(), payload_capacity);
++#endif
+     // Add NAL unit length field.
+     ByteWriter<uint16_t>::WriteBigEndian(&buffer[index], fragment.size());
+     index += kLengthFieldSize;
+@@ -305,6 +329,9 @@ void RtpPacketizerH264::NextAggregatePacket(RtpPacketToSend* rtp_packet) {
+   }
+   RTC_CHECK(is_last_fragment);
+   rtp_packet->SetPayloadSize(index);
++#ifdef WEBRTC_WEBKIT_BUILD
++  return true;
++#endif
+ }
+ 
+ void RtpPacketizerH264::NextFragmentPacket(RtpPacketToSend* rtp_packet) {
+diff --git a/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_h264.h b/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_h264.h
+index 80709f1f43aa..c0d831be6744 100644
+--- a/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_h264.h
++++ b/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_h264.h
+@@ -91,7 +91,11 @@ class RtpPacketizerH264 : public RtpPacketizer {
+ #endif
+   bool PacketizeSingleNalu(size_t fragment_index);
+ 
++#ifdef WEBRTC_WEBKIT_BUILD
++  bool NextAggregatePacket(RtpPacketToSend* rtp_packet);
++#else
+   void NextAggregatePacket(RtpPacketToSend* rtp_packet);
++#endif
+   void NextFragmentPacket(RtpPacketToSend* rtp_packet);
+ 
+   const PayloadSizeLimits limits_;


### PR DESCRIPTION
#### 0f82704494108c1be42e5c094a480b9b5f4aeaeb
<pre>
[WebRTC] Fix logic when parsing H264 packets to make sure the buffer isn&apos;t exceeded
<a href="https://bugs.webkit.org/show_bug.cgi?id=266653">https://bugs.webkit.org/show_bug.cgi?id=266653</a>
<a href="https://rdar.apple.com/118861473">rdar://118861473</a>

Reviewed by NOBODY (OOPS!).

`NextAggregatePacket` can have a free capacity for the buffer that is less than the payload
size of the packet. Added return false to `NextPacket` if this is the case, similar to if
there are no packets to send. `NextFragmentPacket` resets the free capacity so this only
applies if the packets are aggregated

* Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_h264.cc:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f82704494108c1be42e5c094a480b9b5f4aeaeb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31602 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10281 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33317 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34093 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28623 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12634 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7531 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28226 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31950 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8655 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28203 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7465 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7625 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28113 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35438 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28720 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28560 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33753 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7716 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5725 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31604 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9372 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8402 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8223 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->