### PR TITLE
[WGSL] https://compute.toys/view/734 fails to compile

### DIFF
--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -997,6 +997,9 @@ void TypeChecker::visit(AST::CallExpression& call)
                     typeArguments.append(matrixType->element);
                     targetName = makeString("mat", String::number(matrixType->columns), "x", String::number(matrixType->rows));
                 }
+
+                if (std::holds_alternative<Types::Primitive>(*targetBinding->type))
+                    targetName = targetBinding->type->toString();
             }
 
             if (targetBinding->kind == Binding::Value) {

--- a/Source/WebGPU/WGSL/tests/valid/aliases.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/aliases.wgsl
@@ -25,9 +25,23 @@ struct S {
 }
 alias v = vec2<i32>;
 alias s = S;
+alias f = f32;
+alias i = i32;
+alias u = u32;
+alias b = bool;
 
 @compute @workgroup_size(1)
 fn main() {
+
+    let z = 1;
+    _ = f(0);
+    _ = i(0);
+    _ = u(0);
+    _ = b(0);
+    _ = f(z);
+    _ = i(z);
+    _ = u(z);
+    _ = b(z);
 
     let x = v(0);
     let y = s(0);


### PR DESCRIPTION
#### 4375e00da390bbcac9db9ebdc4c28906faed9e9e
<pre>
[WGSL] <a href="https://compute.toys/view/734">https://compute.toys/view/734</a> fails to compile
<a href="https://bugs.webkit.org/show_bug.cgi?id=266638">https://bugs.webkit.org/show_bug.cgi?id=266638</a>
<a href="https://rdar.apple.com/119870669">rdar://119870669</a>

Reviewed by Mike Wyrzykowski.

When using an alias for type conversion we need to update the target to the
resolved type.

* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
* Source/WebGPU/WGSL/tests/valid/aliases.wgsl:

Canonical link: <a href="https://commits.webkit.org/272519@main">https://commits.webkit.org/272519@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc2457097935d347f4f9e8feb216e546b85ceddd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31905 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10600 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33652 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34414 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28902 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12960 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7839 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28490 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32270 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8950 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28503 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7739 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7915 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35758 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29013 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28870 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34022 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8008 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5994 "Found 1 new test failure: fast/shadow-dom/svg-animate-href-in-shadow-tree.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31881 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9657 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7468 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8676 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8530 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->