### PR TITLE
[UnifiedPDF] PDF in style embed renders in the wrong place

### DIFF
--- a/LayoutTests/compositing/plugins/pdf/pdf-in-styled-embed-expected.txt
+++ b/LayoutTests/compositing/plugins/pdf/pdf-in-styled-embed-expected.txt
@@ -1,0 +1,20 @@
+
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 788.00 805.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 788.00 805.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (offsetFromRenderer width=-28 height=-28)
+          (position 180.00 180.00)
+          (bounds 436.00 436.00)
+          (drawsContent 1)
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/compositing/plugins/pdf/pdf-in-styled-embed.html
+++ b/LayoutTests/compositing/plugins/pdf/pdf-in-styled-embed.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ UnifiedPDFEnabled=true PDFPluginHUDEnabled=false ] -->
+<html>
+<head>
+    <style>
+        embed {
+            margin: 200px;
+            width: 300px;
+            height: 300px;
+            border: 20px solid silver;
+            padding: 20px;
+            box-shadow: 0 0 20px black;
+        }
+    </style>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script>
+        if (window.testRunner) {
+            testRunner.waitUntilDone();
+            testRunner.dumpAsText();
+        }
+        window.addEventListener('load', async () => {
+            await UIHelper.renderingUpdate();
+            
+            const layers = document.getElementById('layers');
+            layers.textContent = internals.layerTreeAsText(document);
+            
+            testRunner.notifyDone();
+        }, false);
+    </script>
+</head>
+<body>
+    <embed src="../../../fast/images/resources/green_rectangle.pdf">
+<pre id="layers"></pre>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -41,7 +41,6 @@
 #include "GraphicsLayer.h"
 #include "HTMLBodyElement.h"
 #include "HTMLCanvasElement.h"
-#include "HTMLIFrameElement.h"
 #include "HTMLModelElement.h"
 #include "HTMLNames.h"
 #include "HTMLPlugInElement.h"
@@ -65,7 +64,6 @@
 #include "RenderFragmentContainer.h"
 #include "RenderFragmentedFlow.h"
 #include "RenderHTMLCanvas.h"
-#include "RenderIFrame.h"
 #include "RenderImage.h"
 #include "RenderLayerCompositor.h"
 #include "RenderLayerInlines.h"
@@ -981,6 +979,9 @@ void RenderLayerBacking::updateAfterWidgetResize()
         innerCompositor->frameViewDidChangeSize();
         innerCompositor->frameViewDidChangeLocation(flooredIntPoint(contentsBox().location()));
     }
+
+    if (auto* contentsLayer = layerForContents())
+        contentsLayer->setPosition(flooredIntPoint(contentsBox().location()));
 }
 
 void RenderLayerBacking::updateAfterLayout(bool needsClippingUpdate, bool needsFullRepaint)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -204,6 +204,7 @@ void UnifiedPDFPlugin::updateLayerHierarchy()
 {
     ensureLayers();
 
+    // The m_rootLayer's position is set in RenderLayerBacking::updateAfterWidgetResize().
     m_rootLayer->setSize(size());
     m_overflowControlsContainer->setSize(size());
 


### PR DESCRIPTION
#### e353e4fd2798c593c6f57501514bc3c717e93f2e
<pre>
[UnifiedPDF] PDF in style embed renders in the wrong place
<a href="https://bugs.webkit.org/show_bug.cgi?id=266750">https://bugs.webkit.org/show_bug.cgi?id=266750</a>
<a href="https://rdar.apple.com/119969233">rdar://119969233</a>

Reviewed by Alan Baradlay.

The UnifiedPDFPlugin&apos;s root layer has to be positioned relative to the compositing
layer of the RenderEmbeddedObject, which can be inflated by borders, outlines, padding
and shadows.

RenderLayerBacking knows best how to compute the right offset, so let it position
the plugin&apos;s root layer.

* LayoutTests/compositing/plugins/pdf/pdf-in-styled-embed-expected.txt: Added.
* LayoutTests/compositing/plugins/pdf/pdf-in-styled-embed.html: Added.
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateAfterWidgetResize):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::updateLayerHierarchy):

Canonical link: <a href="https://commits.webkit.org/272443@main">https://commits.webkit.org/272443@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/219800a14627bc8b01818dd12409c20dcf93837e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31625 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10304 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33340 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34116 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28641 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32403 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12658 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7554 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/28246 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31973 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8682 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28223 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7489 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7646 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28133 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35461 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28746 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28580 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33773 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7737 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5745 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31625 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9393 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/27938 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7425 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8422 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8245 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->