### PR TITLE
Replace ConstructionType with OptionSet<TypeFlag>

### DIFF
--- a/Source/WebCore/dom/CharacterData.h
+++ b/Source/WebCore/dom/CharacterData.h
@@ -44,7 +44,7 @@ public:
     void parserAppendData(StringView);
 
 protected:
-    CharacterData(Document& document, String&& text, ConstructionType type = CreateCharacterData)
+    CharacterData(Document& document, String&& text, OptionSet<TypeFlag> type = CreateCharacterData)
         : Node(document, type)
         , m_data(!text.isNull() ? WTFMove(text) : emptyString())
     {

--- a/Source/WebCore/dom/ContainerNode.h
+++ b/Source/WebCore/dom/ContainerNode.h
@@ -144,7 +144,7 @@ public:
     ExceptionOr<void> ensurePreInsertionValidity(Node& newChild, Node* refChild);
 
 protected:
-    explicit ContainerNode(Document&, ConstructionType = CreateContainer);
+    explicit ContainerNode(Document&, OptionSet<TypeFlag> = CreateContainer);
 
     friend void removeDetachedChildrenInContainer(ContainerNode&);
 
@@ -175,7 +175,7 @@ private:
     Node* m_lastChild { nullptr };
 };
 
-inline ContainerNode::ContainerNode(Document& document, ConstructionType type)
+inline ContainerNode::ContainerNode(Document& document, OptionSet<TypeFlag> type)
     : Node(document, type)
 {
 }

--- a/Source/WebCore/dom/DocumentFragment.cpp
+++ b/Source/WebCore/dom/DocumentFragment.cpp
@@ -37,7 +37,7 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(DocumentFragment);
 
-DocumentFragment::DocumentFragment(Document& document, ConstructionType constructionType)
+DocumentFragment::DocumentFragment(Document& document, OptionSet<TypeFlag> constructionType)
     : ContainerNode(document, constructionType)
 {
 }

--- a/Source/WebCore/dom/DocumentFragment.h
+++ b/Source/WebCore/dom/DocumentFragment.h
@@ -44,7 +44,7 @@ public:
     WEBCORE_EXPORT Element* getElementById(const AtomString&) const;
 
 protected:
-    DocumentFragment(Document&, ConstructionType = CreateContainer);
+    DocumentFragment(Document&, OptionSet<TypeFlag> = CreateContainer);
     String nodeName() const final;
 
 private:

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -245,7 +245,7 @@ Ref<Element> Element::create(const QualifiedName& tagName, Document& document)
     return adoptRef(*new Element(tagName, document, CreateElement));
 }
 
-Element::Element(const QualifiedName& tagName, Document& document, ConstructionType type)
+Element::Element(const QualifiedName& tagName, Document& document, OptionSet<TypeFlag> type)
     : ContainerNode(document, type)
     , m_tagName(tagName)
 {

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -763,7 +763,7 @@ public:
     CustomStateSet& ensureCustomStateSet();
 
 protected:
-    Element(const QualifiedName&, Document&, ConstructionType);
+    Element(const QualifiedName&, Document&, OptionSet<TypeFlag>);
 
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) override;
     void removedFromAncestor(RemovalType, ContainerNode&) override;

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -390,7 +390,7 @@ inline void NodeRareData::operator delete(NodeRareData* nodeRareData, std::destr
         destroyAndFree(*nodeRareData);
 }
 
-Node::Node(Document& document, ConstructionType type)
+Node::Node(Document& document, OptionSet<TypeFlag> type)
     : EventTarget(ConstructNode)
     , m_typeFlags(type)
     , m_treeScope((isDocumentNode() || isShadowRoot()) ? nullptr : &document)

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -665,8 +665,7 @@ protected:
     static constexpr auto CreateMathMLElement = CreateElement | TypeFlag::IsMathMLElement;
     static constexpr auto CreateDocument = CreateContainer | TypeFlag::IsDocumentNode;
     static constexpr auto CreateEditingText = CreateText | TypeFlag::IsEditingText;
-    using ConstructionType = OptionSet<TypeFlag>;
-    Node(Document&, ConstructionType);
+    Node(Document&, OptionSet<TypeFlag>);
 
     static constexpr uint32_t s_refCountIncrement = 2;
     static constexpr uint32_t s_refCountMask = ~static_cast<uint32_t>(1);

--- a/Source/WebCore/dom/StyledElement.h
+++ b/Source/WebCore/dom/StyledElement.h
@@ -70,7 +70,7 @@ public:
     virtual const MutableStyleProperties* additionalPresentationalHintStyle() const { return nullptr; }
 
 protected:
-    StyledElement(const QualifiedName& name, Document& document, ConstructionType type)
+    StyledElement(const QualifiedName& name, Document& document, OptionSet<TypeFlag> type)
         : Element(name, document, type)
     {
     }

--- a/Source/WebCore/dom/Text.h
+++ b/Source/WebCore/dom/Text.h
@@ -58,7 +58,7 @@ public:
     String debugDescription() const final;
 
 protected:
-    Text(Document& document, String&& data, ConstructionType type)
+    Text(Document& document, String&& data, OptionSet<TypeFlag> type)
         : CharacterData(document, WTFMove(data), type)
     {
     }

--- a/Source/WebCore/html/HTMLDivElement.cpp
+++ b/Source/WebCore/html/HTMLDivElement.cpp
@@ -34,7 +34,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(HTMLDivElement);
 
 using namespace HTMLNames;
 
-HTMLDivElement::HTMLDivElement(const QualifiedName& tagName, Document& document, ConstructionType constructionType)
+HTMLDivElement::HTMLDivElement(const QualifiedName& tagName, Document& document, OptionSet<TypeFlag> constructionType)
     : HTMLElement(tagName, document, constructionType)
 {
     ASSERT(hasTagName(divTag));

--- a/Source/WebCore/html/HTMLDivElement.h
+++ b/Source/WebCore/html/HTMLDivElement.h
@@ -34,7 +34,7 @@ public:
 
 protected:
     static constexpr auto CreateHTMLDivElement = CreateHTMLElement;
-    HTMLDivElement(const QualifiedName&, Document&, ConstructionType = CreateHTMLDivElement);
+    HTMLDivElement(const QualifiedName&, Document&, OptionSet<TypeFlag> = CreateHTMLDivElement);
 
 private:
     void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) final;

--- a/Source/WebCore/html/HTMLElement.h
+++ b/Source/WebCore/html/HTMLElement.h
@@ -166,7 +166,7 @@ public:
 #endif
 
 protected:
-    HTMLElement(const QualifiedName& tagName, Document&, ConstructionType);
+    HTMLElement(const QualifiedName& tagName, Document&, OptionSet<TypeFlag>);
 
     enum class AllowZeroValue : bool { No, Yes };
     void addHTMLLengthToStyle(MutableStyleProperties&, CSSPropertyID, StringView value, AllowZeroValue = AllowZeroValue::Yes);
@@ -223,7 +223,7 @@ private:
     void addHTMLLengthToStyle(MutableStyleProperties&, CSSPropertyID, StringView value, AllowPercentage, UseCSSPXAsUnitType, IsMultiLength, AllowZeroValue = AllowZeroValue::Yes);
 };
 
-inline HTMLElement::HTMLElement(const QualifiedName& tagName, Document& document, ConstructionType type = CreateHTMLElement)
+inline HTMLElement::HTMLElement(const QualifiedName& tagName, Document& document, OptionSet<TypeFlag> type = CreateHTMLElement)
     : StyledElement(tagName, document, type)
 {
     ASSERT(tagName.localName().impl());

--- a/Source/WebCore/html/HTMLFrameOwnerElement.cpp
+++ b/Source/WebCore/html/HTMLFrameOwnerElement.cpp
@@ -40,7 +40,7 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(HTMLFrameOwnerElement);
 
-HTMLFrameOwnerElement::HTMLFrameOwnerElement(const QualifiedName& tagName, Document& document, ConstructionType constructionType)
+HTMLFrameOwnerElement::HTMLFrameOwnerElement(const QualifiedName& tagName, Document& document, OptionSet<TypeFlag> constructionType)
     : HTMLElement(tagName, document, constructionType)
 {
 }

--- a/Source/WebCore/html/HTMLFrameOwnerElement.h
+++ b/Source/WebCore/html/HTMLFrameOwnerElement.h
@@ -68,7 +68,7 @@ public:
 
 protected:
     static constexpr auto CreateHTMLFrameOwnerElement = CreateHTMLElement;
-    HTMLFrameOwnerElement(const QualifiedName& tagName, Document&, ConstructionType = CreateHTMLFrameOwnerElement);
+    HTMLFrameOwnerElement(const QualifiedName& tagName, Document&, OptionSet<TypeFlag> = CreateHTMLFrameOwnerElement);
     void setSandboxFlags(SandboxFlags);
     bool isProhibitedSelfReference(const URL&) const;
     bool isKeyboardFocusable(KeyboardEvent*) const override;

--- a/Source/WebCore/mathml/MathMLElement.cpp
+++ b/Source/WebCore/mathml/MathMLElement.cpp
@@ -52,7 +52,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(MathMLElement);
 
 using namespace MathMLNames;
 
-MathMLElement::MathMLElement(const QualifiedName& tagName, Document& document, ConstructionType constructionType)
+MathMLElement::MathMLElement(const QualifiedName& tagName, Document& document, OptionSet<TypeFlag> constructionType)
     : StyledElement(tagName, document, constructionType)
 {
 }

--- a/Source/WebCore/mathml/MathMLElement.h
+++ b/Source/WebCore/mathml/MathMLElement.h
@@ -90,7 +90,7 @@ public:
     virtual void updateSelectedChild() { }
 
 protected:
-    MathMLElement(const QualifiedName& tagName, Document&, ConstructionType = CreateMathMLElement);
+    MathMLElement(const QualifiedName& tagName, Document&, OptionSet<TypeFlag> = CreateMathMLElement);
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     bool childShouldCreateRenderer(const Node&) const override;

--- a/Source/WebCore/mathml/MathMLPresentationElement.cpp
+++ b/Source/WebCore/mathml/MathMLPresentationElement.cpp
@@ -51,7 +51,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(MathMLPresentationElement);
 
 using namespace MathMLNames;
 
-MathMLPresentationElement::MathMLPresentationElement(const QualifiedName& tagName, Document& document, ConstructionType constructionType)
+MathMLPresentationElement::MathMLPresentationElement(const QualifiedName& tagName, Document& document, OptionSet<TypeFlag> constructionType)
     : MathMLElement(tagName, document, constructionType)
 {
 }

--- a/Source/WebCore/mathml/MathMLPresentationElement.h
+++ b/Source/WebCore/mathml/MathMLPresentationElement.h
@@ -40,7 +40,7 @@ public:
 
 protected:
     static constexpr auto CreateMathMLPresentationElement = CreateMathMLElement;
-    MathMLPresentationElement(const QualifiedName& tagName, Document&, ConstructionType = CreateMathMLPresentationElement);
+    MathMLPresentationElement(const QualifiedName& tagName, Document&, OptionSet<TypeFlag> = CreateMathMLPresentationElement);
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
 
     static std::optional<bool> toOptionalBool(const BooleanValue& value) { return value == BooleanValue::Default ? std::nullopt : std::optional<bool>(value == BooleanValue::True); }

--- a/Source/WebCore/mathml/MathMLRowElement.cpp
+++ b/Source/WebCore/mathml/MathMLRowElement.cpp
@@ -42,7 +42,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(MathMLRowElement);
 
 using namespace MathMLNames;
 
-MathMLRowElement::MathMLRowElement(const QualifiedName& tagName, Document& document, ConstructionType constructionType)
+MathMLRowElement::MathMLRowElement(const QualifiedName& tagName, Document& document, OptionSet<TypeFlag> constructionType)
     : MathMLPresentationElement(tagName, document, constructionType)
 {
 }

--- a/Source/WebCore/mathml/MathMLRowElement.h
+++ b/Source/WebCore/mathml/MathMLRowElement.h
@@ -38,7 +38,7 @@ public:
 
 protected:
     static constexpr auto CreateMathMLRowElement = CreateMathMLPresentationElement;
-    MathMLRowElement(const QualifiedName& tagName, Document&, ConstructionType = CreateMathMLRowElement);
+    MathMLRowElement(const QualifiedName& tagName, Document&, OptionSet<TypeFlag> = CreateMathMLRowElement);
     void childrenChanged(const ChildChange&) override;
 
     bool acceptsMathVariantAttribute() override;

--- a/Source/WebCore/svg/SVGElement.cpp
+++ b/Source/WebCore/svg/SVGElement.cpp
@@ -69,7 +69,7 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(SVGElement);
 
-SVGElement::SVGElement(const QualifiedName& tagName, Document& document, UniqueRef<SVGPropertyRegistry>&& propertyRegistry, ConstructionType constructionType)
+SVGElement::SVGElement(const QualifiedName& tagName, Document& document, UniqueRef<SVGPropertyRegistry>&& propertyRegistry, OptionSet<TypeFlag> constructionType)
     : StyledElement(tagName, document, constructionType)
     , m_propertyAnimatorFactory(makeUnique<SVGPropertyAnimatorFactory>())
     , m_propertyRegistry(WTFMove(propertyRegistry))

--- a/Source/WebCore/svg/SVGElement.h
+++ b/Source/WebCore/svg/SVGElement.h
@@ -168,7 +168,7 @@ public:
     bool hasAssociatedSVGLayoutBox() const;
 
 protected:
-    SVGElement(const QualifiedName&, Document&, UniqueRef<SVGPropertyRegistry>&&, ConstructionType = CreateSVGElement);
+    SVGElement(const QualifiedName&, Document&, UniqueRef<SVGPropertyRegistry>&&, OptionSet<TypeFlag> = CreateSVGElement);
     virtual ~SVGElement();
 
     bool rendererIsNeeded(const RenderStyle&) override;


### PR DESCRIPTION
#### 92f37c32aa7d82d057568a3f3e55e4dc29469759
<pre>
Replace ConstructionType with OptionSet&lt;TypeFlag&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=266813">https://bugs.webkit.org/show_bug.cgi?id=266813</a>

Reviewed by Alan Baradlay.

Removed ConstructionType in favor of directly using OptionSet&lt;TypeFlag&gt;.

* Source/WebCore/dom/CharacterData.h:
(WebCore::CharacterData::CharacterData):
* Source/WebCore/dom/ContainerNode.h:
(WebCore::ContainerNode::ContainerNode):
* Source/WebCore/dom/DocumentFragment.cpp:
(WebCore::DocumentFragment::DocumentFragment):
* Source/WebCore/dom/DocumentFragment.h:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::Element):
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::Node):
* Source/WebCore/dom/Node.h:
* Source/WebCore/dom/StyledElement.h:
(WebCore::StyledElement::StyledElement):
* Source/WebCore/dom/Text.h:
(WebCore::Text::Text):
* Source/WebCore/html/HTMLDivElement.cpp:
(WebCore::HTMLDivElement::HTMLDivElement):
* Source/WebCore/html/HTMLDivElement.h:
* Source/WebCore/html/HTMLElement.h:
(WebCore::HTMLElement::HTMLElement):
* Source/WebCore/html/HTMLFrameOwnerElement.cpp:
(WebCore::HTMLFrameOwnerElement::HTMLFrameOwnerElement):
* Source/WebCore/html/HTMLFrameOwnerElement.h:
* Source/WebCore/mathml/MathMLElement.cpp:
(WebCore::MathMLElement::MathMLElement):
* Source/WebCore/mathml/MathMLElement.h:
* Source/WebCore/mathml/MathMLPresentationElement.cpp:
(WebCore::MathMLPresentationElement::MathMLPresentationElement):
* Source/WebCore/mathml/MathMLPresentationElement.h:
* Source/WebCore/mathml/MathMLRowElement.cpp:
(WebCore::MathMLRowElement::MathMLRowElement):
* Source/WebCore/mathml/MathMLRowElement.h:
* Source/WebCore/svg/SVGElement.cpp:
(WebCore::SVGElement::SVGElement):
* Source/WebCore/svg/SVGElement.h:

Canonical link: <a href="https://commits.webkit.org/272458@main">https://commits.webkit.org/272458@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4956be6b4984b7a7aa77e45d79d2f3612b319a13

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31702 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10385 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33424 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34193 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28706 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32485 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12742 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7633 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28299 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32053 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8752 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28292 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7549 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7712 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28206 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35538 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28816 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28652 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33832 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7805 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5811 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31687 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9461 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8485 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4142 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8322 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->