### PR TITLE
[css-color] Fix clamping of oklab/oklch lightness component

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4772,7 +4772,6 @@ webkit.org/b/245347 imported/w3c/web-platform-tests/css/css-color/lch-009.html [
 webkit.org/b/245347 imported/w3c/web-platform-tests/css/css-color/lch-010.html [ ImageOnlyFailure ]
 webkit.org/b/245347 imported/w3c/web-platform-tests/css/css-color/oklch-009.html [ ImageOnlyFailure ]
 webkit.org/b/245347 imported/w3c/web-platform-tests/css/css-color/oklch-010.html [ ImageOnlyFailure ]
-webkit.org/b/261898 imported/w3c/web-platform-tests/css/css-color/oklab-l-over-1-2.html [ ImageOnlyFailure ]
 
 # currentColor support in relative color syntax.
 webkit.org/b/245970 imported/w3c/web-platform-tests/css/css-color/relative-currentcolor-a98rgb-01.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color/oklch-l-over-1-1-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color/oklch-l-over-1-1-expected.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: Verify lightness in Oklch is always clamped to a value between 0 to 1</title>
+<style>
+    .ref { background-color: oklch(1 0.5 50); width: 100px; height: 200px}
+</style>
+
+<body>
+    <p>Test passes if you see a single color.</p>
+    <div class="ref"></div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color/oklch-l-over-1-1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color/oklch-l-over-1-1.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: Verify lightness in Oklch is always clamped to a value between 0 to 1</title>
+<link rel="help" href="https://drafts.csswg.org/css-color/#ok-lab">
+<link rel="match" href="oklch-l-over-1-ref.html">
+<meta name="assert" content="oklch() with lightness greater than 1">
+<style>
+    .ref { background-color: oklch(1 0.5 50); width: 100px; height: 100px}
+    /* l = 1.5 should clamp back to 1 */
+    .test { background-color: oklch(1.5 0.5 50); width: 100px; height: 100px}
+</style>
+
+<body>
+    <p>Test passes if you see a single color.</p>
+    <div class="ref"></div>
+    <div class="test"></div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color/oklch-l-over-1-2-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color/oklch-l-over-1-2-expected.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: Verify lightness in Oklch is always clamped to a value between 0 to 1</title>
+<style>
+    .ref { background-color: oklch(1 0.5 50); width: 100px; height: 200px}
+</style>
+
+<body>
+    <p>Test passes if you see a single color.</p>
+    <div class="ref"></div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color/oklch-l-over-1-2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color/oklch-l-over-1-2.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: Verify lightness in Oklch is always clamped to a value between 0% to 100%</title>
+<link rel="help" href="https://drafts.csswg.org/css-color/#ok-lab">
+<link rel="match" href="oklch-l-over-1-ref.html">
+<meta name="assert" content="oklch() with lightness greater than 100%">
+<style>
+    .ref { background-color: oklch(100% 0.5 50); width: 100px; height: 100px}
+    /* l = 150% should clamp back to 100% */
+    .test { background-color: oklch(150% 0.5 50); width: 100px; height: 100px}
+</style>
+
+<body>
+    <p>Test passes if you see a single color.</p>
+    <div class="ref"></div>
+    <div class="test"></div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color/oklch-l-over-1-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color/oklch-l-over-1-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: Verify lightness in Oklch is always clamped to a value between 0 to 1</title>
+<style>
+    .ref { background-color: oklch(1 0.5 50); width: 100px; height: 200px}
+</style>
+
+<body>
+    <p>Test passes if you see a single color.</p>
+    <div class="ref"></div>
+</body>

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -2421,7 +2421,7 @@ static Color parseLabParametersRaw(CSSParserTokenRange& args, ConsumerForLightne
 
     auto normalizedLightness = WTF::switchOn(*lightness,
         [] (NumberRaw number) { return std::clamp(number.value, 0.0, NormalizePercentage<ColorType>::maximumLightnessNumber); },
-        [] (PercentRaw percent) { return std::clamp(normalizeLightnessPercent<ColorType>(percent.value), 0.0, 100.0); },
+        [] (PercentRaw percent) { return std::clamp(normalizeLightnessPercent<ColorType>(percent.value), 0.0, NormalizePercentage<ColorType>::maximumLightnessNumber); },
         [] (NoneRaw) { return std::numeric_limits<double>::quiet_NaN(); }
     );
     auto normalizedA = WTF::switchOn(*aValue,
@@ -2510,7 +2510,7 @@ static Color parseLCHParametersRaw(CSSParserTokenRange& args, ConsumerForLightne
 
     auto normalizedLightness = WTF::switchOn(*lightness,
         [] (NumberRaw number) { return std::clamp(number.value, 0.0, NormalizePercentage<ColorType>::maximumLightnessNumber); },
-        [] (PercentRaw percent) { return std::clamp(normalizeLightnessPercent<ColorType>(percent.value), 0.0, 100.0); },
+        [] (PercentRaw percent) { return std::clamp(normalizeLightnessPercent<ColorType>(percent.value), 0.0, NormalizePercentage<ColorType>::maximumLightnessNumber); },
         [] (NoneRaw) { return std::numeric_limits<double>::quiet_NaN(); }
     );
     auto normalizedChroma = WTF::switchOn(*chroma,


### PR DESCRIPTION
#### 359a95fee6491c844a33d44fcf180fefe78d8096
<pre>
[css-color] Fix clamping of oklab/oklch lightness component
<a href="https://bugs.webkit.org/show_bug.cgi?id=261898">https://bugs.webkit.org/show_bug.cgi?id=261898</a>
<a href="https://rdar.apple.com/116195533">rdar://116195533</a>

Reviewed by Tim Nguyen.

oklab and oklch should clamp their lightness component between 0 and 1. lab and
lch clamp their lightness component between 0 and 100.

In the parsing logic, which is shared by lab/oklab and lch/oklch respectively,
percentage values are always normalized to numeric values. However, the maximum
value for clamping the normalized value is hardcoded to 100, which is only
correct for lab/lch. Consequently, 150% lightness for oklab is normalized to 1.5,
which is incorrectly used, as it less than 100.

Fix by using the existing constant values for the maximum lightness value.

Add missing test coverage for oklch. oklab is covered by an existing test progression.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-color/oklch-l-over-1-1-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-color/oklch-l-over-1-1.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-color/oklch-l-over-1-2-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-color/oklch-l-over-1-2.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-color/oklch-l-over-1-ref.html: Added.
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::parseLabParametersRaw):
(WebCore::CSSPropertyParserHelpers::parseLCHParametersRaw):

Canonical link: <a href="https://commits.webkit.org/272501@main">https://commits.webkit.org/272501@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c14a332d02b8e5281864e19c555c0e57852b41ee

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31849 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10542 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33591 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34352 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28848 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32644 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12902 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7782 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28437 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32212 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8898 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28444 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7686 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7863 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28357 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35699 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28961 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28810 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33967 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7953 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5942 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31826 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9605 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/28164 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7458 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8622 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8474 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->