### PR TITLE
[UIAsyncTextInput] Consolidate `-updateSelectionWithExtentPoint:(withBoundary:)completion:` into one method

### DIFF
--- a/Source/WebKit/UIProcess/ios/UIKitUtilities.h
+++ b/Source/WebKit/UIProcess/ios/UIKitUtilities.h
@@ -49,6 +49,7 @@
 @interface UIGestureRecognizer (WebKitInternal)
 @property (nonatomic, readonly) BOOL _wk_isTextInteractionLoupeGesture;
 @property (nonatomic, readonly) BOOL _wk_isTextInteractionTapGesture;
+@property (nonatomic, readonly) BOOL _wk_hasRecognizedOrEnded;
 @end
 
 @interface UIView (WebKitInternal)

--- a/Source/WebKit/UIProcess/ios/UIKitUtilities.mm
+++ b/Source/WebKit/UIProcess/ios/UIKitUtilities.mm
@@ -242,6 +242,22 @@ static UIAxis axesForDelta(WebCore::FloatSize delta)
     return [self.name isEqualToString:@"UITextInteractionNameSingleTap"];
 }
 
+- (BOOL)_wk_hasRecognizedOrEnded
+{
+    switch (self.state) {
+    case UIGestureRecognizerStateBegan:
+    case UIGestureRecognizerStateChanged:
+    case UIGestureRecognizerStateEnded:
+        return YES;
+    case UIGestureRecognizerStatePossible:
+    case UIGestureRecognizerStateCancelled:
+    case UIGestureRecognizerStateFailed:
+        return NO;
+    }
+    ASSERT_NOT_REACHED();
+    return NO;
+}
+
 @end
 
 namespace WebKit {

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -472,6 +472,7 @@ struct ImageAnalysisContextMenuActionData {
     BOOL _selectionNeedsUpdate;
     BOOL _shouldRestoreSelection;
     BOOL _usingGestureForSelection;
+    BOOL _usingMouseDragForSelection;
     BOOL _inspectorNodeSearchEnabled;
     BOOL _isChangingFocusUsingAccessoryTab;
     BOOL _didAccessoryTabInitiateFocus;


### PR DESCRIPTION
#### fe4d97bab2682759cc7998a5ddb105cc747bf041
<pre>
[UIAsyncTextInput] Consolidate `-updateSelectionWithExtentPoint:(withBoundary:)completion:` into one method
<a href="https://bugs.webkit.org/show_bug.cgi?id=266795">https://bugs.webkit.org/show_bug.cgi?id=266795</a>
<a href="https://rdar.apple.com/120010505">rdar://120010505</a>

Reviewed by Aditya Keerthi.

`UIWKInteractionViewProtocol` currently exposes the following two delegate methods, which behave in
totally different ways in WebKit:

1. `-updateSelectionWithExtentPoint:withBoundary:completionHandler:`, which is called when selecting
    text by clicking and dragging with a trackpad on iPadOS (for instance, a double-click-and-drag
    results in this being called with word granularity). In this case, we use `m_initialSelection`,
    previously set by `-selectTextWithGranularity:atPoint:completionHandler:`, as the selection base
    and update the selection such that the anchor is set to the DOM position corresponding to the
    given `point` in `-updateSelectionWithExtentPoint:completionHandler:`.

2. `-updateSelectionWithExtentPoint:completionHandler:`, which is called when selecting text with a
    shift-click or shift-tap, or by long-pressing the Space key on the software keyboard to enter
    floating cursor mode with the shift key held down. WebKit implements this by expanding the scope
    of the current selection, such that it encompasses the hit-tested DOM position or range at the
    given `point` (respecting the given `granularity` when hit-testing).

In <a href="https://rdar.apple.com/119947213">rdar://119947213</a>, UIKit intends to replace all calls to (2) with (1) instead, passing in
`UITextGranularityCharacter` as the boundary granularity. Without any changes in WebKit, this will
break shift-click/tap in webpages, since `m_initialSelection` may not have been set (or may be
stale). To avoid this, we refactor `-updateSelectionWithExtentPoint:withBoundary:completionHandler:`
such that it falls back to the logic in `-updateSelectionWithExtentPoint:completionHandler:` for the
case where we&apos;re using character granularity and we&apos;re also not dragging to change the selection,
and otherwise behaves the same as it did before this change (for the click-and-drag case).

* Source/WebKit/UIProcess/ios/UIKitUtilities.h:
* Source/WebKit/UIProcess/ios/UIKitUtilities.mm:
(-[UIGestureRecognizer _wk_hasRecognizedOrEnded]):

Drive-by refactoring: pull logic that checks whether the state of a gesture recognizer is one of
{`Began`, `Changed`, or `Ended`} into a separate helper method, and deploy it in several places
where we perform this check.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView cleanUpInteraction]):
(-[WKContentView _isPanningScrollViewOrAncestor:]):
(-[WKContentView textInteractionGesture:shouldBeginAtPoint:]):
(-[WKContentView selectTextWithGranularity:atPoint:completionHandler:]):
(-[WKContentView updateSelectionWithExtentPoint:completionHandler:]):

This now just calls into `-updateSelectionWithExtentPoint:withBoundary:completionHandler:` using
character granularity; it&apos;s still needed for bincompat, but after <a href="https://rdar.apple.com/119947213">rdar://119947213</a> lands we can
remove this method entirely.

(-[WKContentView updateSelectionWithExtentPoint:withBoundary:completionHandler:]):
(-[WKContentView mouseInteraction:changedWithEvent:]):

Reset `_usingMouseDragForSelection` back to NO after `mouseup`.

Canonical link: <a href="https://commits.webkit.org/272453@main">https://commits.webkit.org/272453@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d1337a529fe28e1e6ec66362e5de3c448fe9c4b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31667 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10346 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33383 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34155 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28675 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12720 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7597 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28267 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32015 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8732 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28254 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7517 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7691 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35499 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28796 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28614 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33805 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7773 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5778 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31660 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9430 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7430 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8457 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8286 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->