### PR TITLE
[css-content] AX: Add support for alt text syntax

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/accname/name/comp_name_from_content-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/accname/name/comp_name_from_content-expected.txt
@@ -70,6 +70,17 @@ label
 
 label
 
+Mixed Alternative Text (attr() and strings) for CSS content (previously `alt:`) in pseudo-elements
+
+rendered text should be "before label after"
+
+accessibility label should be "start alt-before end label start alt-after end"
+
+label
+label
+
+label
+
 simple w/ for each child
 
 one two three
@@ -174,9 +185,12 @@ FAIL link name from content no space joiners ::before and ::after assert_equals:
 PASS button name from content with ::before and ::after in rtl
 PASS heading name from content with ::before and ::after in rtl
 PASS link name from content with ::before and ::after in rtl
-FAIL button name from fallback content with ::before and ::after assert_equals: <button data-expectedlabel="alt-before label alt-after" data-testname="button name from fallback content with ::before and ::after" class="ex fallback-before fallback-after">label</button> expected "alt-before label alt-after" but got "before label after"
-FAIL heading name from fallback content with ::before and ::after assert_equals: <h3 data-expectedlabel="alt-before label alt-after" data-testname="heading name from fallback content with ::before and ::after" class="ex fallback-before fallback-after">label</h3> expected "alt-before label alt-after" but got "before label after"
-FAIL link name from fallback content with ::before and ::after assert_equals: <a href="#" data-expectedlabel="alt-before label alt-after" data-testname="link name from fallback content with ::before and ::after" class="ex fallback-before fallback-after">label</a> expected "alt-before label alt-after" but got "before label after"
+PASS button name from fallback content with ::before and ::after
+PASS heading name from fallback content with ::before and ::after
+PASS link name from fallback content with ::before and ::after
+PASS button name from fallback content mixing attr() and strings with ::before and ::after
+PASS heading name from fallback content mixing attr() and strings with ::before and ::after
+PASS link name from fallback content mixing attr() and strings with ::before and ::after
 PASS button name from content for each child
 PASS heading name from content for each child
 PASS link name from content for each child

--- a/LayoutTests/imported/w3c/web-platform-tests/accname/name/comp_name_from_content.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/accname/name/comp_name_from_content.html
@@ -49,6 +49,14 @@
       content: " after "; /* [sic] leading and trailing space */
       content: " after " / " alt-after "; /* Override the previous line for engines that support the Alternative Text syntax. */
     }
+    .fallback-before-mixed::before {
+      content: " before "; /* [sic] leading and trailing space */
+      content: " before " / " start " attr(data-alt-text-before) " end "; /* Override the previous line for engines that support the Alternative Text syntax. */
+    }
+    .fallback-after-mixed::after {
+      content: " after "; /* [sic] leading and trailing space */
+      content: " after " / " start " attr(data-alt-text-after) " end "; /* Override the previous line for engines that support the Alternative Text syntax. */
+    }
     .block > span {
       display: block;
       margin: 0 0.1em;
@@ -127,6 +135,14 @@
 <button data-expectedlabel="alt-before label alt-after" data-testname="button name from fallback content with ::before and ::after" class="ex fallback-before fallback-after">label</button><br>
 <h3 data-expectedlabel="alt-before label alt-after" data-testname="heading name from fallback content with ::before and ::after" class="ex fallback-before fallback-after">label</h3>
 <a href="#" data-expectedlabel="alt-before label alt-after" data-testname="link name from fallback content with ::before and ::after" class="ex fallback-before fallback-after">label</a><br>
+<br>
+
+<h1><a href="https://drafts.csswg.org/css-content/#alt">Mixed Alternative Text (attr() and strings) for  CSS content (previously `alt:`)</a> in pseudo-elements</h1>
+<p>rendered text should be "before label after"</p>
+<p>accessibility label should be "start alt-before end label start alt-after end"</p>
+<button data-alt-text-before="alt-before" data-alt-text-after="alt-after" data-expectedlabel="start alt-before end label start alt-after end" data-testname="button name from fallback content mixing attr() and strings with ::before and ::after" class="ex fallback-before-mixed fallback-after-mixed">label</button><br>
+<h3 data-alt-text-before="alt-before" data-alt-text-after="alt-after" data-expectedlabel="start alt-before end label start alt-after end" data-testname="heading name from fallback content mixing attr() and strings with ::before and ::after" class="ex fallback-before-mixed fallback-after-mixed">label</h3>
+<a href="#" data-alt-text-before="alt-before" data-alt-text-after="alt-after" data-expectedlabel="start alt-before end label start alt-after end" data-testname="link name from fallback content mixing attr() and strings with ::before and ::after" class="ex fallback-before-mixed fallback-after-mixed">label</a><br>
 <br>
 
 <h1>simple w/ for each child</h1>

--- a/Source/WebCore/css/CSSValuePair.cpp
+++ b/Source/WebCore/css/CSSValuePair.cpp
@@ -30,22 +30,28 @@
 
 namespace WebCore {
 
-CSSValuePair::CSSValuePair(Ref<CSSValue> first, Ref<CSSValue> second, IdenticalValueSerialization serialization)
+CSSValuePair::CSSValuePair(ValueSeparator separator, Ref<CSSValue> first, Ref<CSSValue> second, IdenticalValueSerialization serialization)
     : CSSValue(ValuePairClass)
     , m_coalesceIdenticalValues(serialization != IdenticalValueSerialization::DoNotCoalesce)
     , m_first(WTFMove(first))
     , m_second(WTFMove(second))
 {
+    m_valueSeparator = separator;
 }
 
 Ref<CSSValuePair> CSSValuePair::create(Ref<CSSValue> first, Ref<CSSValue> second)
 {
-    return adoptRef(*new CSSValuePair(WTFMove(first), WTFMove(second), IdenticalValueSerialization::Coalesce));
+    return adoptRef(*new CSSValuePair(SpaceSeparator, WTFMove(first), WTFMove(second), IdenticalValueSerialization::Coalesce));
+}
+
+Ref<CSSValuePair> CSSValuePair::createSlashSeparated(Ref<CSSValue> first, Ref<CSSValue> second)
+{
+    return adoptRef(*new CSSValuePair(SlashSeparator, WTFMove(first), WTFMove(second), IdenticalValueSerialization::DoNotCoalesce));
 }
 
 Ref<CSSValuePair> CSSValuePair::createNoncoalescing(Ref<CSSValue> first, Ref<CSSValue> second)
 {
-    return adoptRef(*new CSSValuePair(WTFMove(first), WTFMove(second), IdenticalValueSerialization::DoNotCoalesce));
+    return adoptRef(*new CSSValuePair(SpaceSeparator, WTFMove(first), WTFMove(second), IdenticalValueSerialization::DoNotCoalesce));
 }
 
 String CSSValuePair::customCSSText() const

--- a/Source/WebCore/css/CSSValuePair.h
+++ b/Source/WebCore/css/CSSValuePair.h
@@ -32,6 +32,7 @@ namespace WebCore {
 class CSSValuePair : public CSSValue {
 public:
     static Ref<CSSValuePair> create(Ref<CSSValue>, Ref<CSSValue>);
+    static Ref<CSSValuePair> createSlashSeparated(Ref<CSSValue>, Ref<CSSValue>);
     static Ref<CSSValuePair> createNoncoalescing(Ref<CSSValue>, Ref<CSSValue>);
 
     const CSSValue& first() const { return m_first; }
@@ -44,7 +45,7 @@ private:
     friend bool CSSValue::addHash(Hasher&) const;
 
     enum class IdenticalValueSerialization : bool { DoNotCoalesce, Coalesce };
-    CSSValuePair(Ref<CSSValue>, Ref<CSSValue>, IdenticalValueSerialization);
+    CSSValuePair(ValueSeparator, Ref<CSSValue>, Ref<CSSValue>, IdenticalValueSerialization);
 
     bool addDerivedHash(Hasher&) const;
 

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -1435,8 +1435,26 @@ inline void BuilderCustom::applyValueContent(BuilderState& builderState, CSSValu
         return;
     }
 
+    bool hasAltTextContent = is<CSSValuePair>(value);
+    auto& visibleContentList = hasAltTextContent ? downcast<CSSValuePair>(value).first() : value;
+
+    auto processAttrContent = [&](const CSSPrimitiveValue& primitiveValue) -> AtomString {
+        // FIXME: Can a namespace be specified for an attr(foo)?
+        if (builderState.style().styleType() == PseudoId::None)
+            builderState.style().setHasAttrContent();
+        else
+            const_cast<RenderStyle&>(builderState.parentStyle()).setHasAttrContent();
+        QualifiedName attr(nullAtom(), primitiveValue.stringValue().impl(), nullAtom());
+        const AtomString& attributeValue = builderState.element() ? builderState.element()->getAttribute(attr) : nullAtom();
+
+        // Register the fact that the attribute value affects the style.
+        builderState.registerContentAttribute(attr.localName());
+
+        return attributeValue.isNull() ? emptyAtom() : attributeValue.impl();
+    };
+
     bool didSet = false;
-    for (auto& item : downcast<CSSValueList>(value)) {
+    for (auto& item : downcast<CSSValueList>(visibleContentList)) {
         if (item.isImage()) {
             builderState.style().setContent(builderState.createStyleImage(item), didSet);
             didSet = true;
@@ -1448,17 +1466,8 @@ inline void BuilderCustom::applyValueContent(BuilderState& builderState, CSSValu
             builderState.style().setContent(primitive->stringValue().impl(), didSet);
             didSet = true;
         } else if (primitive && primitive->isAttr()) {
-            // FIXME: Can a namespace be specified for an attr(foo)?
-            if (builderState.style().styleType() == PseudoId::None)
-                builderState.style().setHasAttrContent();
-            else
-                const_cast<RenderStyle&>(builderState.parentStyle()).setHasAttrContent();
-            QualifiedName attr(nullAtom(), primitive->stringValue().impl(), nullAtom());
-            const AtomString& value = builderState.element() ? builderState.element()->getAttribute(attr) : nullAtom();
-            builderState.style().setContent(value.isNull() ? emptyAtom() : value.impl(), didSet);
+            builderState.style().setContent(processAttrContent(*primitive), didSet);
             didSet = true;
-            // Register the fact that the attribute value affects the style.
-            builderState.registerContentAttribute(attr.localName());
         } else if (auto* counter = dynamicDowncast<CSSCounterValue>(item)) {
             ListStyleType listStyleType;
             if (counter->counterStyle())
@@ -1489,8 +1498,25 @@ inline void BuilderCustom::applyValueContent(BuilderState& builderState, CSSValu
             }
         }
     }
-    if (!didSet)
+
+    if (!didSet) {
         builderState.style().clearContent();
+        return;
+    }
+
+    if (!hasAltTextContent)
+        return;
+
+    auto& altTextContentList = downcast<CSSValuePair>(value).second();
+    StringBuilder altText;
+    for (auto& item : downcast<CSSValueList>(altTextContentList)) {
+        auto* primitive = dynamicDowncast<CSSPrimitiveValue>(item);
+        if (primitive && primitive->isString())
+            altText.append(primitive->stringValue());
+        else if (primitive && primitive->isAttr())
+            altText.append(processAttrContent(*primitive));
+    }
+    builderState.style().setContentAltText(altText.toString());
 }
 
 inline void BuilderCustom::applyInheritFontVariantLigatures(BuilderState& builderState)


### PR DESCRIPTION
#### 1b3e497426196dd3289ad58811bdb12cbaa29379
<pre>
[css-content] AX: Add support for alt text syntax
<a href="https://bugs.webkit.org/show_bug.cgi?id=159022">https://bugs.webkit.org/show_bug.cgi?id=159022</a>
<a href="https://rdar.apple.com/26942023">rdar://26942023</a>

Reviewed by Darin Adler.

This adds support for the `content: &quot;foo&quot; / &quot;alt-text&quot;;` syntax. Multiple strings / attr() functions can also be chained.

Counters are not supported by this PR. Other non-text types are intentionally not supported as alt-text per-spec.

Spec: <a href="https://drafts.csswg.org/css-content-3/#alt">https://drafts.csswg.org/css-content-3/#alt</a>

* LayoutTests/imported/w3c/web-platform-tests/accname/name/comp_name_from_content.html:
* LayoutTests/imported/w3c/web-platform-tests/accname/name/comp_name_from_content-expected.txt:
* Source/WebCore/css/CSSValuePair.cpp:
(WebCore::CSSValuePair::CSSValuePair):
(WebCore::CSSValuePair::create):
(WebCore::CSSValuePair::createSlashSeparated):
(WebCore::CSSValuePair::createNoncoalescing):
* Source/WebCore/css/CSSValuePair.h:
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumeContent):
* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::BuilderCustom::applyValueContent):

Canonical link: <a href="https://commits.webkit.org/272455@main">https://commits.webkit.org/272455@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ffe9195e6d8264b17fa6262fb19ac1c7f5ccaa6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31705 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10388 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33429 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34198 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/28710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32490 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12745 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7636 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/28302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32058 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/8755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/28297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/7552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/7715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/28211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35543 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/28819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/28658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/33835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7809 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/5814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/31690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/9464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/28017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8488 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4140 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8325 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->