### PR TITLE
[JSC] Object.defineProperties fast path causes values to be assigned to incorrect property

### DIFF
--- a/JSTests/stress/object-define-properties-index-adjust.js
+++ b/JSTests/stress/object-define-properties-index-adjust.js
@@ -1,0 +1,24 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+class InterfaceConstructor {
+  two() {}
+}
+
+class Interface {}
+
+Object.defineProperties(Interface.prototype, {
+  one: {
+    __proto__: null,
+  },
+
+  two: {
+    value: InterfaceConstructor.prototype.two,
+  },
+});
+
+var interface = new Interface();
+
+shouldBe(typeof interface.two, 'function');


### PR DESCRIPTION
#### c157345d2b9c5b8e4a618509380fdfcaa99e8de7
<pre>
[JSC] Object.defineProperties fast path causes values to be assigned to incorrect property
<a href="https://bugs.webkit.org/show_bug.cgi?id=266611">https://bugs.webkit.org/show_bug.cgi?id=266611</a>
<a href="https://rdar.apple.com/120137648">rdar://120137648</a>

Reviewed by Justin Michaud.

Since we already put descriptor which caused side effect for retrieval, we should increment index.
We also optimize a bit with UNLIKELY and reserveInitialCapacity.

* JSTests/stress/object-define-properties-index-adjust.js: Added.
(shouldBe):
(InterfaceConstructor.prototype.two):
(InterfaceConstructor):
(Interface):
* Source/JavaScriptCore/runtime/ObjectConstructor.cpp:
(JSC::definePropertiesSlow):
(JSC::defineProperties):

Canonical link: <a href="https://commits.webkit.org/272508@main">https://commits.webkit.org/272508@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a227e6eb240ba91ff4475186cbd210498b897ca

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31847 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10540 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33589 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34350 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28846 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12900 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7780 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28435 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32210 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8896 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28442 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7684 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7860 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28355 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35697 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/27343 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28959 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28808 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33965 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/31916 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7951 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5940 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31824 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9603 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/38359 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8620 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8130 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4161 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8472 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->