### PR TITLE
[GStreamer] Continue download of media files even if server sends early FIN

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
@@ -540,6 +540,32 @@ static GstFlowReturn webKitWebSrcCreate(GstPushSrc* pushSrc, GstBuffer** buffer)
 
         queueSize = gst_adapter_available(members->adapter.get());
         GST_TRACE_OBJECT(src, "available %" G_GSIZE_FORMAT, queueSize);
+
+        if (!queueSize && members->doesHaveEOS && members->readPosition < members->size) {
+            // Still no data, this could mean the download ended with early FIN
+            // from buggy web server. Reset request state and send new request
+            // to download the rest of the data.
+            members->requestedPosition = members->readPosition;
+            members->wasResponseReceived = false;
+            members->doesHaveEOS = false;
+            webKitWebSrcMakeRequest(src, members);
+
+            // Wait for the response headers.
+            members->responseCondition.wait(members.mutex(), [&] () {
+                return members->wasResponseReceived || members->isFlushing;
+            });
+
+            if (members->isFlushing)
+                return GST_FLOW_FLUSHING;
+
+            // Wait for data or EOS
+            members->responseCondition.wait(members.mutex(), [&] {
+                return gst_adapter_available(members->adapter.get()) || members->doesHaveEOS;
+            });
+
+            queueSize = gst_adapter_available(members->adapter.get());
+            GST_DEBUG_OBJECT(src, "available %" G_GSIZE_FORMAT, queueSize);
+        }
     }
 
     if (queueSize) {


### PR DESCRIPTION
<pre>
[GStreamer] Continue download of media files even if server sends early FIN
<a href="https://bugs.webkit.org/show_bug.cgi?id=266924">https://bugs.webkit.org/show_bug.cgi?id=266924</a>

Reviewed by NOBODY (OOPS!).

When downloading large 1 GiB media file via 20 Mbps link from an old
nginx server running on an under-powered hardware under severe load,
the server sometimes sends a FIN before the entire file is downloaded.
This ends the download without the file really being fully downloaded
and triggers playback of this incomplete download.

With the following disk cache settings to enforce the file to be fully
cached locally before playback starts, to offset the server and link
slowness, the playback of the incomplete download starts and eventually
runs out of data:
```
WPE_SHELL_MEDIA_DISK_CACHE_SIZE_BYTES=3758096384
WPE_SHELL_MEDIA_DISK_CACHE_SIZE_NSEC=0
```

Add code to detect the condition and trigger subsequent request to
download the rest of the file using another range request from the
server. Once the entire file is downloaded, start playback.

* Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp:
(webKitWebSrcCreate):
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3ff06a5c1cad3edd41fc33489ffad7eb7925653

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31946 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10644 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33710 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34460 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28942 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32749 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13008 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7881 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28536 "Found 1 new test failure: http/tests/media/remove-while-loading.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32316 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9001 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28559 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7786 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7967 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28472 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35804 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29063 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28926 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34064 "Found 1 new test failure: http/tests/security/contentSecurityPolicy/media-src-allowed.html (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8052 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6037 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31923 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9697 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8714 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8575 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->