### PR TITLE
Inline NodeType in C++ side

### DIFF
--- a/Source/WebCore/dom/Attr.cpp
+++ b/Source/WebCore/dom/Attr.cpp
@@ -44,14 +44,14 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(Attr);
 using namespace HTMLNames;
 
 Attr::Attr(Element& element, const QualifiedName& name)
-    : Node(element.document(), CreateAttr)
+    : Node(element.document(), ATTRIBUTE_NODE, CreateAttr)
     , m_element(element)
     , m_name(name)
 {
 }
 
 Attr::Attr(Document& document, const QualifiedName& name, const AtomString& standaloneValue)
-    : Node(document, CreateAttr)
+    : Node(document, ATTRIBUTE_NODE, CreateAttr)
     , m_name(name)
     , m_standaloneValue(standaloneValue)
 {

--- a/Source/WebCore/dom/Attr.h
+++ b/Source/WebCore/dom/Attr.h
@@ -63,7 +63,6 @@ private:
     Attr(Document&, const QualifiedName&, const AtomString& value);
 
     String nodeName() const final { return name(); }
-    NodeType nodeType() const final { return ATTRIBUTE_NODE; }
 
     String nodeValue() const final { return value(); }
     void setNodeValue(const String&) final;

--- a/Source/WebCore/dom/CDATASection.cpp
+++ b/Source/WebCore/dom/CDATASection.cpp
@@ -31,7 +31,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(CDATASection);
 
 inline CDATASection::CDATASection(Document& document, String&& data)
-    : Text(document, WTFMove(data), CreateText)
+    : Text(document, WTFMove(data), CDATA_SECTION_NODE, CreateText)
 {
 }
 
@@ -43,11 +43,6 @@ Ref<CDATASection> CDATASection::create(Document& document, String&& data)
 String CDATASection::nodeName() const
 {
     return "#cdata-section"_s;
-}
-
-Node::NodeType CDATASection::nodeType() const
-{
-    return CDATA_SECTION_NODE;
 }
 
 Ref<Node> CDATASection::cloneNodeInternal(Document& targetDocument, CloningOperation)

--- a/Source/WebCore/dom/CDATASection.h
+++ b/Source/WebCore/dom/CDATASection.h
@@ -35,7 +35,6 @@ private:
     CDATASection(Document&, String&&);
 
     String nodeName() const override;
-    NodeType nodeType() const override;
     Ref<Node> cloneNodeInternal(Document&, CloningOperation) override;
     Ref<Text> virtualCreate(String&&) override;
 };

--- a/Source/WebCore/dom/CharacterData.h
+++ b/Source/WebCore/dom/CharacterData.h
@@ -44,11 +44,11 @@ public:
     void parserAppendData(StringView);
 
 protected:
-    CharacterData(Document& document, String&& text, OptionSet<TypeFlag> type = CreateCharacterData)
-        : Node(document, type)
+    CharacterData(Document& document, String&& text, NodeType type, OptionSet<TypeFlag> typeFlags = CreateCharacterData)
+        : Node(document, type, typeFlags)
         , m_data(!text.isNull() ? WTFMove(text) : emptyString())
     {
-        ASSERT(type == CreateCharacterData || type == CreateText || type == CreateEditingText);
+        ASSERT(typeFlags == CreateCharacterData || typeFlags == CreateText || typeFlags == CreateEditingText);
     }
 
     ~CharacterData();

--- a/Source/WebCore/dom/Comment.cpp
+++ b/Source/WebCore/dom/Comment.cpp
@@ -30,7 +30,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(Comment);
 
 inline Comment::Comment(Document& document, String&& text)
-    : CharacterData(document, WTFMove(text))
+    : CharacterData(document, WTFMove(text), COMMENT_NODE)
 {
 }
 
@@ -42,11 +42,6 @@ Ref<Comment> Comment::create(Document& document, String&& text)
 String Comment::nodeName() const
 {
     return "#comment"_s;
-}
-
-Node::NodeType Comment::nodeType() const
-{
-    return COMMENT_NODE;
 }
 
 Ref<Node> Comment::cloneNodeInternal(Document& targetDocument, CloningOperation)

--- a/Source/WebCore/dom/Comment.h
+++ b/Source/WebCore/dom/Comment.h
@@ -35,7 +35,6 @@ private:
     Comment(Document&, String&&);
 
     String nodeName() const override;
-    NodeType nodeType() const override;
     Ref<Node> cloneNodeInternal(Document&, CloningOperation) override;
 };
 

--- a/Source/WebCore/dom/ContainerNode.h
+++ b/Source/WebCore/dom/ContainerNode.h
@@ -144,7 +144,7 @@ public:
     ExceptionOr<void> ensurePreInsertionValidity(Node& newChild, Node* refChild);
 
 protected:
-    explicit ContainerNode(Document&, OptionSet<TypeFlag> = CreateContainer);
+    explicit ContainerNode(Document&, NodeType, OptionSet<TypeFlag> = CreateContainer);
 
     friend void removeDetachedChildrenInContainer(ContainerNode&);
 
@@ -175,9 +175,10 @@ private:
     Node* m_lastChild { nullptr };
 };
 
-inline ContainerNode::ContainerNode(Document& document, OptionSet<TypeFlag> type)
-    : Node(document, type)
+inline ContainerNode::ContainerNode(Document& document, NodeType type, OptionSet<TypeFlag> typeFlags)
+    : Node(document, type, typeFlags)
 {
+    ASSERT(typeFlags.contains(TypeFlag::IsContainerNode));
 }
 
 inline unsigned Node::countChildNodes() const

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -592,7 +592,7 @@ static Ref<CachedResourceLoader> createCachedResourceLoader(LocalFrame* frame)
 }
 
 Document::Document(LocalFrame* frame, const Settings& settings, const URL& url, DocumentClasses documentClasses, OptionSet<ConstructionFlag> constructionFlags, ScriptExecutionContextIdentifier identifier)
-    : ContainerNode(*this, CreateDocument)
+    : ContainerNode(*this, DOCUMENT_NODE)
     , TreeScope(*this)
     , ScriptExecutionContext(identifier)
     , FrameDestructionObserver(frame)
@@ -2076,11 +2076,6 @@ void Document::forEachMediaElement(const Function<void(HTMLMediaElement&)>& func
 String Document::nodeName() const
 {
     return "#document"_s;
-}
-
-Node::NodeType Document::nodeType() const
-{
-    return DOCUMENT_NODE;
 }
 
 WakeLockManager& Document::wakeLockManager()

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1912,7 +1912,6 @@ private:
     void childrenChanged(const ChildChange&) final;
 
     String nodeName() const final;
-    NodeType nodeType() const final;
     bool childTypeAllowed(NodeType) const final;
     Ref<Node> cloneNodeInternal(Document&, CloningOperation) final;
     void cloneDataFromDocument(const Document&);

--- a/Source/WebCore/dom/DocumentFragment.cpp
+++ b/Source/WebCore/dom/DocumentFragment.cpp
@@ -38,28 +38,23 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(DocumentFragment);
 
 DocumentFragment::DocumentFragment(Document& document, OptionSet<TypeFlag> constructionType)
-    : ContainerNode(document, constructionType)
+    : ContainerNode(document, DOCUMENT_FRAGMENT_NODE, constructionType)
 {
 }
 
 Ref<DocumentFragment> DocumentFragment::create(Document& document)
 {
-    return adoptRef(*new DocumentFragment(document, Node::CreateDocumentFragment));
+    return adoptRef(*new DocumentFragment(document));
 }
 
 Ref<DocumentFragment> DocumentFragment::createForInnerOuterHTML(Document& document)
 {
-    return adoptRef(*new DocumentFragment(document, Node::CreateDocumentFragment | TypeFlag::IsDocumentFragmentForInnerOuterHTML));
+    return adoptRef(*new DocumentFragment(document, CreateContainer | TypeFlag::IsDocumentFragmentForInnerOuterHTML));
 }
 
 String DocumentFragment::nodeName() const
 {
     return "#document-fragment"_s;
-}
-
-Node::NodeType DocumentFragment::nodeType() const
-{
-    return DOCUMENT_FRAGMENT_NODE;
 }
 
 bool DocumentFragment::childTypeAllowed(NodeType type) const

--- a/Source/WebCore/dom/DocumentFragment.h
+++ b/Source/WebCore/dom/DocumentFragment.h
@@ -48,7 +48,6 @@ protected:
     String nodeName() const final;
 
 private:
-    NodeType nodeType() const final;
     Ref<Node> cloneNodeInternal(Document&, CloningOperation) override;
     bool childTypeAllowed(NodeType) const override;
 };

--- a/Source/WebCore/dom/DocumentType.cpp
+++ b/Source/WebCore/dom/DocumentType.cpp
@@ -33,7 +33,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(DocumentType);
 
 DocumentType::DocumentType(Document& document, const String& name, const String& publicId, const String& systemId)
-    : Node(document, CreateDocumentType)
+    : Node(document, DOCUMENT_TYPE_NODE, CreateDocumentType)
     , m_name(name)
     , m_publicId(publicId.isNull() ? emptyString() : publicId)
     , m_systemId(systemId.isNull() ? emptyString() : systemId)
@@ -43,11 +43,6 @@ DocumentType::DocumentType(Document& document, const String& name, const String&
 String DocumentType::nodeName() const
 {
     return name();
-}
-
-Node::NodeType DocumentType::nodeType() const
-{
-    return DOCUMENT_TYPE_NODE;
 }
 
 Ref<Node> DocumentType::cloneNodeInternal(Document& documentTarget, CloningOperation)

--- a/Source/WebCore/dom/DocumentType.h
+++ b/Source/WebCore/dom/DocumentType.h
@@ -45,7 +45,6 @@ private:
     DocumentType(Document&, const String& name, const String& publicId, const String& systemId);
 
     String nodeName() const override;
-    NodeType nodeType() const override;
     Ref<Node> cloneNodeInternal(Document&, CloningOperation) override;
 
     void parentOrShadowHostNode() const = delete; // Call parentNode() instead.

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -246,7 +246,7 @@ Ref<Element> Element::create(const QualifiedName& tagName, Document& document)
 }
 
 Element::Element(const QualifiedName& tagName, Document& document, OptionSet<TypeFlag> type)
-    : ContainerNode(document, type)
+    : ContainerNode(document, ELEMENT_NODE, type)
     , m_tagName(tagName)
 {
 }
@@ -665,11 +665,6 @@ NamedNodeMap& Element::attributes() const
 
     rareData.setAttributeMap(makeUniqueWithoutRefCountedCheck<NamedNodeMap>(const_cast<Element&>(*this)));
     return *rareData.attributeMap();
-}
-
-Node::NodeType Element::nodeType() const
-{
-    return ELEMENT_NODE;
 }
 
 bool Element::hasAttribute(const QualifiedName& name) const

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -834,7 +834,6 @@ private:
 
     void scrollByUnits(int units, ScrollGranularity);
 
-    NodeType nodeType() const final;
     bool childTypeAllowed(NodeType) const final;
 
     void notifyAttributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason = AttributeModificationReason::Directly);

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -390,11 +390,12 @@ inline void NodeRareData::operator delete(NodeRareData* nodeRareData, std::destr
         destroyAndFree(*nodeRareData);
 }
 
-Node::Node(Document& document, OptionSet<TypeFlag> type)
+Node::Node(Document& document, NodeType type, OptionSet<TypeFlag> flags)
     : EventTarget(ConstructNode)
-    , m_typeFlags(type)
+    , m_typeBitFields(constructBitFieldsFromNodeTypeAndFlags(type, flags))
     , m_treeScope((isDocumentNode() || isShadowRoot()) ? nullptr : &document)
 {
+    ASSERT(nodeType() == type);
     ASSERT(isMainThread());
 
     // Allow code to ref the Document while it is being constructed to make our life easier.

--- a/Source/WebCore/dom/ProcessingInstruction.cpp
+++ b/Source/WebCore/dom/ProcessingInstruction.cpp
@@ -45,7 +45,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(ProcessingInstruction);
 
 inline ProcessingInstruction::ProcessingInstruction(Document& document, String&& target, String&& data)
-    : CharacterData(document, WTFMove(data))
+    : CharacterData(document, WTFMove(data), PROCESSING_INSTRUCTION_NODE)
     , m_target(WTFMove(target))
 {
 }
@@ -70,11 +70,6 @@ ProcessingInstruction::~ProcessingInstruction()
 String ProcessingInstruction::nodeName() const
 {
     return m_target;
-}
-
-Node::NodeType ProcessingInstruction::nodeType() const
-{
-    return PROCESSING_INSTRUCTION_NODE;
 }
 
 Ref<Node> ProcessingInstruction::cloneNodeInternal(Document& targetDocument, CloningOperation)

--- a/Source/WebCore/dom/ProcessingInstruction.h
+++ b/Source/WebCore/dom/ProcessingInstruction.h
@@ -61,7 +61,6 @@ private:
     ProcessingInstruction(Document&, String&& target, String&& data);
 
     String nodeName() const override;
-    NodeType nodeType() const override;
     Ref<Node> cloneNodeInternal(Document&, CloningOperation) override;
 
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) override;

--- a/Source/WebCore/dom/TemplateContentDocumentFragment.h
+++ b/Source/WebCore/dom/TemplateContentDocumentFragment.h
@@ -45,7 +45,7 @@ public:
 
 private:
     TemplateContentDocumentFragment(Document& document, const Element& host)
-        : DocumentFragment(document, CreateDocumentFragment)
+        : DocumentFragment(document)
         , m_host(host)
     {
     }

--- a/Source/WebCore/dom/Text.cpp
+++ b/Source/WebCore/dom/Text.cpp
@@ -46,12 +46,12 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(Text);
 
 Ref<Text> Text::create(Document& document, String&& data)
 {
-    return adoptRef(*new Text(document, WTFMove(data), CreateText));
+    return adoptRef(*new Text(document, WTFMove(data), TEXT_NODE, CreateText));
 }
 
 Ref<Text> Text::createEditingText(Document& document, String&& data)
 {
-    return adoptRef(*new Text(document, WTFMove(data), CreateEditingText));
+    return adoptRef(*new Text(document, WTFMove(data), TEXT_NODE, CreateEditingText));
 }
 
 Text::~Text() = default;
@@ -152,11 +152,6 @@ void Text::replaceWholeText(const String& newText)
 String Text::nodeName() const
 {
     return "#text"_s;
-}
-
-Node::NodeType Text::nodeType() const
-{
-    return TEXT_NODE;
 }
 
 Ref<Node> Text::cloneNodeInternal(Document& targetDocument, CloningOperation)

--- a/Source/WebCore/dom/Text.h
+++ b/Source/WebCore/dom/Text.h
@@ -58,14 +58,13 @@ public:
     String debugDescription() const final;
 
 protected:
-    Text(Document& document, String&& data, OptionSet<TypeFlag> type)
-        : CharacterData(document, WTFMove(data), type)
+    Text(Document& document, String&& data, NodeType type, OptionSet<TypeFlag> typeFlags)
+        : CharacterData(document, WTFMove(data), type, typeFlags)
     {
     }
 
 private:
     String nodeName() const override;
-    NodeType nodeType() const override;
     Ref<Node> cloneNodeInternal(Document&, CloningOperation) override;
     void setDataAndUpdate(const String&, unsigned offsetOfReplacedData, unsigned oldLength, unsigned newLength, UpdateLiveRanges) final;
 


### PR DESCRIPTION
#### 871823510e94736614a4c2b1d1610648ddc1da6e
<pre>
Inline NodeType in C++ side
<a href="https://bugs.webkit.org/show_bug.cgi?id=266829">https://bugs.webkit.org/show_bug.cgi?id=266829</a>

Reviewed by Chris Dumez.

This PR inlines Node::nodeType in Node.h by using the remaining bits in m_typeFlags.
To do this optimization, we take the advantage of the fact nodeType is now fast to obtain,
and replace two of the existing TypeFlags (IsDocumentFragment and IsText) in favor of
checking nodeType instead.

* Source/WebCore/dom/Attr.cpp:
(WebCore::Attr::Attr):
* Source/WebCore/dom/Attr.h:
* Source/WebCore/dom/CDATASection.cpp:
(WebCore::CDATASection::CDATASection):
(WebCore::CDATASection::nodeType const): Deleted.
* Source/WebCore/dom/CDATASection.h:
* Source/WebCore/dom/CharacterData.h:
(WebCore::CharacterData::CharacterData):
* Source/WebCore/dom/Comment.cpp:
(WebCore::Comment::Comment):
(WebCore::Comment::nodeType const): Deleted.
* Source/WebCore/dom/Comment.h:
* Source/WebCore/dom/ContainerNode.h:
(WebCore::ContainerNode::ContainerNode):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::Document):
(WebCore::Document::nodeType const): Deleted.
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/DocumentFragment.cpp:
(WebCore::DocumentFragment::DocumentFragment):
(WebCore::DocumentFragment::create):
(WebCore::DocumentFragment::createForInnerOuterHTML):
(WebCore::DocumentFragment::nodeType const): Deleted.
* Source/WebCore/dom/DocumentFragment.h:
* Source/WebCore/dom/DocumentType.cpp:
(WebCore::DocumentType::DocumentType):
(WebCore::DocumentType::nodeType const): Deleted.
* Source/WebCore/dom/DocumentType.h:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::Element):
(WebCore::Element::nodeType const): Deleted.
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::Node):
* Source/WebCore/dom/Node.h:
(WebCore::Node::nodeType const):
(WebCore::Node::isDocumentNode const):
(WebCore::Node::isTreeScope const):
(WebCore::Node::isDocumentFragment const):
(WebCore::Node::typeFlagsMemoryOffset):
(WebCore::Node::constructBitFieldsFromNodeTypeAndFlags):
(WebCore::Node::nodeTypeFromBitFields):
(WebCore::Node::hasTypeFlag const):
* Source/WebCore/dom/ProcessingInstruction.cpp:
(WebCore::ProcessingInstruction::ProcessingInstruction):
(WebCore::ProcessingInstruction::nodeType const): Deleted.
* Source/WebCore/dom/ProcessingInstruction.h:
* Source/WebCore/dom/TemplateContentDocumentFragment.h:
* Source/WebCore/dom/Text.cpp:
(WebCore::Text::create):
(WebCore::Text::createEditingText):
(WebCore::Text::nodeType const): Deleted.
* Source/WebCore/dom/Text.h:
(WebCore::Text::Text):

Canonical link: <a href="https://commits.webkit.org/272482@main">https://commits.webkit.org/272482@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c857d46a9a591df1360a917da596d42d26369d1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31739 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10424 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33468 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34233 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28742 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32527 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12783 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7670 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28333 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32094 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8790 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28332 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7582 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7750 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28246 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35581 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28854 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28694 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33868 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7840 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5842 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31724 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9496 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7450 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8516 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8358 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->