### PR TITLE
[WebGPU] CTS validation/render_pipeline/misc.html is failing

### DIFF
--- a/LayoutTests/http/tests/webgpu/webgpu/api/validation/render_pipeline/misc-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/validation/render_pipeline/misc-expected.txt
@@ -1,1 +1,7 @@
-(Populate me when we're ready to investigate this test)
+
+PASS :basic:isAsync=false
+PASS :basic:isAsync=true
+PASS :vertex_state_only:isAsync=false
+PASS :vertex_state_only:isAsync=true
+PASS :pipeline_layout,device_mismatch:
+

--- a/Source/WebGPU/WebGPU/RenderPipeline.mm
+++ b/Source/WebGPU/WebGPU/RenderPipeline.mm
@@ -872,11 +872,14 @@ Ref<RenderPipeline> Device::createRenderPipeline(const WGPURenderPipelineDescrip
     const PipelineLayout* pipelineLayout = nullptr;
     Vector<Vector<WGPUBindGroupLayoutEntry>> bindGroupEntries;
     if (descriptor.layout) {
-        if (auto& layout = WebGPU::fromAPI(descriptor.layout); layout.isValid() && !layout.isAutoLayout()) {
+        auto& layout = WebGPU::fromAPI(descriptor.layout);
+        if (!layout.isValid())
+            return returnInvalidRenderPipeline(*this, isAsync, "Pipeline layout is not valid"_s);
+        if (&layout.device() != this)
+            return returnInvalidRenderPipeline(*this, isAsync, "Pipeline layout created from different device"_s);
+
+        if (!layout.isAutoLayout())
             pipelineLayout = &layout;
-            if (pipelineLayout && &pipelineLayout->device() != this)
-                return returnInvalidRenderPipeline(*this, isAsync, "Pipeline layout is not valid"_s);
-        }
     }
 
     std::optional<PipelineLayout> vertexPipelineLayout { std::nullopt };


### PR DESCRIPTION
#### ae376a9b68df58fba3394991e40ead87b23446ea
<pre>
[WebGPU] CTS validation/render_pipeline/misc.html is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=266734">https://bugs.webkit.org/show_bug.cgi?id=266734</a>
&lt;radar://119958255&gt;

Reviewed by Tadeu Zagallo.

Correct pipeline device mismatch which was preventing this test from passing.

* LayoutTests/http/tests/webgpu/webgpu/api/validation/render_pipeline/misc-expected.txt:
Add passing expectations.

* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::Device::createRenderPipeline):

Canonical link: <a href="https://commits.webkit.org/272639@main">https://commits.webkit.org/272639@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c2dccd38b6892aa89620d2c1de868dcfc6a34bad

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32429 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11167 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34261 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34986 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29345 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13521 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8371 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28879 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32853 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9419 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28986 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8202 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8347 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28919 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36321 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29480 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29353 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34468 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8474 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6423 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32330 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10137 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7562 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9095 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9046 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->