### PR TITLE
getElementsByName() should only return HTML elements

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/document.getElementsByName/document.getElementsByName-namespace-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/document.getElementsByName/document.getElementsByName-namespace-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL getElementsByName and foreign namespaces assert_equals: expected 1 but got 2
+PASS getElementsByName and foreign namespaces
 a
 +
 b

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/document.getElementsByName/document.getElementsByName-namespace-xhtml-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/document.getElementsByName/document.getElementsByName-namespace-xhtml-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL getElementsByName and foreign namespaces assert_equals: expected 1 but got 2
+PASS getElementsByName and foreign namespaces
 a
 +
 b

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -47,7 +47,6 @@
 #include "LabelsNodeList.h"
 #include "LocalFrameView.h"
 #include "MutationEvent.h"
-#include "NameNodeList.h"
 #include "NodeRareData.h"
 #include "NodeRenderStyle.h"
 #include "RadioNodeList.h"
@@ -1022,11 +1021,6 @@ Ref<HTMLCollection> ContainerNode::getElementsByTagNameNS(const AtomString& name
 {
     ASSERT(!localName.isNull());
     return ensureRareData().ensureNodeLists().addCachedTagCollectionNS(*this, namespaceURI.isEmpty() ? nullAtom() : namespaceURI, localName);
-}
-
-Ref<NodeList> ContainerNode::getElementsByName(const AtomString& elementName)
-{
-    return ensureRareData().ensureNodeLists().addCacheWithAtomName<NameNodeList>(*this, elementName);
 }
 
 Ref<HTMLCollection> ContainerNode::getElementsByClassName(const AtomString& classNames)

--- a/Source/WebCore/dom/ContainerNode.h
+++ b/Source/WebCore/dom/ContainerNode.h
@@ -127,7 +127,6 @@ public:
 
     WEBCORE_EXPORT Ref<HTMLCollection> getElementsByTagName(const AtomString&);
     WEBCORE_EXPORT Ref<HTMLCollection> getElementsByTagNameNS(const AtomString& namespaceURI, const AtomString& localName);
-    WEBCORE_EXPORT Ref<NodeList> getElementsByName(const AtomString& elementName);
     WEBCORE_EXPORT Ref<HTMLCollection> getElementsByClassName(const AtomString& classNames);
     Ref<RadioNodeList> radioNodeList(const AtomString&);
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -6661,6 +6661,11 @@ Ref<HTMLCollection> Document::documentNamedItems(const AtomString& name)
     return ensureRareData().ensureNodeLists().addCachedCollection<DocumentNameCollection>(*this, CollectionType::DocumentNamedItems, name);
 }
 
+Ref<NodeList> Document::getElementsByName(const AtomString& elementName)
+{
+    return ensureRareData().ensureNodeLists().addCacheWithAtomName<NameNodeList>(*this, elementName);
+}
+
 void Document::finishedParsing()
 {
     ASSERT(!scriptableDocumentParser() || !m_parser->isParsing());

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -581,6 +581,8 @@ public:
     Ref<HTMLCollection> windowNamedItems(const AtomString&);
     Ref<HTMLCollection> documentNamedItems(const AtomString&);
 
+    WEBCORE_EXPORT Ref<NodeList> getElementsByName(const AtomString& elementName);
+
     WakeLockManager& wakeLockManager();
 
     // Other methods (not part of DOM)

--- a/Source/WebCore/dom/NameNodeList.cpp
+++ b/Source/WebCore/dom/NameNodeList.cpp
@@ -52,7 +52,7 @@ NameNodeList::~NameNodeList()
 
 bool NameNodeList::elementMatches(Element& element) const
 {
-    return element.getNameAttribute() == m_name;
+    return element.isHTMLElement() && element.getNameAttribute() == m_name;
 }
 
 } // namespace WebCore

--- a/Source/WebKitLegacy/mac/DOM/DOMDocument.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMDocument.mm
@@ -69,7 +69,6 @@
 #import <WebCore/HTMLScriptElement.h>
 #import <WebCore/JSExecState.h>
 #import <WebCore/LocalDOMWindow.h>
-#import <WebCore/NameNodeList.h>
 #import <WebCore/NativeNodeFilter.h>
 #import <WebCore/NodeIterator.h>
 #import <WebCore/NodeList.h>

--- a/Source/WebKitLegacy/mac/DOM/DOMElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMElement.mm
@@ -38,7 +38,6 @@
 #import <WebCore/HTMLCollection.h>
 #import <WebCore/HTMLNames.h>
 #import <WebCore/JSExecState.h>
-#import <WebCore/NameNodeList.h>
 #import <WebCore/NodeList.h>
 #import <WebCore/ScrollIntoViewOptions.h>
 #import <WebCore/StyleProperties.h>

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLButtonElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLButtonElement.mm
@@ -34,7 +34,6 @@
 #import <WebCore/HTMLFormElement.h>
 #import <WebCore/HTMLNames.h>
 #import <WebCore/JSExecState.h>
-#import <WebCore/NameNodeList.h>
 #import <WebCore/NodeList.h>
 #import <WebCore/ThreadCheck.h>
 #import <WebCore/WebScriptObjectPrivate.h>

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLCollection.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLCollection.mm
@@ -31,7 +31,6 @@
 #import "ExceptionHandlers.h"
 #import <WebCore/HTMLCollection.h>
 #import <WebCore/JSExecState.h>
-#import <WebCore/NameNodeList.h>
 #import <WebCore/Node.h>
 #import <WebCore/NodeList.h>
 #import <WebCore/ThreadCheck.h>

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLInputElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLInputElement.mm
@@ -61,7 +61,6 @@
 #import <WebCore/HTMLNames.h>
 #import <WebCore/HitTestResult.h>
 #import <WebCore/JSExecState.h>
-#import <WebCore/NameNodeList.h>
 #import <WebCore/NodeList.h>
 #import <WebCore/RenderElement.h>
 #import <WebCore/ThreadCheck.h>

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLSelectElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLSelectElement.mm
@@ -41,7 +41,6 @@
 #import <WebCore/HTMLOptionsCollection.h>
 #import <WebCore/HTMLSelectElement.h>
 #import <WebCore/JSExecState.h>
-#import <WebCore/NameNodeList.h>
 #import <WebCore/Node.h>
 #import <WebCore/NodeList.h>
 #import <WebCore/ThreadCheck.h>


### PR DESCRIPTION
#### 7883e9ca30c85590b7ac6f16a8b2bbec71fa9d51
<pre>
getElementsByName() should only return HTML elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=266894">https://bugs.webkit.org/show_bug.cgi?id=266894</a>

Reviewed by Simon Fraser.

Move getElementsByName() from ContainerNode to Document, make
NameNodeList only match HTML elements, and remove superfluous
NameNodeList.h includes.

This aligns us with the HTML Standard and Firefox, and generally cleans
up the code.

* LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/document.getElementsByName/document.getElementsByName-namespace-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/document.getElementsByName/document.getElementsByName-namespace-xhtml-expected.txt:
* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::ContainerNode::getElementsByName): Deleted.
* Source/WebCore/dom/ContainerNode.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::getElementsByName):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/NameNodeList.cpp:
(WebCore::NameNodeList::elementMatches const):
* Source/WebKitLegacy/mac/DOM/DOMDocument.mm:
* Source/WebKitLegacy/mac/DOM/DOMElement.mm:
* Source/WebKitLegacy/mac/DOM/DOMHTMLButtonElement.mm:
* Source/WebKitLegacy/mac/DOM/DOMHTMLCollection.mm:
* Source/WebKitLegacy/mac/DOM/DOMHTMLInputElement.mm:
* Source/WebKitLegacy/mac/DOM/DOMHTMLSelectElement.mm:

Canonical link: <a href="https://commits.webkit.org/272530@main">https://commits.webkit.org/272530@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4433d41219e9a608a8bae39e7e1d3903a9eae0c0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31952 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10650 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33705 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34466 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28948 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32755 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13014 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7887 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28543 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32322 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9008 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28555 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7793 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7974 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28468 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35810 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29070 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28922 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34073 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8058 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6044 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31932 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9703 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7477 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8720 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8581 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->