### PR TITLE
Reduce use of downcast<>() in rendering/style code

### DIFF
--- a/Source/WebCore/rendering/style/BasicShapes.cpp
+++ b/Source/WebCore/rendering/style/BasicShapes.cpp
@@ -166,7 +166,7 @@ bool BasicShapeCircle::operator==(const BasicShape& other) const
     if (type() != other.type())
         return false;
 
-    auto& otherCircle = downcast<BasicShapeCircle>(other);
+    auto& otherCircle = uncheckedDowncast<BasicShapeCircle>(other);
     return m_centerX == otherCircle.m_centerX
         && m_centerY == otherCircle.m_centerY
         && m_radius == otherCircle.m_radius
@@ -203,7 +203,7 @@ bool BasicShapeCircle::canBlend(const BasicShape& other) const
     if (type() != other.type())
         return false;
 
-    return radius().canBlend(downcast<BasicShapeCircle>(other).radius());
+    return radius().canBlend(uncheckedDowncast<BasicShapeCircle>(other).radius());
 }
 
 Ref<BasicShape> BasicShapeCircle::blend(const BasicShape& other, const BlendingContext& context) const
@@ -253,7 +253,7 @@ bool BasicShapeEllipse::operator==(const BasicShape& other) const
     if (type() != other.type())
         return false;
 
-    auto& otherEllipse = downcast<BasicShapeEllipse>(other);
+    auto& otherEllipse = uncheckedDowncast<BasicShapeEllipse>(other);
     return m_centerX == otherEllipse.m_centerX
         && m_centerY == otherEllipse.m_centerY
         && m_radiusX == otherEllipse.m_radiusX
@@ -292,7 +292,7 @@ bool BasicShapeEllipse::canBlend(const BasicShape& other) const
     if (type() != other.type())
         return false;
 
-    auto& otherEllipse = downcast<BasicShapeEllipse>(other);
+    auto& otherEllipse = uncheckedDowncast<BasicShapeEllipse>(other);
     return radiusX().canBlend(otherEllipse.radiusX()) && radiusY().canBlend(otherEllipse.radiusY());
 }
 
@@ -367,7 +367,7 @@ bool BasicShapeRect::operator==(const BasicShape& other) const
     if (type() != other.type())
         return false;
 
-    auto& otherRect = downcast<BasicShapeRect>(other);
+    auto& otherRect = uncheckedDowncast<BasicShapeRect>(other);
     return m_edges == otherRect.m_edges
         && m_topLeftRadius == otherRect.m_topLeftRadius
         && m_topRightRadius == otherRect.m_topRightRadius
@@ -471,7 +471,7 @@ bool BasicShapeXywh::operator==(const BasicShape& other) const
     if (type() != other.type())
         return false;
 
-    auto& otherXywh = downcast<BasicShapeXywh>(other);
+    auto& otherXywh = uncheckedDowncast<BasicShapeXywh>(other);
     return m_insetX == otherXywh.m_insetX
         && m_insetY == otherXywh.m_insetY
         && m_width == otherXywh.m_width
@@ -561,7 +561,7 @@ bool BasicShapePolygon::operator==(const BasicShape& other) const
     if (type() != other.type())
         return false;
 
-    auto& otherPolygon = downcast<BasicShapePolygon>(other);
+    auto& otherPolygon = uncheckedDowncast<BasicShapePolygon>(other);
     return m_windRule == otherPolygon.m_windRule
         && m_values == otherPolygon.m_values;
 }
@@ -585,7 +585,7 @@ bool BasicShapePolygon::canBlend(const BasicShape& other) const
     if (type() != other.type())
         return false;
 
-    auto& otherPolygon = downcast<BasicShapePolygon>(other);
+    auto& otherPolygon = uncheckedDowncast<BasicShapePolygon>(other);
     return values().size() == otherPolygon.values().size() && windRule() == otherPolygon.windRule();
 }
 
@@ -654,7 +654,7 @@ bool BasicShapePath::operator==(const BasicShape& other) const
     if (type() != other.type())
         return false;
 
-    auto& otherPath = downcast<BasicShapePath>(other);
+    auto& otherPath = uncheckedDowncast<BasicShapePath>(other);
     return m_zoom == otherPath.m_zoom && m_windRule == otherPath.m_windRule && *m_byteStream == *otherPath.m_byteStream;
 }
 
@@ -663,7 +663,7 @@ bool BasicShapePath::canBlend(const BasicShape& other) const
     if (type() != other.type())
         return false;
 
-    auto& otherPath = downcast<BasicShapePath>(other);
+    auto& otherPath = uncheckedDowncast<BasicShapePath>(other);
     return windRule() == otherPath.windRule() && canBlendSVGPathByteStreams(*m_byteStream, *otherPath.pathData());
 }
 
@@ -722,7 +722,7 @@ bool BasicShapeInset::operator==(const BasicShape& other) const
     if (type() != other.type())
         return false;
 
-    auto& otherInset = downcast<BasicShapeInset>(other);
+    auto& otherInset = uncheckedDowncast<BasicShapeInset>(other);
     return m_right == otherInset.m_right
         && m_top == otherInset.m_top
         && m_bottom == otherInset.m_bottom

--- a/Source/WebCore/rendering/style/ContentData.h
+++ b/Source/WebCore/rendering/style/ContentData.h
@@ -192,13 +192,13 @@ inline bool operator==(const ContentData& a, const ContentData& b)
 
     switch (a.type()) {
     case ContentData::CounterDataType:
-        return downcast<CounterContentData>(a) == downcast<CounterContentData>(b);
+        return uncheckedDowncast<CounterContentData>(a) == uncheckedDowncast<CounterContentData>(b);
     case ContentData::ImageDataType:
-        return downcast<ImageContentData>(a) == downcast<ImageContentData>(b);
+        return uncheckedDowncast<ImageContentData>(a) == uncheckedDowncast<ImageContentData>(b);
     case ContentData::QuoteDataType:
-        return downcast<QuoteContentData>(a) == downcast<QuoteContentData>(b);
+        return uncheckedDowncast<QuoteContentData>(a) == uncheckedDowncast<QuoteContentData>(b);
     case ContentData::TextDataType:
-        return downcast<TextContentData>(a) == downcast<TextContentData>(b);
+        return uncheckedDowncast<TextContentData>(a) == uncheckedDowncast<TextContentData>(b);
     }
 
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/rendering/style/GridPositionsResolver.cpp
+++ b/Source/WebCore/rendering/style/GridPositionsResolver.cpp
@@ -375,16 +375,19 @@ static void adjustGridPositionsFromStyle(const RenderBox& gridItem, GridTrackSiz
     if (finalPosition.isAuto() && initialPosition.isSpan() && !initialPosition.namedGridLine().isNull())
         initialPosition.setSpanPosition(1, String());
 
-    if (isIndefiniteSpan(initialPosition, finalPosition) && is<RenderGrid>(gridItem) && downcast<RenderGrid>(gridItem).isSubgrid(direction)) {
-        // Indefinite span for an item that is subgridded in this axis.
-        int lineCount = (isForColumns ? gridItem.style().orderedNamedGridColumnLines() : gridItem.style().orderedNamedGridRowLines()).map.size();
+    if (isIndefiniteSpan(initialPosition, finalPosition)) {
+        auto* renderGrid = dynamicDowncast<RenderGrid>(gridItem);
+        if (renderGrid && renderGrid->isSubgrid(direction)) {
+            // Indefinite span for an item that is subgridded in this axis.
+            int lineCount = (isForColumns ? gridItem.style().orderedNamedGridColumnLines() : gridItem.style().orderedNamedGridRowLines()).map.size();
 
-        if (initialPosition.isAuto()) {
-            // Set initial position to span <line names - 1>
-            initialPosition.setSpanPosition(std::max(1, lineCount - 1), String());
-        } else {
-            // Set final position to span <line names - 1>
-            finalPosition.setSpanPosition(std::max(1, lineCount - 1), String());
+            if (initialPosition.isAuto()) {
+                // Set initial position to span <line names - 1>
+                initialPosition.setSpanPosition(std::max(1, lineCount - 1), String());
+            } else {
+                // Set final position to span <line names - 1>
+                finalPosition.setSpanPosition(std::max(1, lineCount - 1), String());
+            }
         }
     }
 }

--- a/Source/WebCore/rendering/style/StyleCachedImage.cpp
+++ b/Source/WebCore/rendering/style/StyleCachedImage.cpp
@@ -62,7 +62,8 @@ StyleCachedImage::~StyleCachedImage() = default;
 
 bool StyleCachedImage::operator==(const StyleImage& other) const
 {
-    return is<StyleCachedImage>(other) && equals(downcast<StyleCachedImage>(other));
+    auto* otherCachedImage = dynamicDowncast<StyleCachedImage>(other);
+    return otherCachedImage && equals(*otherCachedImage);
 }
 
 bool StyleCachedImage::equals(const StyleCachedImage& other) const

--- a/Source/WebCore/rendering/style/StyleCanvasImage.cpp
+++ b/Source/WebCore/rendering/style/StyleCanvasImage.cpp
@@ -49,7 +49,8 @@ StyleCanvasImage::~StyleCanvasImage()
 
 bool StyleCanvasImage::operator==(const StyleImage& other) const
 {
-    return is<StyleCanvasImage>(other) && equals(downcast<StyleCanvasImage>(other));
+    auto* otherCanvasImage = dynamicDowncast<StyleCanvasImage>(other);
+    return otherCanvasImage && equals(*otherCanvasImage);
 }
 
 bool StyleCanvasImage::equals(const StyleCanvasImage& other) const

--- a/Source/WebCore/rendering/style/StyleCrossfadeImage.cpp
+++ b/Source/WebCore/rendering/style/StyleCrossfadeImage.cpp
@@ -58,7 +58,8 @@ StyleCrossfadeImage::~StyleCrossfadeImage()
 
 bool StyleCrossfadeImage::operator==(const StyleImage& other) const
 {
-    return is<StyleCrossfadeImage>(other) && equals(downcast<StyleCrossfadeImage>(other));
+    auto* otherCrossfadeImage = dynamicDowncast<StyleCrossfadeImage>(other);
+    return otherCrossfadeImage && equals(*otherCrossfadeImage);
 }
 
 bool StyleCrossfadeImage::equals(const StyleCrossfadeImage& other) const

--- a/Source/WebCore/rendering/style/StyleCursorImage.h
+++ b/Source/WebCore/rendering/style/StyleCursorImage.h
@@ -58,7 +58,7 @@ private:
     Ref<CSSValue> computedStyleValue(const RenderStyle&) const final;
     ImageWithScale selectBestFitImage(const Document&) final;
 
-    SVGCursorElement* updateCursorElement(const Document&);
+    RefPtr<SVGCursorElement> updateCursorElement(const Document&);
 
     Ref<StyleImage> m_image;
     std::optional<IntPoint> m_hotSpot;

--- a/Source/WebCore/rendering/style/StyleFilterImage.cpp
+++ b/Source/WebCore/rendering/style/StyleFilterImage.cpp
@@ -60,7 +60,8 @@ StyleFilterImage::~StyleFilterImage()
 
 bool StyleFilterImage::operator==(const StyleImage& other) const
 {
-    return is<StyleFilterImage>(other) && equals(downcast<StyleFilterImage>(other));
+    auto* otherFilterImage = dynamicDowncast<StyleFilterImage>(other);
+    return otherFilterImage && equals(*otherFilterImage);
 }
 
 bool StyleFilterImage::equals(const StyleFilterImage& other) const
@@ -101,10 +102,8 @@ void StyleFilterImage::load(CachedResourceLoader& cachedResourceLoader, const Re
     }
 
     for (auto& filterOperation : m_filterOperations.operations()) {
-        if (!is<ReferenceFilterOperation>(filterOperation))
-            continue;
-        auto& referenceFilterOperation = downcast<ReferenceFilterOperation>(*filterOperation);
-        referenceFilterOperation.loadExternalDocumentIfNeeded(cachedResourceLoader, options);
+        if (auto* referenceFilterOperation = dynamicDowncast<ReferenceFilterOperation>(filterOperation.get()))
+            referenceFilterOperation->loadExternalDocumentIfNeeded(cachedResourceLoader, options);
     }
 
     m_inputImageIsReady = true;

--- a/Source/WebCore/rendering/style/StyleGradientImage.cpp
+++ b/Source/WebCore/rendering/style/StyleGradientImage.cpp
@@ -84,7 +84,8 @@ StyleGradientImage::~StyleGradientImage() = default;
 
 bool StyleGradientImage::operator==(const StyleImage& other) const
 {
-    return is<StyleGradientImage>(other) && equals(downcast<StyleGradientImage>(other));
+    auto* otherGradientImage = dynamicDowncast<StyleGradientImage>(other);
+    return otherGradientImage && equals(*otherGradientImage);
 }
 
 bool StyleGradientImage::equals(const StyleGradientImage& other) const

--- a/Source/WebCore/rendering/style/StyleImageSet.cpp
+++ b/Source/WebCore/rendering/style/StyleImageSet.cpp
@@ -52,7 +52,8 @@ StyleImageSet::~StyleImageSet() = default;
 
 bool StyleImageSet::operator==(const StyleImage& other) const
 {
-    return is<StyleImageSet>(other) && equals(downcast<StyleImageSet>(other));
+    auto* otherImageSet = dynamicDowncast<StyleImageSet>(other);
+    return otherImageSet && equals(*otherImageSet);
 }
 
 bool StyleImageSet::equals(const StyleImageSet& other) const

--- a/Source/WebCore/rendering/style/StyleMultiImage.cpp
+++ b/Source/WebCore/rendering/style/StyleMultiImage.cpp
@@ -74,11 +74,11 @@ void StyleMultiImage::load(CachedResourceLoader& loader, const ResourceLoaderOpt
         return;
     }
     
-    if (is<StyleCachedImage>(bestFitImage.image)) {
-        if (downcast<StyleCachedImage>(*bestFitImage.image).imageScaleFactor() == bestFitImage.scaleFactor)
-            m_selectedImage = bestFitImage.image;
+    if (RefPtr styleCachedImage = dynamicDowncast<StyleCachedImage>(bestFitImage.image)) {
+        if (styleCachedImage->imageScaleFactor() == bestFitImage.scaleFactor)
+            m_selectedImage = WTFMove(styleCachedImage);
         else
-            m_selectedImage = StyleCachedImage::copyOverridingScaleFactor(downcast<StyleCachedImage>(*bestFitImage.image), bestFitImage.scaleFactor);
+            m_selectedImage = StyleCachedImage::copyOverridingScaleFactor(*styleCachedImage, bestFitImage.scaleFactor);
 
         if (m_selectedImage->isPending())
             m_selectedImage->load(loader, options);

--- a/Source/WebCore/rendering/style/StyleNamedImage.cpp
+++ b/Source/WebCore/rendering/style/StyleNamedImage.cpp
@@ -42,7 +42,8 @@ StyleNamedImage::~StyleNamedImage() = default;
 
 bool StyleNamedImage::operator==(const StyleImage& other) const
 {
-    return is<StyleNamedImage>(other) && equals(downcast<StyleNamedImage>(other));
+    auto* otherNamedImage = dynamicDowncast<StyleNamedImage>(other);
+    return otherNamedImage && equals(*otherNamedImage);
 }
 
 bool StyleNamedImage::equals(const StyleNamedImage& other) const

--- a/Source/WebCore/rendering/style/StylePaintImage.cpp
+++ b/Source/WebCore/rendering/style/StylePaintImage.cpp
@@ -50,7 +50,8 @@ StylePaintImage::~StylePaintImage() = default;
 bool StylePaintImage::operator==(const StyleImage& other) const
 {
     // FIXME: Should probably also compare arguments?
-    return is<StylePaintImage>(other) && downcast<StylePaintImage>(other).m_name == m_name;
+    auto* otherPaintImage = dynamicDowncast<StylePaintImage>(other);
+    return otherPaintImage && otherPaintImage->m_name == m_name;
 }
 
 Ref<CSSValue> StylePaintImage::computedStyleValue(const RenderStyle&) const


### PR DESCRIPTION
#### 97b4d91001b8f19922b9c80bdf8000305d1996aa
<pre>
Reduce use of downcast&lt;&gt;() in rendering/style code
<a href="https://bugs.webkit.org/show_bug.cgi?id=266830">https://bugs.webkit.org/show_bug.cgi?id=266830</a>

Reviewed by Tim Nguyen.

* Source/WebCore/rendering/style/BasicShapes.cpp:
(WebCore::BasicShapeCircle::operator== const):
(WebCore::BasicShapeCircle::canBlend const):
(WebCore::BasicShapeEllipse::operator== const):
(WebCore::BasicShapeEllipse::canBlend const):
(WebCore::BasicShapeRect::operator== const):
(WebCore::BasicShapeXywh::operator== const):
(WebCore::BasicShapePolygon::operator== const):
(WebCore::BasicShapePolygon::canBlend const):
(WebCore::BasicShapePath::operator== const):
(WebCore::BasicShapePath::canBlend const):
(WebCore::BasicShapeInset::operator== const):
* Source/WebCore/rendering/style/ContentData.h:
(WebCore::operator==):
* Source/WebCore/rendering/style/GridPositionsResolver.cpp:
(WebCore::adjustGridPositionsFromStyle):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::setContent):
* Source/WebCore/rendering/style/StyleCachedImage.cpp:
(WebCore::StyleCachedImage::operator== const):
* Source/WebCore/rendering/style/StyleCanvasImage.cpp:
(WebCore::StyleCanvasImage::operator== const):
* Source/WebCore/rendering/style/StyleCrossfadeImage.cpp:
(WebCore::StyleCrossfadeImage::operator== const):
* Source/WebCore/rendering/style/StyleCursorImage.cpp:
(WebCore::StyleCursorImage::operator== const):
(WebCore::StyleCursorImage::selectBestFitImage):
(WebCore::StyleCursorImage::updateCursorElement):
* Source/WebCore/rendering/style/StyleCursorImage.h:
* Source/WebCore/rendering/style/StyleFilterImage.cpp:
(WebCore::StyleFilterImage::operator== const):
(WebCore::StyleFilterImage::load):
* Source/WebCore/rendering/style/StyleGradientImage.cpp:
(WebCore::StyleGradientImage::operator== const):
* Source/WebCore/rendering/style/StyleImageSet.cpp:
(WebCore::StyleImageSet::operator== const):
* Source/WebCore/rendering/style/StyleMultiImage.cpp:
(WebCore::StyleMultiImage::load):
* Source/WebCore/rendering/style/StyleNamedImage.cpp:
(WebCore::StyleNamedImage::operator== const):
* Source/WebCore/rendering/style/StylePaintImage.cpp:
(WebCore::StylePaintImage::operator== const):

Canonical link: <a href="https://commits.webkit.org/272481@main">https://commits.webkit.org/272481@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0177fc650cb98c9fc1cc7241df8d6bc72810cc1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31791 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10482 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33529 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34292 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28789 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32585 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12842 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7724 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/28385 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32153 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8843 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28388 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7634 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7804 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28301 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35639 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28907 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28753 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/33916 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7893 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5891 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/31775 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9547 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7449 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8564 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8415 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->