### PR TITLE
[css-color-5] Implement light-dark() function for color values

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4758,10 +4758,6 @@ webkit.org/b/245970 imported/w3c/web-platform-tests/css/css-color/relative-curre
 webkit.org/b/245970 imported/w3c/web-platform-tests/css/css-color/relative-currentcolor-xyzd50-01.html [ ImageOnlyFailure ]
 webkit.org/b/245970 imported/w3c/web-platform-tests/css/css-color/relative-currentcolor-xyzd65-01.html [ ImageOnlyFailure ]
 
-# light-dark()
-webkit.org/b/266889 imported/w3c/web-platform-tests/css/css-color/light-dark-currentcolor.html [ ImageOnlyFailure ]
-webkit.org/b/266889 imported/w3c/web-platform-tests/css/css-color/light-dark-inheritance.html [ ImageOnlyFailure ]
-
 webkit.org/b/214456 imported/w3c/web-platform-tests/css/css-images/conic-gradient-angle.html [ ImageOnlyFailure ]
 webkit.org/b/214456 imported/w3c/web-platform-tests/css/css-images/conic-gradient-angle-negative.html [ ImageOnlyFailure ]
 webkit.org/b/214456 imported/w3c/web-platform-tests/css/css-images/conic-gradient-center.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color/light-dark-basic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color/light-dark-basic-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL light-dark(white, black) assert_not_equals: Should be valid got disallowed value ""
-FAIL light-dark(light-dark(white, red), red) assert_not_equals: Should be valid got disallowed value ""
+PASS light-dark(white, black)
+PASS light-dark(light-dark(white, red), red)
 

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1118,6 +1118,20 @@ CSSInputSecurityEnabled:
     WebCore:
       default: false
 
+CSSLightDarkEnabled:
+  type: bool
+  status: testable
+  category: css
+  humanReadableName: "CSS light-dark()"
+  humanReadableDescription: "Enable support for CSS light-dark() defined in CSS Color 5"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 CSSMarginTrimEnabled:
   type: bool
   status: stable

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -950,6 +950,7 @@ css/calc/CSSCalcValue.cpp
 css/color/CSSResolvedColorMix.cpp
 css/color/CSSUnresolvedColor.cpp
 css/color/CSSUnresolvedColorMix.cpp
+css/color/CSSUnresolvedLightDark.cpp
 css/parser/CSSAtRuleID.cpp
 css/parser/CSSCustomPropertySyntax.cpp
 css/parser/CSSParser.cpp

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -1588,6 +1588,9 @@ AAA-large
 // color-mix()
 color-mix
 
+// light-dark()
+light-dark
+
 // color-space-interpolation
 in
 // srgb

--- a/Source/WebCore/css/color/CSSUnresolvedColor.cpp
+++ b/Source/WebCore/css/color/CSSUnresolvedColor.cpp
@@ -38,6 +38,9 @@ bool CSSUnresolvedColor::containsCurrentColor() const
     return WTF::switchOn(m_value,
         [&] (const CSSUnresolvedColorMix& unresolved) {
             return StyleColor::containsCurrentColor(unresolved.mixComponents1.color) || StyleColor::containsCurrentColor(unresolved.mixComponents2.color);
+        },
+        [&] (const CSSUnresolvedLightDark& unresolved) {
+            return StyleColor::containsCurrentColor(unresolved.lightColor) || StyleColor::containsCurrentColor(unresolved.darkColor);
         }
     );
 }
@@ -60,7 +63,7 @@ bool CSSUnresolvedColor::equals(const CSSUnresolvedColor& other) const
 StyleColor CSSUnresolvedColor::createStyleColor(const Document& document, RenderStyle& style, Style::ForVisitedLink forVisitedLink) const
 {
     return WTF::switchOn(m_value,
-        [&] (const CSSUnresolvedColorMix& unresolved) {
+        [&] (const auto& unresolved) {
             return WebCore::createStyleColor(unresolved, document, style, forVisitedLink);
         }
     );

--- a/Source/WebCore/css/color/CSSUnresolvedColor.h
+++ b/Source/WebCore/css/color/CSSUnresolvedColor.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "CSSUnresolvedColorMix.h"
+#include "CSSUnresolvedLightDark.h"
 #include <variant>
 #include <wtf/Forward.h>
 
@@ -60,7 +61,8 @@ public:
 private:
     // FIXME: Add support for unresolved relative colors.
     std::variant<
-        CSSUnresolvedColorMix
+        CSSUnresolvedColorMix,
+        CSSUnresolvedLightDark
     > m_value;
 };
 

--- a/Source/WebCore/css/color/CSSUnresolvedLightDark.cpp
+++ b/Source/WebCore/css/color/CSSUnresolvedLightDark.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CSSUnresolvedLightDark.h"
+
+#include "ColorFromPrimitiveValue.h"
+#include "ColorSerialization.h"
+#include "Document.h"
+#include "StyleBuilderState.h"
+
+namespace WebCore {
+
+void serializationForCSS(StringBuilder& builder, const CSSUnresolvedLightDark& lightDark)
+{
+    builder.append("light-dark("_s, lightDark.lightColor->customCSSText(), ", "_s, lightDark.darkColor->customCSSText(), ')');
+}
+
+String serializationForCSS(const CSSUnresolvedLightDark& unresolved)
+{
+    StringBuilder builder;
+    serializationForCSS(builder, unresolved);
+    return builder.toString();
+}
+
+bool operator==(const CSSUnresolvedLightDark& a, const CSSUnresolvedLightDark& b)
+{
+    return compareCSSValue(a.lightColor, b.lightColor)
+        && compareCSSValue(a.darkColor, b.darkColor);
+}
+
+StyleColor createStyleColor(const CSSUnresolvedLightDark& unresolved, const Document& document, RenderStyle& style, Style::ForVisitedLink forVisitedLink)
+{
+    if (document.useDarkAppearance(&style))
+        return colorFromPrimitiveValue(document, style, unresolved.darkColor.get(), forVisitedLink);
+    return colorFromPrimitiveValue(document, style, unresolved.lightColor.get(), forVisitedLink);
+}
+
+} // namespace WebCore

--- a/Source/WebCore/css/color/CSSUnresolvedLightDark.h
+++ b/Source/WebCore/css/color/CSSUnresolvedLightDark.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSPrimitiveValue.h"
+#include "StyleColor.h"
+#include <wtf/Forward.h>
+#include <wtf/RefCounted.h>
+
+namespace WebCore {
+
+namespace Style {
+enum class ForVisitedLink : bool;
+}
+
+class Document;
+class RenderStyle;
+
+struct CSSUnresolvedLightDark {
+    friend bool operator==(const CSSUnresolvedLightDark&, const CSSUnresolvedLightDark&);
+
+    Ref<CSSPrimitiveValue> lightColor;
+    Ref<CSSPrimitiveValue> darkColor;
+};
+
+void serializationForCSS(StringBuilder&, const CSSUnresolvedLightDark&);
+String serializationForCSS(const CSSUnresolvedLightDark&);
+
+StyleColor createStyleColor(const CSSUnresolvedLightDark&, const Document&, RenderStyle&, Style::ForVisitedLink);
+
+} // namespace WebCore

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -57,6 +57,7 @@ CSSParserContext::CSSParserContext(CSSParserMode mode, const URL& baseURL)
     if (mode == UASheetMode) {
         colorMixEnabled = true;
         focusVisibleEnabled = true;
+        lightDarkEnabled = true;
         popoverAttributeEnabled = true;
         propertySettings.cssContainmentEnabled = true;
         propertySettings.cssInputSecurityEnabled = true;
@@ -112,6 +113,7 @@ CSSParserContext::CSSParserContext(const Document& document, const URL& sheetBas
 #if ENABLE(SERVICE_CONTROLS)
     , imageControlsEnabled { document.settings().imageControlsEnabled() }
 #endif
+    , lightDarkEnabled { document.settings().cssLightDarkEnabled() }
     , propertySettings { CSSPropertySettings { document.settings() } }
 {
 }
@@ -153,7 +155,8 @@ void add(Hasher& hasher, const CSSParserContext& context)
 #if ENABLE(SERVICE_CONTROLS)
         | context.imageControlsEnabled                      << 30
 #endif
-        | (uint64_t)context.mode                            << 31; // This is multiple bits, so keep it last.
+        | context.lightDarkEnabled                          << 31
+        | (uint64_t)context.mode                            << 32; // This is multiple bits, so keep it last.
     add(hasher, context.baseURL, context.charset, context.propertySettings, bits);
 }
 

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -104,6 +104,7 @@ struct CSSParserContext {
 #if ENABLE(SERVICE_CONTROLS)
     bool imageControlsEnabled : 1 { false };
 #endif
+    bool lightDarkEnabled : 1 { false };
 
     // Settings, those affecting properties.
     CSSPropertySettings propertySettings;

--- a/Source/WebInspectorUI/UserInterface/Models/CSSKeywordCompletions.js
+++ b/Source/WebInspectorUI/UserInterface/Models/CSSKeywordCompletions.js
@@ -423,7 +423,7 @@ WI.CSSKeywordCompletions._colors = [
     "royalblue", "saddlebrown", "salmon", "sandybrown", "seagreen", "seashell", "sienna", "skyblue", "slateblue",
     "slategray", "slategrey", "snow", "springgreen", "steelblue", "tan", "thistle", "tomato", "turquoise", "violet",
     "wheat", "whitesmoke", "yellowgreen", "rgb()", "rgba()", "hsl()", "hsla()", "color()", "hwb()", "lch()", "lab()",
-    "color-mix()", "color-contrast()",
+    "color-mix()", "color-contrast()", "light-dark()",
 ];
 
 WI.CSSKeywordCompletions._colorAwareProperties = new Set([


### PR DESCRIPTION
#### 9240183bbeb26b30cfaa51cd0f5739eb1429731f
<pre>
[css-color-5] Implement light-dark() function for color values
<a href="https://bugs.webkit.org/show_bug.cgi?id=266889">https://bugs.webkit.org/show_bug.cgi?id=266889</a>
<a href="https://rdar.apple.com/120171629">rdar://120171629</a>

Reviewed by Tim Nguyen.

`light-dark()` allows authors to easily specify colors that adjust depending on
an element&apos;s used color scheme.

Spec: <a href="https://drafts.csswg.org/css-color-5/#light-dark">https://drafts.csswg.org/css-color-5/#light-dark</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-color/light-dark-basic-expected.txt:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/css/color/CSSUnresolvedColor.cpp:
(WebCore::CSSUnresolvedColor::containsCurrentColor const):
(WebCore::CSSUnresolvedColor::createStyleColor const):
* Source/WebCore/css/color/CSSUnresolvedColor.h:
* Source/WebCore/css/color/CSSUnresolvedLightDark.cpp: Added.
(WebCore::serializationForCSS):
(WebCore::operator==):
(WebCore::createStyleColor):
* Source/WebCore/css/color/CSSUnresolvedLightDark.h: Added.
* Source/WebCore/css/parser/CSSParserContext.cpp:
(WebCore::CSSParserContext::CSSParserContext):
(WebCore::add):
* Source/WebCore/css/parser/CSSParserContext.h:
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::parseLightDarkFunctionParameters):
(WebCore::CSSPropertyParserHelpers::parseColorFunctionRaw):

Similar to system colors, there is not an existing mechanism to resolve dynamic
colors in workers.

(WebCore::CSSPropertyParserHelpers::parseColorFunction):
* Source/WebInspectorUI/UserInterface/Models/CSSKeywordCompletions.js:

Canonical link: <a href="https://commits.webkit.org/272560@main">https://commits.webkit.org/272560@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3825a32ceb9762b01ec5ec4fbbf254bb80116b5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32108 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10830 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33901 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34654 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29102 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32941 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13186 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8049 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28679 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32511 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9137 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28697 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7931 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8102 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28612 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35999 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/27595 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29197 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29068 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34214 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/32197 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8221 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6169 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32071 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9862 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/38618 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7501 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8865 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8191 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8749 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->