### PR TITLE
Rename CSSSelector's RelationType to Relation

### DIFF
--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -51,13 +51,13 @@ struct SameSizeAsCSSSelector {
     void* unionPointer;
 };
 
-static_assert(CSSSelector::RelationType::Subselector == static_cast<CSSSelector::RelationType>(0u), "Subselector must be 0 for consumeCombinator.");
+static_assert(CSSSelector::Relation::Subselector == static_cast<CSSSelector::Relation>(0u), "Subselector must be 0 for consumeCombinator.");
 static_assert(sizeof(CSSSelector) == sizeof(SameSizeAsCSSSelector), "CSSSelector should remain small.");
 
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSSelectorRareData);
 
 CSSSelector::CSSSelector(const QualifiedName& tagQName, bool tagIsForNamespaceRule)
-    : m_relation(enumToUnderlyingType(RelationType::DescendantSpace))
+    : m_relation(enumToUnderlyingType(Relation::DescendantSpace))
     , m_match(enumToUnderlyingType(Match::Tag))
     , m_tagIsForNamespaceRule(tagIsForNamespaceRule)
 {
@@ -362,7 +362,7 @@ const CSSSelector* CSSSelector::firstInCompound() const
     auto* selector = this;
     while (!selector->isFirstInTagHistory()) {
         auto* previousSelector = selector - 1;
-        if (previousSelector->relation() != RelationType::Subselector)
+        if (previousSelector->relation() != Relation::Subselector)
             break;
         selector = previousSelector;
     }
@@ -894,7 +894,7 @@ String CSSSelector::selectorText(StringView separator, StringView rightSide) con
             }
         }
 
-        if (cs->relation() != RelationType::Subselector || !cs->tagHistory())
+        if (cs->relation() != Relation::Subselector || !cs->tagHistory())
             break;
         cs = cs->tagHistory();
     }
@@ -903,11 +903,11 @@ String CSSSelector::selectorText(StringView separator, StringView rightSide) con
 
     auto separatorTextForNestingRelative = [&] () -> String {
         switch (cs->relation()) {
-        case CSSSelector::RelationType::Child:
+        case CSSSelector::Relation::Child:
             return "> "_s;
-        case CSSSelector::RelationType::DirectAdjacent:
+        case CSSSelector::Relation::DirectAdjacent:
             return "+ "_s;
-        case CSSSelector::RelationType::IndirectAdjacent:
+        case CSSSelector::Relation::IndirectAdjacent:
             return "~ "_s;
         default:
             return { };
@@ -917,24 +917,24 @@ String CSSSelector::selectorText(StringView separator, StringView rightSide) con
     if (auto* previousSelector = cs->tagHistory()) {
         ASCIILiteral separator = ""_s;
         switch (cs->relation()) {
-        case CSSSelector::RelationType::DescendantSpace:
+        case CSSSelector::Relation::DescendantSpace:
             separator = " "_s;
             break;
-        case CSSSelector::RelationType::Child:
+        case CSSSelector::Relation::Child:
             separator = " > "_s;
             break;
-        case CSSSelector::RelationType::DirectAdjacent:
+        case CSSSelector::Relation::DirectAdjacent:
             separator = " + "_s;
             break;
-        case CSSSelector::RelationType::IndirectAdjacent:
+        case CSSSelector::Relation::IndirectAdjacent:
             separator = " ~ "_s;
             break;
-        case CSSSelector::RelationType::Subselector:
+        case CSSSelector::Relation::Subselector:
             ASSERT_NOT_REACHED();
             break;
-        case CSSSelector::RelationType::ShadowDescendant:
-        case CSSSelector::RelationType::ShadowPartDescendant:
-        case CSSSelector::RelationType::ShadowSlotted:
+        case CSSSelector::Relation::ShadowDescendant:
+        case CSSSelector::Relation::ShadowPartDescendant:
+        case CSSSelector::Relation::ShadowSlotted:
             break;
         }
         return previousSelector->selectorText(separator, builder);

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -91,8 +91,8 @@ struct PossiblyQuotedIdentifier {
             ForgivingUnknownNestContaining
         };
 
-        enum class RelationType : uint8_t {
-            Subselector = 0,
+        enum class Relation : uint8_t {
+            Subselector,
             DescendantSpace,
             Child,
             DirectAdjacent,
@@ -294,9 +294,9 @@ struct PossiblyQuotedIdentifier {
         int nthA() const;
         int nthB() const;
 
-        bool hasDescendantRelation() const { return relation() == RelationType::DescendantSpace; }
+        bool hasDescendantRelation() const { return relation() == Relation::DescendantSpace; }
 
-        bool hasDescendantOrChildRelation() const { return relation() == RelationType::Child || hasDescendantRelation(); }
+        bool hasDescendantOrChildRelation() const { return relation() == Relation::Child || hasDescendantRelation(); }
 
         PseudoClass pseudoClass() const;
         void setPseudoClass(PseudoClass);
@@ -312,8 +312,8 @@ struct PossiblyQuotedIdentifier {
         bool isSiblingSelector() const;
         bool isAttributeSelector() const;
 
-        RelationType relation() const { return static_cast<RelationType>(m_relation); }
-        void setRelation(RelationType);
+        Relation relation() const { return static_cast<Relation>(m_relation); }
+        void setRelation(Relation);
 
         Match match() const { return static_cast<Match>(m_match); }
         void setMatch(Match);
@@ -337,8 +337,8 @@ struct PossiblyQuotedIdentifier {
         bool isImplicit() const { return m_isImplicit; }
 
     private:
-        unsigned m_relation : 4 { enumToUnderlyingType(RelationType::DescendantSpace) }; // enum RelationType.
-        mutable unsigned m_match : 5 { enumToUnderlyingType(Match::Unknown) }; // enum Match.
+        unsigned m_relation : 4 { enumToUnderlyingType(Relation::DescendantSpace) };
+        mutable unsigned m_match : 5 { enumToUnderlyingType(Match::Unknown) };
         mutable unsigned m_pseudoType : 8 { 0 }; // PseudoType.
         // 17 bits
         unsigned m_isLastInSelectorList : 1 { false };
@@ -452,8 +452,8 @@ inline bool isLogicalCombinationPseudoClass(CSSSelector::PseudoClass pseudoClass
 
 inline bool CSSSelector::isSiblingSelector() const
 {
-    return relation() == RelationType::DirectAdjacent
-        || relation() == RelationType::IndirectAdjacent
+    return relation() == Relation::DirectAdjacent
+        || relation() == Relation::IndirectAdjacent
         || (match() == CSSSelector::Match::PseudoClass && pseudoClassIsRelativeToSiblings(pseudoClass()));
 }
 
@@ -578,7 +578,7 @@ inline void CSSSelector::setPagePseudoType(PagePseudoClassType pagePseudoType)
     m_pseudoType = pagePseudoType;
 }
 
-inline void CSSSelector::setRelation(RelationType relation)
+inline void CSSSelector::setRelation(Relation relation)
 {
     m_relation = enumToUnderlyingType(relation);
 }

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -312,7 +312,7 @@ SelectorChecker::MatchResult SelectorChecker::matchRecursively(CheckingContext& 
     LocalContext nextContext(context);
     nextContext.selector = leftSelector;
 
-    if (relation != CSSSelector::RelationType::Subselector) {
+    if (relation != CSSSelector::Relation::Subselector) {
         // Bail-out if this selector is irrelevant for the pseudoId
         if (context.pseudoId != PseudoId::None && !dynamicPseudoIdSet.has(context.pseudoId))
             return MatchResult::fails(Match::SelectorFailsCompletely);
@@ -323,7 +323,7 @@ SelectorChecker::MatchResult SelectorChecker::matchRecursively(CheckingContext& 
 
         nextContext.pseudoId = PseudoId::None;
 
-        bool allowMultiplePseudoElements = relation == CSSSelector::RelationType::ShadowDescendant;
+        bool allowMultiplePseudoElements = relation == CSSSelector::Relation::ShadowDescendant;
         // Virtual pseudo element is only effective in the rightmost fragment.
         if (!allowMultiplePseudoElements)
             nextContext.pseudoElementEffective = false;
@@ -332,7 +332,7 @@ SelectorChecker::MatchResult SelectorChecker::matchRecursively(CheckingContext& 
     }
 
     switch (relation) {
-    case CSSSelector::RelationType::DescendantSpace:
+    case CSSSelector::Relation::DescendantSpace:
         nextContext = localContextForParent(nextContext);
         nextContext.firstSelectorOfTheFragment = nextContext.selector;
         for (; nextContext.element; nextContext = localContextForParent(nextContext)) {
@@ -345,7 +345,7 @@ SelectorChecker::MatchResult SelectorChecker::matchRecursively(CheckingContext& 
         }
         return MatchResult::fails(Match::SelectorFailsCompletely);
 
-    case CSSSelector::RelationType::Child:
+    case CSSSelector::Relation::Child:
         {
             nextContext = localContextForParent(nextContext);
             if (!nextContext.element)
@@ -360,7 +360,7 @@ SelectorChecker::MatchResult SelectorChecker::matchRecursively(CheckingContext& 
             return MatchResult::fails(Match::SelectorFailsAllSiblings);
         }
 
-    case CSSSelector::RelationType::DirectAdjacent:
+    case CSSSelector::Relation::DirectAdjacent:
         {
             auto relation = context.isMatchElement ? Style::Relation::AffectedByPreviousSibling : Style::Relation::DescendantsAffectedByPreviousSibling;
             addStyleRelation(checkingContext, *context.element, relation);
@@ -379,7 +379,7 @@ SelectorChecker::MatchResult SelectorChecker::matchRecursively(CheckingContext& 
 
             return MatchResult::updateWithMatchType(result, matchType);
         }
-    case CSSSelector::RelationType::IndirectAdjacent: {
+    case CSSSelector::Relation::IndirectAdjacent: {
         auto relation = context.isMatchElement ? Style::Relation::AffectedByPreviousSibling : Style::Relation::DescendantsAffectedByPreviousSibling;
         addStyleRelation(checkingContext, *context.element, relation);
 
@@ -397,7 +397,7 @@ SelectorChecker::MatchResult SelectorChecker::matchRecursively(CheckingContext& 
         };
         return MatchResult::fails(Match::SelectorFailsAllSiblings);
     }
-    case CSSSelector::RelationType::Subselector:
+    case CSSSelector::Relation::Subselector:
         {
             // a selector is invalid if something follows a pseudo-element
             // We make an exception for scrollbar pseudo elements and allow a set of pseudo classes (but nothing else)
@@ -413,7 +413,7 @@ SelectorChecker::MatchResult SelectorChecker::matchRecursively(CheckingContext& 
 
             return MatchResult::updateWithMatchType(result, matchType);
         }
-    case CSSSelector::RelationType::ShadowDescendant:  {
+    case CSSSelector::Relation::ShadowDescendant:  {
         auto* host = context.element->shadowHost();
         if (!host)
             return MatchResult::fails(Match::SelectorFailsCompletely);
@@ -426,7 +426,7 @@ SelectorChecker::MatchResult SelectorChecker::matchRecursively(CheckingContext& 
 
         return MatchResult::updateWithMatchType(result, matchType);
     }
-    case CSSSelector::RelationType::ShadowPartDescendant: {
+    case CSSSelector::Relation::ShadowPartDescendant: {
         // Continue matching in the scope where this rule came from.
         auto* host = checkingContext.styleScopeOrdinal == Style::ScopeOrdinal::Element
             ? context.element->shadowHost()
@@ -444,7 +444,7 @@ SelectorChecker::MatchResult SelectorChecker::matchRecursively(CheckingContext& 
 
         return MatchResult::updateWithMatchType(result, matchType);
     }
-    case CSSSelector::RelationType::ShadowSlotted: {
+    case CSSSelector::Relation::ShadowSlotted: {
         // We continue matching in the scope where this rule came from.
         auto slot = Style::assignedSlotForScopeOrdinal(*context.element, checkingContext.styleScopeOrdinal);
         if (!slot)
@@ -638,10 +638,10 @@ static bool canMatchHoverOrActiveInQuirksMode(const SelectorChecker::LocalContex
         }
 
         auto relation = selector->relation();
-        if (relation == CSSSelector::RelationType::ShadowDescendant || relation == CSSSelector::RelationType::ShadowPartDescendant)
+        if (relation == CSSSelector::Relation::ShadowDescendant || relation == CSSSelector::Relation::ShadowPartDescendant)
             return true;
 
-        if (relation != CSSSelector::RelationType::Subselector)
+        if (relation != CSSSelector::Relation::Subselector)
             return false;
     }
     return false;
@@ -1509,7 +1509,7 @@ unsigned SelectorChecker::determineLinkMatchType(const CSSSelector* selector)
             }
         }
         auto relation = selector->relation();
-        if (relation == CSSSelector::RelationType::Subselector)
+        if (relation == CSSSelector::Relation::Subselector)
             continue;
         if (!selector->hasDescendantOrChildRelation())
             return linkMatchType;

--- a/Source/WebCore/css/SelectorFilter.cpp
+++ b/Source/WebCore/css/SelectorFilter.cpp
@@ -188,25 +188,25 @@ void SelectorFilter::collectSelectorHashes(CollectedSelectorHashes& collectedHas
         if (includeRightmost == IncludeRightmost::No)
             return std::tuple { rightmostSelector.tagHistory(), rightmostSelector.relation(), true };
 
-        return std::tuple { &rightmostSelector, CSSSelector::RelationType::Subselector, false };
+        return std::tuple { &rightmostSelector, CSSSelector::Relation::Subselector, false };
     }();
 
     for (; selector; selector = selector->tagHistory()) {
         // Only collect identifiers that match ancestors.
         switch (relation) {
-        case CSSSelector::RelationType::Subselector:
+        case CSSSelector::Relation::Subselector:
             if (!skipOverSubselectors)
                 collectSimpleSelectorHash(collectedHashes, *selector);
             break;
-        case CSSSelector::RelationType::DirectAdjacent:
-        case CSSSelector::RelationType::IndirectAdjacent:
-        case CSSSelector::RelationType::ShadowDescendant:
-        case CSSSelector::RelationType::ShadowPartDescendant:
-        case CSSSelector::RelationType::ShadowSlotted:
+        case CSSSelector::Relation::DirectAdjacent:
+        case CSSSelector::Relation::IndirectAdjacent:
+        case CSSSelector::Relation::ShadowDescendant:
+        case CSSSelector::Relation::ShadowPartDescendant:
+        case CSSSelector::Relation::ShadowSlotted:
             skipOverSubselectors = true;
             break;
-        case CSSSelector::RelationType::DescendantSpace:
-        case CSSSelector::RelationType::Child:
+        case CSSSelector::Relation::DescendantSpace:
+        case CSSSelector::Relation::Child:
             skipOverSubselectors = false;
             collectSimpleSelectorHash(collectedHashes, *selector);
             break;

--- a/Source/WebCore/css/parser/CSSParserSelector.cpp
+++ b/Source/WebCore/css/parser/CSSParserSelector.cpp
@@ -207,7 +207,7 @@ bool CSSParserSelector::matchesPseudoElement() const
     return m_selector->matchesPseudoElement() || selectorListMatchesPseudoElement(m_selector->selectorList());
 }
 
-void CSSParserSelector::insertTagHistory(CSSSelector::RelationType before, std::unique_ptr<CSSParserSelector> selector, CSSSelector::RelationType after)
+void CSSParserSelector::insertTagHistory(CSSSelector::Relation before, std::unique_ptr<CSSParserSelector> selector, CSSSelector::Relation after)
 {
     if (m_tagHistory)
         selector->setTagHistory(WTFMove(m_tagHistory));
@@ -216,7 +216,7 @@ void CSSParserSelector::insertTagHistory(CSSSelector::RelationType before, std::
     m_tagHistory = WTFMove(selector);
 }
 
-void CSSParserSelector::appendTagHistory(CSSSelector::RelationType relation, std::unique_ptr<CSSParserSelector> selector)
+void CSSParserSelector::appendTagHistory(CSSSelector::Relation relation, std::unique_ptr<CSSParserSelector> selector)
 {
     CSSParserSelector* end = this;
     while (end->tagHistory())
@@ -233,8 +233,8 @@ void CSSParserSelector::appendTagHistoryAsRelative(std::unique_ptr<CSSParserSele
 
     // Relation is Descendant by default.
     auto relation = lastSelector->relation();
-    if (relation == CSSSelector::RelationType::Subselector)
-        relation = CSSSelector::RelationType::DescendantSpace;
+    if (relation == CSSSelector::Relation::Subselector)
+        relation = CSSSelector::Relation::DescendantSpace;
 
     appendTagHistory(relation, WTFMove(selector));
 }
@@ -245,19 +245,19 @@ void CSSParserSelector::appendTagHistory(CSSParserSelectorCombinator relation, s
     while (end->tagHistory())
         end = end->tagHistory();
 
-    CSSSelector::RelationType selectorRelation;
+    CSSSelector::Relation selectorRelation;
     switch (relation) {
     case CSSParserSelectorCombinator::Child:
-        selectorRelation = CSSSelector::RelationType::Child;
+        selectorRelation = CSSSelector::Relation::Child;
         break;
     case CSSParserSelectorCombinator::DescendantSpace:
-        selectorRelation = CSSSelector::RelationType::DescendantSpace;
+        selectorRelation = CSSSelector::Relation::DescendantSpace;
         break;
     case CSSParserSelectorCombinator::DirectAdjacent:
-        selectorRelation = CSSSelector::RelationType::DirectAdjacent;
+        selectorRelation = CSSSelector::Relation::DirectAdjacent;
         break;
     case CSSParserSelectorCombinator::IndirectAdjacent:
-        selectorRelation = CSSSelector::RelationType::IndirectAdjacent;
+        selectorRelation = CSSSelector::Relation::IndirectAdjacent;
         break;
     }
     end->setRelation(selectorRelation);
@@ -272,12 +272,12 @@ void CSSParserSelector::prependTagSelector(const QualifiedName& tagQName, bool t
     m_tagHistory = WTFMove(second);
 
     m_selector = makeUnique<CSSSelector>(tagQName, tagIsForNamespaceRule);
-    m_selector->setRelation(CSSSelector::RelationType::Subselector);
+    m_selector->setRelation(CSSSelector::Relation::Subselector);
 }
 
 std::unique_ptr<CSSParserSelector> CSSParserSelector::releaseTagHistory()
 {
-    setRelation(CSSSelector::RelationType::Subselector);
+    setRelation(CSSSelector::Relation::Subselector);
     return WTFMove(m_tagHistory);
 }
 
@@ -290,7 +290,7 @@ bool CSSParserSelector::isHostPseudoSelector() const
 bool CSSParserSelector::startsWithExplicitCombinator() const
 {
     auto relation = leftmostSimpleSelector()->selector()->relation();
-    return relation != CSSSelector::RelationType::Subselector && relation != CSSSelector::RelationType::DescendantSpace;
+    return relation != CSSSelector::Relation::Subselector && relation != CSSSelector::Relation::DescendantSpace;
 }
 
 }

--- a/Source/WebCore/css/parser/CSSParserSelector.h
+++ b/Source/WebCore/css/parser/CSSParserSelector.h
@@ -61,7 +61,7 @@ public:
     void setArgument(const AtomString& value) { m_selector->setArgument(value); }
     void setNth(int a, int b) { m_selector->setNth(a, b); }
     void setMatch(CSSSelector::Match value) { m_selector->setMatch(value); }
-    void setRelation(CSSSelector::RelationType value) { m_selector->setRelation(value); }
+    void setRelation(CSSSelector::Relation value) { m_selector->setRelation(value); }
     void setForPage() { m_selector->setForPage(); }
 
     CSSSelector::Match match() const { return m_selector->match(); }
@@ -98,8 +98,8 @@ public:
     bool startsWithExplicitCombinator() const;
     void setTagHistory(std::unique_ptr<CSSParserSelector> selector) { m_tagHistory = WTFMove(selector); }
     void clearTagHistory() { m_tagHistory.reset(); }
-    void insertTagHistory(CSSSelector::RelationType before, std::unique_ptr<CSSParserSelector>, CSSSelector::RelationType after);
-    void appendTagHistory(CSSSelector::RelationType, std::unique_ptr<CSSParserSelector>);
+    void insertTagHistory(CSSSelector::Relation before, std::unique_ptr<CSSParserSelector>, CSSSelector::Relation after);
+    void appendTagHistory(CSSSelector::Relation, std::unique_ptr<CSSParserSelector>);
     void appendTagHistory(CSSParserSelectorCombinator, std::unique_ptr<CSSParserSelector>);
     void appendTagHistoryAsRelative(std::unique_ptr<CSSParserSelector>);
     void prependTagSelector(const QualifiedName&, bool tagIsForNamespaceRule = false);

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -293,9 +293,9 @@ static OptionSet<CompoundSelectorFlag> extractCompoundFlags(const CSSParserSelec
     return CompoundSelectorFlag::HasPseudoElementForRightmostCompound;
 }
 
-static bool isDescendantCombinator(CSSSelector::RelationType relation)
+static bool isDescendantCombinator(CSSSelector::Relation relation)
 {
-    return relation == CSSSelector::RelationType::DescendantSpace;
+    return relation == CSSSelector::Relation::DescendantSpace;
 }
 
 std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumeNestedComplexSelector(CSSParserTokenRange& range)
@@ -324,7 +324,7 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumeComplexSelector(CSS
 
     while (true) {
         auto combinator = consumeCombinator(range);
-        if (combinator == CSSSelector::RelationType::Subselector)
+        if (combinator == CSSSelector::Relation::Subselector)
             break;
 
         auto nextSelector = consumeCompoundSelector(range);
@@ -352,8 +352,8 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumeRelativeScopeSelect
 {
     auto scopeCombinator = consumeCombinator(range);
 
-    if (scopeCombinator == CSSSelector::RelationType::Subselector)
-        scopeCombinator = CSSSelector::RelationType::DescendantSpace;
+    if (scopeCombinator == CSSSelector::Relation::Subselector)
+        scopeCombinator = CSSSelector::Relation::DescendantSpace;
 
     auto selector = consumeComplexSelector(range);
     if (!selector)
@@ -379,7 +379,7 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumeRelativeNestedSelec
 
     // Nesting should only work with ~ > + combinators in this function. 
     // The descendant combinator is handled in another code path.
-    if (scopeCombinator != CSSSelector::RelationType::DirectAdjacent && scopeCombinator != CSSSelector::RelationType::IndirectAdjacent && scopeCombinator != CSSSelector::RelationType::Child)
+    if (scopeCombinator != CSSSelector::Relation::DirectAdjacent && scopeCombinator != CSSSelector::Relation::IndirectAdjacent && scopeCombinator != CSSSelector::Relation::Child)
         return nullptr;
     
     auto selector = consumeComplexSelector(range);
@@ -517,7 +517,7 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumeCompoundSelector(CS
             m_precedingPseudoElement = simpleSelector->pseudoElementType();
 
         if (compoundSelector)
-            compoundSelector->appendTagHistory(CSSSelector::RelationType::Subselector, WTFMove(simpleSelector));
+            compoundSelector->appendTagHistory(CSSSelector::Relation::Subselector, WTFMove(simpleSelector));
         else
             compoundSelector = WTFMove(simpleSelector);
     }
@@ -976,12 +976,12 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumePseudo(CSSParserTok
     return nullptr;
 }
 
-CSSSelector::RelationType CSSSelectorParser::consumeCombinator(CSSParserTokenRange& range)
+CSSSelector::Relation CSSSelectorParser::consumeCombinator(CSSParserTokenRange& range)
 {
-    auto fallbackResult = CSSSelector::RelationType::Subselector;
+    auto fallbackResult = CSSSelector::Relation::Subselector;
     while (range.peek().type() == WhitespaceToken) {
         range.consume();
-        fallbackResult = CSSSelector::RelationType::DescendantSpace;
+        fallbackResult = CSSSelector::Relation::DescendantSpace;
     }
 
     if (range.peek().type() != DelimiterToken)
@@ -992,10 +992,10 @@ CSSSelector::RelationType CSSSelectorParser::consumeCombinator(CSSParserTokenRan
     if (delimiter == '+' || delimiter == '~' || delimiter == '>') {
         range.consumeIncludingWhitespace();
         if (delimiter == '+')
-            return CSSSelector::RelationType::DirectAdjacent;
+            return CSSSelector::Relation::DirectAdjacent;
         if (delimiter == '~')
-            return CSSSelector::RelationType::IndirectAdjacent;
-        return CSSSelector::RelationType::Child;
+            return CSSSelector::Relation::IndirectAdjacent;
+        return CSSSelector::Relation::Child;
     }
 
     return fallbackResult;
@@ -1229,10 +1229,10 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::splitCompoundAtImplicitSha
 
     auto relation = [&] {
         if (isSlotted)
-            return CSSSelector::RelationType::ShadowSlotted;
+            return CSSSelector::Relation::ShadowSlotted;
         if (isPart)
-            return CSSSelector::RelationType::ShadowPartDescendant;
-        return CSSSelector::RelationType::ShadowDescendant;
+            return CSSSelector::Relation::ShadowPartDescendant;
+        return CSSSelector::Relation::ShadowDescendant;
     }();
     secondCompound->appendTagHistory(relation, WTFMove(compoundSelector));
     return secondCompound;

--- a/Source/WebCore/css/parser/CSSSelectorParser.h
+++ b/Source/WebCore/css/parser/CSSSelectorParser.h
@@ -83,7 +83,7 @@ private:
     std::unique_ptr<CSSParserSelector> consumeAttribute(CSSParserTokenRange&);
     std::unique_ptr<CSSParserSelector> consumeNesting(CSSParserTokenRange&);
 
-    CSSSelector::RelationType consumeCombinator(CSSParserTokenRange&);
+    CSSSelector::Relation consumeCombinator(CSSParserTokenRange&);
     CSSSelector::Match consumeAttributeMatch(CSSParserTokenRange&);
     CSSSelector::AttributeMatchType consumeAttributeFlags(CSSParserTokenRange&);
 

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -650,21 +650,21 @@ void compileSelector(CompiledSelector& compiledSelector, const CSSSelector* sele
     ASSERT(compiledSelector.status != SelectorCompilationStatus::NotCompiled);
 }
 
-static inline FragmentRelation fragmentRelationForSelectorRelation(CSSSelector::RelationType relation)
+static inline FragmentRelation fragmentRelationForSelectorRelation(CSSSelector::Relation relation)
 {
     switch (relation) {
-    case CSSSelector::RelationType::DescendantSpace:
+    case CSSSelector::Relation::DescendantSpace:
         return FragmentRelation::Descendant;
-    case CSSSelector::RelationType::Child:
+    case CSSSelector::Relation::Child:
         return FragmentRelation::Child;
-    case CSSSelector::RelationType::DirectAdjacent:
+    case CSSSelector::Relation::DirectAdjacent:
         return FragmentRelation::DirectAdjacent;
-    case CSSSelector::RelationType::IndirectAdjacent:
+    case CSSSelector::Relation::IndirectAdjacent:
         return FragmentRelation::IndirectAdjacent;
-    case CSSSelector::RelationType::Subselector:
-    case CSSSelector::RelationType::ShadowDescendant:
-    case CSSSelector::RelationType::ShadowPartDescendant:
-    case CSSSelector::RelationType::ShadowSlotted:
+    case CSSSelector::Relation::Subselector:
+    case CSSSelector::Relation::ShadowDescendant:
+    case CSSSelector::Relation::ShadowPartDescendant:
+    case CSSSelector::Relation::ShadowSlotted:
         ASSERT_NOT_REACHED();
     }
     ASSERT_NOT_REACHED();
@@ -1547,16 +1547,16 @@ static FunctionType constructFragmentsInternal(const CSSSelector* rootSelector, 
         }
 
         auto relation = selector->relation();
-        if (relation == CSSSelector::RelationType::Subselector)
+        if (relation == CSSSelector::Relation::Subselector)
             continue;
 
-        if ((relation == CSSSelector::RelationType::ShadowDescendant || relation == CSSSelector::RelationType::ShadowPartDescendant) && !selector->isLastInTagHistory())
+        if ((relation == CSSSelector::Relation::ShadowDescendant || relation == CSSSelector::Relation::ShadowPartDescendant) && !selector->isLastInTagHistory())
             return FunctionType::CannotCompile;
 
-        if (relation == CSSSelector::RelationType::ShadowSlotted)
+        if (relation == CSSSelector::Relation::ShadowSlotted)
             return FunctionType::CannotCompile;
 
-        if (relation == CSSSelector::RelationType::DirectAdjacent || relation == CSSSelector::RelationType::IndirectAdjacent) {
+        if (relation == CSSSelector::Relation::DirectAdjacent || relation == CSSSelector::Relation::IndirectAdjacent) {
             FunctionType relationFunctionType = FunctionType::SelectorCheckerWithCheckingContext;
             if (selectorContext == SelectorContext::QuerySelector)
                 relationFunctionType = FunctionType::SimpleSelectorChecker;

--- a/Source/WebCore/dom/SelectorQuery.cpp
+++ b/Source/WebCore/dom/SelectorQuery.cpp
@@ -83,7 +83,7 @@ static IdMatchingType findIdMatchingType(const CSSSelector& firstSelector)
                 return IdMatchingType::Rightmost;
             return IdMatchingType::Filter;
         }
-        if (selector->relation() != CSSSelector::RelationType::Subselector)
+        if (selector->relation() != CSSSelector::Relation::Subselector)
             inRightmost = false;
     }
     return IdMatchingType::None;
@@ -195,7 +195,7 @@ static const CSSSelector* selectorForIdLookup(const ContainerNode& rootNode, con
     for (const CSSSelector* selector = &firstSelector; selector; selector = selector->tagHistory()) {
         if (canBeUsedForIdFastPath(*selector))
             return selector;
-        if (selector->relation() != CSSSelector::RelationType::Subselector)
+        if (selector->relation() != CSSSelector::Relation::Subselector)
             break;
     }
 
@@ -242,7 +242,7 @@ static ContainerNode& filterRootById(ContainerNode& rootNode, const CSSSelector&
     const CSSSelector* selector = &firstSelector;
     do {
         ASSERT(!canBeUsedForIdFastPath(*selector));
-        if (selector->relation() != CSSSelector::RelationType::Subselector)
+        if (selector->relation() != CSSSelector::Relation::Subselector)
             break;
         selector = selector->tagHistory();
     } while (selector);
@@ -260,9 +260,9 @@ static ContainerNode& filterRootById(ContainerNode& rootNode, const CSSSelector&
                 }
             }
         }
-        if (selector->relation() == CSSSelector::RelationType::Subselector)
+        if (selector->relation() == CSSSelector::Relation::Subselector)
             continue;
-        inAdjacentChain = selector->relation() == CSSSelector::RelationType::DirectAdjacent || selector->relation() == CSSSelector::RelationType::IndirectAdjacent;
+        inAdjacentChain = selector->relation() == CSSSelector::Relation::DirectAdjacent || selector->relation() == CSSSelector::Relation::IndirectAdjacent;
     }
     return rootNode;
 }

--- a/Source/WebCore/style/HasSelectorFilter.cpp
+++ b/Source/WebCore/style/HasSelectorFilter.cpp
@@ -73,7 +73,7 @@ auto HasSelectorFilter::makeKey(const CSSSelector& hasSelector) -> Key
         SelectorFilter::collectSimpleSelectorHash(hashes, *simpleSelector);
         if (!hashes.ids.isEmpty())
             break;
-        if (simpleSelector->relation() != CSSSelector::RelationType::Subselector)
+        if (simpleSelector->relation() != CSSSelector::Relation::Subselector)
             break;
     }
 

--- a/Source/WebCore/style/RuleData.cpp
+++ b/Source/WebCore/style/RuleData.cpp
@@ -129,7 +129,7 @@ static bool computeContainsUncommonAttributeSelector(const CSSSelector& rootSele
             }
         }
 
-        if (selector->relation() != CSSSelector::RelationType::Subselector)
+        if (selector->relation() != CSSSelector::Relation::Subselector)
             matchesRightmostElement = false;
 
         selector = selector->tagHistory();

--- a/Source/WebCore/style/RuleFeature.cpp
+++ b/Source/WebCore/style/RuleFeature.cpp
@@ -134,53 +134,53 @@ RuleFeatureWithInvalidationSelector::RuleFeatureWithInvalidationSelector(const R
 {
 }
 
-static MatchElement computeNextMatchElement(MatchElement matchElement, CSSSelector::RelationType relation)
+static MatchElement computeNextMatchElement(MatchElement matchElement, CSSSelector::Relation relation)
 {
     ASSERT(!isHasPseudoClassMatchElement(matchElement));
 
     if (isSiblingOrSubject(matchElement)) {
         switch (relation) {
-        case CSSSelector::RelationType::Subselector:
+        case CSSSelector::Relation::Subselector:
             return matchElement;
-        case CSSSelector::RelationType::DescendantSpace:
+        case CSSSelector::Relation::DescendantSpace:
             return MatchElement::Ancestor;
-        case CSSSelector::RelationType::Child:
+        case CSSSelector::Relation::Child:
             return MatchElement::Parent;
-        case CSSSelector::RelationType::IndirectAdjacent:
+        case CSSSelector::Relation::IndirectAdjacent:
             if (matchElement == MatchElement::AnySibling)
                 return MatchElement::AnySibling;
             return MatchElement::IndirectSibling;
-        case CSSSelector::RelationType::DirectAdjacent:
+        case CSSSelector::Relation::DirectAdjacent:
             if (matchElement == MatchElement::AnySibling)
                 return MatchElement::AnySibling;
             return matchElement == MatchElement::Subject ? MatchElement::DirectSibling : MatchElement::IndirectSibling;
-        case CSSSelector::RelationType::ShadowDescendant:
-        case CSSSelector::RelationType::ShadowPartDescendant:
+        case CSSSelector::Relation::ShadowDescendant:
+        case CSSSelector::Relation::ShadowPartDescendant:
             return MatchElement::Host;
-        case CSSSelector::RelationType::ShadowSlotted:
+        case CSSSelector::Relation::ShadowSlotted:
             return MatchElement::HostChild;
         };
     }
     switch (relation) {
-    case CSSSelector::RelationType::Subselector:
+    case CSSSelector::Relation::Subselector:
         return matchElement;
-    case CSSSelector::RelationType::DescendantSpace:
-    case CSSSelector::RelationType::Child:
+    case CSSSelector::Relation::DescendantSpace:
+    case CSSSelector::Relation::Child:
         return MatchElement::Ancestor;
-    case CSSSelector::RelationType::IndirectAdjacent:
-    case CSSSelector::RelationType::DirectAdjacent:
+    case CSSSelector::Relation::IndirectAdjacent:
+    case CSSSelector::Relation::DirectAdjacent:
         return matchElement == MatchElement::Parent ? MatchElement::ParentSibling : MatchElement::AncestorSibling;
-    case CSSSelector::RelationType::ShadowDescendant:
-    case CSSSelector::RelationType::ShadowPartDescendant:
+    case CSSSelector::Relation::ShadowDescendant:
+    case CSSSelector::Relation::ShadowPartDescendant:
         return MatchElement::Host;
-    case CSSSelector::RelationType::ShadowSlotted:
+    case CSSSelector::Relation::ShadowSlotted:
         return MatchElement::HostChild;
     };
     ASSERT_NOT_REACHED();
     return matchElement;
 };
 
-static MatchElement computeNextHasPseudoClassMatchElement(MatchElement matchElement, CSSSelector::RelationType relation, CanBreakScope canBreakScope)
+static MatchElement computeNextHasPseudoClassMatchElement(MatchElement matchElement, CSSSelector::Relation relation, CanBreakScope canBreakScope)
 {
     ASSERT(isHasPseudoClassMatchElement(matchElement));
 
@@ -188,10 +188,10 @@ static MatchElement computeNextHasPseudoClassMatchElement(MatchElement matchElem
         return matchElement;
 
     // `:has(:is(foo bar))` can be affected by changes outside the :has scope.
-    if (relation == CSSSelector::RelationType::DescendantSpace || relation == CSSSelector::RelationType::Child)
+    if (relation == CSSSelector::Relation::DescendantSpace || relation == CSSSelector::Relation::Child)
         return MatchElement::HasScopeBreaking;
 
-    if (relation == CSSSelector::RelationType::IndirectAdjacent || relation == CSSSelector::RelationType::DirectAdjacent) {
+    if (relation == CSSSelector::Relation::IndirectAdjacent || relation == CSSSelector::Relation::DirectAdjacent) {
         // `:has(~ :is(.x ~ .y))` must look at previous siblings of the :scope scope too.
         if (matchElement == MatchElement::HasSibling)
             return MatchElement::HasAnySibling;
@@ -360,7 +360,7 @@ static PseudoClassInvalidationKey makePseudoClassInvalidationKey(CSSSelector::Ps
         if (simpleSelector->match() == CSSSelector::Match::Tag)
             tagName = simpleSelector->tagLowercaseLocalName();
 
-        if (simpleSelector->relation() != CSSSelector::RelationType::Subselector)
+        if (simpleSelector->relation() != CSSSelector::Relation::Subselector)
             break;
     }
     if (!className.isEmpty())

--- a/Source/WebCore/style/RuleSet.cpp
+++ b/Source/WebCore/style/RuleSet.cpp
@@ -92,7 +92,7 @@ static bool isHostSelectorMatchingInShadowTree(const CSSSelector& startSelector)
             hasHostInLastCompound = true;
         if (isHostSelectorMatchingInShadowTreeInSelectorList(selector->selectorList()))
             return true;
-        if (selector->tagHistory() && selector->relation() != CSSSelector::RelationType::Subselector) {
+        if (selector->tagHistory() && selector->relation() != CSSSelector::Relation::Subselector) {
             hasOnlyOneCompound = false;
             hasHostInLastCompound = false;
         }
@@ -232,7 +232,7 @@ void RuleSet::addRule(RuleData&& ruleData, CascadeLayerIdentifier cascadeLayerId
         case CSSSelector::Match::PagePseudoClass:
             break;
         }
-        if (selector->relation() != CSSSelector::RelationType::Subselector)
+        if (selector->relation() != CSSSelector::Relation::Subselector)
             break;
         selector = selector->tagHistory();
     } while (selector);


### PR DESCRIPTION
#### 58aaae7fcd532e7eb1d42d01fbd545eae8448b95
<pre>
Rename CSSSelector&apos;s RelationType to Relation
<a href="https://bugs.webkit.org/show_bug.cgi?id=266842">https://bugs.webkit.org/show_bug.cgi?id=266842</a>

Reviewed by Tim Nguyen.

This makes it consistent with the other enums.

* Source/WebCore/css/CSSSelector.cpp:
(WebCore::CSSSelector::CSSSelector):
(WebCore::CSSSelector::firstInCompound const):
(WebCore::CSSSelector::selectorText const):
* Source/WebCore/css/CSSSelector.h:
(WebCore::CSSSelector::hasDescendantRelation const):
(WebCore::CSSSelector::hasDescendantOrChildRelation const):
(WebCore::CSSSelector::relation const):
(WebCore::CSSSelector::isSiblingSelector const):
(WebCore::CSSSelector::setRelation):
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::matchRecursively const):
(WebCore::canMatchHoverOrActiveInQuirksMode):
(WebCore::SelectorChecker::determineLinkMatchType):
* Source/WebCore/css/SelectorFilter.cpp:
(WebCore::SelectorFilter::collectSelectorHashes):
* Source/WebCore/css/parser/CSSParserSelector.cpp:
(WebCore::CSSParserSelector::insertTagHistory):
(WebCore::CSSParserSelector::appendTagHistory):
(WebCore::CSSParserSelector::appendTagHistoryAsRelative):
(WebCore::CSSParserSelector::prependTagSelector):
(WebCore::CSSParserSelector::releaseTagHistory):
(WebCore::CSSParserSelector::startsWithExplicitCombinator const):
* Source/WebCore/css/parser/CSSParserSelector.h:
(WebCore::CSSParserSelector::setRelation):
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::isDescendantCombinator):
(WebCore::CSSSelectorParser::consumeComplexSelector):
(WebCore::CSSSelectorParser::consumeRelativeScopeSelector):
(WebCore::CSSSelectorParser::consumeRelativeNestedSelector):
(WebCore::CSSSelectorParser::consumeCompoundSelector):
(WebCore::CSSSelectorParser::consumeCombinator):
(WebCore::CSSSelectorParser::splitCompoundAtImplicitShadowCrossingCombinator):
* Source/WebCore/css/parser/CSSSelectorParser.h:
* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::fragmentRelationForSelectorRelation):
(WebCore::SelectorCompiler::constructFragmentsInternal):
* Source/WebCore/dom/SelectorQuery.cpp:
(WebCore::findIdMatchingType):
(WebCore::selectorForIdLookup):
(WebCore::filterRootById):
* Source/WebCore/style/HasSelectorFilter.cpp:
(WebCore::Style::HasSelectorFilter::makeKey):
* Source/WebCore/style/RuleData.cpp:
(WebCore::Style::computeContainsUncommonAttributeSelector):
* Source/WebCore/style/RuleFeature.cpp:
(WebCore::Style::computeNextMatchElement):
(WebCore::Style::computeNextHasPseudoClassMatchElement):
(WebCore::Style::makePseudoClassInvalidationKey):
* Source/WebCore/style/RuleSet.cpp:
(WebCore::Style::isHostSelectorMatchingInShadowTree):
(WebCore::Style::RuleSet::addRule):

Canonical link: <a href="https://commits.webkit.org/272475@main">https://commits.webkit.org/272475@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16c77259aef6e470e525bb84d89be982f0ef99dd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31776 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10466 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33512 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34275 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28776 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32568 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12826 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7709 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/28370 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32136 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8827 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28371 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7619 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7788 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/28284 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35622 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28891 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/28734 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/33903 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7878 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5876 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31759 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9533 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7444 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8551 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8398 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->