### PR TITLE
Source/JavaScriptCore/wasm/generateWasm.py: return value in int for memorybits

### DIFF
--- a/Source/JavaScriptCore/wasm/generateWasm.py
+++ b/Source/JavaScriptCore/wasm/generateWasm.py
@@ -136,5 +136,5 @@ def memoryLog2Alignment(op):
         if not match:
             print(op["name"])
         memoryBits = int(match.group(2) if match.group(2) else match.group(1))
-    assert 2 ** math.log(memoryBits, 2) == memoryBits
+    assert 2 ** int(math.log(memoryBits, 2)) == memoryBits
     return str(int(math.log(memoryBits / 8, 2)))


### PR DESCRIPTION
#### 509b303bf5650710bee5e151decc1a723a54657f
<pre>
Source/JavaScriptCore/wasm/generateWasm.py: return value in int for memorybits

<a href="https://bugs.webkit.org/show_bug.cgi?id=266942">https://bugs.webkit.org/show_bug.cgi?id=266942</a>

Reviewed by Justin Michaud.

The assert function currently checks, if power number raised to the
number fits memorybits. This seems not always work on every system,
as it happens, that the float numbers are not correctly rounded.

This patch adds an int, so its being rounded to a full number and works
on my system, where otherwise the rounding would fail. The return method
also returns the result as an int.

Example:
import math

2 ** 3
= 8

2.0 ** 3.0
= 7.999999999999999

int(2.0) ** int(3.0)
= 8

2 ** int(3.0)
= 8

Signed-off-by: Conrad Kostecki &lt;conikost@gentoo.org&gt;
Canonical link: <a href="https://commits.webkit.org/272577@main">https://commits.webkit.org/272577@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fce6680af64124d076b3965f07ecee24ec31b6a1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32002 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10704 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33765 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34524 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29000 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13066 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7940 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28597 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32380 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9057 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28614 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7849 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8023 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28529 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35868 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/27485 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29119 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28983 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34129 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/32077 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8114 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6098 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31987 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9758 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/38512 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7514 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8770 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8172 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8637 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->