### PR TITLE
[UnifiedPDF] PDF content is offset in snapshots

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -182,6 +182,7 @@ private:
     float deviceScaleFactor() const override;
     float pageScaleFactor() const override;
 
+    void paintPDFContent(WebCore::GraphicsContext&, const WebCore::FloatRect& clipRect);
     void ensureLayers();
     void updateLayerHierarchy();
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -264,12 +264,11 @@ void UnifiedPDFPlugin::didChangeIsInWindow()
 void UnifiedPDFPlugin::paint(WebCore::GraphicsContext& context, const WebCore::IntRect&)
 {
     // Only called for snapshotting.
-
     if (size().isEmpty())
         return;
 
     context.translate(-m_scrollOffset.width(), -m_scrollOffset.height());
-    paintContents(m_contentsLayer.get(), context, { FloatPoint(m_scrollOffset), size() }, { });
+    paintPDFContent(context, { FloatPoint(m_scrollOffset), size() });
 }
 
 void UnifiedPDFPlugin::paintContents(const GraphicsLayer* layer, GraphicsContext& context, const FloatRect& clipRect, OptionSet<GraphicsLayerPaintBehavior>)
@@ -307,6 +306,11 @@ void UnifiedPDFPlugin::paintContents(const GraphicsLayer* layer, GraphicsContext
     if (layer != m_contentsLayer.get())
         return;
 
+    paintPDFContent(context, clipRect);
+}
+
+void UnifiedPDFPlugin::paintPDFContent(WebCore::GraphicsContext& context, const WebCore::FloatRect& clipRect)
+{
     if (m_size.isEmpty() || documentSize().isEmpty())
         return;
 

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -410,6 +410,11 @@ void PluginView::initializePlugin()
     }
 }
 
+Ref<PDFPluginBase> PluginView::protectedPlugin() const
+{
+    return m_plugin;
+}
+
 PluginLayerHostingStrategy PluginView::layerHostingStrategy() const
 {
     if (!m_isInitialized)
@@ -514,9 +519,7 @@ void PluginView::paint(GraphicsContext& context, const IntRect& dirtyRect, Widge
     }
 
     // FIXME: We should try to intersect the dirty rect with the plug-in's clip rect here.
-    IntRect paintRect = IntRect(IntPoint(), frameRect().size());
-
-    if (paintRect.isEmpty())
+    if (frameRect().isEmpty())
         return;
 
     if (m_transientPaintingSnapshot) {
@@ -534,7 +537,28 @@ void PluginView::paint(GraphicsContext& context, const IntRect& dirtyRect, Widge
         return;
     }
 
-    m_plugin->paint(context, dirtyRect);
+    bool isSnapshotting = [&]() {
+        auto* frameView = frame()->view();
+        if (!frameView)
+            return false;
+
+        return frameView->paintBehavior().contains(PaintBehavior::FlattenCompositingLayers);
+    }();
+
+    if (!isSnapshotting && m_plugin->layerHostingStrategy() == PluginLayerHostingStrategy::GraphicsLayer)
+        return;
+
+    // RenderWidget::paintContents() translated the context so the origin is aligned with frameRect().location().
+    // Shift it back to align with the plugin origin.
+    GraphicsContextStateSaver stateSaver(context);
+
+    auto widgetOrigin = frameRect().location();
+    context.translate(widgetOrigin);
+
+    auto paintRect = dirtyRect;
+    paintRect.moveBy(-widgetOrigin);
+
+    protectedPlugin()->paint(context, paintRect);
 }
 
 void PluginView::frameRectsChanged()
@@ -840,6 +864,11 @@ void PluginView::redeliverManualStream()
         manualLoadDidFinishLoading();
 }
 
+CheckedPtr<RenderEmbeddedObject> PluginView::checkedRenderer() const
+{
+    return dynamicDowncast<RenderEmbeddedObject>(m_pluginElement->renderer());
+}
+
 void PluginView::invalidateRect(const IntRect& dirtyRect)
 {
     if (!parent() || !m_isInitialized)
@@ -850,13 +879,12 @@ void PluginView::invalidateRect(const IntRect& dirtyRect)
         return;
 #endif
 
-    auto* renderer = m_pluginElement->renderer();
-    if (!is<RenderEmbeddedObject>(renderer))
+    CheckedPtr renderer = checkedRenderer();
+    if (!renderer)
         return;
-    auto& object = downcast<RenderEmbeddedObject>(*renderer);
 
-    IntRect contentRect(dirtyRect);
-    contentRect.move(object.borderLeft() + object.paddingLeft(), object.borderTop() + object.paddingTop());
+    auto contentRect = dirtyRect;
+    contentRect.move(renderer->borderLeft() + renderer->paddingLeft(), renderer->borderTop() + renderer->paddingTop());
     renderer->repaintRectangle(contentRect);
 }
 

--- a/Source/WebKit/WebProcess/Plugins/PluginView.h
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.h
@@ -42,6 +42,7 @@ OBJC_CLASS PDFSelection;
 namespace WebCore {
 class HTMLPlugInElement;
 class LocalFrame;
+class RenderEmbeddedObject;
 }
 
 namespace WebKit {
@@ -114,6 +115,8 @@ private:
 
     void initializePlugin();
 
+    Ref<PDFPluginBase> protectedPlugin() const;
+
     void viewGeometryDidChange();
     void viewVisibilityDidChange();
 
@@ -128,6 +131,8 @@ private:
     bool shouldCreateTransientPaintingSnapshot() const;
 
     void updateDocumentForPluginSizingBehavior();
+
+    CheckedPtr<WebCore::RenderEmbeddedObject> checkedRenderer() const;
 
     // WebCore::PluginViewBase
     WebCore::PluginLayerHostingStrategy layerHostingStrategy() const final;


### PR DESCRIPTION
#### 31001e9814a15c1e2639a8fb4836b1ec65cc2fd1
<pre>
[UnifiedPDF] PDF content is offset in snapshots
<a href="https://bugs.webkit.org/show_bug.cgi?id=266791">https://bugs.webkit.org/show_bug.cgi?id=266791</a>
<a href="https://rdar.apple.com/120014898">rdar://120014898</a>

Reviewed by Tim Horton.

UnifiedPDFPlugin had two issues related to painting; first, it painted the PDF content as well
as rendering it into a layer. Second, that painted content was in the wrong location.

Fix the first issue by checking for a snapshotting paint in PluginView::paint(), and returning
if not snapshotting and the plugin uses PluginLayerHostingStrategy::GraphicsLayer, which is only
true for the UnifiedPDFPlugin. Also factor the PDF painting into a new function,
UnifiedPDFPlugin::paintPDFContent(), which avoids the confusion of passing in m_contentsLayer
when doing a software paint.

The second issue is also fixed in PluginView::paint(); we have to undo the context transform
that RenderWidget::paintContents() does.

Minor cleanup in PluginView::invalidateRect() to use a Checked&lt;&gt; pointer.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::paint):
(WebKit::UnifiedPDFPlugin::paintContents):
(WebKit::UnifiedPDFPlugin::paintPDFContent):
* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::protectedPlugin const):
(WebKit::PluginView::paint):
(WebKit::PluginView::checkedRenderer const):
(WebKit::PluginView::invalidateRect):
* Source/WebKit/WebProcess/Plugins/PluginView.h:

Canonical link: <a href="https://commits.webkit.org/272449@main">https://commits.webkit.org/272449@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a19cad1864cdb4bb549636bde8fa787247fe9217

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31624 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10303 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33339 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34115 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28640 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12657 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7553 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28241 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31972 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8676 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28222 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7483 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7642 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35460 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28741 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28579 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33781 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7736 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5744 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31633 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9392 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7427 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8421 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8244 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->