### PR TITLE
Make Node's OptionSet<TypeFlag> more robust

### DIFF
--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -72,7 +72,7 @@ using namespace HTMLNames;
 WTF_MAKE_ISO_ALLOCATED_IMPL(HTMLModelElement);
 
 HTMLModelElement::HTMLModelElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document, CreateHTMLModelElement)
+    : HTMLElement(tagName, document, TypeFlag::HasCustomStyleResolveCallbacks)
     , ActiveDOMObject(document)
     , m_readyPromise { makeUniqueRef<ReadyPromise>(*this, &HTMLModelElement::readyPromiseResolve) }
 {

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -118,7 +118,6 @@ public:
 #endif
 
 private:
-    static constexpr auto CreateHTMLModelElement = CreateHTMLElement | TypeFlag::HasCustomStyleResolveCallbacks;
     HTMLModelElement(const QualifiedName&, Document&);
 
     URL selectModelSource() const;

--- a/Source/WebCore/dom/Attr.cpp
+++ b/Source/WebCore/dom/Attr.cpp
@@ -44,14 +44,14 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(Attr);
 using namespace HTMLNames;
 
 Attr::Attr(Element& element, const QualifiedName& name)
-    : Node(element.document(), CreateAttr)
+    : Node(element.document(), ATTRIBUTE_NODE, CreateAttr)
     , m_element(element)
     , m_name(name)
 {
 }
 
 Attr::Attr(Document& document, const QualifiedName& name, const AtomString& standaloneValue)
-    : Node(document, CreateAttr)
+    : Node(document, ATTRIBUTE_NODE, CreateAttr)
     , m_name(name)
     , m_standaloneValue(standaloneValue)
 {

--- a/Source/WebCore/dom/Attr.cpp
+++ b/Source/WebCore/dom/Attr.cpp
@@ -44,14 +44,14 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(Attr);
 using namespace HTMLNames;
 
 Attr::Attr(Element& element, const QualifiedName& name)
-    : Node(element.document(), ATTRIBUTE_NODE, CreateAttr)
+    : Node(element.document(), ATTRIBUTE_NODE, { })
     , m_element(element)
     , m_name(name)
 {
 }
 
 Attr::Attr(Document& document, const QualifiedName& name, const AtomString& standaloneValue)
-    : Node(document, ATTRIBUTE_NODE, CreateAttr)
+    : Node(document, ATTRIBUTE_NODE, { })
     , m_name(name)
     , m_standaloneValue(standaloneValue)
 {

--- a/Source/WebCore/dom/Attr.h
+++ b/Source/WebCore/dom/Attr.h
@@ -63,7 +63,6 @@ private:
     Attr(Document&, const QualifiedName&, const AtomString& value);
 
     String nodeName() const final { return name(); }
-    NodeType nodeType() const final { return ATTRIBUTE_NODE; }
 
     String nodeValue() const final { return value(); }
     void setNodeValue(const String&) final;

--- a/Source/WebCore/dom/CDATASection.cpp
+++ b/Source/WebCore/dom/CDATASection.cpp
@@ -31,7 +31,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(CDATASection);
 
 inline CDATASection::CDATASection(Document& document, String&& data)
-    : Text(document, WTFMove(data), CreateText)
+    : Text(document, WTFMove(data), CDATA_SECTION_NODE, CreateText)
 {
 }
 
@@ -43,11 +43,6 @@ Ref<CDATASection> CDATASection::create(Document& document, String&& data)
 String CDATASection::nodeName() const
 {
     return "#cdata-section"_s;
-}
-
-Node::NodeType CDATASection::nodeType() const
-{
-    return CDATA_SECTION_NODE;
 }
 
 Ref<Node> CDATASection::cloneNodeInternal(Document& targetDocument, CloningOperation)

--- a/Source/WebCore/dom/CDATASection.cpp
+++ b/Source/WebCore/dom/CDATASection.cpp
@@ -31,7 +31,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(CDATASection);
 
 inline CDATASection::CDATASection(Document& document, String&& data)
-    : Text(document, WTFMove(data), CDATA_SECTION_NODE, CreateText)
+    : Text(document, WTFMove(data), CDATA_SECTION_NODE, { })
 {
 }
 

--- a/Source/WebCore/dom/CDATASection.h
+++ b/Source/WebCore/dom/CDATASection.h
@@ -35,7 +35,6 @@ private:
     CDATASection(Document&, String&&);
 
     String nodeName() const override;
-    NodeType nodeType() const override;
     Ref<Node> cloneNodeInternal(Document&, CloningOperation) override;
     Ref<Text> virtualCreate(String&&) override;
 };

--- a/Source/WebCore/dom/CharacterData.h
+++ b/Source/WebCore/dom/CharacterData.h
@@ -44,11 +44,11 @@ public:
     void parserAppendData(StringView);
 
 protected:
-    CharacterData(Document& document, String&& text, OptionSet<TypeFlag> type = CreateCharacterData)
-        : Node(document, type)
+    CharacterData(Document& document, String&& text, NodeType type, OptionSet<TypeFlag> typeFlags = CreateCharacterData)
+        : Node(document, type, typeFlags)
         , m_data(!text.isNull() ? WTFMove(text) : emptyString())
     {
-        ASSERT(type == CreateCharacterData || type == CreateText || type == CreateEditingText);
+        ASSERT(typeFlags == CreateCharacterData || typeFlags == CreateText || typeFlags == CreateEditingText);
     }
 
     ~CharacterData();

--- a/Source/WebCore/dom/CharacterData.h
+++ b/Source/WebCore/dom/CharacterData.h
@@ -44,11 +44,12 @@ public:
     void parserAppendData(StringView);
 
 protected:
-    CharacterData(Document& document, String&& text, NodeType type, OptionSet<TypeFlag> typeFlags = CreateCharacterData)
-        : Node(document, type, typeFlags)
+    CharacterData(Document& document, String&& text, NodeType type, OptionSet<TypeFlag> typeFlags = { })
+        : Node(document, type, typeFlags | TypeFlag::IsCharacterData)
         , m_data(!text.isNull() ? WTFMove(text) : emptyString())
     {
-        ASSERT(typeFlags == CreateCharacterData || typeFlags == CreateText || typeFlags == CreateEditingText);
+        ASSERT(!typeFlags.contains(TypeFlag::IsElement));
+        ASSERT(!typeFlags.contains(TypeFlag::IsContainerNode));
     }
 
     ~CharacterData();

--- a/Source/WebCore/dom/Comment.cpp
+++ b/Source/WebCore/dom/Comment.cpp
@@ -30,7 +30,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(Comment);
 
 inline Comment::Comment(Document& document, String&& text)
-    : CharacterData(document, WTFMove(text))
+    : CharacterData(document, WTFMove(text), COMMENT_NODE)
 {
 }
 
@@ -42,11 +42,6 @@ Ref<Comment> Comment::create(Document& document, String&& text)
 String Comment::nodeName() const
 {
     return "#comment"_s;
-}
-
-Node::NodeType Comment::nodeType() const
-{
-    return COMMENT_NODE;
 }
 
 Ref<Node> Comment::cloneNodeInternal(Document& targetDocument, CloningOperation)

--- a/Source/WebCore/dom/Comment.h
+++ b/Source/WebCore/dom/Comment.h
@@ -35,7 +35,6 @@ private:
     Comment(Document&, String&&);
 
     String nodeName() const override;
-    NodeType nodeType() const override;
     Ref<Node> cloneNodeInternal(Document&, CloningOperation) override;
 };
 

--- a/Source/WebCore/dom/ContainerNode.h
+++ b/Source/WebCore/dom/ContainerNode.h
@@ -144,7 +144,7 @@ public:
     ExceptionOr<void> ensurePreInsertionValidity(Node& newChild, Node* refChild);
 
 protected:
-    explicit ContainerNode(Document&, OptionSet<TypeFlag> = CreateContainer);
+    explicit ContainerNode(Document&, NodeType, OptionSet<TypeFlag> = CreateContainer);
 
     friend void removeDetachedChildrenInContainer(ContainerNode&);
 
@@ -175,9 +175,10 @@ private:
     Node* m_lastChild { nullptr };
 };
 
-inline ContainerNode::ContainerNode(Document& document, OptionSet<TypeFlag> type)
-    : Node(document, type)
+inline ContainerNode::ContainerNode(Document& document, NodeType type, OptionSet<TypeFlag> typeFlags)
+    : Node(document, type, typeFlags)
 {
+    ASSERT(typeFlags.contains(TypeFlag::IsContainerNode));
 }
 
 inline unsigned Node::countChildNodes() const

--- a/Source/WebCore/dom/ContainerNode.h
+++ b/Source/WebCore/dom/ContainerNode.h
@@ -144,7 +144,7 @@ public:
     ExceptionOr<void> ensurePreInsertionValidity(Node& newChild, Node* refChild);
 
 protected:
-    explicit ContainerNode(Document&, NodeType, OptionSet<TypeFlag> = CreateContainer);
+    explicit ContainerNode(Document&, NodeType, OptionSet<TypeFlag> = { });
 
     friend void removeDetachedChildrenInContainer(ContainerNode&);
 
@@ -176,9 +176,9 @@ private:
 };
 
 inline ContainerNode::ContainerNode(Document& document, NodeType type, OptionSet<TypeFlag> typeFlags)
-    : Node(document, type, typeFlags)
+    : Node(document, type, typeFlags | TypeFlag::IsContainerNode)
 {
-    ASSERT(typeFlags.contains(TypeFlag::IsContainerNode));
+    ASSERT(!typeFlags.contains(TypeFlag::IsText));
 }
 
 inline unsigned Node::countChildNodes() const

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -592,7 +592,7 @@ static Ref<CachedResourceLoader> createCachedResourceLoader(LocalFrame* frame)
 }
 
 Document::Document(LocalFrame* frame, const Settings& settings, const URL& url, DocumentClasses documentClasses, OptionSet<ConstructionFlag> constructionFlags, ScriptExecutionContextIdentifier identifier)
-    : ContainerNode(*this, CreateDocument)
+    : ContainerNode(*this, DOCUMENT_NODE)
     , TreeScope(*this)
     , ScriptExecutionContext(identifier)
     , FrameDestructionObserver(frame)
@@ -2076,11 +2076,6 @@ void Document::forEachMediaElement(const Function<void(HTMLMediaElement&)>& func
 String Document::nodeName() const
 {
     return "#document"_s;
-}
-
-Node::NodeType Document::nodeType() const
-{
-    return DOCUMENT_NODE;
 }
 
 WakeLockManager& Document::wakeLockManager()

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1912,7 +1912,6 @@ private:
     void childrenChanged(const ChildChange&) final;
 
     String nodeName() const final;
-    NodeType nodeType() const final;
     bool childTypeAllowed(NodeType) const final;
     Ref<Node> cloneNodeInternal(Document&, CloningOperation) final;
     void cloneDataFromDocument(const Document&);

--- a/Source/WebCore/dom/DocumentFragment.cpp
+++ b/Source/WebCore/dom/DocumentFragment.cpp
@@ -38,28 +38,23 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(DocumentFragment);
 
 DocumentFragment::DocumentFragment(Document& document, OptionSet<TypeFlag> constructionType)
-    : ContainerNode(document, constructionType)
+    : ContainerNode(document, DOCUMENT_FRAGMENT_NODE, constructionType)
 {
 }
 
 Ref<DocumentFragment> DocumentFragment::create(Document& document)
 {
-    return adoptRef(*new DocumentFragment(document, Node::CreateDocumentFragment));
+    return adoptRef(*new DocumentFragment(document));
 }
 
 Ref<DocumentFragment> DocumentFragment::createForInnerOuterHTML(Document& document)
 {
-    return adoptRef(*new DocumentFragment(document, Node::CreateDocumentFragment | TypeFlag::IsDocumentFragmentForInnerOuterHTML));
+    return adoptRef(*new DocumentFragment(document, CreateContainer | TypeFlag::IsDocumentFragmentForInnerOuterHTML));
 }
 
 String DocumentFragment::nodeName() const
 {
     return "#document-fragment"_s;
-}
-
-Node::NodeType DocumentFragment::nodeType() const
-{
-    return DOCUMENT_FRAGMENT_NODE;
 }
 
 bool DocumentFragment::childTypeAllowed(NodeType type) const

--- a/Source/WebCore/dom/DocumentFragment.cpp
+++ b/Source/WebCore/dom/DocumentFragment.cpp
@@ -49,7 +49,7 @@ Ref<DocumentFragment> DocumentFragment::create(Document& document)
 
 Ref<DocumentFragment> DocumentFragment::createForInnerOuterHTML(Document& document)
 {
-    return adoptRef(*new DocumentFragment(document, CreateContainer | TypeFlag::IsDocumentFragmentForInnerOuterHTML));
+    return adoptRef(*new DocumentFragment(document, TypeFlag::IsDocumentFragmentForInnerOuterHTML));
 }
 
 String DocumentFragment::nodeName() const

--- a/Source/WebCore/dom/DocumentFragment.h
+++ b/Source/WebCore/dom/DocumentFragment.h
@@ -48,7 +48,6 @@ protected:
     String nodeName() const final;
 
 private:
-    NodeType nodeType() const final;
     Ref<Node> cloneNodeInternal(Document&, CloningOperation) override;
     bool childTypeAllowed(NodeType) const override;
 };

--- a/Source/WebCore/dom/DocumentFragment.h
+++ b/Source/WebCore/dom/DocumentFragment.h
@@ -44,7 +44,7 @@ public:
     WEBCORE_EXPORT Element* getElementById(const AtomString&) const;
 
 protected:
-    DocumentFragment(Document&, OptionSet<TypeFlag> = CreateContainer);
+    DocumentFragment(Document&, OptionSet<TypeFlag> = { });
     String nodeName() const final;
 
 private:

--- a/Source/WebCore/dom/DocumentType.cpp
+++ b/Source/WebCore/dom/DocumentType.cpp
@@ -33,7 +33,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(DocumentType);
 
 DocumentType::DocumentType(Document& document, const String& name, const String& publicId, const String& systemId)
-    : Node(document, CreateDocumentType)
+    : Node(document, DOCUMENT_TYPE_NODE, CreateDocumentType)
     , m_name(name)
     , m_publicId(publicId.isNull() ? emptyString() : publicId)
     , m_systemId(systemId.isNull() ? emptyString() : systemId)
@@ -43,11 +43,6 @@ DocumentType::DocumentType(Document& document, const String& name, const String&
 String DocumentType::nodeName() const
 {
     return name();
-}
-
-Node::NodeType DocumentType::nodeType() const
-{
-    return DOCUMENT_TYPE_NODE;
 }
 
 Ref<Node> DocumentType::cloneNodeInternal(Document& documentTarget, CloningOperation)

--- a/Source/WebCore/dom/DocumentType.cpp
+++ b/Source/WebCore/dom/DocumentType.cpp
@@ -33,7 +33,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(DocumentType);
 
 DocumentType::DocumentType(Document& document, const String& name, const String& publicId, const String& systemId)
-    : Node(document, DOCUMENT_TYPE_NODE, CreateDocumentType)
+    : Node(document, DOCUMENT_TYPE_NODE, { })
     , m_name(name)
     , m_publicId(publicId.isNull() ? emptyString() : publicId)
     , m_systemId(systemId.isNull() ? emptyString() : systemId)

--- a/Source/WebCore/dom/DocumentType.h
+++ b/Source/WebCore/dom/DocumentType.h
@@ -45,7 +45,6 @@ private:
     DocumentType(Document&, const String& name, const String& publicId, const String& systemId);
 
     String nodeName() const override;
-    NodeType nodeType() const override;
     Ref<Node> cloneNodeInternal(Document&, CloningOperation) override;
 
     void parentOrShadowHostNode() const = delete; // Call parentNode() instead.

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -246,7 +246,7 @@ Ref<Element> Element::create(const QualifiedName& tagName, Document& document)
 }
 
 Element::Element(const QualifiedName& tagName, Document& document, OptionSet<TypeFlag> type)
-    : ContainerNode(document, type)
+    : ContainerNode(document, ELEMENT_NODE, type)
     , m_tagName(tagName)
 {
 }
@@ -665,11 +665,6 @@ NamedNodeMap& Element::attributes() const
 
     rareData.setAttributeMap(makeUniqueWithoutRefCountedCheck<NamedNodeMap>(const_cast<Element&>(*this)));
     return *rareData.attributeMap();
-}
-
-Node::NodeType Element::nodeType() const
-{
-    return ELEMENT_NODE;
 }
 
 bool Element::hasAttribute(const QualifiedName& name) const

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -242,11 +242,11 @@ static HashMap<CheckedRef<Element>, ElementIdentifier>& elementIdentifiersMap()
 
 Ref<Element> Element::create(const QualifiedName& tagName, Document& document)
 {
-    return adoptRef(*new Element(tagName, document, CreateElement));
+    return adoptRef(*new Element(tagName, document, { }));
 }
 
 Element::Element(const QualifiedName& tagName, Document& document, OptionSet<TypeFlag> type)
-    : ContainerNode(document, ELEMENT_NODE, type)
+    : ContainerNode(document, ELEMENT_NODE, type | TypeFlag::IsElement)
     , m_tagName(tagName)
 {
 }

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -834,7 +834,6 @@ private:
 
     void scrollByUnits(int units, ScrollGranularity);
 
-    NodeType nodeType() const final;
     bool childTypeAllowed(NodeType) const final;
 
     void notifyAttributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason = AttributeModificationReason::Directly);

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -390,11 +390,12 @@ inline void NodeRareData::operator delete(NodeRareData* nodeRareData, std::destr
         destroyAndFree(*nodeRareData);
 }
 
-Node::Node(Document& document, OptionSet<TypeFlag> type)
+Node::Node(Document& document, NodeType type, OptionSet<TypeFlag> flags)
     : EventTarget(ConstructNode)
-    , m_typeFlags(type)
+    , m_typeBitFields(constructBitFieldsFromNodeTypeAndFlags(type, flags))
     , m_treeScope((isDocumentNode() || isShadowRoot()) ? nullptr : &document)
 {
+    ASSERT(nodeType() == type);
     ASSERT(isMainThread());
 
     // Allow code to ref the Document while it is being constructed to make our life easier.

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -651,19 +651,6 @@ protected:
     void setIsParsingChildrenFinished() { clearStateFlag(StateFlag::IsParsingChildren); }
     void clearIsParsingChildrenFinished() { setStateFlag(StateFlag::IsParsingChildren); }
 
-    static constexpr auto DefaultTypeFlags = OptionSet<TypeFlag> { };
-    static constexpr auto CreateAttr = DefaultTypeFlags;
-    static constexpr auto CreateDocumentType = DefaultTypeFlags;
-    static constexpr auto CreateCharacterData = DefaultTypeFlags | TypeFlag::IsCharacterData;
-    static constexpr auto CreateText = CreateCharacterData | TypeFlag::IsText;
-    static constexpr auto CreateContainer = DefaultTypeFlags | TypeFlag::IsContainerNode;
-    static constexpr auto CreateElement = CreateContainer | TypeFlag::IsElement;
-    static constexpr auto CreatePseudoElement = CreateElement | TypeFlag::HasCustomStyleResolveCallbacks;
-    static constexpr auto CreateShadowRoot = CreateContainer | TypeFlag::IsShadowRoot;
-    static constexpr auto CreateHTMLElement = CreateElement | TypeFlag::IsHTMLElement;
-    static constexpr auto CreateSVGElement = CreateElement | TypeFlag::IsSVGElement | TypeFlag::HasCustomStyleResolveCallbacks;
-    static constexpr auto CreateMathMLElement = CreateElement | TypeFlag::IsMathMLElement;
-    static constexpr auto CreateEditingText = CreateText | TypeFlag::IsEditingText;
     Node(Document&, NodeType, OptionSet<TypeFlag>);
 
     static constexpr uint32_t s_refCountIncrement = 2;

--- a/Source/WebCore/dom/ProcessingInstruction.cpp
+++ b/Source/WebCore/dom/ProcessingInstruction.cpp
@@ -45,7 +45,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(ProcessingInstruction);
 
 inline ProcessingInstruction::ProcessingInstruction(Document& document, String&& target, String&& data)
-    : CharacterData(document, WTFMove(data))
+    : CharacterData(document, WTFMove(data), PROCESSING_INSTRUCTION_NODE)
     , m_target(WTFMove(target))
 {
 }
@@ -70,11 +70,6 @@ ProcessingInstruction::~ProcessingInstruction()
 String ProcessingInstruction::nodeName() const
 {
     return m_target;
-}
-
-Node::NodeType ProcessingInstruction::nodeType() const
-{
-    return PROCESSING_INSTRUCTION_NODE;
 }
 
 Ref<Node> ProcessingInstruction::cloneNodeInternal(Document& targetDocument, CloningOperation)

--- a/Source/WebCore/dom/ProcessingInstruction.h
+++ b/Source/WebCore/dom/ProcessingInstruction.h
@@ -61,7 +61,6 @@ private:
     ProcessingInstruction(Document&, String&& target, String&& data);
 
     String nodeName() const override;
-    NodeType nodeType() const override;
     Ref<Node> cloneNodeInternal(Document&, CloningOperation) override;
 
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) override;

--- a/Source/WebCore/dom/PseudoElement.cpp
+++ b/Source/WebCore/dom/PseudoElement.cpp
@@ -49,7 +49,7 @@ const QualifiedName& pseudoElementTagName()
 }
 
 PseudoElement::PseudoElement(Element& host, PseudoId pseudoId)
-    : Element(pseudoElementTagName(), host.document(), CreatePseudoElement)
+    : Element(pseudoElementTagName(), host.document(), TypeFlag::HasCustomStyleResolveCallbacks)
     , m_hostElement(host)
     , m_pseudoId(pseudoId)
 {

--- a/Source/WebCore/dom/ShadowRoot.cpp
+++ b/Source/WebCore/dom/ShadowRoot.cpp
@@ -64,7 +64,7 @@ static_assert(sizeof(WeakPtr<Element, WeakPtrImplWithEventTargetData>) == sizeof
 #endif
 
 ShadowRoot::ShadowRoot(Document& document, ShadowRootMode mode, SlotAssignmentMode assignmentMode, DelegatesFocus delegatesFocus, Cloneable cloneable, AvailableToElementInternals availableToElementInternals)
-    : DocumentFragment(document, CreateShadowRoot)
+    : DocumentFragment(document, TypeFlag::IsShadowRoot)
     , TreeScope(*this, document)
     , m_delegatesFocus(delegatesFocus == DelegatesFocus::Yes)
     , m_isCloneable(cloneable == Cloneable::Yes)
@@ -80,7 +80,7 @@ ShadowRoot::ShadowRoot(Document& document, ShadowRootMode mode, SlotAssignmentMo
 
 
 ShadowRoot::ShadowRoot(Document& document, std::unique_ptr<SlotAssignment>&& slotAssignment)
-    : DocumentFragment(document, CreateShadowRoot)
+    : DocumentFragment(document, TypeFlag::IsShadowRoot)
     , TreeScope(*this, document)
     , m_mode(ShadowRootMode::UserAgent)
     , m_styleScope(makeUnique<Style::Scope>(*this))

--- a/Source/WebCore/dom/TemplateContentDocumentFragment.h
+++ b/Source/WebCore/dom/TemplateContentDocumentFragment.h
@@ -45,7 +45,7 @@ public:
 
 private:
     TemplateContentDocumentFragment(Document& document, const Element& host)
-        : DocumentFragment(document, CreateDocumentFragment)
+        : DocumentFragment(document)
         , m_host(host)
     {
     }

--- a/Source/WebCore/dom/Text.cpp
+++ b/Source/WebCore/dom/Text.cpp
@@ -46,12 +46,12 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(Text);
 
 Ref<Text> Text::create(Document& document, String&& data)
 {
-    return adoptRef(*new Text(document, WTFMove(data), CreateText));
+    return adoptRef(*new Text(document, WTFMove(data), TEXT_NODE, CreateText));
 }
 
 Ref<Text> Text::createEditingText(Document& document, String&& data)
 {
-    return adoptRef(*new Text(document, WTFMove(data), CreateEditingText));
+    return adoptRef(*new Text(document, WTFMove(data), TEXT_NODE, CreateEditingText));
 }
 
 Text::~Text() = default;
@@ -152,11 +152,6 @@ void Text::replaceWholeText(const String& newText)
 String Text::nodeName() const
 {
     return "#text"_s;
-}
-
-Node::NodeType Text::nodeType() const
-{
-    return TEXT_NODE;
 }
 
 Ref<Node> Text::cloneNodeInternal(Document& targetDocument, CloningOperation)

--- a/Source/WebCore/dom/Text.cpp
+++ b/Source/WebCore/dom/Text.cpp
@@ -46,12 +46,12 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(Text);
 
 Ref<Text> Text::create(Document& document, String&& data)
 {
-    return adoptRef(*new Text(document, WTFMove(data), TEXT_NODE, CreateText));
+    return adoptRef(*new Text(document, WTFMove(data), TEXT_NODE, { }));
 }
 
 Ref<Text> Text::createEditingText(Document& document, String&& data)
 {
-    return adoptRef(*new Text(document, WTFMove(data), TEXT_NODE, CreateEditingText));
+    return adoptRef(*new Text(document, WTFMove(data), TEXT_NODE, TypeFlag::IsEditingText));
 }
 
 Text::~Text() = default;

--- a/Source/WebCore/dom/Text.h
+++ b/Source/WebCore/dom/Text.h
@@ -58,14 +58,13 @@ public:
     String debugDescription() const final;
 
 protected:
-    Text(Document& document, String&& data, OptionSet<TypeFlag> type)
-        : CharacterData(document, WTFMove(data), type)
+    Text(Document& document, String&& data, NodeType type, OptionSet<TypeFlag> typeFlags)
+        : CharacterData(document, WTFMove(data), type, typeFlags)
     {
     }
 
 private:
     String nodeName() const override;
-    NodeType nodeType() const override;
     Ref<Node> cloneNodeInternal(Document&, CloningOperation) override;
     void setDataAndUpdate(const String&, unsigned offsetOfReplacedData, unsigned oldLength, unsigned newLength, UpdateLiveRanges) final;
 

--- a/Source/WebCore/dom/Text.h
+++ b/Source/WebCore/dom/Text.h
@@ -59,7 +59,7 @@ public:
 
 protected:
     Text(Document& document, String&& data, NodeType type, OptionSet<TypeFlag> typeFlags)
-        : CharacterData(document, WTFMove(data), type, typeFlags)
+        : CharacterData(document, WTFMove(data), type, typeFlags | TypeFlag::IsText)
     {
     }
 

--- a/Source/WebCore/html/HTMLDivElement.h
+++ b/Source/WebCore/html/HTMLDivElement.h
@@ -33,8 +33,7 @@ public:
     static Ref<HTMLDivElement> create(const QualifiedName&, Document&);
 
 protected:
-    static constexpr auto CreateHTMLDivElement = CreateHTMLElement;
-    HTMLDivElement(const QualifiedName&, Document&, OptionSet<TypeFlag> = CreateHTMLDivElement);
+    HTMLDivElement(const QualifiedName&, Document&, OptionSet<TypeFlag> = { });
 
 private:
     void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) final;

--- a/Source/WebCore/html/HTMLElement.h
+++ b/Source/WebCore/html/HTMLElement.h
@@ -166,7 +166,7 @@ public:
 #endif
 
 protected:
-    HTMLElement(const QualifiedName& tagName, Document&, OptionSet<TypeFlag>);
+    HTMLElement(const QualifiedName& tagName, Document&, OptionSet<TypeFlag> = { });
 
     enum class AllowZeroValue : bool { No, Yes };
     void addHTMLLengthToStyle(MutableStyleProperties&, CSSPropertyID, StringView value, AllowZeroValue = AllowZeroValue::Yes);
@@ -223,10 +223,13 @@ private:
     void addHTMLLengthToStyle(MutableStyleProperties&, CSSPropertyID, StringView value, AllowPercentage, UseCSSPXAsUnitType, IsMultiLength, AllowZeroValue = AllowZeroValue::Yes);
 };
 
-inline HTMLElement::HTMLElement(const QualifiedName& tagName, Document& document, OptionSet<TypeFlag> type = CreateHTMLElement)
-    : StyledElement(tagName, document, type)
+inline HTMLElement::HTMLElement(const QualifiedName& tagName, Document& document, OptionSet<TypeFlag> type)
+    : StyledElement(tagName, document, type | TypeFlag::IsHTMLElement)
 {
     ASSERT(tagName.localName().impl());
+    ASSERT(isHTMLElement());
+    ASSERT(!isSVGElement());
+    ASSERT(!isMathMLElement());
 }
 
 inline bool Node::hasTagName(const HTMLQualifiedName& name) const

--- a/Source/WebCore/html/HTMLFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLFormControlElement.cpp
@@ -59,7 +59,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(HTMLFormControlElement);
 using namespace HTMLNames;
 
 HTMLFormControlElement::HTMLFormControlElement(const QualifiedName& tagName, Document& document, HTMLFormElement* form)
-    : HTMLElement(tagName, document, CreateHTMLFormControlElement)
+    : HTMLElement(tagName, document, TypeFlag::HasCustomStyleResolveCallbacks)
     , ValidatedFormListedElement(form)
     , m_isRequired(false)
     , m_valueMatchesRenderer(false)

--- a/Source/WebCore/html/HTMLFormControlElement.h
+++ b/Source/WebCore/html/HTMLFormControlElement.h
@@ -110,7 +110,6 @@ public:
     using Node::deref;
 
 protected:
-    static constexpr auto CreateHTMLFormControlElement = CreateHTMLElement | TypeFlag::HasCustomStyleResolveCallbacks;
     HTMLFormControlElement(const QualifiedName& tagName, Document&, HTMLFormElement*);
 
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) override;

--- a/Source/WebCore/html/HTMLFrameElementBase.cpp
+++ b/Source/WebCore/html/HTMLFrameElementBase.cpp
@@ -49,7 +49,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(HTMLFrameElementBase);
 using namespace HTMLNames;
 
 HTMLFrameElementBase::HTMLFrameElementBase(const QualifiedName& tagName, Document& document)
-    : HTMLFrameOwnerElement(tagName, document, CreateHTMLFrameElementBase)
+    : HTMLFrameOwnerElement(tagName, document, TypeFlag::HasCustomStyleResolveCallbacks)
 {
 }
 

--- a/Source/WebCore/html/HTMLFrameElementBase.h
+++ b/Source/WebCore/html/HTMLFrameElementBase.h
@@ -40,7 +40,6 @@ public:
     ScrollbarMode scrollingMode() const final;
 
 protected:
-    static constexpr auto CreateHTMLFrameElementBase = CreateHTMLFrameOwnerElement | TypeFlag::HasCustomStyleResolveCallbacks;
     HTMLFrameElementBase(const QualifiedName&, Document&);
 
     bool canLoad() const;

--- a/Source/WebCore/html/HTMLFrameOwnerElement.h
+++ b/Source/WebCore/html/HTMLFrameOwnerElement.h
@@ -67,8 +67,7 @@ public:
     virtual bool isLazyLoadObserverActive() const { return false; }
 
 protected:
-    static constexpr auto CreateHTMLFrameOwnerElement = CreateHTMLElement;
-    HTMLFrameOwnerElement(const QualifiedName& tagName, Document&, OptionSet<TypeFlag> = CreateHTMLFrameOwnerElement);
+    HTMLFrameOwnerElement(const QualifiedName& tagName, Document&, OptionSet<TypeFlag> = { });
     void setSandboxFlags(SandboxFlags);
     bool isProhibitedSelfReference(const URL&) const;
     bool isKeyboardFocusable(KeyboardEvent*) const override;

--- a/Source/WebCore/html/HTMLFrameSetElement.cpp
+++ b/Source/WebCore/html/HTMLFrameSetElement.cpp
@@ -51,7 +51,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(HTMLFrameSetElement);
 using namespace HTMLNames;
 
 HTMLFrameSetElement::HTMLFrameSetElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document, CreateHTMLFrameSetElement)
+    : HTMLElement(tagName, document, TypeFlag::HasCustomStyleResolveCallbacks)
     , m_totalRows(1)
     , m_totalCols(1)
     , m_border(6)

--- a/Source/WebCore/html/HTMLFrameSetElement.h
+++ b/Source/WebCore/html/HTMLFrameSetElement.h
@@ -54,7 +54,6 @@ public:
     bool isSupportedPropertyName(const AtomString&);
 
 private:
-    static constexpr auto CreateHTMLFrameSetElement = CreateHTMLElement | TypeFlag::HasCustomStyleResolveCallbacks;
     HTMLFrameSetElement(const QualifiedName&, Document&);
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -77,7 +77,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(HTMLImageElement);
 using namespace HTMLNames;
 
 HTMLImageElement::HTMLImageElement(const QualifiedName& tagName, Document& document, HTMLFormElement* form)
-    : HTMLElement(tagName, document, CreateHTMLImageElement)
+    : HTMLElement(tagName, document, TypeFlag::HasCustomStyleResolveCallbacks)
     , FormAssociatedElement(form)
     , ActiveDOMObject(document)
     , m_imageLoader(makeUnique<HTMLImageLoader>(*this))

--- a/Source/WebCore/html/HTMLImageElement.h
+++ b/Source/WebCore/html/HTMLImageElement.h
@@ -178,7 +178,6 @@ public:
     void collectExtraStyleForPresentationalHints(MutableStyleProperties&);
 
 protected:
-    static constexpr auto CreateHTMLImageElement = CreateHTMLElement | TypeFlag::HasCustomStyleResolveCallbacks;
     HTMLImageElement(const QualifiedName&, Document&, HTMLFormElement* = nullptr);
 
     void didMoveToNewDocument(Document& oldDocument, Document& newDocument) override;

--- a/Source/WebCore/html/HTMLLIElement.cpp
+++ b/Source/WebCore/html/HTMLLIElement.cpp
@@ -41,7 +41,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(HTMLLIElement);
 using namespace HTMLNames;
 
 HTMLLIElement::HTMLLIElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document, CreateHTMLLIElement)
+    : HTMLElement(tagName, document, TypeFlag::HasCustomStyleResolveCallbacks)
 {
     ASSERT(hasTagName(liTag));
 }

--- a/Source/WebCore/html/HTMLLIElement.h
+++ b/Source/WebCore/html/HTMLLIElement.h
@@ -33,7 +33,6 @@ public:
     static Ref<HTMLLIElement> create(const QualifiedName&, Document&);
 
 private:
-    static constexpr auto CreateHTMLLIElement = CreateHTMLElement | TypeFlag::HasCustomStyleResolveCallbacks;
     HTMLLIElement(const QualifiedName&, Document&);
 
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const final;

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -429,7 +429,7 @@ static bool defaultVolumeLocked()
 }
 
 HTMLMediaElement::HTMLMediaElement(const QualifiedName& tagName, Document& document, bool createdByParser)
-    : HTMLElement(tagName, document, CreateHTMLMediaElement)
+    : HTMLElement(tagName, document)
     , ActiveDOMObject(document)
     , m_progressEventTimer(*this, &HTMLMediaElement::progressEventTimerFired)
     , m_playbackProgressTimer(*this, &HTMLMediaElement::playbackProgressTimerFired)

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -648,7 +648,6 @@ public:
     void updateMediaState();
 
 protected:
-    static constexpr auto CreateHTMLMediaElement = CreateHTMLElement | TypeFlag::HasCustomStyleResolveCallbacks;
     HTMLMediaElement(const QualifiedName&, Document&, bool createdByParser);
     virtual ~HTMLMediaElement();
 

--- a/Source/WebCore/html/HTMLOptionElement.cpp
+++ b/Source/WebCore/html/HTMLOptionElement.cpp
@@ -54,7 +54,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(HTMLOptionElement);
 using namespace HTMLNames;
 
 HTMLOptionElement::HTMLOptionElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document, CreateHTMLOptionElement)
+    : HTMLElement(tagName, document, TypeFlag::HasCustomStyleResolveCallbacks)
 {
     ASSERT(hasTagName(optionTag));
 }

--- a/Source/WebCore/html/HTMLOptionElement.h
+++ b/Source/WebCore/html/HTMLOptionElement.h
@@ -68,7 +68,6 @@ public:
     bool selectedWithoutUpdate() const { return m_isSelected; }
 
 private:
-    static constexpr auto CreateHTMLOptionElement = CreateHTMLElement | TypeFlag::HasCustomStyleResolveCallbacks;
     HTMLOptionElement(const QualifiedName&, Document&);
 
     bool isFocusable() const final;

--- a/Source/WebCore/html/HTMLPlugInElement.cpp
+++ b/Source/WebCore/html/HTMLPlugInElement.cpp
@@ -64,7 +64,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(HTMLPlugInElement);
 using namespace HTMLNames;
 
 HTMLPlugInElement::HTMLPlugInElement(const QualifiedName& tagName, Document& document)
-    : HTMLFrameOwnerElement(tagName, document, CreateHTMLPlugInElement)
+    : HTMLFrameOwnerElement(tagName, document, TypeFlag::HasCustomStyleResolveCallbacks)
     , m_swapRendererTimer(*this, &HTMLPlugInElement::swapRendererTimerFired)
 {
 }

--- a/Source/WebCore/html/HTMLPlugInElement.h
+++ b/Source/WebCore/html/HTMLPlugInElement.h
@@ -75,7 +75,6 @@ public:
     WEBCORE_EXPORT bool isReplacementObscured();
 
 protected:
-    static constexpr auto CreateHTMLPlugInElement = CreateHTMLFrameOwnerElement | TypeFlag::HasCustomStyleResolveCallbacks;
     HTMLPlugInElement(const QualifiedName& tagName, Document&);
 
     bool canContainRangeEndPoint() const override { return false; }

--- a/Source/WebCore/html/HTMLProgressElement.cpp
+++ b/Source/WebCore/html/HTMLProgressElement.cpp
@@ -41,7 +41,7 @@ const double HTMLProgressElement::IndeterminatePosition = -1;
 const double HTMLProgressElement::InvalidPosition = -2;
 
 HTMLProgressElement::HTMLProgressElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document, CreateHTMLProgressElement)
+    : HTMLElement(tagName, document, TypeFlag::HasCustomStyleResolveCallbacks)
     , m_value(0)
     , m_isDeterminate(false)
 {

--- a/Source/WebCore/html/HTMLProgressElement.h
+++ b/Source/WebCore/html/HTMLProgressElement.h
@@ -44,7 +44,6 @@ public:
     double position() const;
 
 private:
-    static constexpr auto CreateHTMLProgressElement = CreateHTMLElement | TypeFlag::HasCustomStyleResolveCallbacks;
     HTMLProgressElement(const QualifiedName&, Document&);
     virtual ~HTMLProgressElement();
 

--- a/Source/WebCore/html/HTMLUnknownElement.h
+++ b/Source/WebCore/html/HTMLUnknownElement.h
@@ -43,7 +43,7 @@ public:
 
 private:
     HTMLUnknownElement(const QualifiedName& tagName, Document& document)
-        : HTMLElement(tagName, document, CreateHTMLElement | TypeFlag::IsUnknownElement)
+        : HTMLElement(tagName, document, TypeFlag::IsUnknownElement)
     {
     }
 };

--- a/Source/WebCore/html/shadow/DateTimeFieldElement.cpp
+++ b/Source/WebCore/html/shadow/DateTimeFieldElement.cpp
@@ -53,7 +53,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(DateTimeFieldElement);
 DateTimeFieldElement::FieldOwner::~FieldOwner() = default;
 
 DateTimeFieldElement::DateTimeFieldElement(Document& document, FieldOwner& fieldOwner)
-    : HTMLDivElement(divTag, document, CreateDateTimeFieldElement)
+    : HTMLDivElement(divTag, document, TypeFlag::HasCustomStyleResolveCallbacks)
     , m_fieldOwner(fieldOwner)
 {
 }

--- a/Source/WebCore/html/shadow/DateTimeFieldElement.h
+++ b/Source/WebCore/html/shadow/DateTimeFieldElement.h
@@ -75,7 +75,6 @@ public:
     virtual String placeholderValue() const = 0;
 
 protected:
-    static constexpr auto CreateDateTimeFieldElement = CreateHTMLDivElement | TypeFlag::HasCustomStyleResolveCallbacks;
     DateTimeFieldElement(Document&, FieldOwner&);
     void initialize(const AtomString& pseudo);
     Locale& localeForOwner() const;

--- a/Source/WebCore/html/shadow/SliderThumbElement.cpp
+++ b/Source/WebCore/html/shadow/SliderThumbElement.cpp
@@ -190,7 +190,7 @@ Ref<SliderThumbElement> SliderThumbElement::create(Document& document)
 }
 
 SliderThumbElement::SliderThumbElement(Document& document)
-    : HTMLDivElement(HTMLNames::divTag, document, CreateSliderThumbElement)
+    : HTMLDivElement(HTMLNames::divTag, document, TypeFlag::HasCustomStyleResolveCallbacks)
 {
 }
 
@@ -585,7 +585,7 @@ Ref<Element> SliderThumbElement::cloneElementWithoutAttributesAndChildren(Docume
 // --------------------------------
 
 inline SliderContainerElement::SliderContainerElement(Document& document)
-    : HTMLDivElement(HTMLNames::divTag, document, CreateSliderContainerElement)
+    : HTMLDivElement(HTMLNames::divTag, document, TypeFlag::HasCustomStyleResolveCallbacks)
 {
 }
 

--- a/Source/WebCore/html/shadow/SliderThumbElement.h
+++ b/Source/WebCore/html/shadow/SliderThumbElement.h
@@ -57,7 +57,6 @@ public:
     void hostDisabledStateChanged();
 
 private:
-    static constexpr auto CreateSliderThumbElement = CreateHTMLDivElement | TypeFlag::HasCustomStyleResolveCallbacks;
     explicit SliderThumbElement(Document&);
     bool isSliderThumbElement() const final { return true; }
 
@@ -113,7 +112,6 @@ public:
     static Ref<SliderContainerElement> create(Document&);
 
 private:
-    static constexpr auto CreateSliderContainerElement = CreateHTMLDivElement | TypeFlag::HasCustomStyleResolveCallbacks;
     explicit SliderContainerElement(Document&);
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;
     bool isSliderContainerElement() const final { return true; }

--- a/Source/WebCore/html/shadow/SpinButtonElement.cpp
+++ b/Source/WebCore/html/shadow/SpinButtonElement.cpp
@@ -50,7 +50,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(SpinButtonElement);
 using namespace HTMLNames;
 
 inline SpinButtonElement::SpinButtonElement(Document& document, SpinButtonOwner& spinButtonOwner)
-    : HTMLDivElement(divTag, document, CreateSpinButtonElement)
+    : HTMLDivElement(divTag, document, TypeFlag::HasCustomStyleResolveCallbacks)
     , m_spinButtonOwner(spinButtonOwner)
     , m_capturing(false)
     , m_upDownState(Indeterminate)

--- a/Source/WebCore/html/shadow/SpinButtonElement.h
+++ b/Source/WebCore/html/shadow/SpinButtonElement.h
@@ -68,7 +68,6 @@ public:
     void forwardEvent(Event&);
 
 private:
-    static constexpr auto CreateSpinButtonElement = CreateHTMLDivElement | TypeFlag::HasCustomStyleResolveCallbacks;
     SpinButtonElement(Document&, SpinButtonOwner&);
 
     void willDetachRenderers() override;

--- a/Source/WebCore/html/shadow/SwitchThumbElement.cpp
+++ b/Source/WebCore/html/shadow/SwitchThumbElement.cpp
@@ -45,7 +45,7 @@ Ref<SwitchThumbElement> SwitchThumbElement::create(Document& document)
 }
 
 SwitchThumbElement::SwitchThumbElement(Document& document)
-    : HTMLDivElement(HTMLNames::divTag, document, CreateSwitchThumbElement)
+    : HTMLDivElement(HTMLNames::divTag, document, TypeFlag::HasCustomStyleResolveCallbacks)
 {
 }
 

--- a/Source/WebCore/html/shadow/SwitchThumbElement.h
+++ b/Source/WebCore/html/shadow/SwitchThumbElement.h
@@ -36,7 +36,6 @@ class SwitchThumbElement final : public HTMLDivElement {
 public:
     static Ref<SwitchThumbElement> create(Document&);
 private:
-    static constexpr auto CreateSwitchThumbElement = CreateHTMLDivElement | TypeFlag::HasCustomStyleResolveCallbacks;
     explicit SwitchThumbElement(Document&);
 };
 

--- a/Source/WebCore/html/shadow/SwitchTrackElement.cpp
+++ b/Source/WebCore/html/shadow/SwitchTrackElement.cpp
@@ -44,7 +44,7 @@ Ref<SwitchTrackElement> SwitchTrackElement::create(Document& document)
 }
 
 SwitchTrackElement::SwitchTrackElement(Document& document)
-    : HTMLDivElement(HTMLNames::divTag, document, CreateSwitchTrackElement)
+    : HTMLDivElement(HTMLNames::divTag, document, TypeFlag::HasCustomStyleResolveCallbacks)
 {
 }
 

--- a/Source/WebCore/html/shadow/SwitchTrackElement.h
+++ b/Source/WebCore/html/shadow/SwitchTrackElement.h
@@ -36,7 +36,6 @@ class SwitchTrackElement final : public HTMLDivElement {
 public:
     static Ref<SwitchTrackElement> create(Document&);
 private:
-    static constexpr auto CreateSwitchTrackElement = CreateHTMLDivElement | TypeFlag::HasCustomStyleResolveCallbacks;
     explicit SwitchTrackElement(Document&);
 };
 

--- a/Source/WebCore/html/shadow/TextControlInnerElements.cpp
+++ b/Source/WebCore/html/shadow/TextControlInnerElements.cpp
@@ -66,7 +66,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(SearchFieldCancelButtonElement);
 using namespace HTMLNames;
 
 TextControlInnerContainer::TextControlInnerContainer(Document& document)
-    : HTMLDivElement(divTag, document, CreateTextControlInnerContainer)
+    : HTMLDivElement(divTag, document, TypeFlag::HasCustomStyleResolveCallbacks)
 {
 }
 
@@ -98,7 +98,7 @@ std::optional<Style::ResolvedStyle> TextControlInnerContainer::resolveCustomStyl
 }
 
 TextControlInnerElement::TextControlInnerElement(Document& document)
-    : HTMLDivElement(divTag, document, CreateTextControlInnerElement)
+    : HTMLDivElement(divTag, document, TypeFlag::HasCustomStyleResolveCallbacks)
 {
 }
 
@@ -144,7 +144,7 @@ std::optional<Style::ResolvedStyle> TextControlInnerElement::resolveCustomStyle(
 // MARK: TextControlInnerTextElement
 
 inline TextControlInnerTextElement::TextControlInnerTextElement(Document& document)
-    : HTMLDivElement(divTag, document, CreateTextControlInnerTextElement)
+    : HTMLDivElement(divTag, document, TypeFlag::HasCustomStyleResolveCallbacks)
 {
 }
 
@@ -204,7 +204,7 @@ std::optional<Style::ResolvedStyle> TextControlInnerTextElement::resolveCustomSt
 // MARK: TextControlPlaceholderElement
 
 inline TextControlPlaceholderElement::TextControlPlaceholderElement(Document& document)
-    : HTMLDivElement(divTag, document, CreateTextControlPlaceholderElement)
+    : HTMLDivElement(divTag, document, TypeFlag::HasCustomStyleResolveCallbacks)
 {
 }
 
@@ -240,7 +240,7 @@ static inline bool searchFieldStyleHasExplicitlySpecifiedTextFieldAppearance(con
 }
 
 inline SearchFieldResultsButtonElement::SearchFieldResultsButtonElement(Document& document)
-    : HTMLDivElement(divTag, document, CreateSearchFieldResultsButtonElement)
+    : HTMLDivElement(divTag, document, TypeFlag::HasCustomStyleResolveCallbacks)
 {
     if (document.quirks().shouldHideSearchFieldResultsButton())
         setInlineStyleProperty(CSSPropertyDisplay, CSSValueNone);
@@ -314,7 +314,7 @@ bool SearchFieldResultsButtonElement::willRespondToMouseClickEventsWithEditabili
 // MARK: SearchFieldCancelButtonElement
 
 inline SearchFieldCancelButtonElement::SearchFieldCancelButtonElement(Document& document)
-    : HTMLDivElement(divTag, document, CreateSearchFieldCancelButtonElement)
+    : HTMLDivElement(divTag, document, TypeFlag::HasCustomStyleResolveCallbacks)
 {
 }
 

--- a/Source/WebCore/html/shadow/TextControlInnerElements.h
+++ b/Source/WebCore/html/shadow/TextControlInnerElements.h
@@ -38,7 +38,6 @@ class TextControlInnerContainer final : public HTMLDivElement {
 public:
     static Ref<TextControlInnerContainer> create(Document&);
 private:
-    static constexpr auto CreateTextControlInnerContainer = CreateHTMLDivElement | TypeFlag::HasCustomStyleResolveCallbacks;
     explicit TextControlInnerContainer(Document&);
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) override;
     std::optional<Style::ResolvedStyle> resolveCustomStyle(const Style::ResolutionContext&, const RenderStyle* shadowHostStyle) override;
@@ -50,7 +49,6 @@ public:
     static Ref<TextControlInnerElement> create(Document&);
 
 private:
-    static constexpr auto CreateTextControlInnerElement = CreateHTMLDivElement | TypeFlag::HasCustomStyleResolveCallbacks;
     explicit TextControlInnerElement(Document&);
     std::optional<Style::ResolvedStyle> resolveCustomStyle(const Style::ResolutionContext&, const RenderStyle* shadowHostStyle) override;
 
@@ -75,7 +73,6 @@ public:
 private:
     void updateInnerTextElementEditabilityImpl(bool isEditable, bool initialization);
 
-    static constexpr auto CreateTextControlInnerTextElement = CreateHTMLDivElement | TypeFlag::HasCustomStyleResolveCallbacks;
     explicit TextControlInnerTextElement(Document&);
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) override;
     std::optional<Style::ResolvedStyle> resolveCustomStyle(const Style::ResolutionContext&, const RenderStyle* shadowHostStyle) override;
@@ -89,7 +86,6 @@ public:
     static Ref<TextControlPlaceholderElement> create(Document&);
 
 private:
-    static constexpr auto CreateTextControlPlaceholderElement = CreateHTMLDivElement | TypeFlag::HasCustomStyleResolveCallbacks;
     explicit TextControlPlaceholderElement(Document&);
     
     std::optional<Style::ResolvedStyle> resolveCustomStyle(const Style::ResolutionContext&, const RenderStyle* shadowHostStyle) override;
@@ -108,7 +104,6 @@ public:
     bool canAdjustStyleForAppearance() const { return m_canAdjustStyleForAppearance; }
 
 private:
-    static constexpr auto CreateSearchFieldResultsButtonElement = CreateHTMLDivElement | TypeFlag::HasCustomStyleResolveCallbacks;
     explicit SearchFieldResultsButtonElement(Document&);
     bool isMouseFocusable() const override { return false; }
     std::optional<Style::ResolvedStyle> resolveCustomStyle(const Style::ResolutionContext&, const RenderStyle* shadowHostStyle) override;
@@ -128,7 +123,6 @@ public:
 #endif
 
 private:
-    static constexpr auto CreateSearchFieldCancelButtonElement = CreateHTMLDivElement | TypeFlag::HasCustomStyleResolveCallbacks;
     explicit SearchFieldCancelButtonElement(Document&);
     bool isMouseFocusable() const override { return false; }
     std::optional<Style::ResolvedStyle> resolveCustomStyle(const Style::ResolutionContext&, const RenderStyle* shadowHostStyle) override;

--- a/Source/WebCore/html/track/TextTrackCue.cpp
+++ b/Source/WebCore/html/track/TextTrackCue.cpp
@@ -73,7 +73,7 @@ Ref<TextTrackCueBox> TextTrackCueBox::create(Document& document, TextTrackCue& c
 }
 
 TextTrackCueBox::TextTrackCueBox(Document& document, TextTrackCue& cue)
-    : HTMLElement(HTMLNames::divTag, document, CreateTextTrackCueBox)
+    : HTMLElement(HTMLNames::divTag, document, TypeFlag::HasCustomStyleResolveCallbacks)
     , m_cue(cue)
 {
 }

--- a/Source/WebCore/html/track/TextTrackCue.h
+++ b/Source/WebCore/html/track/TextTrackCue.h
@@ -56,7 +56,6 @@ public:
 protected:
     void initialize();
 
-    static constexpr auto CreateTextTrackCueBox = CreateHTMLElement | TypeFlag::HasCustomStyleResolveCallbacks;
     TextTrackCueBox(Document&, TextTrackCue&);
     ~TextTrackCueBox() { }
 

--- a/Source/WebCore/html/track/WebVTTElement.cpp
+++ b/Source/WebCore/html/track/WebVTTElement.cpp
@@ -80,7 +80,7 @@ static const QualifiedName& nodeTypeToTagName(WebVTTNodeType nodeType)
 
 WebVTTElement::WebVTTElement(WebVTTNodeType nodeType, AtomString language, Document& document)
     : WebVTTElementImpl(nodeType, language)
-    , Element(nodeTypeToTagName(nodeType), document, CreateElement)
+    , Element(nodeTypeToTagName(nodeType), document, { })
 {
 }
 

--- a/Source/WebCore/mathml/MathMLElement.cpp
+++ b/Source/WebCore/mathml/MathMLElement.cpp
@@ -52,9 +52,12 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(MathMLElement);
 
 using namespace MathMLNames;
 
-MathMLElement::MathMLElement(const QualifiedName& tagName, Document& document, OptionSet<TypeFlag> constructionType)
-    : StyledElement(tagName, document, constructionType)
+MathMLElement::MathMLElement(const QualifiedName& tagName, Document& document, OptionSet<TypeFlag> typeFlags)
+    : StyledElement(tagName, document, typeFlags | TypeFlag::IsMathMLElement)
 {
+    ASSERT(isMathMLElement());
+    ASSERT(!isSVGElement());
+    ASSERT(!isHTMLElement());
 }
 
 Ref<MathMLElement> MathMLElement::create(const QualifiedName& tagName, Document& document)

--- a/Source/WebCore/mathml/MathMLElement.h
+++ b/Source/WebCore/mathml/MathMLElement.h
@@ -90,7 +90,7 @@ public:
     virtual void updateSelectedChild() { }
 
 protected:
-    MathMLElement(const QualifiedName& tagName, Document&, OptionSet<TypeFlag> = CreateMathMLElement);
+    MathMLElement(const QualifiedName& tagName, Document&, OptionSet<TypeFlag> = { });
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     bool childShouldCreateRenderer(const Node&) const override;

--- a/Source/WebCore/mathml/MathMLMathElement.cpp
+++ b/Source/WebCore/mathml/MathMLMathElement.cpp
@@ -41,7 +41,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(MathMLMathElement);
 using namespace MathMLNames;
 
 inline MathMLMathElement::MathMLMathElement(const QualifiedName& tagName, Document& document)
-    : MathMLRowElement(tagName, document, CreateMathMLMathElement)
+    : MathMLRowElement(tagName, document, TypeFlag::HasCustomStyleResolveCallbacks)
 {
 }
 

--- a/Source/WebCore/mathml/MathMLMathElement.h
+++ b/Source/WebCore/mathml/MathMLMathElement.h
@@ -39,7 +39,6 @@ public:
     static Ref<MathMLMathElement> create(const QualifiedName& tagName, Document&);
 
 private:
-    static constexpr auto CreateMathMLMathElement = CreateMathMLRowElement | TypeFlag::HasCustomStyleResolveCallbacks;
     MathMLMathElement(const QualifiedName& tagName, Document&);
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void didAttachRenderers() final;

--- a/Source/WebCore/mathml/MathMLPresentationElement.h
+++ b/Source/WebCore/mathml/MathMLPresentationElement.h
@@ -39,8 +39,7 @@ public:
     static Ref<MathMLPresentationElement> create(const QualifiedName& tagName, Document&);
 
 protected:
-    static constexpr auto CreateMathMLPresentationElement = CreateMathMLElement;
-    MathMLPresentationElement(const QualifiedName& tagName, Document&, OptionSet<TypeFlag> = CreateMathMLPresentationElement);
+    MathMLPresentationElement(const QualifiedName& tagName, Document&, OptionSet<TypeFlag> = { });
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
 
     static std::optional<bool> toOptionalBool(const BooleanValue& value) { return value == BooleanValue::Default ? std::nullopt : std::optional<bool>(value == BooleanValue::True); }

--- a/Source/WebCore/mathml/MathMLRowElement.h
+++ b/Source/WebCore/mathml/MathMLRowElement.h
@@ -37,8 +37,7 @@ public:
     static Ref<MathMLRowElement> create(const QualifiedName& tagName, Document&);
 
 protected:
-    static constexpr auto CreateMathMLRowElement = CreateMathMLPresentationElement;
-    MathMLRowElement(const QualifiedName& tagName, Document&, OptionSet<TypeFlag> = CreateMathMLRowElement);
+    MathMLRowElement(const QualifiedName& tagName, Document&, OptionSet<TypeFlag> = { });
     void childrenChanged(const ChildChange&) override;
 
     bool acceptsMathVariantAttribute() override;

--- a/Source/WebCore/mathml/MathMLTokenElement.cpp
+++ b/Source/WebCore/mathml/MathMLTokenElement.cpp
@@ -42,7 +42,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(MathMLTokenElement);
 using namespace MathMLNames;
 
 MathMLTokenElement::MathMLTokenElement(const QualifiedName& tagName, Document& document)
-    : MathMLPresentationElement(tagName, document, CreateMathMLTokenElement)
+    : MathMLPresentationElement(tagName, document, TypeFlag::HasCustomStyleResolveCallbacks)
 {
 }
 

--- a/Source/WebCore/mathml/MathMLTokenElement.h
+++ b/Source/WebCore/mathml/MathMLTokenElement.h
@@ -41,7 +41,6 @@ public:
     static std::optional<char32_t> convertToSingleCodePoint(StringView);
 
 protected:
-    static constexpr auto CreateMathMLTokenElement = CreateMathMLPresentationElement | TypeFlag::HasCustomStyleResolveCallbacks;
     MathMLTokenElement(const QualifiedName& tagName, Document&);
     void childrenChanged(const ChildChange&) override;
 

--- a/Source/WebCore/mathml/MathMLUnknownElement.h
+++ b/Source/WebCore/mathml/MathMLUnknownElement.h
@@ -41,7 +41,7 @@ public:
 
 private:
     MathMLUnknownElement(const QualifiedName& tagName, Document& document)
-        : MathMLElement(tagName, document, CreateMathMLElement | TypeFlag::IsUnknownElement)
+        : MathMLElement(tagName, document, TypeFlag::IsUnknownElement)
     {
     }
 

--- a/Source/WebCore/svg/SVGElement.cpp
+++ b/Source/WebCore/svg/SVGElement.cpp
@@ -69,11 +69,14 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(SVGElement);
 
-SVGElement::SVGElement(const QualifiedName& tagName, Document& document, UniqueRef<SVGPropertyRegistry>&& propertyRegistry, OptionSet<TypeFlag> constructionType)
-    : StyledElement(tagName, document, constructionType)
+SVGElement::SVGElement(const QualifiedName& tagName, Document& document, UniqueRef<SVGPropertyRegistry>&& propertyRegistry, OptionSet<TypeFlag> typeFlags)
+    : StyledElement(tagName, document, typeFlags | TypeFlag::IsSVGElement | TypeFlag::HasCustomStyleResolveCallbacks)
     , m_propertyAnimatorFactory(makeUnique<SVGPropertyAnimatorFactory>())
     , m_propertyRegistry(WTFMove(propertyRegistry))
 {
+    ASSERT(isSVGElement());
+    ASSERT(!isMathMLElement());
+    ASSERT(!isHTMLElement());
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [] {
         PropertyRegistry::registerProperty<HTMLNames::classAttr, &SVGElement::m_className>();

--- a/Source/WebCore/svg/SVGElement.h
+++ b/Source/WebCore/svg/SVGElement.h
@@ -168,7 +168,7 @@ public:
     bool hasAssociatedSVGLayoutBox() const;
 
 protected:
-    SVGElement(const QualifiedName&, Document&, UniqueRef<SVGPropertyRegistry>&&, OptionSet<TypeFlag> = CreateSVGElement);
+    SVGElement(const QualifiedName&, Document&, UniqueRef<SVGPropertyRegistry>&&, OptionSet<TypeFlag> = { });
     virtual ~SVGElement();
 
     bool rendererIsNeeded(const RenderStyle&) override;

--- a/Source/WebCore/svg/SVGUnknownElement.h
+++ b/Source/WebCore/svg/SVGUnknownElement.h
@@ -45,7 +45,7 @@ public:
 
 private:
     SVGUnknownElement(const QualifiedName& tagName, Document& document)
-        : SVGElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this), CreateSVGElement | TypeFlag::IsUnknownElement)
+        : SVGElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this), TypeFlag::IsUnknownElement)
     {
     }
 


### PR DESCRIPTION
#### c11b717094bb29ce1bc8b2eba53fc2eb9a4ece15
<pre>
Make Node&apos;s OptionSet&lt;TypeFlag&gt; more robust
<a href="https://bugs.webkit.org/show_bug.cgi?id=266836">https://bugs.webkit.org/show_bug.cgi?id=266836</a>

Reviewed by NOBODY (OOPS!).

Prior to this PR, each most derived class which specifies OptionSet&lt;TypeFlag&gt; was responsible for
specifying the union of all super classes&apos; TypeFlag. This is rather fragile since each derived class
which specifies OptionSet&lt;TypeFlag&gt; needs to be updated when any new value of TypeFlag gets introduced
or an existing TypeFlag gets removed.

This PR changes it so that each Node&apos;s subclass adds TypeFlag which is responsible for representing
the subclass. In other words, each class specifies the difference between the class and its superclass.
The PR removes all Create* declarations and adds more debug assertions in various constructors.

* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::HTMLModelElement):
* Source/WebCore/Modules/model-element/HTMLModelElement.h:
* Source/WebCore/dom/Attr.cpp:
(WebCore::Attr::Attr):
* Source/WebCore/dom/CDATASection.cpp:
(WebCore::CDATASection::CDATASection):
* Source/WebCore/dom/CharacterData.h:
(WebCore::CharacterData::CharacterData):
* Source/WebCore/dom/ContainerNode.h:
(WebCore::ContainerNode::ContainerNode):
* Source/WebCore/dom/DocumentFragment.cpp:
(WebCore::DocumentFragment::createForInnerOuterHTML):
* Source/WebCore/dom/DocumentFragment.h:
(WebCore::DocumentFragment::DocumentFragment):
* Source/WebCore/dom/DocumentType.cpp:
(WebCore::DocumentType::DocumentType):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::create):
(WebCore::Element::Element):
* Source/WebCore/dom/Node.h:
* Source/WebCore/dom/PseudoElement.cpp:
(WebCore::PseudoElement::PseudoElement):
* Source/WebCore/dom/ShadowRoot.cpp:
(WebCore::ShadowRoot::ShadowRoot):
* Source/WebCore/dom/Text.cpp:
(WebCore::Text::create):
(WebCore::Text::createEditingText):
* Source/WebCore/dom/Text.h:
(WebCore::Text::Text):
* Source/WebCore/html/HTMLDivElement.h:
(WebCore::HTMLDivElement::HTMLDivElement):
* Source/WebCore/html/HTMLElement.h:
(WebCore::HTMLElement::HTMLElement):
* Source/WebCore/html/HTMLFormControlElement.cpp:
(WebCore::HTMLFormControlElement::HTMLFormControlElement):
* Source/WebCore/html/HTMLFormControlElement.h:
* Source/WebCore/html/HTMLFrameElementBase.cpp:
(WebCore::HTMLFrameElementBase::HTMLFrameElementBase):
* Source/WebCore/html/HTMLFrameElementBase.h:
* Source/WebCore/html/HTMLFrameOwnerElement.h:
(WebCore::HTMLFrameOwnerElement::HTMLFrameOwnerElement):
* Source/WebCore/html/HTMLFrameSetElement.cpp:
(WebCore::HTMLFrameSetElement::HTMLFrameSetElement):
* Source/WebCore/html/HTMLFrameSetElement.h:
* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::HTMLImageElement):
* Source/WebCore/html/HTMLImageElement.h:
* Source/WebCore/html/HTMLLIElement.cpp:
(WebCore::HTMLLIElement::HTMLLIElement):
* Source/WebCore/html/HTMLLIElement.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::HTMLMediaElement):
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/html/HTMLOptionElement.cpp:
(WebCore::HTMLOptionElement::HTMLOptionElement):
* Source/WebCore/html/HTMLOptionElement.h:
* Source/WebCore/html/HTMLPlugInElement.cpp:
(WebCore::HTMLPlugInElement::HTMLPlugInElement):
* Source/WebCore/html/HTMLPlugInElement.h:
* Source/WebCore/html/HTMLProgressElement.cpp:
(WebCore::HTMLProgressElement::HTMLProgressElement):
* Source/WebCore/html/HTMLProgressElement.h:
* Source/WebCore/html/HTMLUnknownElement.h:
* Source/WebCore/html/shadow/DateTimeFieldElement.cpp:
(WebCore::DateTimeFieldElement::DateTimeFieldElement):
* Source/WebCore/html/shadow/DateTimeFieldElement.h:
* Source/WebCore/html/shadow/SliderThumbElement.cpp:
(WebCore::SliderThumbElement::SliderThumbElement):
(WebCore::SliderContainerElement::SliderContainerElement):
* Source/WebCore/html/shadow/SliderThumbElement.h:
* Source/WebCore/html/shadow/SpinButtonElement.cpp:
(WebCore::SpinButtonElement::SpinButtonElement):
* Source/WebCore/html/shadow/SpinButtonElement.h:
* Source/WebCore/html/shadow/SwitchThumbElement.cpp:
(WebCore::SwitchThumbElement::SwitchThumbElement):
* Source/WebCore/html/shadow/SwitchThumbElement.h:
* Source/WebCore/html/shadow/SwitchTrackElement.cpp:
(WebCore::SwitchTrackElement::SwitchTrackElement):
* Source/WebCore/html/shadow/SwitchTrackElement.h:
* Source/WebCore/html/shadow/TextControlInnerElements.cpp:
(WebCore::TextControlInnerContainer::TextControlInnerContainer):
(WebCore::TextControlInnerElement::TextControlInnerElement):
(WebCore::TextControlInnerTextElement::TextControlInnerTextElement):
(WebCore::TextControlPlaceholderElement::TextControlPlaceholderElement):
(WebCore::SearchFieldResultsButtonElement::SearchFieldResultsButtonElement):
(WebCore::SearchFieldCancelButtonElement::SearchFieldCancelButtonElement):
* Source/WebCore/html/shadow/TextControlInnerElements.h:
* Source/WebCore/html/track/TextTrackCue.cpp:
(WebCore::TextTrackCueBox::TextTrackCueBox):
* Source/WebCore/html/track/TextTrackCue.h:
* Source/WebCore/html/track/WebVTTElement.cpp:
(WebCore::WebVTTElement::WebVTTElement):
* Source/WebCore/mathml/MathMLElement.cpp:
(WebCore::MathMLElement::MathMLElement):
* Source/WebCore/mathml/MathMLElement.h:
(WebCore::MathMLElement::MathMLElement):
* Source/WebCore/mathml/MathMLMathElement.cpp:
(WebCore::MathMLMathElement::MathMLMathElement):
* Source/WebCore/mathml/MathMLMathElement.h:
* Source/WebCore/mathml/MathMLPresentationElement.h:
(WebCore::MathMLPresentationElement::MathMLPresentationElement):
* Source/WebCore/mathml/MathMLRowElement.h:
(WebCore::MathMLRowElement::MathMLRowElement):
* Source/WebCore/mathml/MathMLTokenElement.cpp:
(WebCore::MathMLTokenElement::MathMLTokenElement):
* Source/WebCore/mathml/MathMLTokenElement.h:
* Source/WebCore/mathml/MathMLUnknownElement.h:
* Source/WebCore/svg/SVGElement.cpp:
(WebCore::SVGElement::SVGElement):
* Source/WebCore/svg/SVGElement.h:
(WebCore::SVGElement::SVGElement):
* Source/WebCore/svg/SVGUnknownElement.h:
</pre>
----------------------------------------------------------------------
#### 2c857d46a9a591df1360a917da596d42d26369d1
<pre>
Inline NodeType in C++ side
<a href="https://bugs.webkit.org/show_bug.cgi?id=266829">https://bugs.webkit.org/show_bug.cgi?id=266829</a>

Reviewed by NOBODY (OOPS!).

This PR inlines Node::nodeType in Node.h by using the remaining bits in m_typeFlags.
To do this optimization, we take the advantage of the fact nodeType is now fast to obtain,
and replace two of the existing TypeFlags (IsDocumentFragment and IsText) in favor of
checking nodeType instead.

* Source/WebCore/dom/Attr.cpp:
(WebCore::Attr::Attr):
* Source/WebCore/dom/Attr.h:
* Source/WebCore/dom/CDATASection.cpp:
(WebCore::CDATASection::CDATASection):
(WebCore::CDATASection::nodeType const): Deleted.
* Source/WebCore/dom/CDATASection.h:
* Source/WebCore/dom/CharacterData.h:
(WebCore::CharacterData::CharacterData):
* Source/WebCore/dom/Comment.cpp:
(WebCore::Comment::Comment):
(WebCore::Comment::nodeType const): Deleted.
* Source/WebCore/dom/Comment.h:
* Source/WebCore/dom/ContainerNode.h:
(WebCore::ContainerNode::ContainerNode):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::Document):
(WebCore::Document::nodeType const): Deleted.
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/DocumentFragment.cpp:
(WebCore::DocumentFragment::DocumentFragment):
(WebCore::DocumentFragment::create):
(WebCore::DocumentFragment::createForInnerOuterHTML):
(WebCore::DocumentFragment::nodeType const): Deleted.
* Source/WebCore/dom/DocumentFragment.h:
* Source/WebCore/dom/DocumentType.cpp:
(WebCore::DocumentType::DocumentType):
(WebCore::DocumentType::nodeType const): Deleted.
* Source/WebCore/dom/DocumentType.h:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::Element):
(WebCore::Element::nodeType const): Deleted.
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::Node):
* Source/WebCore/dom/Node.h:
(WebCore::Node::nodeType const):
(WebCore::Node::isDocumentNode const):
(WebCore::Node::isTreeScope const):
(WebCore::Node::isDocumentFragment const):
(WebCore::Node::typeFlagsMemoryOffset):
(WebCore::Node::constructBitFieldsFromNodeTypeAndFlags):
(WebCore::Node::nodeTypeFromBitFields):
(WebCore::Node::hasTypeFlag const):
* Source/WebCore/dom/ProcessingInstruction.cpp:
(WebCore::ProcessingInstruction::ProcessingInstruction):
(WebCore::ProcessingInstruction::nodeType const): Deleted.
* Source/WebCore/dom/ProcessingInstruction.h:
* Source/WebCore/dom/TemplateContentDocumentFragment.h:
* Source/WebCore/dom/Text.cpp:
(WebCore::Text::create):
(WebCore::Text::createEditingText):
(WebCore::Text::nodeType const): Deleted.
* Source/WebCore/dom/Text.h:
(WebCore::Text::Text):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c11b717094bb29ce1bc8b2eba53fc2eb9a4ece15

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31753 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10438 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33483 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34247 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28754 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32541 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12798 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7684 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28345 "Found 12 new test failures: fast/css/object-fit/object-fit-video-poster.html, fast/mediastream/mediaPlayer-visibility.html, http/tests/webrtc/paused-video-mediastream-invisible-autoplay.html, imported/w3c/web-platform-tests/quirks/table-cell-width-calculation.html, media/video-concurrent-visible-playback.html, media/video-main-content-allow-then-deny.html, media/video-main-content-allow-then-scroll.html, media/video-main-content-autoplay.html, media/video-restricted-invisible-autoplay-allowed-if-audible.html, media/video-restricted-invisible-autoplay-allowed-when-visible.html ... (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32108 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8803 "Found 18 new test failures: fast/css/object-fit/object-fit-video-poster.html, fast/mediastream/mediaPlayer-visibility.html, fast/mediastream/video-mediastream-restricted-invisible-autoplay-not-allowed.html, fast/mediastream/video-mediastream-restricted-invisible-autoplay-user-click.html, fast/mediastream/video-srcObject-fit-fill.html, fast/mediastream/video-srcObject-set-twice.html, http/tests/webrtc/muted-video-mediastream-invisible-autoplay.html, http/tests/webrtc/paused-video-mediastream-invisible-autoplay.html, http/tests/webrtc/video-mediastream-invisible-autoplay-detached.html, media/video-concurrent-visible-playback.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28344 "2 api tests failed or timed out") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7594 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7763 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28258 "Found 8 new test failures: fast/css/object-fit/object-fit-video-poster.html, imported/w3c/web-platform-tests/quirks/table-cell-width-calculation.html, media/video-concurrent-visible-playback.html, media/video-main-content-allow-then-deny.html, media/video-main-content-allow.html, media/video-main-content-autoplay.html, media/video-restricted-invisible-autoplay-allowed-if-audible.html, media/video-restricted-invisible-autoplay-allowed-when-visible.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35594 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28867 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28706 "Found 18 new test failures: fast/css/object-fit/object-fit-video-poster.html, fast/mediastream/mediaPlayer-visibility.html, fast/mediastream/video-mediastream-restricted-invisible-autoplay-not-allowed.html, fast/mediastream/video-mediastream-restricted-invisible-autoplay-user-click.html, fast/mediastream/video-rotation2.html, fast/mediastream/video-srcObject-fit-fill.html, http/tests/webrtc/muted-video-mediastream-invisible-autoplay.html, http/tests/webrtc/paused-video-mediastream-invisible-autoplay.html, http/tests/webrtc/video-mediastream-invisible-autoplay-detached.html, imported/w3c/web-platform-tests/quirks/table-cell-width-calculation.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33879 "Found 13 new test failures: compositing/video/poster.html, fast/css/object-fit/object-fit-video-poster.html, fast/mediastream/mediaPlayer-visibility.html, http/tests/webrtc/paused-video-mediastream-invisible-autoplay.html, imported/w3c/web-platform-tests/quirks/table-cell-width-calculation.html, media/video-concurrent-visible-playback.html, media/video-main-content-allow-then-deny.html, media/video-main-content-allow-then-scroll.html, media/video-main-content-allow.html, media/video-restricted-invisible-autoplay-allowed-if-audible.html ... (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7854 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5854 "Found 17 new test failures: fast/css/object-fit/object-fit-video-poster.html, fast/mediastream/mediaPlayer-visibility.html, fast/mediastream/video-mediastream-restricted-invisible-autoplay-not-allowed.html, fast/mediastream/video-mediastream-restricted-invisible-autoplay-user-click.html, fast/mediastream/video-rotation2.html, fast/mediastream/video-srcObject-fit-fill.html, http/tests/webrtc/muted-video-mediastream-invisible-autoplay.html, http/tests/webrtc/paused-video-mediastream-invisible-autoplay.html, http/tests/webrtc/video-mediastream-invisible-autoplay-detached.html, imported/w3c/web-platform-tests/quirks/table-cell-width-calculation.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31735 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9508 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8529 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8371 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->