### PR TITLE
[WebGPU] WGSL compilation failure opening https://threejs.org/examples/?q=webgpu#webgpu_backdrop_water

### DIFF
--- a/Source/WebGPU/WGSL/ConstantFunctions.h
+++ b/Source/WebGPU/WGSL/ConstantFunctions.h
@@ -717,9 +717,22 @@ CONSTANT_FUNCTION(BitwiseShiftRight)
 
 CONSTANT_CONSTRUCTOR(Bool, bool)
 CONSTANT_CONSTRUCTOR(I32, int32_t)
-CONSTANT_CONSTRUCTOR(U32, uint32_t)
 CONSTANT_CONSTRUCTOR(F32, float)
 CONSTANT_CONSTRUCTOR(F16, half)
+
+CONSTANT_FUNCTION(U32)
+{
+    if (arguments.size()) {
+        if (auto* abstractInt = std::get_if<int64_t>(&arguments[0])) {
+            auto result = convertInteger<uint32_t>(*abstractInt);
+            if (result)
+                return { *result };
+            return makeUnexpected(makeString("value ", String::number(*abstractInt), " cannot be represented as 'u32'"));
+        }
+    }
+
+    return { constantConstructor<uint32_t>(resultType, arguments) };
+}
 
 CONSTANT_FUNCTION(Vec2)
 {

--- a/Source/WebGPU/WGSL/Overload.cpp
+++ b/Source/WebGPU/WGSL/Overload.cpp
@@ -308,6 +308,10 @@ ConversionRank OverloadResolver::calculateRank(const AbstractType& parameter, co
     if (auto* variable = std::get_if<TypeVariable>(parameter.get())) {
         auto* resolvedType = resolve(*variable);
         ASSERT(resolvedType);
+        if (variable->constraints) {
+            resolvedType = satisfyOrPromote(resolvedType, variable->constraints, m_types);
+            ASSERT(resolvedType);
+        }
         return conversionRank(argumentType, resolvedType);
     }
 

--- a/Source/WebGPU/WGSL/TypeDeclarations.rb
+++ b/Source/WebGPU/WGSL/TypeDeclarations.rb
@@ -348,6 +348,7 @@ constructor :u32, {
     const: true,
 
     [T < ConcreteScalar].(T) => u32,
+    [].(abstract_int) => u32,
 }
 
 # 16.1.2.17.

--- a/Source/WebGPU/WGSL/tests/invalid/constants.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/constants.wgsl
@@ -38,7 +38,14 @@ fn testOutOfBounds()
     }
 }
 
+fn testInvalidExplicitU32Conversion()
+{
+    // CHECK-L: value 37359285590000 cannot be represented as 'u32'
+    let x = u32(37359285590000);
+}
+
 fn main()
 {
     testOutOfBounds();
+    testInvalidExplicitU32Conversion();
 }

--- a/Source/WebGPU/WGSL/tests/valid/constants.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/constants.wgsl
@@ -1,5 +1,11 @@
 // RUN: %wgslc
 
+fn testU32ConstantsThatOverflowI32()
+{
+    let x1 = u32(4294967295);
+    let x2 = u32(3735928559);
+}
+
 fn testLiteralConstants()
 {
     {


### PR DESCRIPTION
#### b1e573cb61f6b3a509c7d076af34a46caf78adad
<pre>
[WebGPU] WGSL compilation failure opening <a href="https://threejs.org/examples/?q=webgpu#webgpu_backdrop_water">https://threejs.org/examples/?q=webgpu#webgpu_backdrop_water</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=266823">https://bugs.webkit.org/show_bug.cgi?id=266823</a>
<a href="https://rdar.apple.com/120054632">rdar://120054632</a>

Reviewed by Mike Wyrzykowski.

The spec was updated to add an overload to u32 that accepts abstract_int as an
argument, and this patch updates our implementation to match the updated spec.
This required specializing the constant u32 constructor to handle the abstract_int
special case, since it differs from the other types in that it needs to check
for that can&apos;t fit in a u32. It also required fixing a bug in the overload resolution
where a type variable can be resolved to a type that doesn&apos;t satisfy its constraints.

* Source/WebGPU/WGSL/ConstantFunctions.h:
(WGSL::CONSTANT_FUNCTION):
* Source/WebGPU/WGSL/Overload.cpp:
(WGSL::OverloadResolver::calculateRank):
* Source/WebGPU/WGSL/TypeDeclarations.rb:
* Source/WebGPU/WGSL/tests/invalid/constants.wgsl:
* Source/WebGPU/WGSL/tests/valid/constants.wgsl:

Canonical link: <a href="https://commits.webkit.org/272520@main">https://commits.webkit.org/272520@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1ad2f4b06f36bb6849bee0b06afd21cb3d6f2b0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31906 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10601 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33653 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34415 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28903 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12961 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7840 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28492 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32271 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8952 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28502 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7741 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7917 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35759 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29015 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28869 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34018 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8009 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5997 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31877 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9658 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7469 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8677 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8531 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->