### PR TITLE
Rename PseudoClassType to PseudoClass

### DIFF
--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -170,19 +170,19 @@ SelectorSpecificity simpleSelectorSpecificity(const CSSSelector& simpleSelector)
     case CSSSelector::Match::PagePseudoClass:
         break;
     case CSSSelector::Match::PseudoClass:
-        switch (simpleSelector.pseudoClassType()) {
-        case CSSSelector::PseudoClassType::Is:
-        case CSSSelector::PseudoClassType::Matches:
-        case CSSSelector::PseudoClassType::Not:
-        case CSSSelector::PseudoClassType::Has:
+        switch (simpleSelector.pseudoClass()) {
+        case CSSSelector::PseudoClass::Is:
+        case CSSSelector::PseudoClass::Matches:
+        case CSSSelector::PseudoClass::Not:
+        case CSSSelector::PseudoClass::Has:
             return maxSpecificity(simpleSelector.selectorList());
-        case CSSSelector::PseudoClassType::Where:
+        case CSSSelector::PseudoClass::Where:
             return 0;
-        case CSSSelector::PseudoClassType::NthChild:
-        case CSSSelector::PseudoClassType::NthLastChild:
-        case CSSSelector::PseudoClassType::Host:
+        case CSSSelector::PseudoClass::NthChild:
+        case CSSSelector::PseudoClass::NthLastChild:
+        case CSSSelector::PseudoClass::Host:
             return SelectorSpecificityIncrement::ClassB + maxSpecificity(simpleSelector.selectorList());
-        case CSSSelector::PseudoClassType::HasScope:
+        case CSSSelector::PseudoClass::HasScope:
             return 0;
         default:
             return SelectorSpecificityIncrement::ClassB;
@@ -371,13 +371,13 @@ const CSSSelector* CSSSelector::firstInCompound() const
 
 static void appendPseudoClassFunctionTail(StringBuilder& builder, const CSSSelector* selector)
 {
-    switch (selector->pseudoClassType()) {
-    case CSSSelector::PseudoClassType::Dir:
-    case CSSSelector::PseudoClassType::Lang:
-    case CSSSelector::PseudoClassType::NthChild:
-    case CSSSelector::PseudoClassType::NthLastChild:
-    case CSSSelector::PseudoClassType::NthOfType:
-    case CSSSelector::PseudoClassType::NthLastOfType:
+    switch (selector->pseudoClass()) {
+    case CSSSelector::PseudoClass::Dir:
+    case CSSSelector::PseudoClass::Lang:
+    case CSSSelector::PseudoClass::NthChild:
+    case CSSSelector::PseudoClass::NthLastChild:
+    case CSSSelector::PseudoClass::NthOfType:
+    case CSSSelector::PseudoClass::NthLastOfType:
         builder.append(selector->argument(), ')');
         break;
     default:
@@ -471,197 +471,197 @@ String CSSSelector::selectorText(StringView separator, StringView rightSide) con
         } else if (cs->match() == Match::ForgivingUnknown || cs->match() == Match::ForgivingUnknownNestContaining) {
             builder.append(cs->value());
         } else if (cs->match() == Match::PseudoClass) {
-            switch (cs->pseudoClassType()) {
+            switch (cs->pseudoClass()) {
 #if ENABLE(FULLSCREEN_API)
-            case CSSSelector::PseudoClassType::AnimatingFullScreenTransition:
+            case CSSSelector::PseudoClass::AnimatingFullScreenTransition:
                 builder.append(":-webkit-animating-full-screen-transition");
                 break;
 #endif
-            case CSSSelector::PseudoClassType::Any: {
+            case CSSSelector::PseudoClass::Any: {
                 builder.append(":-webkit-any(");
                 cs->selectorList()->buildSelectorsText(builder);
                 builder.append(')');
                 break;
             }
-            case CSSSelector::PseudoClassType::AnyLink:
+            case CSSSelector::PseudoClass::AnyLink:
                 builder.append(":any-link");
                 break;
-            case CSSSelector::PseudoClassType::AnyLinkDeprecated:
+            case CSSSelector::PseudoClass::AnyLinkDeprecated:
                 builder.append(":-webkit-any-link");
                 break;
-            case CSSSelector::PseudoClassType::Autofill:
+            case CSSSelector::PseudoClass::Autofill:
                 builder.append(":autofill");
                 break;
-            case CSSSelector::PseudoClassType::AutofillAndObscured:
+            case CSSSelector::PseudoClass::AutofillAndObscured:
                 builder.append(":-webkit-autofill-and-obscured");
                 break;
-            case CSSSelector::PseudoClassType::AutofillStrongPassword:
+            case CSSSelector::PseudoClass::AutofillStrongPassword:
                 builder.append(":-webkit-autofill-strong-password");
                 break;
-            case CSSSelector::PseudoClassType::AutofillStrongPasswordViewable:
+            case CSSSelector::PseudoClass::AutofillStrongPasswordViewable:
                 builder.append(":-webkit-autofill-strong-password-viewable");
                 break;
-            case CSSSelector::PseudoClassType::Drag:
+            case CSSSelector::PseudoClass::Drag:
                 builder.append(":-webkit-drag");
                 break;
-            case CSSSelector::PseudoClassType::FullPageMedia:
+            case CSSSelector::PseudoClass::FullPageMedia:
                 builder.append(":-webkit-full-page-media");
                 break;
 #if ENABLE(FULLSCREEN_API)
-            case CSSSelector::PseudoClassType::Fullscreen:
+            case CSSSelector::PseudoClass::Fullscreen:
                 builder.append(":fullscreen");
                 break;
-            case CSSSelector::PseudoClassType::WebkitFullScreen:
+            case CSSSelector::PseudoClass::WebkitFullScreen:
                 builder.append(":-webkit-full-screen");
                 break;
-            case CSSSelector::PseudoClassType::FullScreenAncestor:
+            case CSSSelector::PseudoClass::FullScreenAncestor:
                 builder.append(":-webkit-full-screen-ancestor");
                 break;
-            case CSSSelector::PseudoClassType::FullScreenDocument:
+            case CSSSelector::PseudoClass::FullScreenDocument:
                 builder.append(":-webkit-full-screen-document");
                 break;
-            case CSSSelector::PseudoClassType::FullScreenControlsHidden:
+            case CSSSelector::PseudoClass::FullScreenControlsHidden:
                 builder.append(":-webkit-full-screen-controls-hidden");
                 break;
 #endif
 #if ENABLE(PICTURE_IN_PICTURE_API)
-            case CSSSelector::PseudoClassType::PictureInPicture:
+            case CSSSelector::PseudoClass::PictureInPicture:
                 builder.append(":picture-in-picture");
                 break;
 #endif
-            case CSSSelector::PseudoClassType::Active:
+            case CSSSelector::PseudoClass::Active:
                 builder.append(":active");
                 break;
-            case CSSSelector::PseudoClassType::Checked:
+            case CSSSelector::PseudoClass::Checked:
                 builder.append(":checked");
                 break;
-            case CSSSelector::PseudoClassType::CornerPresent:
+            case CSSSelector::PseudoClass::CornerPresent:
                 builder.append(":corner-present");
                 break;
-            case CSSSelector::PseudoClassType::Decrement:
+            case CSSSelector::PseudoClass::Decrement:
                 builder.append(":decrement");
                 break;
-            case CSSSelector::PseudoClassType::Default:
+            case CSSSelector::PseudoClass::Default:
                 builder.append(":default");
                 break;
-            case CSSSelector::PseudoClassType::Dir:
+            case CSSSelector::PseudoClass::Dir:
                 builder.append(":dir(");
                 appendPseudoClassFunctionTail(builder, cs);
                 break;
-            case CSSSelector::PseudoClassType::Disabled:
+            case CSSSelector::PseudoClass::Disabled:
                 builder.append(":disabled");
                 break;
-            case CSSSelector::PseudoClassType::DoubleButton:
+            case CSSSelector::PseudoClass::DoubleButton:
                 builder.append(":double-button");
                 break;
-            case CSSSelector::PseudoClassType::Empty:
+            case CSSSelector::PseudoClass::Empty:
                 builder.append(":empty");
                 break;
-            case CSSSelector::PseudoClassType::Enabled:
+            case CSSSelector::PseudoClass::Enabled:
                 builder.append(":enabled");
                 break;
-            case CSSSelector::PseudoClassType::End:
+            case CSSSelector::PseudoClass::End:
                 builder.append(":end");
                 break;
-            case CSSSelector::PseudoClassType::FirstChild:
+            case CSSSelector::PseudoClass::FirstChild:
                 builder.append(":first-child");
                 break;
-            case CSSSelector::PseudoClassType::FirstOfType:
+            case CSSSelector::PseudoClass::FirstOfType:
                 builder.append(":first-of-type");
                 break;
-            case CSSSelector::PseudoClassType::Focus:
+            case CSSSelector::PseudoClass::Focus:
                 builder.append(":focus");
                 break;
-            case CSSSelector::PseudoClassType::FocusVisible:
+            case CSSSelector::PseudoClass::FocusVisible:
                 builder.append(":focus-visible");
                 break;
-            case CSSSelector::PseudoClassType::FocusWithin:
+            case CSSSelector::PseudoClass::FocusWithin:
                 builder.append(":focus-within");
                 break;
 #if ENABLE(VIDEO)
-            case CSSSelector::PseudoClassType::Future:
+            case CSSSelector::PseudoClass::Future:
                 builder.append(":future");
                 break;
-            case CSSSelector::PseudoClassType::Playing:
+            case CSSSelector::PseudoClass::Playing:
                 builder.append(":playing");
                 break;
-            case CSSSelector::PseudoClassType::Paused:
+            case CSSSelector::PseudoClass::Paused:
                 builder.append(":paused");
                 break;
-            case CSSSelector::PseudoClassType::Seeking:
+            case CSSSelector::PseudoClass::Seeking:
                 builder.append(":seeking");
                 break;
-            case CSSSelector::PseudoClassType::Buffering:
+            case CSSSelector::PseudoClass::Buffering:
                 builder.append(":buffering");
                 break;
-            case CSSSelector::PseudoClassType::Stalled:
+            case CSSSelector::PseudoClass::Stalled:
                 builder.append(":stalled");
                 break;
-            case CSSSelector::PseudoClassType::Muted:
+            case CSSSelector::PseudoClass::Muted:
                 builder.append(":muted");
                 break;
-            case CSSSelector::PseudoClassType::VolumeLocked:
+            case CSSSelector::PseudoClass::VolumeLocked:
                 builder.append(":volume-locked");
                 break;
 #endif
-            case CSSSelector::PseudoClassType::Has:
+            case CSSSelector::PseudoClass::Has:
                 builder.append(":has(");
                 cs->selectorList()->buildSelectorsText(builder);
                 builder.append(')');
                 break;
 #if ENABLE(ATTACHMENT_ELEMENT)
-            case CSSSelector::PseudoClassType::HasAttachment:
+            case CSSSelector::PseudoClass::HasAttachment:
                 builder.append(":has-attachment");
                 break;
 #endif
-            case CSSSelector::PseudoClassType::Horizontal:
+            case CSSSelector::PseudoClass::Horizontal:
                 builder.append(":horizontal");
                 break;
-            case CSSSelector::PseudoClassType::Hover:
+            case CSSSelector::PseudoClass::Hover:
                 builder.append(":hover");
                 break;
-            case CSSSelector::PseudoClassType::InRange:
+            case CSSSelector::PseudoClass::InRange:
                 builder.append(":in-range");
                 break;
-            case CSSSelector::PseudoClassType::Increment:
+            case CSSSelector::PseudoClass::Increment:
                 builder.append(":increment");
                 break;
-            case CSSSelector::PseudoClassType::Indeterminate:
+            case CSSSelector::PseudoClass::Indeterminate:
                 builder.append(":indeterminate");
                 break;
-            case CSSSelector::PseudoClassType::Invalid:
+            case CSSSelector::PseudoClass::Invalid:
                 builder.append(":invalid");
                 break;
-            case CSSSelector::PseudoClassType::HtmlDocument:
+            case CSSSelector::PseudoClass::HtmlDocument:
                 builder.append(":-internal-html-document");
                 break;
-            case CSSSelector::PseudoClassType::Lang:
+            case CSSSelector::PseudoClass::Lang:
                 builder.append(":lang(");
                 ASSERT_WITH_MESSAGE(cs->argumentList() && !cs->argumentList()->isEmpty(), "An empty :lang() is invalid and should never be generated by the parser.");
                 appendLangArgumentList(builder, *cs->argumentList());
                 builder.append(')');
                 break;
-            case CSSSelector::PseudoClassType::LastChild:
+            case CSSSelector::PseudoClass::LastChild:
                 builder.append(":last-child");
                 break;
-            case CSSSelector::PseudoClassType::LastOfType:
+            case CSSSelector::PseudoClass::LastOfType:
                 builder.append(":last-of-type");
                 break;
-            case CSSSelector::PseudoClassType::Link:
+            case CSSSelector::PseudoClass::Link:
                 builder.append(":link");
                 break;
-            case CSSSelector::PseudoClassType::Modal:
+            case CSSSelector::PseudoClass::Modal:
                 builder.append(":modal");
                 break;
-            case CSSSelector::PseudoClassType::NoButton:
+            case CSSSelector::PseudoClass::NoButton:
                 builder.append(":no-button");
                 break;
-            case CSSSelector::PseudoClassType::Not:
+            case CSSSelector::PseudoClass::Not:
                 builder.append(":not(");
                 cs->selectorList()->buildSelectorsText(builder);
                 builder.append(')');
                 break;
-            case CSSSelector::PseudoClassType::NthChild:
+            case CSSSelector::PseudoClass::NthChild:
                 builder.append(":nth-child(");
                 outputNthChildAnPlusB(*cs, builder);
                 if (const CSSSelectorList* selectorList = cs->selectorList()) {
@@ -670,7 +670,7 @@ String CSSSelector::selectorText(StringView separator, StringView rightSide) con
                 }
                 builder.append(')');
                 break;
-            case CSSSelector::PseudoClassType::NthLastChild:
+            case CSSSelector::PseudoClass::NthLastChild:
                 builder.append(":nth-last-child(");
                 outputNthChildAnPlusB(*cs, builder);
                 if (const CSSSelectorList* selectorList = cs->selectorList()) {
@@ -679,106 +679,106 @@ String CSSSelector::selectorText(StringView separator, StringView rightSide) con
                 }
                 builder.append(')');
                 break;
-            case CSSSelector::PseudoClassType::NthLastOfType:
+            case CSSSelector::PseudoClass::NthLastOfType:
                 builder.append(":nth-last-of-type(");
                 appendPseudoClassFunctionTail(builder, cs);
                 break;
-            case CSSSelector::PseudoClassType::NthOfType:
+            case CSSSelector::PseudoClass::NthOfType:
                 builder.append(":nth-of-type(");
                 appendPseudoClassFunctionTail(builder, cs);
                 break;
-            case CSSSelector::PseudoClassType::OnlyChild:
+            case CSSSelector::PseudoClass::OnlyChild:
                 builder.append(":only-child");
                 break;
-            case CSSSelector::PseudoClassType::OnlyOfType:
+            case CSSSelector::PseudoClass::OnlyOfType:
                 builder.append(":only-of-type");
                 break;
-            case CSSSelector::PseudoClassType::PopoverOpen:
+            case CSSSelector::PseudoClass::PopoverOpen:
                 builder.append(":popover-open");
                 break;
-            case CSSSelector::PseudoClassType::Optional:
+            case CSSSelector::PseudoClass::Optional:
                 builder.append(":optional");
                 break;
-            case CSSSelector::PseudoClassType::Is: {
+            case CSSSelector::PseudoClass::Is: {
                 builder.append(":is(");
                 cs->selectorList()->buildSelectorsText(builder);
                 builder.append(')');
                 break;
             }
-            case CSSSelector::PseudoClassType::Matches: {
+            case CSSSelector::PseudoClass::Matches: {
                 builder.append(":matches(");
                 cs->selectorList()->buildSelectorsText(builder);
                 builder.append(')');
                 break;
             }
-            case CSSSelector::PseudoClassType::Where: {
+            case CSSSelector::PseudoClass::Where: {
                 builder.append(":where(");
                 cs->selectorList()->buildSelectorsText(builder);
                 builder.append(')');
                 break;
             }
-            case CSSSelector::PseudoClassType::PlaceholderShown:
+            case CSSSelector::PseudoClass::PlaceholderShown:
                 builder.append(":placeholder-shown");
                 break;
-            case CSSSelector::PseudoClassType::OutOfRange:
+            case CSSSelector::PseudoClass::OutOfRange:
                 builder.append(":out-of-range");
                 break;
 #if ENABLE(VIDEO)
-            case CSSSelector::PseudoClassType::Past:
+            case CSSSelector::PseudoClass::Past:
                 builder.append(":past");
                 break;
 #endif
-            case CSSSelector::PseudoClassType::ReadOnly:
+            case CSSSelector::PseudoClass::ReadOnly:
                 builder.append(":read-only");
                 break;
-            case CSSSelector::PseudoClassType::ReadWrite:
+            case CSSSelector::PseudoClass::ReadWrite:
                 builder.append(":read-write");
                 break;
-            case CSSSelector::PseudoClassType::Required:
+            case CSSSelector::PseudoClass::Required:
                 builder.append(":required");
                 break;
-            case CSSSelector::PseudoClassType::Root:
+            case CSSSelector::PseudoClass::Root:
                 builder.append(":root");
                 break;
-            case CSSSelector::PseudoClassType::Scope:
+            case CSSSelector::PseudoClass::Scope:
                 builder.append(":scope");
                 break;
-            case CSSSelector::PseudoClassType::State:
+            case CSSSelector::PseudoClass::State:
                 builder.append(":state(");
                 serializeIdentifier(cs->argument(), builder);
                 builder.append(')');
                 break;
-            case CSSSelector::PseudoClassType::HasScope:
+            case CSSSelector::PseudoClass::HasScope:
                 // Remove the space from the start to generate a relative selector string like in ":has(> foo)".
                 return makeString(separator.substring(1), rightSide);
-            case CSSSelector::PseudoClassType::SingleButton:
+            case CSSSelector::PseudoClass::SingleButton:
                 builder.append(":single-button");
                 break;
-            case CSSSelector::PseudoClassType::Start:
+            case CSSSelector::PseudoClass::Start:
                 builder.append(":start");
                 break;
-            case CSSSelector::PseudoClassType::Target:
+            case CSSSelector::PseudoClass::Target:
                 builder.append(":target");
                 break;
-            case CSSSelector::PseudoClassType::UserInvalid:
+            case CSSSelector::PseudoClass::UserInvalid:
                 builder.append(":user-invalid");
                 break;
-            case CSSSelector::PseudoClassType::UserValid:
+            case CSSSelector::PseudoClass::UserValid:
                 builder.append(":user-valid");
                 break;
-            case CSSSelector::PseudoClassType::Valid:
+            case CSSSelector::PseudoClass::Valid:
                 builder.append(":valid");
                 break;
-            case CSSSelector::PseudoClassType::Vertical:
+            case CSSSelector::PseudoClass::Vertical:
                 builder.append(":vertical");
                 break;
-            case CSSSelector::PseudoClassType::Visited:
+            case CSSSelector::PseudoClass::Visited:
                 builder.append(":visited");
                 break;
-            case CSSSelector::PseudoClassType::WindowInactive:
+            case CSSSelector::PseudoClass::WindowInactive:
                 builder.append(":window-inactive");
                 break;
-            case CSSSelector::PseudoClassType::Host:
+            case CSSSelector::PseudoClass::Host:
                 builder.append(":host");
                 if (auto* selectorList = cs->selectorList()) {
                     builder.append('(');
@@ -786,7 +786,7 @@ String CSSSelector::selectorText(StringView separator, StringView rightSide) con
                     builder.append(')');
                 }
                 break;
-            case CSSSelector::PseudoClassType::Defined:
+            case CSSSelector::PseudoClass::Defined:
                 builder.append(":defined");
                 break;
             }
@@ -1096,7 +1096,7 @@ void CSSSelector::resolveNestingParentSelectors(const CSSSelectorList& parent)
         if (selector.match() == CSSSelector::Match::NestingParent) {
             // FIXME: Optimize cases where we can include the parent selector directly instead of wrapping it in a ":is" pseudo class.
             selector.setMatch(Match::PseudoClass);
-            selector.setPseudoClassType(PseudoClassType::Is);
+            selector.setPseudoClass(PseudoClass::Is);
             selector.setSelectorList(makeUnique<CSSSelectorList>(parent));
         }
         return false;
@@ -1111,7 +1111,7 @@ void CSSSelector::replaceNestingParentByPseudoClassScope()
         if (selector.match() == CSSSelector::Match::NestingParent) {
             // Replace by :scope
             selector.setMatch(Match::PseudoClass);
-            selector.setPseudoClassType(PseudoClassType::Scope);
+            selector.setPseudoClass(PseudoClass::Scope);
         }
         return false;
     };
@@ -1137,7 +1137,7 @@ bool CSSSelector::hasExplicitNestingParent() const
 bool CSSSelector::hasExplicitPseudoClassScope() const
 {
     auto check = [] (const CSSSelector& selector) {
-        if (selector.match() == Match::PseudoClass && selector.pseudoClassType() == PseudoClassType::Scope)
+        if (selector.match() == Match::PseudoClass && selector.pseudoClass() == PseudoClass::Scope)
             return true;
 
         return false;

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -102,7 +102,7 @@ struct PossiblyQuotedIdentifier {
             ShadowSlotted
         };
 
-        enum class PseudoClassType : uint8_t {
+        enum class PseudoClass : uint8_t {
             Empty,
             FirstChild,
             FirstOfType,
@@ -298,8 +298,8 @@ struct PossiblyQuotedIdentifier {
 
         bool hasDescendantOrChildRelation() const { return relation() == RelationType::Child || hasDescendantRelation(); }
 
-        PseudoClassType pseudoClassType() const;
-        void setPseudoClassType(PseudoClassType);
+        PseudoClass pseudoClass() const;
+        void setPseudoClass(PseudoClass);
 
         PseudoElementType pseudoElementType() const;
         void setPseudoElementType(PseudoElementType);
@@ -415,35 +415,35 @@ inline bool CSSSelector::isWebKitCustomPseudoElement() const
     return pseudoElementType() == PseudoElementWebKitCustom || pseudoElementType() == PseudoElementWebKitCustomLegacyPrefixed;
 }
 
-static inline bool pseudoClassIsRelativeToSiblings(CSSSelector::PseudoClassType type)
+static inline bool pseudoClassIsRelativeToSiblings(CSSSelector::PseudoClass type)
 {
-    return type == CSSSelector::PseudoClassType::Empty
-        || type == CSSSelector::PseudoClassType::FirstChild
-        || type == CSSSelector::PseudoClassType::FirstOfType
-        || type == CSSSelector::PseudoClassType::LastChild
-        || type == CSSSelector::PseudoClassType::LastOfType
-        || type == CSSSelector::PseudoClassType::OnlyChild
-        || type == CSSSelector::PseudoClassType::OnlyOfType
-        || type == CSSSelector::PseudoClassType::NthChild
-        || type == CSSSelector::PseudoClassType::NthOfType
-        || type == CSSSelector::PseudoClassType::NthLastChild
-        || type == CSSSelector::PseudoClassType::NthLastOfType;
+    return type == CSSSelector::PseudoClass::Empty
+        || type == CSSSelector::PseudoClass::FirstChild
+        || type == CSSSelector::PseudoClass::FirstOfType
+        || type == CSSSelector::PseudoClass::LastChild
+        || type == CSSSelector::PseudoClass::LastOfType
+        || type == CSSSelector::PseudoClass::OnlyChild
+        || type == CSSSelector::PseudoClass::OnlyOfType
+        || type == CSSSelector::PseudoClass::NthChild
+        || type == CSSSelector::PseudoClass::NthOfType
+        || type == CSSSelector::PseudoClass::NthLastChild
+        || type == CSSSelector::PseudoClass::NthLastOfType;
 }
 
-static inline bool isTreeStructuralPseudoClass(CSSSelector::PseudoClassType type)
+static inline bool isTreeStructuralPseudoClass(CSSSelector::PseudoClass type)
 {
-    return pseudoClassIsRelativeToSiblings(type) || type == CSSSelector::PseudoClassType::Root;
+    return pseudoClassIsRelativeToSiblings(type) || type == CSSSelector::PseudoClass::Root;
 }
 
-inline bool isLogicalCombinationPseudoClass(CSSSelector::PseudoClassType pseudoClassType)
+inline bool isLogicalCombinationPseudoClass(CSSSelector::PseudoClass pseudoClass)
 {
-    switch (pseudoClassType) {
-    case CSSSelector::PseudoClassType::Is:
-    case CSSSelector::PseudoClassType::Where:
-    case CSSSelector::PseudoClassType::Not:
-    case CSSSelector::PseudoClassType::Any:
-    case CSSSelector::PseudoClassType::Matches:
-    case CSSSelector::PseudoClassType::Has:
+    switch (pseudoClass) {
+    case CSSSelector::PseudoClass::Is:
+    case CSSSelector::PseudoClass::Where:
+    case CSSSelector::PseudoClass::Not:
+    case CSSSelector::PseudoClass::Any:
+    case CSSSelector::PseudoClass::Matches:
+    case CSSSelector::PseudoClass::Has:
         return true;
     default:
         return false;
@@ -454,7 +454,7 @@ inline bool CSSSelector::isSiblingSelector() const
 {
     return relation() == RelationType::DirectAdjacent
         || relation() == RelationType::IndirectAdjacent
-        || (match() == CSSSelector::Match::PseudoClass && pseudoClassIsRelativeToSiblings(pseudoClassType()));
+        || (match() == CSSSelector::Match::PseudoClass && pseudoClassIsRelativeToSiblings(pseudoClass()));
 }
 
 inline bool CSSSelector::isAttributeSelector() const
@@ -543,16 +543,16 @@ inline bool CSSSelector::attributeValueMatchingIsCaseInsensitive() const
     return m_caseInsensitiveAttributeValueMatching;
 }
 
-inline auto CSSSelector::pseudoClassType() const -> PseudoClassType
+inline auto CSSSelector::pseudoClass() const -> PseudoClass
 {
     ASSERT(match() == Match::PseudoClass);
-    return static_cast<PseudoClassType>(m_pseudoType);
+    return static_cast<PseudoClass>(m_pseudoType);
 }
 
-inline void CSSSelector::setPseudoClassType(PseudoClassType pseudoType)
+inline void CSSSelector::setPseudoClass(PseudoClass pseudoClass)
 {
-    m_pseudoType = enumToUnderlyingType(pseudoType);
-    ASSERT(static_cast<PseudoClassType>(m_pseudoType) == pseudoType);
+    m_pseudoType = enumToUnderlyingType(pseudoClass);
+    ASSERT(static_cast<PseudoClass>(m_pseudoType) == pseudoClass);
 }
 
 inline auto CSSSelector::pseudoElementType() const -> PseudoElementType

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -247,7 +247,7 @@ static SelectorChecker::LocalContext localContextForParent(const SelectorChecker
     }
 
     // Move to the shadow host if matching :host and the parent is the shadow root.
-    if (context.selector->match() == CSSSelector::Match::PseudoClass && context.selector->pseudoClassType() == CSSSelector::PseudoClassType::Host) {
+    if (context.selector->match() == CSSSelector::Match::PseudoClass && context.selector->pseudoClass() == CSSSelector::PseudoClass::Host) {
         if (auto* shadowRoot = dynamicDowncast<ShadowRoot>(context.element->parentNode())) {
             updatedContext.element = shadowRoot->host();
             updatedContext.mustMatchHostPseudoClass = true;
@@ -612,8 +612,8 @@ static bool canMatchHoverOrActiveInQuirksMode(const SelectorChecker::LocalContex
                 return true;
             break;
         case CSSSelector::Match::PseudoClass: {
-            CSSSelector::PseudoClassType pseudoClassType = selector->pseudoClassType();
-            if (pseudoClassType != CSSSelector::PseudoClassType::Hover && pseudoClassType != CSSSelector::PseudoClassType::Active)
+            auto pseudoClass = selector->pseudoClass();
+            if (pseudoClass != CSSSelector::PseudoClass::Hover && pseudoClass != CSSSelector::PseudoClass::Active)
                 return true;
             break;
         }
@@ -669,7 +669,7 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, const LocalCont
 
     if (context.mustMatchHostPseudoClass) {
         // :host doesn't combine with anything except pseudo elements.
-        bool isHostPseudoClass = selector.match() == CSSSelector::Match::PseudoClass && selector.pseudoClassType() == CSSSelector::PseudoClassType::Host;
+        bool isHostPseudoClass = selector.match() == CSSSelector::Match::PseudoClass && selector.pseudoClass() == CSSSelector::PseudoClass::Host;
         bool isPseudoElement = selector.match() == CSSSelector::Match::PseudoElement;
         if (!isHostPseudoClass && !isPseudoElement)
             return false;
@@ -709,7 +709,7 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, const LocalCont
 
     if (selector.match() == CSSSelector::Match::PseudoClass) {
         // Handle :not up front.
-        if (selector.pseudoClassType() == CSSSelector::PseudoClassType::Not) {
+        if (selector.pseudoClass() == CSSSelector::PseudoClass::Not) {
             const CSSSelectorList* selectorList = selector.selectorList();
 
             for (const CSSSelector* subselector = selectorList->first(); subselector; subselector = CSSSelectorList::next(subselector)) {
@@ -734,12 +734,12 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, const LocalCont
         }
 
         // Normal element pseudo class checking.
-        switch (selector.pseudoClassType()) {
+        switch (selector.pseudoClass()) {
             // Pseudo classes:
-        case CSSSelector::PseudoClassType::Not:
+        case CSSSelector::PseudoClass::Not:
             ASSERT_NOT_REACHED();
             break; // Already handled up above.
-        case CSSSelector::PseudoClassType::Empty:
+        case CSSSelector::PseudoClass::Empty:
             {
                 bool result = true;
                 for (Node* node = element.firstChild(); node; node = node->nextSibling()) {
@@ -758,7 +758,7 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, const LocalCont
 
                 return result;
             }
-        case CSSSelector::PseudoClassType::FirstChild: {
+        case CSSSelector::PseudoClass::FirstChild: {
             // first-child matches the first child that is an element
             bool isFirstChild = isFirstChildElement(element);
             if (auto* parentElement = dynamicDowncast<Element>(element.parentNode()))
@@ -768,7 +768,7 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, const LocalCont
             addStyleRelation(checkingContext, element, Style::Relation::FirstChild);
             return true;
         }
-        case CSSSelector::PseudoClassType::FirstOfType: {
+        case CSSSelector::PseudoClass::FirstOfType: {
             // first-of-type matches the first element of its type
             if (auto* parentElement = dynamicDowncast<Element>(element.parentNode())) {
                 auto relation = context.isSubjectOrAdjacentElement ? Style::Relation::ChildrenAffectedByForwardPositionalRules : Style::Relation::DescendantsAffectedByForwardPositionalRules;
@@ -776,7 +776,7 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, const LocalCont
             }
             return isFirstOfType(element, element.tagQName());
         }
-        case CSSSelector::PseudoClassType::LastChild: {
+        case CSSSelector::PseudoClass::LastChild: {
             // last-child matches the last child that is an element
             bool isLastChild = isLastChildElement(element);
             if (auto* parentElement = dynamicDowncast<Element>(element.parentNode())) {
@@ -789,7 +789,7 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, const LocalCont
             addStyleRelation(checkingContext, element, Style::Relation::LastChild);
             return true;
         }
-        case CSSSelector::PseudoClassType::LastOfType: {
+        case CSSSelector::PseudoClass::LastOfType: {
             // last-of-type matches the last element of its type
             if (auto* parentElement = dynamicDowncast<Element>(element.parentNode())) {
                 auto relation = context.isSubjectOrAdjacentElement ? Style::Relation::ChildrenAffectedByBackwardPositionalRules : Style::Relation::DescendantsAffectedByBackwardPositionalRules;
@@ -799,7 +799,7 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, const LocalCont
             }
             return isLastOfType(element, element.tagQName());
         }
-        case CSSSelector::PseudoClassType::OnlyChild: {
+        case CSSSelector::PseudoClass::OnlyChild: {
             bool firstChild = isFirstChildElement(element);
             bool onlyChild = firstChild && isLastChildElement(element);
             if (auto* parentElement = dynamicDowncast<Element>(element.parentNode())) {
@@ -814,7 +814,7 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, const LocalCont
                 addStyleRelation(checkingContext, element, Style::Relation::LastChild);
             return onlyChild;
         }
-        case CSSSelector::PseudoClassType::OnlyOfType: {
+        case CSSSelector::PseudoClass::OnlyOfType: {
             // FIXME: This selector is very slow.
             if (auto* parentElement = dynamicDowncast<Element>(element.parentNode())) {
                 auto forwardRelation = context.isSubjectOrAdjacentElement ? Style::Relation::ChildrenAffectedByForwardPositionalRules : Style::Relation::DescendantsAffectedByForwardPositionalRules;
@@ -827,10 +827,10 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, const LocalCont
             }
             return isFirstOfType(element, element.tagQName()) && isLastOfType(element, element.tagQName());
         }
-        case CSSSelector::PseudoClassType::Is:
-        case CSSSelector::PseudoClassType::Where:
-        case CSSSelector::PseudoClassType::Matches:
-        case CSSSelector::PseudoClassType::Any:
+        case CSSSelector::PseudoClass::Is:
+        case CSSSelector::PseudoClass::Where:
+        case CSSSelector::PseudoClass::Matches:
+        case CSSSelector::PseudoClass::Any:
             {
                 bool hasMatchedAnything = false;
 
@@ -860,20 +860,20 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, const LocalCont
                     matchType = localMatchType;
                 return hasMatchedAnything;
             }
-        case CSSSelector::PseudoClassType::Has: {
+        case CSSSelector::PseudoClass::Has: {
             for (auto* hasSelector = selector.selectorList()->first(); hasSelector; hasSelector = CSSSelectorList::next(hasSelector)) {
                 if (matchHasPseudoClass(checkingContext, element, *hasSelector))
                     return true;
             }
             return false;
         }
-        case CSSSelector::PseudoClassType::PlaceholderShown:
+        case CSSSelector::PseudoClass::PlaceholderShown:
             if (auto* formControl = dynamicDowncast<HTMLTextFormControlElement>(element)) {
                 addStyleRelation(checkingContext, element, Style::Relation::Unique);
                 return formControl->isPlaceholderVisible();
             }
             return false;
-        case CSSSelector::PseudoClassType::NthChild: {
+        case CSSSelector::PseudoClass::NthChild: {
             if (auto* parentElement = dynamicDowncast<Element>(element.parentNode())) {
                 auto relation = context.isSubjectOrAdjacentElement ? Style::Relation::ChildrenAffectedByForwardPositionalRules : Style::Relation::DescendantsAffectedByForwardPositionalRules;
                 addStyleRelation(checkingContext, *parentElement, relation);
@@ -899,7 +899,7 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, const LocalCont
                 return true;
             break;
         }
-        case CSSSelector::PseudoClassType::NthOfType: {
+        case CSSSelector::PseudoClass::NthOfType: {
             if (auto* parentElement = dynamicDowncast<Element>(element.parentNode())) {
                 auto relation = context.isSubjectOrAdjacentElement ? Style::Relation::ChildrenAffectedByForwardPositionalRules : Style::Relation::DescendantsAffectedByForwardPositionalRules;
                 addStyleRelation(checkingContext, *parentElement, relation);
@@ -910,7 +910,7 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, const LocalCont
                 return true;
             break;
         }
-        case CSSSelector::PseudoClassType::NthLastChild: {
+        case CSSSelector::PseudoClass::NthLastChild: {
             if (auto* parentElement = dynamicDowncast<Element>(element.parentNode())) {
                 if (const CSSSelectorList* selectorList = selector.selectorList()) {
                     if (!matchSelectorList(checkingContext, context, element, *selectorList))
@@ -936,7 +936,7 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, const LocalCont
 
             return selector.matchNth(count);
         }
-        case CSSSelector::PseudoClassType::NthLastOfType: {
+        case CSSSelector::PseudoClass::NthLastOfType: {
             if (auto* parentElement = dynamicDowncast<Element>(element.parentNode())) {
                 auto relation = context.isSubjectOrAdjacentElement ? Style::Relation::ChildrenAffectedByBackwardPositionalRules : Style::Relation::DescendantsAffectedByBackwardPositionalRules;
                 addStyleRelation(checkingContext, *parentElement, relation);
@@ -947,134 +947,134 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, const LocalCont
             int count = 1 + countElementsOfTypeAfter(element, element.tagQName());
             return selector.matchNth(count);
         }
-        case CSSSelector::PseudoClassType::Target:
-            if (&element == element.document().cssTarget() || InspectorInstrumentation::forcePseudoState(element, CSSSelector::PseudoClassType::Target))
+        case CSSSelector::PseudoClass::Target:
+            if (&element == element.document().cssTarget() || InspectorInstrumentation::forcePseudoState(element, CSSSelector::PseudoClass::Target))
                 return true;
             break;
-        case CSSSelector::PseudoClassType::Autofill:
+        case CSSSelector::PseudoClass::Autofill:
             return isAutofilled(element);
-        case CSSSelector::PseudoClassType::AutofillAndObscured:
+        case CSSSelector::PseudoClass::AutofillAndObscured:
             return isAutofilledAndObscured(element);
-        case CSSSelector::PseudoClassType::AutofillStrongPassword:
+        case CSSSelector::PseudoClass::AutofillStrongPassword:
             return isAutofilledStrongPassword(element);
-        case CSSSelector::PseudoClassType::AutofillStrongPasswordViewable:
+        case CSSSelector::PseudoClass::AutofillStrongPasswordViewable:
             return isAutofilledStrongPasswordViewable(element);
-        case CSSSelector::PseudoClassType::AnyLink:
-        case CSSSelector::PseudoClassType::AnyLinkDeprecated:
-        case CSSSelector::PseudoClassType::Link:
+        case CSSSelector::PseudoClass::AnyLink:
+        case CSSSelector::PseudoClass::AnyLinkDeprecated:
+        case CSSSelector::PseudoClass::Link:
             // :visited and :link matches are separated later when applying the style. Here both classes match all links...
             return element.isLink();
-        case CSSSelector::PseudoClassType::Visited:
+        case CSSSelector::PseudoClass::Visited:
             // ...except if :visited matching is disabled for ancestor/sibling matching.
             // Inside functional pseudo class except for :not, :visited never matches.
             if (context.inFunctionalPseudoClass)
                 return false;
             return element.isLink() && context.visitedMatchType == VisitedMatchType::Enabled;
-        case CSSSelector::PseudoClassType::Drag:
+        case CSSSelector::PseudoClass::Drag:
             return element.isBeingDragged();
-        case CSSSelector::PseudoClassType::Focus:
+        case CSSSelector::PseudoClass::Focus:
             return matchesFocusPseudoClass(element);
-        case CSSSelector::PseudoClassType::FocusVisible:
+        case CSSSelector::PseudoClass::FocusVisible:
             return matchesFocusVisiblePseudoClass(element);
-        case CSSSelector::PseudoClassType::FocusWithin:
+        case CSSSelector::PseudoClass::FocusWithin:
             return matchesFocusWithinPseudoClass(element);
-        case CSSSelector::PseudoClassType::Hover:
+        case CSSSelector::PseudoClass::Hover:
             if (m_strictParsing || element.isLink() || canMatchHoverOrActiveInQuirksMode(context)) {
                 // See the comment in generateElementIsHovered() in SelectorCompiler.
                 if (checkingContext.resolvingMode == SelectorChecker::Mode::CollectingRulesIgnoringVirtualPseudoElements && !context.isMatchElement)
                     return true;
 
-                if (element.hovered() || InspectorInstrumentation::forcePseudoState(element, CSSSelector::PseudoClassType::Hover))
+                if (element.hovered() || InspectorInstrumentation::forcePseudoState(element, CSSSelector::PseudoClass::Hover))
                     return true;
             }
             break;
-        case CSSSelector::PseudoClassType::Active:
+        case CSSSelector::PseudoClass::Active:
             if (m_strictParsing || element.isLink() || canMatchHoverOrActiveInQuirksMode(context)) {
-                if (element.active() || InspectorInstrumentation::forcePseudoState(element, CSSSelector::PseudoClassType::Active))
+                if (element.active() || InspectorInstrumentation::forcePseudoState(element, CSSSelector::PseudoClass::Active))
                     return true;
             }
             break;
-        case CSSSelector::PseudoClassType::Enabled:
+        case CSSSelector::PseudoClass::Enabled:
             return matchesEnabledPseudoClass(element);
-        case CSSSelector::PseudoClassType::FullPageMedia:
+        case CSSSelector::PseudoClass::FullPageMedia:
             return isMediaDocument(element);
-        case CSSSelector::PseudoClassType::Default:
+        case CSSSelector::PseudoClass::Default:
             return matchesDefaultPseudoClass(element);
-        case CSSSelector::PseudoClassType::Disabled:
+        case CSSSelector::PseudoClass::Disabled:
             return matchesDisabledPseudoClass(element);
-        case CSSSelector::PseudoClassType::ReadOnly:
+        case CSSSelector::PseudoClass::ReadOnly:
             return matchesReadOnlyPseudoClass(element);
-        case CSSSelector::PseudoClassType::ReadWrite:
+        case CSSSelector::PseudoClass::ReadWrite:
             return matchesReadWritePseudoClass(element);
-        case CSSSelector::PseudoClassType::Optional:
+        case CSSSelector::PseudoClass::Optional:
             return isOptionalFormControl(element);
-        case CSSSelector::PseudoClassType::Required:
+        case CSSSelector::PseudoClass::Required:
             return isRequiredFormControl(element);
-        case CSSSelector::PseudoClassType::Valid:
+        case CSSSelector::PseudoClass::Valid:
             return isValid(element);
-        case CSSSelector::PseudoClassType::Invalid:
+        case CSSSelector::PseudoClass::Invalid:
             return isInvalid(element);
-        case CSSSelector::PseudoClassType::Checked:
+        case CSSSelector::PseudoClass::Checked:
             return isChecked(element);
-        case CSSSelector::PseudoClassType::Indeterminate:
+        case CSSSelector::PseudoClass::Indeterminate:
             return matchesIndeterminatePseudoClass(element);
-        case CSSSelector::PseudoClassType::Root:
+        case CSSSelector::PseudoClass::Root:
             if (&element == element.document().documentElement())
                 return true;
             break;
-        case CSSSelector::PseudoClassType::Lang:
+        case CSSSelector::PseudoClass::Lang:
             ASSERT(selector.argumentList() && !selector.argumentList()->isEmpty());
             return matchesLangPseudoClass(element, *selector.argumentList());
 #if ENABLE(FULLSCREEN_API)
-        case CSSSelector::PseudoClassType::Fullscreen:
+        case CSSSelector::PseudoClass::Fullscreen:
             return matchesFullscreenPseudoClass(element);
-        case CSSSelector::PseudoClassType::WebkitFullScreen:
+        case CSSSelector::PseudoClass::WebkitFullScreen:
             return matchesWebkitFullScreenPseudoClass(element);
-        case CSSSelector::PseudoClassType::AnimatingFullScreenTransition:
+        case CSSSelector::PseudoClass::AnimatingFullScreenTransition:
             return matchesFullScreenAnimatingFullScreenTransitionPseudoClass(element);
-        case CSSSelector::PseudoClassType::FullScreenAncestor:
+        case CSSSelector::PseudoClass::FullScreenAncestor:
             return matchesFullScreenAncestorPseudoClass(element);
-        case CSSSelector::PseudoClassType::FullScreenDocument:
+        case CSSSelector::PseudoClass::FullScreenDocument:
             return matchesFullScreenDocumentPseudoClass(element);
-        case CSSSelector::PseudoClassType::FullScreenControlsHidden:
+        case CSSSelector::PseudoClass::FullScreenControlsHidden:
             return matchesFullScreenControlsHiddenPseudoClass(element);
 #endif
 #if ENABLE(PICTURE_IN_PICTURE_API)
-        case CSSSelector::PseudoClassType::PictureInPicture:
+        case CSSSelector::PseudoClass::PictureInPicture:
             return matchesPictureInPicturePseudoClass(element);
 #endif
-        case CSSSelector::PseudoClassType::InRange:
+        case CSSSelector::PseudoClass::InRange:
             return isInRange(element);
-        case CSSSelector::PseudoClassType::OutOfRange:
+        case CSSSelector::PseudoClass::OutOfRange:
             return isOutOfRange(element);
 #if ENABLE(VIDEO)
-        case CSSSelector::PseudoClassType::Future:
+        case CSSSelector::PseudoClass::Future:
             return matchesFutureCuePseudoClass(element);
-        case CSSSelector::PseudoClassType::Past:
+        case CSSSelector::PseudoClass::Past:
             return matchesPastCuePseudoClass(element);
-        case CSSSelector::PseudoClassType::Playing:
+        case CSSSelector::PseudoClass::Playing:
             return matchesPlayingPseudoClass(element);
-        case CSSSelector::PseudoClassType::Paused:
+        case CSSSelector::PseudoClass::Paused:
             return matchesPausedPseudoClass(element);
-        case CSSSelector::PseudoClassType::Seeking:
+        case CSSSelector::PseudoClass::Seeking:
             return matchesSeekingPseudoClass(element);
-        case CSSSelector::PseudoClassType::Buffering:
+        case CSSSelector::PseudoClass::Buffering:
             return matchesBufferingPseudoClass(element);
-        case CSSSelector::PseudoClassType::Stalled:
+        case CSSSelector::PseudoClass::Stalled:
             return matchesStalledPseudoClass(element);
-        case CSSSelector::PseudoClassType::Muted:
+        case CSSSelector::PseudoClass::Muted:
             return matchesMutedPseudoClass(element);
-        case CSSSelector::PseudoClassType::VolumeLocked:
+        case CSSSelector::PseudoClass::VolumeLocked:
             return matchesVolumeLockedPseudoClass(element);
 #endif
 
-        case CSSSelector::PseudoClassType::Scope: {
+        case CSSSelector::PseudoClass::Scope: {
             const Node* contextualReferenceNode = !checkingContext.scope ? element.document().documentElement() : checkingContext.scope;
             return &element == contextualReferenceNode;
         }
-        case CSSSelector::PseudoClassType::State:
+        case CSSSelector::PseudoClass::State:
             return element.hasCustomState(selector.argument());
-        case CSSSelector::PseudoClassType::HasScope: {
+        case CSSSelector::PseudoClass::HasScope: {
             bool matches = &element == checkingContext.hasScope || checkingContext.matchesAllHasScopes;
 
             if (!matches && checkingContext.hasScope) {
@@ -1084,48 +1084,48 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, const LocalCont
 
             return matches;
         }
-        case CSSSelector::PseudoClassType::Host: {
+        case CSSSelector::PseudoClass::Host: {
             if (!context.mustMatchHostPseudoClass)
                 return false;
             return matchHostPseudoClass(selector, element, checkingContext);
         }
-        case CSSSelector::PseudoClassType::Defined:
+        case CSSSelector::PseudoClass::Defined:
             return isDefinedElement(element);
-        case CSSSelector::PseudoClassType::WindowInactive:
+        case CSSSelector::PseudoClass::WindowInactive:
             return isWindowInactive(element);
 
-        case CSSSelector::PseudoClassType::Horizontal:
-        case CSSSelector::PseudoClassType::Vertical:
-        case CSSSelector::PseudoClassType::Decrement:
-        case CSSSelector::PseudoClassType::Increment:
-        case CSSSelector::PseudoClassType::Start:
-        case CSSSelector::PseudoClassType::End:
-        case CSSSelector::PseudoClassType::DoubleButton:
-        case CSSSelector::PseudoClassType::SingleButton:
-        case CSSSelector::PseudoClassType::NoButton:
-        case CSSSelector::PseudoClassType::CornerPresent:
+        case CSSSelector::PseudoClass::Horizontal:
+        case CSSSelector::PseudoClass::Vertical:
+        case CSSSelector::PseudoClass::Decrement:
+        case CSSSelector::PseudoClass::Increment:
+        case CSSSelector::PseudoClass::Start:
+        case CSSSelector::PseudoClass::End:
+        case CSSSelector::PseudoClass::DoubleButton:
+        case CSSSelector::PseudoClass::SingleButton:
+        case CSSSelector::PseudoClass::NoButton:
+        case CSSSelector::PseudoClass::CornerPresent:
             return false;
 
-        case CSSSelector::PseudoClassType::Dir:
+        case CSSSelector::PseudoClass::Dir:
             return matchesDirPseudoClass(element, selector.argument());
 
 #if ENABLE(ATTACHMENT_ELEMENT)
-        case CSSSelector::PseudoClassType::HasAttachment:
+        case CSSSelector::PseudoClass::HasAttachment:
             return hasAttachment(element);
 #endif
-        case CSSSelector::PseudoClassType::HtmlDocument:
+        case CSSSelector::PseudoClass::HtmlDocument:
             return matchesHtmlDocumentPseudoClass(element);
 
-        case CSSSelector::PseudoClassType::PopoverOpen:
+        case CSSSelector::PseudoClass::PopoverOpen:
             return matchesPopoverOpenPseudoClass(element);
 
-        case CSSSelector::PseudoClassType::Modal:
+        case CSSSelector::PseudoClass::Modal:
             return matchesModalPseudoClass(element);
 
-        case CSSSelector::PseudoClassType::UserInvalid:
+        case CSSSelector::PseudoClass::UserInvalid:
             return matchesUserInvalidPseudoClass(element);
 
-        case CSSSelector::PseudoClassType::UserValid:
+        case CSSSelector::PseudoClass::UserValid:
             return matchesUserValidPseudoClass(element);
         }
         return false;
@@ -1453,36 +1453,36 @@ bool SelectorChecker::checkScrollbarPseudoClass(const CheckingContext& checkingC
 {
     ASSERT(selector.match() == CSSSelector::Match::PseudoClass);
 
-    switch (selector.pseudoClassType()) {
-    case CSSSelector::PseudoClassType::WindowInactive:
+    switch (selector.pseudoClass()) {
+    case CSSSelector::PseudoClass::WindowInactive:
         return isWindowInactive(element);
-    case CSSSelector::PseudoClassType::Enabled:
+    case CSSSelector::PseudoClass::Enabled:
         return scrollbarMatchesEnabledPseudoClass(checkingContext);
-    case CSSSelector::PseudoClassType::Disabled:
+    case CSSSelector::PseudoClass::Disabled:
         return scrollbarMatchesDisabledPseudoClass(checkingContext);
-    case CSSSelector::PseudoClassType::Hover:
+    case CSSSelector::PseudoClass::Hover:
         return scrollbarMatchesHoverPseudoClass(checkingContext);
-    case CSSSelector::PseudoClassType::Active:
+    case CSSSelector::PseudoClass::Active:
         return scrollbarMatchesActivePseudoClass(checkingContext);
-    case CSSSelector::PseudoClassType::Horizontal:
+    case CSSSelector::PseudoClass::Horizontal:
         return scrollbarMatchesHorizontalPseudoClass(checkingContext);
-    case CSSSelector::PseudoClassType::Vertical:
+    case CSSSelector::PseudoClass::Vertical:
         return scrollbarMatchesVerticalPseudoClass(checkingContext);
-    case CSSSelector::PseudoClassType::Decrement:
+    case CSSSelector::PseudoClass::Decrement:
         return scrollbarMatchesDecrementPseudoClass(checkingContext);
-    case CSSSelector::PseudoClassType::Increment:
+    case CSSSelector::PseudoClass::Increment:
         return scrollbarMatchesIncrementPseudoClass(checkingContext);
-    case CSSSelector::PseudoClassType::Start:
+    case CSSSelector::PseudoClass::Start:
         return scrollbarMatchesStartPseudoClass(checkingContext);
-    case CSSSelector::PseudoClassType::End:
+    case CSSSelector::PseudoClass::End:
         return scrollbarMatchesEndPseudoClass(checkingContext);
-    case CSSSelector::PseudoClassType::DoubleButton:
+    case CSSSelector::PseudoClass::DoubleButton:
         return scrollbarMatchesDoubleButtonPseudoClass(checkingContext);
-    case CSSSelector::PseudoClassType::SingleButton:
+    case CSSSelector::PseudoClass::SingleButton:
         return scrollbarMatchesSingleButtonPseudoClass(checkingContext);
-    case CSSSelector::PseudoClassType::NoButton:
+    case CSSSelector::PseudoClass::NoButton:
         return scrollbarMatchesNoButtonPseudoClass(checkingContext);
-    case CSSSelector::PseudoClassType::CornerPresent:
+    case CSSSelector::PseudoClass::CornerPresent:
         return scrollbarMatchesCornerPresentPseudoClass(checkingContext);
     default:
         return false;
@@ -1497,11 +1497,11 @@ unsigned SelectorChecker::determineLinkMatchType(const CSSSelector* selector)
     // :visited never matches other elements than the innermost link element.
     for (; selector; selector = selector->tagHistory()) {
         if (selector->match() == CSSSelector::Match::PseudoClass) {
-            switch (selector->pseudoClassType()) {
-            case CSSSelector::PseudoClassType::Link:
+            switch (selector->pseudoClass()) {
+            case CSSSelector::PseudoClass::Link:
                 linkMatchType &= ~SelectorChecker::MatchVisited;
                 break;
-            case CSSSelector::PseudoClassType::Visited:
+            case CSSSelector::PseudoClass::Visited:
                 linkMatchType &= ~SelectorChecker::MatchLink;
                 break;
             default:

--- a/Source/WebCore/css/SelectorChecker.h
+++ b/Source/WebCore/css/SelectorChecker.h
@@ -134,12 +134,12 @@ inline bool SelectorChecker::isCommonPseudoClassSelector(const CSSSelector* sele
 {
     if (selector->match() != CSSSelector::Match::PseudoClass)
         return false;
-    CSSSelector::PseudoClassType pseudoType = selector->pseudoClassType();
-    return pseudoType == CSSSelector::PseudoClassType::Link
-        || pseudoType == CSSSelector::PseudoClassType::AnyLink
-        || pseudoType == CSSSelector::PseudoClassType::AnyLinkDeprecated
-        || pseudoType == CSSSelector::PseudoClassType::Visited
-        || pseudoType == CSSSelector::PseudoClassType::Focus;
+    auto pseudoType = selector->pseudoClass();
+    return pseudoType == CSSSelector::PseudoClass::Link
+        || pseudoType == CSSSelector::PseudoClass::AnyLink
+        || pseudoType == CSSSelector::PseudoClass::AnyLinkDeprecated
+        || pseudoType == CSSSelector::PseudoClass::Visited
+        || pseudoType == CSSSelector::PseudoClass::Focus;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/SelectorCheckerTestFunctions.h
+++ b/Source/WebCore/css/SelectorCheckerTestFunctions.h
@@ -541,7 +541,7 @@ ALWAYS_INLINE bool isFrameFocused(const Element& element)
 
 ALWAYS_INLINE bool matchesLegacyDirectFocusPseudoClass(const Element& element)
 {
-    if (InspectorInstrumentation::forcePseudoState(element, CSSSelector::PseudoClassType::Focus))
+    if (InspectorInstrumentation::forcePseudoState(element, CSSSelector::PseudoClass::Focus))
         return true;
 
     return element.focused() && isFrameFocused(element);
@@ -555,7 +555,7 @@ ALWAYS_INLINE bool doesShadowTreeContainFocusedElement(const Element& element)
 
 ALWAYS_INLINE bool matchesFocusPseudoClass(const Element& element)
 {
-    if (InspectorInstrumentation::forcePseudoState(element, CSSSelector::PseudoClassType::Focus))
+    if (InspectorInstrumentation::forcePseudoState(element, CSSSelector::PseudoClass::Focus))
         return true;
 
     return (element.focused() || doesShadowTreeContainFocusedElement(element)) && isFrameFocused(element);
@@ -566,7 +566,7 @@ ALWAYS_INLINE bool matchesFocusVisiblePseudoClass(const Element& element)
     if (!element.document().settings().focusVisibleEnabled())
         return matchesLegacyDirectFocusPseudoClass(element);
 
-    if (InspectorInstrumentation::forcePseudoState(element, CSSSelector::PseudoClassType::FocusVisible))
+    if (InspectorInstrumentation::forcePseudoState(element, CSSSelector::PseudoClass::FocusVisible))
         return true;
 
     return element.hasFocusVisible() && isFrameFocused(element);
@@ -574,7 +574,7 @@ ALWAYS_INLINE bool matchesFocusVisiblePseudoClass(const Element& element)
 
 ALWAYS_INLINE bool matchesFocusWithinPseudoClass(const Element& element)
 {
-    if (InspectorInstrumentation::forcePseudoState(element, CSSSelector::PseudoClassType::FocusWithin))
+    if (InspectorInstrumentation::forcePseudoState(element, CSSSelector::PseudoClass::FocusWithin))
         return true;
 
     return element.hasFocusWithin() && isFrameFocused(element);

--- a/Source/WebCore/css/SelectorFilter.cpp
+++ b/Source/WebCore/css/SelectorFilter.cpp
@@ -165,9 +165,9 @@ void SelectorFilter::collectSimpleSelectorHash(CollectedSelectorHashes& collecte
         break;
     }
     case CSSSelector::Match::PseudoClass:
-        switch (selector.pseudoClassType()) {
-        case CSSSelector::PseudoClassType::Is:
-        case CSSSelector::PseudoClassType::Where:
+        switch (selector.pseudoClass()) {
+        case CSSSelector::PseudoClass::Is:
+        case CSSSelector::PseudoClass::Where:
             // We can use the filter in the trivial case of single argument :is()/:where().
             // Supporting the multiargument case would require more than one hash.
             if (selector.selectorList()->listSize() == 1)

--- a/Source/WebCore/css/SelectorPseudoClassAndCompatibilityElementMap.in
+++ b/Source/WebCore/css/SelectorPseudoClassAndCompatibilityElementMap.in
@@ -1,7 +1,7 @@
 -khtml-drag
 -internal-html-document
 -webkit-any
--webkit-any-link, PseudoClassType::AnyLinkDeprecated
+-webkit-any-link, PseudoClass::AnyLinkDeprecated
 -webkit-autofill
 -webkit-autofill-and-obscured
 -webkit-autofill-strong-password
@@ -36,7 +36,7 @@ has
 has-attachment
 #endif
 horizontal
-host, PseudoClassType::Host
+host, PseudoClass::Host
 hover
 in-range
 increment
@@ -81,7 +81,7 @@ window-inactive
 #if ENABLE(FULLSCREEN_API)
 fullscreen
 -webkit-animating-full-screen-transition
--webkit-full-screen, PseudoClassType::WebkitFullScreen
+-webkit-full-screen, PseudoClass::WebkitFullScreen
 -webkit-full-screen-ancestor
 -webkit-full-screen-document
 -webkit-full-screen-controls-hidden

--- a/Source/WebCore/css/SelectorPseudoTypeMap.h
+++ b/Source/WebCore/css/SelectorPseudoTypeMap.h
@@ -30,7 +30,7 @@
 namespace WebCore {
 
 struct PseudoClassOrCompatibilityPseudoElement {
-    std::optional<CSSSelector::PseudoClassType> pseudoClass;
+    std::optional<CSSSelector::PseudoClass> pseudoClass;
     std::optional<CSSSelector::PseudoElementType> compatibilityPseudoElement;
 };
 

--- a/Source/WebCore/css/makeSelectorPseudoClassAndCompatibilityElementMap.py
+++ b/Source/WebCore/css/makeSelectorPseudoClassAndCompatibilityElementMap.py
@@ -29,7 +29,7 @@ import subprocess
 
 
 def enumerablePseudoType(stringPseudoType):
-    output = ['CSSSelector::PseudoClassType::']
+    output = ['CSSSelector::PseudoClass::']
 
     if stringPseudoType.endswith('('):
         stringPseudoType = stringPseudoType[:-1]

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -75,7 +75,7 @@ static void appendImplicitSelectorPseudoClassScopeIfNeeded(CSSParserSelector& se
     if ((!selector.hasExplicitNestingParent() && !selector.hasExplicitPseudoClassScope()) || selector.startsWithExplicitCombinator()) {
         auto scopeSelector = makeUnique<CSSParserSelector>();
         scopeSelector->setMatch(CSSSelector::Match::PseudoClass);
-        scopeSelector->setPseudoClassType(CSSSelector::PseudoClassType::Scope);
+        scopeSelector->setPseudoClass(CSSSelector::PseudoClass::Scope);
         scopeSelector->selector()->setImplicit();
         selector.appendTagHistoryAsRelative(WTFMove(scopeSelector));
     }

--- a/Source/WebCore/css/parser/CSSParserSelector.cpp
+++ b/Source/WebCore/css/parser/CSSParserSelector.cpp
@@ -82,7 +82,7 @@ std::unique_ptr<CSSParserSelector> CSSParserSelector::parsePseudoClassSelector(S
     if (pseudoType.pseudoClass) {
         auto selector = makeUnique<CSSParserSelector>();
         selector->m_selector->setMatch(CSSSelector::Match::PseudoClass);
-        selector->m_selector->setPseudoClassType(*pseudoType.pseudoClass);
+        selector->m_selector->setPseudoClass(*pseudoType.pseudoClass);
         return selector;
     }
     if (pseudoType.compatibilityPseudoElement) {
@@ -284,7 +284,7 @@ std::unique_ptr<CSSParserSelector> CSSParserSelector::releaseTagHistory()
 // FIXME-NEWPARSER: Add support for :host-context
 bool CSSParserSelector::isHostPseudoSelector() const
 {
-    return match() == CSSSelector::Match::PseudoClass && pseudoClassType() == CSSSelector::PseudoClassType::Host;
+    return match() == CSSSelector::Match::PseudoClass && pseudoClass() == CSSSelector::PseudoClass::Host;
 }
 
 bool CSSParserSelector::startsWithExplicitCombinator() const

--- a/Source/WebCore/css/parser/CSSParserSelector.h
+++ b/Source/WebCore/css/parser/CSSParserSelector.h
@@ -69,13 +69,13 @@ public:
     const CSSSelectorList* selectorList() const { return m_selector->selectorList(); }
     
     void setPseudoElementType(CSSSelector::PseudoElementType type) { m_selector->setPseudoElementType(type); }
-    void setPseudoClassType(CSSSelector::PseudoClassType type) { m_selector->setPseudoClassType(type); }
+    void setPseudoClass(CSSSelector::PseudoClass type) { m_selector->setPseudoClass(type); }
 
     void adoptSelectorVector(Vector<std::unique_ptr<CSSParserSelector>>&&);
     void setArgumentList(FixedVector<PossiblyQuotedIdentifier>);
     void setSelectorList(std::unique_ptr<CSSSelectorList>);
 
-    CSSSelector::PseudoClassType pseudoClassType() const { return m_selector->pseudoClassType(); }
+    CSSSelector::PseudoClass pseudoClass() const { return m_selector->pseudoClass(); }
 
     bool isPseudoElementCueFunction() const;
 

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -365,7 +365,7 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumeRelativeScopeSelect
 
     auto scopeSelector = makeUnique<CSSParserSelector>();
     scopeSelector->setMatch(CSSSelector::Match::PseudoClass);
-    scopeSelector->setPseudoClassType(CSSSelector::PseudoClassType::HasScope);
+    scopeSelector->setPseudoClass(CSSSelector::PseudoClass::HasScope);
 
     end->setRelation(scopeCombinator);
     end->setTagHistory(WTFMove(scopeSelector));
@@ -392,45 +392,45 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumeRelativeNestedSelec
     return selector;
 }
 
-static bool isScrollbarPseudoClass(CSSSelector::PseudoClassType pseudo)
+static bool isScrollbarPseudoClass(CSSSelector::PseudoClass pseudo)
 {
     switch (pseudo) {
-    case CSSSelector::PseudoClassType::Enabled:
-    case CSSSelector::PseudoClassType::Disabled:
-    case CSSSelector::PseudoClassType::Hover:
-    case CSSSelector::PseudoClassType::Active:
-    case CSSSelector::PseudoClassType::Horizontal:
-    case CSSSelector::PseudoClassType::Vertical:
-    case CSSSelector::PseudoClassType::Decrement:
-    case CSSSelector::PseudoClassType::Increment:
-    case CSSSelector::PseudoClassType::Start:
-    case CSSSelector::PseudoClassType::End:
-    case CSSSelector::PseudoClassType::DoubleButton:
-    case CSSSelector::PseudoClassType::SingleButton:
-    case CSSSelector::PseudoClassType::NoButton:
-    case CSSSelector::PseudoClassType::CornerPresent:
-    case CSSSelector::PseudoClassType::WindowInactive:
+    case CSSSelector::PseudoClass::Enabled:
+    case CSSSelector::PseudoClass::Disabled:
+    case CSSSelector::PseudoClass::Hover:
+    case CSSSelector::PseudoClass::Active:
+    case CSSSelector::PseudoClass::Horizontal:
+    case CSSSelector::PseudoClass::Vertical:
+    case CSSSelector::PseudoClass::Decrement:
+    case CSSSelector::PseudoClass::Increment:
+    case CSSSelector::PseudoClass::Start:
+    case CSSSelector::PseudoClass::End:
+    case CSSSelector::PseudoClass::DoubleButton:
+    case CSSSelector::PseudoClass::SingleButton:
+    case CSSSelector::PseudoClass::NoButton:
+    case CSSSelector::PseudoClass::CornerPresent:
+    case CSSSelector::PseudoClass::WindowInactive:
         return true;
     default:
         return false;
     }
 }
 
-static bool isUserActionPseudoClass(CSSSelector::PseudoClassType pseudo)
+static bool isUserActionPseudoClass(CSSSelector::PseudoClass pseudo)
 {
     switch (pseudo) {
-    case CSSSelector::PseudoClassType::Hover:
-    case CSSSelector::PseudoClassType::Focus:
-    case CSSSelector::PseudoClassType::Active:
-    case CSSSelector::PseudoClassType::FocusVisible:
-    case CSSSelector::PseudoClassType::FocusWithin:
+    case CSSSelector::PseudoClass::Hover:
+    case CSSSelector::PseudoClass::Focus:
+    case CSSSelector::PseudoClass::Active:
+    case CSSSelector::PseudoClass::FocusVisible:
+    case CSSSelector::PseudoClass::FocusWithin:
         return true;
     default:
         return false;
     }
 }
 
-static bool isPseudoClassValidAfterPseudoElement(CSSSelector::PseudoClassType pseudoClass, CSSSelector::PseudoElementType compoundPseudoElement)
+static bool isPseudoClassValidAfterPseudoElement(CSSSelector::PseudoClass pseudoClass, CSSSelector::PseudoElementType compoundPseudoElement)
 {
     // Validity of these is determined by their content.
     if (isLogicalCombinationPseudoClass(pseudoClass))
@@ -450,7 +450,7 @@ static bool isPseudoClassValidAfterPseudoElement(CSSSelector::PseudoClassType ps
     case CSSSelector::PseudoElementScrollbarTrackPiece:
         return isScrollbarPseudoClass(pseudoClass);
     case CSSSelector::PseudoElementSelection:
-        return pseudoClass == CSSSelector::PseudoClassType::WindowInactive;
+        return pseudoClass == CSSSelector::PseudoClass::WindowInactive;
     case CSSSelector::PseudoElementWebKitCustom:
     case CSSSelector::PseudoElementWebKitCustomLegacyPrefixed:
         return isUserActionPseudoClass(pseudoClass);
@@ -486,7 +486,7 @@ static bool isSimpleSelectorValidAfterPseudoElement(const CSSParserSelector& sim
     if (simpleSelector.match() != CSSSelector::Match::PseudoClass)
         return false;
 
-    return isPseudoClassValidAfterPseudoElement(simpleSelector.pseudoClassType(), compoundPseudoElement);
+    return isPseudoClassValidAfterPseudoElement(simpleSelector.pseudoClass(), compoundPseudoElement);
 }
 
 static bool atEndIgnoringWhitespace(CSSParserTokenRange range)
@@ -707,22 +707,22 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumeAttribute(CSSParser
     return selector;
 }
 
-static bool isOnlyPseudoClassFunction(CSSSelector::PseudoClassType pseudoClassType)
+static bool isOnlyPseudoClassFunction(CSSSelector::PseudoClass pseudoClass)
 {
-    switch (pseudoClassType) {
-    case CSSSelector::PseudoClassType::Not:
-    case CSSSelector::PseudoClassType::Is:
-    case CSSSelector::PseudoClassType::Matches:
-    case CSSSelector::PseudoClassType::Where:
-    case CSSSelector::PseudoClassType::Has:
-    case CSSSelector::PseudoClassType::NthChild:
-    case CSSSelector::PseudoClassType::NthLastChild:
-    case CSSSelector::PseudoClassType::NthOfType:
-    case CSSSelector::PseudoClassType::NthLastOfType:
-    case CSSSelector::PseudoClassType::Lang:
-    case CSSSelector::PseudoClassType::Any:
-    case CSSSelector::PseudoClassType::Dir:
-    case CSSSelector::PseudoClassType::State:
+    switch (pseudoClass) {
+    case CSSSelector::PseudoClass::Not:
+    case CSSSelector::PseudoClass::Is:
+    case CSSSelector::PseudoClass::Matches:
+    case CSSSelector::PseudoClass::Where:
+    case CSSSelector::PseudoClass::Has:
+    case CSSSelector::PseudoClass::NthChild:
+    case CSSSelector::PseudoClass::NthLastChild:
+    case CSSSelector::PseudoClass::NthOfType:
+    case CSSSelector::PseudoClass::NthLastOfType:
+    case CSSSelector::PseudoClass::Lang:
+    case CSSSelector::PseudoClass::Any:
+    case CSSSelector::PseudoClass::Dir:
+    case CSSSelector::PseudoClass::State:
         return true;
     default:
         break;
@@ -770,18 +770,18 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumePseudo(CSSParserTok
         if (!selector)
             return nullptr;
         if (selector->match() == CSSSelector::Match::PseudoClass) {
-            if (!m_context.focusVisibleEnabled && selector->pseudoClassType() == CSSSelector::PseudoClassType::FocusVisible)
+            if (!m_context.focusVisibleEnabled && selector->pseudoClass() == CSSSelector::PseudoClass::FocusVisible)
                 return nullptr;
-            if (!m_context.hasPseudoClassEnabled && selector->pseudoClassType() == CSSSelector::PseudoClassType::Has)
+            if (!m_context.hasPseudoClassEnabled && selector->pseudoClass() == CSSSelector::PseudoClass::Has)
                 return nullptr;
-            if (!m_context.popoverAttributeEnabled && selector->pseudoClassType() == CSSSelector::PseudoClassType::PopoverOpen)
+            if (!m_context.popoverAttributeEnabled && selector->pseudoClass() == CSSSelector::PseudoClass::PopoverOpen)
                 return nullptr;
-            if (!m_context.customStateSetEnabled && selector->pseudoClassType() == CSSSelector::PseudoClassType::State)
+            if (!m_context.customStateSetEnabled && selector->pseudoClass() == CSSSelector::PseudoClass::State)
                 return nullptr;
-            if (m_context.mode != UASheetMode && selector->pseudoClassType() == CSSSelector::PseudoClassType::HtmlDocument)
+            if (m_context.mode != UASheetMode && selector->pseudoClass() == CSSSelector::PseudoClass::HtmlDocument)
                 return nullptr;
 #if ENABLE(ATTACHMENT_ELEMENT)
-            if (!DeprecatedGlobalSettings::attachmentElementEnabled() && selector->pseudoClassType() == CSSSelector::PseudoClassType::HasAttachment)
+            if (!DeprecatedGlobalSettings::attachmentElementEnabled() && selector->pseudoClass() == CSSSelector::PseudoClass::HasAttachment)
                 return nullptr;
 #endif
         }
@@ -805,7 +805,7 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumePseudo(CSSParserTok
     if (token.type() == IdentToken) {
         range.consume();
         if ((selector->match() == CSSSelector::Match::PseudoElement && isOnlyPseudoElementFunction(selector->pseudoElementType()))
-            || (selector->match() == CSSSelector::Match::PseudoClass && isOnlyPseudoClassFunction(selector->pseudoClassType())))
+            || (selector->match() == CSSSelector::Match::PseudoClass && isOnlyPseudoClassFunction(selector->pseudoClass())))
             return nullptr;
         return selector;
     }
@@ -816,8 +816,8 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumePseudo(CSSParserTok
         return nullptr;
 
     if (selector->match() == CSSSelector::Match::PseudoClass) {
-        switch (selector->pseudoClassType()) {
-        case CSSSelector::PseudoClassType::Not: {
+        switch (selector->pseudoClass()) {
+        case CSSSelector::PseudoClass::Not: {
             SetForScope resistDefaultNamespace(m_resistDefaultNamespace, true);
             auto selectorList = consumeComplexSelectorList(block);
             if (selectorList.size() < 1 || !block.atEnd())
@@ -825,10 +825,10 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumePseudo(CSSParserTok
             selector->setSelectorList(makeUnique<CSSSelectorList>(WTFMove(selectorList)));
             return selector;
         }
-        case CSSSelector::PseudoClassType::NthChild:
-        case CSSSelector::PseudoClassType::NthLastChild:
-        case CSSSelector::PseudoClassType::NthOfType:
-        case CSSSelector::PseudoClassType::NthLastOfType: {
+        case CSSSelector::PseudoClass::NthChild:
+        case CSSSelector::PseudoClass::NthLastChild:
+        case CSSSelector::PseudoClass::NthOfType:
+        case CSSSelector::PseudoClass::NthLastOfType: {
             std::pair<int, int> ab;
             if (!consumeANPlusB(block, ab))
                 return nullptr;
@@ -836,8 +836,8 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumePseudo(CSSParserTok
             // FIXME: We should be able to do this lazily. See: https://bugs.webkit.org/show_bug.cgi?id=217149
             selector->setArgument(serializeANPlusB(ab));
             if (!block.atEnd()) {
-                auto type = selector->pseudoClassType();
-                if (type == CSSSelector::PseudoClassType::NthOfType || type == CSSSelector::PseudoClassType::NthLastOfType)
+                auto type = selector->pseudoClass();
+                if (type == CSSSelector::PseudoClass::NthOfType || type == CSSSelector::PseudoClass::NthLastOfType)
                     return nullptr;
                 if (block.peek().type() != IdentToken)
                     return nullptr;
@@ -853,17 +853,17 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumePseudo(CSSParserTok
             selector->setNth(ab.first, ab.second);
             return selector;
         }
-        case CSSSelector::PseudoClassType::Lang: {
+        case CSSSelector::PseudoClass::Lang: {
             auto list = consumeLangArgumentList(block);
             if (list.isEmpty() || !block.atEnd())
                 return nullptr;
             selector->setArgumentList(WTFMove(list));
             return selector;
         }
-        case CSSSelector::PseudoClassType::Is:
-        case CSSSelector::PseudoClassType::Where:
-        case CSSSelector::PseudoClassType::Matches:
-        case CSSSelector::PseudoClassType::Any: {
+        case CSSSelector::PseudoClass::Is:
+        case CSSSelector::PseudoClass::Where:
+        case CSSSelector::PseudoClass::Matches:
+        case CSSSelector::PseudoClass::Any: {
             SetForScope resistDefaultNamespace(m_resistDefaultNamespace, true);
             auto selectorList = makeUnique<CSSSelectorList>();
             auto consumedBlock = consumeComplexForgivingSelectorList(block);
@@ -876,7 +876,7 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumePseudo(CSSParserTok
             selector->setSelectorList(WTFMove(selectorList));
             return selector;
         }
-        case CSSSelector::PseudoClassType::Host: {
+        case CSSSelector::PseudoClass::Host: {
             auto innerSelector = consumeCompoundSelector(block);
             block.consumeWhitespace();
             if (!innerSelector || !block.atEnd())
@@ -884,7 +884,7 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumePseudo(CSSParserTok
             selector->adoptSelectorVector(Vector<std::unique_ptr<CSSParserSelector>>::from(WTFMove(innerSelector)));
             return selector;
         }
-        case CSSSelector::PseudoClassType::Has: {
+        case CSSSelector::PseudoClass::Has: {
             if (m_disallowHasPseudoClass)
                 return nullptr;
             SetForScope resistDefaultNamespace(m_resistDefaultNamespace, true);
@@ -895,14 +895,14 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumePseudo(CSSParserTok
             selector->setSelectorList(makeUnique<CSSSelectorList>(WTFMove(selectorList)));
             return selector;
         }
-        case CSSSelector::PseudoClassType::Dir: {
+        case CSSSelector::PseudoClass::Dir: {
             const CSSParserToken& ident = block.consumeIncludingWhitespace();
             if (ident.type() != IdentToken || !block.atEnd())
                 return nullptr;
             selector->setArgument(ident.value().toAtomString());
             return selector;
         }
-        case CSSSelector::PseudoClassType::State: {
+        case CSSSelector::PseudoClass::State: {
             const CSSParserToken& ident = block.consumeIncludingWhitespace();
             if (ident.type() != IdentToken || !block.atEnd())
                 return nullptr;

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -78,7 +78,7 @@
 namespace WebCore {
 namespace SelectorCompiler {
 
-using PseudoClassesSet = HashSet<CSSSelector::PseudoClassType, IntHash<CSSSelector::PseudoClassType>, WTF::StrongEnumHashTraits<CSSSelector::PseudoClassType>>;
+using PseudoClassesSet = HashSet<CSSSelector::PseudoClass, IntHash<CSSSelector::PseudoClass>, WTF::StrongEnumHashTraits<CSSSelector::PseudoClass>>;
 
 #if ENABLE(SELECTOR_OPERATION_STATS)
 
@@ -695,7 +695,7 @@ static inline FunctionType addPseudoElementPseudoClassType(const CSSSelector&, S
 }
 
 // Handle the forward :nth-child() and backward :nth-last-child().
-static FunctionType addNthChildType(const CSSSelector& selector, SelectorContext selectorContext, FragmentPositionInRootFragments positionInRootFragments, CSSSelector::PseudoClassType firstMatchAlternative, bool visitedMatchEnabled, Vector<std::pair<int, int>, 2>& simpleCases, Vector<NthChildOfSelectorInfo>& filteredCases, PseudoClassesSet& pseudoClasses)
+static FunctionType addNthChildType(const CSSSelector& selector, SelectorContext selectorContext, FragmentPositionInRootFragments positionInRootFragments, CSSSelector::PseudoClass firstMatchAlternative, bool visitedMatchEnabled, Vector<std::pair<int, int>, 2>& simpleCases, Vector<NthChildOfSelectorInfo>& filteredCases, PseudoClassesSet& pseudoClasses)
 {
     int a = selector.nthA();
     int b = selector.nthB();
@@ -1050,199 +1050,199 @@ JSC_DEFINE_JIT_OPERATION(operationIsUserValid, bool, (const Element& element))
 
 static inline FunctionType addPseudoClassType(const CSSSelector& selector, SelectorFragment& fragment, SelectorContext selectorContext, FragmentsLevel fragmentLevel, FragmentPositionInRootFragments positionInRootFragments, bool visitedMatchEnabled, VisitedMode& visitedMode, PseudoElementMatchingBehavior pseudoElementMatchingBehavior)
 {
-    CSSSelector::PseudoClassType type = selector.pseudoClassType();
+    auto type = selector.pseudoClass();
     switch (type) {
     // Unoptimized pseudo selector. They are just function call to a simple testing function.
-    case CSSSelector::PseudoClassType::Autofill:
+    case CSSSelector::PseudoClass::Autofill:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationIsAutofilled));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassType::AutofillAndObscured:
+    case CSSSelector::PseudoClass::AutofillAndObscured:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationIsAutofilledAndObscured));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassType::AutofillStrongPassword:
+    case CSSSelector::PseudoClass::AutofillStrongPassword:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationIsAutofilledStrongPassword));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassType::AutofillStrongPasswordViewable:
+    case CSSSelector::PseudoClass::AutofillStrongPasswordViewable:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationIsAutofilledStrongPasswordViewable));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassType::Checked:
+    case CSSSelector::PseudoClass::Checked:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationIsChecked));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassType::Default:
+    case CSSSelector::PseudoClass::Default:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesDefaultPseudoClass));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassType::Disabled:
+    case CSSSelector::PseudoClass::Disabled:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesDisabledPseudoClass));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassType::Enabled:
+    case CSSSelector::PseudoClass::Enabled:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesEnabledPseudoClass));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassType::Defined:
+    case CSSSelector::PseudoClass::Defined:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationIsDefinedElement));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassType::Focus:
+    case CSSSelector::PseudoClass::Focus:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesFocusPseudoClass));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassType::FocusVisible:
+    case CSSSelector::PseudoClass::FocusVisible:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesFocusVisiblePseudoClass));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassType::FocusWithin:
+    case CSSSelector::PseudoClass::FocusWithin:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesFocusWithinPseudoClass));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassType::FullPageMedia:
+    case CSSSelector::PseudoClass::FullPageMedia:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationIsMediaDocument));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassType::InRange:
+    case CSSSelector::PseudoClass::InRange:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationIsInRange));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassType::Indeterminate:
+    case CSSSelector::PseudoClass::Indeterminate:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesIndeterminatePseudoClass));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassType::Invalid:
+    case CSSSelector::PseudoClass::Invalid:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationIsInvalid));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassType::Optional:
+    case CSSSelector::PseudoClass::Optional:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationIsOptionalFormControl));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassType::OutOfRange:
+    case CSSSelector::PseudoClass::OutOfRange:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationIsOutOfRange));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassType::ReadOnly:
+    case CSSSelector::PseudoClass::ReadOnly:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesReadOnlyPseudoClass));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassType::ReadWrite:
+    case CSSSelector::PseudoClass::ReadWrite:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesReadWritePseudoClass));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassType::Required:
+    case CSSSelector::PseudoClass::Required:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationIsRequiredFormControl));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassType::Valid:
+    case CSSSelector::PseudoClass::Valid:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationIsValid));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassType::WindowInactive:
+    case CSSSelector::PseudoClass::WindowInactive:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationIsWindowInactive));
         return FunctionType::SimpleSelectorChecker;
 
 #if ENABLE(FULLSCREEN_API)
-    case CSSSelector::PseudoClassType::Fullscreen:
+    case CSSSelector::PseudoClass::Fullscreen:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesFullscreenPseudoClass));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassType::WebkitFullScreen:
+    case CSSSelector::PseudoClass::WebkitFullScreen:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesWebkitFullScreenPseudoClass));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassType::FullScreenDocument:
+    case CSSSelector::PseudoClass::FullScreenDocument:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesFullScreenDocumentPseudoClass));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassType::FullScreenAncestor:
+    case CSSSelector::PseudoClass::FullScreenAncestor:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesFullScreenAncestorPseudoClass));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassType::AnimatingFullScreenTransition:
+    case CSSSelector::PseudoClass::AnimatingFullScreenTransition:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesFullScreenAnimatingFullScreenTransitionPseudoClass));
         return FunctionType::SimpleSelectorChecker;
 
-    case CSSSelector::PseudoClassType::FullScreenControlsHidden:
+    case CSSSelector::PseudoClass::FullScreenControlsHidden:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesFullScreenControlsHiddenPseudoClass));
         return FunctionType::SimpleSelectorChecker;
 #endif
 
 #if ENABLE(PICTURE_IN_PICTURE_API)
-    case CSSSelector::PseudoClassType::PictureInPicture:
+    case CSSSelector::PseudoClass::PictureInPicture:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesPictureInPicturePseudoClass));
         return FunctionType::SimpleSelectorChecker;
 #endif
 
 #if ENABLE(VIDEO)
-    case CSSSelector::PseudoClassType::Future:
+    case CSSSelector::PseudoClass::Future:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesFutureCuePseudoClass));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassType::Past:
+    case CSSSelector::PseudoClass::Past:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesPastCuePseudoClass));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassType::Playing:
+    case CSSSelector::PseudoClass::Playing:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesPlayingPseudoClass));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassType::Paused:
+    case CSSSelector::PseudoClass::Paused:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesPausedPseudoClass));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassType::Seeking:
+    case CSSSelector::PseudoClass::Seeking:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesSeekingPseudoClass));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassType::Buffering:
+    case CSSSelector::PseudoClass::Buffering:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesBufferingPseudoClass));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassType::Stalled:
+    case CSSSelector::PseudoClass::Stalled:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesStalledPseudoClass));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassType::Muted:
+    case CSSSelector::PseudoClass::Muted:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesMutedPseudoClass));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassType::VolumeLocked:
+    case CSSSelector::PseudoClass::VolumeLocked:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesVolumeLockedPseudoClass));
         return FunctionType::SimpleSelectorChecker;
 #endif
 
 #if ENABLE(ATTACHMENT_ELEMENT)
-    case CSSSelector::PseudoClassType::HasAttachment:
+    case CSSSelector::PseudoClass::HasAttachment:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationHasAttachment));
         return FunctionType::SimpleSelectorChecker;
 #endif
 
-    case CSSSelector::PseudoClassType::HtmlDocument:
+    case CSSSelector::PseudoClass::HtmlDocument:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesHtmlDocumentPseudoClass));
         return FunctionType::SimpleSelectorChecker;
 
-    case CSSSelector::PseudoClassType::PopoverOpen:
+    case CSSSelector::PseudoClass::PopoverOpen:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesPopoverOpenPseudoClass));
         return FunctionType::SimpleSelectorChecker;
 
-    case CSSSelector::PseudoClassType::Modal:
+    case CSSSelector::PseudoClass::Modal:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesModalPseudoClass));
         return FunctionType::SimpleSelectorChecker;
 
-    case CSSSelector::PseudoClassType::UserInvalid:
+    case CSSSelector::PseudoClass::UserInvalid:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationIsUserInvalid));
         return FunctionType::SimpleSelectorChecker;
 
-    case CSSSelector::PseudoClassType::UserValid:
+    case CSSSelector::PseudoClass::UserValid:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationIsUserValid));
         return FunctionType::SimpleSelectorChecker;
 
     // These pseudo-classes only have meaning with scrollbars.
-    case CSSSelector::PseudoClassType::Horizontal:
-    case CSSSelector::PseudoClassType::Vertical:
-    case CSSSelector::PseudoClassType::Decrement:
-    case CSSSelector::PseudoClassType::Increment:
-    case CSSSelector::PseudoClassType::Start:
-    case CSSSelector::PseudoClassType::End:
-    case CSSSelector::PseudoClassType::DoubleButton:
-    case CSSSelector::PseudoClassType::SingleButton:
-    case CSSSelector::PseudoClassType::NoButton:
-    case CSSSelector::PseudoClassType::CornerPresent:
+    case CSSSelector::PseudoClass::Horizontal:
+    case CSSSelector::PseudoClass::Vertical:
+    case CSSSelector::PseudoClass::Decrement:
+    case CSSSelector::PseudoClass::Increment:
+    case CSSSelector::PseudoClass::Start:
+    case CSSSelector::PseudoClass::End:
+    case CSSSelector::PseudoClass::DoubleButton:
+    case CSSSelector::PseudoClass::SingleButton:
+    case CSSSelector::PseudoClass::NoButton:
+    case CSSSelector::PseudoClass::CornerPresent:
         return FunctionType::CannotMatchAnything;
 
     // FIXME: Compile these pseudoclasses, too!
-    case CSSSelector::PseudoClassType::FirstOfType:
-    case CSSSelector::PseudoClassType::LastOfType:
-    case CSSSelector::PseudoClassType::OnlyOfType:
-    case CSSSelector::PseudoClassType::NthOfType:
-    case CSSSelector::PseudoClassType::NthLastOfType:
-    case CSSSelector::PseudoClassType::Drag:
-    case CSSSelector::PseudoClassType::Has:
-    case CSSSelector::PseudoClassType::HasScope:
-    case CSSSelector::PseudoClassType::State:
+    case CSSSelector::PseudoClass::FirstOfType:
+    case CSSSelector::PseudoClass::LastOfType:
+    case CSSSelector::PseudoClass::OnlyOfType:
+    case CSSSelector::PseudoClass::NthOfType:
+    case CSSSelector::PseudoClass::NthLastOfType:
+    case CSSSelector::PseudoClass::Drag:
+    case CSSSelector::PseudoClass::Has:
+    case CSSSelector::PseudoClass::HasScope:
+    case CSSSelector::PseudoClass::State:
         return FunctionType::CannotCompile;
 
     // Optimized pseudo selectors.
-    case CSSSelector::PseudoClassType::AnyLink:
-    case CSSSelector::PseudoClassType::Link:
-    case CSSSelector::PseudoClassType::Root:
+    case CSSSelector::PseudoClass::AnyLink:
+    case CSSSelector::PseudoClass::Link:
+    case CSSSelector::PseudoClass::Root:
         fragment.pseudoClasses.add(type);
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassType::AnyLinkDeprecated:
-        fragment.pseudoClasses.add(CSSSelector::PseudoClassType::AnyLink);
+    case CSSSelector::PseudoClass::AnyLinkDeprecated:
+        fragment.pseudoClasses.add(CSSSelector::PseudoClass::AnyLink);
         return FunctionType::SimpleSelectorChecker;
 
-    case CSSSelector::PseudoClassType::Visited:
+    case CSSSelector::PseudoClass::Visited:
         // Determine this :visited cannot match anything statically.
         if (!visitedMatchEnabled)
             return FunctionType::CannotMatchAnything;
@@ -1256,30 +1256,30 @@ static inline FunctionType addPseudoClassType(const CSSSelector& selector, Selec
         visitedMode = VisitedMode::Visited;
         return FunctionType::SimpleSelectorChecker;
 
-    case CSSSelector::PseudoClassType::Scope:
-        fragment.pseudoClasses.add(CSSSelector::PseudoClassType::Scope);
+    case CSSSelector::PseudoClass::Scope:
+        fragment.pseudoClasses.add(CSSSelector::PseudoClass::Scope);
         return FunctionType::SelectorCheckerWithCheckingContext;
 
-    case CSSSelector::PseudoClassType::Active:
-    case CSSSelector::PseudoClassType::Empty:
-    case CSSSelector::PseudoClassType::FirstChild:
-    case CSSSelector::PseudoClassType::Hover:
-    case CSSSelector::PseudoClassType::LastChild:
-    case CSSSelector::PseudoClassType::OnlyChild:
-    case CSSSelector::PseudoClassType::PlaceholderShown:
-    case CSSSelector::PseudoClassType::Target:
+    case CSSSelector::PseudoClass::Active:
+    case CSSSelector::PseudoClass::Empty:
+    case CSSSelector::PseudoClass::FirstChild:
+    case CSSSelector::PseudoClass::Hover:
+    case CSSSelector::PseudoClass::LastChild:
+    case CSSSelector::PseudoClass::OnlyChild:
+    case CSSSelector::PseudoClass::PlaceholderShown:
+    case CSSSelector::PseudoClass::Target:
         fragment.pseudoClasses.add(type);
         if (selectorContext == SelectorContext::QuerySelector)
             return FunctionType::SimpleSelectorChecker;
         return FunctionType::SelectorCheckerWithCheckingContext;
 
-    case CSSSelector::PseudoClassType::NthChild:
-        return addNthChildType(selector, selectorContext, positionInRootFragments, CSSSelector::PseudoClassType::FirstChild, visitedMatchEnabled, fragment.nthChildFilters, fragment.nthChildOfFilters, fragment.pseudoClasses);
+    case CSSSelector::PseudoClass::NthChild:
+        return addNthChildType(selector, selectorContext, positionInRootFragments, CSSSelector::PseudoClass::FirstChild, visitedMatchEnabled, fragment.nthChildFilters, fragment.nthChildOfFilters, fragment.pseudoClasses);
 
-    case CSSSelector::PseudoClassType::NthLastChild:
-        return addNthChildType(selector, selectorContext, positionInRootFragments, CSSSelector::PseudoClassType::LastChild, visitedMatchEnabled, fragment.nthLastChildFilters, fragment.nthLastChildOfFilters, fragment.pseudoClasses);
+    case CSSSelector::PseudoClass::NthLastChild:
+        return addNthChildType(selector, selectorContext, positionInRootFragments, CSSSelector::PseudoClass::LastChild, visitedMatchEnabled, fragment.nthLastChildFilters, fragment.nthLastChildOfFilters, fragment.pseudoClasses);
 
-    case CSSSelector::PseudoClassType::Not:
+    case CSSSelector::PseudoClass::Not:
         {
             const CSSSelectorList* selectorList = selector.selectorList();
 
@@ -1317,7 +1317,7 @@ static inline FunctionType addPseudoClassType(const CSSSelector& selector, Selec
 
             return functionType;
         }
-    case CSSSelector::PseudoClassType::Dir:
+    case CSSSelector::PseudoClass::Dir:
         {
             auto& dirArgument = selector.argument();
             if (equalIgnoringASCIICase(dirArgument, "ltr"_s))
@@ -1329,15 +1329,15 @@ static inline FunctionType addPseudoClassType(const CSSSelector& selector, Selec
             return FunctionType::SimpleSelectorChecker;
         }
 
-    case CSSSelector::PseudoClassType::Lang:
+    case CSSSelector::PseudoClass::Lang:
         ASSERT(selector.argumentList() && !selector.argumentList()->isEmpty());
         fragment.languageArgumentsList.append(selector.argumentList());
         return FunctionType::SimpleSelectorChecker;
 
-    case CSSSelector::PseudoClassType::Is:
-    case CSSSelector::PseudoClassType::Where:
-    case CSSSelector::PseudoClassType::Matches:
-    case CSSSelector::PseudoClassType::Any:
+    case CSSSelector::PseudoClass::Is:
+    case CSSSelector::PseudoClass::Where:
+    case CSSSelector::PseudoClass::Matches:
+    case CSSSelector::PseudoClass::Any:
         {
             SelectorList matchesList;
             const CSSSelectorList* selectorList = selector.selectorList();
@@ -1381,7 +1381,7 @@ static inline FunctionType addPseudoClassType(const CSSSelector& selector, Selec
 
             return functionType;
         }
-    case CSSSelector::PseudoClassType::Host:
+    case CSSSelector::PseudoClass::Host:
         return FunctionType::CannotCompile;
     }
 
@@ -1413,8 +1413,8 @@ inline SelectorCodeGenerator::SelectorCodeGenerator(const CSSSelector* rootSelec
 
 static bool pseudoClassOnlyMatchesLinksInQuirksMode(const CSSSelector& selector)
 {
-    CSSSelector::PseudoClassType pseudoClassType = selector.pseudoClassType();
-    return pseudoClassType == CSSSelector::PseudoClassType::Hover || pseudoClassType == CSSSelector::PseudoClassType::Active;
+    auto pseudoClass = selector.pseudoClass();
+    return pseudoClass == CSSSelector::PseudoClass::Hover || pseudoClass == CSSSelector::PseudoClass::Active;
 }
 
 static FunctionType constructFragmentsInternal(const CSSSelector* rootSelector, SelectorContext selectorContext, SelectorFragmentList& selectorFragments, FragmentsLevel fragmentLevel, FragmentPositionInRootFragments positionInRootFragments, bool visitedMatchEnabled, VisitedMode& visitedMode, PseudoElementMatchingBehavior pseudoElementMatchingBehavior)
@@ -3143,13 +3143,13 @@ void SelectorCodeGenerator::generateElementMatching(Assembler::JumpList& matchin
 
     generateElementLinkMatching(matchingPostTagNameFailureCases, fragment);
 
-    if (fragment.pseudoClasses.contains(CSSSelector::PseudoClassType::Root))
+    if (fragment.pseudoClasses.contains(CSSSelector::PseudoClass::Root))
         generateElementIsRoot(matchingPostTagNameFailureCases);
 
-    if (fragment.pseudoClasses.contains(CSSSelector::PseudoClassType::Scope))
+    if (fragment.pseudoClasses.contains(CSSSelector::PseudoClass::Scope))
         generateElementIsScopeRoot(matchingPostTagNameFailureCases);
 
-    if (fragment.pseudoClasses.contains(CSSSelector::PseudoClassType::Target))
+    if (fragment.pseudoClasses.contains(CSSSelector::PseudoClass::Target))
         generateElementIsTarget(matchingPostTagNameFailureCases);
 
     for (unsigned i = 0; i < fragment.unoptimizedPseudoClasses.size(); ++i)
@@ -3157,19 +3157,19 @@ void SelectorCodeGenerator::generateElementMatching(Assembler::JumpList& matchin
 
     generateElementDataMatching(matchingPostTagNameFailureCases, fragment);
 
-    if (fragment.pseudoClasses.contains(CSSSelector::PseudoClassType::Active))
+    if (fragment.pseudoClasses.contains(CSSSelector::PseudoClass::Active))
         generateElementIsActive(matchingPostTagNameFailureCases, fragment);
-    if (fragment.pseudoClasses.contains(CSSSelector::PseudoClassType::Empty))
+    if (fragment.pseudoClasses.contains(CSSSelector::PseudoClass::Empty))
         generateElementIsEmpty(matchingPostTagNameFailureCases);
-    if (fragment.pseudoClasses.contains(CSSSelector::PseudoClassType::Hover))
+    if (fragment.pseudoClasses.contains(CSSSelector::PseudoClass::Hover))
         generateElementIsHovered(matchingPostTagNameFailureCases, fragment);
-    if (fragment.pseudoClasses.contains(CSSSelector::PseudoClassType::OnlyChild))
+    if (fragment.pseudoClasses.contains(CSSSelector::PseudoClass::OnlyChild))
         generateElementIsOnlyChild(matchingPostTagNameFailureCases);
-    if (fragment.pseudoClasses.contains(CSSSelector::PseudoClassType::PlaceholderShown))
+    if (fragment.pseudoClasses.contains(CSSSelector::PseudoClass::PlaceholderShown))
         generateElementHasPlaceholderShown(matchingPostTagNameFailureCases);
-    if (fragment.pseudoClasses.contains(CSSSelector::PseudoClassType::FirstChild))
+    if (fragment.pseudoClasses.contains(CSSSelector::PseudoClass::FirstChild))
         generateElementIsFirstChild(matchingPostTagNameFailureCases);
-    if (fragment.pseudoClasses.contains(CSSSelector::PseudoClassType::LastChild))
+    if (fragment.pseudoClasses.contains(CSSSelector::PseudoClass::LastChild))
         generateElementIsLastChild(matchingPostTagNameFailureCases);
     if (!fragment.nthChildFilters.isEmpty())
         generateElementIsNthChild(matchingPostTagNameFailureCases, fragment);
@@ -3194,7 +3194,7 @@ void SelectorCodeGenerator::generateElementMatching(Assembler::JumpList& matchin
 
     // Reach here when the generateElementMatching matching succeeded.
     // Only when the matching succeeeded, the last visited element should be stored and checked at the end of the whole matching.
-    if (fragment.pseudoClasses.contains(CSSSelector::PseudoClassType::Visited))
+    if (fragment.pseudoClasses.contains(CSSSelector::PseudoClass::Visited))
         generateStoreLastVisitedElement(elementAddressRegister);
 }
 
@@ -3221,9 +3221,9 @@ void SelectorCodeGenerator::generateElementDataMatching(Assembler::JumpList& fai
 
 void SelectorCodeGenerator::generateElementLinkMatching(Assembler::JumpList& failureCases, const SelectorFragment& fragment)
 {
-    if (fragment.pseudoClasses.contains(CSSSelector::PseudoClassType::Link)
-        || fragment.pseudoClasses.contains(CSSSelector::PseudoClassType::AnyLink)
-        || fragment.pseudoClasses.contains(CSSSelector::PseudoClassType::Visited))
+    if (fragment.pseudoClasses.contains(CSSSelector::PseudoClass::Link)
+        || fragment.pseudoClasses.contains(CSSSelector::PseudoClass::AnyLink)
+        || fragment.pseudoClasses.contains(CSSSelector::PseudoClass::Visited))
         generateElementIsLink(failureCases);
 }
 
@@ -3717,7 +3717,7 @@ void SelectorCodeGenerator::generateElementFunctionCallTest(Assembler::JumpList&
 JSC_DEFINE_JIT_OPERATION(operationElementIsActive, bool, (const Element* element))
 {
     COUNT_SELECTOR_OPERATION(operationElementIsActive);
-    return element->active() || InspectorInstrumentation::forcePseudoState(*element, CSSSelector::PseudoClassType::Active);
+    return element->active() || InspectorInstrumentation::forcePseudoState(*element, CSSSelector::PseudoClass::Active);
 }
 
 void SelectorCodeGenerator::generateElementIsActive(Assembler::JumpList& failureCases, const SelectorFragment& fragment)
@@ -3824,7 +3824,7 @@ void SelectorCodeGenerator::generateElementIsFirstChild(Assembler::JumpList& fai
 JSC_DEFINE_JIT_OPERATION(operationElementIsHovered, bool, (const Element* element))
 {
     COUNT_SELECTOR_OPERATION(operationElementIsHovered);
-    return element->hovered() || InspectorInstrumentation::forcePseudoState(*element, CSSSelector::PseudoClassType::Hover);
+    return element->hovered() || InspectorInstrumentation::forcePseudoState(*element, CSSSelector::PseudoClass::Hover);
 }
 
 void SelectorCodeGenerator::generateElementIsHovered(Assembler::JumpList& failureCases, const SelectorFragment& fragment)
@@ -4453,7 +4453,7 @@ void SelectorCodeGenerator::generateElementIsScopeRoot(Assembler::JumpList& fail
 JSC_DEFINE_JIT_OPERATION(operationElementIsTarget, bool, (const Element* element))
 {
     COUNT_SELECTOR_OPERATION(operationElementIsTarget);
-    return element == element->document().cssTarget() || InspectorInstrumentation::forcePseudoState(*element, CSSSelector::PseudoClassType::Target);
+    return element == element->document().cssTarget() || InspectorInstrumentation::forcePseudoState(*element, CSSSelector::PseudoClass::Target);
 }
 
 void SelectorCodeGenerator::generateElementIsTarget(Assembler::JumpList& failureCases)

--- a/Source/WebCore/dom/CustomStateSet.cpp
+++ b/Source/WebCore/dom/CustomStateSet.cpp
@@ -39,7 +39,7 @@ bool CustomStateSet::addToSetLike(const AtomString& state)
 {
     std::optional<Style::PseudoClassChangeInvalidation> styleInvalidation;
     if (RefPtr element = m_element.get())
-        styleInvalidation.emplace(*element, CSSSelector::PseudoClassType::State, Style::PseudoClassChangeInvalidation::AnyValue);
+        styleInvalidation.emplace(*element, CSSSelector::PseudoClass::State, Style::PseudoClassChangeInvalidation::AnyValue);
 
     return m_states.add(AtomString(state)).isNewEntry;
 }
@@ -48,7 +48,7 @@ bool CustomStateSet::removeFromSetLike(const AtomString& state)
 {
     std::optional<Style::PseudoClassChangeInvalidation> styleInvalidation;
     if (RefPtr element = m_element.get())
-        styleInvalidation.emplace(*element, CSSSelector::PseudoClassType::State, Style::PseudoClassChangeInvalidation::AnyValue);
+        styleInvalidation.emplace(*element, CSSSelector::PseudoClass::State, Style::PseudoClassChangeInvalidation::AnyValue);
 
     return m_states.remove(AtomString(state));
 }
@@ -57,7 +57,7 @@ void CustomStateSet::clearFromSetLike()
 {
     std::optional<Style::PseudoClassChangeInvalidation> styleInvalidation;
     if (RefPtr element = m_element.get())
-        styleInvalidation.emplace(*element, CSSSelector::PseudoClassType::State, Style::PseudoClassChangeInvalidation::AnyValue);
+        styleInvalidation.emplace(*element, CSSSelector::PseudoClass::State, Style::PseudoClassChangeInvalidation::AnyValue);
 
     m_states.clear();
 }

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -5327,11 +5327,11 @@ void Document::setCSSTarget(Element* newTarget)
 
     std::optional<Style::PseudoClassChangeInvalidation> oldInvalidation;
     if (m_cssTarget)
-        emplace(oldInvalidation, *m_cssTarget, { { CSSSelector::PseudoClassType::Target, false } });
+        emplace(oldInvalidation, *m_cssTarget, { { CSSSelector::PseudoClass::Target, false } });
 
     std::optional<Style::PseudoClassChangeInvalidation> newInvalidation;
     if (newTarget)
-        emplace(newInvalidation, *newTarget, { { CSSSelector::PseudoClassType::Target, true } });
+        emplace(newInvalidation, *newTarget, { { CSSSelector::PseudoClass::Target, true } });
     m_cssTarget = newTarget;
 }
 
@@ -8057,33 +8057,33 @@ void Document::updateHoverActiveState(const HitTestRequest& request, Element* in
             elementsToSetHover.append(element);
     }
 
-    auto changeState = [](auto& elements, auto pseudoClassType, auto value, auto&& setter) {
+    auto changeState = [](auto& elements, auto pseudoClass, auto value, auto&& setter) {
         if (elements.isEmpty())
             return;
 
-        Style::PseudoClassChangeInvalidation styleInvalidation { *elements.last(), pseudoClassType, value, Style::InvalidationScope::Descendants };
+        Style::PseudoClassChangeInvalidation styleInvalidation { *elements.last(), pseudoClass, value, Style::InvalidationScope::Descendants };
 
         // We need to do descendant invalidation for each shadow tree separately as the style is per-scope.
         Vector<Style::PseudoClassChangeInvalidation> shadowDescendantStyleInvalidations;
         for (auto& element : elements) {
             if (hasShadowRootParent(*element))
-                shadowDescendantStyleInvalidations.append({ *element, pseudoClassType, value, Style::InvalidationScope::Descendants });
+                shadowDescendantStyleInvalidations.append({ *element, pseudoClass, value, Style::InvalidationScope::Descendants });
         }
 
         for (auto& element : elements)
             setter(*element);
     };
 
-    changeState(elementsToClearActive, CSSSelector::PseudoClassType::Active, false, [](auto& element) {
+    changeState(elementsToClearActive, CSSSelector::PseudoClass::Active, false, [](auto& element) {
         element.setActive(false, Style::InvalidationScope::SelfChildrenAndSiblings);
     });
-    changeState(elementsToSetActive, CSSSelector::PseudoClassType::Active, true, [](auto& element) {
+    changeState(elementsToSetActive, CSSSelector::PseudoClass::Active, true, [](auto& element) {
         element.setActive(true, Style::InvalidationScope::SelfChildrenAndSiblings);
     });
-    changeState(elementsToClearHover, CSSSelector::PseudoClassType::Hover, false, [request](auto& element) {
+    changeState(elementsToClearHover, CSSSelector::PseudoClass::Hover, false, [request](auto& element) {
         element.setHovered(false, Style::InvalidationScope::SelfChildrenAndSiblings, request);
     });
-    changeState(elementsToSetHover, CSSSelector::PseudoClassType::Hover, true, [request](auto& element) {
+    changeState(elementsToSetHover, CSSSelector::PseudoClass::Hover, true, [request](auto& element) {
         element.setHovered(true, Style::InvalidationScope::SelfChildrenAndSiblings, request);
     });
 }
@@ -9538,11 +9538,11 @@ void Document::setPictureInPictureElement(HTMLVideoElement* element)
 
     std::optional<Style::PseudoClassChangeInvalidation> oldInvalidation;
     if (oldElement)
-        emplace(oldInvalidation, *oldElement, { { CSSSelector::PseudoClassType::PictureInPicture, false } });
+        emplace(oldInvalidation, *oldElement, { { CSSSelector::PseudoClass::PictureInPicture, false } });
 
     std::optional<Style::PseudoClassChangeInvalidation> newInvalidation;
     if (element)
-        emplace(newInvalidation, *element, { { CSSSelector::PseudoClassType::PictureInPicture, true } });
+        emplace(newInvalidation, *element, { { CSSSelector::PseudoClass::PictureInPicture, true } });
 
     m_pictureInPictureElement = element;
 }

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -856,7 +856,7 @@ void Element::setActive(bool value, Style::InvalidationScope invalidationScope)
     if (value == active())
         return;
     {
-        Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassType::Active, value, invalidationScope);
+        Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClass::Active, value, invalidationScope);
         document().userActionElements().setActive(*this, value);
     }
 
@@ -878,7 +878,7 @@ void Element::setFocus(bool value, FocusVisibility visibility)
     if (value == focused())
         return;
     
-    Style::PseudoClassChangeInvalidation focusStyleInvalidation(*this, { { CSSSelector::PseudoClassType::Focus, value }, { CSSSelector::PseudoClassType::FocusVisible, value } });
+    Style::PseudoClassChangeInvalidation focusStyleInvalidation(*this, { { CSSSelector::PseudoClass::Focus, value }, { CSSSelector::PseudoClass::FocusVisible, value } });
     protectedDocument()->userActionElements().setFocused(*this, value);
 
     // Shadow host with a slot that contain focused element is not considered focused.
@@ -915,7 +915,7 @@ void Element::setHasFocusWithin(bool value)
     if (hasFocusWithin() == value)
         return;
     {
-        Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassType::FocusWithin, value);
+        Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClass::FocusWithin, value);
         protectedDocument()->userActionElements().setHasFocusWithin(*this, value);
     }
 }
@@ -934,7 +934,7 @@ void Element::setHovered(bool value, Style::InvalidationScope invalidationScope,
     if (value == hovered())
         return;
     {
-        Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassType::Hover, value, invalidationScope);
+        Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClass::Hover, value, invalidationScope);
         protectedDocument()->userActionElements().setHovered(*this, value);
     }
 
@@ -949,7 +949,7 @@ void Element::setBeingDragged(bool value)
     if (value == isBeingDragged())
         return;
 
-    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassType::Drag, value);
+    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClass::Drag, value);
     protectedDocument()->userActionElements().setBeingDragged(*this, value);
 }
 
@@ -2200,7 +2200,7 @@ void Element::attributeChanged(const QualifiedName& name, const AtomString& oldV
 
 void Element::updateEffectiveLangStateAndPropagateToDescendants()
 {
-    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassType::Lang, Style::PseudoClassChangeInvalidation::AnyValue);
+    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClass::Lang, Style::PseudoClassChangeInvalidation::AnyValue);
     updateEffectiveLangState();
 
     for (auto it = descendantsOfType<Element>(*this).begin(); it;) {
@@ -2209,7 +2209,7 @@ void Element::updateEffectiveLangStateAndPropagateToDescendants()
             it.traverseNextSkippingChildren();
             continue;
         }
-        Style::PseudoClassChangeInvalidation styleInvalidation(element, CSSSelector::PseudoClassType::Lang, Style::PseudoClassChangeInvalidation::AnyValue);
+        Style::PseudoClassChangeInvalidation styleInvalidation(element, CSSSelector::PseudoClass::Lang, Style::PseudoClassChangeInvalidation::AnyValue);
         element->updateEffectiveLangStateFromParent();
         it.traverseNext();
     }
@@ -2376,9 +2376,9 @@ void Element::setIsLink(bool flag)
     if (isLink() == flag)
         return;
     Style::PseudoClassChangeInvalidation styleInvalidation(*this, {
-        { CSSSelector::PseudoClassType::AnyLink, flag },
-        { CSSSelector::PseudoClassType::AnyLinkDeprecated, flag },
-        { CSSSelector::PseudoClassType::Link, flag }
+        { CSSSelector::PseudoClass::AnyLink, flag },
+        { CSSSelector::PseudoClass::AnyLinkDeprecated, flag },
+        { CSSSelector::PseudoClass::Link, flag }
     });
     setStateFlag(StateFlag::IsLink, flag);
 }
@@ -3037,7 +3037,7 @@ ShadowRoot& Element::createUserAgentShadowRoot()
 inline void Node::setCustomElementState(CustomElementState state)
 {
     Style::PseudoClassChangeInvalidation styleInvalidation(checkedDowncast<Element>(*this),
-        CSSSelector::PseudoClassType::Defined,
+        CSSSelector::PseudoClass::Defined,
         state == CustomElementState::Custom || state == CustomElementState::Uncustomized
     );
     auto bitfields = rareDataBitfields();
@@ -4478,7 +4478,7 @@ void Element::requestFullscreen(FullscreenOptions&&, RefPtr<DeferredPromise>&& p
 
 void Element::setFullscreenFlag(bool flag)
 {
-    Style::PseudoClassChangeInvalidation styleInvalidation(*this, { { CSSSelector::PseudoClassType::Fullscreen, flag }, { CSSSelector::PseudoClassType::Modal, flag } });
+    Style::PseudoClassChangeInvalidation styleInvalidation(*this, { { CSSSelector::PseudoClass::Fullscreen, flag }, { CSSSelector::PseudoClass::Modal, flag } });
     if (flag)
         setStateFlag(StateFlag::IsFullscreen);
     else

--- a/Source/WebCore/dom/FullscreenManager.cpp
+++ b/Source/WebCore/dom/FullscreenManager.cpp
@@ -737,7 +737,7 @@ void FullscreenManager::setAnimatingFullscreen(bool flag)
 
     std::optional<Style::PseudoClassChangeInvalidation> styleInvalidation;
     if (m_fullscreenElement)
-        emplace(styleInvalidation, *m_fullscreenElement, { { CSSSelector::PseudoClassType::AnimatingFullScreenTransition, flag } });
+        emplace(styleInvalidation, *m_fullscreenElement, { { CSSSelector::PseudoClass::AnimatingFullScreenTransition, flag } });
     m_isAnimatingFullscreen = flag;
 }
 
@@ -755,7 +755,7 @@ void FullscreenManager::setFullscreenControlsHidden(bool flag)
 
     std::optional<Style::PseudoClassChangeInvalidation> styleInvalidation;
     if (m_fullscreenElement)
-        emplace(styleInvalidation, *m_fullscreenElement, { { CSSSelector::PseudoClassType::FullScreenControlsHidden, flag } });
+        emplace(styleInvalidation, *m_fullscreenElement, { { CSSSelector::PseudoClass::FullScreenControlsHidden, flag } });
     m_areFullscreenControlsHidden = flag;
 }
 

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -2199,9 +2199,9 @@ static Vector<Style::PseudoClassChangeInvalidation> invalidateFocusedElementAndS
 {
     Vector<Style::PseudoClassChangeInvalidation> invalidations;
     for (RefPtr element = focusedElement; element; element = element->shadowHost()) {
-        invalidations.append({ *element, { { CSSSelector::PseudoClassType::Focus, activeAndFocused }, { CSSSelector::PseudoClassType::FocusVisible, activeAndFocused } } });
+        invalidations.append({ *element, { { CSSSelector::PseudoClass::Focus, activeAndFocused }, { CSSSelector::PseudoClass::FocusVisible, activeAndFocused } } });
         for (auto& lineage : lineageOfType<Element>(*element))
-            invalidations.append({ lineage, CSSSelector::PseudoClassType::FocusWithin, activeAndFocused });
+            invalidations.append({ lineage, CSSSelector::PseudoClass::FocusWithin, activeAndFocused });
     }
     return invalidations;
 }

--- a/Source/WebCore/html/HTMLDialogElement.cpp
+++ b/Source/WebCore/html/HTMLDialogElement.cpp
@@ -173,7 +173,7 @@ void HTMLDialogElement::setIsModal(bool newValue)
 {
     if (m_isModal == newValue)
         return;
-    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassType::Modal, newValue);
+    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClass::Modal, newValue);
     m_isModal = newValue;
 }
 

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -944,7 +944,7 @@ void HTMLElement::dirAttributeChanged(const AtomString& value)
 
 void HTMLElement::updateEffectiveDirectionality(std::optional<TextDirection> direction)
 {
-    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassType::Dir, Style::PseudoClassChangeInvalidation::AnyValue);
+    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClass::Dir, Style::PseudoClassChangeInvalidation::AnyValue);
     auto effectiveDirection = direction.value_or(TextDirection::LTR);
     setUsesEffectiveTextDirection(!!direction);
     if (direction)
@@ -963,7 +963,7 @@ void HTMLElement::updateEffectiveDirectionality(std::optional<TextDirection> dir
             continue;
         }
         updateEffectiveTextDirectionOfShadowRoot(element);
-        Style::PseudoClassChangeInvalidation styleInvalidation(element, CSSSelector::PseudoClassType::Dir, Style::PseudoClassChangeInvalidation::AnyValue);
+        Style::PseudoClassChangeInvalidation styleInvalidation(element, CSSSelector::PseudoClass::Dir, Style::PseudoClassChangeInvalidation::AnyValue);
         element->setUsesEffectiveTextDirection(!!direction);
         if (direction)
             element->setEffectiveTextDirection(effectiveDirection);
@@ -1438,7 +1438,7 @@ ExceptionOr<void> HTMLElement::showPopover(const HTMLFormControlElement* invoker
 
     popoverData()->setPreviouslyFocusedElement(nullptr);
 
-    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassType::PopoverOpen, true);
+    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClass::PopoverOpen, true);
     popoverData()->setVisibilityState(PopoverVisibilityState::Showing);
 
     runPopoverFocusingSteps(*this);
@@ -1498,7 +1498,7 @@ ExceptionOr<void> HTMLElement::hidePopoverInternal(FocusPreviousElement focusPre
 
     removeFromTopLayer();
 
-    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassType::PopoverOpen, false);
+    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClass::PopoverOpen, false);
     popoverData()->setVisibilityState(PopoverVisibilityState::Hidden);
 
     if (fireEvents == FireEvents::Yes)
@@ -1562,7 +1562,7 @@ void HTMLElement::popoverAttributeChanged(const AtomString& value)
     if (newPopoverState == oldPopoverState)
         return;
 
-    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassType::PopoverOpen, false);
+    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClass::PopoverOpen, false);
 
     if (isPopoverShowing()) {
         hidePopoverInternal(FocusPreviousElement::Yes, FireEvents::Yes);

--- a/Source/WebCore/html/HTMLFieldSetElement.cpp
+++ b/Source/WebCore/html/HTMLFieldSetElement.cpp
@@ -206,7 +206,7 @@ void HTMLFieldSetElement::addInvalidDescendant(const HTMLElement& invalidFormCon
 
     std::optional<Style::PseudoClassChangeInvalidation> styleInvalidation;
     if (m_invalidDescendants.isEmptyIgnoringNullReferences())
-        emplace(styleInvalidation, *this, { { CSSSelector::PseudoClassType::Valid, false }, { CSSSelector::PseudoClassType::Invalid, true } });
+        emplace(styleInvalidation, *this, { { CSSSelector::PseudoClass::Valid, false }, { CSSSelector::PseudoClass::Invalid, true } });
 
     m_invalidDescendants.add(invalidFormControlElement);
 }
@@ -218,7 +218,7 @@ void HTMLFieldSetElement::removeInvalidDescendant(const HTMLElement& formControl
 
     std::optional<Style::PseudoClassChangeInvalidation> styleInvalidation;
     if (m_invalidDescendants.computeSize() == 1)
-        emplace(styleInvalidation, *this, { { CSSSelector::PseudoClassType::Valid, true }, { CSSSelector::PseudoClassType::Invalid, false } });
+        emplace(styleInvalidation, *this, { { CSSSelector::PseudoClass::Valid, true }, { CSSSelector::PseudoClass::Invalid, false } });
 
     m_invalidDescendants.remove(formControlElement);
 }

--- a/Source/WebCore/html/HTMLFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLFormControlElement.cpp
@@ -147,7 +147,7 @@ void HTMLFormControlElement::attributeChanged(const QualifiedName& name, const A
     if (name == requiredAttr) {
         bool newRequired = !newValue.isNull();
         if (m_isRequired != newRequired) {
-            Style::PseudoClassChangeInvalidation requiredInvalidation(*this, { { CSSSelector::PseudoClassType::Required, newRequired }, { CSSSelector::PseudoClassType::Optional, !newRequired } });
+            Style::PseudoClassChangeInvalidation requiredInvalidation(*this, { { CSSSelector::PseudoClass::Required, newRequired }, { CSSSelector::PseudoClass::Optional, !newRequired } });
             m_isRequired = newRequired;
             requiredStateChanged();
         }

--- a/Source/WebCore/html/HTMLFormElement.cpp
+++ b/Source/WebCore/html/HTMLFormElement.cpp
@@ -623,7 +623,7 @@ void HTMLFormElement::addInvalidFormControl(const HTMLElement& formControlElemen
 
     std::optional<Style::PseudoClassChangeInvalidation> styleInvalidation;
     if (m_invalidFormControls.isEmptyIgnoringNullReferences())
-        emplace(styleInvalidation, *this, { { CSSSelector::PseudoClassType::Valid, false }, { CSSSelector::PseudoClassType::Invalid, true } });
+        emplace(styleInvalidation, *this, { { CSSSelector::PseudoClass::Valid, false }, { CSSSelector::PseudoClass::Invalid, true } });
 
     m_invalidFormControls.add(formControlElement);
 }
@@ -635,7 +635,7 @@ void HTMLFormElement::removeInvalidFormControlIfNeeded(const HTMLElement& formCo
 
     std::optional<Style::PseudoClassChangeInvalidation> styleInvalidation;
     if (m_invalidFormControls.computeSize() == 1)
-        emplace(styleInvalidation, *this, { { CSSSelector::PseudoClassType::Valid, true }, { CSSSelector::PseudoClassType::Invalid, false } });
+        emplace(styleInvalidation, *this, { { CSSSelector::PseudoClass::Valid, true }, { CSSSelector::PseudoClass::Invalid, false } });
 
     m_invalidFormControls.remove(formControlElement);
 }

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -518,7 +518,7 @@ void HTMLInputElement::updateType(const AtomString& typeAttributeValue)
         return;
     ASSERT(m_inputType->type() != newType->type());
 
-    Style::PseudoClassChangeInvalidation defaultInvalidation(*this, CSSSelector::PseudoClassType::Default, Style::PseudoClassChangeInvalidation::AnyValue);
+    Style::PseudoClassChangeInvalidation defaultInvalidation(*this, CSSSelector::PseudoClass::Default, Style::PseudoClassChangeInvalidation::AnyValue);
 
     removeFromRadioButtonGroup();
     resignStrongPasswordAppearance();
@@ -553,7 +553,7 @@ void HTMLInputElement::updateType(const AtomString& typeAttributeValue)
         updateTextDirectionalityAfterInputTypeChange();
 
     if (UNLIKELY(didSupportReadOnly != willSupportReadOnly && hasAttributeWithoutSynchronization(readonlyAttr))) {
-        emplace(readWriteInvalidation, *this, { { CSSSelector::PseudoClassType::ReadWrite, !willSupportReadOnly }, { CSSSelector::PseudoClassType::ReadOnly, willSupportReadOnly } });
+        emplace(readWriteInvalidation, *this, { { CSSSelector::PseudoClass::ReadWrite, !willSupportReadOnly }, { CSSSelector::PseudoClass::ReadOnly, willSupportReadOnly } });
         readOnlyStateChanged();
     }
 
@@ -1050,7 +1050,7 @@ void HTMLInputElement::setDefaultCheckedState(bool isDefaultChecked)
 
     std::optional<Style::PseudoClassChangeInvalidation> defaultInvalidation;
     if (m_inputType->isCheckable())
-        defaultInvalidation.emplace(*this, CSSSelector::PseudoClassType::Default, isDefaultChecked);
+        defaultInvalidation.emplace(*this, CSSSelector::PseudoClass::Default, isDefaultChecked);
     m_isDefaultChecked = isDefaultChecked;
 }
 
@@ -1062,7 +1062,7 @@ void HTMLInputElement::setChecked(bool isChecked, WasSetByJavaScript wasCheckedB
 
     m_inputType->willUpdateCheckedness(isChecked, wasCheckedByJavaScript);
 
-    Style::PseudoClassChangeInvalidation checkedInvalidation(*this, CSSSelector::PseudoClassType::Checked, isChecked);
+    Style::PseudoClassChangeInvalidation checkedInvalidation(*this, CSSSelector::PseudoClass::Checked, isChecked);
 
     m_isChecked = isChecked;
 
@@ -1086,7 +1086,7 @@ void HTMLInputElement::setIndeterminate(bool newValue)
     if (indeterminate() == newValue)
         return;
 
-    Style::PseudoClassChangeInvalidation indeterminateInvalidation(*this, CSSSelector::PseudoClassType::Indeterminate, newValue);
+    Style::PseudoClassChangeInvalidation indeterminateInvalidation(*this, CSSSelector::PseudoClass::Indeterminate, newValue);
     m_isIndeterminate = newValue;
 
     if (auto* renderer = this->renderer(); renderer && renderer->style().hasEffectiveAppearance())
@@ -1498,7 +1498,7 @@ void HTMLInputElement::setAutoFilled(bool autoFilled)
     if (autoFilled == m_isAutoFilled)
         return;
 
-    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassType::Autofill, autoFilled);
+    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClass::Autofill, autoFilled);
     m_isAutoFilled = autoFilled;
 }
 
@@ -1507,7 +1507,7 @@ void HTMLInputElement::setAutoFilledAndViewable(bool autoFilledAndViewable)
     if (autoFilledAndViewable == m_isAutoFilledAndViewable)
         return;
 
-    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassType::AutofillStrongPasswordViewable, autoFilledAndViewable);
+    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClass::AutofillStrongPasswordViewable, autoFilledAndViewable);
     m_isAutoFilledAndViewable = autoFilledAndViewable;
 }
 
@@ -1516,7 +1516,7 @@ void HTMLInputElement::setAutoFilledAndObscured(bool autoFilledAndObscured)
     if (autoFilledAndObscured == m_isAutoFilledAndObscured)
         return;
 
-    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassType::AutofillAndObscured, autoFilledAndObscured);
+    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClass::AutofillAndObscured, autoFilledAndObscured);
     m_isAutoFilledAndObscured = autoFilledAndObscured;
 
     if (auto* cache = document().existingAXObjectCache())

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -3635,7 +3635,7 @@ void HTMLMediaElement::setSeeking(bool seeking)
 {
     if (m_seeking == seeking)
         return;
-    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassType::Seeking, seeking);
+    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClass::Seeking, seeking);
     m_seeking = seeking;
 }
 
@@ -3804,8 +3804,8 @@ void HTMLMediaElement::setPaused(bool paused)
     if (m_paused == paused)
         return;
     Style::PseudoClassChangeInvalidation styleInvalidation(*this, {
-        { CSSSelector::PseudoClassType::Paused, paused },
-        { CSSSelector::PseudoClassType::Playing, !paused },
+        { CSSSelector::PseudoClass::Paused, paused },
+        { CSSSelector::PseudoClass::Playing, !paused },
     });
     m_paused = paused;
     updateBufferingState();
@@ -4276,7 +4276,7 @@ void HTMLMediaElement::setMuted(bool muted)
             if (hasAudio() && muted)
                 userDidInterfereWithAutoplay();
         }
-        Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassType::Muted, muted);
+        Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClass::Muted, muted);
         m_muted = muted;
         m_explicitlyMuted = true;
 
@@ -4311,7 +4311,7 @@ void HTMLMediaElement::setVolumeLocked(bool locked)
     if (m_volumeLocked == locked)
         return;
 
-    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassType::VolumeLocked, locked);
+    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClass::VolumeLocked, locked);
     m_volumeLocked = locked;
 }
 
@@ -4328,7 +4328,7 @@ void HTMLMediaElement::updateBufferingState()
     // matches the element.)
     bool buffering = !paused() && m_networkState == NETWORK_LOADING && m_readyState <= HAVE_CURRENT_DATA;
     if (m_buffering != buffering) {
-        Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassType::Buffering, buffering);
+        Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClass::Buffering, buffering);
         m_buffering = buffering;
     }
 }
@@ -4347,7 +4347,7 @@ void HTMLMediaElement::updateStalledState()
     // also matches the element.)
     bool stalled = !paused() && m_networkState == NETWORK_LOADING && m_readyState <= HAVE_CURRENT_DATA && m_sentStalledEvent;
     if (m_stalled != stalled) {
-        Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassType::Stalled, stalled);
+        Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClass::Stalled, stalled);
         m_stalled = stalled;
     }
 }

--- a/Source/WebCore/html/HTMLOptGroupElement.cpp
+++ b/Source/WebCore/html/HTMLOptGroupElement.cpp
@@ -98,11 +98,11 @@ void HTMLOptGroupElement::attributeChanged(const QualifiedName& name, const Atom
     if (name == disabledAttr) {
         bool newDisabled = !newValue.isNull();
         if (m_isDisabled != newDisabled) {
-            Style::PseudoClassChangeInvalidation disabledInvalidation(*this, { { CSSSelector::PseudoClassType::Disabled, newDisabled }, { CSSSelector::PseudoClassType::Enabled, !newDisabled } });
+            Style::PseudoClassChangeInvalidation disabledInvalidation(*this, { { CSSSelector::PseudoClass::Disabled, newDisabled }, { CSSSelector::PseudoClass::Enabled, !newDisabled } });
 
             Vector<Style::PseudoClassChangeInvalidation> optionInvalidation;
             for (auto& descendant : descendantsOfType<HTMLOptionElement>(*this))
-                optionInvalidation.append({ descendant, { { CSSSelector::PseudoClassType::Disabled, newDisabled }, { CSSSelector::PseudoClassType::Enabled, !newDisabled } } });
+                optionInvalidation.append({ descendant, { { CSSSelector::PseudoClass::Disabled, newDisabled }, { CSSSelector::PseudoClass::Enabled, !newDisabled } } });
 
             m_isDisabled = newDisabled;
         }

--- a/Source/WebCore/html/HTMLOptionElement.cpp
+++ b/Source/WebCore/html/HTMLOptionElement.cpp
@@ -171,7 +171,7 @@ void HTMLOptionElement::attributeChanged(const QualifiedName& name, const AtomSt
     case AttributeNames::disabledAttr: {
         bool newDisabled = !newValue.isNull();
         if (m_disabled != newDisabled) {
-            Style::PseudoClassChangeInvalidation disabledInvalidation(*this, { { CSSSelector::PseudoClassType::Disabled, newDisabled },  { CSSSelector::PseudoClassType::Enabled, !newDisabled } });
+            Style::PseudoClassChangeInvalidation disabledInvalidation(*this, { { CSSSelector::PseudoClass::Disabled, newDisabled },  { CSSSelector::PseudoClass::Enabled, !newDisabled } });
             m_disabled = newDisabled;
             if (renderer() && renderer()->style().hasEffectiveAppearance())
                 renderer()->theme().stateChanged(*renderer(), ControlStyle::State::Enabled);
@@ -180,7 +180,7 @@ void HTMLOptionElement::attributeChanged(const QualifiedName& name, const AtomSt
     }
     case AttributeNames::selectedAttr: {
         // FIXME: Use PseudoClassChangeInvalidation in other elements that implement matchesDefaultPseudoClass().
-        Style::PseudoClassChangeInvalidation defaultInvalidation(*this, CSSSelector::PseudoClassType::Default, !newValue.isNull());
+        Style::PseudoClassChangeInvalidation defaultInvalidation(*this, CSSSelector::PseudoClass::Default, !newValue.isNull());
         m_isDefault = !newValue.isNull();
 
         // FIXME: WebKit still need to implement 'dirtiness'. See: https://bugs.webkit.org/show_bug.cgi?id=258073
@@ -244,7 +244,7 @@ void HTMLOptionElement::setSelectedState(bool selected, AllowStyleInvalidation a
 
     std::optional<Style::PseudoClassChangeInvalidation> checkedInvalidation;
     if (allowStyleInvalidation == AllowStyleInvalidation::Yes)
-        emplace(checkedInvalidation, *this, { { CSSSelector::PseudoClassType::Checked, selected } });
+        emplace(checkedInvalidation, *this, { { CSSSelector::PseudoClass::Checked, selected } });
 
     m_isSelected = selected;
 

--- a/Source/WebCore/html/HTMLProgressElement.cpp
+++ b/Source/WebCore/html/HTMLProgressElement.cpp
@@ -129,7 +129,7 @@ void HTMLProgressElement::updateDeterminateState()
     bool newIsDeterminate = hasAttributeWithoutSynchronization(valueAttr);
     if (m_isDeterminate == newIsDeterminate)
         return;
-    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassType::Indeterminate, !newIsDeterminate);
+    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClass::Indeterminate, !newIsDeterminate);
     m_isDeterminate = newIsDeterminate;
 }
 

--- a/Source/WebCore/html/HTMLTextFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLTextFormControlElement.cpp
@@ -188,7 +188,7 @@ void HTMLTextFormControlElement::updatePlaceholderVisibility()
     if (m_isPlaceholderVisible == newIsPlaceholderVisible)
         return;
 
-    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassType::PlaceholderShown, newIsPlaceholderVisible);
+    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClass::PlaceholderShown, newIsPlaceholderVisible);
     m_isPlaceholderVisible = newIsPlaceholderVisible;
 
     if (RefPtr placeholder = placeholderElement())

--- a/Source/WebCore/html/InputType.cpp
+++ b/Source/WebCore/html/InputType.cpp
@@ -810,7 +810,7 @@ void InputType::setValue(const String& sanitizedValue, bool valueChanged, TextFi
 
     std::optional<Style::PseudoClassChangeInvalidation> styleInvalidation;
     if (wasInRange != inRange)
-        emplace(styleInvalidation, *element(), { { CSSSelector::PseudoClassType::InRange, inRange }, { CSSSelector::PseudoClassType::OutOfRange, !inRange } });
+        emplace(styleInvalidation, *element(), { { CSSSelector::PseudoClass::InRange, inRange }, { CSSSelector::PseudoClass::OutOfRange, !inRange } });
 
     element()->setValueInternal(sanitizedValue, eventBehavior);
 

--- a/Source/WebCore/html/ValidatedFormListedElement.cpp
+++ b/Source/WebCore/html/ValidatedFormListedElement.cpp
@@ -211,8 +211,8 @@ void ValidatedFormListedElement::setDisabledInternal(bool disabled, bool disable
     std::optional<Style::PseudoClassChangeInvalidation> styleInvalidation;
     if (changingDisabledState) {
         emplace(styleInvalidation, asHTMLElement(), {
-            { CSSSelector::PseudoClassType::Disabled, newDisabledState },
-            { CSSSelector::PseudoClassType::Enabled, !newDisabledState },
+            { CSSSelector::PseudoClass::Disabled, newDisabledState },
+            { CSSSelector::PseudoClass::Enabled, !newDisabledState },
         });
     }
 
@@ -254,10 +254,10 @@ void ValidatedFormListedElement::updateValidity()
     if (newIsValid != m_isValid) {
         HTMLElement& element = asHTMLElement();
         Style::PseudoClassChangeInvalidation styleInvalidation(element, {
-            { CSSSelector::PseudoClassType::Valid, newIsValid },
-            { CSSSelector::PseudoClassType::Invalid, !newIsValid },
-            { CSSSelector::PseudoClassType::UserValid, m_wasInteractedWithSinceLastFormSubmitEvent && newIsValid },
-            { CSSSelector::PseudoClassType::UserInvalid, m_wasInteractedWithSinceLastFormSubmitEvent && !newIsValid },
+            { CSSSelector::PseudoClass::Valid, newIsValid },
+            { CSSSelector::PseudoClass::Invalid, !newIsValid },
+            { CSSSelector::PseudoClass::UserValid, m_wasInteractedWithSinceLastFormSubmitEvent && newIsValid },
+            { CSSSelector::PseudoClass::UserInvalid, m_wasInteractedWithSinceLastFormSubmitEvent && !newIsValid },
         });
 
         m_isValid = newIsValid;
@@ -314,7 +314,7 @@ void ValidatedFormListedElement::parseReadOnlyAttribute(const AtomString& value)
     bool newHasReadOnlyAttribute = !value.isNull();
     if (m_hasReadOnlyAttribute != newHasReadOnlyAttribute) {
         bool newMatchesReadWrite = supportsReadOnly() && !newHasReadOnlyAttribute;
-        Style::PseudoClassChangeInvalidation readWriteInvalidation(asHTMLElement(), { { CSSSelector::PseudoClassType::ReadWrite, newMatchesReadWrite }, { CSSSelector::PseudoClassType::ReadOnly, !newMatchesReadWrite } });
+        Style::PseudoClassChangeInvalidation readWriteInvalidation(asHTMLElement(), { { CSSSelector::PseudoClass::ReadWrite, newMatchesReadWrite }, { CSSSelector::PseudoClass::ReadOnly, !newMatchesReadWrite } });
         m_hasReadOnlyAttribute = newHasReadOnlyAttribute;
         readOnlyStateChanged();
     }
@@ -505,8 +505,8 @@ void ValidatedFormListedElement::setInteractedWithSinceLastFormSubmitEvent(bool 
         return;
 
     Style::PseudoClassChangeInvalidation styleInvalidation(asHTMLElement(), {
-        { CSSSelector::PseudoClassType::UserValid, interactedWith && matchesValidPseudoClass() },
-        { CSSSelector::PseudoClassType::UserInvalid, interactedWith && matchesInvalidPseudoClass() },
+        { CSSSelector::PseudoClass::UserValid, interactedWith && matchesValidPseudoClass() },
+        { CSSSelector::PseudoClass::UserInvalid, interactedWith && matchesInvalidPseudoClass() },
     });
 
     m_wasInteractedWithSinceLastFormSubmitEvent = interactedWith;

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -328,7 +328,7 @@ bool InspectorInstrumentation::handleMousePressImpl(InstrumentingAgents& instrum
     return false;
 }
 
-bool InspectorInstrumentation::forcePseudoStateImpl(InstrumentingAgents& instrumentingAgents, const Element& element, CSSSelector::PseudoClassType pseudoState)
+bool InspectorInstrumentation::forcePseudoStateImpl(InstrumentingAgents& instrumentingAgents, const Element& element, CSSSelector::PseudoClass pseudoState)
 {
     if (auto* cssAgent = instrumentingAgents.enabledCSSAgent())
         return cssAgent->forcePseudoState(element, pseudoState);

--- a/Source/WebCore/inspector/InspectorInstrumentation.h
+++ b/Source/WebCore/inspector/InspectorInstrumentation.h
@@ -151,7 +151,7 @@ public:
     static void mouseDidMoveOverElement(Page&, const HitTestResult&, OptionSet<PlatformEventModifier>);
     static bool handleMousePress(LocalFrame&);
     static bool handleTouchEvent(LocalFrame&, Node&);
-    static bool forcePseudoState(const Element&, CSSSelector::PseudoClassType);
+    static bool forcePseudoState(const Element&, CSSSelector::PseudoClass);
 
     static void willSendXMLHttpRequest(ScriptExecutionContext*, const String& url);
     static void willFetch(ScriptExecutionContext&, const String& url);
@@ -380,7 +380,7 @@ private:
     static void mouseDidMoveOverElementImpl(InstrumentingAgents&, const HitTestResult&, OptionSet<PlatformEventModifier>);
     static bool handleMousePressImpl(InstrumentingAgents&);
     static bool handleTouchEventImpl(InstrumentingAgents&, Node&);
-    static bool forcePseudoStateImpl(InstrumentingAgents&, const Element&, CSSSelector::PseudoClassType);
+    static bool forcePseudoStateImpl(InstrumentingAgents&, const Element&, CSSSelector::PseudoClass);
 
     static void willSendXMLHttpRequestImpl(InstrumentingAgents&, const String& url);
     static void willFetchImpl(InstrumentingAgents&, const String& url);
@@ -788,7 +788,7 @@ inline bool InspectorInstrumentation::handleMousePress(LocalFrame& frame)
     return false;
 }
 
-inline bool InspectorInstrumentation::forcePseudoState(const Element& element, CSSSelector::PseudoClassType pseudoState)
+inline bool InspectorInstrumentation::forcePseudoState(const Element& element, CSSSelector::PseudoClass pseudoState)
 {
     FAST_RETURN_IF_NO_FRONTENDS(false);
     if (auto* agents = instrumentingAgents(element.document()))

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
@@ -379,7 +379,7 @@ void InspectorCSSAgent::setActiveStyleSheetsForDocument(Document& document, Vect
     }
 }
 
-bool InspectorCSSAgent::forcePseudoState(const Element& element, CSSSelector::PseudoClassType pseudoClassType)
+bool InspectorCSSAgent::forcePseudoState(const Element& element, CSSSelector::PseudoClass pseudoClass)
 {
     if (m_nodeIdToForcedPseudoState.isEmpty())
         return false;
@@ -392,7 +392,7 @@ bool InspectorCSSAgent::forcePseudoState(const Element& element, CSSSelector::Ps
     if (!nodeId)
         return false;
 
-    return m_nodeIdToForcedPseudoState.get(nodeId).contains(pseudoClassType);
+    return m_nodeIdToForcedPseudoState.get(nodeId).contains(pseudoClass);
 }
 
 std::optional<Protocol::CSS::PseudoId> InspectorCSSAgent::protocolValueForPseudoId(PseudoId pseudoId)
@@ -938,31 +938,31 @@ Protocol::ErrorStringOr<void> InspectorCSSAgent::forcePseudoState(Protocol::DOM:
 
         switch (*pseudoClass) {
         case Protocol::CSS::ForceablePseudoClass::Active:
-            forcedPseudoClassesToSet.add(CSSSelector::PseudoClassType::Active);
+            forcedPseudoClassesToSet.add(CSSSelector::PseudoClass::Active);
             break;
 
         case Protocol::CSS::ForceablePseudoClass::Hover:
-            forcedPseudoClassesToSet.add(CSSSelector::PseudoClassType::Hover);
+            forcedPseudoClassesToSet.add(CSSSelector::PseudoClass::Hover);
             break;
 
         case Protocol::CSS::ForceablePseudoClass::Focus:
-            forcedPseudoClassesToSet.add(CSSSelector::PseudoClassType::Focus);
+            forcedPseudoClassesToSet.add(CSSSelector::PseudoClass::Focus);
             break;
 
         case Protocol::CSS::ForceablePseudoClass::FocusVisible:
-            forcedPseudoClassesToSet.add(CSSSelector::PseudoClassType::FocusVisible);
+            forcedPseudoClassesToSet.add(CSSSelector::PseudoClass::FocusVisible);
             break;
 
         case Protocol::CSS::ForceablePseudoClass::FocusWithin:
-            forcedPseudoClassesToSet.add(CSSSelector::PseudoClassType::FocusWithin);
+            forcedPseudoClassesToSet.add(CSSSelector::PseudoClass::FocusWithin);
             break;
 
         case Protocol::CSS::ForceablePseudoClass::Target:
-            forcedPseudoClassesToSet.add(CSSSelector::PseudoClassType::Target);
+            forcedPseudoClassesToSet.add(CSSSelector::PseudoClass::Target);
             break;
 
         case Protocol::CSS::ForceablePseudoClass::Visited:
-            forcedPseudoClassesToSet.add(CSSSelector::PseudoClassType::Visited);
+            forcedPseudoClassesToSet.add(CSSSelector::PseudoClass::Visited);
             break;
         }
     }

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.h
@@ -122,7 +122,7 @@ public:
     void documentDetached(Document&);
     void mediaQueryResultChanged();
     void activeStyleSheetsUpdated(Document&);
-    bool forcePseudoState(const Element&, CSSSelector::PseudoClassType);
+    bool forcePseudoState(const Element&, CSSSelector::PseudoClass);
     void didChangeRendererForDOMNode(Node&);
     void didAddEventListener(EventTarget&);
     void willRemoveEventListener(EventTarget&);
@@ -153,7 +153,7 @@ private:
     typedef HashMap<Inspector::Protocol::CSS::StyleSheetId, RefPtr<InspectorStyleSheet>> IdToInspectorStyleSheet;
     typedef HashMap<CSSStyleSheet*, RefPtr<InspectorStyleSheet>> CSSStyleSheetToInspectorStyleSheet;
     typedef HashMap<RefPtr<Document>, Vector<RefPtr<InspectorStyleSheet>>> DocumentToViaInspectorStyleSheet; // "via inspector" stylesheets
-    typedef HashSet<CSSSelector::PseudoClassType, IntHash<CSSSelector::PseudoClassType>, WTF::StrongEnumHashTraits<CSSSelector::PseudoClassType>> PseudoClassHashSet;
+    typedef HashSet<CSSSelector::PseudoClass, IntHash<CSSSelector::PseudoClass>, WTF::StrongEnumHashTraits<CSSSelector::PseudoClass>> PseudoClassHashSet;
 
     InspectorStyleSheetForInlineStyle& asInspectorStyleSheet(StyledElement&);
     Element* elementForId(Inspector::Protocol::ErrorString&, Inspector::Protocol::DOM::NodeId);

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -3833,7 +3833,7 @@ bool EventHandler::internalKeyEvent(const PlatformKeyboardEvent& initialKeyEvent
         bool userHasInteractedViaKeyword = keydown->modifierKeys().isEmpty() || ((keydown->shiftKey() || keydown->capsLockKey()) && !initialKeyEvent.text().isEmpty());
 
         if (element.focused() && userHasInteractedViaKeyword) {
-            Style::PseudoClassChangeInvalidation focusVisibleStyleInvalidation(element, CSSSelector::PseudoClassType::FocusVisible, true);
+            Style::PseudoClassChangeInvalidation focusVisibleStyleInvalidation(element, CSSSelector::PseudoClass::FocusVisible, true);
             element.setHasFocusVisible(true);
         }
     };

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -119,7 +119,7 @@ bool elementMatchesHoverRules(Element& element)
     bool foundHoverRules = false;
     bool initialValue = element.isUserActionElement() && element.document().userActionElements().isHovered(element);
 
-    for (auto key : Style::makePseudoClassInvalidationKeys(CSSSelector::PseudoClassType::Hover, element)) {
+    for (auto key : Style::makePseudoClassInvalidationKeys(CSSSelector::PseudoClass::Hover, element)) {
         auto& ruleSets = element.styleResolver().ruleSets();
         auto* invalidationRuleSets = ruleSets.pseudoClassInvalidationRuleSets(key);
         if (!invalidationRuleSets)

--- a/Source/WebCore/style/ChildChangeInvalidation.cpp
+++ b/Source/WebCore/style/ChildChangeInvalidation.cpp
@@ -103,7 +103,7 @@ void ChildChangeInvalidation::invalidateForChangedElement(Element& changedElemen
         }
     };
 
-    for (auto key : makePseudoClassInvalidationKeys(CSSSelector::PseudoClassType::Has, changedElement))
+    for (auto key : makePseudoClassInvalidationKeys(CSSSelector::PseudoClass::Has, changedElement))
         addHasInvalidation(ruleSets.hasPseudoClassInvalidationRuleSets(key));
 
     Invalidator::invalidateWithMatchElementRuleSets(changedElement, matchElementRuleSets);

--- a/Source/WebCore/style/HasSelectorFilter.cpp
+++ b/Source/WebCore/style/HasSelectorFilter.cpp
@@ -68,7 +68,7 @@ auto HasSelectorFilter::makeKey(const CSSSelector& hasSelector) -> Key
     SelectorFilter::CollectedSelectorHashes hashes;
     bool hasHoverInCompound = false;
     for (auto* simpleSelector = &hasSelector; simpleSelector; simpleSelector = simpleSelector->tagHistory()) {
-        if (simpleSelector->match() == CSSSelector::Match::PseudoClass && simpleSelector->pseudoClassType() == CSSSelector::PseudoClassType::Hover)
+        if (simpleSelector->match() == CSSSelector::Match::PseudoClass && simpleSelector->pseudoClass() == CSSSelector::PseudoClass::Hover)
             hasHoverInCompound = true;
         SelectorFilter::collectSimpleSelectorHash(hashes, *simpleSelector);
         if (!hashes.ids.isEmpty())

--- a/Source/WebCore/style/PseudoClassChangeInvalidation.cpp
+++ b/Source/WebCore/style/PseudoClassChangeInvalidation.cpp
@@ -33,7 +33,7 @@
 namespace WebCore {
 namespace Style {
 
-Vector<PseudoClassInvalidationKey, 4> makePseudoClassInvalidationKeys(CSSSelector::PseudoClassType pseudoClass, const Element& element)
+Vector<PseudoClassInvalidationKey, 4> makePseudoClassInvalidationKeys(CSSSelector::PseudoClass pseudoClass, const Element& element)
 {
     Vector<PseudoClassInvalidationKey, 4> keys;
 
@@ -52,13 +52,13 @@ Vector<PseudoClassInvalidationKey, 4> makePseudoClassInvalidationKeys(CSSSelecto
     return keys;
 };
 
-void PseudoClassChangeInvalidation::computeInvalidation(CSSSelector::PseudoClassType pseudoClass, Value value, InvalidationScope invalidationScope)
+void PseudoClassChangeInvalidation::computeInvalidation(CSSSelector::PseudoClass pseudoClass, Value value, InvalidationScope invalidationScope)
 {
     bool shouldInvalidateCurrent = false;
     bool mayAffectStyleInShadowTree = false;
 
     traverseRuleFeatures(m_element, [&] (const RuleFeatureSet& features, bool mayAffectShadowTree) {
-        if (mayAffectShadowTree && features.pseudoClassTypes.contains(pseudoClass))
+        if (mayAffectShadowTree && features.pseudoClasss.contains(pseudoClass))
             mayAffectStyleInShadowTree = true;
         if (m_element.shadowRoot() && features.pseudoClassesAffectingHost.contains(pseudoClass))
             shouldInvalidateCurrent = true;

--- a/Source/WebCore/style/PseudoClassChangeInvalidation.h
+++ b/Source/WebCore/style/PseudoClassChangeInvalidation.h
@@ -35,16 +35,16 @@ namespace Style {
 
 class PseudoClassChangeInvalidation {
 public:
-    PseudoClassChangeInvalidation(Element&, CSSSelector::PseudoClassType, bool value, InvalidationScope = InvalidationScope::All);
+    PseudoClassChangeInvalidation(Element&, CSSSelector::PseudoClass, bool value, InvalidationScope = InvalidationScope::All);
     enum AnyValueTag { AnyValue };
-    PseudoClassChangeInvalidation(Element&, CSSSelector::PseudoClassType, AnyValueTag);
-    PseudoClassChangeInvalidation(Element&, std::initializer_list<std::pair<CSSSelector::PseudoClassType, bool>>);
+    PseudoClassChangeInvalidation(Element&, CSSSelector::PseudoClass, AnyValueTag);
+    PseudoClassChangeInvalidation(Element&, std::initializer_list<std::pair<CSSSelector::PseudoClass, bool>>);
 
     ~PseudoClassChangeInvalidation();
 
 private:
     enum class Value : uint8_t { False, True, Any };
-    void computeInvalidation(CSSSelector::PseudoClassType, Value, Style::InvalidationScope);
+    void computeInvalidation(CSSSelector::PseudoClass, Value, Style::InvalidationScope);
     void collectRuleSets(const PseudoClassInvalidationKey&, Value, InvalidationScope);
     void invalidateBeforeChange();
     void invalidateAfterChange();
@@ -56,14 +56,14 @@ private:
     Invalidator::MatchElementRuleSets m_afterChangeRuleSets;
 };
 
-Vector<PseudoClassInvalidationKey, 4> makePseudoClassInvalidationKeys(CSSSelector::PseudoClassType, const Element&);
+Vector<PseudoClassInvalidationKey, 4> makePseudoClassInvalidationKeys(CSSSelector::PseudoClass, const Element&);
 
-inline void emplace(std::optional<PseudoClassChangeInvalidation>& invalidation, Element& element, std::initializer_list<std::pair<CSSSelector::PseudoClassType, bool>> pseudoClasses)
+inline void emplace(std::optional<PseudoClassChangeInvalidation>& invalidation, Element& element, std::initializer_list<std::pair<CSSSelector::PseudoClass, bool>> pseudoClasses)
 {
     invalidation.emplace(element, pseudoClasses);
 }
 
-inline PseudoClassChangeInvalidation::PseudoClassChangeInvalidation(Element& element, CSSSelector::PseudoClassType pseudoClass, bool value, Style::InvalidationScope invalidationScope)
+inline PseudoClassChangeInvalidation::PseudoClassChangeInvalidation(Element& element, CSSSelector::PseudoClass pseudoClass, bool value, Style::InvalidationScope invalidationScope)
     : m_isEnabled(element.needsStyleInvalidation())
     , m_element(element)
 
@@ -74,7 +74,7 @@ inline PseudoClassChangeInvalidation::PseudoClassChangeInvalidation(Element& ele
     invalidateBeforeChange();
 }
 
-inline PseudoClassChangeInvalidation::PseudoClassChangeInvalidation(Element& element, CSSSelector::PseudoClassType pseudoClass, AnyValueTag)
+inline PseudoClassChangeInvalidation::PseudoClassChangeInvalidation(Element& element, CSSSelector::PseudoClass pseudoClass, AnyValueTag)
     : m_isEnabled(element.needsStyleInvalidation())
     , m_element(element)
 
@@ -85,7 +85,7 @@ inline PseudoClassChangeInvalidation::PseudoClassChangeInvalidation(Element& ele
     invalidateBeforeChange();
 }
 
-inline PseudoClassChangeInvalidation::PseudoClassChangeInvalidation(Element& element, std::initializer_list<std::pair<CSSSelector::PseudoClassType, bool>> pseudoClasses)
+inline PseudoClassChangeInvalidation::PseudoClassChangeInvalidation(Element& element, std::initializer_list<std::pair<CSSSelector::PseudoClass, bool>> pseudoClasses)
     : m_isEnabled(element.needsStyleInvalidation())
     , m_element(element)
 {

--- a/Source/WebCore/style/RuleFeature.h
+++ b/Source/WebCore/style/RuleFeature.h
@@ -123,8 +123,8 @@ struct RuleFeatureSet {
 
     HashSet<AtomString> classesAffectingHost;
     HashSet<AtomString> attributesAffectingHost;
-    HashSet<CSSSelector::PseudoClassType, IntHash<CSSSelector::PseudoClassType>, WTF::StrongEnumHashTraits<CSSSelector::PseudoClassType>> pseudoClassesAffectingHost;
-    HashSet<CSSSelector::PseudoClassType, IntHash<CSSSelector::PseudoClassType>, WTF::StrongEnumHashTraits<CSSSelector::PseudoClassType>> pseudoClassTypes;
+    HashSet<CSSSelector::PseudoClass, IntHash<CSSSelector::PseudoClass>, WTF::StrongEnumHashTraits<CSSSelector::PseudoClass>> pseudoClassesAffectingHost;
+    HashSet<CSSSelector::PseudoClass, IntHash<CSSSelector::PseudoClass>, WTF::StrongEnumHashTraits<CSSSelector::PseudoClass>> pseudoClasss;
 
     std::array<bool, matchElementCount> usedMatchElements { };
 
@@ -151,7 +151,7 @@ bool isHasPseudoClassMatchElement(MatchElement);
 MatchElement computeHasPseudoClassMatchElement(const CSSSelector&);
 
 enum class InvalidationKeyType : uint8_t { Universal = 1, Class, Id, Tag };
-PseudoClassInvalidationKey makePseudoClassInvalidationKey(CSSSelector::PseudoClassType, InvalidationKeyType, const AtomString& = starAtom());
+PseudoClassInvalidationKey makePseudoClassInvalidationKey(CSSSelector::PseudoClass, InvalidationKeyType, const AtomString& = starAtom());
 
 inline bool isUniversalInvalidation(const PseudoClassInvalidationKey& key)
 {

--- a/Source/WebCore/style/RuleSet.cpp
+++ b/Source/WebCore/style/RuleSet.cpp
@@ -88,7 +88,7 @@ static bool isHostSelectorMatchingInShadowTree(const CSSSelector& startSelector)
     bool hasOnlyOneCompound = true;
     bool hasHostInLastCompound = false;
     for (auto* selector = &startSelector; selector; selector = selector->tagHistory()) {
-        if (selector->match() == CSSSelector::Match::PseudoClass && selector->pseudoClassType() == CSSSelector::PseudoClassType::Host)
+        if (selector->match() == CSSSelector::Match::PseudoClass && selector->pseudoClass() == CSSSelector::PseudoClass::Host)
             hasHostInLastCompound = true;
         if (isHostSelectorMatchingInShadowTreeInSelectorList(selector->selectorList()))
             return true;
@@ -207,18 +207,18 @@ void RuleSet::addRule(RuleData&& ruleData, CascadeLayerIdentifier cascadeLayerId
             }
             break;
         case CSSSelector::Match::PseudoClass:
-            switch (selector->pseudoClassType()) {
-            case CSSSelector::PseudoClassType::Link:
-            case CSSSelector::PseudoClassType::Visited:
-            case CSSSelector::PseudoClassType::AnyLink:
-            case CSSSelector::PseudoClassType::AnyLinkDeprecated:
+            switch (selector->pseudoClass()) {
+            case CSSSelector::PseudoClass::Link:
+            case CSSSelector::PseudoClass::Visited:
+            case CSSSelector::PseudoClass::AnyLink:
+            case CSSSelector::PseudoClass::AnyLinkDeprecated:
                 linkSelector = selector;
                 break;
-            case CSSSelector::PseudoClassType::Focus:
-            case CSSSelector::PseudoClassType::FocusVisible:
+            case CSSSelector::PseudoClass::Focus:
+            case CSSSelector::PseudoClass::FocusVisible:
                 focusSelector = selector;
                 break;
-            case CSSSelector::PseudoClassType::Host:
+            case CSSSelector::PseudoClass::Host:
                 hostPseudoClassSelector = selector;
                 break;
             default:

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -255,7 +255,7 @@ ResolvedStyle Resolver::styleForElement(const Element& element, const Resolution
         style.setIsLink(true);
         InsideLink linkState = document().visitedLinkState().determineLinkState(element);
         if (linkState != InsideLink::NotInside) {
-            bool forceVisited = InspectorInstrumentation::forcePseudoState(element, CSSSelector::PseudoClassType::Visited);
+            bool forceVisited = InspectorInstrumentation::forcePseudoState(element, CSSSelector::PseudoClass::Visited);
             if (forceVisited)
                 linkState = InsideLink::InsideVisited;
         }


### PR DESCRIPTION
#### 9604379ebaf71d6f9e60ddfc8c621ffb0f95eadd
<pre>
Rename PseudoClassType to PseudoClass
<a href="https://bugs.webkit.org/show_bug.cgi?id=266841">https://bugs.webkit.org/show_bug.cgi?id=266841</a>

Reviewed by Tim Nguyen.

* Source/WebCore/css/CSSSelector.cpp:
(WebCore::simpleSelectorSpecificity):
(WebCore::appendPseudoClassFunctionTail):
(WebCore::CSSSelector::selectorText const):
(WebCore::CSSSelector::resolveNestingParentSelectors):
(WebCore::CSSSelector::replaceNestingParentByPseudoClassScope):
(WebCore::CSSSelector::hasExplicitPseudoClassScope const):
* Source/WebCore/css/CSSSelector.h:
(WebCore::pseudoClassIsRelativeToSiblings):
(WebCore::isTreeStructuralPseudoClass):
(WebCore::isLogicalCombinationPseudoClass):
(WebCore::CSSSelector::isSiblingSelector const):
(WebCore::CSSSelector::pseudoClass const):
(WebCore::CSSSelector::setPseudoClass):
(WebCore::CSSSelector::pseudoClassType const): Deleted.
(WebCore::CSSSelector::setPseudoClassType): Deleted.
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::localContextForParent):
(WebCore::canMatchHoverOrActiveInQuirksMode):
(WebCore::SelectorChecker::checkOne const):
(WebCore::SelectorChecker::checkScrollbarPseudoClass const):
(WebCore::SelectorChecker::determineLinkMatchType):
* Source/WebCore/css/SelectorChecker.h:
(WebCore::SelectorChecker::isCommonPseudoClassSelector):
* Source/WebCore/css/SelectorCheckerTestFunctions.h:
(WebCore::matchesLegacyDirectFocusPseudoClass):
(WebCore::matchesFocusPseudoClass):
(WebCore::matchesFocusVisiblePseudoClass):
(WebCore::matchesFocusWithinPseudoClass):
* Source/WebCore/css/SelectorFilter.cpp:
(WebCore::SelectorFilter::collectSimpleSelectorHash):
* Source/WebCore/css/SelectorPseudoClassAndCompatibilityElementMap.in:
* Source/WebCore/css/SelectorPseudoTypeMap.h:
* Source/WebCore/css/makeSelectorPseudoClassAndCompatibilityElementMap.py:
(enumerablePseudoType):
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::appendImplicitSelectorPseudoClassScopeIfNeeded):
* Source/WebCore/css/parser/CSSParserSelector.cpp:
(WebCore::CSSParserSelector::parsePseudoClassSelector):
(WebCore::CSSParserSelector::isHostPseudoSelector const):
* Source/WebCore/css/parser/CSSParserSelector.h:
(WebCore::CSSParserSelector::setPseudoClass):
(WebCore::CSSParserSelector::pseudoClass const):
(WebCore::CSSParserSelector::setPseudoClassType): Deleted.
(WebCore::CSSParserSelector::pseudoClassType const): Deleted.
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParser::consumeRelativeScopeSelector):
(WebCore::isScrollbarPseudoClass):
(WebCore::isUserActionPseudoClass):
(WebCore::isPseudoClassValidAfterPseudoElement):
(WebCore::isSimpleSelectorValidAfterPseudoElement):
(WebCore::isOnlyPseudoClassFunction):
(WebCore::CSSSelectorParser::consumePseudo):
* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::addNthChildType):
(WebCore::SelectorCompiler::addPseudoClassType):
(WebCore::SelectorCompiler::pseudoClassOnlyMatchesLinksInQuirksMode):
(WebCore::SelectorCompiler::SelectorCodeGenerator::generateElementMatching):
(WebCore::SelectorCompiler::SelectorCodeGenerator::generateElementLinkMatching):
(WebCore::SelectorCompiler::JSC_DEFINE_JIT_OPERATION):
* Source/WebCore/dom/CustomStateSet.cpp:
(WebCore::CustomStateSet::addToSetLike):
(WebCore::CustomStateSet::removeFromSetLike):
(WebCore::CustomStateSet::clearFromSetLike):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::setCSSTarget):
(WebCore::Document::updateHoverActiveState):
(WebCore::Document::setPictureInPictureElement):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::setActive):
(WebCore::Element::setFocus):
(WebCore::Element::setHasFocusWithin):
(WebCore::Element::setHovered):
(WebCore::Element::setBeingDragged):
(WebCore::Element::updateEffectiveLangStateAndPropagateToDescendants):
(WebCore::Element::setIsLink):
(WebCore::Node::setCustomElementState):
(WebCore::Element::setFullscreenFlag):
* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::setAnimatingFullscreen):
(WebCore::FullscreenManager::setFullscreenControlsHidden):
* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::invalidateFocusedElementAndShadowIncludingAncestors):
* Source/WebCore/html/HTMLDialogElement.cpp:
(WebCore::HTMLDialogElement::setIsModal):
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::updateEffectiveDirectionality):
(WebCore::HTMLElement::showPopover):
(WebCore::HTMLElement::hidePopoverInternal):
(WebCore::HTMLElement::popoverAttributeChanged):
* Source/WebCore/html/HTMLFieldSetElement.cpp:
(WebCore::HTMLFieldSetElement::addInvalidDescendant):
(WebCore::HTMLFieldSetElement::removeInvalidDescendant):
* Source/WebCore/html/HTMLFormControlElement.cpp:
(WebCore::HTMLFormControlElement::attributeChanged):
* Source/WebCore/html/HTMLFormElement.cpp:
(WebCore::HTMLFormElement::addInvalidFormControl):
(WebCore::HTMLFormElement::removeInvalidFormControlIfNeeded):
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::updateType):
(WebCore::HTMLInputElement::setDefaultCheckedState):
(WebCore::HTMLInputElement::setChecked):
(WebCore::HTMLInputElement::setIndeterminate):
(WebCore::HTMLInputElement::setAutoFilled):
(WebCore::HTMLInputElement::setAutoFilledAndViewable):
(WebCore::HTMLInputElement::setAutoFilledAndObscured):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::setSeeking):
(WebCore::HTMLMediaElement::setPaused):
(WebCore::HTMLMediaElement::setMuted):
(WebCore::HTMLMediaElement::setVolumeLocked):
(WebCore::HTMLMediaElement::updateBufferingState):
(WebCore::HTMLMediaElement::updateStalledState):
* Source/WebCore/html/HTMLOptGroupElement.cpp:
(WebCore::HTMLOptGroupElement::attributeChanged):
* Source/WebCore/html/HTMLOptionElement.cpp:
(WebCore::HTMLOptionElement::attributeChanged):
(WebCore::HTMLOptionElement::setSelectedState):
* Source/WebCore/html/HTMLProgressElement.cpp:
(WebCore::HTMLProgressElement::updateDeterminateState):
* Source/WebCore/html/HTMLTextFormControlElement.cpp:
(WebCore::HTMLTextFormControlElement::updatePlaceholderVisibility):
* Source/WebCore/html/InputType.cpp:
(WebCore::InputType::setValue):
* Source/WebCore/html/ValidatedFormListedElement.cpp:
(WebCore::ValidatedFormListedElement::setDisabledInternal):
(WebCore::ValidatedFormListedElement::updateValidity):
(WebCore::ValidatedFormListedElement::parseReadOnlyAttribute):
(WebCore::ValidatedFormListedElement::setInteractedWithSinceLastFormSubmitEvent):
* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::forcePseudoStateImpl):
* Source/WebCore/inspector/InspectorInstrumentation.h:
(WebCore::InspectorInstrumentation::forcePseudoState):
* Source/WebCore/inspector/agents/InspectorCSSAgent.cpp:
(WebCore::InspectorCSSAgent::forcePseudoState):
* Source/WebCore/inspector/agents/InspectorCSSAgent.h:
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::internalKeyEvent):
* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::elementMatchesHoverRules):
* Source/WebCore/style/ChildChangeInvalidation.cpp:
(WebCore::Style::ChildChangeInvalidation::invalidateForChangedElement):
* Source/WebCore/style/HasSelectorFilter.cpp:
(WebCore::Style::HasSelectorFilter::makeKey):
* Source/WebCore/style/PseudoClassChangeInvalidation.cpp:
(WebCore::Style::makePseudoClassInvalidationKeys):
(WebCore::Style::PseudoClassChangeInvalidation::computeInvalidation):
* Source/WebCore/style/PseudoClassChangeInvalidation.h:
(WebCore::Style::emplace):
(WebCore::Style::PseudoClassChangeInvalidation::PseudoClassChangeInvalidation):
* Source/WebCore/style/RuleFeature.cpp:
(WebCore::Style::computeSubSelectorMatchElement):
(WebCore::Style::RuleFeatureSet::recursivelyCollectFeaturesFromSelector):
(WebCore::Style::makePseudoClassInvalidationKey):
(WebCore::Style::RuleFeatureSet::collectFeatures):
(WebCore::Style::RuleFeatureSet::add):
(WebCore::Style::RuleFeatureSet::clear):
* Source/WebCore/style/RuleFeature.h:
* Source/WebCore/style/RuleSet.cpp:
(WebCore::Style::isHostSelectorMatchingInShadowTree):
(WebCore::Style::RuleSet::addRule):
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::styleForElement):

Canonical link: <a href="https://commits.webkit.org/272468@main">https://commits.webkit.org/272468@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae465db8475bdfd8291c6264afcc7e330e2d0a86

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31763 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10450 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33495 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34259 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28762 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32552 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12809 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7695 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28356 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32120 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8813 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28356 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7605 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7773 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28270 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35606 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28877 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28719 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33889 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7863 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5865 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31745 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9518 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7439 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8538 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8382 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->