### PR TITLE
::-apple-attachment-controls-container should be gated behind ImageControlsEnabled

### DIFF
--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -323,8 +323,7 @@ std::optional<CSSSelector::PseudoElement> CSSSelector::parsePseudoElement(String
 
     auto type = parsePseudoElementString(name);
     if (!type) {
-        // FIXME: Investigate removing -apple- as it's non-standard.
-        if (name.startsWithIgnoringASCIICase("-webkit-"_s) || name.startsWithIgnoringASCIICase("-apple-"_s))
+        if (name.startsWithIgnoringASCIICase("-webkit-"_s))
             return PseudoElement::WebKitCustom;
         return type;
     }
@@ -333,6 +332,10 @@ std::optional<CSSSelector::PseudoElement> CSSSelector::parsePseudoElement(String
     case PseudoElement::WebKitCustom:
         if (!context.thumbAndTrackPseudoElementsEnabled && (equalLettersIgnoringASCIICase(name, "thumb"_s) || equalLettersIgnoringASCIICase(name, "track"_s)))
             return std::nullopt;
+#if ENABLE(SERVICE_CONTROLS)
+        if (!context.imageControlsEnabled && equalLettersIgnoringASCIICase(name, "-apple-attachment-controls-container"_s))
+            return std::nullopt;
+#endif
         break;
     case PseudoElement::Highlight:
         if (!context.highlightAPIEnabled)

--- a/Source/WebCore/css/SelectorPseudoElementMap.in
+++ b/Source/WebCore/css/SelectorPseudoElementMap.in
@@ -1,3 +1,6 @@
+#if ENABLE(SERVICE_CONTROLS)
+-apple-attachment-controls-container, PseudoElement::WebKitCustom
+#endif
 after
 backdrop
 before

--- a/Source/WebCore/css/makeSelectorPseudoElementsMap.py
+++ b/Source/WebCore/css/makeSelectorPseudoElementsMap.py
@@ -31,16 +31,9 @@ import subprocess
 def enumerablePseudoType(stringPseudoType):
     output = ['CSSSelector::PseudoElement::']
 
-    if stringPseudoType.endswith('('):
-        stringPseudoType = stringPseudoType[:-1]
-
     webkitPrefix = '-webkit-'
     if (stringPseudoType.startswith(webkitPrefix)):
         stringPseudoType = stringPseudoType[len(webkitPrefix):]
-
-    khtmlPrefix = '-khtml-'
-    if (stringPseudoType.startswith(khtmlPrefix)):
-        stringPseudoType = stringPseudoType[len(khtmlPrefix):]
 
     substring_start = 0
     next_dash_position = stringPseudoType.find('-')

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -109,6 +109,9 @@ CSSParserContext::CSSParserContext(const Document& document, const URL& sheetBas
     , grammarAndSpellingPseudoElementsEnabled { document.settings().grammarAndSpellingPseudoElementsEnabled() }
     , customStateSetEnabled { document.settings().customStateSetEnabled() }
     , thumbAndTrackPseudoElementsEnabled { document.settings().thumbAndTrackPseudoElementsEnabled() }
+#if ENABLE(SERVICE_CONTROLS)
+    , imageControlsEnabled { document.settings().imageControlsEnabled() }
+#endif
     , propertySettings { CSSPropertySettings { document.settings() } }
 {
 }
@@ -147,7 +150,10 @@ void add(Hasher& hasher, const CSSParserContext& context)
         | context.grammarAndSpellingPseudoElementsEnabled   << 27
         | context.customStateSetEnabled                     << 28
         | context.thumbAndTrackPseudoElementsEnabled        << 29
-        | (uint64_t)context.mode                            << 30; // This is multiple bits, so keep it last.
+#if ENABLE(SERVICE_CONTROLS)
+        | context.imageControlsEnabled                      << 30
+#endif
+        | (uint64_t)context.mode                            << 31; // This is multiple bits, so keep it last.
     add(hasher, context.baseURL, context.charset, context.propertySettings, bits);
 }
 

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -101,6 +101,9 @@ struct CSSParserContext {
     bool grammarAndSpellingPseudoElementsEnabled : 1 { false };
     bool customStateSetEnabled : 1 { false };
     bool thumbAndTrackPseudoElementsEnabled : 1 { false };
+#if ENABLE(SERVICE_CONTROLS)
+    bool imageControlsEnabled : 1 { false };
+#endif
 
     // Settings, those affecting properties.
     CSSPropertySettings propertySettings;

--- a/Source/WebCore/css/parser/CSSSelectorParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParserContext.cpp
@@ -40,6 +40,9 @@ CSSSelectorParserContext::CSSSelectorParserContext(const CSSParserContext& conte
     , grammarAndSpellingPseudoElementsEnabled(context.grammarAndSpellingPseudoElementsEnabled)
     , hasPseudoClassEnabled(context.hasPseudoClassEnabled)
     , highlightAPIEnabled(context.highlightAPIEnabled)
+#if ENABLE(SERVICE_CONTROLS)
+    , imageControlsEnabled(context.imageControlsEnabled)
+#endif
     , popoverAttributeEnabled(context.popoverAttributeEnabled)
     , thumbAndTrackPseudoElementsEnabled(context.thumbAndTrackPseudoElementsEnabled)
     , viewTransitionsEnabled(context.propertySettings.viewTransitionsEnabled)
@@ -54,6 +57,9 @@ CSSSelectorParserContext::CSSSelectorParserContext(const Document& document)
     , grammarAndSpellingPseudoElementsEnabled(document.settings().grammarAndSpellingPseudoElementsEnabled())
     , hasPseudoClassEnabled(document.settings().hasPseudoClassEnabled())
     , highlightAPIEnabled(document.settings().highlightAPIEnabled())
+#if ENABLE(SERVICE_CONTROLS)
+    , imageControlsEnabled(document.settings().imageControlsEnabled())
+#endif
     , popoverAttributeEnabled(document.settings().popoverAttributeEnabled())
     , thumbAndTrackPseudoElementsEnabled(document.settings().thumbAndTrackPseudoElementsEnabled())
     , viewTransitionsEnabled(document.settings().viewTransitionsEnabled())
@@ -70,6 +76,9 @@ void add(Hasher& hasher, const CSSSelectorParserContext& context)
         context.grammarAndSpellingPseudoElementsEnabled,
         context.hasPseudoClassEnabled,
         context.highlightAPIEnabled,
+#if ENABLE(SERVICE_CONTROLS)
+        context.imageControlsEnabled,
+#endif
         context.popoverAttributeEnabled,
         context.thumbAndTrackPseudoElementsEnabled,
         context.viewTransitionsEnabled

--- a/Source/WebCore/css/parser/CSSSelectorParserContext.h
+++ b/Source/WebCore/css/parser/CSSSelectorParserContext.h
@@ -42,6 +42,9 @@ struct CSSSelectorParserContext {
     bool grammarAndSpellingPseudoElementsEnabled { false };
     bool hasPseudoClassEnabled { false };
     bool highlightAPIEnabled { false };
+#if ENABLE(SERVICE_CONTROLS)
+    bool imageControlsEnabled { false };
+#endif
     bool popoverAttributeEnabled { false };
     bool thumbAndTrackPseudoElementsEnabled { false };
     bool viewTransitionsEnabled { false };


### PR DESCRIPTION
#### 2b997ee28d1cc967b8dd04e5c453adf94ef1ba71
<pre>
::-apple-attachment-controls-container should be gated behind ImageControlsEnabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=266810">https://bugs.webkit.org/show_bug.cgi?id=266810</a>
<a href="https://rdar.apple.com/120268884">rdar://120268884</a>

Reviewed by Tim Nguyen.

As ::-apple-attachment-controls-container is the sole -apple-prefixed
pseudo-element and only used for an unstable feature we stop treating
all -apple-prefixed pseudo-elements as valid and instead special case
this specific one and preference gate it.

The impact on web developers is that they can no longer rely on
-apple-prefixed pseudo-elements to be valid in WebKit-based browsers.

Additionally remove some no-op code in the related Python script.

* Source/WebCore/css/CSSSelector.cpp:
(WebCore::CSSSelector::parsePseudoElement):
* Source/WebCore/css/SelectorPseudoElementMap.in:
* Source/WebCore/css/makeSelectorPseudoElementsMap.py:
(enumerablePseudoType):
* Source/WebCore/css/parser/CSSParserContext.cpp:
(WebCore::add):
* Source/WebCore/css/parser/CSSParserContext.h:
* Source/WebCore/css/parser/CSSSelectorParserContext.cpp:
(WebCore::CSSSelectorParserContext::CSSSelectorParserContext):
(WebCore::add):
* Source/WebCore/css/parser/CSSSelectorParserContext.h:

Canonical link: <a href="https://commits.webkit.org/272538@main">https://commits.webkit.org/272538@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd9f8e24262f55c2b8f60dd90e845174788fc2b0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32006 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10710 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33771 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34530 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29004 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32818 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13072 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7944 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/28606 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32386 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/9065 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28621 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7858 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8031 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/28536 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35874 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29127 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28990 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/34137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8120 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6102 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/31995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9764 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8774 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4163 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8643 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->