### PR TITLE
The encoding argument to PAL::decodeURLEscapeSequencesAsData is unnecessary

### DIFF
--- a/Source/WebCore/PAL/pal/text/DecodeEscapeSequences.h
+++ b/Source/WebCore/PAL/pal/text/DecodeEscapeSequences.h
@@ -154,10 +154,8 @@ String decodeEscapeSequences(StringView string, const TextEncoding& encoding)
     return result.toString();
 }
 
-inline Vector<uint8_t> decodeURLEscapeSequencesAsData(StringView string, const TextEncoding& encoding)
+inline Vector<uint8_t> decodeURLEscapeSequencesAsData(StringView string)
 {
-    ASSERT(encoding.isValid());
-
     Vector<uint8_t> result;
     size_t decodedPosition = 0;
     size_t searchPosition = 0;
@@ -174,7 +172,7 @@ inline Vector<uint8_t> decodeURLEscapeSequencesAsData(StringView string, const T
         }
 
         // Strings are encoded as requested.
-        result.appendVector(encoding.encode(string.substring(decodedPosition, encodedRunPosition - decodedPosition), PAL::UnencodableHandling::URLEncodedEntities));
+        result.appendVector(PAL::UTF8Encoding().encodeForURLParsing(string.substring(decodedPosition, encodedRunPosition - decodedPosition)));
 
         if (encodedRunPosition == notFound)
             return result;

--- a/Source/WebCore/platform/network/DataURLDecoder.cpp
+++ b/Source/WebCore/platform/network/DataURLDecoder.cpp
@@ -150,13 +150,6 @@ static std::unique_ptr<DecodeTask> createDecodeTask(const URL& url, const Schedu
     );
 }
 
-static Vector<uint8_t> decodeEscaped(const DecodeTask& task)
-{
-    PAL::TextEncoding encodingFromCharset(task.result.charset);
-    auto& encoding = encodingFromCharset.isValid() ? encodingFromCharset : PAL::UTF8Encoding();
-    return PAL::decodeURLEscapeSequencesAsData(task.encodedData, encoding);
-}
-
 static std::optional<Result> decodeSynchronously(DecodeTask& task)
 {
     if (!task.process())
@@ -169,7 +162,7 @@ static std::optional<Result> decodeSynchronously(DecodeTask& task)
             return std::nullopt;
         task.result.data = WTFMove(*decodedData);
     } else
-        task.result.data = decodeEscaped(task);
+        task.result.data = PAL::decodeURLEscapeSequencesAsData(task.encodedData);
 
     task.result.data.shrinkToFit();
     return WTFMove(task.result);


### PR DESCRIPTION
#### 7e4ae6913e3e45bd2a6016d165b9fa73af23e9e2
<pre>
The encoding argument to PAL::decodeURLEscapeSequencesAsData is unnecessary
<a href="https://bugs.webkit.org/show_bug.cgi?id=235308">https://bugs.webkit.org/show_bug.cgi?id=235308</a>
<a href="https://rdar.apple.com/88000173">rdar://88000173</a>

Reviewed by Alex Christensen.

As the input is a serialized URL, it cannot contain non-ASCII. This
does not remove result.charset as that appears bound to
ResourceResponse.

* Source/WebCore/PAL/pal/text/DecodeEscapeSequences.h:
(PAL::decodeURLEscapeSequencesAsData):
* Source/WebCore/platform/network/DataURLDecoder.cpp:
(WebCore::DataURLDecoder::decodeSynchronously):
(WebCore::DataURLDecoder::decodeEscaped): Deleted.

Canonical link: <a href="https://commits.webkit.org/272569@main">https://commits.webkit.org/272569@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/956418b571371d9c39f95186f643b23f844a003c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31970 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10670 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33728 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34488 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28968 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32776 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13033 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7907 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28564 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32344 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9027 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28577 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7815 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7994 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28495 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35832 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29089 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28944 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34094 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8078 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6064 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31953 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9722 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7508 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8738 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8602 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->