### PR TITLE
WPT synchronize css/css-view-transitions

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: view-transitions
+  files: "**"

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/document-element-detached-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/document-element-detached-crash.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<html class="test-wait">
 <title>View transitions: documentElement.remove</title>
 <link rel="help" href="https://github.com/WICG/view-transitions">
 <link rel="author" href="mailto:vmpstr@chromium.org">
@@ -10,12 +11,15 @@ html {
 </style>
 
 <script>
-async function runTest() {
+function runTest() {
   document.startViewTransition(() => {
-    requestAnimationFrame(() => document.documentElement.remove());
-  })
-
+    requestAnimationFrame(() => {
+      const html = document.documentElement;
+      html.remove();
+      html.classList.remove('test-wait');
+    });
+  });
 }
 onload = () => requestAnimationFrame(runTest);
 </script>
-
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/list-style-position-style-change-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/list-style-position-style-change-crash.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html class="test-wait">
+<title>View transitions: list-style-position crash</title>
+<link rel="help" href="https://github.com/WICG/view-transitions">
+<link rel="author" href="mailto:bokan@chromium.org">
+
+<script>
+onload = async () => {
+  let vt = document.startViewTransition();
+  await vt.ready;
+  await new Promise(resolve => requestAnimationFrame(resolve));
+
+  document.documentElement.style.listStylePosition = 'inside';
+  // Force style update.
+  window.scrollX;
+
+  document.documentElement.classList.remove('test-wait');
+}
+</script>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/no-crash-set-exception.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/no-crash-set-exception.html
@@ -28,10 +28,6 @@ html::view-transition-new(shared) {
 <div></div>
 
 <script>
-function validate_background(pseudoString) {
-  return window.getComputedStyle(document.documentElement, pseudoString).style.background != 'blue';
-}
-
 promise_test(async t => {
   assert_implements(document.startViewTransition, "Missing document.startViewTransition");
   return new Promise((resolve, reject) => {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/only-child-on-root-element-with-view-transition.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/only-child-on-root-element-with-view-transition.html
@@ -36,7 +36,7 @@ promise_test(() => {
     let transition = document.startViewTransition();
     transition.ready.then(() => {
       let style = getComputedStyle(
-        document.documentElement, ":view-transition");
+        document.documentElement, "::view-transition");
       if (style.backgroundColor == "rgb(255, 0, 0)")
         resolve();
       else

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/only-child-view-transition.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/only-child-view-transition.html
@@ -23,7 +23,7 @@ promise_test(() => {
     let transition = document.startViewTransition();
     transition.ready.then(() => {
       let style = getComputedStyle(
-        document.documentElement, ":view-transition");
+        document.documentElement, "::view-transition");
       if (style.backgroundColor == "rgb(255, 0, 0)")
         resolve();
       else

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/parsing/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/parsing/w3c-import.log
@@ -14,5 +14,8 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/parsing/pseudo-elements-invalid.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/parsing/pseudo-elements-valid.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/parsing/view-transition-name-computed.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/parsing/view-transition-name-invalid.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/parsing/view-transition-name-valid.html

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/style-inheritance.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/style-inheritance.html
@@ -34,20 +34,20 @@ promise_test(() => {
   return new Promise(async (resolve, reject) => {
     let transition = document.startViewTransition();
     transition.ready.then(() => {
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition").backgroundColor, "rgb(255, 0, 0)", ":view-transition");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition").backgroundColor, "rgb(255, 0, 0)", "::view-transition");
 
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-group(root)").backgroundColor, "rgb(255, 0, 0)", "group");
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-group(root)").color, "rgb(0, 0, 255)", "group");
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-group(root)").animationDuration, "0.321s", "group");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(root)").backgroundColor, "rgb(255, 0, 0)", "group");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(root)").color, "rgb(0, 0, 255)", "group");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(root)").animationDuration, "0.321s", "group");
 
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-image-pair(root)").color, "rgb(0, 0, 255)", "wrapper");
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-image-pair(root)").overflowX, "clip", "wrapper");
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-image-pair(root)").animationDuration, "0.321s", "wrapper");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-image-pair(root)").color, "rgb(0, 0, 255)", "wrapper");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-image-pair(root)").overflowX, "clip", "wrapper");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-image-pair(root)").animationDuration, "0.321s", "wrapper");
 
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-old(root)").overflowX, "clip", "outgoing");
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-old(root)").animationDuration, "0.321s", "outgoing");
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-new(root)").overflowX, "clip", "incoming");
-      assert_equals(getComputedStyle(document.documentElement, ":view-transition-new(root)").animationDuration, "0.321s", "incoming");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-old(root)").overflowX, "clip", "outgoing");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-old(root)").animationDuration, "0.321s", "outgoing");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-new(root)").overflowX, "clip", "incoming");
+      assert_equals(getComputedStyle(document.documentElement, "::view-transition-new(root)").animationDuration, "0.321s", "incoming");
     });
     await transition.finished;
     resolve();

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/w3c-import.log
@@ -20,6 +20,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/3d-transform-outgoing-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/3d-transform-outgoing-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/3d-transform-outgoing.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/WEB_FEATURES.yml
 /LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/animating-new-content-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/animating-new-content-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/animating-new-content-subset-expected.html
@@ -100,7 +101,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/dialog-in-top-layer-during-transition-old-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/dialog-in-top-layer-during-transition-old.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/dialog-in-top-layer-during-transition-ref.html
-/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/document-element-detatched-crash.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/document-element-detached-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/duplicate-tag-rejects-capture.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/duplicate-tag-rejects-start.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/element-is-grouping-during-animation-expected.html
@@ -180,6 +181,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/japanese-tag-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/japanese-tag-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/japanese-tag.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/list-style-position-style-change-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-below-and-on-top-of-viewport-partially-onscreen-new-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-below-and-on-top-of-viewport-partially-onscreen-new.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-below-and-on-top-of-viewport-partially-onscreen-old-expected.html


### PR DESCRIPTION
#### 5ce16869264e81a4fa80c960cfc0fac1e97b9e99
<pre>
WPT synchronize css/css-view-transitions
<a href="https://bugs.webkit.org/show_bug.cgi?id=266877">https://bugs.webkit.org/show_bug.cgi?id=266877</a>

Reviewed by Tim Nguyen.

Up to and including:
<a href="https://github.com/web-platform-tests/wpt/commit/3d8c4cd8fe0cf25cb8a602507de5f85e163521b4">https://github.com/web-platform-tests/wpt/commit/3d8c4cd8fe0cf25cb8a602507de5f85e163521b4</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/WEB_FEATURES.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/document-element-detached-crash.html: Renamed from LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/document-element-detatched-crash.html.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/list-style-position-style-change-crash.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/no-crash-set-exception.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/only-child-on-root-element-with-view-transition.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/only-child-view-transition.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/parsing/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/style-inheritance.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/272496@main">https://commits.webkit.org/272496@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e70d66cbcc272241156b5e5205628b808a7502fd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31825 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10518 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33567 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34328 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28824 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12878 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7758 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28416 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32188 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8878 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28422 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7665 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7842 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28335 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35675 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28941 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28788 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33947 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7929 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5922 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31806 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9581 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/28142 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8598 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4157 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8450 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->