### PR TITLE
Stop using CheckedPtr with ViewGestureController

### DIFF
--- a/Source/WebKit/UIProcess/ViewGestureController.cpp
+++ b/Source/WebKit/UIProcess/ViewGestureController.cpp
@@ -66,10 +66,10 @@ static const float minimumScrollEventRatioForSwipe = 0.5;
 static const float swipeSnapshotRemovalRenderTreeSizeTargetFraction = 0.5;
 #endif
 
-static HashMap<WebPageProxyIdentifier, CheckedPtr<ViewGestureController>>& viewGestureControllersForAllPages()
+static HashMap<WebPageProxyIdentifier, WeakRef<ViewGestureController>>& viewGestureControllersForAllPages()
 {
     // The key in this map is the associated page ID.
-    static NeverDestroyed<HashMap<WebPageProxyIdentifier, CheckedPtr<ViewGestureController>>> viewGestureControllers;
+    static NeverDestroyed<HashMap<WebPageProxyIdentifier, WeakRef<ViewGestureController>>> viewGestureControllers;
     return viewGestureControllers.get();
 }
 
@@ -86,7 +86,7 @@ ViewGestureController::ViewGestureController(WebPageProxy& webPageProxy)
     if (webPageProxy.hasRunningProcess())
         connectToProcess();
 
-    viewGestureControllersForAllPages().add(webPageProxy.identifier(), this);
+    viewGestureControllersForAllPages().add(webPageProxy.identifier(), *this);
 }
 
 ViewGestureController::~ViewGestureController()
@@ -123,7 +123,7 @@ ViewGestureController* ViewGestureController::controllerForGesture(WebPageProxyI
         return nullptr;
     if (gestureControllerIter->value->m_currentGestureID != gestureID)
         return nullptr;
-    return gestureControllerIter->value.get();
+    return gestureControllerIter->value.ptr();
 }
 
 ViewGestureController::GestureID ViewGestureController::takeNextGestureID()

--- a/Source/WebKit/UIProcess/ViewGestureController.h
+++ b/Source/WebKit/UIProcess/ViewGestureController.h
@@ -97,7 +97,7 @@ class WebBackForwardListItem;
 class WebPageProxy;
 class WebProcessProxy;
 
-class ViewGestureController : private IPC::MessageReceiver, public CanMakeCheckedPtr {
+class ViewGestureController : public IPC::MessageReceiver {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(ViewGestureController);
 public:


### PR DESCRIPTION
#### 4acf76ce5557de841550611d8c00b6403f158b7b
<pre>
Stop using CheckedPtr with ViewGestureController
<a href="https://bugs.webkit.org/show_bug.cgi?id=266796">https://bugs.webkit.org/show_bug.cgi?id=266796</a>

Reviewed by Ryosuke Niwa.

Stop using CheckedPtr with ViewGestureController. Use WeakRef instead to generate
more actionable crashes.

* Source/WebKit/UIProcess/ViewGestureController.cpp:
(WebKit::viewGestureControllersForAllPages):
(WebKit::ViewGestureController::ViewGestureController):
(WebKit::ViewGestureController::controllerForGesture):
* Source/WebKit/UIProcess/ViewGestureController.h:

Canonical link: <a href="https://commits.webkit.org/272442@main">https://commits.webkit.org/272442@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa2e10410f6b2984aca317e611f5f5fd03d3701a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31628 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10307 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33343 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34117 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28642 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12661 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7557 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/28242 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31976 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8683 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28226 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7484 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7647 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35463 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28747 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28583 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33770 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7738 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5746 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31623 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9395 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8423 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4134 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8247 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->