### PR TITLE
Turn PseudoElementType and PagePseudoClassType into enum classes

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -2554,13 +2554,13 @@ add_custom_command(
     VERBATIM)
 list(APPEND WebCore_SOURCES ${WebCore_DERIVED_SOURCES_DIR}/SelectorPseudoClassAndCompatibilityElementMap.cpp)
 add_custom_command(
-    OUTPUT ${WebCore_DERIVED_SOURCES_DIR}/SelectorPseudoElementTypeMap.gperf ${WebCore_DERIVED_SOURCES_DIR}/SelectorPseudoElementTypeMap.cpp
-    MAIN_DEPENDENCY ${WEBCORE_DIR}/css/SelectorPseudoElementTypeMap.in
+    OUTPUT ${WebCore_DERIVED_SOURCES_DIR}/SelectorPseudoElementMap.gperf ${WebCore_DERIVED_SOURCES_DIR}/SelectorPseudoElementMap.cpp
+    MAIN_DEPENDENCY ${WEBCORE_DIR}/css/SelectorPseudoElementMap.in
     DEPENDS ${WEBCORE_DIR}/css/makeSelectorPseudoElementsMap.py
     WORKING_DIRECTORY ${WebCore_DERIVED_SOURCES_DIR}
-    COMMAND ${PYTHON_EXECUTABLE} ${WEBCORE_DIR}/css/makeSelectorPseudoElementsMap.py ${WEBCORE_DIR}/css/SelectorPseudoElementTypeMap.in "${GPERF_EXECUTABLE}" "${FEATURE_DEFINES_WITH_SPACE_SEPARATOR}"
+    COMMAND ${PYTHON_EXECUTABLE} ${WEBCORE_DIR}/css/makeSelectorPseudoElementsMap.py ${WEBCORE_DIR}/css/SelectorPseudoElementMap.in "${GPERF_EXECUTABLE}" "${FEATURE_DEFINES_WITH_SPACE_SEPARATOR}"
     VERBATIM)
-list(APPEND WebCore_SOURCES ${WebCore_DERIVED_SOURCES_DIR}/SelectorPseudoElementTypeMap.cpp)
+list(APPEND WebCore_SOURCES ${WebCore_DERIVED_SOURCES_DIR}/SelectorPseudoElementMap.cpp)
 
 # Generate user agent styles
 add_custom_command(

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1243,7 +1243,7 @@ $(PROJECT_DIR)/css/MediaQueryList.idl
 $(PROJECT_DIR)/css/MediaQueryListEvent.idl
 $(PROJECT_DIR)/css/SVGCSSValueKeywords.in
 $(PROJECT_DIR)/css/SelectorPseudoClassAndCompatibilityElementMap.in
-$(PROJECT_DIR)/css/SelectorPseudoElementTypeMap.in
+$(PROJECT_DIR)/css/SelectorPseudoElementMap.in
 $(PROJECT_DIR)/css/StyleMedia.idl
 $(PROJECT_DIR)/css/StyleSheet.idl
 $(PROJECT_DIR)/css/StyleSheetList.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -3434,7 +3434,7 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/SVGElementTypeHelpers.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/SVGNames.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/SVGNames.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/SelectorPseudoClassAndCompatibilityElementMap.cpp
-$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/SelectorPseudoElementTypeMap.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/SelectorPseudoElementMap.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/ServiceWorkerGlobalScopeConstructors.idl
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/Settings.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/Settings.h

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -1808,7 +1808,7 @@ all : \
     SVGNames.cpp \
     SVGNames.h \
     SelectorPseudoClassAndCompatibilityElementMap.cpp \
-    SelectorPseudoElementTypeMap.cpp \
+    SelectorPseudoElementMap.cpp \
     StyleBuilderGenerated.cpp \
     StylePropertyShorthandFunctions.cpp \
     StylePropertyShorthandFunctions.h \
@@ -1867,8 +1867,8 @@ $(CSS_VALUE_KEYWORD_FILES_PATTERNS) : $(WEBCORE_CSS_VALUE_KEYWORDS) $(WebCore)/c
 SelectorPseudoClassAndCompatibilityElementMap.cpp : $(WebCore)/css/makeSelectorPseudoClassAndCompatibilityElementMap.py $(WebCore)/css/SelectorPseudoClassAndCompatibilityElementMap.in $(FEATURE_AND_PLATFORM_DEFINE_DEPENDENCIES)
 	$(PYTHON) "$(WebCore)/css/makeSelectorPseudoClassAndCompatibilityElementMap.py" $(WebCore)/css/SelectorPseudoClassAndCompatibilityElementMap.in $(GPERF) "$(FEATURE_AND_PLATFORM_DEFINES)"
 
-SelectorPseudoElementTypeMap.cpp : $(WebCore)/css/makeSelectorPseudoElementsMap.py $(WebCore)/css/SelectorPseudoElementTypeMap.in $(FEATURE_AND_PLATFORM_DEFINE_DEPENDENCIES)
-	$(PYTHON) "$(WebCore)/css/makeSelectorPseudoElementsMap.py" $(WebCore)/css/SelectorPseudoElementTypeMap.in $(GPERF) "$(FEATURE_AND_PLATFORM_DEFINES)"
+SelectorPseudoElementMap.cpp : $(WebCore)/css/makeSelectorPseudoElementsMap.py $(WebCore)/css/SelectorPseudoElementMap.in $(FEATURE_AND_PLATFORM_DEFINE_DEPENDENCIES)
+	$(PYTHON) "$(WebCore)/css/makeSelectorPseudoElementsMap.py" $(WebCore)/css/SelectorPseudoElementMap.in $(GPERF) "$(FEATURE_AND_PLATFORM_DEFINES)"
 
 # --------
 

--- a/Source/WebCore/animation/WebAnimationUtilities.cpp
+++ b/Source/WebCore/animation/WebAnimationUtilities.cpp
@@ -356,9 +356,9 @@ ExceptionOr<PseudoId> pseudoIdFromString(const String& pseudoElement)
 
     // FIXME: This parserContext should include a document to get the proper settings.
     CSSSelectorParserContext parserContext { CSSParserContext { HTMLStandardMode } };
-    auto pseudoType = CSSSelector::parsePseudoElementType(StringView(pseudoElement).substring(isLegacy ? 1 : 2), parserContext);
-    // FIXME: Excluding CSSSelector::PseudoElementWebKitCustom is almost certainly a bug.
-    if (!pseudoType || pseudoType == CSSSelector::PseudoElementWebKitCustom)
+    auto pseudoType = CSSSelector::parsePseudoElement(StringView(pseudoElement).substring(isLegacy ? 1 : 2), parserContext);
+    // FIXME: Excluding CSSSelector::PseudoElement::WebKitCustom is almost certainly a bug.
+    if (!pseudoType || pseudoType == CSSSelector::PseudoElement::WebKitCustom)
         return Exception { ExceptionCode::SyntaxError };
     return CSSSelector::pseudoId(*pseudoType);
 }

--- a/Source/WebCore/css/CSSComputedStyleDeclaration.cpp
+++ b/Source/WebCore/css/CSSComputedStyleDeclaration.cpp
@@ -56,7 +56,7 @@ CSSComputedStyleDeclaration::CSSComputedStyleDeclaration(Element& element, bool 
         name = name.substring(1);
     if (name.startsWith(':'))
         name = name.substring(1);
-    auto pseudoType = CSSSelector::parsePseudoElementType(name, CSSSelectorParserContext { element.document() });
+    auto pseudoType = CSSSelector::parsePseudoElement(name, CSSSelectorParserContext { element.document() });
     m_pseudoElementSpecifier = pseudoType ? CSSSelector::pseudoId(*pseudoType) : PseudoId::None;
 }
 

--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -203,7 +203,7 @@ SelectorSpecificity simpleSelectorSpecificity(const CSSSelector& simpleSelector)
     case CSSSelector::Match::PseudoElement:
         // Slotted only competes with other slotted selectors for specificity,
         // so whether we add the ClassC specificity shouldn't be observable.
-        if (simpleSelector.pseudoElementType() == CSSSelector::PseudoElementSlotted)
+        if (simpleSelector.pseudoElement() == CSSSelector::PseudoElement::Slotted)
             return maxSpecificity(simpleSelector.selectorList());
         return SelectorSpecificityIncrement::ClassC;
     case CSSSelector::Match::Unknown:
@@ -238,12 +238,12 @@ unsigned CSSSelector::specificityForPage() const
             s += tagQName().localName() == starAtom() ? 0 : 4;
             break;
         case Match::PagePseudoClass:
-            switch (component->pagePseudoClassType()) {
-            case PagePseudoClassFirst:
+            switch (component->pagePseudoClass()) {
+            case PagePseudoClass::First:
                 s += 2;
                 break;
-            case PagePseudoClassLeft:
-            case PagePseudoClassRight:
+            case PagePseudoClass::Left:
+            case PagePseudoClass::Right:
                 s += 1;
                 break;
             }
@@ -255,60 +255,60 @@ unsigned CSSSelector::specificityForPage() const
     return s;
 }
 
-PseudoId CSSSelector::pseudoId(PseudoElementType type)
+PseudoId CSSSelector::pseudoId(PseudoElement type)
 {
     switch (type) {
-    case PseudoElementFirstLine:
+    case PseudoElement::FirstLine:
         return PseudoId::FirstLine;
-    case PseudoElementFirstLetter:
+    case PseudoElement::FirstLetter:
         return PseudoId::FirstLetter;
-    case PseudoElementGrammarError:
+    case PseudoElement::GrammarError:
         return PseudoId::GrammarError;
-    case PseudoElementSpellingError:
+    case PseudoElement::SpellingError:
         return PseudoId::SpellingError;
-    case PseudoElementSelection:
+    case PseudoElement::Selection:
         return PseudoId::Selection;
-    case PseudoElementHighlight:
+    case PseudoElement::Highlight:
         return PseudoId::Highlight;
-    case PseudoElementMarker:
+    case PseudoElement::Marker:
         return PseudoId::Marker;
-    case PseudoElementBackdrop:
+    case PseudoElement::Backdrop:
         return PseudoId::Backdrop;
-    case PseudoElementBefore:
+    case PseudoElement::Before:
         return PseudoId::Before;
-    case PseudoElementAfter:
+    case PseudoElement::After:
         return PseudoId::After;
-    case PseudoElementScrollbar:
+    case PseudoElement::Scrollbar:
         return PseudoId::Scrollbar;
-    case PseudoElementScrollbarButton:
+    case PseudoElement::ScrollbarButton:
         return PseudoId::ScrollbarButton;
-    case PseudoElementScrollbarCorner:
+    case PseudoElement::ScrollbarCorner:
         return PseudoId::ScrollbarCorner;
-    case PseudoElementScrollbarThumb:
+    case PseudoElement::ScrollbarThumb:
         return PseudoId::ScrollbarThumb;
-    case PseudoElementScrollbarTrack:
+    case PseudoElement::ScrollbarTrack:
         return PseudoId::ScrollbarTrack;
-    case PseudoElementScrollbarTrackPiece:
+    case PseudoElement::ScrollbarTrackPiece:
         return PseudoId::ScrollbarTrackPiece;
-    case PseudoElementResizer:
+    case PseudoElement::Resizer:
         return PseudoId::Resizer;
-    case PseudoElementViewTransition:
+    case PseudoElement::ViewTransition:
         return PseudoId::ViewTransition;
-    case PseudoElementViewTransitionGroup:
+    case PseudoElement::ViewTransitionGroup:
         return PseudoId::ViewTransitionGroup;
-    case PseudoElementViewTransitionImagePair:
+    case PseudoElement::ViewTransitionImagePair:
         return PseudoId::ViewTransitionImagePair;
-    case PseudoElementViewTransitionOld:
+    case PseudoElement::ViewTransitionOld:
         return PseudoId::ViewTransitionOld;
-    case PseudoElementViewTransitionNew:
+    case PseudoElement::ViewTransitionNew:
         return PseudoId::ViewTransitionNew;
 #if ENABLE(VIDEO)
-    case PseudoElementCue:
+    case PseudoElement::Cue:
 #endif
-    case PseudoElementSlotted:
-    case PseudoElementPart:
-    case PseudoElementWebKitCustom:
-    case PseudoElementWebKitCustomLegacyPrefixed:
+    case PseudoElement::Slotted:
+    case PseudoElement::Part:
+    case PseudoElement::WebKitCustom:
+    case PseudoElement::WebKitCustomLegacyPrefixed:
         return PseudoId::None;
     }
 
@@ -316,7 +316,7 @@ PseudoId CSSSelector::pseudoId(PseudoElementType type)
     return PseudoId::None;
 }
 
-std::optional<CSSSelector::PseudoElementType> CSSSelector::parsePseudoElementType(StringView name, const CSSSelectorParserContext& context)
+std::optional<CSSSelector::PseudoElement> CSSSelector::parsePseudoElement(StringView name, const CSSSelectorParserContext& context)
 {
     if (name.isNull())
         return std::nullopt;
@@ -325,29 +325,29 @@ std::optional<CSSSelector::PseudoElementType> CSSSelector::parsePseudoElementTyp
     if (!type) {
         // FIXME: Investigate removing -apple- as it's non-standard.
         if (name.startsWithIgnoringASCIICase("-webkit-"_s) || name.startsWithIgnoringASCIICase("-apple-"_s))
-            return PseudoElementWebKitCustom;
+            return PseudoElement::WebKitCustom;
         return type;
     }
 
     switch (*type) {
-    case PseudoElementWebKitCustom:
+    case PseudoElement::WebKitCustom:
         if (!context.thumbAndTrackPseudoElementsEnabled && (equalLettersIgnoringASCIICase(name, "thumb"_s) || equalLettersIgnoringASCIICase(name, "track"_s)))
             return std::nullopt;
         break;
-    case PseudoElementHighlight:
+    case PseudoElement::Highlight:
         if (!context.highlightAPIEnabled)
             return std::nullopt;
         break;
-    case PseudoElementGrammarError:
-    case PseudoElementSpellingError:
+    case PseudoElement::GrammarError:
+    case PseudoElement::SpellingError:
         if (!context.grammarAndSpellingPseudoElementsEnabled)
             return std::nullopt;
         break;
-    case PseudoElementViewTransition:
-    case PseudoElementViewTransitionGroup:
-    case PseudoElementViewTransitionImagePair:
-    case PseudoElementViewTransitionOld:
-    case PseudoElementViewTransitionNew:
+    case PseudoElement::ViewTransition:
+    case PseudoElement::ViewTransitionGroup:
+    case PseudoElement::ViewTransitionImagePair:
+    case PseudoElement::ViewTransitionOld:
+    case PseudoElement::ViewTransitionNew:
         if (!context.viewTransitionsEnabled)
             return std::nullopt;
         break;
@@ -791,23 +791,23 @@ String CSSSelector::selectorText(StringView separator, StringView rightSide) con
                 break;
             }
         } else if (cs->match() == Match::PseudoElement) {
-            switch (cs->pseudoElementType()) {
-            case CSSSelector::PseudoElementSlotted:
+            switch (cs->pseudoElement()) {
+            case CSSSelector::PseudoElement::Slotted:
                 builder.append("::slotted("_s);
                 cs->selectorList()->buildSelectorsText(builder);
                 builder.append(')');
                 break;
-            case CSSSelector::PseudoElementHighlight:
-            case CSSSelector::PseudoElementViewTransitionGroup:
-            case CSSSelector::PseudoElementViewTransitionImagePair:
-            case CSSSelector::PseudoElementViewTransitionOld:
-            case CSSSelector::PseudoElementViewTransitionNew: {
+            case CSSSelector::PseudoElement::Highlight:
+            case CSSSelector::PseudoElement::ViewTransitionGroup:
+            case CSSSelector::PseudoElement::ViewTransitionImagePair:
+            case CSSSelector::PseudoElement::ViewTransitionOld:
+            case CSSSelector::PseudoElement::ViewTransitionNew: {
                 builder.append("::"_s, cs->serializingValue(), '(');
                 serializeIdentifierOrStar(cs->argumentList()->first().identifier);
                 builder.append(')');
                 break;
             }
-            case CSSSelector::PseudoElementPart: {
+            case CSSSelector::PseudoElement::Part: {
                 builder.append("::part("_s);
                 bool isFirst = true;
                 for (auto& partName : *cs->argumentList()) {
@@ -819,14 +819,14 @@ String CSSSelector::selectorText(StringView separator, StringView rightSide) con
                 builder.append(')');
                 break;
             }
-            case CSSSelector::PseudoElementWebKitCustomLegacyPrefixed:
+            case CSSSelector::PseudoElement::WebKitCustomLegacyPrefixed:
                 if (cs->value() == "placeholder"_s)
                     builder.append("::-webkit-input-placeholder"_s);
                 if (cs->value() == "file-selector-button"_s)
                     builder.append("::-webkit-file-upload-button"_s);
                 break;
 #if ENABLE(VIDEO)
-            case CSSSelector::PseudoElementCue: {
+            case CSSSelector::PseudoElement::Cue: {
                 if (auto* selectorList = cs->selectorList()) {
                     builder.append("::cue("_s);
                     selectorList->buildSelectorsText(builder);
@@ -881,14 +881,14 @@ String CSSSelector::selectorText(StringView separator, StringView rightSide) con
                     builder.append(']');
             }
         } else if (cs->match() == Match::PagePseudoClass) {
-            switch (cs->pagePseudoClassType()) {
-            case PagePseudoClassFirst:
+            switch (cs->pagePseudoClass()) {
+            case PagePseudoClass::First:
                 builder.append(":first");
                 break;
-            case PagePseudoClassLeft:
+            case PagePseudoClass::Left:
                 builder.append(":left");
                 break;
-            case PagePseudoClassRight:
+            case PagePseudoClass::Right:
                 builder.append(":right");
                 break;
             }

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -201,68 +201,49 @@ struct PossiblyQuotedIdentifier {
             UserValid
         };
 
-        enum PseudoElementType {
-            PseudoElementAfter,
-            PseudoElementBackdrop,
-            PseudoElementBefore,
+        enum class PseudoElement : uint8_t {
+            After,
+            Backdrop,
+            Before,
 #if ENABLE(VIDEO)
-            PseudoElementCue,
+            Cue,
 #endif
-            PseudoElementFirstLetter,
-            PseudoElementFirstLine,
-            PseudoElementGrammarError,
-            PseudoElementHighlight,
-            PseudoElementMarker,
-            PseudoElementPart,
-            PseudoElementResizer,
-            PseudoElementScrollbar,
-            PseudoElementScrollbarButton,
-            PseudoElementScrollbarCorner,
-            PseudoElementScrollbarThumb,
-            PseudoElementScrollbarTrack,
-            PseudoElementScrollbarTrackPiece,
-            PseudoElementSelection,
-            PseudoElementSlotted,
-            PseudoElementSpellingError,
-            PseudoElementViewTransition,
-            PseudoElementViewTransitionGroup,
-            PseudoElementViewTransitionImagePair,
-            PseudoElementViewTransitionOld,
-            PseudoElementViewTransitionNew,
-            PseudoElementWebKitCustom,
+            FirstLetter,
+            FirstLine,
+            GrammarError,
+            Highlight,
+            Marker,
+            Part,
+            Resizer,
+            Scrollbar,
+            ScrollbarButton,
+            ScrollbarCorner,
+            ScrollbarThumb,
+            ScrollbarTrack,
+            ScrollbarTrackPiece,
+            Selection,
+            Slotted,
+            SpellingError,
+            ViewTransition,
+            ViewTransitionGroup,
+            ViewTransitionImagePair,
+            ViewTransitionOld,
+            ViewTransitionNew,
+            WebKitCustom,
 
             // WebKitCustom that appeared in an old prefixed form
             // and need special handling.
-            PseudoElementWebKitCustomLegacyPrefixed,
+            WebKitCustomLegacyPrefixed,
         };
 
-        enum PagePseudoClassType {
-            PagePseudoClassFirst = 1,
-            PagePseudoClassLeft,
-            PagePseudoClassRight,
+        enum class PagePseudoClass : uint8_t {
+            First,
+            Left,
+            Right,
         };
 
-        enum MarginBoxType {
-            TopLeftCornerMarginBox,
-            TopLeftMarginBox,
-            TopCenterMarginBox,
-            TopRightMarginBox,
-            TopRightCornerMarginBox,
-            BottomLeftCornerMarginBox,
-            BottomLeftMarginBox,
-            BottomCenterMarginBox,
-            BottomRightMarginBox,
-            BottomRightCornerMarginBox,
-            LeftTopMarginBox,
-            LeftMiddleMarginBox,
-            LeftBottomMarginBox,
-            RightTopMarginBox,
-            RightMiddleMarginBox,
-            RightBottomMarginBox,
-        };
-
-        static std::optional<PseudoElementType> parsePseudoElementType(StringView, const CSSSelectorParserContext&);
-        static PseudoId pseudoId(PseudoElementType);
+        static std::optional<PseudoElement> parsePseudoElement(StringView, const CSSSelectorParserContext&);
+        static PseudoId pseudoId(PseudoElement);
 
         // Selectors are kept in an array by CSSSelectorList.
         // The next component of the selector is the next item in the array.
@@ -301,11 +282,11 @@ struct PossiblyQuotedIdentifier {
         PseudoClass pseudoClass() const;
         void setPseudoClass(PseudoClass);
 
-        PseudoElementType pseudoElementType() const;
-        void setPseudoElementType(PseudoElementType);
+        PseudoElement pseudoElement() const;
+        void setPseudoElement(PseudoElement);
 
-        PagePseudoClassType pagePseudoClassType() const;
-        void setPagePseudoType(PagePseudoClassType);
+        PagePseudoClass pagePseudoClass() const;
+        void setPagePseudoClass(PagePseudoClass);
 
         bool matchesPseudoElement() const;
         bool isWebKitCustomPseudoElement() const;
@@ -412,7 +393,7 @@ inline bool CSSSelector::matchesPseudoElement() const
 
 inline bool CSSSelector::isWebKitCustomPseudoElement() const
 {
-    return pseudoElementType() == PseudoElementWebKitCustom || pseudoElementType() == PseudoElementWebKitCustomLegacyPrefixed;
+    return pseudoElement() == PseudoElement::WebKitCustom || pseudoElement() == PseudoElement::WebKitCustomLegacyPrefixed;
 }
 
 static inline bool pseudoClassIsRelativeToSiblings(CSSSelector::PseudoClass type)
@@ -555,27 +536,28 @@ inline void CSSSelector::setPseudoClass(PseudoClass pseudoClass)
     ASSERT(static_cast<PseudoClass>(m_pseudoType) == pseudoClass);
 }
 
-inline auto CSSSelector::pseudoElementType() const -> PseudoElementType
+inline auto CSSSelector::pseudoElement() const -> PseudoElement
 {
     ASSERT(match() == Match::PseudoElement);
-    return static_cast<PseudoElementType>(m_pseudoType);
+    return static_cast<PseudoElement>(m_pseudoType);
 }
 
-inline void CSSSelector::setPseudoElementType(PseudoElementType pseudoElementType)
+inline void CSSSelector::setPseudoElement(PseudoElement pseudoElement)
 {
-    m_pseudoType = pseudoElementType;
-    ASSERT(m_pseudoType == pseudoElementType);
+    m_pseudoType = enumToUnderlyingType(pseudoElement);
+    ASSERT(static_cast<PseudoElement>(m_pseudoType) == pseudoElement);
 }
 
-inline auto CSSSelector::pagePseudoClassType() const -> PagePseudoClassType
+inline auto CSSSelector::pagePseudoClass() const -> PagePseudoClass
 {
     ASSERT(match() == Match::PagePseudoClass);
-    return static_cast<PagePseudoClassType>(m_pseudoType);
+    return static_cast<PagePseudoClass>(m_pseudoType);
 }
 
-inline void CSSSelector::setPagePseudoType(PagePseudoClassType pagePseudoType)
+inline void CSSSelector::setPagePseudoClass(PagePseudoClass pagePseudoClass)
 {
-    m_pseudoType = pagePseudoType;
+    m_pseudoType = enumToUnderlyingType(pagePseudoClass);
+    ASSERT(static_cast<PagePseudoClass>(m_pseudoType) == pagePseudoClass);
 }
 
 inline void CSSSelector::setRelation(Relation relation)

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -294,7 +294,7 @@ SelectorChecker::MatchResult SelectorChecker::matchRecursively(CheckingContext& 
             if (checkingContext.resolvingMode == Mode::QueryingRules)
                 return MatchResult::fails(Match::SelectorFailsCompletely);
 
-            PseudoId pseudoId = CSSSelector::pseudoId(context.selector->pseudoElementType());
+            auto pseudoId = CSSSelector::pseudoId(context.selector->pseudoElement());
             if (pseudoId != PseudoId::None)
                 dynamicPseudoIdSet.add(pseudoId);
             matchType = MatchType::VirtualPseudoElementOnly;
@@ -1132,9 +1132,9 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, const LocalCont
     }
 
     if (selector.match() == CSSSelector::Match::PseudoElement) {
-        switch (selector.pseudoElementType()) {
+        switch (selector.pseudoElement()) {
 #if ENABLE(VIDEO)
-        case CSSSelector::PseudoElementCue: {
+        case CSSSelector::PseudoElement::Cue: {
             LocalContext subcontext(context);
 
             const CSSSelector* const & selector = context.selector;
@@ -1149,7 +1149,7 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, const LocalCont
             return false;
         }
 #endif
-        case CSSSelector::PseudoElementSlotted: {
+        case CSSSelector::PseudoElement::Slotted: {
             if (!context.element->assignedSlot())
                 return false;
             // ::slotted matches after flattening so it can't match an active <slot>.
@@ -1164,7 +1164,7 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, const LocalCont
             PseudoIdSet ignoredDynamicPseudo;
             return matchRecursively(checkingContext, subcontext, ignoredDynamicPseudo).match == Match::SelectorMatches;
         }
-        case CSSSelector::PseudoElementPart: {
+        case CSSSelector::PseudoElement::Part: {
             auto translatePartNameToRuleScope = [&](AtomString partName) {
                 Vector<AtomString, 1> mappedNames { partName };
 
@@ -1200,7 +1200,7 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, const LocalCont
             return true;
         }
 
-        case CSSSelector::PseudoElementHighlight:
+        case CSSSelector::PseudoElement::Highlight:
             // Always matches when not specifically requested so it gets added to the pseudoIdSet.
             if (checkingContext.pseudoId == PseudoId::None)
                 return true;
@@ -1208,14 +1208,14 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, const LocalCont
                 return false;
             return selector.argumentList()->first() == checkingContext.nameIdentifier;
 
-        case CSSSelector::PseudoElementViewTransitionGroup:
-        case CSSSelector::PseudoElementViewTransitionImagePair:
-        case CSSSelector::PseudoElementViewTransitionOld:
-        case CSSSelector::PseudoElementViewTransitionNew: {
+        case CSSSelector::PseudoElement::ViewTransitionGroup:
+        case CSSSelector::PseudoElement::ViewTransitionImagePair:
+        case CSSSelector::PseudoElement::ViewTransitionOld:
+        case CSSSelector::PseudoElement::ViewTransitionNew: {
             // Always matches when not specifically requested so it gets added to the pseudoIdSet.
             if (checkingContext.pseudoId == PseudoId::None)
                 return true;
-            if (checkingContext.pseudoId != CSSSelector::pseudoId(selector.pseudoElementType()) || !selector.argumentList())
+            if (checkingContext.pseudoId != CSSSelector::pseudoId(selector.pseudoElement()) || !selector.argumentList())
                 return false;
 
             // Wildcard always matches.

--- a/Source/WebCore/css/SelectorPseudoClassAndCompatibilityElementMap.in
+++ b/Source/WebCore/css/SelectorPseudoClassAndCompatibilityElementMap.in
@@ -9,10 +9,10 @@
 -webkit-drag
 -webkit-full-page-media
 active
-after, std::nullopt, PseudoElementAfter
+after, std::nullopt, PseudoElement::After
 any-link
 autofill
-before, std::nullopt, PseudoElementBefore
+before, std::nullopt, PseudoElement::Before
 checked
 corner-present
 decrement
@@ -25,8 +25,8 @@ empty
 enabled
 end
 first-child
-first-letter, std::nullopt, PseudoElementFirstLetter
-first-line, std::nullopt, PseudoElementFirstLine
+first-letter, std::nullopt, PseudoElement::FirstLetter
+first-line, std::nullopt, PseudoElement::FirstLine
 first-of-type
 focus
 focus-visible

--- a/Source/WebCore/css/SelectorPseudoElementMap.in
+++ b/Source/WebCore/css/SelectorPseudoElementMap.in
@@ -10,10 +10,10 @@ grammar-error
 highlight
 marker
 part
-file-selector-button, PseudoElementWebKitCustom
-placeholder, PseudoElementWebKitCustom
--webkit-input-placeholder, PseudoElementWebKitCustomLegacyPrefixed
--webkit-file-upload-button, PseudoElementWebKitCustomLegacyPrefixed
+file-selector-button, PseudoElement::WebKitCustom
+placeholder, PseudoElement::WebKitCustom
+-webkit-input-placeholder, PseudoElement::WebKitCustomLegacyPrefixed
+-webkit-file-upload-button, PseudoElement::WebKitCustomLegacyPrefixed
 -webkit-resizer
 -webkit-scrollbar
 -webkit-scrollbar-button
@@ -24,8 +24,8 @@ placeholder, PseudoElementWebKitCustom
 selection
 slotted
 spelling-error
-thumb, PseudoElementWebKitCustom
-track, PseudoElementWebKitCustom
+thumb, PseudoElement::WebKitCustom
+track, PseudoElement::WebKitCustom
 view-transition
 view-transition-group
 view-transition-image-pair

--- a/Source/WebCore/css/SelectorPseudoTypeMap.h
+++ b/Source/WebCore/css/SelectorPseudoTypeMap.h
@@ -31,10 +31,10 @@ namespace WebCore {
 
 struct PseudoClassOrCompatibilityPseudoElement {
     std::optional<CSSSelector::PseudoClass> pseudoClass;
-    std::optional<CSSSelector::PseudoElementType> compatibilityPseudoElement;
+    std::optional<CSSSelector::PseudoElement> compatibilityPseudoElement;
 };
 
 PseudoClassOrCompatibilityPseudoElement parsePseudoClassAndCompatibilityElementString(StringView pseudoTypeString);
-std::optional<CSSSelector::PseudoElementType> parsePseudoElementString(StringView pseudoTypeString);
+std::optional<CSSSelector::PseudoElement> parsePseudoElementString(StringView pseudoTypeString);
 
 } // namespace WebCore

--- a/Source/WebCore/css/makeSelectorPseudoElementsMap.py
+++ b/Source/WebCore/css/makeSelectorPseudoElementsMap.py
@@ -29,7 +29,7 @@ import subprocess
 
 
 def enumerablePseudoType(stringPseudoType):
-    output = ['CSSSelector::PseudoElement']
+    output = ['CSSSelector::PseudoElement::']
 
     if stringPseudoType.endswith('('):
         stringPseudoType = stringPseudoType[:-1]
@@ -58,7 +58,8 @@ def enumerablePseudoType(stringPseudoType):
 def expand_ifdef_condition(condition):
     return condition.replace('(', '_').replace(')', '')
 
-output_file = open('SelectorPseudoElementTypeMap.gperf', 'w')
+
+output_file = open('SelectorPseudoElementMap.gperf', 'w')
 
 output_file.write("""
 %{
@@ -101,13 +102,13 @@ namespace WebCore {
 
 struct SelectorPseudoTypeEntry {
     const char* name;
-    std::optional<CSSSelector::PseudoElementType> type;
+    std::optional<CSSSelector::PseudoElement> type;
 };
 
 %}
 %struct-type
 %define initializer-suffix ,std::nullopt
-%define class-name SelectorPseudoElementTypeMapHash
+%define class-name SelectorPseudoElementMapHash
 %omit-struct-type
 %language=C++
 %readonly-tables
@@ -158,16 +159,16 @@ for line in input_file:
 
 output_file.write("""%%
 
-static inline std::optional<CSSSelector::PseudoElementType> parsePseudoElementString(const LChar* characters, unsigned length)
+static inline std::optional<CSSSelector::PseudoElement> parsePseudoElementString(const LChar* characters, unsigned length)
 {
-    if (const SelectorPseudoTypeEntry* entry = SelectorPseudoElementTypeMapHash::in_word_set(reinterpret_cast<const char*>(characters), length))
+    if (const SelectorPseudoTypeEntry* entry = SelectorPseudoElementMapHash::in_word_set(reinterpret_cast<const char*>(characters), length))
         return entry->type;
     return std::nullopt;
 }""")
 
 output_file.write("""
 
-static inline std::optional<CSSSelector::PseudoElementType> parsePseudoElementString(const UChar* characters, unsigned length)
+static inline std::optional<CSSSelector::PseudoElement> parsePseudoElementString(const UChar* characters, unsigned length)
 {
     const unsigned maxKeywordLength = %s;
     LChar buffer[maxKeywordLength];
@@ -186,7 +187,7 @@ static inline std::optional<CSSSelector::PseudoElementType> parsePseudoElementSt
 """ % longest_keyword)
 
 output_file.write("""
-std::optional<CSSSelector::PseudoElementType> parsePseudoElementString(StringView pseudoTypeString)
+std::optional<CSSSelector::PseudoElement> parsePseudoElementString(StringView pseudoTypeString)
 {
     if (pseudoTypeString.is8Bit())
         return parsePseudoElementString(pseudoTypeString.characters8(), pseudoTypeString.length());
@@ -204,6 +205,6 @@ gperf_command = sys.argv[2]
 if 'GPERF' in os.environ:
     gperf_command = os.environ['GPERF']
 
-if subprocess.call([gperf_command, '--key-positions=*', '-m', '10', '-s', '2', 'SelectorPseudoElementTypeMap.gperf', '--output-file=SelectorPseudoElementTypeMap.cpp']) != 0:
-    print("Error when generating SelectorPseudoElementTypeMap.cpp from SelectorPseudoElementTypeMap.gperf :(")
+if subprocess.call([gperf_command, '--key-positions=*', '-m', '10', '-s', '2', 'SelectorPseudoElementMap.gperf', '--output-file=SelectorPseudoElementMap.cpp']) != 0:
+    print("Error when generating SelectorPseudoElementMap.cpp from SelectorPseudoElementMap.gperf :(")
     sys.exit(gperf_return)

--- a/Source/WebCore/css/parser/CSSParserSelector.cpp
+++ b/Source/WebCore/css/parser/CSSParserSelector.cpp
@@ -34,33 +34,33 @@ namespace WebCore {
 
 std::unique_ptr<CSSParserSelector> CSSParserSelector::parsePagePseudoSelector(StringView pseudoTypeString)
 {
-    CSSSelector::PagePseudoClassType pseudoType;
+    CSSSelector::PagePseudoClass pseudoType;
     if (equalLettersIgnoringASCIICase(pseudoTypeString, "first"_s))
-        pseudoType = CSSSelector::PagePseudoClassFirst;
+        pseudoType = CSSSelector::PagePseudoClass::First;
     else if (equalLettersIgnoringASCIICase(pseudoTypeString, "left"_s))
-        pseudoType = CSSSelector::PagePseudoClassLeft;
+        pseudoType = CSSSelector::PagePseudoClass::Left;
     else if (equalLettersIgnoringASCIICase(pseudoTypeString, "right"_s))
-        pseudoType = CSSSelector::PagePseudoClassRight;
+        pseudoType = CSSSelector::PagePseudoClass::Right;
     else
         return nullptr;
 
     auto selector = makeUnique<CSSParserSelector>();
     selector->m_selector->setMatch(CSSSelector::Match::PagePseudoClass);
-    selector->m_selector->setPagePseudoType(pseudoType);
+    selector->m_selector->setPagePseudoClass(pseudoType);
     return selector;
 }
 
 std::unique_ptr<CSSParserSelector> CSSParserSelector::parsePseudoElementSelector(StringView pseudoTypeString, const CSSSelectorParserContext& context)
 {
-    auto pseudoType = CSSSelector::parsePseudoElementType(pseudoTypeString, context);
+    auto pseudoType = CSSSelector::parsePseudoElement(pseudoTypeString, context);
     if (!pseudoType)
         return nullptr;
 
     auto selector = makeUnique<CSSParserSelector>();
     selector->m_selector->setMatch(CSSSelector::Match::PseudoElement);
-    selector->m_selector->setPseudoElementType(*pseudoType);
+    selector->m_selector->setPseudoElement(*pseudoType);
     AtomString name;
-    if (*pseudoType != CSSSelector::PseudoElementWebKitCustomLegacyPrefixed)
+    if (*pseudoType != CSSSelector::PseudoElement::WebKitCustomLegacyPrefixed)
         name = pseudoTypeString.convertToASCIILowercaseAtom();
     else {
         if (equalLettersIgnoringASCIICase(pseudoTypeString, "-webkit-input-placeholder"_s))
@@ -88,7 +88,7 @@ std::unique_ptr<CSSParserSelector> CSSParserSelector::parsePseudoClassSelector(S
     if (pseudoType.compatibilityPseudoElement) {
         auto selector = makeUnique<CSSParserSelector>();
         selector->m_selector->setMatch(CSSSelector::Match::PseudoElement);
-        selector->m_selector->setPseudoElementType(*pseudoType.compatibilityPseudoElement);
+        selector->m_selector->setPseudoElement(*pseudoType.compatibilityPseudoElement);
         selector->m_selector->setValue(pseudoTypeString.convertToASCIILowercaseAtom());
         return selector;
     }

--- a/Source/WebCore/css/parser/CSSParserSelector.h
+++ b/Source/WebCore/css/parser/CSSParserSelector.h
@@ -65,10 +65,10 @@ public:
     void setForPage() { m_selector->setForPage(); }
 
     CSSSelector::Match match() const { return m_selector->match(); }
-    CSSSelector::PseudoElementType pseudoElementType() const { return m_selector->pseudoElementType(); }
+    CSSSelector::PseudoElement pseudoElement() const { return m_selector->pseudoElement(); }
     const CSSSelectorList* selectorList() const { return m_selector->selectorList(); }
     
-    void setPseudoElementType(CSSSelector::PseudoElementType type) { m_selector->setPseudoElementType(type); }
+    void setPseudoElement(CSSSelector::PseudoElement type) { m_selector->setPseudoElement(type); }
     void setPseudoClass(CSSSelector::PseudoClass type) { m_selector->setPseudoClass(type); }
 
     void adoptSelectorVector(Vector<std::unique_ptr<CSSParserSelector>>&&);
@@ -113,19 +113,19 @@ private:
 inline bool CSSParserSelector::needsImplicitShadowCombinatorForMatching() const
 {
     return match() == CSSSelector::Match::PseudoElement
-        && (pseudoElementType() == CSSSelector::PseudoElementWebKitCustom
+        && (pseudoElement() == CSSSelector::PseudoElement::WebKitCustom
 #if ENABLE(VIDEO)
-            || pseudoElementType() == CSSSelector::PseudoElementCue
+            || pseudoElement() == CSSSelector::PseudoElement::Cue
 #endif
-            || pseudoElementType() == CSSSelector::PseudoElementPart
-            || pseudoElementType() == CSSSelector::PseudoElementSlotted
-            || pseudoElementType() == CSSSelector::PseudoElementWebKitCustomLegacyPrefixed);
+            || pseudoElement() == CSSSelector::PseudoElement::Part
+            || pseudoElement() == CSSSelector::PseudoElement::Slotted
+            || pseudoElement() == CSSSelector::PseudoElement::WebKitCustomLegacyPrefixed);
 }
 
 inline bool CSSParserSelector::isPseudoElementCueFunction() const
 {
 #if ENABLE(VIDEO)
-    return m_selector->match() == CSSSelector::Match::PseudoElement && m_selector->pseudoElementType() == CSSSelector::PseudoElementCue;
+    return m_selector->match() == CSSSelector::Match::PseudoElement && m_selector->pseudoElement() == CSSSelector::PseudoElement::Cue;
 #else
     return false;
 #endif

--- a/Source/WebCore/css/parser/CSSSelectorParser.h
+++ b/Source/WebCore/css/parser/CSSSelectorParser.h
@@ -107,7 +107,7 @@ private:
     bool m_resistDefaultNamespace { false };
     bool m_ignoreDefaultNamespace { false };
     bool m_disableForgivingParsing { false };
-    std::optional<CSSSelector::PseudoElementType> m_precedingPseudoElement;
+    std::optional<CSSSelector::PseudoElement> m_precedingPseudoElement;
 };
 
 std::optional<CSSSelectorList> parseCSSSelectorList(CSSParserTokenRange, const CSSSelectorParserContext&, StyleSheetContents* = nullptr, CSSParserEnum::IsNestedContext = CSSParserEnum::IsNestedContext::No);

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -1471,39 +1471,39 @@ static FunctionType constructFragmentsInternal(const CSSSelector* rootSelector, 
             if (selectorContext == SelectorContext::QuerySelector)
                 return FunctionType::CannotMatchAnything;
 
-            switch (selector->pseudoElementType()) {
-            case CSSSelector::PseudoElementAfter:
-            case CSSSelector::PseudoElementBackdrop:
-            case CSSSelector::PseudoElementBefore:
-            case CSSSelector::PseudoElementFirstLetter:
-            case CSSSelector::PseudoElementFirstLine:
-            case CSSSelector::PseudoElementGrammarError:
-            case CSSSelector::PseudoElementMarker:
-            case CSSSelector::PseudoElementResizer:
-            case CSSSelector::PseudoElementScrollbar:
-            case CSSSelector::PseudoElementScrollbarButton:
-            case CSSSelector::PseudoElementScrollbarCorner:
-            case CSSSelector::PseudoElementScrollbarThumb:
-            case CSSSelector::PseudoElementScrollbarTrack:
-            case CSSSelector::PseudoElementScrollbarTrackPiece:
-            case CSSSelector::PseudoElementSelection:
-            case CSSSelector::PseudoElementSpellingError:
-            case CSSSelector::PseudoElementViewTransition:
-            case CSSSelector::PseudoElementWebKitCustom:
-            case CSSSelector::PseudoElementWebKitCustomLegacyPrefixed:
+            switch (selector->pseudoElement()) {
+            case CSSSelector::PseudoElement::After:
+            case CSSSelector::PseudoElement::Backdrop:
+            case CSSSelector::PseudoElement::Before:
+            case CSSSelector::PseudoElement::FirstLetter:
+            case CSSSelector::PseudoElement::FirstLine:
+            case CSSSelector::PseudoElement::GrammarError:
+            case CSSSelector::PseudoElement::Marker:
+            case CSSSelector::PseudoElement::Resizer:
+            case CSSSelector::PseudoElement::Scrollbar:
+            case CSSSelector::PseudoElement::ScrollbarButton:
+            case CSSSelector::PseudoElement::ScrollbarCorner:
+            case CSSSelector::PseudoElement::ScrollbarThumb:
+            case CSSSelector::PseudoElement::ScrollbarTrack:
+            case CSSSelector::PseudoElement::ScrollbarTrackPiece:
+            case CSSSelector::PseudoElement::Selection:
+            case CSSSelector::PseudoElement::SpellingError:
+            case CSSSelector::PseudoElement::ViewTransition:
+            case CSSSelector::PseudoElement::WebKitCustom:
+            case CSSSelector::PseudoElement::WebKitCustomLegacyPrefixed:
                 ASSERT(!fragment->pseudoElementSelector);
                 fragment->pseudoElementSelector = selector;
                 break;
 #if ENABLE(VIDEO)
-            case CSSSelector::PseudoElementCue:
+            case CSSSelector::PseudoElement::Cue:
 #endif
-            case CSSSelector::PseudoElementHighlight:
-            case CSSSelector::PseudoElementPart:
-            case CSSSelector::PseudoElementSlotted:
-            case CSSSelector::PseudoElementViewTransitionGroup:
-            case CSSSelector::PseudoElementViewTransitionImagePair:
-            case CSSSelector::PseudoElementViewTransitionOld:
-            case CSSSelector::PseudoElementViewTransitionNew:
+            case CSSSelector::PseudoElement::Highlight:
+            case CSSSelector::PseudoElement::Part:
+            case CSSSelector::PseudoElement::Slotted:
+            case CSSSelector::PseudoElement::ViewTransitionGroup:
+            case CSSSelector::PseudoElement::ViewTransitionImagePair:
+            case CSSSelector::PseudoElement::ViewTransitionOld:
+            case CSSSelector::PseudoElement::ViewTransitionNew:
                 return FunctionType::CannotCompile;
             }
 
@@ -4422,7 +4422,7 @@ void SelectorCodeGenerator::generateRequestedPseudoElementEqualsToSelectorPseudo
             failureCases.append(m_assembler.branch8(Assembler::NotEqual, Assembler::Address(checkingContext, OBJECT_OFFSETOF(SelectorChecker::CheckingContext, pseudoId)), Assembler::TrustedImm32(static_cast<unsigned>(PseudoId::None))));
         else {
             Assembler::Jump skip = m_assembler.branch8(Assembler::Equal, Assembler::Address(checkingContext, OBJECT_OFFSETOF(SelectorChecker::CheckingContext, pseudoId)), Assembler::TrustedImm32(static_cast<unsigned>(PseudoId::None)));
-            failureCases.append(m_assembler.branch8(Assembler::NotEqual, Assembler::Address(checkingContext, OBJECT_OFFSETOF(SelectorChecker::CheckingContext, pseudoId)), Assembler::TrustedImm32(static_cast<unsigned>(CSSSelector::pseudoId(fragment.pseudoElementSelector->pseudoElementType())))));
+            failureCases.append(m_assembler.branch8(Assembler::NotEqual, Assembler::Address(checkingContext, OBJECT_OFFSETOF(SelectorChecker::CheckingContext, pseudoId)), Assembler::TrustedImm32(static_cast<unsigned>(CSSSelector::pseudoId(fragment.pseudoElementSelector->pseudoElement())))));
             skip.link(&m_assembler);
         }
     }
@@ -4512,7 +4512,7 @@ void SelectorCodeGenerator::generateMarkPseudoStyleForPseudoElement(Assembler::J
     successCases.append(branchOnResolvingModeWithCheckingContext(Assembler::Equal, SelectorChecker::Mode::CollectingRulesIgnoringVirtualPseudoElements, checkingContext));
 
     // When resolving mode is ResolvingStyle, mark the pseudo style for pseudo element.
-    PseudoId dynamicPseudo = CSSSelector::pseudoId(fragment.pseudoElementSelector->pseudoElementType());
+    PseudoId dynamicPseudo = CSSSelector::pseudoId(fragment.pseudoElementSelector->pseudoElement());
     if (dynamicPseudo < PseudoId::FirstInternalPseudoId) {
         failureCases.append(branchOnResolvingModeWithCheckingContext(Assembler::NotEqual, SelectorChecker::Mode::ResolvingStyle, checkingContext));
 

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -1668,7 +1668,7 @@ RefPtr<CSSRuleList> LocalDOMWindow::getMatchedCSSRules(Element* element, const S
 
     // FIXME: This parser context won't get the right settings without a document.
     auto parserContext = document() ? CSSSelectorParserContext { *document() } : CSSSelectorParserContext { CSSParserContext { HTMLStandardMode } };
-    auto pseudoType = CSSSelector::parsePseudoElementType(StringView { pseudoElement }.substring(colonStart), parserContext);
+    auto pseudoType = CSSSelector::parsePseudoElement(StringView { pseudoElement }.substring(colonStart), parserContext);
     if (!pseudoType && !pseudoElement.isEmpty())
         return nullptr;
 

--- a/Source/WebCore/style/PageRuleCollector.cpp
+++ b/Source/WebCore/style/PageRuleCollector.cpp
@@ -98,10 +98,10 @@ static bool checkPageSelectorComponents(const CSSSelector* selector, bool isLeft
             if (localName != starAtom() && localName != pageName)
                 return false;
         } else if (component->match() == CSSSelector::Match::PagePseudoClass) {
-            CSSSelector::PagePseudoClassType pseudoType = component->pagePseudoClassType();
-            if ((pseudoType == CSSSelector::PagePseudoClassLeft && !isLeftPage)
-                || (pseudoType == CSSSelector::PagePseudoClassRight && isLeftPage)
-                || (pseudoType == CSSSelector::PagePseudoClassFirst && !isFirstPage))
+            auto pseudoType = component->pagePseudoClass();
+            if ((pseudoType == CSSSelector::PagePseudoClass::Left && !isLeftPage)
+                || (pseudoType == CSSSelector::PagePseudoClass::Right && isLeftPage)
+                || (pseudoType == CSSSelector::PagePseudoClass::First && !isFirstPage))
             {
                 return false;
             }

--- a/Source/WebCore/style/RuleData.cpp
+++ b/Source/WebCore/style/RuleData.cpp
@@ -141,10 +141,10 @@ static inline PropertyAllowlist determinePropertyAllowlist(const CSSSelector* se
 {
     for (const CSSSelector* component = selector; component; component = component->tagHistory()) {
 #if ENABLE(VIDEO)
-        if (component->match() == CSSSelector::Match::PseudoElement && (component->pseudoElementType() == CSSSelector::PseudoElementCue || component->value() == ShadowPseudoIds::cue()))
+        if (component->match() == CSSSelector::Match::PseudoElement && (component->pseudoElement() == CSSSelector::PseudoElement::Cue || component->value() == ShadowPseudoIds::cue()))
             return PropertyAllowlist::Cue;
 #endif
-        if (component->match() == CSSSelector::Match::PseudoElement && component->pseudoElementType() == CSSSelector::PseudoElementMarker)
+        if (component->match() == CSSSelector::Match::PseudoElement && component->pseudoElement() == CSSSelector::PseudoElement::Marker)
             return propertyAllowlistForPseudoId(PseudoId::Marker);
 
         if (const auto* selectorList = selector->selectorList()) {

--- a/Source/WebCore/style/RuleFeature.cpp
+++ b/Source/WebCore/style/RuleFeature.cpp
@@ -266,7 +266,7 @@ static MatchElement computeSubSelectorMatchElement(MatchElement matchElement, co
     }
     if (selector.match() == CSSSelector::Match::PseudoElement) {
         // Similarly for ::slotted().
-        if (selector.pseudoElementType() == CSSSelector::PseudoElementSlotted)
+        if (selector.pseudoElement() == CSSSelector::PseudoElement::Slotted)
             return MatchElement::Host;
     }
 
@@ -290,11 +290,11 @@ DoesBreakScope RuleFeatureSet::recursivelyCollectFeaturesFromSelector(SelectorFe
             attributeLocalNamesInRules.add(selector->attribute().localName());
             selectorFeatures.attributes.append({ selector, matchElement, isNegation });
         } else if (selector->match() == CSSSelector::Match::PseudoElement) {
-            switch (selector->pseudoElementType()) {
-            case CSSSelector::PseudoElementFirstLine:
+            switch (selector->pseudoElement()) {
+            case CSSSelector::PseudoElement::FirstLine:
                 usesFirstLineRules = true;
                 break;
-            case CSSSelector::PseudoElementFirstLetter:
+            case CSSSelector::PseudoElement::FirstLetter:
                 usesFirstLetterRules = true;
                 break;
             default:

--- a/Source/WebCore/style/RuleSet.cpp
+++ b/Source/WebCore/style/RuleSet.cpp
@@ -186,19 +186,19 @@ void RuleSet::addRule(RuleData&& ruleData, CascadeLayerIdentifier cascadeLayerId
                 tagSelector = selector;
             break;
         case CSSSelector::Match::PseudoElement:
-            switch (selector->pseudoElementType()) {
-            case CSSSelector::PseudoElementWebKitCustom:
-            case CSSSelector::PseudoElementWebKitCustomLegacyPrefixed:
+            switch (selector->pseudoElement()) {
+            case CSSSelector::PseudoElement::WebKitCustom:
+            case CSSSelector::PseudoElement::WebKitCustomLegacyPrefixed:
                 customPseudoElementSelector = selector;
                 break;
-            case CSSSelector::PseudoElementSlotted:
+            case CSSSelector::PseudoElement::Slotted:
                 slottedPseudoElementSelector = selector;
                 break;
-            case CSSSelector::PseudoElementPart:
+            case CSSSelector::PseudoElement::Part:
                 partPseudoElementSelector = selector;
                 break;
 #if ENABLE(VIDEO)
-            case CSSSelector::PseudoElementCue:
+            case CSSSelector::PseudoElement::Cue:
                 cuePseudoElementSelector = selector;
                 break;
 #endif
@@ -266,7 +266,7 @@ void RuleSet::addRule(RuleData&& ruleData, CascadeLayerIdentifier cascadeLayerId
         ruleData.disableSelectorFiltering();
 
         auto* nextSelector = customPseudoElementSelector->tagHistory();
-        if (nextSelector && nextSelector->match() == CSSSelector::Match::PseudoElement && nextSelector->pseudoElementType() == CSSSelector::PseudoElementPart) {
+        if (nextSelector && nextSelector->match() == CSSSelector::Match::PseudoElement && nextSelector->pseudoElement() == CSSSelector::PseudoElement::Part) {
             // Handle selectors like ::part(foo)::placeholder with the part codepath.
             m_partPseudoElementRules.append(ruleData);
             return;


### PR DESCRIPTION
#### cc14ba9d68a9036c8ca24e1db6263324fc9182a1
<pre>
Turn PseudoElementType and PagePseudoClassType into enum classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=266839">https://bugs.webkit.org/show_bug.cgi?id=266839</a>

Reviewed by Tim Nguyen.

Also rename them and adjacent functionality to PseudoElement and
PagePseudoClass.

And remove the unused MarginBoxType as well.

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/animation/WebAnimationUtilities.cpp:
(WebCore::pseudoIdFromString):
* Source/WebCore/css/CSSComputedStyleDeclaration.cpp:
(WebCore::CSSComputedStyleDeclaration::CSSComputedStyleDeclaration):
* Source/WebCore/css/CSSSelector.cpp:
(WebCore::simpleSelectorSpecificity):
(WebCore::CSSSelector::specificityForPage const):
(WebCore::CSSSelector::pseudoId):
(WebCore::CSSSelector::parsePseudoElement):
(WebCore::CSSSelector::selectorText const):
(WebCore::CSSSelector::parsePseudoElementType): Deleted.
* Source/WebCore/css/CSSSelector.h:
(WebCore::CSSSelector::isWebKitCustomPseudoElement const):
(WebCore::CSSSelector::pseudoElement const):
(WebCore::CSSSelector::setPseudoElement):
(WebCore::CSSSelector::pagePseudoClass const):
(WebCore::CSSSelector::setPagePseudoClass):
(WebCore::CSSSelector::pseudoElementType const): Deleted.
(WebCore::CSSSelector::setPseudoElementType): Deleted.
(WebCore::CSSSelector::pagePseudoClassType const): Deleted.
(WebCore::CSSSelector::setPagePseudoType): Deleted.
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::matchRecursively const):
(WebCore::SelectorChecker::checkOne const):
* Source/WebCore/css/SelectorPseudoClassAndCompatibilityElementMap.in:
* Source/WebCore/css/SelectorPseudoElementMap.in: Renamed from Source/WebCore/css/SelectorPseudoElementTypeMap.in.
* Source/WebCore/css/SelectorPseudoTypeMap.h:
* Source/WebCore/css/makeSelectorPseudoElementsMap.py:
(enumerablePseudoType):
* Source/WebCore/css/parser/CSSParserSelector.cpp:
(WebCore::CSSParserSelector::parsePagePseudoSelector):
(WebCore::CSSParserSelector::parsePseudoElementSelector):
(WebCore::CSSParserSelector::parsePseudoClassSelector):
* Source/WebCore/css/parser/CSSParserSelector.h:
(WebCore::CSSParserSelector::pseudoElement const):
(WebCore::CSSParserSelector::setPseudoElement):
(WebCore::CSSParserSelector::needsImplicitShadowCombinatorForMatching const):
(WebCore::CSSParserSelector::isPseudoElementCueFunction const):
(WebCore::CSSParserSelector::pseudoElementType const): Deleted.
(WebCore::CSSParserSelector::setPseudoElementType): Deleted.
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::extractCompoundFlags):
(WebCore::isPseudoClassValidAfterPseudoElement):
(WebCore::isTreeAbidingPseudoElement):
(WebCore::isSimpleSelectorValidAfterPseudoElement):
(WebCore::CSSSelectorParser::consumeCompoundSelector):
(WebCore::isOnlyPseudoElementFunction):
(WebCore::CSSSelectorParser::consumePseudo):
(WebCore::CSSSelectorParser::splitCompoundAtImplicitShadowCrossingCombinator):
(WebCore::CSSSelectorParser::containsUnknownWebKitPseudoElements):
* Source/WebCore/css/parser/CSSSelectorParser.h:
* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::constructFragmentsInternal):
(WebCore::SelectorCompiler::SelectorCodeGenerator::generateRequestedPseudoElementEqualsToSelectorPseudoElement):
(WebCore::SelectorCompiler::SelectorCodeGenerator::generateMarkPseudoStyleForPseudoElement):
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::getMatchedCSSRules const):
* Source/WebCore/style/PageRuleCollector.cpp:
(WebCore::Style::checkPageSelectorComponents):
* Source/WebCore/style/RuleData.cpp:
(WebCore::Style::determinePropertyAllowlist):
* Source/WebCore/style/RuleFeature.cpp:
(WebCore::Style::computeSubSelectorMatchElement):
(WebCore::Style::RuleFeatureSet::recursivelyCollectFeaturesFromSelector):
* Source/WebCore/style/RuleSet.cpp:
(WebCore::Style::RuleSet::addRule):

Canonical link: <a href="https://commits.webkit.org/272477@main">https://commits.webkit.org/272477@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3395baf4519b30abe9cbc0e9989b59095ddf0afc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31780 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10470 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33517 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34280 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28780 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32573 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12830 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7713 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28375 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32141 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8831 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28376 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7624 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7792 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28289 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35627 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28895 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28739 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33908 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7883 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5880 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31765 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9538 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7446 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8555 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8403 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->