### PR TITLE
[WebGPU] CTS validation/render_pipeline/shader_module.html is failing

### DIFF
--- a/LayoutTests/http/tests/webgpu/webgpu/api/validation/render_pipeline/shader_module-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/validation/render_pipeline/shader_module-expected.txt
@@ -1,1 +1,11 @@
-(Populate me when we're ready to investigate this test)
+
+PASS :device_mismatch:
+PASS :invalid,vertex:isAsync=true;isVertexShaderValid=true
+PASS :invalid,vertex:isAsync=true;isVertexShaderValid=false
+PASS :invalid,vertex:isAsync=false;isVertexShaderValid=true
+PASS :invalid,vertex:isAsync=false;isVertexShaderValid=false
+PASS :invalid,fragment:isAsync=true;isFragmentShaderValid=true
+PASS :invalid,fragment:isAsync=true;isFragmentShaderValid=false
+PASS :invalid,fragment:isAsync=false;isFragmentShaderValid=true
+PASS :invalid,fragment:isAsync=false;isFragmentShaderValid=false
+


### PR DESCRIPTION
#### 7e2a446cab8b2ce68f8a41caee2225e93b545b5d
<pre>
[WebGPU] CTS validation/render_pipeline/shader_module.html is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=266739">https://bugs.webkit.org/show_bug.cgi?id=266739</a>
&lt;radar://119958283&gt;

Reviewed by Tadeu Zagallo.

ShaderModule was just missing device mismatch to pass and correction
for vertex-only pipelines.

* LayoutTests/http/tests/webgpu/webgpu/api/validation/render_pipeline/shader_module-expected.txt:
Add passing expectations.

* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::Device::createRenderPipeline):

Canonical link: <a href="https://commits.webkit.org/272612@main">https://commits.webkit.org/272612@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/acf0ae0a6c7420242f69a9b0b3f36ba2e2a752d5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32328 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11065 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34180 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34882 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29267 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13417 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8271 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28815 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32746 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9331 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28917 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8124 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8264 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28848 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36223 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29392 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29276 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34392 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8393 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6340 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32255 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10052 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7543 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9024 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8957 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->