### PR TITLE
[WebGPU] unpack4x8unorm does not appear to be implemented

### DIFF
--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -1598,6 +1598,62 @@ static void emitBitcast(FunctionDefinitionWriter* writer, AST::CallExpression& c
     writer->stringBuilder().append(")");
 }
 
+static void emitPack2x16Float(FunctionDefinitionWriter* writer, AST::CallExpression& call)
+{
+    writer->stringBuilder().append("as_type<uint>(half2(");
+    writer->visit(call.arguments()[0]);
+    writer->stringBuilder().append("))");
+}
+
+static void emitUnpack2x16Float(FunctionDefinitionWriter* writer, AST::CallExpression& call)
+{
+    writer->stringBuilder().append("float2(as_type<half2>(");
+    writer->visit(call.arguments()[0]);
+    writer->stringBuilder().append("))");
+}
+
+static void emitPack4xI8(FunctionDefinitionWriter* writer, AST::CallExpression& call)
+{
+    writer->stringBuilder().append("as_type<uint>(char4(");
+    writer->visit(call.arguments()[0]);
+    writer->stringBuilder().append("))");
+}
+
+static void emitPack4xI8Clamp(FunctionDefinitionWriter* writer, AST::CallExpression& call)
+{
+    writer->stringBuilder().append("as_type<uint>(char4(clamp(");
+    writer->visit(call.arguments()[0]);
+    writer->stringBuilder().append(", -128, 127)))");
+}
+
+static void emitUnpack4xI8(FunctionDefinitionWriter* writer, AST::CallExpression& call)
+{
+    writer->stringBuilder().append("int4(as_type<char4>(");
+    writer->visit(call.arguments()[0]);
+    writer->stringBuilder().append("))");
+}
+
+static void emitPack4xU8(FunctionDefinitionWriter* writer, AST::CallExpression& call)
+{
+    writer->stringBuilder().append("as_type<uint>(uchar4(");
+    writer->visit(call.arguments()[0]);
+    writer->stringBuilder().append("))");
+}
+
+static void emitPack4xU8Clamp(FunctionDefinitionWriter* writer, AST::CallExpression& call)
+{
+    writer->stringBuilder().append("as_type<uint>(uchar4(min(");
+    writer->visit(call.arguments()[0]);
+    writer->stringBuilder().append(", 255)))");
+}
+
+static void emitUnpack4xU8(FunctionDefinitionWriter* writer, AST::CallExpression& call)
+{
+    writer->stringBuilder().append("uint4(as_type<uchar4>(");
+    writer->visit(call.arguments()[0]);
+    writer->stringBuilder().append("))");
+}
+
 void FunctionDefinitionWriter::visit(const Type* type, AST::CallExpression& call)
 {
     if (is<AST::ElaboratedTypeExpression>(call.target())) {
@@ -1650,6 +1706,11 @@ void FunctionDefinitionWriter::visit(const Type* type, AST::CallExpression& call
             { "atomicSub", emitAtomicSub },
             { "atomicXor", emitAtomicXor },
             { "distance", emitDistance },
+            { "pack2x16float", emitPack2x16Float },
+            { "pack4xI8", emitPack4xI8 },
+            { "pack4xI8Clamp", emitPack4xI8Clamp },
+            { "pack4xU8", emitPack4xU8 },
+            { "pack4xU8Clamp", emitPack4xU8Clamp },
             { "storageBarrier", emitStorageBarrier },
             { "textureDimensions", emitTextureDimensions },
             { "textureGather", emitTextureGather },
@@ -1666,6 +1727,9 @@ void FunctionDefinitionWriter::visit(const Type* type, AST::CallExpression& call
             { "textureSampleGrad", emitTextureSampleGrad },
             { "textureSampleLevel", emitTextureSampleLevel },
             { "textureStore", emitTextureStore },
+            { "unpack2x16float", emitUnpack2x16Float },
+            { "unpack4xI8", emitUnpack4xI8 },
+            { "unpack4xU8", emitUnpack4xU8 },
             { "workgroupBarrier", emitWorkgroupBarrier },
             { "workgroupUniformLoad", emitWorkgroupUniformLoad },
         };
@@ -1695,7 +1759,15 @@ void FunctionDefinitionWriter::visit(const Type* type, AST::CallExpression& call
             { "insertBits", "insert_bits"_s },
             { "inverseSqrt", "rsqrt"_s },
             { "modf", "__wgslModf"_s },
+            { "pack2x16snorm", "pack_float_to_snorm2x16"_s },
+            { "pack2x16unorm", "pack_float_to_unorm2x16"_s },
+            { "pack4x8snorm", "pack_float_to_snorm4x8"_s },
+            { "pack4x8unorm", "pack_float_to_unorm4x8"_s },
             { "reverseBits", "reverse_bits"_s },
+            { "unpack2x16snorm", "unpack_snorm2x16_to_float"_s },
+            { "unpack2x16unorm", "unpack_unorm2x16_to_float"_s },
+            { "unpack4x8snorm", "unpack_snorm4x8_to_float"_s },
+            { "unpack4x8unorm", "unpack_unorm4x8_to_float"_s },
         };
         static constexpr SortedArrayMap mappedNames { directMappings };
         if (call.isConstructor()) {

--- a/Source/WebGPU/WGSL/TypeDeclarations.rb
+++ b/Source/WebGPU/WGSL/TypeDeclarations.rb
@@ -1395,10 +1395,136 @@ function :atomicCompareExchangeWeak, {
 }
 
 # 16.9. Data Packing Built-in Functions (https://www.w3.org/TR/WGSL/#pack-builtin-functions)
-# FIXME: implement
+
+# 16.9.1
+function :pack4x8snorm, {
+    # @const @must_use fn pack4x8snorm(e: vec4<f32>) -> u32
+    const: true,
+    must_use: true,
+    [].(vec4[f32]) => u32,
+}
+
+# 16.9.2
+function :pack4x8unorm, {
+    # @const @must_use fn pack4x8unorm(e: vec4<f32>) -> u32
+    const: true,
+    must_use: true,
+    [].(vec4[f32]) => u32,
+}
+
+# 16.9.3
+function :pack4xI8, {
+    # @const @must_use fn pack4xI8(e: vec4<i32>) -> u32
+    const: true,
+    must_use: true,
+    [].(vec4[i32]) => u32,
+}
+
+# 16.9.4
+function :pack4xU8, {
+    # @const @must_use fn pack4xu8(e: vec4<i32>) -> u32
+    const: true,
+    must_use: true,
+    [].(vec4[u32]) => u32,
+}
+
+# 16.9.5
+function :pack4xI8Clamp, {
+    # @const @must_use fn pack4xI8Clamp(e: vec4<i32>) -> u32
+    const: true,
+    must_use: true,
+    [].(vec4[i32]) => u32,
+}
+
+# 16.9.6
+function :pack4xU8Clamp, {
+    # @const @must_use fn pack4xU8Clamp(e: vec4<i32>) -> u32
+    const: true,
+    must_use: true,
+    [].(vec4[u32]) => u32,
+}
+
+# 16.9.7
+function :pack2x16snorm, {
+    # @const @must_use fn pack2x16snorm(e: vec2<f32>) -> u32
+    const: true,
+    must_use: true,
+    [].(vec2[f32]) => u32,
+}
+
+# 16.9.8
+function :pack2x16unorm, {
+    # @const @must_use fn pack2x16unorm(e: vec2<f32>) -> u32
+    const: true,
+    must_use: true,
+    [].(vec2[f32]) => u32,
+}
+
+# 16.9.9
+function :pack2x16float, {
+    # @const @must_use fn pack2x16float(e: vec2<f32>) -> u32
+    const: true,
+    must_use: true,
+    [].(vec2[f32]) => u32,
+}
 
 # 16.10. Data Unpacking Built-in Functions (https://www.w3.org/TR/WGSL/#unpack-builtin-functions)
-# FIXME: implement
+
+# 16.10.1
+function :unpack4x8snorm, {
+    # @const @must_use fn unpack4x8snorm(e: u32) -> vec4<f32>
+    const: true,
+    must_use: true,
+    [].(u32) => vec4[f32],
+}
+
+# 16.10.2
+function :unpack4x8unorm, {
+    # @const @must_use fn unpack4x8unorm(e: u32) -> vec4<f32>
+    const: true,
+    must_use: true,
+    [].(u32) => vec4[f32],
+}
+
+# 16.10.3
+function :unpack4xI8, {
+    # @const @must_use fn unpack4xI8(e: u32) -> vec4<i32>
+    const: true,
+    must_use: true,
+    [].(u32) => vec4[i32],
+}
+
+# 16.10.4
+function :unpack4xU8, {
+    # @const @must_use fn unpack4xU8(e: u32) -> vec4<u32>
+    const: true,
+    must_use: true,
+    [].(u32) => vec4[u32],
+}
+
+# 16.10.5
+function :unpack2x16snorm, {
+    # @const @must_use fn unpack2x16snorm(e: u32) -> vec2<f32>
+    const: true,
+    must_use: true,
+    [].(u32) => vec2[f32],
+}
+
+# 16.10.6
+function :unpack2x16unorm, {
+    # @const @must_use fn unpack2x16unorm(e: u32) -> vec2<f32>
+    const: true,
+    must_use: true,
+    [].(u32) => vec2[f32],
+}
+
+# 16.10.7
+function :unpack2x16float, {
+    # @const @must_use fn unpack2x16float(e: u32) -> vec2<f32>
+    const: true,
+    must_use: true,
+    [].(u32) => vec2[f32],
+}
 
 # 16.11. Synchronization Built-in Functions (https://www.w3.org/TR/WGSL/#sync-builtin-functions)
 

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -3569,10 +3569,57 @@ fn testAtomicReadWriteModify()
 }
 
 // 16.9. Data Packing Built-in Functions (https://www.w3.org/TR/WGSL/#pack-builtin-functions)
-// FIXME: implement
+// RUN: %metal-compile testDataPackingFunction
+@compute @workgroup_size(1)
+fn testDataPackingFunctions()
+{
+    { let x = pack4x8snorm(vec4f(0)); }
+    { let x = pack4x8unorm(vec4f(0)); }
+    { let x = pack4xI8(vec4i(0)); }
+    { let x = pack4xU8(vec4u(0)); }
+    { let x = pack4xI8Clamp(vec4i(0)); }
+    { let x = pack4xU8Clamp(vec4u(0)); }
+    { let x = pack2x16snorm(vec2f(0)); }
+    { let x = pack2x16unorm(vec2f(0)); }
+    { let x = pack2x16float(vec2f(0)); }
+
+    let v2f = vec2f(0);
+    let v4f = vec4f(0);
+    let v4i = vec4i(0);
+    let v4u = vec4u(0);
+    { let x = pack4x8snorm(v4f); }
+    { let x = pack4x8unorm(v4f); }
+    { let x = pack4xI8(v4i); }
+    { let x = pack4xU8(v4u); }
+    { let x = pack4xI8Clamp(v4i); }
+    { let x = pack4xU8Clamp(v4u); }
+    { let x = pack2x16snorm(v2f); }
+    { let x = pack2x16unorm(v2f); }
+    { let x = pack2x16float(v2f); }
+}
 
 // 16.10. Data Unpacking Built-in Functions (https://www.w3.org/TR/WGSL/#unpack-builtin-functions)
-// FIXME: implement
+// RUN: %metal-compile testDataUnpackingFunction
+@compute @workgroup_size(1)
+fn testDataUnpackingFunction()
+{
+    { let x = unpack4x8snorm(0); }
+    { let x = unpack4x8unorm(0); }
+    { let x = unpack4xI8(0); }
+    { let x = unpack4xU8(0); }
+    { let x = unpack2x16snorm(0); }
+    { let x = unpack2x16unorm(0); }
+    { let x = unpack2x16float(0); }
+
+    let u = 0u;
+    { let x = unpack4x8snorm(u); }
+    { let x = unpack4x8unorm(u); }
+    { let x = unpack4xI8(u); }
+    { let x = unpack4xU8(u); }
+    { let x = unpack2x16snorm(u); }
+    { let x = unpack2x16unorm(u); }
+    { let x = unpack2x16float(u); }
+}
 
 // 16.11. Synchronization Built-in Functions (https://www.w3.org/TR/WGSL/#sync-builtin-functions)
 

--- a/Source/WebGPU/WGSL/tests/valid/pack-unpack.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/pack-unpack.wgsl
@@ -1,0 +1,32 @@
+// RUN: %metal-compile main 2>&1| %check
+
+@compute @workgroup_size(1)
+fn main()
+{
+    // CHECK: 1., 0.50\d*, -0.49\d*, -1.
+    { let x = unpack4x8snorm(pack4x8snorm(vec4f(1.0, 0.5, -0.5, -1))); }
+
+    // CHECK: 1., 0.50\d*, 0.25\d*, 0.
+    { let x = unpack4x8unorm(pack4x8unorm(vec4f(1.0, 0.5, 0.25, 0))); }
+
+    // CHECK: -128, 127, -128, 127
+    { let x = unpack4xI8(pack4xI8(vec4i(128, 127, -128, -129))); }
+
+    // CHECK: 0u, 255u, 128u, 64u
+    { let x = unpack4xU8(pack4xU8(vec4u(256, 255, 128, 64))); }
+
+    // CHECK: 127, 127, -128, -128
+    { let x = unpack4xI8(pack4xI8Clamp(vec4i(128, 127, -128, -129))); }
+
+    // CHECK: 255u, 255u, 128u, 64u
+    { let x = unpack4xU8(pack4xU8Clamp(vec4u(256, 255, 128, 64))); }
+
+    // CHECK: 0.50\d*, -0.49\d*
+    { let x = unpack2x16snorm(pack2x16snorm(vec2f(0.5, -0.5))); }
+
+    // CHECK: 0.50\d*, 0.
+    { let x = unpack2x16unorm(pack2x16unorm(vec2f(0.5, -0.5))); }
+
+    // CHECK: 0.5, -0.5
+    { let x = unpack2x16float(pack2x16float(vec2f(0.5, -0.5))); }
+}


### PR DESCRIPTION
#### 41341242c718622e4e3b1970cb19197f2af39bfc
<pre>
[WebGPU] unpack4x8unorm does not appear to be implemented
<a href="https://bugs.webkit.org/show_bug.cgi?id=266871">https://bugs.webkit.org/show_bug.cgi?id=266871</a>
<a href="https://rdar.apple.com/120107356">rdar://120107356</a>

Reviewed by Mike Wyrzykowski.

Implement data packing[1] and unpacking[2] built-in functions.

[1]. <a href="https://www.w3.org/TR/WGSL/#pack-builtin-functions">https://www.w3.org/TR/WGSL/#pack-builtin-functions</a>
[2]. <a href="https://www.w3.org/TR/WGSL/#unpack-builtin-functions">https://www.w3.org/TR/WGSL/#unpack-builtin-functions</a>

* Source/WebGPU/WGSL/ConstantFunctions.h:
(WGSL::CONSTANT_FUNCTION):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::emitPack2x16Float):
(WGSL::Metal::emitUnpack2x16Float):
(WGSL::Metal::emitPack4xI8):
(WGSL::Metal::emitPack4xI8Clamp):
(WGSL::Metal::emitUnpack4xI8):
(WGSL::Metal::emitPack4xU8):
(WGSL::Metal::emitPack4xU8Clamp):
(WGSL::Metal::emitUnpack4xU8):
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/TypeDeclarations.rb:
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:
* Source/WebGPU/WGSL/tests/valid/pack-unpack.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/272528@main">https://commits.webkit.org/272528@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ced4c5c771e6cd9a371da7eb29098d389c0974ff

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31956 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10655 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33711 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34471 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28952 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13018 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7891 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28547 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32327 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9011 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28560 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7797 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7977 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35815 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29073 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28927 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34077 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8063 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6048 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31936 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9707 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7476 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8724 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8586 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->