### PR TITLE
Make FloatQuad::boundingBox manage large finite values and infinite ones

### DIFF
--- a/LayoutTests/fast/css/transform-infinity-expected.txt
+++ b/LayoutTests/fast/css/transform-infinity-expected.txt
@@ -1,0 +1,1 @@
+Test passes if it does not crash.

--- a/LayoutTests/fast/css/transform-infinity.html
+++ b/LayoutTests/fast/css/transform-infinity.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <script>
+            if (window.testRunner)
+                testRunner.dumpAsText();
+        </script>
+        <style>
+            body {
+                -webkit-transform: matrix(913497906,874,-270122.666907739,44,-933.66,101839.742) scale(-988337314) skew(540817045turn,33481.000001turn) translateY(75959.0%) matrix(12388309,8375,1982.08233,-480110910,646202686,69006.99) skewX(4213.720135962deg) scale(+5.833098,+80974) scaleX(491057862) scale(+133,331676);
+            }
+        </style>
+    </head>
+    <body>
+        Test passes if it does not crash.
+    </body>
+</html>

--- a/Source/WebCore/platform/graphics/FloatQuad.cpp
+++ b/Source/WebCore/platform/graphics/FloatQuad.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2008 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2021 Google Inc. All rights reserved.
  * Copyright (C) 2012 Nokia Corporation and/or its subsidiary(-ies)
  * Copyright (C) 2013 Xidorn Quan (quanxunzhen@gmail.com)
  *
@@ -32,6 +33,7 @@
 #include "FloatQuad.h"
 
 #include <algorithm>
+#include <cmath>
 #include <limits>
 #include <wtf/MathExtras.h>
 #include <wtf/text/TextStream.h>
@@ -81,13 +83,21 @@ inline bool isPointInTriangle(const FloatPoint& p, const FloatPoint& t1, const F
     return (u >= 0) && (v >= 0) && (u + v <= 1);
 }
 
+static inline float clampToIntRange(float value)
+{
+    if (UNLIKELY(std::isinf(value) || std::abs(value) > (static_cast<float>(std::numeric_limits<int>::max()))))
+        return std::signbit(value) ? std::numeric_limits<int>::min() : (static_cast<float>(std::numeric_limits<int>::max()));
+
+    return value;
+}
+
 FloatRect FloatQuad::boundingBox() const
 {
-    float left   = min4(m_p1.x(), m_p2.x(), m_p3.x(), m_p4.x());
-    float top    = min4(m_p1.y(), m_p2.y(), m_p3.y(), m_p4.y());
+    float left   = clampToIntRange(min4(m_p1.x(), m_p2.x(), m_p3.x(), m_p4.x()));
+    float top    = clampToIntRange(min4(m_p1.y(), m_p2.y(), m_p3.y(), m_p4.y()));
 
-    float right  = max4(m_p1.x(), m_p2.x(), m_p3.x(), m_p4.x());
-    float bottom = max4(m_p1.y(), m_p2.y(), m_p3.y(), m_p4.y());
+    float right  = clampToIntRange(max4(m_p1.x(), m_p2.x(), m_p3.x(), m_p4.x()));
+    float bottom = clampToIntRange(max4(m_p1.y(), m_p2.y(), m_p3.y(), m_p4.y()));
     
     return FloatRect(left, top, right - left, bottom - top);
 }

--- a/Tools/TestWebKitAPI/Tests/WebCore/FloatQuadTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/FloatQuadTests.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2021 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -164,6 +165,38 @@ TEST(FloatQuad, IsEmpty)
         FloatPoint(1, 1),
         FloatPoint(3, 3),
     });
+}
+
+TEST(FloatQuad, BoundingBox)
+{
+    FloatQuad quad(FloatPoint(2, 3), FloatPoint(5, 7), FloatPoint(11, 13), FloatPoint(17, 19));
+    FloatRect rect = quad.boundingBox();
+    ASSERT_EQ(rect.x(), 2);
+    ASSERT_EQ(rect.y(), 3);
+    ASSERT_EQ(rect.width(), 17 - 2);
+    ASSERT_EQ(rect.height(), 19 - 3);
+}
+
+TEST(FloatQuad, BoundingBoxSaturateInf)
+{
+    constexpr double inf = std::numeric_limits<double>::infinity();
+    FloatQuad quad(FloatPoint(-inf, 3), FloatPoint(5, inf), FloatPoint(11, 13), FloatPoint(17, 19));
+    FloatRect rect = quad.boundingBox();
+    ASSERT_EQ(rect.x(), std::numeric_limits<int>::min());
+    ASSERT_EQ(rect.y(), 3.0f);
+    ASSERT_EQ(rect.width(), 17.0f - std::numeric_limits<int>::min());
+    ASSERT_EQ(rect.height(), static_cast<float>(std::numeric_limits<int>::max()) - 3.0f);
+}
+
+TEST(FloatQuad, BoundingBoxSaturateLarge)
+{
+    constexpr double large = std::numeric_limits<float>::max() * 4;
+    FloatQuad quad(FloatPoint(-large, 3), FloatPoint(5, large), FloatPoint(11, 13), FloatPoint(17, 19));
+    FloatRect rect = quad.boundingBox();
+    ASSERT_EQ(rect.x(), std::numeric_limits<int>::min());
+    ASSERT_EQ(rect.y(), 3.0f);
+    ASSERT_EQ(rect.width(), 17.0f - std::numeric_limits<int>::min());
+    ASSERT_EQ(rect.height(), static_cast<float>(std::numeric_limits<int>::max()) - 3.0f);
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 57f898204047c2950cdb7cbe02436a5faf1ba104
<pre>
Make FloatQuad::boundingBox manage large finite values and infinite ones

<a href="https://bugs.webkit.org/show_bug.cgi?id=266855">https://bugs.webkit.org/show_bug.cgi?id=266855</a>

Reviewed by Alan Baradlay.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/6f25d3a7fca5d1a30eb5f05c4057ee33aa7eb702">https://chromium.googlesource.com/chromium/src.git/+/6f25d3a7fca5d1a30eb5f05c4057ee33aa7eb702</a> ,
<a href="https://chromium.googlesource.com/chromium/src/+/76905b16d9f5ba9533a7e8d41724fcd383fa4d37">https://chromium.googlesource.com/chromium/src/+/76905b16d9f5ba9533a7e8d41724fcd383fa4d37</a> and
<a href="https://chromium.googlesource.com/chromium/src/+/fdda021cbb442c16633595fa580614b6039132e3">https://chromium.googlesource.com/chromium/src/+/fdda021cbb442c16633595fa580614b6039132e3</a>

This PR is to change FloatQuad::boundingBox() to check for -Infinity and Infinity when
converting to a FloatRect, thereby allowing the returned rect to be used
and snapped without hitting the isNaN() check when clamping to saturate.

Further, this is to extend FloatQuad::boundingBox to treat large finite values the
same way it treats infinite values, by clamping them to the range of int.

* Source/WebCore/platform/graphics/FloatQuad.cpp:
(clampToIntRange): For clamping new function
(FloatQuad::boundingBox): Use above new function
* Tools/TestWebKitAPI/Tests/WebCore/FloatQuadTests.cpp: New API tests
* LayoutTests/fast/css/transform-infinity.html: Add Test Case
* LayoutTests/fast/css/transform-infinity-expected.txt: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/272533@main">https://commits.webkit.org/272533@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/829cc511be3095e957debe483ba1746957b3a236

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31899 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10594 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33646 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34408 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28896 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32697 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12954 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7833 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28487 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32264 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8947 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28496 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7736 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7930 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28409 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35752 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29010 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28863 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34015 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8002 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5990 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31874 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9651 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/28216 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7480 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8670 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8524 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->