### PR TITLE
Fix wide-attachment-image-controls-basic test

### DIFF
--- a/LayoutTests/fast/attachment/mac/wide-attachment-image-controls-basic-expected.txt
+++ b/LayoutTests/fast/attachment/mac/wide-attachment-image-controls-basic-expected.txt
@@ -4,14 +4,16 @@ layer at (0,0) size 800x98
   RenderBlock {HTML} at (0,0) size 800x98
     RenderBody {BODY} at (8,8) size 784x82
       RenderAttachment {ATTACHMENT} at (1,1) size 266x80
-        RenderFlexibleBox {DIV} at (0,0) size 266x80 [bgcolor=#0000000D]
-          RenderGrid {DIV} at (14,14) size 0x52
-            RenderImage {IMG} at (0,26) size 0x0
-          RenderFlexibleBox {DIV} at (32,0) size 210x80
-            RenderGrid {DIV} at (0,40) size 210x0
-      RenderText {#text} at (268,26) size 4x18
-        text run at (268,26) width 4: " "
-      RenderImage {IMG} at (272,20) size 20x20
+        RenderFlexibleBox {DIV} at (0,0) size 266x80 [bgcolor=#0000000C]
+          RenderGrid {DIV} at (14,14) size 52x52
+            RenderImage {IMG} at (0,0) size 52x52
+          RenderFlexibleBox {DIV} at (84,0) size 158x80
+            RenderGrid {DIV} at (0,40) size 158x0
+      RenderText {#text} at (268,52) size 4x18
+        text run at (268,52) width 4: " "
+      RenderImage {IMG} at (272,46) size 20x20
+      RenderText {#text} at (0,0) size 0x0
+      RenderText {#text} at (0,0) size 0x0
       RenderText {#text} at (0,0) size 0x0
 layer at (9,9) size 266x80
   RenderBlock (relative positioned) {DIV} at (0,0) size 266x80 [color=#00000000]

--- a/LayoutTests/fast/attachment/mac/wide-attachment-image-controls-basic.html
+++ b/LayoutTests/fast/attachment/mac/wide-attachment-image-controls-basic.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true AttachmentWideLayoutEnabled=true ] -->
-<html>
+<html class="reftest-wait">
 <head>
 <script>
     if (window.internals)
@@ -9,5 +9,9 @@
 <body>
     <attachment id="test" type="application/pdf" src="../resources/green_rectangle.pdf"></attachment>
     <img src="400x200-circle.png"></img>
+<script src="../resources/attachment-test-utils.js"></script>
+<script>
+takeActualScreenshotWhenAttachmentsSettled();
+</script>
 </body>
 </html>

--- a/LayoutTests/platform/mac-monterey/fast/attachment/mac/wide-attachment-image-controls-basic-expected.txt
+++ b/LayoutTests/platform/mac-monterey/fast/attachment/mac/wide-attachment-image-controls-basic-expected.txt
@@ -4,14 +4,16 @@ layer at (0,0) size 800x98
   RenderBlock {HTML} at (0,0) size 800x98
     RenderBody {BODY} at (8,8) size 784x82
       RenderAttachment {ATTACHMENT} at (1,1) size 266x80
-        RenderGrid {DIV} at (0,0) size 266x80 [bgcolor=#0000000C]
-          RenderGrid {DIV} at (0,0) size 68x80
-            RenderAttachment {ATTACHMENT} at (8,14) size 52x52
-          RenderGrid {DIV} at (68,0) size 198x80
-            RenderGrid {DIV} at (4,40) size 170x0
-      RenderText {#text} at (268,54) size 4x18
-        text run at (268,54) width 4: " "
-      RenderImage {IMG} at (272,48) size 20x20
+        RenderFlexibleBox {DIV} at (0,0) size 266x80 [bgcolor=#0000000D]
+          RenderGrid {DIV} at (14,14) size 52x52
+            RenderImage {IMG} at (0,0) size 52x52
+          RenderFlexibleBox {DIV} at (84,0) size 158x80
+            RenderGrid {DIV} at (0,40) size 158x0
+      RenderText {#text} at (268,52) size 4x18
+        text run at (268,52) width 4: " "
+      RenderImage {IMG} at (272,46) size 20x20
+      RenderText {#text} at (0,0) size 0x0
+      RenderText {#text} at (0,0) size 0x0
       RenderText {#text} at (0,0) size 0x0
 layer at (9,9) size 266x80
   RenderBlock (relative positioned) {DIV} at (0,0) size 266x80 [color=#00000000]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1766,8 +1766,6 @@ webkit.org/b/259403 [ x86_64 ] fast/canvas/webgl/texImage2D-video-flipY-false.ht
 
 webkit.org/b/259464 [ Monterey+ ] fast/events/wheel/redispatched-wheel-event.html [ Pass Failure ]
 
-webkit.org/b/259183 fast/attachment/mac/wide-attachment-image-controls-basic.html [ Pass Failure ]
-
 webkit.org/b/259708 fast/mediastream/video-rotation-gpu-process-crash.html [ Pass Crash Failure Timeout ]
 
 webkit.org/b/259740 [ Ventura Release arm64 ] css3/color-filters/color-filter-outline.html [ Pass ImageOnlyFailure ]


### PR DESCRIPTION
#### 44fccba78690ca1160f1d8c8776103e8540a0bae
<pre>
Fix wide-attachment-image-controls-basic test
<a href="https://bugs.webkit.org/show_bug.cgi?id=259528">https://bugs.webkit.org/show_bug.cgi?id=259528</a>
<a href="https://rdar.apple.com/112918166">rdar://112918166</a>

Reviewed by Tim Nguyen.

Delay the rendering screenshot until the attachment icon has loaded.

* LayoutTests/fast/attachment/mac/wide-attachment-image-controls-basic.html:
* LayoutTests/platform/mac-wk2/TestExpectations:

* LayoutTests/fast/attachment/mac/wide-attachment-image-controls-basic-expected.txt:
* LayoutTests/platform/mac-monterey/fast/attachment/mac/wide-attachment-image-controls-basic-expected.txt: Renamed from LayoutTests/platform/mac/fast/attachment/mac/wide-attachment-image-controls-basic-expected.txt.
There is a slight difference between how Monterey and Sonoma blend
the attachment background, which is the tertiary-fill (0,0,0,5%).
5% of 255 is 12.75.
- On Monterey this is rounded up to 13 -&gt; #0000000D
- On Sonoma this is truncated down to 12 -&gt; #0000000C

Canonical link: <a href="https://commits.webkit.org/272548@main">https://commits.webkit.org/272548@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/284fab800b73d343c4135ad1d7f3a4409397b736

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31962 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10662 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33719 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34479 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28960 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13025 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7899 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28555 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32335 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9018 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28568 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7806 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7985 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28481 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35823 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29080 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28935 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34085 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8070 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6056 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31944 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9715 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/28288 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7487 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8731 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8593 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->