### PR TITLE
Refactor content distribution functions in Grid

### DIFF
--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -371,7 +371,7 @@ void RenderFlexibleBox::styleDidChange(StyleDifference diff, const RenderStyle* 
     if (!oldStyle || diff != StyleDifference::Layout)
         return;
 
-    auto oldStyleAlignItemsIsStrecth = oldStyle->resolvedAlignItems(selfAlignmentNormalBehavior()).position() == ItemPosition::Stretch;
+    auto oldStyleAlignItemsIsStretch = oldStyle->resolvedAlignItems(selfAlignmentNormalBehavior()).position() == ItemPosition::Stretch;
     for (auto& flexItem : childrenOfType<RenderBox>(*this)) {
         if (flexItem.needsPreferredWidthsRecalculation())
             flexItem.setPreferredLogicalWidthsDirty(true, MarkingBehavior::MarkOnlyThis);
@@ -380,7 +380,7 @@ void RenderFlexibleBox::styleDidChange(StyleDifference diff, const RenderStyle* 
         // can compute new available cross axis space. This is only necessary for
         // stretching since other alignment values don't change the size of the
         // box.
-        if (oldStyleAlignItemsIsStrecth) {
+        if (oldStyleAlignItemsIsStretch) {
             ItemPosition previousAlignment = flexItem.style().resolvedAlignSelf(oldStyle, selfAlignmentNormalBehavior()).position();
             if (previousAlignment == ItemPosition::Stretch && previousAlignment != flexItem.style().resolvedAlignSelf(&style(), selfAlignmentNormalBehavior()).position())
                 flexItem.setChildNeedsLayout(MarkOnlyThis);

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -2241,48 +2241,6 @@ ContentPosition static resolveContentDistributionFallback(ContentDistribution di
     return ContentPosition::Normal;
 }
 
-static void contentDistributionOffset(ContentAlignmentData& offset, const LayoutUnit& availableFreeSpace, ContentPosition& fallbackPosition, ContentDistribution distribution, unsigned numberOfGridTracks)
-{
-    if (distribution != ContentDistribution::Default && fallbackPosition == ContentPosition::Normal)
-        fallbackPosition = resolveContentDistributionFallback(distribution);
-
-    // Initialize to an invalid offset.
-    offset.positionOffset = -1_lu;
-    offset.distributionOffset = -1_lu;
-    if (availableFreeSpace <= 0)
-        return;
-
-    LayoutUnit positionOffset;
-    LayoutUnit distributionOffset;
-    switch (distribution) {
-    case ContentDistribution::SpaceBetween:
-        if (numberOfGridTracks < 2)
-            return;
-        distributionOffset = availableFreeSpace / (numberOfGridTracks - 1);
-        positionOffset = 0_lu;
-        break;
-    case ContentDistribution::SpaceAround:
-        if (numberOfGridTracks < 1)
-            return;
-        distributionOffset = availableFreeSpace / numberOfGridTracks;
-        positionOffset = distributionOffset / 2;
-        break;
-    case ContentDistribution::SpaceEvenly:
-        distributionOffset = availableFreeSpace / (numberOfGridTracks + 1);
-        positionOffset = distributionOffset;
-        break;
-    case ContentDistribution::Stretch:
-    case ContentDistribution::Default:
-        return;
-    default:
-        ASSERT_NOT_REACHED();
-        return;
-    }
-
-    offset.positionOffset = positionOffset;
-    offset.distributionOffset = distributionOffset;
-}
-
 StyleContentAlignmentData RenderGrid::contentAlignment(GridTrackSizingDirection direction) const
 {
     return direction == GridTrackSizingDirection::ForColumns ? style().resolvedJustifyContent(contentAlignmentNormalBehaviorGrid()) : style().resolvedAlignContent(contentAlignmentNormalBehaviorGrid());
@@ -2293,62 +2251,82 @@ void RenderGrid::computeContentPositionAndDistributionOffset(GridTrackSizingDire
     bool isRowAxis = direction == GridTrackSizingDirection::ForColumns;
     auto& offset =
         isRowAxis ? m_offsetBetweenColumns : m_offsetBetweenRows;
-    if (isRowAxis ? isSubgridColumns() : isSubgridRows()) {
-        offset.positionOffset = 0_lu;
-        offset.distributionOffset = 0_lu;
+
+    // Initialize to start alignment.
+    offset.positionOffset = 0_lu;
+    offset.distributionOffset = 0_lu;
+
+    if (isRowAxis ? isSubgridColumns() : isSubgridRows())
         return;
-    }
+
     auto contentAlignmentData = contentAlignment(direction);
+    auto distribution = contentAlignmentData.distribution();
     auto position = contentAlignmentData.position();
-    // If <content-distribution> value can't be applied, 'position' will become the associated
-    // <content-position> fallback value.
-    contentDistributionOffset(offset, availableFreeSpace, position, contentAlignmentData.distribution(), numberOfGridTracks);
-    if (offset.isValid())
-        return;
 
-    if (availableFreeSpace <= 0 && contentAlignmentData.overflow() == OverflowAlignment::Safe) {
-        offset.positionOffset = 0_lu;
-        offset.distributionOffset = 0_lu;
-        return;
+    // Apply <content-distribution> and return, or continue to fallback positioning if we can't distribute.
+    if (distribution != ContentDistribution::Default) {
+        if (position == ContentPosition::Normal)
+            position = resolveContentDistributionFallback(distribution);
+        if (availableFreeSpace > 0) {
+            switch (distribution) {
+            case ContentDistribution::SpaceBetween:
+                if (numberOfGridTracks < 2)
+                    break;
+                offset.distributionOffset = availableFreeSpace / (numberOfGridTracks - 1);
+                return;
+            case ContentDistribution::SpaceAround:
+                if (numberOfGridTracks < 1)
+                    break;
+                offset.distributionOffset = availableFreeSpace / numberOfGridTracks;
+                offset.positionOffset = offset.distributionOffset / 2;
+                return;
+            case ContentDistribution::SpaceEvenly:
+                offset.distributionOffset = availableFreeSpace / (numberOfGridTracks + 1);
+                offset.positionOffset = offset.distributionOffset;
+                return;
+            case ContentDistribution::Stretch:
+                break;
+            default:
+                ASSERT_NOT_REACHED();
+            }
+        }
     }
 
-    LayoutUnit positionOffset;
+    // Apply alignment safety.
+    if (availableFreeSpace <= 0 && contentAlignmentData.overflow() == OverflowAlignment::Safe)
+        return;
+
+    // Apply <content-position> / fallback positioning.
     switch (position) {
     case ContentPosition::Left:
         ASSERT(isRowAxis);
-        positionOffset = style().isLeftToRightDirection() ? 0_lu : availableFreeSpace;
-        break;
+        if (!style().isLeftToRightDirection())
+            offset.positionOffset = availableFreeSpace;
+        return;
     case ContentPosition::Right:
         ASSERT(isRowAxis);
-        positionOffset = style().isLeftToRightDirection() ? availableFreeSpace : 0_lu;
-        break;
+        if (style().isLeftToRightDirection())
+            offset.positionOffset = availableFreeSpace;
+        return;
     case ContentPosition::Center:
-        positionOffset = availableFreeSpace / 2;
-        break;
+        offset.positionOffset = availableFreeSpace / 2;
+        return;
     case ContentPosition::FlexEnd: // Only used in flex layout, for other layout, it's equivalent to 'end'.
     case ContentPosition::End:
-        positionOffset = availableFreeSpace;
-        break;
+        offset.positionOffset = availableFreeSpace;
+        return;
     case ContentPosition::FlexStart: // Only used in flex layout, for other layout, it's equivalent to 'start'.
     case ContentPosition::Start:
-        if (isRowAxis)
-            positionOffset = 0_lu;
-        break;
     case ContentPosition::Baseline:
     case ContentPosition::LastBaseline:
-        // FIXME: Implement the previous values. For now, we always 'start' align.
+        // FIXME: Implement the baseline values. For now, we always 'start' align.
         // http://webkit.org/b/145566
-        if (isRowAxis)
-            positionOffset = 0_lu;
-        break;
+        return;
     case ContentPosition::Normal:
     default:
         ASSERT_NOT_REACHED();
         return;
     }
-
-    offset.positionOffset = positionOffset;
-    offset.distributionOffset = 0_lu;
 }
 
 LayoutUnit RenderGrid::translateRTLCoordinate(LayoutUnit coordinate) const

--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -41,7 +41,6 @@ struct ContentAlignmentData {
     WTF_MAKE_NONCOPYABLE(ContentAlignmentData); WTF_MAKE_FAST_ALLOCATED;
 public:
     ContentAlignmentData() = default;
-    bool isValid() const { return positionOffset >= 0 && distributionOffset >= 0; }
 
     LayoutUnit positionOffset;
     LayoutUnit distributionOffset;


### PR DESCRIPTION
#### 9c0b2b0c72a40ec9e1c7db4f2ff5adcdaa9a7e19
<pre>
Refactor content distribution functions in Grid
<a href="https://bugs.webkit.org/show_bug.cgi?id=266838">https://bugs.webkit.org/show_bug.cgi?id=266838</a>
<a href="https://rdar.apple.com/problem/120064485">rdar://problem/120064485</a>

Reviewed by Sammy Gill.

Improves clarity of content alignment in RenderGrid by:
- Inlines the single-use contentDistributionOffset function into its caller
  to make the logic flow in computeContentPositionAndDistributionOffset more
  straightforward--and to avoid doing a weird thing with an otherwise-
  nonsensical .isValid() that pretends negative numbers are special, but only
  for this one function (because they are otherwise valid in these offsets).
- Reorganizes the logic flow in computeContentPositionAndDistributionOffset
  to start by initializing to zero, and then adjusting where it&apos;s not zero,
  instead of setting things to zero right before every possible return.
- Sets the offsets directly instead of indirectly, now that the control flow
  is simplified.
- Makes it obvious that the offsets are always set, never left uninitialized.

Also fixes a typo in RenderFlexible Box.

* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::styleDidChange): Fix typo.
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::computeContentPositionAndDistributionOffset): Restructure.
(WebCore::contentDistributionOffset): Deleted (folded into computeContentPositionAndDistributionOffset).
* Source/WebCore/rendering/RenderGrid.h:
(WebCore::ContentAlignmentData::isValid const): Deleted.

Canonical link: <a href="https://commits.webkit.org/272591@main">https://commits.webkit.org/272591@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18e145702193c718e573edf0323c256916b6c6ee

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32221 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10955 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34036 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34781 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29200 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33071 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13308 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8165 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28765 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32639 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9239 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28809 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8042 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8199 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28727 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36126 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29299 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29174 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34323 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8321 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6259 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32186 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9962 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7527 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8954 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8860 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->