### PR TITLE
Fix invalid CSS state web platform tests

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/custom-state-pseudo-class/state-css-selector.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-state-pseudo-class/state-css-selector.tentative-expected.txt
@@ -7,8 +7,8 @@ I should be blue
 PASS state selector has no influence when state is not applied
 PASS state selector has no influence on sibling selectors when not applied
 PASS state selector has influence when state is applied
-FAIL state selector influences siblings when state is applied assert_equals: expected "rgb(0, 0, 255)" but got "rgb(255, 0, 0)"
-FAIL state selector influences has() when state is applied assert_equals: expected "rgb(0, 0, 255)" but got "rgb(255, 0, 0)"
+PASS state selector influences siblings when state is applied
+PASS state selector influences has() when state is applied
 PASS state selector only applies on given ident
 PASS state selector only applies to siblings on given ident
 PASS state selector only applies to has() on given ident

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-state-pseudo-class/state-css-selector.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-state-pseudo-class/state-css-selector.tentative.html
@@ -28,9 +28,9 @@
         color: #0f0;
       }
       body:has(custom-state:state(--green)) p {
-        color: #f00;
+        color: #0ff;
       }
-      custom-state:state(--green) + p {
+      custom-state:state(--green) + p[id] {
         color: #00f;
       }
       custom-state:--green + p {
@@ -72,7 +72,7 @@
         myCE.elementInternals.states.add('--green');
         t.add_cleanup(() => { myCE.elementInternals.states.delete('--green') });
         assert_true(myCE.elementInternals.states.has('--green'));
-        assert_equals(getComputedStyle(myHas).getPropertyValue('color'), 'rgb(0, 0, 255)');
+        assert_equals(getComputedStyle(myHas).getPropertyValue('color'), 'rgb(0, 255, 255)');
     }, "state selector influences has() when state is applied");
 
     test(function(t) {


### PR DESCRIPTION
#### f91046e9de3965769ec297b369d14afcfb644d61
<pre>
Fix invalid CSS state web platform tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=266822">https://bugs.webkit.org/show_bug.cgi?id=266822</a>

Reviewed by Tim Nguyen.

Due to specificity of the :has() selector overriding the sibling
selector, the sibling selector test was never valid. Adding `[id]` to
the sibling selector bumps the specificity high enough to override the
`:has` style rule so that the sibling selector style rule can take
precedence, leading to a valid test.

Additionally, the `:has` style rule rendering the red colour meant that the
`:has` test was also always invalid. Changing the stylerule to use a
cyan (#0ff) helps differentiate the test. The actual test checked to see
if the colour was blue, which is obviously incorrect and this has now
  also been changed to assert that it should be the same teal as applied
  in the style rule.

* LayoutTests/imported/w3c/web-platform-tests/custom-state-pseudo-class/state-css-selector.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-state-pseudo-class/state-css-selector.tentative.html:

Canonical link: <a href="https://commits.webkit.org/272465@main">https://commits.webkit.org/272465@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d5c5cac11f93451df8944fe05436d5f0ce6d64e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31729 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10411 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33454 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34221 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28731 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12768 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7659 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/28321 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32082 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8776 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28319 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7571 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7736 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28233 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35566 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28840 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28680 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33854 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7829 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5832 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31710 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9486 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/28040 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7437 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8507 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8346 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->