### PR TITLE
LegacyCustomProtocolManager is incorrectly using the NetworkProcess object off the main thread

### DIFF
--- a/Source/WebKit/NetworkProcess/CustomProtocols/Cocoa/LegacyCustomProtocolManagerCocoa.mm
+++ b/Source/WebKit/NetworkProcess/CustomProtocols/Cocoa/LegacyCustomProtocolManagerCocoa.mm
@@ -108,16 +108,20 @@ void LegacyCustomProtocolManager::networkProcessCreated(NetworkProcess& networkP
 
 - (void)startLoading
 {
-    if (auto* customProtocolManager = firstNetworkProcess()->supplement<LegacyCustomProtocolManager>())
-        customProtocolManager->startLoading(self.customProtocolID, [self request]);
+    ensureOnMainRunLoop([customProtocolID = self.customProtocolID, request = retainPtr([self request])] {
+        if (auto* customProtocolManager = firstNetworkProcess()->supplement<LegacyCustomProtocolManager>())
+            customProtocolManager->startLoading(customProtocolID, request.get());
+    });
 }
 
 - (void)stopLoading
 {
-    if (auto* customProtocolManager = firstNetworkProcess()->supplement<LegacyCustomProtocolManager>()) {
-        customProtocolManager->stopLoading(self.customProtocolID);
-        customProtocolManager->removeCustomProtocol(self.customProtocolID);
-    }
+    ensureOnMainRunLoop([customProtocolID = self.customProtocolID] {
+        if (auto* customProtocolManager = firstNetworkProcess()->supplement<LegacyCustomProtocolManager>()) {
+            customProtocolManager->stopLoading(customProtocolID);
+            customProtocolManager->removeCustomProtocol(customProtocolID);
+        }
+    });
 }
 
 @end

--- a/Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.cpp
+++ b/Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.cpp
@@ -49,6 +49,7 @@ LegacyCustomProtocolManager::LegacyCustomProtocolManager(NetworkProcess& network
 
 Ref<NetworkProcess> LegacyCustomProtocolManager::protectedNetworkProcess() const
 {
+    ASSERT(RunLoop::isMain());
     return m_networkProcess.get();
 }
 


### PR DESCRIPTION
#### ca9aa80579f0a3eab81504e3e8fcb81d75be4ea9
<pre>
LegacyCustomProtocolManager is incorrectly using the NetworkProcess object off the main thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=266787">https://bugs.webkit.org/show_bug.cgi?id=266787</a>

Reviewed by Alex Christensen.

LegacyCustomProtocolManager is incorrectly using the NetworkProcess object off the
main thread. NetworkProcess is only safe to use on the main thread.

Found this the hardware when I tried adding a threading assertion in 272402@main.

This patch fixes the bug and re-lands the threading assertion.

* Source/WebKit/NetworkProcess/CustomProtocols/Cocoa/LegacyCustomProtocolManagerCocoa.mm:
(-[WKCustomProtocol startLoading]):
(-[WKCustomProtocol stopLoading]):
* Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.cpp:
(WebKit::LegacyCustomProtocolManager::protectedNetworkProcess const):

Canonical link: <a href="https://commits.webkit.org/272437@main">https://commits.webkit.org/272437@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6dae2355928dc328cde36b4621ca400c7ca7bead

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31609 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10288 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33324 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34100 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28630 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12641 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7538 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/28230 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31957 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8660 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28209 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7469 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7630 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35445 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28725 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28566 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33759 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7723 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5730 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31611 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9379 "Built successfully") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/7421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8409 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4133 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8230 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->