### PR TITLE
Decrease use of downcast<>() in rendering code

### DIFF
--- a/Source/WebCore/rendering/line/LineBreaker.cpp
+++ b/Source/WebCore/rendering/line/LineBreaker.cpp
@@ -67,10 +67,12 @@ void LineBreaker::skipLeadingWhitespace(InlineBidiResolver& resolver, LineInfo& 
             }
         } else if (object.isFloating())
             m_block.legacyLineLayout()->positionNewFloatOnLine(*m_block.insertFloatingObject(downcast<RenderBox>(object)), lastFloatFromPreviousLine, lineInfo, width);
-        else if (object.style().hasTextCombine() && is<RenderCombineText>(object)) {
-            downcast<RenderCombineText>(object).combineTextIfNeeded();
-            if (downcast<RenderCombineText>(object).isCombined())
-                continue;
+        else if (object.style().hasTextCombine()) {
+            if (CheckedPtr combineText = dynamicDowncast<RenderCombineText>(object)) {
+                combineText->combineTextIfNeeded();
+                if (combineText->isCombined())
+                    continue;
+            }
         }
         resolver.increment();
     }

--- a/Source/WebCore/rendering/line/LineInlineHeaders.h
+++ b/Source/WebCore/rendering/line/LineInlineHeaders.h
@@ -107,11 +107,10 @@ inline bool requiresLineBox(const LegacyInlineIterator& it, const LineInfo& line
         return true;
 
     bool rendererIsEmptyInline = false;
-    if (is<RenderInline>(*it.renderer())) {
-        const auto& inlineRenderer = downcast<RenderInline>(*it.renderer());
-        if (!alwaysRequiresLineBox(inlineRenderer) && !requiresLineBoxForContent(inlineRenderer, lineInfo))
+    if (auto* inlineRenderer = dynamicDowncast<RenderInline>(*it.renderer())) {
+        if (!alwaysRequiresLineBox(*inlineRenderer) && !requiresLineBoxForContent(*inlineRenderer, lineInfo))
             return false;
-        rendererIsEmptyInline = isEmptyInline(inlineRenderer);
+        rendererIsEmptyInline = isEmptyInline(*inlineRenderer);
     }
 
     if (!shouldCollapseWhiteSpace(&it.renderer()->style(), lineInfo, whitespacePosition))
@@ -128,12 +127,12 @@ inline void setStaticPositions(RenderBlockFlow& block, RenderBox& child, IndentT
     // will work for the common cases
     RenderElement* containerBlock = child.container();
     LayoutUnit blockHeight = block.logicalHeight();
-    if (is<RenderInline>(*containerBlock)) {
+    if (auto* renderInline = dynamicDowncast<RenderInline>(*containerBlock)) {
         // A relative positioned inline encloses us. In this case, we also have to determine our
         // position as though we were an inline. Set |staticInlinePosition| and |staticBlockPosition| on the relative positioned
         // inline so that we can obtain the value later.
-        downcast<RenderInline>(*containerBlock).layer()->setStaticInlinePosition(block.startAlignedOffsetForLine(blockHeight, DoNotIndentText));
-        downcast<RenderInline>(*containerBlock).layer()->setStaticBlockPosition(blockHeight);
+        renderInline->layer()->setStaticInlinePosition(block.startAlignedOffsetForLine(blockHeight, DoNotIndentText));
+        renderInline->layer()->setStaticBlockPosition(blockHeight);
     }
     block.updateStaticInlinePositionForChild(child, blockHeight, shouldIndentText);
     child.layer()->setStaticBlockPosition(blockHeight);

--- a/Source/WebCore/rendering/mathml/RenderMathMLFenced.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLFenced.cpp
@@ -83,8 +83,8 @@ void RenderMathMLFenced::updateFromElement()
 
     if (firstChild()) {
         // FIXME: The mfenced element fails to update dynamically when its open, close and separators attributes are changed (https://bugs.webkit.org/show_bug.cgi?id=57696).
-        if (is<RenderMathMLFencedOperator>(*firstChild()))
-            downcast<RenderMathMLFencedOperator>(*firstChild()).updateOperatorContent(m_open);
+        if (auto* fencedOperator = dynamicDowncast<RenderMathMLFencedOperator>(*firstChild()))
+            fencedOperator->updateOperatorContent(m_open);
         m_closeFenceRenderer->updateOperatorContent(m_close);
     }
 }

--- a/Source/WebCore/rendering/mathml/RenderMathMLFraction.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLFraction.cpp
@@ -170,10 +170,11 @@ RenderMathMLFraction::FractionParameters RenderMathMLFraction::stackParameters()
 
 RenderMathMLOperator* RenderMathMLFraction::unembellishedOperator() const
 {
-    if (!isValid() || !is<RenderMathMLBlock>(numerator()))
+    if (!isValid())
         return nullptr;
 
-    return downcast<RenderMathMLBlock>(numerator()).unembellishedOperator();
+    auto* mathMLBlock = dynamicDowncast<RenderMathMLBlock>(numerator());
+    return mathMLBlock ? mathMLBlock->unembellishedOperator() : nullptr;
 }
 
 void RenderMathMLFraction::computePreferredLogicalWidths()

--- a/Source/WebCore/rendering/mathml/RenderMathMLRow.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLRow.cpp
@@ -66,8 +66,8 @@ std::optional<LayoutUnit> RenderMathMLRow::firstLineBaseline() const
 
 static RenderMathMLOperator* toVerticalStretchyOperator(RenderBox* box)
 {
-    if (is<RenderMathMLBlock>(box)) {
-        auto* renderOperator = downcast<RenderMathMLBlock>(*box).unembellishedOperator();
+    if (auto* mathMLBlock = dynamicDowncast<RenderMathMLBlock>(box)) {
+        auto* renderOperator = mathMLBlock->unembellishedOperator();
         if (renderOperator && renderOperator->isStretchy() && renderOperator->isVertical())
             return renderOperator;
     }

--- a/Source/WebCore/rendering/mathml/RenderMathMLScripts.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLScripts.cpp
@@ -62,10 +62,8 @@ MathMLScriptsElement::ScriptType RenderMathMLScripts::scriptType() const
 
 RenderMathMLOperator* RenderMathMLScripts::unembellishedOperator() const
 {
-    auto base = firstChildBox();
-    if (!is<RenderMathMLBlock>(base))
-        return nullptr;
-    return downcast<RenderMathMLBlock>(base)->unembellishedOperator();
+    auto* base = dynamicDowncast<RenderMathMLBlock>(firstChildBox());
+    return base ? base->unembellishedOperator() : nullptr;
 }
 
 std::optional<RenderMathMLScripts::ReferenceChildren> RenderMathMLScripts::validateAndGetReferenceChildren()
@@ -165,8 +163,8 @@ LayoutUnit RenderMathMLScripts::spaceAfterScript()
 
 LayoutUnit RenderMathMLScripts::italicCorrection(const ReferenceChildren& reference)
 {
-    if (is<RenderMathMLBlock>(*reference.base)) {
-        if (auto* renderOperator = downcast<RenderMathMLBlock>(*reference.base).unembellishedOperator())
+    if (auto* mathMLBlock = dynamicDowncast<RenderMathMLBlock>(*reference.base)) {
+        if (auto* renderOperator = mathMLBlock->unembellishedOperator())
             return renderOperator->italicCorrection();
     }
     return 0;

--- a/Source/WebCore/rendering/mathml/RenderMathMLUnderOver.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLUnderOver.cpp
@@ -54,10 +54,11 @@ MathMLUnderOverElement& RenderMathMLUnderOver::element() const
 
 static RenderMathMLOperator* horizontalStretchyOperator(const RenderBox& box)
 {
-    if (!is<RenderMathMLBlock>(box))
+    auto* mathMLBlock = dynamicDowncast<RenderMathMLBlock>(box);
+    if (!mathMLBlock)
         return nullptr;
 
-    auto* renderOperator = downcast<RenderMathMLBlock>(box).unembellishedOperator();
+    auto* renderOperator = mathMLBlock->unembellishedOperator();
     if (!renderOperator)
         return nullptr;
 
@@ -221,10 +222,10 @@ bool RenderMathMLUnderOver::hasAccent(bool accentUnder) const
         return true;
     if (attributeValue == MathMLElement::BooleanValue::False)
         return false;
-    RenderBox& script = accentUnder ? under() : over();
-    if (!is<RenderMathMLBlock>(script))
+    auto* script = dynamicDowncast<RenderMathMLBlock>(accentUnder ? under() : over());
+    if (!script)
         return false;
-    auto* scriptOperator = downcast<RenderMathMLBlock>(script).unembellishedOperator();
+    auto* scriptOperator = script->unembellishedOperator();
     return scriptOperator && scriptOperator->hasOperatorFlag(MathMLOperatorDictionary::Accent);
 }
 
@@ -255,8 +256,8 @@ RenderMathMLUnderOver::VerticalParameters RenderMathMLUnderOver::verticalParamet
         return parameters;
     }
 
-    if (is<RenderMathMLBlock>(base())) {
-        if (auto* baseOperator = downcast<RenderMathMLBlock>(base()).unembellishedOperator()) {
+    if (auto* mathMLBlock = dynamicDowncast<RenderMathMLBlock>(base())) {
+        if (auto* baseOperator = mathMLBlock->unembellishedOperator()) {
             if (baseOperator->hasOperatorFlag(MathMLOperatorDictionary::LargeOp)) {
                 // The base is a large operator so we read UpperLimit/LowerLimit constants from the MATH table.
                 parameters.underGapMin = mathData->getMathConstant(primaryFont, OpenTypeMathData::LowerLimitGapMin);

--- a/Source/WebCore/rendering/shapes/Shape.cpp
+++ b/Source/WebCore/rendering/shapes/Shape.cpp
@@ -102,7 +102,7 @@ Ref<const Shape> Shape::createShape(const BasicShape& basicShape, const LayoutPo
     switch (basicShape.type()) {
 
     case BasicShape::Type::Circle: {
-        const auto& circle = downcast<BasicShapeCircle>(basicShape);
+        const auto& circle = uncheckedDowncast<BasicShapeCircle>(basicShape);
         float centerX = floatValueForCenterCoordinate(circle.centerX(), boxWidth);
         float centerY = floatValueForCenterCoordinate(circle.centerY(), boxHeight);
         float radius = circle.floatValueForRadiusInBox(boxWidth, boxHeight, { centerX, centerY });
@@ -114,7 +114,7 @@ Ref<const Shape> Shape::createShape(const BasicShape& basicShape, const LayoutPo
     }
 
     case BasicShape::Type::Ellipse: {
-        const auto& ellipse = downcast<BasicShapeEllipse>(basicShape);
+        const auto& ellipse = uncheckedDowncast<BasicShapeEllipse>(basicShape);
         float centerX = floatValueForCenterCoordinate(ellipse.centerX(), boxWidth);
         float centerY = floatValueForCenterCoordinate(ellipse.centerY(), boxHeight);
         float radiusX = ellipse.floatValueForRadiusInBox(ellipse.radiusX(), centerX, boxWidth);
@@ -127,7 +127,7 @@ Ref<const Shape> Shape::createShape(const BasicShape& basicShape, const LayoutPo
     }
 
     case BasicShape::Type::Polygon: {
-        const auto& polygon = downcast<BasicShapePolygon>(basicShape);
+        const auto& polygon = uncheckedDowncast<BasicShapePolygon>(basicShape);
         const Vector<Length>& values = polygon.values();
         size_t valuesSize = values.size();
         ASSERT(!(valuesSize % 2));
@@ -144,7 +144,7 @@ Ref<const Shape> Shape::createShape(const BasicShape& basicShape, const LayoutPo
     }
 
     case BasicShape::Type::Inset: {
-        const auto& inset = downcast<BasicShapeInset>(basicShape);
+        const auto& inset = uncheckedDowncast<BasicShapeInset>(basicShape);
         float left = floatValueForLength(inset.left(), boxWidth);
         float top = floatValueForLength(inset.top(), boxHeight);
         FloatRect rect(left,

--- a/Source/WebCore/rendering/shapes/ShapeOutsideInfo.cpp
+++ b/Source/WebCore/rendering/shapes/ShapeOutsideInfo.cpp
@@ -149,7 +149,8 @@ Ref<const Shape> makeShapeForShapeOutside(const RenderBox& renderer)
         styleImage->setContainerContextForRenderer(renderer, imageSize, style.effectiveZoom());
 
         auto marginRect = getShapeImageMarginRect(renderer, boxSize);
-        auto imageRect = is<RenderImage>(renderer) ? downcast<RenderImage>(renderer).replacedContentRect() : LayoutRect { { }, imageSize };
+        auto* renderImage = dynamicDowncast<RenderImage>(renderer);
+        auto imageRect = renderImage ? renderImage->replacedContentRect() : LayoutRect { { }, imageSize };
 
         ASSERT(!styleImage->isPending());
         RefPtr<Image> image = styleImage->image(const_cast<RenderBox*>(&renderer), imageSize);


### PR DESCRIPTION
#### 8faf2e8d8d0c8f86f9b4833917927ef4d3808545
<pre>
Decrease use of downcast&lt;&gt;() in rendering code
<a href="https://bugs.webkit.org/show_bug.cgi?id=266831">https://bugs.webkit.org/show_bug.cgi?id=266831</a>

Reviewed by Brent Fulgham.

* Source/WebCore/rendering/line/BreakingContext.h:
(WebCore::inlineLogicalWidth):
(WebCore::shouldSkipWhitespaceAfterStartObject):
(WebCore::BreakingContext::handleReplaced):
(WebCore::BreakingContext::handleText):
(WebCore::BreakingContext::canBreakAtThisPosition):
(WebCore::BreakingContext::commitAndUpdateLineBreakIfNeeded):
* Source/WebCore/rendering/line/LineBreaker.cpp:
(WebCore::LineBreaker::skipLeadingWhitespace):
* Source/WebCore/rendering/line/LineInlineHeaders.h:
(WebCore::requiresLineBox):
(WebCore::setStaticPositions):
* Source/WebCore/rendering/mathml/MathMLStyle.cpp:
(WebCore::MathMLStyle::getMathMLStyle):
(WebCore::MathMLStyle::resolveMathMLStyleTree):
(WebCore::MathMLStyle::updateStyleIfNeeded):
(WebCore::MathMLStyle::resolveMathMLStyle):
* Source/WebCore/rendering/mathml/RenderMathMLFenced.cpp:
(WebCore::RenderMathMLFenced::updateFromElement):
* Source/WebCore/rendering/mathml/RenderMathMLFraction.cpp:
(WebCore::RenderMathMLFraction::unembellishedOperator const):
* Source/WebCore/rendering/mathml/RenderMathMLRow.cpp:
(WebCore::toVerticalStretchyOperator):
* Source/WebCore/rendering/mathml/RenderMathMLScripts.cpp:
(WebCore::RenderMathMLScripts::unembellishedOperator const):
(WebCore::RenderMathMLScripts::italicCorrection):
* Source/WebCore/rendering/mathml/RenderMathMLUnderOver.cpp:
(WebCore::horizontalStretchyOperator):
(WebCore::RenderMathMLUnderOver::hasAccent const):
(WebCore::RenderMathMLUnderOver::verticalParameters const):
* Source/WebCore/rendering/shapes/Shape.cpp:
(WebCore::Shape::createShape):
* Source/WebCore/rendering/shapes/ShapeOutsideInfo.cpp:
(WebCore::makeShapeForShapeOutside):

Canonical link: <a href="https://commits.webkit.org/272473@main">https://commits.webkit.org/272473@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5aa683cf2e5a9e1dd8011dfea27bfc79ee995727

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31743 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10428 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33472 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34237 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28746 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32531 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12787 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7674 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28337 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32098 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8795 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28336 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7586 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7755 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28250 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35584 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28859 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28698 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33871 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7844 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5846 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31727 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9500 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8520 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4148 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8362 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->