### PR TITLE
IFrameFullscreenFlag doesn't need to be on Node

### DIFF
--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -4483,16 +4483,6 @@ void Element::setFullscreenFlag(bool flag)
         setStateFlag(StateFlag::IsFullscreen);
     else
         clearStateFlag(StateFlag::IsFullscreen);
-
-    clearStateFlag(StateFlag::IsIFrameFullscreen);
-}
-
-void Element::setIFrameFullscreenFlag(bool flag)
-{
-    if (flag)
-        setStateFlag(StateFlag::IsIFrameFullscreen);
-    else
-        clearStateFlag(StateFlag::IsIFrameFullscreen);
 }
 
 #endif

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -601,9 +601,7 @@ public:
 
 #if ENABLE(FULLSCREEN_API)
     bool hasFullscreenFlag() const { return hasStateFlag(StateFlag::IsFullscreen); }
-    bool hasIFrameFullscreenFlag() const { return hasStateFlag(StateFlag::IsIFrameFullscreen); }
     void setFullscreenFlag(bool);
-    void setIFrameFullscreenFlag(bool);
     WEBCORE_EXPORT void webkitRequestFullscreen();
     virtual void requestFullscreen(FullscreenOptions&&, RefPtr<DeferredPromise>&&);
 #endif

--- a/Source/WebCore/dom/FullscreenManager.cpp
+++ b/Source/WebCore/dom/FullscreenManager.cpp
@@ -329,11 +329,20 @@ static Vector<Ref<Document>> documentsToUnfullscreen(Document& firstDocument)
         if (!frame)
             break;
         auto frameOwner = frame->ownerElement();
-        if (!frameOwner || frameOwner->hasIFrameFullscreenFlag())
+        if (!frameOwner)
+            break;
+        if (auto* iframe = dynamicDowncast<HTMLIFrameElement>(frameOwner); iframe && iframe->hasIFrameFullscreenFlag())
             break;
         documents.append(frameOwner->document());
     }
     return documents;
+}
+
+static void clearFullscreenFlags(Element& element)
+{
+    element.setFullscreenFlag(false);
+    if (auto* frameOwner = dynamicDowncast<HTMLIFrameElement>(element))
+        frameOwner->setIFrameFullscreenFlag(false);
 }
 
 void FullscreenManager::exitFullscreen(RefPtr<DeferredPromise>&& promise)
@@ -356,7 +365,7 @@ void FullscreenManager::exitFullscreen(RefPtr<DeferredPromise>&& promise)
     auto element = exitingDocument->fullscreenManager().fullscreenElement();
     if (element && !element->isConnected()) {
         addDocumentToFullscreenChangeEventQueue(exitingDocument);
-        element->setFullscreenFlag(false);
+        clearFullscreenFlags(*element);
         element->removeFromTopLayer();
     }
 
@@ -433,7 +442,7 @@ void FullscreenManager::finishExitFullscreen(Document& currentDocument, ExitMode
         for (auto& element : document->topLayerElements()) {
             if (!element->hasFullscreenFlag())
                 continue;
-            element->setFullscreenFlag(false);
+            clearFullscreenFlags(element);
             toRemove.append(element);
         }
         for (auto& element : toRemove)
@@ -447,7 +456,7 @@ void FullscreenManager::finishExitFullscreen(Document& currentDocument, ExitMode
             unfullscreenDocument(exitDocument);
         else {
             auto fullscreenElement = exitDocument->fullscreenManager().fullscreenElement();
-            fullscreenElement->setFullscreenFlag(false);
+            clearFullscreenFlags(*fullscreenElement);
             fullscreenElement->removeFromTopLayer();
         }
     }
@@ -537,6 +546,9 @@ bool FullscreenManager::willEnterFullscreen(Element& element)
             containingBlockBeforeStyleResolution = renderer->containingBlock();
 
         ancestor->setFullscreenFlag(true);
+        // FIXME: Why is "iframe fullscreen" getting unset here?
+        if (auto* frameElement = dynamicDowncast<HTMLIFrameElement>(ancestor.get()))
+            frameElement->setIFrameFullscreenFlag(false);
         ancestor->document().resolveStyle(Document::ResolveStyleType::Rebuild);
 
         // Remove before adding, so we always add at the end of the top layer.
@@ -550,8 +562,8 @@ bool FullscreenManager::willEnterFullscreen(Element& element)
     for (auto ancestor : ancestorsInTreeOrder)
         addDocumentToFullscreenChangeEventQueue(ancestor->document());
 
-    if (is<HTMLIFrameElement>(element))
-        element.setIFrameFullscreenFlag(true);
+    if (auto* iframe = dynamicDowncast<HTMLIFrameElement>(element))
+        iframe->setIFrameFullscreenFlag(true);
 
     if (!document().quirks().shouldDelayFullscreenEventWhenExitingPictureInPictureQuirk())
         notifyAboutFullscreenChangeOrError();
@@ -711,7 +723,7 @@ void FullscreenManager::exitRemovedFullscreenElement(Element& element)
         INFO_LOG(LOGIDENTIFIER, "Fullscreen element removed; exiting fullscreen");
         exitFullscreen(nullptr);
     } else
-        element.setFullscreenFlag(false);
+        clearFullscreenFlags(element);
 }
 
 bool FullscreenManager::isAnimatingFullscreen() const

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -605,7 +605,6 @@ protected:
         NeedsUpdateQueryContainerDependentStyle = 1 << 8,
 #if ENABLE(FULLSCREEN_API)
         IsFullscreen = 1 << 9,
-        IsIFrameFullscreen = 1 << 10,
 #endif
     };
 

--- a/Source/WebCore/html/HTMLIFrameElement.h
+++ b/Source/WebCore/html/HTMLIFrameElement.h
@@ -52,6 +52,11 @@ public:
 
     void loadDeferredFrame();
 
+#if ENABLE(FULLSCREEN_API)
+    bool hasIFrameFullscreenFlag() const { return m_IFrameFullscreenFlag; }
+    void setIFrameFullscreenFlag(bool value) { m_IFrameFullscreenFlag = value; }
+#endif
+
 private:
     HTMLIFrameElement(const QualifiedName&, Document&);
 
@@ -70,6 +75,9 @@ private:
 
     std::unique_ptr<DOMTokenList> m_sandbox;
     mutable std::optional<FeaturePolicy> m_featurePolicy;
+#if ENABLE(FULLSCREEN_API)
+    bool m_IFrameFullscreenFlag { false };
+#endif
     std::unique_ptr<LazyLoadFrameObserver> m_lazyLoadFrameObserver;
 };
 


### PR DESCRIPTION
#### 519d5e9d71a1a8e89e96dd82797544323fdee474
<pre>
IFrameFullscreenFlag doesn&apos;t need to be on Node
<a href="https://bugs.webkit.org/show_bug.cgi?id=266812">https://bugs.webkit.org/show_bug.cgi?id=266812</a>

Reviewed by Tim Nguyen and Alan Baradlay.

Move IFrameFullscreenFlag from Node to HTMLIFrameElement where this flag is only ever set true.

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::setFullscreenFlag):
(WebCore::Element::setIFrameFullscreenFlag): Deleted.
* Source/WebCore/dom/Element.h:
(WebCore::Element::hasFullscreenFlag const):
(WebCore::Element::hasIFrameFullscreenFlag const): Deleted.
* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::documentsToUnfullscreen):
(WebCore::clearFullscreenFlags): Added.
(WebCore::FullscreenManager::exitFullscreen):
(WebCore::FullscreenManager::finishExitFullscreen):
(WebCore::FullscreenManager::willEnterFullscreen):
(WebCore::FullscreenManager::exitRemovedFullscreenElement):
* Source/WebCore/dom/Node.h:
* Source/WebCore/html/HTMLIFrameElement.h:

Canonical link: <a href="https://commits.webkit.org/272459@main">https://commits.webkit.org/272459@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af8596270cf6e0e094caa04480e7963ef1f04b0e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31704 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10387 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33427 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34196 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28709 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32488 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12744 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7635 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/28304 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32056 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8754 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28296 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7554 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7714 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28210 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35541 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28818 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28657 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/33837 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7808 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5813 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31693 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9463 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8487 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4143 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8324 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->