### PR TITLE
JSTests options need to be updated after 272208@main.

### DIFF
--- a/JSTests/stress/bad-osr-exit-checkpoint-state-assertion-during-js-lock-destruction.js
+++ b/JSTests/stress/bad-osr-exit-checkpoint-state-assertion-during-js-lock-destruction.js
@@ -1,4 +1,4 @@
-//@ runDefault("--maximumInliningRecursion=10", "--maximumInliningDepth=10", "--maximumFunctionForConstructInlineCandidateBytecoodeCost=1000", "--maximumFunctionForClosureCallInlineCandidateBytecodeCost=1000", "--maximumFunctionForCallInlineCandidateBytecodeCost=1000", "--useConcurrentJIT=0")
+//@ runDefault("--maximumInliningRecursion=10", "--maximumInliningDepth=10", "--maximumFunctionForConstructInlineCandidateBytecodeCostForDFG=1000", "--maximumFunctionForConstructInlineCandidateBytecodeCostForFTL=1000", "--maximumFunctionForClosureCallInlineCandidateBytecodeCostForDFG=1000", "--maximumFunctionForClosureCallInlineCandidateBytecodeCostForFTL=1000", "--maximumFunctionForCallInlineCandidateBytecodeCostForDFG=1000", "--maximumFunctionForCallInlineCandidateBytecodeCostForFTL=1000", "--useConcurrentJIT=0")
 
 let depth;
 const limit = 5;

--- a/JSTests/stress/dfg-scan-inlined-tail-caller-frames-liveness.js
+++ b/JSTests/stress/dfg-scan-inlined-tail-caller-frames-liveness.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--jitPolicyScale=0", "--maximumFunctionForCallInlineCandidateInstructionCount=1000", "--validateFTLOSRExitLiveness=1")
+//@ requireOptions("--jitPolicyScale=0", "--maximumFunctionForCallInlineCandidateBytecodeCostForDFG=1000", "--maximumFunctionForCallInlineCandidateBytecodeCostForFTL=1000", "--validateFTLOSRExitLiveness=1")
 
 for (let i = 0; i < 100000; i++) {
     (function foo() { [0].concat().indexOf(0) })()

--- a/JSTests/stress/early-return-from-builtin2.js
+++ b/JSTests/stress/early-return-from-builtin2.js
@@ -1,4 +1,4 @@
-//@ runDefault("--returnEarlyFromInfiniteLoopsForFuzzing=1", "--earlyReturnFromInfiniteLoopsLimit=1000", "--jitPolicyScale=0", "--maximumFunctionForCallInlineCandidateBytecodeCost=1000", "--useConcurrentJIT=0", "--useFTLJIT=0")
+//@ runDefault("--returnEarlyFromInfiniteLoopsForFuzzing=1", "--earlyReturnFromInfiniteLoopsLimit=1000", "--jitPolicyScale=0", "--maximumFunctionForCallInlineCandidateBytecodeCostForDFG=1000", "--maximumFunctionForCallInlineCandidateBytecodeCostForFTL=1000", "--useConcurrentJIT=0", "--useFTLJIT=0")
 const a = [null, 0, 0, 0, 0, 0, 0];
 
 function foo() {

--- a/JSTests/stress/eval-liveness-should-not-come-from-parser.js
+++ b/JSTests/stress/eval-liveness-should-not-come-from-parser.js
@@ -1,4 +1,4 @@
-//@ runDefault("--validateGraphAtEachPhase=1", "--validateFTLOSRExitLiveness=1", "--useConcurrentJIT=0", "--jitPolicyScale=0", "--maximumFunctionForCallInlineCandidateBytecodeCost=300")
+//@ runDefault("--validateGraphAtEachPhase=1", "--validateFTLOSRExitLiveness=1", "--useConcurrentJIT=0", "--jitPolicyScale=0", "--maximumFunctionForCallInlineCandidateBytecodeCostForDFG=300", "--maximumFunctionForCallInlineCandidateBytecodeCostForFTL=300")
 
 function foo(a0, a1) {
     if (a0) {

--- a/JSTests/stress/for-of-bad-internal-field-hoist.js
+++ b/JSTests/stress/for-of-bad-internal-field-hoist.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--maximumFunctionForCallInlineCandidateBytecodeCost=500")
+//@ requireOptions("--maximumFunctionForCallInlineCandidateBytecodeCostForDFG=500", "--maximumFunctionForCallInlineCandidateBytecodeCostForFTL=500")
 
 function foo() {
   let x = ''

--- a/JSTests/stress/inlining-for-of-should-validate.js
+++ b/JSTests/stress/inlining-for-of-should-validate.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--maximumFunctionForCallInlineCandidateBytecodeCost=1000")
+//@ requireOptions("--maximumFunctionForCallInlineCandidateBytecodeCostForDFG=1000", "--maximumFunctionForCallInlineCandidateBytecodeCostForFTL=1000")
 
 function bar() {
   foo();

--- a/JSTests/stress/verify-can-gc-node-index.js
+++ b/JSTests/stress/verify-can-gc-node-index.js
@@ -1,6 +1,6 @@
 // Often hits JSCTEST_memoryLimit on ARM with --memory-limited.
 //@ skip if $memoryLimited
-//@ runDefault("--destroy-vm", "--maximumFunctionForCallInlineCandidateBytecodeCost=500", "--maximumInliningRecursion=5")
+//@ runDefault("--destroy-vm", "--maximumFunctionForCallInlineCandidateBytecodeCostForDFG=500", "--maximumFunctionForCallInlineCandidateBytecodeCostForFTL=500", "--maximumInliningRecursion=5")
 
 function* gen() {
 }

--- a/Tools/Scripts/run-jsc-stress-tests
+++ b/Tools/Scripts/run-jsc-stress-tests
@@ -648,7 +648,7 @@ if $testWriter
 end
 
 # We force all tests to use a smaller (1.5M) stack so that stack overflow tests can run faster.
-BASE_OPTIONS = ["--useFTLJIT=false", "--useFunctionDotArguments=true", "--validateExceptionChecks=true", "--useDollarVM=true", "--maxPerThreadStackUsage=1572864"]
+BASE_OPTIONS = ["--validateOptions=true", "--useFTLJIT=false", "--useFunctionDotArguments=true", "--validateExceptionChecks=true", "--useDollarVM=true", "--maxPerThreadStackUsage=1572864"]
 EAGER_OPTIONS = ["--thresholdForJITAfterWarmUp=10", "--thresholdForJITSoon=10", "--thresholdForOptimizeAfterWarmUp=20", "--thresholdForOptimizeAfterLongWarmUp=20", "--thresholdForOptimizeSoon=20", "--thresholdForFTLOptimizeAfterWarmUp=20", "--thresholdForFTLOptimizeSoon=20", "--thresholdForOMGOptimizeAfterWarmUp=20", "--thresholdForOMGOptimizeSoon=20", "--maximumEvalCacheableSourceLength=150000", "--useEagerCodeBlockJettisonTiming=true", "--repatchBufferingCountdown=0"]
 # NOTE: Tests rely on this using scribbleFreeCells.
 NO_CJIT_OPTIONS = ["--useConcurrentJIT=false", "--thresholdForJITAfterWarmUp=100", "--scribbleFreeCells=true"]
@@ -1631,12 +1631,12 @@ def runProfiler
 end
 
 def runExceptionFuzz
-    subCommand = escapeAll(vmCommand + ["--useDollarVM=true", "--useExceptionFuzz=true", $benchmark.to_s])
+    subCommand = escapeAll(vmCommand + ["--validateOptions=true", "--useDollarVM=true", "--useExceptionFuzz=true", $benchmark.to_s])
     addRunCommand("exception-fuzz", ["perl", (pathToHelpers + "js-exception-fuzz").to_s, subCommand], silentOutputHandler, simpleErrorHandler)
 end
 
 def runExecutableAllocationFuzz(name, *options)
-    subCommand = escapeAll(vmCommand + ["--useDollarVM=true", $benchmark.to_s] + options)
+    subCommand = escapeAll(vmCommand + ["--validateOptions=true", "--useDollarVM=true", $benchmark.to_s] + options)
     addRunCommand("executable-allocation-fuzz-" + name, ["perl", (pathToHelpers + "js-executable-allocation-fuzz").to_s, subCommand], silentOutputHandler, simpleErrorHandler)
 end
 


### PR DESCRIPTION
#### a6cfb812b779ddc109abb36193c8778dd54c8877
<pre>
JSTests options need to be updated after 272208@main.
<a href="https://bugs.webkit.org/show_bug.cgi?id=266837">https://bugs.webkit.org/show_bug.cgi?id=266837</a>
<a href="https://rdar.apple.com/120064300">rdar://120064300</a>

Reviewed by Justin Michaud.

Because --validateOptions=true is not enabled, some tests were silently ignoring required
options after the options got renamed / changed.

This patch also adds --validateOptions=true as a base option for JSC stress tests.  This will
ensure that such issues arising from options changing won&apos;t go unnoticed again.

* JSTests/stress/bad-osr-exit-checkpoint-state-assertion-during-js-lock-destruction.js:
* JSTests/stress/dfg-scan-inlined-tail-caller-frames-liveness.js:
* JSTests/stress/early-return-from-builtin2.js:
* JSTests/stress/eval-liveness-should-not-come-from-parser.js:
* JSTests/stress/for-of-bad-internal-field-hoist.js:
* JSTests/stress/inlining-for-of-should-validate.js:
* JSTests/stress/verify-can-gc-node-index.js:
* Tools/Scripts/run-jsc-stress-tests:

Canonical link: <a href="https://commits.webkit.org/272471@main">https://commits.webkit.org/272471@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0a85cc187d8cae5264804b5050e788a6f1ae9f3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31754 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10439 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33484 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34248 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28755 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32542 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12799 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7685 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28346 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32109 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8804 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28347 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7595 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7764 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28261 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35595 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/27250 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28868 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28720 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33880 "Passed tests") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/31817 "Found 1 new JSC binary failure: testapi (failure)") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7855 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5855 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31736 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9509 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/38266 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8530 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8118 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4146 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8372 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->