### PR TITLE
Fix invalid CSS state web platform test

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/custom-state-pseudo-class/state-css-selector-shadow-dom.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-state-pseudo-class/state-css-selector-shadow-dom.tentative-expected.txt
@@ -1,5 +1,5 @@
 
 PASS state selector has no influence when state is not applied
-FAIL state selector has influence when state is applied assert_equals: expected "rgb(0, 255, 0)" but got "rgb(255, 0, 0)"
+PASS state selector has influence when state is applied
 PASS state selector only applies on given ident
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-state-pseudo-class/state-css-selector-shadow-dom.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-state-pseudo-class/state-css-selector-shadow-dom.tentative.html
@@ -28,7 +28,7 @@
               :host {
                 color: #f00;
               }
-              :host:state(green) {
+              :host(:state(green)) {
                 color: #0f0;
               }
             `);


### PR DESCRIPTION
#### 4dd84e9fa371bf1f511c21bb3552fb4138334ba5
<pre>
Fix invalid CSS state web platform test
<a href="https://bugs.webkit.org/show_bug.cgi?id=266844">https://bugs.webkit.org/show_bug.cgi?id=266844</a>

Reviewed by Tim Nguyen.

This test uses the wrong CSS selector, it uses `:host:state(green)`
which is invalid, as the bare `:host` selector doesn&apos;t match on pseudo
states. Instead the `:host()` selector function should be used, so the
selector becomes `:host(:state(green))`.

* LayoutTests/imported/w3c/web-platform-tests/custom-state-pseudo-class/state-css-selector-shadow-dom.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-state-pseudo-class/state-css-selector-shadow-dom.tentative.html:

Canonical link: <a href="https://commits.webkit.org/272469@main">https://commits.webkit.org/272469@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f32343cbc767792ec09e2dc1458aff780f1f1bbf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31769 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10458 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33503 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34267 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28769 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12817 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7702 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/28362 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32128 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8820 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28362 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7611 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7781 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28276 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35614 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28884 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28726 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33895 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7870 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5870 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31751 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9525 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/28083 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7440 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8544 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8390 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->