### PR TITLE
[GStreamer] Fix delayed dispatch of async task post MediaPlayer destruction

### DIFF
--- a/Source/WebCore/platform/AbortableTaskQueue.h
+++ b/Source/WebCore/platform/AbortableTaskQueue.h
@@ -75,6 +75,7 @@ public:
         ASSERT(isMainThread());
         ASSERT(!m_lock.isHeld());
         ASSERT(m_channel.isEmpty());
+        startAborting();
     }
 
     // ===========================

--- a/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp
@@ -183,8 +183,10 @@ void TrackPrivateBaseGStreamer::disconnect()
         m_bestUpstreamPad.clear();
     }
 
-    if (m_pad)
+    if (m_pad) {
+        g_signal_handlers_disconnect_matched(m_pad.get(), G_SIGNAL_MATCH_DATA, 0, 0, nullptr, nullptr, this);
         m_pad.clear();
+    }
 }
 
 void TrackPrivateBaseGStreamer::tagsChanged()


### PR DESCRIPTION
#### bda86858ca813149fbfc74acc73169ce0ac7c30b
<pre>
[GStreamer] Fix delayed dispatch of async task post MediaPlayer destruction
<a href="https://bugs.webkit.org/show_bug.cgi?id=266715">https://bugs.webkit.org/show_bug.cgi?id=266715</a>

Reviewed by Philippe Normand.

When the media player is destroyed, there can still be async tasks (from AbortableTaskQueue)
ongoing, some of them related to tracks. Those tasks should be aborted, because they depend
on objects that are no longer there.

This patch aborts all pending tasks on AbortableTaskQueue destruction and also unregisters
all pending callbacks from TrackPrivateBaseGStreamer.

See: <a href="https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1231">https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1231</a>

Original author: &quot;Vivek.A&quot; &lt;Vivek_Arumugam@comcast.com&gt;

* Source/WebCore/platform/AbortableTaskQueue.h: Abort tasks on destruction.
* Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp:
(WebCore::TrackPrivateBaseGStreamer::disconnect): Disconnect handlers.

Canonical link: <a href="https://commits.webkit.org/272517@main">https://commits.webkit.org/272517@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/482b79baf0c96b80c4a33161de23b7288c34bb73

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31911 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10607 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33659 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34421 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28908 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32710 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12968 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7846 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28498 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32277 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8961 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28509 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7748 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7926 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28422 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35765 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29024 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28876 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34028 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8014 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6003 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31887 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9663 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7466 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8682 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8537 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->