### PR TITLE
WPT synchronize web-animations

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: web-animations
+  files: "**"

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animatable/animate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animatable/animate-expected.txt
@@ -149,6 +149,6 @@ PASS animate() with a non-null invalid pseudoElement '' throws a SyntaxError
 PASS animate() with a non-null invalid pseudoElement 'before' throws a SyntaxError
 PASS animate() with a non-null invalid pseudoElement ':abc' throws a SyntaxError
 PASS animate() with a non-null invalid pseudoElement '::abc' throws a SyntaxError
-PASS animate() with a non-null invalid pseudoElement '::placeholder' throws a SyntaxError
+FAIL animate() with pseudoElement ::placeholder does not throw The string did not match the expected pattern.
 PASS Finished fill animation doesn't replace animation on a different pseudoElement
 

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animatable/animate.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animatable/animate.html
@@ -331,7 +331,6 @@ for (const pseudo of [
   'before',
   ':abc',
   '::abc',
-  '::placeholder',
 ]) {
   test(t => {
     const div = createDiv(t);
@@ -341,6 +340,11 @@ for (const pseudo of [
   }, `animate() with a non-null invalid pseudoElement '${pseudo}' throws a ` +
      `SyntaxError`);
 }
+
+test(t => {
+  const div = createDiv(t);
+  div.animate(null, { pseudoElement: '::placeHOLDER' });
+}, `animate() with pseudoElement ::placeholder does not throw`);
 
 promise_test(async t => {
   const div = createDiv(t);

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/KeyframeEffect/target-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/KeyframeEffect/target-expected.txt
@@ -22,5 +22,5 @@ PASS Changing pseudoElement to a non-null invalid pseudo-selector '' throws a Sy
 PASS Changing pseudoElement to a non-null invalid pseudo-selector 'before' throws a SyntaxError
 PASS Changing pseudoElement to a non-null invalid pseudo-selector ':abc' throws a SyntaxError
 PASS Changing pseudoElement to a non-null invalid pseudo-selector '::abc' throws a SyntaxError
-PASS Changing pseudoElement to a non-null invalid pseudo-selector '::placeholder' throws a SyntaxError
+FAIL Changing pseudoElement to ::placeHOLDER works The string did not match the expected pattern.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/KeyframeEffect/target.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/KeyframeEffect/target.html
@@ -253,7 +253,6 @@ for (const pseudo of [
   'before',
   ':abc',
   '::abc',
-  '::placeholder',
 ]) {
   test(t => {
     const effect = new KeyframeEffect(null, gKeyFrames, 100 * MS_PER_SEC);
@@ -261,6 +260,12 @@ for (const pseudo of [
   }, `Changing pseudoElement to a non-null invalid pseudo-selector ` +
      `'${pseudo}' throws a SyntaxError`);
 }
+
+test(t => {
+  const effect = new KeyframeEffect(null, gKeyFrames, 100 * MS_PER_SEC);
+  effect.pseudoElement = '::placeHOLDER';
+  assert_equals(effect.pseudoElement, '::placeholder');
+}, `Changing pseudoElement to ::placeHOLDER works`);
 
 </script>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/w3c-import.log
@@ -16,5 +16,6 @@ None
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/web-animations/META.yml
 /LayoutTests/imported/w3c/web-platform-tests/web-animations/README.md
+/LayoutTests/imported/w3c/web-platform-tests/web-animations/WEB_FEATURES.yml
 /LayoutTests/imported/w3c/web-platform-tests/web-animations/idlharness.window.js
 /LayoutTests/imported/w3c/web-platform-tests/web-animations/testcommon.js


### PR DESCRIPTION
#### 63b217ca3c008ad648402c556755265cc1648402
<pre>
WPT synchronize web-animations
<a href="https://bugs.webkit.org/show_bug.cgi?id=266878">https://bugs.webkit.org/show_bug.cgi?id=266878</a>

Reviewed by Tim Nguyen.

Up to and including commit:
<a href="https://github.com/web-platform-tests/wpt/commit/3d8c4cd8fe0cf25cb8a602507de5f85e163521b4">https://github.com/web-platform-tests/wpt/commit/3d8c4cd8fe0cf25cb8a602507de5f85e163521b4</a>

* LayoutTests/imported/w3c/web-platform-tests/web-animations/WEB_FEATURES.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animatable/animate-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animatable/animate.html:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/KeyframeEffect/target-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/KeyframeEffect/target.html:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/272495@main">https://commits.webkit.org/272495@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5dc2dc3a8e8f6d0093be720e17c54d96b8474e3a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31826 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10519 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33568 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34329 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28825 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12879 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7759 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28417 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32189 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8877 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28424 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7666 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7841 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28337 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35676 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28940 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28790 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33948 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7930 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5921 "Found 1 new test failure: media/video-remove-insert-repaints.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31807 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9582 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/28144 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8599 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4156 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8451 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->