### PR TITLE
Horizontal scrollbars unusable with rtl element

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -1393,6 +1393,7 @@ webkit.org/b/137572 scrollbars/scrollable-iframe-remove-crash.html [ Skip ] # Ti
 webkit.org/b/137572 scrollbars/scrollbar-drag-thumb-with-large-content.html [ Failure ]
 webkit.org/b/137572 scrollbars/scrollbar-selectors.html [ Failure ]
 scrollbars/scrolling-by-page-on-keyboard-spacebar.html [ Failure ]
+scrollbars/scrollbar-drag-thumb-rtl.html [ Failure ]
 
 webkit.org/b/237150 fast/events/autoscroll-in-iframe-body.html [ Pass Failure ]
 

--- a/LayoutTests/scrollbars/scrollbar-drag-thumb-rtl-expected.txt
+++ b/LayoutTests/scrollbars/scrollbar-drag-thumb-rtl-expected.txt
@@ -1,0 +1,1 @@
+Scrolled to -450

--- a/LayoutTests/scrollbars/scrollbar-drag-thumb-rtl.html
+++ b/LayoutTests/scrollbars/scrollbar-drag-thumb-rtl.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .box {
+            width: 100px;
+            height: 100px;
+            background-color: blue;
+        }
+        
+        .scroller {
+            width: 300px;
+            height: 300px;
+            overflow-x: scroll;
+            border: 1px solid black;
+        }
+        
+        .contents {
+            width: 300%;
+            height: 100%;
+            background-color: silver;
+        }
+        
+    </style>
+    <script>
+        if (window.testRunner)
+            testRunner.dumpAsText();
+
+        function runTest()
+        {
+            const scroller = document.getElementsByClassName("scroller")[0];
+            const scrollerBounds = scroller.getBoundingClientRect();
+
+            if (window.eventSender) {
+                const startX = scrollerBounds.width - 20;
+                const eventY = scrollerBounds.height - 8;
+                eventSender.mouseMoveTo(startX, eventY);
+                eventSender.mouseDown();
+                eventSender.mouseMoveTo(startX - 150, eventY);
+                eventSender.mouseUp();
+            }
+
+            if (window.testRunner)
+                document.getElementById("result").innerText = `Scrolled to ${scroller.scrollLeft}`;
+        }
+    
+        window.addEventListener('load', () => {
+            runTest();
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="scroller" dir="rtl">
+        <div class="contents"></div>
+    </div>
+    
+    <p id="result">Test did not run.</p>    
+</body>
+</html>

--- a/Source/WebCore/platform/ScrollableArea.cpp
+++ b/Source/WebCore/platform/ScrollableArea.cpp
@@ -205,11 +205,11 @@ void ScrollableArea::scrollToOffsetWithoutAnimation(const FloatPoint& offset, Sc
 
 void ScrollableArea::scrollToOffsetWithoutAnimation(ScrollbarOrientation orientation, float offset)
 {
-    auto currentPosition = scrollAnimator().currentPosition();
+    auto currentOffset = scrollOffsetFromPosition(scrollAnimator().currentPosition(), toFloatSize(scrollOrigin()));
     if (orientation == ScrollbarOrientation::Horizontal)
-        scrollAnimator().scrollToPositionWithoutAnimation(FloatPoint(offset, currentPosition.y()));
+        scrollToOffsetWithoutAnimation(FloatPoint(offset, currentOffset.y()));
     else
-        scrollAnimator().scrollToPositionWithoutAnimation(FloatPoint(currentPosition.x(), offset));
+        scrollToOffsetWithoutAnimation(FloatPoint(currentOffset.x(), offset));
 }
 
 void ScrollableArea::notifyScrollPositionChanged(const ScrollPosition& position)

--- a/Source/WebCore/platform/Scrollbar.cpp
+++ b/Source/WebCore/platform/Scrollbar.cpp
@@ -307,8 +307,8 @@ void Scrollbar::moveThumb(int pos, bool draggingDocument)
         delta = std::max(-thumbPos, delta);
     
     if (delta) {
-        float newPosition = static_cast<float>(thumbPos + delta) * maximum() / (trackLen - thumbLen);
-        m_scrollableArea.scrollToOffsetWithoutAnimation(m_orientation, newPosition);
+        float newOffset = static_cast<float>(thumbPos + delta) * maximum() / (trackLen - thumbLen);
+        m_scrollableArea.scrollToOffsetWithoutAnimation(m_orientation, newOffset);
     }
 }
 

--- a/Source/WebCore/rendering/RenderListBox.cpp
+++ b/Source/WebCore/rendering/RenderListBox.cpp
@@ -731,8 +731,7 @@ bool RenderListBox::scrollToRevealElementAtListIndex(int index)
     if (style().isFlippedBlocksWritingMode())
         newOffset *= -1;
 
-    scrollToOffsetWithoutAnimation(scrollbarOrientationForWritingMode(), newOffset);
-
+    scrollToPosition(newOffset);
     return true;
 }
 
@@ -946,6 +945,25 @@ int RenderListBox::logicalScrollTop() const
     return logicalTop;
 }
 
+void RenderListBox::scrollToPosition(int positionIndex)
+{
+    auto orientation = scrollbarOrientationForWritingMode();
+    auto scrollOrigin = this->scrollOrigin();
+
+    int offsetIndex = positionIndex;
+
+    switch (orientation) {
+    case ScrollbarOrientation::Vertical:
+        offsetIndex = positionIndex + scrollOrigin.y();
+        break;
+    case ScrollbarOrientation::Horizontal:
+        offsetIndex = positionIndex + scrollOrigin.x();
+        break;
+    }
+
+    scrollToOffsetWithoutAnimation(orientation, offsetIndex);
+}
+
 void RenderListBox::setLogicalScrollTop(int newLogicalScrollTop)
 {
     bool isFlippedBlocksWritingMode = style().isFlippedBlocksWritingMode();
@@ -963,7 +981,7 @@ void RenderListBox::setLogicalScrollTop(int newLogicalScrollTop)
         index *= -1;
 
     setupWheelEventTestMonitor(*this);
-    scrollToOffsetWithoutAnimation(scrollbarOrientationForWritingMode(), index);
+    scrollToPosition(index);
 }
 
 bool RenderListBox::nodeAtPoint(const HitTestRequest& request, HitTestResult& result, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction hitTestAction)

--- a/Source/WebCore/rendering/RenderListBox.h
+++ b/Source/WebCore/rendering/RenderListBox.h
@@ -166,6 +166,8 @@ private:
     // NOTE: This should only be called by the overridden setScrollOffset from ScrollableArea.
     void scrollTo(const ScrollPosition&);
 
+    void scrollToPosition(int positionIndex);
+
     using PaintFunction = Function<void(PaintInfo&, const LayoutPoint&, int listItemIndex)>;
     void paintItem(PaintInfo&, const LayoutPoint&, const PaintFunction&);
 


### PR DESCRIPTION
#### d7611e7b6b1a052b3d55fefc52f620a45b6089ed
<pre>
Horizontal scrollbars unusable with rtl element
<a href="https://bugs.webkit.org/show_bug.cgi?id=256995">https://bugs.webkit.org/show_bug.cgi?id=256995</a>
<a href="https://rdar.apple.com/109858866">rdar://109858866</a>

Reviewed by Aditya Keerthi and Antti Koivisto.

Fix scroll offset/position confusion in ScrollableArea::scrollToOffsetWithoutAnimation().
In RTL, the offset is zero-based, but the position is relative to the scroll origin.

This also revealed offset/position confusion in RenderListBox, breaking vertical-rl
tests. Fix that code to do proper offset/position conversions.

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/scrollbars/scrollbar-drag-thumb-rtl-expected.txt: Added.
* LayoutTests/scrollbars/scrollbar-drag-thumb-rtl.html: Added.
* Source/WebCore/platform/ScrollableArea.cpp:
(WebCore::ScrollableArea::scrollToOffsetWithoutAnimation):
* Source/WebCore/platform/Scrollbar.cpp:
(WebCore::Scrollbar::moveThumb):
* Source/WebCore/rendering/RenderListBox.cpp:
(WebCore::RenderListBox::scrollToRevealElementAtListIndex):
(WebCore::RenderListBox::scrollToPosition):
(WebCore::RenderListBox::setLogicalScrollTop):
* Source/WebCore/rendering/RenderListBox.h:

Canonical link: <a href="https://commits.webkit.org/272466@main">https://commits.webkit.org/272466@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ed056b475745112f53cf4ca1f0766622981addd2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31721 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10403 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33446 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34213 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28723 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32506 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12770 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7651 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28313 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32074 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8779 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28309 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7563 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7739 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28223 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35558 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28843 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28670 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33843 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7821 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5824 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31700 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9477 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/28030 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7438 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8499 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8338 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->