### PR TITLE
Weaken memory ordering of objects we do not care about

### DIFF
--- a/Source/WTF/wtf/Atomics.h
+++ b/Source/WTF/wtf/Atomics.h
@@ -86,18 +86,12 @@ struct Atomic {
     ALWAYS_INLINE bool compareExchangeWeak(T expected, T desired, std::memory_order order = std::memory_order_seq_cst)
     {
         T expectedOrActual = expected;
-        return value.compare_exchange_weak(expectedOrActual, desired, order);
+        return value.compare_exchange_weak(expectedOrActual, desired, order, std::memory_order_relaxed);
     }
 
     ALWAYS_INLINE bool compareExchangeWeakRelaxed(T expected, T desired)
     {
         return compareExchangeWeak(expected, desired, std::memory_order_relaxed);
-    }
-
-    ALWAYS_INLINE bool compareExchangeWeak(T expected, T desired, std::memory_order order_success, std::memory_order order_failure)
-    {
-        T expectedOrActual = expected;
-        return value.compare_exchange_weak(expectedOrActual, desired, order_success, order_failure);
     }
 
     // WARNING: This does not have strong fencing guarantees when it fails. For example, stores could
@@ -205,6 +199,12 @@ template<typename T>
 inline T atomicCompareExchangeStrong(T* location, T expected, T newValue, std::memory_order order = std::memory_order_seq_cst)
 {
     return bitwise_cast<Atomic<T>*>(location)->compareExchangeStrong(expected, newValue, order);
+}
+
+template<typename T>
+inline T atomicCompareExchangeStrong(T* location, T expected, T newValue, std::memory_order order_success, std::memory_order order_failure)
+{
+    return bitwise_cast<Atomic<T>*>(location)->compareExchangeStrong(expected, newValue, order_success, order_failure);
 }
 
 template<typename T, typename U>

--- a/Source/WTF/wtf/LockAlgorithm.h
+++ b/Source/WTF/wtf/LockAlgorithm.h
@@ -63,7 +63,7 @@ public:
                 value = Hooks::lockHook(value);
                 return true;
             },
-            std::memory_order_acquire);
+            std::memory_order_relaxed);
     }
     
     static void lock(Atomic<LockType>& lock)

--- a/Source/WebCore/platform/ios/wak/WebCoreThread.mm
+++ b/Source/WebCore/platform/ios/wak/WebCoreThread.mm
@@ -44,7 +44,6 @@
 #import <Foundation/NSInvocation.h>
 #import <JavaScriptCore/InitializeThreading.h>
 #import <JavaScriptCore/JSLock.h>
-#import <libkern/OSAtomic.h>
 #import <objc/runtime.h>
 #import <wtf/Assertions.h>
 #import <wtf/BlockPtr.h>

--- a/Source/WebKit/Platform/IPC/StreamConnectionBuffer.h
+++ b/Source/WebKit/Platform/IPC/StreamConnectionBuffer.h
@@ -113,7 +113,7 @@ public:
     uint8_t* data() const { return static_cast<uint8_t*>(m_sharedMemory->data()) + headerSize(); }
     size_t dataSize() const { return m_dataSize; }
 
-    static constexpr size_t maximumSize() { return std::min(static_cast<size_t>(ClientOffset::serverIsSleepingTag), static_cast<size_t>(ClientOffset::serverIsSleepingTag)) - 1; }
+    static constexpr size_t maximumSize() { return static_cast<size_t>(ClientOffset::serverIsSleepingTag) - 1; }
 
     std::span<uint8_t> headerForTesting();
     std::span<uint8_t> dataForTesting();

--- a/Source/WebKit/Platform/IPC/StreamServerConnectionBuffer.h
+++ b/Source/WebKit/Platform/IPC/StreamServerConnectionBuffer.h
@@ -73,7 +73,7 @@ inline std::optional<std::span<uint8_t>> StreamServerConnectionBuffer::tryAcquir
 
     auto result = alignedSpan(m_serverOffset, clampedLimit(serverLimit));
     if (result.size() < minimumMessageSize) {
-        serverLimit = sharedServerLimit().compareExchangeStrong(serverLimit, ServerLimit::serverIsSleepingTag, std::memory_order_acq_rel, std::memory_order_acquire);
+        serverLimit = sharedServerLimit().compareExchangeStrong(serverLimit, ServerLimit::serverIsSleepingTag, std::memory_order_release, std::memory_order_acquire);
         result = alignedSpan(m_serverOffset, clampedLimit(serverLimit));
     }
 

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -256,6 +256,7 @@
 #import <pal/spi/mac/NSViewSPI.h>
 #import <pal/spi/mac/NSWindowSPI.h>
 #import <wtf/Assertions.h>
+#import <wtf/Atomics.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/FileSystem.h>
 #import <wtf/HashTraits.h>
@@ -327,7 +328,6 @@
 #import <WebCore/WebEvent.h>
 #import <WebCore/WebSQLiteDatabaseTrackerClient.h>
 #import <WebCore/WebVideoFullscreenControllerAVKit.h>
-#import <libkern/OSAtomic.h>
 #import <pal/spi/ios/ManagedConfigurationSPI.h>
 #import <pal/spi/ios/MobileGestaltSPI.h>
 #import <wtf/FastMalloc.h>
@@ -2267,10 +2267,8 @@ static NSMutableSet *knownPluginMIMETypes()
         return;
     }
 
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    if (!OSAtomicCompareAndSwap32(0, 1, &_private->didDrawTiles))
+    if (!WTF::atomicCompareExchangeStrong(&_private->didDrawTiles, NO, YES, std::memory_order_relaxed, std::memory_order_relaxed))
         return;
-ALLOW_DEPRECATED_DECLARATIONS_END
 
     WebThreadLock();
 
@@ -3431,7 +3429,7 @@ IGNORE_WARNINGS_END
 - (void)_didCommitLoadForFrame:(WebFrame *)frame
 {
     if (frame == [self mainFrame])
-        _private->didDrawTiles = 0;
+        WTF::atomicStore(&_private->didDrawTiles, NO, std::memory_order_relaxed);
 }
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKitLegacy/mac/WebView/WebViewData.h
+++ b/Source/WebKitLegacy/mac/WebView/WebViewData.h
@@ -242,7 +242,7 @@ class WebSelectionServiceController;
 
     CGSize fixedLayoutSize;
     BOOL mainViewIsScrollingOrZooming;
-    int32_t didDrawTiles;
+    BOOL didDrawTiles;
     WTF::Lock pendingFixedPositionLayoutRectMutex;
     CGRect pendingFixedPositionLayoutRect;
 #endif

--- a/Source/bmalloc/bmalloc/StaticPerProcess.h
+++ b/Source/bmalloc/bmalloc/StaticPerProcess.h
@@ -81,11 +81,11 @@ private:
     {
         using Storage = typename StaticPerProcessStorageTraits<T>::Storage;
         LockHolder lock(Storage::s_mutex);
-        if (!Storage::s_object.load(std::memory_order_consume)) {
+        if (!Storage::s_object.load(std::memory_order_relaxed)) {
             T* t = new (&Storage::s_memory) T(lock);
             Storage::s_object.store(t, std::memory_order_release);
         }
-        return Storage::s_object.load(std::memory_order_consume);
+        return Storage::s_object.load(std::memory_order_relaxed);
     }
 };
 


### PR DESCRIPTION
<pre>
Weaken memory ordering of objects we do not care about
https://bugs.webkit.org/show_bug.cgi?id=266867

For objects that are not used when written to in case of failure,
objects that do not realistically have a chance of a data race, and
objects that will not affect the program if a data race were to happen
to them, we should be relaxing their memory barriers.

For objects that are not used when written to in case of failure,
objects that do not realistically have a chance of a data race, and
objects that will not affect the program if a data race were to happen
to them, we should be relaxing their memory barriers.

* Source/WTF/wtf/Atomics.h: Optimize memory ordering.
(WTF::Atomic::compareExchangeWeak): Ditto.
* Source/WebKit/Platform/IPC/StreamClientConnectionBuffer.h: Ditto.
(IPC::StreamClientConnectionBuffer::tryAcquire): Ditto.
(IPC::StreamClientConnectionBuffer::tryAcquireAll): Ditto.
* Source/WebKit/Platform/IPC/StreamConnectionBuffer.h: Ditto.
(IPC::StreamConnectionBuffer::maximumSize): Ditto.
* Source/WebKit/Platform/IPC/StreamServerConnectionBuffer.h: Ditto.
(IPC::StreamServerConnectionBuffer::tryAcquire): Ditto.
* Source/WebCore/platform/ios/wak/WebCoreThread.mm: Remove
libkern/OSAtomics import.
* Source/WebKitLegacy/mac/WebView/WebView.mm: Make didDrawTiles a proper
BOOL and replace OSAtomicCompareAndSwap32 with
WTF::atomicCompareExchangeStrong.
* Source/WebKitLegacy/mac/WebView/WebViewData.h: Make didDrawTiles a
proper BOOL.
* Source/bmalloc/bmalloc/StaticPerProcess.h:
(bmalloc::StaticPerProcess::getSlowCase): Use relaxed instead of
consume.
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16678820380367c3c8e75ef03661ab382013c8ee

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31944 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10642 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33697 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34458 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28941 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32747 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13006 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7879 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28535 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32314 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9000 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28548 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7785 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7966 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28461 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35802 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/27424 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29062 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28915 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34069 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/32013 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8051 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6036 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31928 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9696 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/38455 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8713 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8164 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8574 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->