### PR TITLE
[WebGPU] bind group dynamic offsets are not implemented correctly, they don't correspond to the proper stage

### DIFF
--- a/Source/WebGPU/WebGPU/BindGroupLayout.h
+++ b/Source/WebGPU/WebGPU/BindGroupLayout.h
@@ -63,6 +63,7 @@ public:
         std::optional<uint32_t> vertexDynamicOffset;
         std::optional<uint32_t> fragmentDynamicOffset;
         std::optional<uint32_t> computeDynamicOffset;
+        uint32_t dynamicOffsetsIndex;
     };
     using EntriesContainer = HashMap<uint32_t, Entry, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
 

--- a/Source/WebGPU/WebGPU/PipelineLayout.mm
+++ b/Source/WebGPU/WebGPU/PipelineLayout.mm
@@ -209,7 +209,7 @@ const Vector<uint32_t>* PipelineLayout::offsetVectorForBindGroup(uint32_t bindGr
     auto& bindGroupLayouts = *m_bindGroupLayouts;
     if (auto it = stageOffsets.find(bindGroupIndex); it != stageOffsets.end()) {
         auto& container = it->value;
-        uint32_t dynamicOffsetIndex = 0, stageOffsetIndex = 0;
+        uint32_t stageOffsetIndex = 0;
         auto& bindGroupLayout = bindGroupLayouts[bindGroupIndex];
         for (auto& entryKvp : bindGroupLayout->entries()) {
             auto& entry = entryKvp.value;
@@ -218,12 +218,10 @@ const Vector<uint32_t>* PipelineLayout::offsetVectorForBindGroup(uint32_t bindGr
                 continue;
 
             if (entry.visibility & stage) {
-                ASSERT(container.size() > stageOffsetIndex && dynamicOffsets.size() > dynamicOffsetIndex);
-                container[stageOffsetIndex] = dynamicOffsets[dynamicOffsetIndex];
+                RELEASE_ASSERT(container.size() > stageOffsetIndex && dynamicOffsets.size() > entry.dynamicOffsetsIndex);
+                container[stageOffsetIndex] = dynamicOffsets[entry.dynamicOffsetsIndex];
                 ++stageOffsetIndex;
             }
-
-            ++dynamicOffsetIndex;
         }
 
         return &container;


### PR DESCRIPTION
#### ca382024b6d3ecf1dc7042ed2d260d58fd1aa5c1
<pre>
[WebGPU] bind group dynamic offsets are not implemented correctly, they don&apos;t correspond to the proper stage
<a href="https://bugs.webkit.org/show_bug.cgi?id=266815">https://bugs.webkit.org/show_bug.cgi?id=266815</a>&gt;
&lt;radar://120049732&gt;

Reviewed by Tadeu Zagallo.

Dynamic offsets assumed buffers had linearly increasing bind
group indices, which does not necessarily hold and is not
the case in Unity&apos;s demos.

Break this assumption by computing the corresponding index
from the source dynamic offsets buffer during bind group
layout generation time.

Then use this precomputed index instead of a linearly increasing
value in the PipelineLayout.

* Source/WebGPU/WebGPU/BindGroupLayout.h:
* Source/WebGPU/WebGPU/BindGroupLayout.mm:
(WebGPU::Device::createBindGroupLayout):
* Source/WebGPU/WebGPU/PipelineLayout.mm:
(WebGPU::PipelineLayout::offsetVectorForBindGroup):

Canonical link: <a href="https://commits.webkit.org/272522@main">https://commits.webkit.org/272522@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6617b16efd16a508de2ab0656a83172a769d2b79

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31708 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10391 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33433 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34201 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28713 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12748 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7639 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28306 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32061 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8757 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28298 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7556 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7717 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35546 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28821 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28659 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33838 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7812 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5815 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31698 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9467 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7471 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8491 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8328 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->