### PR TITLE
Remove <param> element behavior

### DIFF
--- a/LayoutTests/http/tests/security/contentSecurityPolicy/object-src-param-src-blocked2-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/object-src-param-src-blocked2-expected.txt
@@ -1,2 +1,2 @@
-CONSOLE MESSAGE: Refused to load http://127.0.0.1:8000/security/contentSecurityPolicy/resources/alert-fail.html because it does not appear in the object-src directive of the Content Security Policy.
+CONSOLE MESSAGE: Refused to load because it does not appear in the object-src directive of the Content Security Policy.
 

--- a/Source/WebCore/html/HTMLObjectElement.cpp
+++ b/Source/WebCore/html/HTMLObjectElement.cpp
@@ -156,58 +156,16 @@ static void mapDataParamToSrc(Vector<AtomString>& paramNames, Vector<AtomString>
     }
 }
 
-// FIXME: This function should not deal with url or serviceType!
-void HTMLObjectElement::parametersForPlugin(Vector<AtomString>& paramNames, Vector<AtomString>& paramValues, String& url, String& serviceType)
+void HTMLObjectElement::parametersForPlugin(Vector<AtomString>& paramNames, Vector<AtomString>& paramValues)
 {
-    HashSet<StringImpl*, ASCIICaseInsensitiveHash> uniqueParamNames;
-    String urlParameter;
-
-    // Scan the PARAM children and store their name/value pairs.
-    // Get the URL and type from the params if we don't already have them.
-    for (auto& param : childrenOfType<HTMLParamElement>(*this)) {
-        String name = param.name();
-        if (name.isEmpty())
-            continue;
-
-        uniqueParamNames.add(name.impl());
-        paramNames.append(param.name());
-        paramValues.append(param.value());
-
-        // FIXME: url adjustment does not belong in this function.
-        if (url.isEmpty() && urlParameter.isEmpty() && (equalLettersIgnoringASCIICase(name, "src"_s) || equalLettersIgnoringASCIICase(name, "movie"_s) || equalLettersIgnoringASCIICase(name, "code"_s) || equalLettersIgnoringASCIICase(name, "url"_s)))
-            urlParameter = param.value().string().trim(isASCIIWhitespace);
-        // FIXME: serviceType calculation does not belong in this function.
-        if (serviceType.isEmpty() && equalLettersIgnoringASCIICase(name, "type"_s)) {
-            serviceType = param.value();
-            size_t pos = serviceType.find(';');
-            if (pos != notFound)
-                serviceType = serviceType.left(pos);
-        }
-    }
-
-    // Turn the attributes of the <object> element into arrays, but don't override <param> values.
     if (hasAttributes()) {
         for (const Attribute& attribute : attributesIterator()) {
-            const AtomString& name = attribute.name().localName();
-            if (!uniqueParamNames.contains(name.impl())) {
-                paramNames.append(name);
-                paramValues.append(attribute.value());
-            }
+            paramNames.append(attribute.name().localName());
+            paramValues.append(attribute.value());
         }
     }
 
     mapDataParamToSrc(paramNames, paramValues);
-
-    // HTML5 says that an object resource's URL is specified by the object's data
-    // attribute, not by a param element. However, for compatibility, allow the
-    // resource's URL to be given by a param named "src", "movie", "code" or "url"
-    // if we know that resource points to a plug-in.
-
-    if (url.isEmpty() && !urlParameter.isEmpty()) {
-        auto& loader = document().frame()->loader().subframeLoader();
-        if (loader.resourceWillUsePlugin(urlParameter, serviceType))
-            url = urlParameter;
-    }
 }
 
 bool HTMLObjectElement::hasFallbackContent() const
@@ -244,15 +202,12 @@ void HTMLObjectElement::updateWidget(CreatePlugins createPlugins)
         return;
     }
 
-    String url = this->url();
-    String serviceType = this->serviceType();
-
     // FIXME: These should be joined into a PluginParameters class.
     Vector<AtomString> paramNames;
     Vector<AtomString> paramValues;
-    parametersForPlugin(paramNames, paramValues, url, serviceType);
+    parametersForPlugin(paramNames, paramValues);
 
-    // Note: url is modified above by parametersForPlugin.
+    auto url = this->url();
     if (!canLoadURL(url)) {
         setNeedsWidgetUpdate(false);
         return;
@@ -260,6 +215,7 @@ void HTMLObjectElement::updateWidget(CreatePlugins createPlugins)
 
     // FIXME: It's unfortunate that we have this special case here.
     // See http://trac.webkit.org/changeset/25128 and the plugins/netscape-plugin-setwindow-size.html test.
+    auto serviceType = this->serviceType();
     if (createPlugins == CreatePlugins::No && wouldLoadAsPlugIn(url, serviceType))
         return;
 

--- a/Source/WebCore/html/HTMLObjectElement.h
+++ b/Source/WebCore/html/HTMLObjectElement.h
@@ -76,9 +76,8 @@ private:
     void updateWidget(CreatePlugins) final;
     void updateExposedState();
 
-    // FIXME: This function should not deal with url or serviceType
-    // so that we can better share code between <object> and <embed>.
-    void parametersForPlugin(Vector<AtomString>& paramNames, Vector<AtomString>& paramValues, String& url, String& serviceType);
+    // FIXME: Better share code between <object> and <embed>.
+    void parametersForPlugin(Vector<AtomString>& paramNames, Vector<AtomString>& paramValues);
 
     void refFormAssociatedElement() const final { ref(); }
     void derefFormAssociatedElement() const final { deref(); }

--- a/Source/WebCore/html/HTMLParamElement.cpp
+++ b/Source/WebCore/html/HTMLParamElement.cpp
@@ -23,8 +23,6 @@
 #include "config.h"
 #include "HTMLParamElement.h"
 
-#include "Document.h"
-#include "ElementInlines.h"
 #include "HTMLNames.h"
 #include <wtf/IsoMallocInlines.h>
 
@@ -43,40 +41,6 @@ inline HTMLParamElement::HTMLParamElement(const QualifiedName& tagName, Document
 Ref<HTMLParamElement> HTMLParamElement::create(const QualifiedName& tagName, Document& document)
 {
     return adoptRef(*new HTMLParamElement(tagName, document));
-}
-
-AtomString HTMLParamElement::name() const
-{
-    if (hasName())
-        return getNameAttribute();
-    return document().isHTMLDocument() ? emptyAtom() : getIdAttribute();
-}
-
-AtomString HTMLParamElement::value() const
-{
-    return attributeWithoutSynchronization(valueAttr);
-}
-
-bool HTMLParamElement::isURLParameter(const String& name)
-{
-    return equalLettersIgnoringASCIICase(name, "data"_s) || equalLettersIgnoringASCIICase(name, "movie"_s) || equalLettersIgnoringASCIICase(name, "src"_s);
-}
-
-bool HTMLParamElement::isURLAttribute(const Attribute& attribute) const
-{
-    if (attribute.name() == valueAttr && isURLParameter(name()))
-        return true;
-    return HTMLElement::isURLAttribute(attribute);
-}
-
-void HTMLParamElement::addSubresourceAttributeURLs(ListHashSet<URL>& urls) const
-{
-    HTMLElement::addSubresourceAttributeURLs(urls);
-
-    if (!isURLParameter(name()))
-        return;
-
-    addSubresourceURL(urls, document().completeURL(value()));
 }
 
 }

--- a/Source/WebCore/html/HTMLParamElement.h
+++ b/Source/WebCore/html/HTMLParamElement.h
@@ -31,16 +31,8 @@ class HTMLParamElement final : public HTMLElement {
 public:
     static Ref<HTMLParamElement> create(const QualifiedName&, Document&);
 
-    AtomString name() const;
-    AtomString value() const;
-
-    static bool isURLParameter(const String&);
-
 private:
     HTMLParamElement(const QualifiedName&, Document&);
-
-    bool isURLAttribute(const Attribute&) const final;
-    void addSubresourceAttributeURLs(ListHashSet<URL>&) const final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLParamElement.idl
+++ b/Source/WebCore/html/HTMLParamElement.idl
@@ -25,4 +25,3 @@
     [CEReactions=NotNeeded, Reflect] attribute DOMString value;
     [CEReactions=NotNeeded, Reflect] attribute DOMString valueType;
 };
-


### PR DESCRIPTION
#### acfd1f38e4e75a35df0f9f801e03736bdf38f1b4
<pre>
Remove &lt;param&gt; element behavior
<a href="https://bugs.webkit.org/show_bug.cgi?id=239188">https://bugs.webkit.org/show_bug.cgi?id=239188</a>
<a href="https://rdar.apple.com/91983957">rdar://91983957</a>

Reviewed by Alex Christensen.

This has been removed from the HTML Standard and other browsers.

* LayoutTests/http/tests/security/contentSecurityPolicy/object-src-param-src-blocked2-expected.txt:
* Source/WebCore/html/HTMLObjectElement.cpp:
(WebCore::HTMLObjectElement::parametersForPlugin):
(WebCore::HTMLObjectElement::updateWidget):
* Source/WebCore/html/HTMLObjectElement.h:
* Source/WebCore/html/HTMLParamElement.cpp:
(WebCore::HTMLParamElement::name const): Deleted.
(WebCore::HTMLParamElement::value const): Deleted.
(WebCore::HTMLParamElement::isURLParameter): Deleted.
(WebCore::HTMLParamElement::isURLAttribute const): Deleted.
(WebCore::HTMLParamElement::addSubresourceAttributeURLs const): Deleted.
* Source/WebCore/html/HTMLParamElement.h:
* Source/WebCore/html/HTMLParamElement.idl:

Canonical link: <a href="https://commits.webkit.org/272734@main">https://commits.webkit.org/272734@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f50962847be96bef49a7dc7fc21b8732f743ee2e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31977 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10677 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33736 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34496 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28975 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32784 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13040 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7914 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28572 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32352 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9032 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28585 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7823 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7999 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28499 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35840 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29094 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28953 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34103 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8086 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6071 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31961 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9730 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7628 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8745 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8610 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->