### PR TITLE
Remove unused 'VisibleUnits::inSameDocument' function

### DIFF
--- a/Source/WebCore/editing/VisibleUnits.cpp
+++ b/Source/WebCore/editing/VisibleUnits.cpp
@@ -1425,20 +1425,6 @@ VisiblePosition endOfDocument(const VisiblePosition& c)
     return endOfDocument(c.deepEquivalent().protectedDeprecatedNode().get());
 }
 
-bool inSameDocument(const VisiblePosition& a, const VisiblePosition& b)
-{
-    Position ap = a.deepEquivalent();
-    RefPtr an = ap.deprecatedNode();
-    if (!an)
-        return false;
-    Position bp = b.deepEquivalent();
-    RefPtr bn = bp.deprecatedNode();
-    if (an == bn)
-        return true;
-
-    return &an->document() == &bn->document();
-}
-
 bool isStartOfDocument(const VisiblePosition& p)
 {
     return p.isNotNull() && p.previous(CanCrossEditingBoundary).isNull();

--- a/Source/WebCore/editing/VisibleUnits.h
+++ b/Source/WebCore/editing/VisibleUnits.h
@@ -90,7 +90,6 @@ WEBCORE_EXPORT VisiblePosition startOfDocument(const Node*);
 WEBCORE_EXPORT VisiblePosition endOfDocument(const Node*);
 WEBCORE_EXPORT VisiblePosition startOfDocument(const VisiblePosition&);
 WEBCORE_EXPORT VisiblePosition endOfDocument(const VisiblePosition&);
-bool inSameDocument(const VisiblePosition&, const VisiblePosition&);
 WEBCORE_EXPORT bool isStartOfDocument(const VisiblePosition&);
 WEBCORE_EXPORT bool isEndOfDocument(const VisiblePosition&);
 


### PR DESCRIPTION
#### 787a773cc50a1c2a9bd61932f525ad640582b3db
<pre>
Remove unused &apos;VisibleUnits::inSameDocument&apos; function

<a href="https://bugs.webkit.org/show_bug.cgi?id=266854">https://bugs.webkit.org/show_bug.cgi?id=266854</a>

Reviewed by Wenson Hsieh.

This patch is to remove unused &apos;inSameDocument&apos; function from VisibleUnits.cpp|h.

* Source/WebCore/editing/VisibleUnits.cpp:
(inSameDocument): Deleted
* Source/WebCore/editing/VisibleUnits.h: Delete &apos;inSameDocument&apos; definition

Canonical link: <a href="https://commits.webkit.org/272478@main">https://commits.webkit.org/272478@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12aa8b35a485b3aa8b0916ba80108df230442150

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31779 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10469 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33515 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34278 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28779 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32571 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12829 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7712 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28372 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32139 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8830 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28374 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7621 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7791 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28287 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35625 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28894 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28737 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33905 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7881 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5879 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31771 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9536 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7447 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8554 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8401 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->