### PR TITLE
Update 'animate-initial-pause-unpause.html' to use 'testharness' and deflake

### DIFF
--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -1761,8 +1761,6 @@ webkit.org/b/209544 svg/custom/object-sizing-explicit-width.xhtml [ Pass Failure
 
 webkit.org/b/209869 crypto/subtle/rsa-indexeddb-non-exportable-private.html [ Pass Timeout ]
 
-webkit.org/b/209908 svg/custom/animate-initial-pause-unpause.html [ Pass Timeout ]
-
 webkit.org/b/206750 http/tests/security/appcache-in-private-browsing.html [ Pass Timeout ]
 
 webkit.org/b/210201 [ Debug ] editing/editability/empty-document-delete.html [ Pass Crash ]

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -1681,8 +1681,6 @@ webkit.org/b/207858 fast/canvas/webgl/simulated-vertexAttrib0-invalid-indicies.h
 
 webkit.org/b/209619 compositing/clipping/border-radius-async-overflow-stacking.html [ Pass ImageOnlyFailure ]
 
-webkit.org/b/209908 svg/custom/animate-initial-pause-unpause.html [ Pass Timeout ]
-
 webkit.org/b/210046 [ Release ] storage/indexeddb/value-cursor-cycle.html [ Pass Failure ]
 
 webkit.org/b/207160 css2.1/20110323/replaced-intrinsic-ratio-001.htm [ Pass Failure ]

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -914,8 +914,6 @@ webkit.org/b/219465 imported/w3c/web-platform-tests/html/browsers/browsing-the-w
 
 webkit.org/b/219470 fast/visual-viewport/visual-viewport-resize-subframe-in-rendering-update.html [ Timeout Pass ]
 
-webkit.org/b/219474 svg/custom/animate-initial-pause-unpause.html [ Timeout Pass ]
-
 # Flaky tests detected from 29Jan2023 to 23Feb2023
 webkit.org/b/252878 css3/flexbox/image-percent-max-height.html [ ImageOnlyFailure Pass ]
 webkit.org/b/252878 fast/css3-text/css3-text-decoration/repaint/underline-outside-of-layout-rect-altered.html [ ImageOnlyFailure Pass ]

--- a/LayoutTests/svg/custom/animate-initial-pause-unpause-expected.txt
+++ b/LayoutTests/svg/custom/animate-initial-pause-unpause-expected.txt
@@ -1,1 +1,3 @@
-PASS
+
+PASS Pausing and unpausing an animation before it starts should have no effect
+

--- a/LayoutTests/svg/custom/animate-initial-pause-unpause.html
+++ b/LayoutTests/svg/custom/animate-initial-pause-unpause.html
@@ -1,36 +1,31 @@
 <!DOCTYPE HTML>
-<html>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
 <!--
     Test for WK89943: pausing and unpausing an animation before it starts should have no effect.
 -->
-<body>
-    <svg id="svg" width="400" height="400">
-        <rect x="0" y="0" width="100" height="100" fill="red"/>
-        <rect id="rect" x="100" y="0" width="100" height="100" fill="green">
-            <set attributeName="x" to="0" begin="10ms" end="30ms" fill="freeze" onend="handleEndEvent()"/>
-        </rect>
-    </svg>
-    <script>
-        if (window.testRunner) {
-            testRunner.waitUntilDone();
-            testRunner.dumpAsText();
-        }
+<svg id="svg" width="400" height="400">
+  <rect x="0" y="0" width="100" height="100" fill="red"/>
+  <rect id="rect" x="100" y="0" width="100" height="100" fill="green">
+    <set attributeName="x" to="0" begin="0.01s" fill="freeze"/>
+  </rect>
+</svg>
+<script>
+async_test(function(t) {
+  var svg = document.getElementById("svg");
 
-        var svg = document.getElementById("svg");
-        var rect = document.getElementById("rect");
+  svg.pauseAnimations();
+  svg.unpauseAnimations();
 
-        svg.pauseAnimations();
-        svg.unpauseAnimations();
+  var endStep = t.step_func_done(function() {
+    var rect = document.getElementById("rect");
+    assert_equals(rect.x.animVal.value, 0, "<set> is applied");
+  });
 
-        function handleEndEvent() {
-            if (rect.x.animVal.value == 0)
-                document.body.innerHTML = "PASS";
-            else
-                document.body.innerHTML = "FAIL : rect.x.animVal.value was " + rect.x.animVal.value + " but we expected 0.";
-
-            if (window.testRunner)
-                testRunner.notifyDone();
-        }
-    </script>
-</body>
-</html>
+  window.onload = function() {
+    requestAnimationFrame(function() {
+      setTimeout(endStep, 50);
+    });
+  };
+}, "Pausing and unpausing an animation before it starts should have no effect");
+</script>


### PR DESCRIPTION
#### 008483f2054324eb36aabbd31f58a59ffeff8da8
<pre>
Update &apos;animate-initial-pause-unpause.html&apos; to use &apos;testharness&apos; and deflake

<a href="https://bugs.webkit.org/show_bug.cgi?id=266865">https://bugs.webkit.org/show_bug.cgi?id=266865</a>

Reviewed by Tim Nguyen.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/45ca0a5d79d8cbc9faf8470c30fc5cb02e1bbe1f">https://chromium.googlesource.com/chromium/src.git/+/45ca0a5d79d8cbc9faf8470c30fc5cb02e1bbe1f</a>

This patch is to import test using testharness from Blink / Chromium source, it is an attempt
to deflake the test.

* LayoutTests/svg/custom/animate-initial-pause-unpause.html: Updated
* LayoutTests/svg/custom/animate-initial-pause-unpause-expected.txt: Updated Expectation Files
* LayoutTests/platform/wpe/TestExpectations: Remove &apos;flaky&apos; expectation
* LayoutTests/platform/mac/TestExpectations: Ditto
* LayoutTests/platform/ios-wk2/TestExpectations: Ditto

Canonical link: <a href="https://commits.webkit.org/272493@main">https://commits.webkit.org/272493@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cbc32571c5181c10855d31d97553fc1c8b09e186

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31809 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10502 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33551 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34312 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28808 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12862 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7742 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28402 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32172 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8863 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28409 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7651 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7824 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28322 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35659 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28926 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28775 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33933 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7913 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5907 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31792 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9565 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/28129 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7456 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8582 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8434 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->