### PR TITLE
Fix process launch signposts

### DIFF
--- a/Source/WebKit/Resources/Signposts/SystemTracePoints.plist
+++ b/Source/WebKit/Resources/Signposts/SystemTracePoints.plist
@@ -758,6 +758,46 @@
                  <string>14003</string>
                  <key>CodeEnd</key>
                  <string>14004</string>
+                 <key>EventsMatchedBy</key>
+                 <string>Arg1</string>
+                 <key>ArgNamesBegin</key>
+                 <dict>
+                     <key>Arg1</key>
+                     <string>WebKit ID</string>
+                 </dict>
+                 <key>ArgValueTypesBegin</key>
+                 <dict>
+                     <key>Arg1</key>
+                     <string>UInt64</string>
+                 </dict>
+                 <key>ArgNamesEnd</key>
+                 <dict>
+                     <key>Arg1</key>
+                     <string>WebKit ID</string>
+                     <key>Arg2</key>
+                     <string>Process Type</string>
+                     <key>Arg3</key>
+                     <string>PID</string>
+                 </dict>
+                 <key>ArgValueTypesEnd</key>
+                 <dict>
+                     <key>Arg1</key>
+                     <string>UInt64</string>
+                     <key>Arg3</key>
+                     <string>UInt64</string>
+                 </dict>
+                 <key>ArgValueLabelsEnd</key>
+                 <dict>
+                     <key>Arg2</key>
+                     <dict>
+                         <key>0x0</key>
+                         <string>WebProcess</string>
+                         <key>0x1</key>
+                         <string>NetworkProcess</string>
+                         <key>0x2</key>
+                         <string>GPUProcess</string>
+                     </dict>
+                 </dict>
              </dict>
              <dict>
                  <key>Name</key>

--- a/Source/WebKit/UIProcess/Launcher/ProcessLauncher.h
+++ b/Source/WebKit/UIProcess/Launcher/ProcessLauncher.h
@@ -132,6 +132,7 @@ private:
     void didFinishLaunchingProcess(ProcessID, IPC::Connection::Identifier);
 
     void platformInvalidate();
+    void platformDestroy();
 
 #if PLATFORM(COCOA)
     void terminateXPCConnection();

--- a/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
+++ b/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
@@ -139,7 +139,7 @@ static const char* serviceName(const ProcessLauncher::LaunchOptions& launchOptio
     }
 }
 
-ProcessLauncher::~ProcessLauncher()
+void ProcessLauncher::platformDestroy()
 {
 #if USE(EXTENSIONKIT)
     [m_process invalidate];


### PR DESCRIPTION
#### e7e610b7120d2fd688e1d0881d7460921273394e
<pre>
Fix process launch signposts
<a href="https://bugs.webkit.org/show_bug.cgi?id=266783">https://bugs.webkit.org/show_bug.cgi?id=266783</a>
<a href="https://rdar.apple.com/120010295">rdar://120010295</a>

Reviewed by Simon Fraser.

The current process launch signposts don&apos;t handle overlapping process launches or process launches
that terminate early correctly. Fix this by nesting the signposts by their ProcessIdentifier, and by
emitting a ProcessLaunchEnd signpost in the case that the process terminated while being launched.

* Source/WebKit/Resources/Signposts/SystemTracePoints.plist:
* Source/WebKit/UIProcess/Launcher/ProcessLauncher.cpp:
(WebKit::ProcessLauncher::ProcessLauncher):
(WebKit::ProcessLauncher::~ProcessLauncher):
(WebKit::ProcessLauncher::platformDestroy):
(WebKit::ProcessLauncher::didFinishLaunchingProcess):
* Source/WebKit/UIProcess/Launcher/ProcessLauncher.h:
* Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm:
(WebKit::ProcessLauncher::platformDestroy):
(WebKit::ProcessLauncher::~ProcessLauncher): Deleted.

Canonical link: <a href="https://commits.webkit.org/272457@main">https://commits.webkit.org/272457@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e414b8f938ab27be71f6751f19a61db2220bfca

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31603 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10282 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33318 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34094 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28624 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12635 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7532 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28227 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31951 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8658 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28205 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7466 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7628 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35439 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28723 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28562 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33755 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7717 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5726 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31607 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9373 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7431 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8403 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8224 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->