### PR TITLE
[WebGPU] CTS validation/render_pipeline/primitive_state.html is failing

### DIFF
--- a/LayoutTests/http/tests/webgpu/webgpu/api/validation/render_pipeline/primitive_state-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/validation/render_pipeline/primitive_state-expected.txt
@@ -1,1 +1,42 @@
-(Populate me when we're ready to investigate this test)
+
+PASS :strip_index_format:isAsync=false;topology="_undef_";stripIndexFormat="_undef_"
+PASS :strip_index_format:isAsync=false;topology="_undef_";stripIndexFormat="uint16"
+PASS :strip_index_format:isAsync=false;topology="_undef_";stripIndexFormat="uint32"
+PASS :strip_index_format:isAsync=false;topology="point-list";stripIndexFormat="_undef_"
+PASS :strip_index_format:isAsync=false;topology="point-list";stripIndexFormat="uint16"
+PASS :strip_index_format:isAsync=false;topology="point-list";stripIndexFormat="uint32"
+PASS :strip_index_format:isAsync=false;topology="line-list";stripIndexFormat="_undef_"
+PASS :strip_index_format:isAsync=false;topology="line-list";stripIndexFormat="uint16"
+PASS :strip_index_format:isAsync=false;topology="line-list";stripIndexFormat="uint32"
+PASS :strip_index_format:isAsync=false;topology="line-strip";stripIndexFormat="_undef_"
+PASS :strip_index_format:isAsync=false;topology="line-strip";stripIndexFormat="uint16"
+PASS :strip_index_format:isAsync=false;topology="line-strip";stripIndexFormat="uint32"
+PASS :strip_index_format:isAsync=false;topology="triangle-list";stripIndexFormat="_undef_"
+PASS :strip_index_format:isAsync=false;topology="triangle-list";stripIndexFormat="uint16"
+PASS :strip_index_format:isAsync=false;topology="triangle-list";stripIndexFormat="uint32"
+PASS :strip_index_format:isAsync=false;topology="triangle-strip";stripIndexFormat="_undef_"
+PASS :strip_index_format:isAsync=false;topology="triangle-strip";stripIndexFormat="uint16"
+PASS :strip_index_format:isAsync=false;topology="triangle-strip";stripIndexFormat="uint32"
+PASS :strip_index_format:isAsync=true;topology="_undef_";stripIndexFormat="_undef_"
+PASS :strip_index_format:isAsync=true;topology="_undef_";stripIndexFormat="uint16"
+PASS :strip_index_format:isAsync=true;topology="_undef_";stripIndexFormat="uint32"
+PASS :strip_index_format:isAsync=true;topology="point-list";stripIndexFormat="_undef_"
+PASS :strip_index_format:isAsync=true;topology="point-list";stripIndexFormat="uint16"
+PASS :strip_index_format:isAsync=true;topology="point-list";stripIndexFormat="uint32"
+PASS :strip_index_format:isAsync=true;topology="line-list";stripIndexFormat="_undef_"
+PASS :strip_index_format:isAsync=true;topology="line-list";stripIndexFormat="uint16"
+PASS :strip_index_format:isAsync=true;topology="line-list";stripIndexFormat="uint32"
+PASS :strip_index_format:isAsync=true;topology="line-strip";stripIndexFormat="_undef_"
+PASS :strip_index_format:isAsync=true;topology="line-strip";stripIndexFormat="uint16"
+PASS :strip_index_format:isAsync=true;topology="line-strip";stripIndexFormat="uint32"
+PASS :strip_index_format:isAsync=true;topology="triangle-list";stripIndexFormat="_undef_"
+PASS :strip_index_format:isAsync=true;topology="triangle-list";stripIndexFormat="uint16"
+PASS :strip_index_format:isAsync=true;topology="triangle-list";stripIndexFormat="uint32"
+PASS :strip_index_format:isAsync=true;topology="triangle-strip";stripIndexFormat="_undef_"
+PASS :strip_index_format:isAsync=true;topology="triangle-strip";stripIndexFormat="uint16"
+PASS :strip_index_format:isAsync=true;topology="triangle-strip";stripIndexFormat="uint32"
+PASS :unclipped_depth:isAsync=false;unclippedDepth=false
+PASS :unclipped_depth:isAsync=false;unclippedDepth=true
+PASS :unclipped_depth:isAsync=true;unclippedDepth=false
+PASS :unclipped_depth:isAsync=true;unclippedDepth=true
+


### PR DESCRIPTION
#### 2c3ec21a16cab3f8eb040f617eebce8a866929c8
<pre>
[WebGPU] CTS validation/render_pipeline/primitive_state.html is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=266737">https://bugs.webkit.org/show_bug.cgi?id=266737</a>
&lt;radar://119958339&gt;

Reviewed by Tadeu Zagallo.

Add passing expectations for primitive_state and correct some missing
validation logic.

* LayoutTests/http/tests/webgpu/webgpu/api/validation/render_pipeline/primitive_state-expected.txt:
Add passing expectations.

* Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp:
(WebCore::WebGPU::convertToBacking):
(WebCore::WebGPU::DeviceImpl::createRenderPipeline):
(WebCore::WebGPU::DeviceImpl::createRenderPipelineAsync):
* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::Device::createRenderPipeline):

Canonical link: <a href="https://commits.webkit.org/272646@main">https://commits.webkit.org/272646@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa78e6a91136bfb9d6cfb9e394c52de0e06cf752

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32491 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11229 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34327 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35046 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29385 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33348 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13582 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8428 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28912 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32917 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9467 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29033 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8241 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8384 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28966 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36382 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29529 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29391 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34507 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8516 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6468 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32368 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10183 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7568 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9135 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9096 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->