### PR TITLE
REGRESSION (271171@main): Unable to scroll web views using pan gesture in the 喜马拉雅 app

### DIFF
--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -115,6 +115,7 @@ enum class SDKAlignedBehavior {
     OnlyLoadWellKnownAboutURLs,
     AsyncFragmentNavigationPolicyDecision,
     DoNotLoadStyleSheetIfHTTPStatusIsNotOK,
+    ScrollViewSubclassImplementsAddGestureRecognizer,
 
     NumberOfBehaviors
 };

--- a/Source/WebCore/platform/RuntimeApplicationChecks.h
+++ b/Source/WebCore/platform/RuntimeApplicationChecks.h
@@ -114,6 +114,7 @@ WEBCORE_EXPORT bool isEvernote();
 WEBCORE_EXPORT bool isFIFACompanion();
 WEBCORE_EXPORT bool isFeedly();
 WEBCORE_EXPORT bool isFirefox();
+WEBCORE_EXPORT bool isHimalaya();
 WEBCORE_EXPORT bool isHoYoLAB();
 WEBCORE_EXPORT bool isIMDb();
 WEBCORE_EXPORT bool isGmail();

--- a/Source/WebCore/platform/cocoa/RuntimeApplicationChecksCocoa.mm
+++ b/Source/WebCore/platform/cocoa/RuntimeApplicationChecksCocoa.mm
@@ -457,7 +457,13 @@ bool IOSApplication::isDOFUSTouch()
     return isDOFUSTouch;
 }
 
-#endif
+bool IOSApplication::isHimalaya()
+{
+    static bool isHimalayaApp = applicationBundleIsEqualTo("com.gemd.iting"_s);
+    return isHimalayaApp;
+}
+
+#endif // PLATFORM(IOS_FAMILY)
 
 } // namespace WebCore
 


### PR DESCRIPTION
#### 57c88bfd87f4f5907337cc6a81a988188281d7a4
<pre>
REGRESSION (271171@main): Unable to scroll web views using pan gesture in the 喜马拉雅 app
<a href="https://bugs.webkit.org/show_bug.cgi?id=266856">https://bugs.webkit.org/show_bug.cgi?id=266856</a>
<a href="https://rdar.apple.com/119851795">rdar://119851795</a>

Reviewed by Aditya Keerthi.

Add a temporary workaround to keep scrolling in web views working in the 喜马拉雅 app on iOS. The
changes in 271171@main added an implementation of `-addGestureRecognizer:` to the new common WebKit
scroll view subclass, `WKBaseScrollView`. This causes bincompat issues in this app, due to how the
app intercepts all invocations of `-[UIView addGestureRecognizer:]` using the ObjC runtime functions
`class_getInstanceMethod` and `method_setImplementation`. For reasons that are still unclear, it
avoids calling into the original implementation in UIKit in the case where the method is invoked in
the context of a `objc_msgSendSuper` call from within a subclass, which results in the pan gesture
not being installed on the scroll view at all.

To mitigate this, we refactor this code to avoid implementing `-addGestureRecognizer:` on the scroll
view subclass altogether for this app (behind a linked-on-or-after check, such that it will force
this app to eventually fix this when updating to a new iOS SDK).

No change in behavior, outside of 喜马拉雅.

* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h:
* Source/WebCore/platform/RuntimeApplicationChecks.h:
* Source/WebCore/platform/cocoa/RuntimeApplicationChecksCocoa.mm:
(WebCore::IOSApplication::isHimalaya):
* Source/WebKit/UIProcess/ios/WKBaseScrollView.mm:
(-[WKBaseScrollView initWithFrame:]):
(+[WKBaseScrollView _overrideAddGestureRecognizerIfNeeded]):

See above for more details — don&apos;t implement and override `-addGestureRecognizer:` in this subclass
when this app-specific quirk is active.

(-[WKBaseScrollView _wk_addGestureRecognizer:]):
(-[WKBaseScrollView addGestureRecognizer:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/272571@main">https://commits.webkit.org/272571@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15459634e42357cb6002628b7d7397bce4264a4c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31789 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10480 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33527 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34290 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28787 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32583 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12840 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7722 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28383 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32151 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8841 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28386 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7632 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7802 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28299 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35637 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/27283 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28905 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28751 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33914 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/31856 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7891 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5889 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31773 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9545 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/38301 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7509 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8562 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8122 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8413 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->