### PR TITLE
Reduce use of downcast<>() in rendering/svg code

### DIFF
--- a/Source/WebCore/rendering/svg/RenderSVGGradientStop.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGGradientStop.cpp
@@ -72,9 +72,7 @@ void RenderSVGGradientStop::layout()
 
 SVGGradientElement* RenderSVGGradientStop::gradientElement()
 {
-    if (is<SVGGradientElement>(element().parentElement()))
-        return downcast<SVGGradientElement>(element().parentElement());
-    return nullptr;
+    return dynamicDowncast<SVGGradientElement>(element().parentElement());
 }
 
 }

--- a/Source/WebCore/rendering/svg/RenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGImage.cpp
@@ -173,8 +173,8 @@ ImageDrawResult RenderSVGImage::paintIntoRect(PaintInfo& paintInfo, const FloatR
     if (!image || image->isNull())
         return ImageDrawResult::DidNothing;
 
-    if (is<BitmapImage>(image))
-        downcast<BitmapImage>(*image).updateFromSettings(settings());
+    if (auto* bitmapImage = dynamicDowncast<BitmapImage>(*image))
+        bitmapImage->updateFromSettings(settings());
 
     ImagePaintingOptions options {
         CompositeOperator::SourceOver,

--- a/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
@@ -232,9 +232,8 @@ bool RenderSVGModelObject::checkIntersection(RenderElement* renderer, const Floa
         return false;
     if (!isGraphicsElement(*renderer))
         return false;
-    SVGElement* svgElement = downcast<SVGElement>(renderer->element());
-    ASSERT(is<SVGGraphicsElement>(svgElement));
-    auto ctm = downcast<SVGGraphicsElement>(*svgElement).getCTM(SVGLocatable::DisallowStyleUpdate);
+    auto* svgElement = downcast<SVGGraphicsElement>(renderer->element());
+    auto ctm = svgElement->getCTM(SVGLocatable::DisallowStyleUpdate);
     // FIXME: [SVG] checkEnclosure implementation is inconsistent
     // https://bugs.webkit.org/show_bug.cgi?id=262709
     return intersectsAllowingEmpty(rect, ctm.mapRect(renderer->repaintRectInLocalCoordinates(RepaintRectCalculation::Accurate)));
@@ -246,9 +245,8 @@ bool RenderSVGModelObject::checkEnclosure(RenderElement* renderer, const FloatRe
         return false;
     if (!isGraphicsElement(*renderer))
         return false;
-    SVGElement* svgElement = downcast<SVGElement>(renderer->element());
-    ASSERT(is<SVGGraphicsElement>(svgElement));
-    auto ctm = downcast<SVGGraphicsElement>(*svgElement).getCTM(SVGLocatable::DisallowStyleUpdate);
+    auto* svgElement = downcast<SVGGraphicsElement>(renderer->element());
+    auto ctm = svgElement->getCTM(SVGLocatable::DisallowStyleUpdate);
     // FIXME: [SVG] checkEnclosure implementation is inconsistent
     // https://bugs.webkit.org/show_bug.cgi?id=262709
     return rect.contains(ctm.mapRect(renderer->repaintRectInLocalCoordinates(RepaintRectCalculation::Accurate)));

--- a/Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp
@@ -105,7 +105,6 @@ void RenderSVGResourceClipper::applyPathClipping(GraphicsContext& context, const
     auto* clipRendererPtr = graphicsElement.renderer();
     ASSERT(clipRendererPtr);
     ASSERT(clipRendererPtr->hasLayer());
-    ASSERT(is<RenderSVGModelObject>(clipRendererPtr));
     auto& clipRenderer = downcast<RenderSVGModelObject>(*clipRendererPtr);
 
     AffineTransform clipPathTransform;

--- a/Source/WebCore/rendering/svg/RenderSVGTransformableContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGTransformableContainer.cpp
@@ -52,13 +52,13 @@ inline SVGUseElement* associatedUseElement(SVGGraphicsElement& element)
     // If we're either the renderer for a <use> element, or for any <g> element inside the shadow
     // tree, that was created during the use/symbol/svg expansion in SVGUseElement. These containers
     // need to respect the translations induced by their corresponding use elements x/y attributes.
-    if (is<SVGUseElement>(element))
-        return &downcast<SVGUseElement>(element);
+    if (auto* useElement = dynamicDowncast<SVGUseElement>(element))
+        return useElement;
 
     if (element.isInShadowTree() && is<SVGGElement>(element)) {
         SVGElement* correspondingElement = element.correspondingElement();
-        if (is<SVGUseElement>(correspondingElement))
-            return downcast<SVGUseElement>(correspondingElement);
+        if (auto* useElement = dynamicDowncast<SVGUseElement>(correspondingElement))
+            return useElement;
     }
 
     return nullptr;

--- a/Source/WebCore/rendering/svg/RenderSVGViewportContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGViewportContainer.cpp
@@ -71,10 +71,8 @@ FloatPoint RenderSVGViewportContainer::computeViewportLocation() const
 
 FloatSize RenderSVGViewportContainer::computeViewportSize() const
 {
-    if (isOutermostSVGViewportContainer()) {
-        ASSERT(is<RenderSVGRoot>(parent()));
+    if (isOutermostSVGViewportContainer())
         return downcast<RenderSVGRoot>(*parent()).computeViewportSize();
-    }
 
     auto& useSVGSVGElement = svgSVGElement();
     SVGLengthContext lengthContext(&useSVGSVGElement);

--- a/Source/WebCore/rendering/svg/SVGContainerLayout.cpp
+++ b/Source/WebCore/rendering/svg/SVGContainerLayout.cpp
@@ -66,8 +66,8 @@ void SVGContainerLayout::layoutChildren(bool containerNeedsLayout)
 
         if (transformChanged) {
             // If the transform changed we need to update the text metrics (note: this also happens for layoutSizeChanged=true).
-            if (is<RenderSVGText>(child))
-                downcast<RenderSVGText>(child).setNeedsTextMetricsUpdate();
+            if (CheckedPtr text = dynamicDowncast<RenderSVGText>(child))
+                text->setNeedsTextMetricsUpdate();
             needsLayout = true;
         }
 
@@ -75,16 +75,15 @@ void SVGContainerLayout::layoutChildren(bool containerNeedsLayout)
             if (child.isAnonymous()) {
                 ASSERT(is<RenderSVGViewportContainer>(child));
                 needsLayout = true;
-            } else if (is<SVGElement>(*child.node())) {
+            } else if (auto* element = dynamicDowncast<SVGElement>(*child.node())) {
                 // When containerNeedsLayout is false and the layout size changed, we have to check whether this child uses relative lengths
-                if (auto& element = downcast<SVGElement>(*child.node()); element.hasRelativeLengths()) {
+                if (element->hasRelativeLengths()) {
                     // When the layout size changed and when using relative values tell the RenderSVGShape to update its shape object
-                    if (is<RenderSVGShape>(child))
-                        downcast<RenderSVGShape>(child).setNeedsShapeUpdate();
-                    else if (is<RenderSVGText>(child)) {
-                        auto& svgText = downcast<RenderSVGText>(child);
-                        svgText.setNeedsTextMetricsUpdate();
-                        svgText.setNeedsPositioningValuesUpdate();
+                    if (CheckedPtr shape = dynamicDowncast<RenderSVGShape>(child))
+                        shape->setNeedsShapeUpdate();
+                    else if (CheckedPtr svgText = dynamicDowncast<RenderSVGText>(child)) {
+                        svgText->setNeedsTextMetricsUpdate();
+                        svgText->setNeedsPositioningValuesUpdate();
                     }
 
                     needsLayout = true;
@@ -95,13 +94,12 @@ void SVGContainerLayout::layoutChildren(bool containerNeedsLayout)
         if (needsLayout)
             child.setNeedsLayout(MarkOnlyThis);
 
-        if (is<RenderElement>(child)) {
-            auto& element = downcast<RenderElement>(child);
-            if (element.needsLayout())
-                element.layout();
+        if (auto* element = dynamicDowncast<RenderElement>(child)) {
+            if (element->needsLayout())
+                element->layout();
 
-            if (!childEverHadLayout && element.checkForRepaintDuringLayout())
-                element.repaint();
+            if (!childEverHadLayout && element->checkForRepaintDuringLayout())
+                element->repaint();
         }
 
         ASSERT(!child.needsLayout());
@@ -135,8 +133,8 @@ void SVGContainerLayout::positionChildrenRelativeToContainer()
         // only meaningful for the children of the RenderSVGRoot. RenderSVGRoot itself is positioned according to
         // the CSS box model object, where we need to respect border & padding, encoded in the contentBoxLocation().
         // -> Position all RenderSVGRoot children relative to the contentBoxLocation() to avoid intruding border/padding area.
-        if (is<RenderSVGRoot>(m_container))
-            return -downcast<RenderSVGRoot>(m_container).contentBoxLocation();
+        if (auto* svgRoot = dynamicDowncast<RenderSVGRoot>(m_container))
+            return -svgRoot->contentBoxLocation();
 
         // For (inner) RenderSVGViewportContainer nominalSVGLayoutLocation() returns the viewport boundaries,
         // including the effect of the 'x'/'y' attribute values. Do not subtract the location, otherwise the
@@ -223,14 +221,14 @@ bool SVGContainerLayout::layoutSizeOfNearestViewportChanged() const
 bool SVGContainerLayout::transformToRootChanged(const RenderObject* ancestor)
 {
     while (ancestor) {
-        if (is<RenderSVGTransformableContainer>(*ancestor))
-            return downcast<const RenderSVGTransformableContainer>(*ancestor).didTransformToRootUpdate();
+        if (CheckedPtr container = dynamicDowncast<RenderSVGTransformableContainer>(*ancestor))
+            return container->didTransformToRootUpdate();
 
-        if (is<RenderSVGViewportContainer>(*ancestor))
-            return downcast<const RenderSVGViewportContainer>(*ancestor).didTransformToRootUpdate();
+        if (CheckedPtr container = dynamicDowncast<RenderSVGViewportContainer>(*ancestor))
+            return container->didTransformToRootUpdate();
 
-        if (is<RenderSVGRoot>(*ancestor))
-            return downcast<const RenderSVGRoot>(*ancestor).didTransformToRootUpdate();
+        if (CheckedPtr svgRoot = dynamicDowncast<RenderSVGRoot>(*ancestor))
+            return svgRoot->didTransformToRootUpdate();
         ancestor = ancestor->parent();
     }
 

--- a/Source/WebCore/rendering/svg/SVGInlineFlowBox.cpp
+++ b/Source/WebCore/rendering/svg/SVGInlineFlowBox.cpp
@@ -41,10 +41,10 @@ void SVGInlineFlowBox::paintSelectionBackground(PaintInfo& paintInfo)
 
     PaintInfo childPaintInfo(paintInfo);
     for (auto* child = firstChild(); child; child = child->nextOnLine()) {
-        if (is<SVGInlineTextBox>(*child))
-            downcast<SVGInlineTextBox>(*child).paintSelectionBackground(childPaintInfo);
-        else if (is<SVGInlineFlowBox>(*child))
-            downcast<SVGInlineFlowBox>(*child).paintSelectionBackground(childPaintInfo);
+        if (auto* textBox = dynamicDowncast<SVGInlineTextBox>(*child))
+            textBox->paintSelectionBackground(childPaintInfo);
+        else if (auto* flowBox = dynamicDowncast<SVGInlineFlowBox>(*child))
+            flowBox->paintSelectionBackground(childPaintInfo);
     }
 }
 
@@ -64,12 +64,12 @@ FloatRect SVGInlineFlowBox::calculateBoundaries() const
 {
     FloatRect childRect;
     for (auto* child = firstChild(); child; child = child->nextOnLine()) {
-        if (is<SVGInlineTextBox>(child)) {
-            childRect.unite(downcast<SVGInlineTextBox>(*child).calculateBoundaries());
+        if (auto* textBox = dynamicDowncast<SVGInlineTextBox>(child)) {
+            childRect.unite(textBox->calculateBoundaries());
             continue;
         }
-        if (is<SVGInlineFlowBox>(child)) {
-            childRect.unite(downcast<SVGInlineFlowBox>(*child).calculateBoundaries());
+        if (auto* flowBox = dynamicDowncast<SVGInlineFlowBox>(child)) {
+            childRect.unite(flowBox->calculateBoundaries());
             continue;
         }
     }

--- a/Source/WebCore/rendering/svg/SVGInlineTextBox.cpp
+++ b/Source/WebCore/rendering/svg/SVGInlineTextBox.cpp
@@ -316,8 +316,10 @@ void SVGInlineTextBox::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffse
     }
 
     // Finally, paint the outline if any.
-    if (renderer().style().hasOutline() && is<RenderInline>(parentRenderer))
-        downcast<RenderInline>(parentRenderer).paintOutline(paintInfo, paintOffset);
+    if (renderer().style().hasOutline()) {
+        if (CheckedPtr renderInline = dynamicDowncast<RenderInline>(parentRenderer))
+            renderInline->paintOutline(paintInfo, paintOffset);
+    }
 
     ASSERT(!m_paintingResource);
 }

--- a/Source/WebCore/rendering/svg/SVGPathData.cpp
+++ b/Source/WebCore/rendering/svg/SVGPathData.cpp
@@ -43,10 +43,8 @@
 
 namespace WebCore {
 
-static Path pathFromCircleElement(const SVGElement& element)
+static Path pathFromCircleElement(const SVGCircleElement& element)
 {
-    ASSERT(is<SVGCircleElement>(element));
-
     RenderElement* renderer = element.renderer();
     if (!renderer)
         return { };
@@ -63,7 +61,7 @@ static Path pathFromCircleElement(const SVGElement& element)
     return path;
 }
 
-static Path pathFromEllipseElement(const SVGElement& element)
+static Path pathFromEllipseElement(const SVGEllipseElement& element)
 {
     RenderElement* renderer = element.renderer();
     if (!renderer)
@@ -86,25 +84,23 @@ static Path pathFromEllipseElement(const SVGElement& element)
     return path;
 }
 
-static Path pathFromLineElement(const SVGElement& element)
+static Path pathFromLineElement(const SVGLineElement& element)
 {
     Path path;
-    const auto& line = downcast<SVGLineElement>(element);
-
     SVGLengthContext lengthContext(&element);
-    path.moveTo(FloatPoint(line.x1().value(lengthContext), line.y1().value(lengthContext)));
-    path.addLineTo(FloatPoint(line.x2().value(lengthContext), line.y2().value(lengthContext)));
+    path.moveTo(FloatPoint(element.x1().value(lengthContext), element.y1().value(lengthContext)));
+    path.addLineTo(FloatPoint(element.x2().value(lengthContext), element.y2().value(lengthContext)));
     return path;
 }
 
-static Path pathFromPathElement(const SVGElement& element)
+static Path pathFromPathElement(const SVGPathElement& element)
 {
-    return downcast<SVGPathElement>(element).path();
+    return element.path();
 }
 
-static Path pathFromPolygonElement(const SVGElement& element)
+static Path pathFromPolygonElement(const SVGPolygonElement& element)
 {
-    auto& points = downcast<SVGPolygonElement>(element).points().items();
+    auto& points = element.points().items();
     if (points.isEmpty())
         return { };
 
@@ -119,9 +115,9 @@ static Path pathFromPolygonElement(const SVGElement& element)
     return path;
 }
 
-static Path pathFromPolylineElement(const SVGElement& element)
+static Path pathFromPolylineElement(const SVGPolylineElement& element)
 {
-    auto& points = downcast<SVGPolylineElement>(element).points().items();
+    auto& points = element.points().items();
     if (points.isEmpty())
         return { };
 
@@ -134,7 +130,7 @@ static Path pathFromPolylineElement(const SVGElement& element)
     return path;
 }
 
-static Path pathFromRectElement(const SVGElement& element)
+static Path pathFromRectElement(const SVGRectElement& element)
 {
     RenderElement* renderer = element.renderer();
     if (!renderer)
@@ -184,17 +180,15 @@ static Path pathFromRectElement(const SVGElement& element)
     return path;
 }
 
-static Path pathFromUseElement(const SVGElement& element)
+static Path pathFromUseElement(const SVGUseElement& element)
 {
-    const auto& useElement = downcast<SVGUseElement>(element);
-
-    RefPtr clipChildElement = useElement.clipChild();
+    RefPtr clipChildElement = element.clipChild();
     if (!clipChildElement)
         return { };
 
     SVGLengthContext lengthContext(&element);
-    auto x = useElement.x().value(lengthContext);
-    auto y = useElement.y().value(lengthContext);
+    auto x = element.x().value(lengthContext);
+    auto y = element.y().value(lengthContext);
 
     auto path = pathFromGraphicsElement(*clipChildElement.get());
     if (x || y)
@@ -207,21 +201,21 @@ Path pathFromGraphicsElement(const SVGElement& element)
 {
     switch (element.tagQName().nodeName()) {
     case ElementNames::SVG::circle:
-        return pathFromCircleElement(element);
+        return pathFromCircleElement(uncheckedDowncast<SVGCircleElement>(element));
     case ElementNames::SVG::ellipse:
-        return pathFromEllipseElement(element);
+        return pathFromEllipseElement(uncheckedDowncast<SVGEllipseElement>(element));
     case ElementNames::SVG::line:
-        return pathFromLineElement(element);
+        return pathFromLineElement(uncheckedDowncast<SVGLineElement>(element));
     case ElementNames::SVG::path:
-        return pathFromPathElement(element);
+        return pathFromPathElement(uncheckedDowncast<SVGPathElement>(element));
     case ElementNames::SVG::polygon:
-        return pathFromPolygonElement(element);
+        return pathFromPolygonElement(uncheckedDowncast<SVGPolygonElement>(element));
     case ElementNames::SVG::polyline:
-        return pathFromPolylineElement(element);
+        return pathFromPolylineElement(uncheckedDowncast<SVGPolylineElement>(element));
     case ElementNames::SVG::rect:
-        return pathFromRectElement(element);
+        return pathFromRectElement(uncheckedDowncast<SVGRectElement>(element));
     case ElementNames::SVG::use:
-        return pathFromUseElement(element);
+        return pathFromUseElement(uncheckedDowncast<SVGUseElement>(element));
     default:
         break;
     }

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
@@ -93,8 +93,8 @@ const RenderElement& SVGRenderSupport::localToParentTransform(const RenderElemen
 
     // At the SVG/HTML boundary (aka LegacyRenderSVGRoot), we apply the localToBorderBoxTransform
     // to map an element from SVG viewport coordinates to CSS box coordinates.
-    if (is<LegacyRenderSVGRoot>(parent))
-        transform = downcast<LegacyRenderSVGRoot>(parent).localToBorderBoxTransform() * renderer.localToParentTransform();
+    if (auto* svgRoot = dynamicDowncast<LegacyRenderSVGRoot>(parent))
+        transform = svgRoot->localToBorderBoxTransform() * renderer.localToParentTransform();
     else
         transform = renderer.localToParentTransform();
 
@@ -129,14 +129,15 @@ bool SVGRenderSupport::checkForSVGRepaintDuringLayout(const RenderElement& rende
         return false;
     // When a parent container is transformed in SVG, all children will be painted automatically
     // so we are able to skip redundant repaint checks.
-    auto parent = renderer.parent();
-    return !(is<LegacyRenderSVGContainer>(parent) && downcast<LegacyRenderSVGContainer>(*parent).didTransformToRootUpdate());
+    auto* parent = dynamicDowncast<LegacyRenderSVGContainer>(renderer.parent());
+    return !parent || !parent->didTransformToRootUpdate();
 }
 
 // Update a bounding box taking into account the validity of the other bounding box.
 static inline void updateObjectBoundingBox(FloatRect& objectBoundingBox, bool& objectBoundingBoxValid, const RenderObject* other, FloatRect otherBoundingBox)
 {
-    bool otherValid = is<LegacyRenderSVGContainer>(*other) ? downcast<LegacyRenderSVGContainer>(*other).isObjectBoundingBoxValid() : true;
+    auto* otherContainer = dynamicDowncast<LegacyRenderSVGContainer>(*other);
+    bool otherValid = !otherContainer || otherContainer->isObjectBoundingBoxValid();
     if (!otherValid)
         return;
 
@@ -159,7 +160,7 @@ void SVGRenderSupport::computeContainerBoundingBoxes(const RenderElement& contai
             continue;
 
         // Don't include elements in the union that do not render.
-        if (is<LegacyRenderSVGShape>(current) && downcast<LegacyRenderSVGShape>(current).isRenderingDisabled())
+        if (auto* shape = dynamicDowncast<LegacyRenderSVGShape>(current); shape && shape->isRenderingDisabled())
             continue;
 
         const AffineTransform& transform = current.localToParentTransform();
@@ -182,12 +183,12 @@ FloatRect SVGRenderSupport::computeContainerStrokeBoundingBox(const RenderElemen
             continue;
 
         // Don't include elements in the union that do not render.
-        if (is<LegacyRenderSVGShape>(current) && downcast<LegacyRenderSVGShape>(current).isRenderingDisabled())
+        if (auto* shape = dynamicDowncast<LegacyRenderSVGShape>(current); shape && shape->isRenderingDisabled())
             continue;
 
         FloatRect childStrokeBoundingBox = current.strokeBoundingBox();
-        if (is<RenderElement>(current))
-            SVGRenderSupport::intersectRepaintRectWithResources(downcast<RenderElement>(current), childStrokeBoundingBox, RepaintRectCalculation::Accurate);
+        if (auto* currentElement = dynamicDowncast<RenderElement>(current))
+            SVGRenderSupport::intersectRepaintRectWithResources(*currentElement, childStrokeBoundingBox, RepaintRectCalculation::Accurate);
         const AffineTransform& transform = current.localToParentTransform();
         if (transform.isIdentity())
             strokeBoundingBox.unite(childStrokeBoundingBox);
@@ -227,24 +228,23 @@ static inline void invalidateResourcesOfChildren(RenderElement& renderer)
 
 static inline bool layoutSizeOfNearestViewportChanged(const RenderElement& renderer)
 {
-    const RenderElement* start = &renderer;
-    while (start && !is<LegacyRenderSVGRoot>(*start) && !is<LegacyRenderSVGViewportContainer>(*start))
-        start = start->parent();
-
-    ASSERT(start);
-    if (is<LegacyRenderSVGViewportContainer>(*start))
-        return downcast<LegacyRenderSVGViewportContainer>(*start).isLayoutSizeChanged();
-
-    return downcast<LegacyRenderSVGRoot>(*start).isLayoutSizeChanged();
+    for (auto* start = &renderer; start; start = start->parent()) {
+        if (auto* svgRoot = dynamicDowncast<LegacyRenderSVGRoot>(*start))
+            return svgRoot->isLayoutSizeChanged();
+        if (auto* container = dynamicDowncast<LegacyRenderSVGViewportContainer>(*start))
+            return container->isLayoutSizeChanged();
+    }
+    ASSERT_NOT_REACHED();
+    return false;
 }
 
 bool SVGRenderSupport::transformToRootChanged(RenderElement* ancestor)
 {
     while (ancestor && !ancestor->isRenderOrLegacyRenderSVGRoot()) {
-        if (is<LegacyRenderSVGTransformableContainer>(*ancestor))
-            return downcast<LegacyRenderSVGTransformableContainer>(*ancestor).didTransformToRootUpdate();
-        if (is<LegacyRenderSVGViewportContainer>(*ancestor))
-            return downcast<LegacyRenderSVGViewportContainer>(*ancestor).didTransformToRootUpdate();
+        if (CheckedPtr container = dynamicDowncast<LegacyRenderSVGTransformableContainer>(*ancestor))
+            return container->didTransformToRootUpdate();
+        if (CheckedPtr container = dynamicDowncast<LegacyRenderSVGViewportContainer>(*ancestor))
+            return container->didTransformToRootUpdate();
         ancestor = ancestor->parent();
     }
 
@@ -272,22 +272,20 @@ void SVGRenderSupport::layoutChildren(RenderElement& start, bool selfNeedsLayout
 
         if (transformChanged) {
             // If the transform changed we need to update the text metrics (note: this also happens for layoutSizeChanged=true).
-            if (is<RenderSVGText>(child))
-                downcast<RenderSVGText>(child).setNeedsTextMetricsUpdate();
+            if (CheckedPtr text = dynamicDowncast<RenderSVGText>(child))
+                text->setNeedsTextMetricsUpdate();
             needsLayout = true;
         }
 
-        if (layoutSizeChanged && is<SVGElement>(*child.node())) {
+        if (layoutSizeChanged) {
             // When selfNeedsLayout is false and the layout size changed, we have to check whether this child uses relative lengths
-            auto& element = downcast<SVGElement>(*child.node());
-            if (element.hasRelativeLengths()) {
+            if (auto* element = dynamicDowncast<SVGElement>(*child.node()); element && element->hasRelativeLengths()) {
                 // When the layout size changed and when using relative values tell the LegacyRenderSVGShape to update its shape object
-                if (is<LegacyRenderSVGShape>(child))
-                    downcast<LegacyRenderSVGShape>(child).setNeedsShapeUpdate();
-                else if (is<RenderSVGText>(child)) {
-                    auto& svgText = downcast<RenderSVGText>(child);
-                    svgText.setNeedsTextMetricsUpdate();
-                    svgText.setNeedsPositioningValuesUpdate();
+                if (CheckedPtr shape = dynamicDowncast<LegacyRenderSVGShape>(child))
+                    shape->setNeedsShapeUpdate();
+                else if (CheckedPtr svgText = dynamicDowncast<RenderSVGText>(child)) {
+                    svgText->setNeedsTextMetricsUpdate();
+                    svgText->setNeedsPositioningValuesUpdate();
                 }
                 child.setNeedsTransformUpdate();
                 needsLayout = true;
@@ -298,16 +296,19 @@ void SVGRenderSupport::layoutChildren(RenderElement& start, bool selfNeedsLayout
             child.setNeedsLayout(MarkOnlyThis);
 
         if (child.needsLayout()) {
-            layoutDifferentRootIfNeeded(downcast<RenderElement>(child));
-            downcast<RenderElement>(child).layout();
+            CheckedRef childElement = downcast<RenderElement>(child);
+            layoutDifferentRootIfNeeded(childElement);
+            childElement->layout();
             // Renderers are responsible for repainting themselves when changing, except
             // for the initial paint to avoid potential double-painting caused by non-sensical "old" bounds.
             // We could handle this in the individual objects, but for now it's easier to have
             // parent containers call repaint().  (RenderBlock::layout* has similar logic.)
             if (!childEverHadLayout)
                 child.repaint();
-        } else if (layoutSizeChanged && is<RenderElement>(child))
-            elementsThatDidNotReceiveLayout.add(downcast<RenderElement>(child));
+        } else if (layoutSizeChanged) {
+            if (auto* childElement = dynamicDowncast<RenderElement>(child))
+                elementsThatDidNotReceiveLayout.add(*childElement);
+        }
 
         ASSERT(!child.needsLayout());
     }
@@ -391,19 +392,17 @@ inline FloatRect clipPathReferenceBox(const RenderElement& renderer, CSSBoxType 
 inline bool isPointInCSSClippingArea(const RenderElement& renderer, const FloatPoint& point)
 {
     PathOperation* clipPathOperation = renderer.style().clipPath();
-    if (is<ShapePathOperation>(clipPathOperation)) {
-        auto& clipPath = downcast<ShapePathOperation>(*clipPathOperation);
-        FloatRect referenceBox = clipPathReferenceBox(renderer, clipPath.referenceBox());
+    if (auto* clipPath = dynamicDowncast<ShapePathOperation>(clipPathOperation)) {
+        FloatRect referenceBox = clipPathReferenceBox(renderer, clipPath->referenceBox());
         if (!referenceBox.contains(point))
             return false;
-        return clipPath.pathForReferenceRect(referenceBox).contains(point, clipPath.windRule());
+        return clipPath->pathForReferenceRect(referenceBox).contains(point, clipPath->windRule());
     }
-    if (is<BoxPathOperation>(clipPathOperation)) {
-        auto& clipPath = downcast<BoxPathOperation>(*clipPathOperation);
-        FloatRect referenceBox = clipPathReferenceBox(renderer, clipPath.referenceBox());
+    if (auto* clipPath = dynamicDowncast<BoxPathOperation>(clipPathOperation)) {
+        FloatRect referenceBox = clipPathReferenceBox(renderer, clipPath->referenceBox());
         if (!referenceBox.contains(point))
             return false;
-        return clipPath.pathForReferenceRect(FloatRoundedRect {referenceBox}).contains(point);
+        return clipPath->pathForReferenceRect(FloatRoundedRect { referenceBox }).contains(point);
     }
 
     return true;
@@ -412,22 +411,20 @@ inline bool isPointInCSSClippingArea(const RenderElement& renderer, const FloatP
 void SVGRenderSupport::clipContextToCSSClippingArea(GraphicsContext& context, const RenderElement& renderer)
 {
     PathOperation* clipPathOperation = renderer.style().clipPath();
-    if (is<ShapePathOperation>(clipPathOperation)) {
-        auto& clipPath = downcast<ShapePathOperation>(*clipPathOperation);
+    if (auto* clipPath = dynamicDowncast<ShapePathOperation>(clipPathOperation)) {
         auto localToParentTransform = renderer.localToParentTransform();
 
-        auto referenceBox = clipPathReferenceBox(renderer, clipPath.referenceBox());
+        auto referenceBox = clipPathReferenceBox(renderer, clipPath->referenceBox());
         referenceBox = localToParentTransform.mapRect(referenceBox);
 
-        auto path = clipPath.pathForReferenceRect(referenceBox);
+        auto path = clipPath->pathForReferenceRect(referenceBox);
         path.transform(valueOrDefault(localToParentTransform.inverse()));
 
-        context.clipPath(path, clipPath.windRule());
+        context.clipPath(path, clipPath->windRule());
     }
-    if (is<BoxPathOperation>(clipPathOperation)) {
-        auto& clipPath = downcast<BoxPathOperation>(*clipPathOperation);
-        FloatRect referenceBox = clipPathReferenceBox(renderer, clipPath.referenceBox());
-        context.clipPath(clipPath.pathForReferenceRect(FloatRoundedRect {referenceBox}));
+    if (auto* clipPath = dynamicDowncast<BoxPathOperation>(clipPathOperation)) {
+        FloatRect referenceBox = clipPathReferenceBox(renderer, clipPath->referenceBox());
+        context.clipPath(clipPath->pathForReferenceRect(FloatRoundedRect { referenceBox }));
     }
 }
 
@@ -465,15 +462,15 @@ bool SVGRenderSupport::pointInClippingArea(const RenderElement& renderer, const 
 
 void SVGRenderSupport::applyStrokeStyleToContext(GraphicsContext& context, const RenderStyle& style, const RenderElement& renderer)
 {
-    Element* element = renderer.element();
-    if (!is<SVGElement>(element)) {
+    RefPtr element = dynamicDowncast<SVGElement>(renderer.element());
+    if (!element) {
         ASSERT_NOT_REACHED();
         return;
     }
 
     const SVGRenderStyle& svgStyle = style.svgStyle();
 
-    SVGLengthContext lengthContext(downcast<SVGElement>(renderer.element()));
+    SVGLengthContext lengthContext(element.get());
     context.setStrokeThickness(lengthContext.valueForLength(style.strokeWidth()));
     context.setLineCap(style.capStyle());
     context.setLineJoin(style.joinStyle());
@@ -486,15 +483,15 @@ void SVGRenderSupport::applyStrokeStyleToContext(GraphicsContext& context, const
     else {
         float scaleFactor = 1;
 
-        if (is<SVGGeometryElement>(element)) {
+        if (auto geometryElement = dynamicDowncast<SVGGeometryElement>(*element)) {
             ASSERT(renderer.isRenderOrLegacyRenderSVGShape());
             // FIXME: A value of zero is valid. Need to differentiate this case from being unspecified.
-            if (float pathLength = downcast<SVGGeometryElement>(element)->pathLength()) {
-                if (is<LegacyRenderSVGShape>(renderer))
-                    scaleFactor = downcast<LegacyRenderSVGShape>(renderer).getTotalLength() / pathLength;
+            if (float pathLength = geometryElement->pathLength()) {
+                if (auto* shape = dynamicDowncast<LegacyRenderSVGShape>(renderer))
+                    scaleFactor = shape->getTotalLength() / pathLength;
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
-                else if (is<RenderSVGShape>(renderer))
-                    scaleFactor = downcast<RenderSVGShape>(renderer).getTotalLength() / pathLength;
+                else if (auto* shape = dynamicDowncast<RenderSVGShape>(renderer))
+                    scaleFactor = shape->getTotalLength() / pathLength;
 #endif
             }
         }
@@ -656,12 +653,9 @@ FloatRect SVGRenderSupport::calculateApproximateStrokeBoundingBox(const RenderEl
     };
 
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
-    if (is<LegacyRenderSVGShape>(renderer)) {
-        const auto& shape = downcast<LegacyRenderSVGShape>(renderer);
-        return shape.adjustStrokeBoundingBoxForMarkersAndZeroLengthLinecaps(RepaintRectCalculation::Fast, calculate(shape));
-    }
+    if (auto* shape = dynamicDowncast<LegacyRenderSVGShape>(renderer))
+        return shape->adjustStrokeBoundingBoxForMarkersAndZeroLengthLinecaps(RepaintRectCalculation::Fast, calculate(*shape));
 
-    ASSERT(is<RenderSVGShape>(renderer));
     const auto& shape = downcast<RenderSVGShape>(renderer);
     return shape.adjustStrokeBoundingBoxForZeroLengthLinecaps(RepaintRectCalculation::Fast, calculate(shape));
 #else

--- a/Source/WebCore/rendering/svg/SVGRenderingContext.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderingContext.cpp
@@ -102,9 +102,9 @@ void SVGRenderingContext::prepareToRenderSVGContent(RenderElement& renderer, Pai
     bool isolateMaskForBlending = false;
 
 #if ENABLE(CSS_COMPOSITING)
-    if (style.hasPositionedMask() && is<SVGGraphicsElement>(downcast<SVGElement>(*renderer.element()))) {
-        SVGGraphicsElement& graphicsElement = downcast<SVGGraphicsElement>(*renderer.element());
-        isolateMaskForBlending = graphicsElement.shouldIsolateBlending();
+    if (style.hasPositionedMask()) {
+        if (auto* graphicsElement = dynamicDowncast<SVGGraphicsElement>(*renderer.element()))
+            isolateMaskForBlending = graphicsElement->shouldIsolateBlending();
     }
 #endif
 

--- a/Source/WebCore/rendering/svg/SVGResourcesCache.cpp
+++ b/Source/WebCore/rendering/svg/SVGResourcesCache.cpp
@@ -262,8 +262,7 @@ void SVGResourcesCache::resourceDestroyed(LegacyRenderSVGResourceContainer& reso
         if (it.value->resourceDestroyed(resource)) {
             // Mark users of destroyed resources as pending resolution based on the id of the old resource.
             auto& clientElement = *it.key->element();
-            RELEASE_ASSERT(is<SVGElement>(clientElement));
-            clientElement.treeScopeForSVGReferences().addPendingSVGResource(resource.element().getIdAttribute(), downcast<SVGElement>(clientElement));
+            clientElement.treeScopeForSVGReferences().addPendingSVGResource(resource.element().getIdAttribute(), checkedDowncast<SVGElement>(clientElement));
         }
     }
 }

--- a/Source/WebCore/rendering/svg/SVGResourcesCycleSolver.cpp
+++ b/Source/WebCore/rendering/svg/SVGResourcesCycleSolver.cpp
@@ -50,8 +50,8 @@ bool SVGResourcesCycleSolver::resourceContainsCycles(LegacyRenderSVGResourceCont
             node = node->nextInPreOrderAfterChildren(&resource);
             continue;
         }
-        if (is<RenderElement>(*node)) {
-            if (auto* resources = SVGResourcesCache::cachedResourcesForRenderer(downcast<RenderElement>(*node))) {
+        if (auto* element = dynamicDowncast<RenderElement>(*node)) {
+            if (auto* resources = SVGResourcesCache::cachedResourcesForRenderer(*element)) {
                 SingleThreadWeakHashSet<LegacyRenderSVGResourceContainer> resourceSet;
                 resources->buildSetOfResources(resourceSet);
 
@@ -83,8 +83,8 @@ void SVGResourcesCycleSolver::resolveCycles(RenderElement& renderer, SVGResource
     SingleThreadWeakHashSet<LegacyRenderSVGResourceContainer> activeResources;
     SingleThreadWeakHashSet<LegacyRenderSVGResourceContainer> acyclicResources;
 
-    if (is<LegacyRenderSVGResourceContainer>(renderer))
-        activeResources.add(downcast<LegacyRenderSVGResourceContainer>(renderer));
+    if (auto* container = dynamicDowncast<LegacyRenderSVGResourceContainer>(renderer))
+        activeResources.add(*container);
 
     // The job of this function is to determine wheter any of the 'resources' associated with the given 'renderer'
     // references us (or whether any of its kids references us) -> that's a cycle, we need to find and break it.


### PR DESCRIPTION
#### 55b0823de716fae92930f0fe939e99c82f428a07
<pre>
Reduce use of downcast&lt;&gt;() in rendering/svg code
<a href="https://bugs.webkit.org/show_bug.cgi?id=266792">https://bugs.webkit.org/show_bug.cgi?id=266792</a>

Reviewed by Simon Fraser.

* Source/WebCore/rendering/svg/RenderSVGGradientStop.cpp:
(WebCore::RenderSVGGradientStop::gradientElement):
* Source/WebCore/rendering/svg/RenderSVGImage.cpp:
(WebCore::RenderSVGImage::paintIntoRect):
* Source/WebCore/rendering/svg/RenderSVGModelObject.cpp:
(WebCore::RenderSVGModelObject::checkIntersection):
(WebCore::RenderSVGModelObject::checkEnclosure):
* Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp:
(WebCore::RenderSVGResourceClipper::applyPathClipping):
* Source/WebCore/rendering/svg/RenderSVGText.cpp:
(WebCore::collectLayoutAttributes):
(WebCore::findPreviousAndNextAttributes):
(WebCore::updateFontInAllDescendants):
* Source/WebCore/rendering/svg/RenderSVGTransformableContainer.cpp:
(WebCore::associatedUseElement):
* Source/WebCore/rendering/svg/RenderSVGViewportContainer.cpp:
(WebCore::RenderSVGViewportContainer::computeViewportSize const):
* Source/WebCore/rendering/svg/SVGBoundingBoxComputation.cpp:
(WebCore::SVGBoundingBoxComputation::handleShapeOrTextOrInline const):
(WebCore::SVGBoundingBoxComputation::handleRootOrContainer const):
* Source/WebCore/rendering/svg/SVGContainerLayout.cpp:
(WebCore::SVGContainerLayout::layoutChildren):
(WebCore::SVGContainerLayout::positionChildrenRelativeToContainer):
(WebCore::SVGContainerLayout::transformToRootChanged):
* Source/WebCore/rendering/svg/SVGInlineFlowBox.cpp:
(WebCore::SVGInlineFlowBox::paintSelectionBackground):
(WebCore::SVGInlineFlowBox::calculateBoundaries const):
* Source/WebCore/rendering/svg/SVGInlineTextBox.cpp:
(WebCore::SVGInlineTextBox::paint):
* Source/WebCore/rendering/svg/SVGPathData.cpp:
(WebCore::pathFromCircleElement):
(WebCore::pathFromEllipseElement):
(WebCore::pathFromLineElement):
(WebCore::pathFromPathElement):
(WebCore::pathFromPolygonElement):
(WebCore::pathFromPolylineElement):
(WebCore::pathFromRectElement):
(WebCore::pathFromUseElement):
(WebCore::pathFromGraphicsElement):
* Source/WebCore/rendering/svg/SVGRenderSupport.cpp:
(WebCore::SVGRenderSupport::localToParentTransform):
(WebCore::SVGRenderSupport::checkForSVGRepaintDuringLayout):
(WebCore::updateObjectBoundingBox):
(WebCore::SVGRenderSupport::computeContainerBoundingBoxes):
(WebCore::SVGRenderSupport::computeContainerStrokeBoundingBox):
(WebCore::layoutSizeOfNearestViewportChanged):
(WebCore::SVGRenderSupport::transformToRootChanged):
(WebCore::SVGRenderSupport::layoutChildren):
(WebCore::isPointInCSSClippingArea):
(WebCore::SVGRenderSupport::clipContextToCSSClippingArea):
(WebCore::SVGRenderSupport::applyStrokeStyleToContext):
(WebCore::SVGRenderSupport::calculateApproximateStrokeBoundingBox):
* Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp:
(WebCore::writeSVGPaintingResource):
(WebCore::writeSVGStrokePaintingResource):
(WebCore::writeSVGPaintingFeatures):
(WebCore::writeSVGGraphicsElement):
(WebCore::writeSVGInlineTextBoxes):
(WebCore::writeResources):
* Source/WebCore/rendering/svg/SVGRenderingContext.cpp:
(WebCore::SVGRenderingContext::prepareToRenderSVGContent):
* Source/WebCore/rendering/svg/SVGResources.cpp:
(WebCore::targetReferenceFromResource):
(WebCore::SVGResources::buildCachedResources):
* Source/WebCore/rendering/svg/SVGResourcesCache.cpp:
(WebCore::SVGResourcesCache::resourceDestroyed):
* Source/WebCore/rendering/svg/SVGResourcesCycleSolver.cpp:
(WebCore::SVGResourcesCycleSolver::resourceContainsCycles):
(WebCore::SVGResourcesCycleSolver::resolveCycles):

Canonical link: <a href="https://commits.webkit.org/272445@main">https://commits.webkit.org/272445@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/706b5a680305d448a7f1f212c79abb540247f029

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31621 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10300 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33336 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34112 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28637 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32399 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12654 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7550 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28237 "Found 1 new test failure: media/media-source/media-source-abort-resets-parser.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31969 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8671 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28218 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7479 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7639 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28128 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35457 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28736 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28588 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33765 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7733 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5741 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31617 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9389 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8418 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4137 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8241 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->