### PR TITLE
[fullscreen] Stop unnecessarily unsetting the iframe fullscreen flag

### DIFF
--- a/Source/WebCore/dom/FullscreenManager.cpp
+++ b/Source/WebCore/dom/FullscreenManager.cpp
@@ -341,8 +341,8 @@ static Vector<Ref<Document>> documentsToUnfullscreen(Document& firstDocument)
 static void clearFullscreenFlags(Element& element)
 {
     element.setFullscreenFlag(false);
-    if (auto* frameOwner = dynamicDowncast<HTMLIFrameElement>(element))
-        frameOwner->setIFrameFullscreenFlag(false);
+    if (auto* iframe = dynamicDowncast<HTMLIFrameElement>(element))
+        iframe->setIFrameFullscreenFlag(false);
 }
 
 void FullscreenManager::exitFullscreen(RefPtr<DeferredPromise>&& promise)
@@ -546,9 +546,6 @@ bool FullscreenManager::willEnterFullscreen(Element& element)
             containingBlockBeforeStyleResolution = renderer->containingBlock();
 
         ancestor->setFullscreenFlag(true);
-        // FIXME: Why is "iframe fullscreen" getting unset here?
-        if (auto* frameElement = dynamicDowncast<HTMLIFrameElement>(ancestor.get()))
-            frameElement->setIFrameFullscreenFlag(false);
         ancestor->document().resolveStyle(Document::ResolveStyleType::Rebuild);
 
         // Remove before adding, so we always add at the end of the top layer.


### PR DESCRIPTION
#### 176e163ba0ff9b47f4486079ecf2a78ace837bcc
<pre>
[fullscreen] Stop unnecessarily unsetting the iframe fullscreen flag
<a href="https://bugs.webkit.org/show_bug.cgi?id=266820">https://bugs.webkit.org/show_bug.cgi?id=266820</a>
<a href="https://rdar.apple.com/120052751">rdar://120052751</a>

Reviewed by Ryosuke Niwa.

Remove this code to match the spec closer: <a href="https://fullscreen.spec.whatwg.org/#dom-element-requestfullscreen">https://fullscreen.spec.whatwg.org/#dom-element-requestfullscreen</a>

It was originally to address a review comment:
<a href="https://github.com/WebKit/WebKit/pull/5467#discussion_r1041296533">https://github.com/WebKit/WebKit/pull/5467#discussion_r1041296533</a>

But this review comment no longer applies now that `Element::setFullscreenFlag` only sets a single flag.

* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::clearFullscreenFlags): rename variable to be more consistent with other iframe downcasts in the file.
(WebCore::FullscreenManager::willEnterFullscreen):

Canonical link: <a href="https://commits.webkit.org/272462@main">https://commits.webkit.org/272462@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a157730052c20e0b5d948939a1cdc99ed5100711

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31727 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10409 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33452 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34219 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/28729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32512 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12766 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7657 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/28319 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32080 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8771 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28314 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7569 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7731 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28228 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35564 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28835 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28675 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/33853 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/7827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/5830 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31709 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9484 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7435 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/8505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8344 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->