### PR TITLE
Add CSSSelector::parseStandalonePseudoElement()

### DIFF
--- a/LayoutTests/fast/css/getComputedStyle/computed-style-properties-expected.txt
+++ b/LayoutTests/fast/css/getComputedStyle/computed-style-properties-expected.txt
@@ -10,14 +10,14 @@ Subheading B
 Heading B
 
 PASS computedStyleFor('outline', null, 'outline-offset') is '5px'
-PASS computedStyleFor('content', 'before', 'content') is "\"text\""
-PASS computedStyleFor('content', 'after', 'content') is "\"test \" url(\"data:image/gif;base64,R0lGODlhAQABAJAAAP8AAAAAACwAAAAAAQABAAACAgQBADs=\")"
+PASS computedStyleFor('content', ':before', 'content') is "\"text\""
+PASS computedStyleFor('content', ':after', 'content') is "\"test \" url(\"data:image/gif;base64,R0lGODlhAQABAJAAAP8AAAAAACwAAAAAAQABAAACAgQBADs=\")"
 PASS computedStyleFor('counter', null, 'counter-reset') is "section 0"
 PASS str.indexOf('subsection 0') != -1 is true
 PASS str.indexOf('anothercounter 5') != -1 is true
-PASS computedStyleFor('counter1', 'before', 'counter-increment') is "section 1"
-PASS computedStyleFor('subcounter2', 'before', 'counter-increment') is "subsection 1"
-PASS computedStyleFor('subcounter2', 'before', 'content') is "counter(section) \".\" counter(subsection) \". \""
+PASS computedStyleFor('counter1', ':before', 'counter-increment') is "section 1"
+PASS computedStyleFor('subcounter2', ':before', 'counter-increment') is "subsection 1"
+PASS computedStyleFor('subcounter2', ':before', 'content') is "counter(section) \".\" counter(subsection) \". \""
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/css/getComputedStyle/computed-style-properties.html
+++ b/LayoutTests/fast/css/getComputedStyle/computed-style-properties.html
@@ -65,15 +65,15 @@ function computedStyleFor(id, pseudo, property)
 
 shouldBe("computedStyleFor('outline', null, 'outline-offset')", "'5px'");
 
-shouldBeEqualToString("computedStyleFor('content', 'before', 'content')", '"text"');
-shouldBeEqualToString("computedStyleFor('content', 'after', 'content')", `"test " url(\"data:image/gif;base64,R0lGODlhAQABAJAAAP8AAAAAACwAAAAAAQABAAACAgQBADs=\")`);
+shouldBeEqualToString("computedStyleFor('content', ':before', 'content')", '"text"');
+shouldBeEqualToString("computedStyleFor('content', ':after', 'content')", `"test " url(\"data:image/gif;base64,R0lGODlhAQABAJAAAP8AAAAAACwAAAAAAQABAAACAgQBADs=\")`);
 shouldBeEqualToString("computedStyleFor('counter', null, 'counter-reset')", "section 0");
 var str = computedStyleFor('subcounter', null, 'counter-reset');
 shouldBe("str.indexOf('subsection 0') != -1", "true");
 shouldBe("str.indexOf('anothercounter 5') != -1", "true");
-shouldBeEqualToString("computedStyleFor('counter1', 'before', 'counter-increment')", "section 1");
-shouldBeEqualToString("computedStyleFor('subcounter2', 'before', 'counter-increment')", "subsection 1");
-shouldBeEqualToString("computedStyleFor('subcounter2', 'before', 'content')", `counter(section) "." counter(subsection) ". "`);
+shouldBeEqualToString("computedStyleFor('counter1', ':before', 'counter-increment')", "section 1");
+shouldBeEqualToString("computedStyleFor('subcounter2', ':before', 'counter-increment')", "subsection 1");
+shouldBeEqualToString("computedStyleFor('subcounter2', ':before', 'content')", `counter(section) "." counter(subsection) ". "`);
 </script>
 <script src="../../../resources/js-test-post.js"></script>
 </html>

--- a/LayoutTests/fast/css/getComputedStyle/getComputedStyle-with-pseudo-element-expected.txt
+++ b/LayoutTests/fast/css/getComputedStyle/getComputedStyle-with-pseudo-element-expected.txt
@@ -17,7 +17,7 @@ This should be at full opacity.
 PASS Expected 'rgb(165, 42, 42)' for color in the computed style for element with id testFirsts and pseudo-element :first-line and got 'rgb(165, 42, 42)'
 PASS Expected 'rgb(0, 0, 255)' for color in the computed style for element with id testFirsts and pseudo-element :first-letter and got 'rgb(0, 0, 255)'
 PASS Expected 'rgb(0, 0, 255)' for color in the computed style for element with id testFirsts and pseudo-element ::first-letter and got 'rgb(0, 0, 255)'
-PASS Expected 'rgb(0, 0, 255)' for color in the computed style for element with id testFirsts and pseudo-element first-letter and got 'rgb(0, 0, 255)'
+PASS Expected 'rgb(0, 0, 255)' for color in the computed style for element with id testFirsts and pseudo-element :first-letter and got 'rgb(0, 0, 255)'
 PASS Expected 'rgb(0, 0, 0)' for color in the computed style for element with id testFirsts and pseudo-element null and got 'rgb(0, 0, 0)'
 PASS Expected 'rgb(165, 42, 42)' for color in the computed style for element with id testBeforeAfter and pseudo-element :before and got 'rgb(165, 42, 42)'
 PASS Expected 'rgb(0, 0, 255)' for color in the computed style for element with id testBeforeAfter and pseudo-element :after and got 'rgb(0, 0, 255)'

--- a/LayoutTests/fast/css/getComputedStyle/getComputedStyle-with-pseudo-element.html
+++ b/LayoutTests/fast/css/getComputedStyle/getComputedStyle-with-pseudo-element.html
@@ -134,7 +134,7 @@
         { 'elementId' : 'testFirsts', 'pseudoElement' : ':first-line', 'property' : 'color', 'expectedValue' : 'rgb(165, 42, 42)' },
         { 'elementId' : 'testFirsts', 'pseudoElement' : ':first-letter', 'property' : 'color', 'expectedValue' : 'rgb(0, 0, 255)' },
         { 'elementId' : 'testFirsts', 'pseudoElement' : '::first-letter', 'property' : 'color', 'expectedValue' : 'rgb(0, 0, 255)' },
-        { 'elementId' : 'testFirsts', 'pseudoElement' : 'first-letter', 'property' : 'color', 'expectedValue' : 'rgb(0, 0, 255)' },
+        { 'elementId' : 'testFirsts', 'pseudoElement' : ':first-letter', 'property' : 'color', 'expectedValue' : 'rgb(0, 0, 255)' },
         { 'elementId' : 'testFirsts', 'pseudoElement' : null, 'property' : 'color', 'expectedValue' : 'rgb(0, 0, 0)' },
         { 'elementId' : 'testBeforeAfter', 'pseudoElement' : ':before', 'property' : 'color', 'expectedValue' : 'rgb(165, 42, 42)' },
         { 'elementId' : 'testBeforeAfter', 'pseudoElement' : ':after', 'property' : 'color', 'expectedValue' : 'rgb(0, 0, 255)' },

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animatable/animate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animatable/animate-expected.txt
@@ -149,6 +149,6 @@ PASS animate() with a non-null invalid pseudoElement '' throws a SyntaxError
 PASS animate() with a non-null invalid pseudoElement 'before' throws a SyntaxError
 PASS animate() with a non-null invalid pseudoElement ':abc' throws a SyntaxError
 PASS animate() with a non-null invalid pseudoElement '::abc' throws a SyntaxError
-FAIL animate() with pseudoElement ::placeholder does not throw The string did not match the expected pattern.
+PASS animate() with pseudoElement ::placeholder does not throw
 PASS Finished fill animation doesn't replace animation on a different pseudoElement
 

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/KeyframeEffect/target-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/KeyframeEffect/target-expected.txt
@@ -22,5 +22,5 @@ PASS Changing pseudoElement to a non-null invalid pseudo-selector '' throws a Sy
 PASS Changing pseudoElement to a non-null invalid pseudo-selector 'before' throws a SyntaxError
 PASS Changing pseudoElement to a non-null invalid pseudo-selector ':abc' throws a SyntaxError
 PASS Changing pseudoElement to a non-null invalid pseudo-selector '::abc' throws a SyntaxError
-FAIL Changing pseudoElement to ::placeHOLDER works The string did not match the expected pattern.
+FAIL Changing pseudoElement to ::placeHOLDER works assert_equals: expected (string) "::placeholder" but got (object) null
 

--- a/Source/WebCore/animation/DeclarativeAnimationEvent.cpp
+++ b/Source/WebCore/animation/DeclarativeAnimationEvent.cpp
@@ -45,9 +45,9 @@ DeclarativeAnimationEvent::DeclarativeAnimationEvent(const AtomString& type, con
     , m_elapsedTime(elapsedTime)
     , m_pseudoElement(pseudoElement)
 {
-    auto pseudoIdOrException = pseudoIdFromString(m_pseudoElement);
-    if (!pseudoIdOrException.hasException())
-        m_pseudoId = pseudoIdOrException.returnValue();
+    auto pseudoId = pseudoIdFromString(m_pseudoElement);
+    if (pseudoId)
+        m_pseudoId = *pseudoId;
 }
 
 DeclarativeAnimationEvent::~DeclarativeAnimationEvent() = default;

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -1227,17 +1227,16 @@ const String KeyframeEffect::pseudoElement() const
 
 ExceptionOr<void> KeyframeEffect::setPseudoElement(const String& pseudoElement)
 {
-    // https://drafts.csswg.org/web-animations/#dom-keyframeeffect-pseudoelement
-    auto pseudoIdOrException = pseudoIdFromString(pseudoElement);
-    if (pseudoIdOrException.hasException())
-        return pseudoIdOrException.releaseException();
-    auto pseudoId = pseudoIdOrException.returnValue();
+    // https://drafts.csswg.org/web-animations-1/#dom-keyframeeffect-pseudoelement
+    auto pseudoId = pseudoIdFromString(pseudoElement);
+    if (!pseudoId)
+        return Exception { ExceptionCode::SyntaxError, "Parsing pseudo-element selector failed"_s };
 
-    if (pseudoId == m_pseudoId)
+    if (*pseudoId == m_pseudoId)
         return { };
 
     auto& previousTargetStyleable = targetStyleable();
-    m_pseudoId = pseudoId;
+    m_pseudoId = *pseudoId;
     didChangeTargetStyleable(previousTargetStyleable);
 
     return { };

--- a/Source/WebCore/animation/WebAnimationUtilities.h
+++ b/Source/WebCore/animation/WebAnimationUtilities.h
@@ -59,7 +59,7 @@ const auto timeEpsilon = Seconds::fromMilliseconds(0.001);
 bool compareAnimationsByCompositeOrder(const WebAnimation&, const WebAnimation&);
 bool compareAnimationEventsByCompositeOrder(const AnimationEventBase&, const AnimationEventBase&);
 String pseudoIdAsString(PseudoId);
-ExceptionOr<PseudoId> pseudoIdFromString(const String&);
+std::optional<PseudoId> pseudoIdFromString(const String&);
 AtomString animatablePropertyAsString(AnimatableCSSProperty);
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSComputedStyleDeclaration.cpp
+++ b/Source/WebCore/css/CSSComputedStyleDeclaration.cpp
@@ -51,13 +51,9 @@ CSSComputedStyleDeclaration::CSSComputedStyleDeclaration(Element& element, bool 
     : m_element(element)
     , m_allowVisitedStyle(allowVisitedStyle)
 {
-    StringView name = pseudoElementName;
-    if (name.startsWith(':'))
-        name = name.substring(1);
-    if (name.startsWith(':'))
-        name = name.substring(1);
-    auto pseudoType = CSSSelector::parsePseudoElement(name, CSSSelectorParserContext { element.document() });
-    m_pseudoElementSpecifier = pseudoType ? CSSSelector::pseudoId(*pseudoType) : PseudoId::None;
+    // FIXME: This should return a style with initial values if the pseudo-element is invalid (webkit.org/b/243539).
+    auto pseudoId = CSSSelector::parseStandalonePseudoElement(pseudoElementName, CSSSelectorParserContext { element.document() });
+    m_pseudoElementSpecifier = pseudoId ? *pseudoId : PseudoId::None;
 }
 
 CSSComputedStyleDeclaration::~CSSComputedStyleDeclaration() = default;

--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -318,7 +318,7 @@ PseudoId CSSSelector::pseudoId(PseudoElement type)
 
 std::optional<CSSSelector::PseudoElement> CSSSelector::parsePseudoElement(StringView name, const CSSSelectorParserContext& context)
 {
-    if (name.isNull())
+    if (name.isEmpty())
         return std::nullopt;
 
     auto type = parsePseudoElementString(name);
@@ -355,6 +355,24 @@ std::optional<CSSSelector::PseudoElement> CSSSelector::parsePseudoElement(String
         break;
     }
     return type;
+}
+
+std::optional<PseudoId> CSSSelector::parseStandalonePseudoElement(StringView input, const CSSSelectorParserContext& context)
+{
+    // FIXME: Tokenize input.
+    if (input.startsWith("::"_s)) {
+        auto pseudoElement = parsePseudoElement(input.substring(2), context);
+        if (!pseudoElement)
+            return std::nullopt;
+        return pseudoId(*pseudoElement);
+    }
+    if (input.startsWith(":"_s)) {
+        auto pseudoClassOrElement = parsePseudoClassAndCompatibilityElementString(input.substring(1));
+        if (!pseudoClassOrElement.compatibilityPseudoElement)
+            return std::nullopt;
+        return pseudoId(*pseudoClassOrElement.compatibilityPseudoElement);
+    }
+    return std::nullopt;
 }
 
 const CSSSelector* CSSSelector::firstInCompound() const

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -242,8 +242,9 @@ struct PossiblyQuotedIdentifier {
             Right,
         };
 
-        static std::optional<PseudoElement> parsePseudoElement(StringView, const CSSSelectorParserContext&);
         static PseudoId pseudoId(PseudoElement);
+        static std::optional<PseudoElement> parsePseudoElement(StringView, const CSSSelectorParserContext&);
+        static std::optional<PseudoId> parseStandalonePseudoElement(StringView, const CSSSelectorParserContext&);
 
         // Selectors are kept in an array by CSSSelectorList.
         // The next component of the selector is the next item in the array.


### PR DESCRIPTION
#### d4994b28b489ed0ca40eb28d5399431964076621
<pre>
Add CSSSelector::parseStandalonePseudoElement()
<a href="https://bugs.webkit.org/show_bug.cgi?id=266862">https://bugs.webkit.org/show_bug.cgi?id=266862</a>

Reviewed by Tim Nguyen.

Abstract the logic of non-selector-parser callers of
parsePseudoElement() into a more correct static method.

This means that from now on we require that standalone pseudo-elements
start with &quot;::&quot; (or just &quot;:&quot; for 4 legacy pseudo-elements), which is
aligned with the specification and Firefox.

This also fixes what appears to be a regression in
LocalDOMWindow::getMatchedCSSRules() introduced 272429@main. It
incorrectly assumes to have a CSSSelector::PseudoElement from
which it can obtain a PseudoId.

This also helps <a href="https://bugs.webkit.org/show_bug.cgi?id=243539.">https://bugs.webkit.org/show_bug.cgi?id=243539.</a>

* LayoutTests/fast/css/getComputedStyle/computed-style-properties-expected.txt:
* LayoutTests/fast/css/getComputedStyle/computed-style-properties.html:
* LayoutTests/fast/css/getComputedStyle/getComputedStyle-with-pseudo-element-expected.txt:
* LayoutTests/fast/css/getComputedStyle/getComputedStyle-with-pseudo-element.html:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animatable/animate-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/KeyframeEffect/target-expected.txt:
* Source/WebCore/animation/DeclarativeAnimationEvent.cpp:
(WebCore::DeclarativeAnimationEvent::DeclarativeAnimationEvent):
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::setPseudoElement):
* Source/WebCore/animation/WebAnimationUtilities.cpp:
(WebCore::pseudoIdFromString):
* Source/WebCore/animation/WebAnimationUtilities.h:
* Source/WebCore/css/CSSComputedStyleDeclaration.cpp:
(WebCore::CSSComputedStyleDeclaration::CSSComputedStyleDeclaration):
* Source/WebCore/css/CSSSelector.cpp:
(WebCore::CSSSelector::parsePseudoElement):
(WebCore::CSSSelector::parseStandalonePseudoElement):
* Source/WebCore/css/CSSSelector.h:
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::getMatchedCSSRules const):

Canonical link: <a href="https://commits.webkit.org/272499@main">https://commits.webkit.org/272499@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77571db45a7fc4153b9a4557fb26c7d12d954cc3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31844 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10537 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33586 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34347 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28843 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32639 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12897 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7777 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28432 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32207 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8893 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28439 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7681 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7857 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28352 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35694 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28956 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28805 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33963 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7948 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5937 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31822 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9600 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/28159 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7457 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8617 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8469 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->