### PR TITLE
Correct getComputedStyle() for invalid pseudo-elements

### DIFF
--- a/LayoutTests/fast/css/getComputedStyle/getComputedStyle-with-pseudo-element-expected.txt
+++ b/LayoutTests/fast/css/getComputedStyle/getComputedStyle-with-pseudo-element-expected.txt
@@ -60,7 +60,7 @@ PASS Expected 'rgb(165, 42, 42)' for color in the computed style for element wit
 PASS Expected 'rgb(165, 42, 42)' for color in the computed style for element with id testNoPseudoElement and pseudo-element :first-letter and got 'rgb(165, 42, 42)'
 PASS Expected 'rgb(165, 42, 42)' for color in the computed style for element with id testNoPseudoElement and pseudo-element :before and got 'rgb(165, 42, 42)'
 PASS Expected 'rgb(165, 42, 42)' for color in the computed style for element with id testNoPseudoElement and pseudo-element :after and got 'rgb(165, 42, 42)'
-PASS Expected 'rgb(165, 42, 42)' for color in the computed style for element with id testNoPseudoElement and pseudo-element :garbage and got 'rgb(165, 42, 42)'
+PASS Expected '' for color in the computed style for element with id testNoPseudoElement and pseudo-element :garbage and got ''
 PASS Expected '100px' for height in the computed style for element with id testNoPseudoElement and pseudo-element null and got '100px'
 PASS Expected '100px' for width in the computed style for element with id testNoPseudoElement and pseudo-element null and got '100px'
 PASS Expected 'auto' for height in the computed style for element with id testNoPseudoElement and pseudo-element :after and got 'auto'

--- a/LayoutTests/fast/css/getComputedStyle/getComputedStyle-with-pseudo-element.html
+++ b/LayoutTests/fast/css/getComputedStyle/getComputedStyle-with-pseudo-element.html
@@ -177,7 +177,7 @@
         { 'elementId' : 'testNoPseudoElement', 'pseudoElement' : ':first-letter', 'property' : 'color', 'expectedValue' : 'rgb(165, 42, 42)' },
         { 'elementId' : 'testNoPseudoElement', 'pseudoElement' : ':before', 'property' : 'color', 'expectedValue' : 'rgb(165, 42, 42)' },
         { 'elementId' : 'testNoPseudoElement', 'pseudoElement' : ':after', 'property' : 'color', 'expectedValue' : 'rgb(165, 42, 42)' },
-        { 'elementId' : 'testNoPseudoElement', 'pseudoElement' : ':garbage', 'property' : 'color', 'expectedValue' : 'rgb(165, 42, 42)' },
+        { 'elementId' : 'testNoPseudoElement', 'pseudoElement' : ':garbage', 'property' : 'color', 'expectedValue' : '' },
         { 'elementId' : 'testNoPseudoElement', 'pseudoElement' : null, 'property' : 'height', 'expectedValue' : '100px' },
         { 'elementId' : 'testNoPseudoElement', 'pseudoElement' : null, 'property' : 'width', 'expectedValue' : '100px' },
         { 'elementId' : 'testNoPseudoElement', 'pseudoElement' : ':after', 'property' : 'height', 'expectedValue' : 'auto' },

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/highlight-pseudo-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/highlight-pseudo-computed-expected.txt
@@ -1,13 +1,13 @@
 
-FAIL getComputedStyle() for ::highlight(foo) assert_equals: Background color is green. expected "rgb(0, 128, 0)" but got "rgba(0, 0, 0, 0)"
-FAIL Different getComputedStyle() for ::highlight(bar) and same element assert_equals: Background color is cyan. expected "rgb(0, 255, 255)" but got "rgba(0, 0, 0, 0)"
-PASS getComputedStyle() for ::highlight(foo): should be element's default
-PASS getComputedStyle() for ::highlight(foo)) should be element's default
-PASS getComputedStyle() for ::highlight(foo)( should be element's default
+FAIL getComputedStyle() for ::highlight(foo) assert_equals: Background color is green. expected "rgb(0, 128, 0)" but got ""
+FAIL Different getComputedStyle() for ::highlight(bar) and same element assert_equals: Background color is cyan. expected "rgb(0, 255, 255)" but got ""
+FAIL getComputedStyle() for ::highlight(foo): should be element's default assert_equals: Background color is element's default. expected "rgba(0, 0, 0, 0)" but got ""
+FAIL getComputedStyle() for ::highlight(foo)) should be element's default assert_equals: Background color is element's default. expected "rgba(0, 0, 0, 0)" but got ""
+FAIL getComputedStyle() for ::highlight(foo)( should be element's default assert_equals: Background color is element's default. expected "rgba(0, 0, 0, 0)" but got ""
 PASS getComputedStyle() for ::highlight should be element's default
-PASS getComputedStyle() for ::highlight(foo)(foo) should be element's default
-PASS getComputedStyle() for ::highlight(foo)() should be element's default
-PASS getComputedStyle() for :::highlight(foo) should be element's default
-PASS getComputedStyle() for ::highlight(foo). should be element's default
-PASS getComputedStyle() for ::highlight(foo,bar) should be element's default
+FAIL getComputedStyle() for ::highlight(foo)(foo) should be element's default assert_equals: Background color is element's default. expected "rgba(0, 0, 0, 0)" but got ""
+FAIL getComputedStyle() for ::highlight(foo)() should be element's default assert_equals: Background color is element's default. expected "rgba(0, 0, 0, 0)" but got ""
+FAIL getComputedStyle() for :::highlight(foo) should be element's default assert_equals: Background color is element's default. expected "rgba(0, 0, 0, 0)" but got ""
+FAIL getComputedStyle() for ::highlight(foo). should be element's default assert_equals: Background color is element's default. expected "rgba(0, 0, 0, 0)" but got ""
+FAIL getComputedStyle() for ::highlight(foo,bar) should be element's default assert_equals: Background color is element's default. expected "rgba(0, 0, 0, 0)" but got ""
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-currentcolor-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-currentcolor-computed-expected.txt
@@ -1,12 +1,12 @@
 
 PASS getComputedStyle() for ::selection at #target1
 PASS getComputedStyle() for ::selection at #target2
-FAIL getComputedStyle() for ::target-text at #target1 assert_equals: Background color is lime. expected "rgb(0, 255, 0)" but got "rgb(0, 128, 0)"
-FAIL getComputedStyle() for ::target-text at #target2 assert_equals: Background color is lime. expected "rgb(0, 255, 0)" but got "rgba(0, 0, 0, 0)"
+FAIL getComputedStyle() for ::target-text at #target1 assert_equals: Background color is lime. expected "rgb(0, 255, 0)" but got ""
+FAIL getComputedStyle() for ::target-text at #target2 assert_equals: Background color is lime. expected "rgb(0, 255, 0)" but got ""
 PASS getComputedStyle() for ::spelling-error at #target1
 PASS getComputedStyle() for ::spelling-error at #target2
 PASS getComputedStyle() for ::grammar-error at #target1
 PASS getComputedStyle() for ::grammar-error at #target2
-FAIL getComputedStyle() for ::highlight(foo) at #target1 assert_equals: Background color is lime. expected "rgb(0, 255, 0)" but got "rgb(0, 128, 0)"
-FAIL getComputedStyle() for ::highlight(foo) at #target2 assert_equals: Background color is lime. expected "rgb(0, 255, 0)" but got "rgba(0, 0, 0, 0)"
+FAIL getComputedStyle() for ::highlight(foo) at #target1 assert_equals: Background color is lime. expected "rgb(0, 255, 0)" but got ""
+FAIL getComputedStyle() for ::highlight(foo) at #target2 assert_equals: Background color is lime. expected "rgb(0, 255, 0)" but got ""
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-currentcolor-computed-inheritance-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-currentcolor-computed-inheritance-expected.txt
@@ -1,7 +1,7 @@
 
 FAIL getComputedStyle() for ::selection assert_equals: Background color is lime. expected "rgb(0, 255, 0)" but got "rgba(0, 0, 0, 0)"
-FAIL getComputedStyle() for ::target-text assert_equals: Background color is lime. expected "rgb(0, 255, 0)" but got "rgba(0, 0, 0, 0)"
+FAIL getComputedStyle() for ::target-text assert_equals: Background color is lime. expected "rgb(0, 255, 0)" but got ""
 FAIL getComputedStyle() for ::spelling-error assert_equals: Background color is lime. expected "rgb(0, 255, 0)" but got "rgba(0, 0, 0, 0)"
 FAIL getComputedStyle() for ::grammar-error assert_equals: Background color is lime. expected "rgb(0, 255, 0)" but got "rgba(0, 0, 0, 0)"
-FAIL getComputedStyle() for ::highlight(foo) assert_equals: Background color is lime. expected "rgb(0, 255, 0)" but got "rgba(0, 0, 0, 0)"
+FAIL getComputedStyle() for ::highlight(foo) assert_equals: Background color is lime. expected "rgb(0, 255, 0)" but got ""
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-currentcolor-computed-visited-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-currentcolor-computed-visited-expected.txt
@@ -1,12 +1,12 @@
 
 PASS getComputedStyle() for ::selection at #target1
 PASS getComputedStyle() for ::selection at #target2
-PASS getComputedStyle() for ::target-text at #target1
-PASS getComputedStyle() for ::target-text at #target2
+FAIL getComputedStyle() for ::target-text at #target1 assert_equals: Color is lime. expected "rgb(0, 255, 0)" but got ""
+FAIL getComputedStyle() for ::target-text at #target2 assert_equals: Color is lime. expected "rgb(0, 255, 0)" but got ""
 PASS getComputedStyle() for ::spelling-error at #target1
 PASS getComputedStyle() for ::spelling-error at #target2
 PASS getComputedStyle() for ::grammar-error at #target1
 PASS getComputedStyle() for ::grammar-error at #target2
-PASS getComputedStyle() for ::highlight(foo) at #target1
-PASS getComputedStyle() for ::highlight(foo) at #target2
+FAIL getComputedStyle() for ::highlight(foo) at #target1 assert_equals: Color is lime. expected "rgb(0, 255, 0)" but got ""
+FAIL getComputedStyle() for ::highlight(foo) at #target2 assert_equals: Color is lime. expected "rgb(0, 255, 0)" but got ""
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-pseudos-inheritance-computed-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-pseudos-inheritance-computed-001-expected.txt
@@ -1,12 +1,12 @@
 
 FAIL getComputedStyle() for ::selection at #child1 assert_equals: Background color is green. expected "rgb(0, 128, 0)" but got "rgba(0, 0, 0, 0)"
 FAIL getComputedStyle() for ::selection at #child2 assert_equals: Background color is green. expected "rgb(0, 128, 0)" but got "rgba(0, 0, 0, 0)"
-FAIL getComputedStyle() for ::target-text at #child1 assert_equals: Background color is green. expected "rgb(0, 128, 0)" but got "rgba(0, 0, 0, 0)"
-FAIL getComputedStyle() for ::target-text at #child2 assert_equals: Background color is green. expected "rgb(0, 128, 0)" but got "rgba(0, 0, 0, 0)"
+FAIL getComputedStyle() for ::target-text at #child1 assert_equals: Background color is green. expected "rgb(0, 128, 0)" but got ""
+FAIL getComputedStyle() for ::target-text at #child2 assert_equals: Background color is green. expected "rgb(0, 128, 0)" but got ""
 FAIL getComputedStyle() for ::spelling-error at #child1 assert_equals: Background color is green. expected "rgb(0, 128, 0)" but got "rgba(0, 0, 0, 0)"
 FAIL getComputedStyle() for ::spelling-error at #child2 assert_equals: Background color is green. expected "rgb(0, 128, 0)" but got "rgba(0, 0, 0, 0)"
 FAIL getComputedStyle() for ::grammar-error at #child1 assert_equals: Background color is green. expected "rgb(0, 128, 0)" but got "rgba(0, 0, 0, 0)"
 FAIL getComputedStyle() for ::grammar-error at #child2 assert_equals: Background color is green. expected "rgb(0, 128, 0)" but got "rgba(0, 0, 0, 0)"
-FAIL getComputedStyle() for ::highlight(foo) at #child1 assert_equals: Background color is green. expected "rgb(0, 128, 0)" but got "rgba(0, 0, 0, 0)"
-FAIL getComputedStyle() for ::highlight(foo) at #child2 assert_equals: Background color is green. expected "rgb(0, 128, 0)" but got "rgba(0, 0, 0, 0)"
+FAIL getComputedStyle() for ::highlight(foo) at #child1 assert_equals: Background color is green. expected "rgb(0, 128, 0)" but got ""
+FAIL getComputedStyle() for ::highlight(foo) at #child2 assert_equals: Background color is green. expected "rgb(0, 128, 0)" but got ""
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-pseudos-visited-computed-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-pseudos-visited-computed-001-expected.txt
@@ -1,12 +1,12 @@
 
 PASS getComputedStyle() for ::selection at #target1
 PASS getComputedStyle() for ::selection at #target2
-FAIL getComputedStyle() for ::target-text at #target1 assert_equals: Color is lime. expected "rgb(0, 255, 0)" but got "rgb(0, 0, 238)"
-FAIL getComputedStyle() for ::target-text at #target2 assert_equals: Color is lime. expected "rgb(0, 255, 0)" but got "rgb(0, 0, 238)"
+FAIL getComputedStyle() for ::target-text at #target1 assert_equals: Color is lime. expected "rgb(0, 255, 0)" but got ""
+FAIL getComputedStyle() for ::target-text at #target2 assert_equals: Color is lime. expected "rgb(0, 255, 0)" but got ""
 PASS getComputedStyle() for ::spelling-error at #target1
 PASS getComputedStyle() for ::spelling-error at #target2
 PASS getComputedStyle() for ::grammar-error at #target1
 PASS getComputedStyle() for ::grammar-error at #target2
-FAIL getComputedStyle() for ::highlight(foo) at #target1 assert_equals: Color is lime. expected "rgb(0, 255, 0)" but got "rgb(0, 0, 238)"
-FAIL getComputedStyle() for ::highlight(foo) at #target2 assert_equals: Color is lime. expected "rgb(0, 255, 0)" but got "rgb(0, 0, 238)"
+FAIL getComputedStyle() for ::highlight(foo) at #target1 assert_equals: Color is lime. expected "rgb(0, 255, 0)" but got ""
+FAIL getComputedStyle() for ::highlight(foo) at #target2 assert_equals: Color is lime. expected "rgb(0, 255, 0)" but got ""
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/mix-blend-mode-only-on-transition-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/mix-blend-mode-only-on-transition-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Blend modes are set up on paired transitions assert_equals: expected "isolate" but got "auto"
+FAIL Blend modes are set up on paired transitions assert_equals: expected "auto" but got ""
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/only-child-group-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/only-child-group-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL :only-child should match because ::view-transition-group is generated for root element only promise_test: Unhandled rejection with value: "rgb(0, 0, 0) and rgb(0, 0, 0)"
-FAIL :only-child should not match because ::view-transition-group is generated for multiple elements promise_test: Unhandled rejection with value: "rgb(0, 0, 0) and rgb(0, 0, 0)"
-FAIL :only-child should match because ::view-transition-group is generated for sub element only promise_test: Unhandled rejection with value: "rgb(0, 0, 0) and rgb(0, 0, 0)"
-FAIL :only-child should not match because ::view-transition-group is generated for multiple sub elements promise_test: Unhandled rejection with value: "rgb(0, 0, 0) and rgb(0, 0, 0)"
+FAIL :only-child should match because ::view-transition-group is generated for root element only promise_test: Unhandled rejection with value: " and "
+FAIL :only-child should not match because ::view-transition-group is generated for multiple elements promise_test: Unhandled rejection with value: " and "
+FAIL :only-child should match because ::view-transition-group is generated for sub element only promise_test: Unhandled rejection with value: " and "
+FAIL :only-child should not match because ::view-transition-group is generated for multiple sub elements promise_test: Unhandled rejection with value: " and "
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/only-child-image-pair-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/only-child-image-pair-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL :only-child should always match for ::view-transition-image-pair promise_test: Unhandled rejection with value: "rgb(0, 0, 0) and rgb(0, 0, 0)"
+FAIL :only-child should always match for ::view-transition-image-pair promise_test: Unhandled rejection with value: " and "
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/only-child-new-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/only-child-new-expected.txt
@@ -1,8 +1,8 @@
 
-FAIL :only-child should match because ::view-transition-old is not generated (none to root) promise_test: Unhandled rejection with value: "rgb(0, 0, 0) and rgb(0, 0, 0)"
-FAIL :only-child should not match because ::view-transition-old is generated (root to root) promise_test: Unhandled rejection with value: "rgb(0, 0, 0) and rgb(0, 0, 0)"
-FAIL :only-child should not match because ::view-transition-old is generated (element to root) promise_test: Unhandled rejection with value: "rgb(0, 0, 0) and rgb(0, 0, 0)"
-FAIL :only-child should match because ::view-transition-old is not generated (none to element) promise_test: Unhandled rejection with value: "rgb(0, 0, 0) and rgb(0, 0, 0)"
-FAIL :only-child should not match because ::view-transition-old is generated (root to element) promise_test: Unhandled rejection with value: "rgb(0, 0, 0) and rgb(0, 0, 0)"
-FAIL :only-child should not match because ::view-transition-old is generated (element to element) promise_test: Unhandled rejection with value: "rgb(0, 0, 0) and rgb(0, 0, 0)"
+FAIL :only-child should match because ::view-transition-old is not generated (none to root) promise_test: Unhandled rejection with value: " and "
+FAIL :only-child should not match because ::view-transition-old is generated (root to root) promise_test: Unhandled rejection with value: " and "
+FAIL :only-child should not match because ::view-transition-old is generated (element to root) promise_test: Unhandled rejection with value: " and "
+FAIL :only-child should match because ::view-transition-old is not generated (none to element) promise_test: Unhandled rejection with value: " and "
+FAIL :only-child should not match because ::view-transition-old is generated (root to element) promise_test: Unhandled rejection with value: " and "
+FAIL :only-child should not match because ::view-transition-old is generated (element to element) promise_test: Unhandled rejection with value: " and "
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/only-child-old-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/only-child-old-expected.txt
@@ -1,8 +1,8 @@
 
-FAIL :only-child should match because ::view-transition-new is not generated (root to none) promise_test: Unhandled rejection with value: "rgb(0, 0, 0) and rgb(0, 0, 0)"
-FAIL :only-child should not match because ::view-transition-new is generated (root to root) promise_test: Unhandled rejection with value: "rgb(0, 0, 0) and rgb(0, 0, 0)"
-FAIL :only-child should not match because ::view-transition-new is generated (root to element) promise_test: Unhandled rejection with value: "rgb(0, 0, 0) and rgb(0, 0, 0)"
-FAIL :only-child should match because ::view-transition-new is not generated (element to none) promise_test: Unhandled rejection with value: "rgb(0, 0, 0) and rgb(0, 0, 0)"
-FAIL :only-child should not match because ::view-transition-new is generated (element to root) promise_test: Unhandled rejection with value: "rgb(0, 0, 0) and rgb(0, 0, 0)"
-FAIL :only-child should not match because ::view-transition-new is generated (element to element) promise_test: Unhandled rejection with value: "rgb(0, 0, 0) and rgb(0, 0, 0)"
+FAIL :only-child should match because ::view-transition-new is not generated (root to none) promise_test: Unhandled rejection with value: " and "
+FAIL :only-child should not match because ::view-transition-new is generated (root to root) promise_test: Unhandled rejection with value: " and "
+FAIL :only-child should not match because ::view-transition-new is generated (root to element) promise_test: Unhandled rejection with value: " and "
+FAIL :only-child should match because ::view-transition-new is not generated (element to none) promise_test: Unhandled rejection with value: " and "
+FAIL :only-child should not match because ::view-transition-new is generated (element to root) promise_test: Unhandled rejection with value: " and "
+FAIL :only-child should not match because ::view-transition-new is generated (element to element) promise_test: Unhandled rejection with value: " and "
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/style-inheritance-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/style-inheritance-expected.txt
@@ -1,6 +1,6 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_equals: group expected "rgb(255, 0, 0)" but got "rgba(0, 0, 0, 0)"
+CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_equals: group expected "rgb(255, 0, 0)" but got ""
 
-Harness Error (FAIL), message = Unhandled rejection: assert_equals: group expected "rgb(255, 0, 0)" but got "rgba(0, 0, 0, 0)"
+Harness Error (FAIL), message = Unhandled rejection: assert_equals: group expected "rgb(255, 0, 0)" but got ""
 
 PASS style inheritance of pseudo elements
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-pseudo-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-pseudo-expected.txt
@@ -1,7 +1,7 @@
 Item
 
 PASS Resolution of width is correct for ::before and ::after pseudo-elements
-FAIL Pseudo-elements can use the full range of CSS syntax assert_equals: expected "50px" but got "100px"
+FAIL Pseudo-elements can use the full range of CSS syntax assert_equals: expected "50px" but got ""
 PASS Resolution of width is correct for ::before and ::after pseudo-elements of display: contents elements
 PASS Resolution of nonexistent pseudo-element styles
 PASS Resolution of pseudo-element styles in display: none elements
@@ -9,17 +9,17 @@ PASS Item-based blockification of pseudo-elements
 FAIL Item-based blockification of nonexistent pseudo-elements assert_equals: Pseudo-styles of display: flex elements should get blockified expected "block" but got "inline"
 PASS display: contents on pseudo-elements
 PASS Dynamically change to display: contents on pseudo-elements
-FAIL Unknown pseudo-elements assert_true: Should return an empty style for unknown pseudo-elements starting with double-colon expected true got false
-FAIL Unknown pseudo-element with a known identifier: backdrop assert_true: Should return an empty style for :backdrop expected true got false
-FAIL Unknown pseudo-element with a known identifier: file-selector-button assert_true: Should return an empty style for :file-selector-button expected true got false
-FAIL Unknown pseudo-element with a known identifier: grammar-error assert_true: Should return an empty style for :grammar-error expected true got false
-FAIL Unknown pseudo-element with a known identifier: highlight(name) assert_true: Should return an empty style for :highlight(name) expected true got false
-FAIL Unknown pseudo-element with a known identifier: marker assert_true: Should return an empty style for :marker expected true got false
-FAIL Unknown pseudo-element with a known identifier: placeholder assert_true: Should return an empty style for :placeholder expected true got false
-FAIL Unknown pseudo-element with a known identifier: spelling-error assert_true: Should return an empty style for :spelling-error expected true got false
-FAIL Unknown pseudo-element with a known identifier: view-transition assert_true: Should return an empty style for :view-transition expected true got false
-FAIL Unknown pseudo-element with a known identifier: view-transition-image-pair(name) assert_true: Should return an empty style for :view-transition-image-pair(name) expected true got false
-FAIL Unknown pseudo-element with a known identifier: view-transition-group(name) assert_true: Should return an empty style for :view-transition-group(name) expected true got false
-FAIL Unknown pseudo-element with a known identifier: view-transition-old(name) assert_true: Should return an empty style for :view-transition-old(name) expected true got false
-FAIL Unknown pseudo-element with a known identifier: view-transition-new(name) assert_true: Should return an empty style for :view-transition-new(name) expected true got false
+PASS Unknown pseudo-elements
+PASS Unknown pseudo-element with a known identifier: backdrop
+FAIL Unknown pseudo-element with a known identifier: file-selector-button assert_equals: Should return the ::file-selector-button style expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+PASS Unknown pseudo-element with a known identifier: grammar-error
+FAIL Unknown pseudo-element with a known identifier: highlight(name) assert_equals: Should return the ::highlight(name) style expected "rgb(0, 128, 0)" but got ""
+PASS Unknown pseudo-element with a known identifier: marker
+FAIL Unknown pseudo-element with a known identifier: placeholder assert_equals: Should return the ::placeholder style expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+PASS Unknown pseudo-element with a known identifier: spelling-error
+PASS Unknown pseudo-element with a known identifier: view-transition
+FAIL Unknown pseudo-element with a known identifier: view-transition-image-pair(name) assert_equals: Should return the ::view-transition-image-pair(name) style expected "rgb(0, 128, 0)" but got ""
+FAIL Unknown pseudo-element with a known identifier: view-transition-group(name) assert_equals: Should return the ::view-transition-group(name) style expected "rgb(0, 128, 0)" but got ""
+FAIL Unknown pseudo-element with a known identifier: view-transition-old(name) assert_equals: Should return the ::view-transition-old(name) style expected "rgb(0, 128, 0)" but got ""
+FAIL Unknown pseudo-element with a known identifier: view-transition-new(name) assert_equals: Should return the ::view-transition-new(name) style expected "rgb(0, 128, 0)" but got ""
 

--- a/Source/WebCore/css/CSSComputedStyleDeclaration.h
+++ b/Source/WebCore/css/CSSComputedStyleDeclaration.h
@@ -36,7 +36,8 @@ class MutableStyleProperties;
 class CSSComputedStyleDeclaration final : public CSSStyleDeclaration, public RefCounted<CSSComputedStyleDeclaration> {
     WTF_MAKE_ISO_ALLOCATED_EXPORT(CSSComputedStyleDeclaration, WEBCORE_EXPORT);
 public:
-    WEBCORE_EXPORT static Ref<CSSComputedStyleDeclaration> create(Element&, bool allowVisitedStyle = false, StringView pseudoElementName = StringView { });
+    WEBCORE_EXPORT static Ref<CSSComputedStyleDeclaration> create(Element&, bool allowVisitedStyle);
+    static Ref<CSSComputedStyleDeclaration> create(Element&, std::optional<PseudoId>);
     WEBCORE_EXPORT virtual ~CSSComputedStyleDeclaration();
 
     void ref() final { RefCounted::ref(); }
@@ -45,7 +46,8 @@ public:
     String getPropertyValue(CSSPropertyID) const;
 
 private:
-    CSSComputedStyleDeclaration(Element&, bool allowVisitedStyle, StringView);
+    CSSComputedStyleDeclaration(Element&, bool allowVisitedStyle);
+    CSSComputedStyleDeclaration(Element&, std::optional<PseudoId>);
 
     // CSSOM functions. Don't make these public.
     CSSRule* parentRule() const final;
@@ -71,8 +73,8 @@ private:
     const FixedVector<CSSPropertyID>& exposedComputedCSSPropertyIDs() const;
 
     mutable Ref<Element> m_element;
-    PseudoId m_pseudoElementSpecifier;
-    bool m_allowVisitedStyle;
+    std::optional<PseudoId> m_pseudoElementSpecifier { PseudoId::None };
+    bool m_allowVisitedStyle { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -1656,7 +1656,11 @@ StyleMedia& LocalDOMWindow::styleMedia()
 
 Ref<CSSStyleDeclaration> LocalDOMWindow::getComputedStyle(Element& element, const String& pseudoElt) const
 {
-    return CSSComputedStyleDeclaration::create(element, false, pseudoElt);
+    std::optional<PseudoId> pseudoId = PseudoId::None;
+    // FIXME: This does not work for pseudo-elements that take arguments (webkit.org/b/264103).
+    if (pseudoElt.startsWith(":"_s))
+        pseudoId = CSSSelector::parseStandalonePseudoElement(pseudoElt, CSSSelectorParserContext { element.document() });
+    return CSSComputedStyleDeclaration::create(element, pseudoId);
 }
 
 RefPtr<CSSRuleList> LocalDOMWindow::getMatchedCSSRules(Element* element, const String& pseudoElement, bool authorOnly) const


### PR DESCRIPTION
#### 080d12dea41b1cb711e6e941f8e04b5a820b8a62
<pre>
Correct getComputedStyle() for invalid pseudo-elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=243539">https://bugs.webkit.org/show_bug.cgi?id=243539</a>
<a href="https://rdar.apple.com/98504661">rdar://98504661</a>

Reviewed by Tim Nguyen.

Give CSSComputedStyleDeclaration separate constructors for its distinct
callers. Then make CSSComputedStyleDeclaration account for invalid
pseudo-elements by allowing std::nullopt as value for
m_pseudoElementSpecifier. In this state CSSComputedStyleDeclaration
serves as an empty immutable CSSStyleDeclaration.

This appears to be the most straightforward way to create an empty
immutable CSSStyleDeclaration that is exposed to JavaScript in WebKit.
(Various other attempts were made in the creation of this patch, in
particular quite some time went into researching making
ImmutableStyleProperties have some of the features of
MutableStyleProperties.)

The pseudo-element parsing logic is moved to getComputedStyle() as it&apos;s
somewhat separate from the function of a CSSComputedStyleDeclaration.
This also matches the model of the specification better.

* LayoutTests/fast/css/getComputedStyle/getComputedStyle-with-pseudo-element-expected.txt:
* LayoutTests/fast/css/getComputedStyle/getComputedStyle-with-pseudo-element.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/highlight-pseudo-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-currentcolor-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-currentcolor-computed-inheritance-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-currentcolor-computed-visited-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-pseudos-inheritance-computed-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-pseudos-visited-computed-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/mix-blend-mode-only-on-transition-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/only-child-group-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/only-child-image-pair-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/only-child-new-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/only-child-old-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/style-inheritance-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-pseudo-expected.txt:
* Source/WebCore/css/CSSComputedStyleDeclaration.cpp:
(WebCore::CSSComputedStyleDeclaration::CSSComputedStyleDeclaration):
(WebCore::CSSComputedStyleDeclaration::create):
(WebCore::CSSComputedStyleDeclaration::getPropertyCSSValue const):
(WebCore::CSSComputedStyleDeclaration::copyProperties const):
(WebCore::CSSComputedStyleDeclaration::getPropertyValue const):
(WebCore::CSSComputedStyleDeclaration::length const):
(WebCore::CSSComputedStyleDeclaration::item const):
(WebCore::CSSComputedStyleDeclaration::getPropertyCSSValue):
(WebCore::CSSComputedStyleDeclaration::getPropertyValue):
* Source/WebCore/css/CSSComputedStyleDeclaration.h:
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::getComputedStyle const):

Canonical link: <a href="https://commits.webkit.org/272543@main">https://commits.webkit.org/272543@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98d6d565f6fad654fa85bb170a373544689baf78

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32027 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10738 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33803 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34561 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29022 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32848 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13096 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7968 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28609 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32417 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9069 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28625 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7861 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8035 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28540 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35905 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29131 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28995 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34140 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8140 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6106 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31998 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9779 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/28345 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7484 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8790 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8662 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->