### PR TITLE
Fix rounding of very large and very small LayoutUnits

### DIFF
--- a/LayoutTests/platform/ios/fast/block/float/overhanging-tall-block-expected.txt
+++ b/LayoutTests/platform/ios/fast/block/float/overhanging-tall-block-expected.txt
@@ -1,4 +1,4 @@
-layer at (0,0) size 800x33554431
+layer at (0,0) size 800x33554432
   RenderView at (0,0) size 800x600
 layer at (0,0) size 800x33554431
   RenderBlock {HTML} at (0,0) size 800x33554431

--- a/LayoutTests/platform/mac/fast/block/float/overhanging-tall-block-expected.txt
+++ b/LayoutTests/platform/mac/fast/block/float/overhanging-tall-block-expected.txt
@@ -1,4 +1,4 @@
-layer at (0,0) size 800x33554431
+layer at (0,0) size 800x33554432
   RenderView at (0,0) size 800x600
 layer at (0,0) size 800x33554431
   RenderBlock {HTML} at (0,0) size 800x33554431

--- a/LayoutTests/platform/wpe/fast/block/float/overhanging-tall-block-expected.txt
+++ b/LayoutTests/platform/wpe/fast/block/float/overhanging-tall-block-expected.txt
@@ -1,4 +1,4 @@
-layer at (0,0) size 800x33554431
+layer at (0,0) size 800x33554432
   RenderView at (0,0) size 800x600
 layer at (0,0) size 800x33554431
   RenderBlock {HTML} at (0,0) size 800x33554431

--- a/Source/WebCore/platform/LayoutUnit.h
+++ b/Source/WebCore/platform/LayoutUnit.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2014, Google Inc. All rights reserved.
+ * Copyright (c) 2012-2017, Google Inc. All rights reserved.
  * Copyright (c) 2012-2023, Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -158,7 +158,7 @@ public:
 
     int round() const
     {
-        return saturatedSum<int>(rawValue(), kFixedPointDenominator / 2) >> kLayoutUnitFractionalBits;
+        return toInt() + ((fraction().rawValue() + (kFixedPointDenominator / 2)) >> kLayoutUnitFractionalBits);
     }
 
     int floor() const

--- a/Tools/TestWebKitAPI/Tests/WebCore/LayoutUnitTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/LayoutUnitTests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Google Inc. All rights reserved.
+ * Copyright (c) 2012-2017, Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -104,6 +104,13 @@ TEST(WebCoreLayoutUnit, LayoutUnitRounding)
     ASSERT_EQ(LayoutUnit::fromFloatRound(1.49f).round(), 1);
     ASSERT_EQ(LayoutUnit::fromFloatRound(1.5f).round(), 2);
     ASSERT_EQ(LayoutUnit::fromFloatRound(1.51f).round(), 2);
+    // The fractional part of LayoutUnit::Max() is 0x3f, so it should round up.
+    ASSERT_EQ(((std::numeric_limits<int>::max() / kFixedPointDenominator) + 1), LayoutUnit::max().round());
+    // The fractional part of LayoutUnit::Min() is 0, so the next bigger possible
+    // value should round down.
+    LayoutUnit epsilon;
+    epsilon.setRawValue(1);
+    ASSERT_EQ(((std::numeric_limits<int>::min() / kFixedPointDenominator)), (LayoutUnit::min() + epsilon).round());
 }
 
 TEST(WebCoreLayoutUnit, LayoutUnitMultiplication)


### PR DESCRIPTION
#### 2afefe7449cd82d4b70c9ed85add5827f44e7278
<pre>
Fix rounding of very large and very small LayoutUnits

<a href="https://bugs.webkit.org/show_bug.cgi?id=266869">https://bugs.webkit.org/show_bug.cgi?id=266869</a>

Reviewed by Alan Baradlay.

Merge: <a href="https://source.chromium.org/chromium/chromium/src/+/a7b04f8fe15406cbf98995da00fc63f73e9fff61">https://source.chromium.org/chromium/chromium/src/+/a7b04f8fe15406cbf98995da00fc63f73e9fff61</a>

Previously, LayoutUnit&apos;s between nearlyMax() and max() would round
down, even though their fractional parts are &gt; 0.5.  Similarly,
LayoutUnit&apos;s between min() and nearlyMin() would round up (toward
zero), even though their fractional parts are &lt; -0.5.

* Source/WebCore/platform/LayoutUnit.h:
(round):
* Tools/TestWebKitAPI/Tests/WebCore/LayoutUnitTests.cpp:
(LayoutUnitRounding): Added new test case
* LayoutTests/platform/ios/fast/block/float/overhanging-tall-block-expected.txt: Rebaselined
* LayoutTests/platform/wpe/fast/block/float/overhanging-tall-block-expected.txt: Ditto
* LayoutTests/platform/mac/fast/block/float/overhanging-tall-block-expected.txt: Ditto

Canonical link: <a href="https://commits.webkit.org/272534@main">https://commits.webkit.org/272534@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d3717dde093f5c73fe3e6d534bc67e14f7b14e46

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31823 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10516 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33565 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34326 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28822 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32618 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12876 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7756 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28414 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32186 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8875 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28421 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7663 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7839 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28334 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35673 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28938 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28787 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33945 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7927 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5919 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31804 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9579 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7479 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8596 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8448 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->