### PR TITLE
rdar://120053975 ([WebGPU] writeBuffer and writeTexture should use noCopy variants when creating temporary buffers (266821))

### DIFF
--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.cpp
@@ -70,20 +70,41 @@ void QueueImpl::onSubmittedWorkDone(CompletionHandler<void()>&& callback)
 }
 
 void QueueImpl::writeBuffer(
+    const Buffer&,
+    Size64,
+    const void*,
+    size_t,
+    Size64,
+    std::optional<Size64>)
+{
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+void QueueImpl::writeTexture(
+    const ImageCopyTexture&,
+    const void*,
+    size_t,
+    const ImageDataLayout&,
+    const Extent3D&)
+{
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+void QueueImpl::writeBuffer(
     const Buffer& buffer,
     Size64 bufferOffset,
-    const void* source,
+    void* source,
     size_t byteLength,
     Size64 dataOffset,
     std::optional<Size64> size)
 {
     // FIXME: Use checked arithmetic and check the cast
-    wgpuQueueWriteBuffer(m_backing.get(), m_convertToBackingContext->convertToBacking(buffer), bufferOffset, static_cast<const uint8_t*>(source) + dataOffset, static_cast<size_t>(size.value_or(byteLength - dataOffset)));
+    wgpuQueueWriteBuffer(m_backing.get(), m_convertToBackingContext->convertToBacking(buffer), bufferOffset, static_cast<uint8_t*>(source) + dataOffset, static_cast<size_t>(size.value_or(byteLength - dataOffset)));
 }
 
 void QueueImpl::writeTexture(
     const ImageCopyTexture& destination,
-    const void* source,
+    void* source,
     size_t byteLength,
     const ImageDataLayout& dataLayout,
     const Extent3D& size)

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.h
@@ -77,6 +77,21 @@ private:
         const ImageDataLayout&,
         const Extent3D& size) final;
 
+    void writeBuffer(
+        const Buffer&,
+        Size64 bufferOffset,
+        void* source,
+        size_t byteLength,
+        Size64 dataOffset,
+        std::optional<Size64>) final;
+
+    void writeTexture(
+        const ImageCopyTexture& destination,
+        void* source,
+        size_t byteLength,
+        const ImageDataLayout&,
+        const Extent3D& size) final;
+
     void copyExternalImageToTexture(
         const ImageCopyExternalImage& source,
         const ImageCopyTextureTagged& destination,

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUQueue.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUQueue.h
@@ -76,6 +76,21 @@ public:
         const ImageDataLayout&,
         const Extent3D& size) = 0;
 
+    virtual void writeBuffer(
+        const Buffer&,
+        Size64 bufferOffset,
+        void* source,
+        size_t byteLength,
+        Size64 dataOffset = 0,
+        std::optional<Size64> = std::nullopt) = 0;
+
+    virtual void writeTexture(
+        const ImageCopyTexture& destination,
+        void* source,
+        size_t byteLength,
+        const ImageDataLayout&,
+        const Extent3D& size) = 0;
+
     virtual void copyExternalImageToTexture(
         const ImageCopyExternalImage& source,
         const ImageCopyTextureTagged& destination,

--- a/Source/WebGPU/WebGPU/Queue.h
+++ b/Source/WebGPU/WebGPU/Queue.h
@@ -60,9 +60,9 @@ public:
 
     void onSubmittedWorkDone(CompletionHandler<void(WGPUQueueWorkDoneStatus)>&& callback);
     void submit(Vector<std::reference_wrapper<CommandBuffer>>&& commands);
-    void writeBuffer(const Buffer&, uint64_t bufferOffset, const void* data, size_t);
-    void writeBuffer(id<MTLBuffer>, uint64_t bufferOffset, const void* data, size_t);
-    void writeTexture(const WGPUImageCopyTexture& destination, const void* data, size_t dataSize, const WGPUTextureDataLayout&, const WGPUExtent3D& writeSize);
+    void writeBuffer(const Buffer&, uint64_t bufferOffset, void* data, size_t);
+    void writeBuffer(id<MTLBuffer>, uint64_t bufferOffset, void* data, size_t);
+    void writeTexture(const WGPUImageCopyTexture& destination, void* data, size_t dataSize, const WGPUTextureDataLayout&, const WGPUExtent3D& writeSize);
     void setLabel(String&&);
 
     void onSubmittedWorkScheduled(CompletionHandler<void()>&&);

--- a/Source/WebGPU/WebGPU/WebGPU.h
+++ b/Source/WebGPU/WebGPU/WebGPU.h
@@ -1447,8 +1447,8 @@ typedef void (*WGPUProcQuerySetRelease)(WGPUQuerySet querySet) WGPU_FUNCTION_ATT
 typedef void (*WGPUProcQueueOnSubmittedWorkDone)(WGPUQueue queue, WGPUQueueWorkDoneCallback callback, void * userdata) WGPU_FUNCTION_ATTRIBUTE;
 typedef void (*WGPUProcQueueSetLabel)(WGPUQueue queue, char const * label) WGPU_FUNCTION_ATTRIBUTE;
 typedef void (*WGPUProcQueueSubmit)(WGPUQueue queue, size_t commandCount, WGPUCommandBuffer const * commands) WGPU_FUNCTION_ATTRIBUTE;
-typedef void (*WGPUProcQueueWriteBuffer)(WGPUQueue queue, WGPUBuffer buffer, uint64_t bufferOffset, void const * data, size_t size) WGPU_FUNCTION_ATTRIBUTE;
-typedef void (*WGPUProcQueueWriteTexture)(WGPUQueue queue, WGPUImageCopyTexture const * destination, void const * data, size_t dataSize, WGPUTextureDataLayout const * dataLayout, WGPUExtent3D const * writeSize) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPUProcQueueWriteBuffer)(WGPUQueue queue, WGPUBuffer buffer, uint64_t bufferOffset, void * data, size_t size) WGPU_FUNCTION_ATTRIBUTE;
+typedef void (*WGPUProcQueueWriteTexture)(WGPUQueue queue, WGPUImageCopyTexture const * destination, void * data, size_t dataSize, WGPUTextureDataLayout const * dataLayout, WGPUExtent3D const * writeSize) WGPU_FUNCTION_ATTRIBUTE;
 typedef void (*WGPUProcQueueReference)(WGPUQueue queue) WGPU_FUNCTION_ATTRIBUTE;
 typedef void (*WGPUProcQueueRelease)(WGPUQueue queue) WGPU_FUNCTION_ATTRIBUTE;
 
@@ -1679,8 +1679,8 @@ WGPU_EXPORT void wgpuQuerySetRelease(WGPUQuerySet querySet) WGPU_FUNCTION_ATTRIB
 WGPU_EXPORT void wgpuQueueOnSubmittedWorkDone(WGPUQueue queue, WGPUQueueWorkDoneCallback callback, void * userdata) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuQueueSetLabel(WGPUQueue queue, char const * label) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuQueueSubmit(WGPUQueue queue, size_t commandCount, WGPUCommandBuffer const * commands) WGPU_FUNCTION_ATTRIBUTE;
-WGPU_EXPORT void wgpuQueueWriteBuffer(WGPUQueue queue, WGPUBuffer buffer, uint64_t bufferOffset, void const * data, size_t size) WGPU_FUNCTION_ATTRIBUTE;
-WGPU_EXPORT void wgpuQueueWriteTexture(WGPUQueue queue, WGPUImageCopyTexture const * destination, void const * data, size_t dataSize, WGPUTextureDataLayout const * dataLayout, WGPUExtent3D const * writeSize) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuQueueWriteBuffer(WGPUQueue queue, WGPUBuffer buffer, uint64_t bufferOffset, void * data, size_t size) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuQueueWriteTexture(WGPUQueue queue, WGPUImageCopyTexture const * destination, void * data, size_t dataSize, WGPUTextureDataLayout const * dataLayout, WGPUExtent3D const * writeSize) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuQueueReference(WGPUQueue queue) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuQueueRelease(WGPUQueue queue) WGPU_FUNCTION_ATTRIBUTE;
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp
@@ -105,6 +105,27 @@ void RemoteQueueProxy::writeTexture(
     UNUSED_VARIABLE(sendResult);
 }
 
+void RemoteQueueProxy::writeBuffer(
+    const WebCore::WebGPU::Buffer&,
+    WebCore::WebGPU::Size64,
+    void*,
+    size_t,
+    WebCore::WebGPU::Size64,
+    std::optional<WebCore::WebGPU::Size64>)
+{
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+void RemoteQueueProxy::writeTexture(
+    const WebCore::WebGPU::ImageCopyTexture&,
+    void*,
+    size_t,
+    const WebCore::WebGPU::ImageDataLayout&,
+    const WebCore::WebGPU::Extent3D&)
+{
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
 void RemoteQueueProxy::copyExternalImageToTexture(
     const WebCore::WebGPU::ImageCopyExternalImage& source,
     const WebCore::WebGPU::ImageCopyTextureTagged& destination,

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h
@@ -92,6 +92,21 @@ private:
         const WebCore::WebGPU::ImageDataLayout&,
         const WebCore::WebGPU::Extent3D& size) final;
 
+    void writeBuffer(
+        const WebCore::WebGPU::Buffer&,
+        WebCore::WebGPU::Size64 bufferOffset,
+        void* source,
+        size_t byteLength,
+        WebCore::WebGPU::Size64 dataOffset = 0,
+        std::optional<WebCore::WebGPU::Size64> = std::nullopt) final;
+
+    void writeTexture(
+        const WebCore::WebGPU::ImageCopyTexture& destination,
+        void* source,
+        size_t byteLength,
+        const WebCore::WebGPU::ImageDataLayout&,
+        const WebCore::WebGPU::Extent3D& size) final;
+
     void copyExternalImageToTexture(
         const WebCore::WebGPU::ImageCopyExternalImage& source,
         const WebCore::WebGPU::ImageCopyTextureTagged& destination,


### PR DESCRIPTION
#### 668a3349c7066b8b0fbc2a7bddb4df995266d6c0
<pre>
<a href="https://rdar.apple.com/120053975">rdar://120053975</a> ([WebGPU] writeBuffer and writeTexture should use noCopy variants when creating temporary buffers (266821))
<a href="https://bugs.webkit.org/show_bug.cgi?id=266821">https://bugs.webkit.org/show_bug.cgi?id=266821</a>
&lt;radar://120053975&gt;

Reviewed by Tadeu Zagallo.

Some more complex demos can copy 300MB textures or buffers and copying
these is expensive and leads to OOM situations.

Establish a threshold, currently 32MB, where we use the no-copy variant
to avoid duplicating the memory. It requires us to submit the command buffer
immedietly, otherwise the memory may get deallocated too soon. That is the
trade off with the no-copy variants.

* Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.cpp:
(WebCore::WebGPU::QueueImpl::writeBuffer):
(WebCore::WebGPU::QueueImpl::writeTexture):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUQueue.h:
* Source/WebGPU/WebGPU/Queue.h:
* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::Queue::writeBuffer):
(WebGPU::Queue::writeTexture):
(wgpuQueueWriteBuffer):
(wgpuQueueWriteTexture):
* Source/WebGPU/WebGPU/WebGPU.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp:
(WebKit::WebGPU::RemoteQueueProxy::writeBuffer):
(WebKit::WebGPU::RemoteQueueProxy::writeTexture):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h:

Canonical link: <a href="https://commits.webkit.org/272596@main">https://commits.webkit.org/272596@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b98f623ab1f7f44d5f55f895091873a3d66a15b9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31731 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10413 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33456 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34223 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28733 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32516 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12771 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7661 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28323 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32084 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8777 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28320 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7573 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7737 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28234 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35568 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28841 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28681 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33855 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7831 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5834 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31711 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9488 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7533 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8509 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8348 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->