### PR TITLE
Make pseudo attribute values of DateTimeFieldElements proper ShadowPseudoIds

### DIFF
--- a/Source/WebCore/html/shadow/DateTimeFieldElement.cpp
+++ b/Source/WebCore/html/shadow/DateTimeFieldElement.cpp
@@ -58,11 +58,6 @@ DateTimeFieldElement::DateTimeFieldElement(Document& document, FieldOwner& field
 {
 }
 
-void DateTimeFieldElement::initialize(const AtomString& pseudo)
-{
-    setPseudo(pseudo);
-}
-
 std::optional<Style::ResolvedStyle> DateTimeFieldElement::resolveCustomStyle(const Style::ResolutionContext& resolutionContext, const RenderStyle* shadowHostStyle)
 {
     auto elementStyle = resolveStyle(resolutionContext);

--- a/Source/WebCore/html/shadow/DateTimeFieldElement.h
+++ b/Source/WebCore/html/shadow/DateTimeFieldElement.h
@@ -77,7 +77,6 @@ public:
 protected:
     static constexpr auto CreateDateTimeFieldElement = CreateHTMLDivElement | TypeFlag::HasCustomStyleResolveCallbacks;
     DateTimeFieldElement(Document&, FieldOwner&);
-    void initialize(const AtomString& pseudo);
     Locale& localeForOwner() const;
     AtomString localeIdentifier() const;
     void updateVisibleValue(EventBehavior);

--- a/Source/WebCore/html/shadow/DateTimeFieldElements.cpp
+++ b/Source/WebCore/html/shadow/DateTimeFieldElements.cpp
@@ -34,6 +34,7 @@
 #include "HTMLNames.h"
 #include "LocalizedStrings.h"
 #include "ScriptDisallowedScope.h"
+#include "ShadowPseudoIds.h"
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
@@ -48,9 +49,8 @@ DateTimeDayFieldElement::DateTimeDayFieldElement(Document& document, FieldOwner&
 Ref<DateTimeDayFieldElement> DateTimeDayFieldElement::create(Document& document, FieldOwner& fieldOwner)
 {
     auto element = adoptRef(*new DateTimeDayFieldElement(document, fieldOwner));
-    static MainThreadNeverDestroyed<const AtomString> dayPseudoId("-webkit-datetime-edit-day-field"_s);
     ScriptDisallowedScope::EventAllowedScope eventAllowedScope { element };
-    element->initialize(dayPseudoId);
+    element->setPseudo(ShadowPseudoIds::webkitDatetimeEditDayField());
     element->setAttributeWithoutSynchronization(HTMLNames::aria_labelAttr, AtomString { AXDateFieldDayText() });
     element->setAttributeWithoutSynchronization(HTMLNames::roleAttr, AtomString { "spinbutton"_s });
     return element;
@@ -77,9 +77,8 @@ DateTimeHourFieldElement::DateTimeHourFieldElement(Document& document, FieldOwne
 Ref<DateTimeHourFieldElement> DateTimeHourFieldElement::create(Document& document, FieldOwner& fieldOwner, int minimum, int maximum)
 {
     auto element = adoptRef(*new DateTimeHourFieldElement(document, fieldOwner, minimum, maximum));
-    static MainThreadNeverDestroyed<const AtomString> hourPseudoId("-webkit-datetime-edit-hour-field"_s);
     ScriptDisallowedScope::EventAllowedScope eventAllowedScope { element };
-    element->initialize(hourPseudoId);
+    element->setPseudo(ShadowPseudoIds::webkitDatetimeEditHourField());
     return element;
 }
 
@@ -143,9 +142,8 @@ DateTimeMeridiemFieldElement::DateTimeMeridiemFieldElement(Document& document, F
 Ref<DateTimeMeridiemFieldElement> DateTimeMeridiemFieldElement::create(Document& document, FieldOwner& fieldOwner, const Vector<String>& labels)
 {
     auto element = adoptRef(*new DateTimeMeridiemFieldElement(document, fieldOwner, labels));
-    static MainThreadNeverDestroyed<const AtomString> meridiemPseudoId("-webkit-datetime-edit-meridiem-field"_s);
     ScriptDisallowedScope::EventAllowedScope eventAllowedScope { element };
-    element->initialize(meridiemPseudoId);
+    element->setPseudo(ShadowPseudoIds::webkitDatetimeEditMeridiemField());
     return element;
 }
 
@@ -170,9 +168,8 @@ DateTimeMillisecondFieldElement::DateTimeMillisecondFieldElement(Document& docum
 Ref<DateTimeMillisecondFieldElement> DateTimeMillisecondFieldElement::create(Document& document, FieldOwner& fieldOwner)
 {
     auto element = adoptRef(*new DateTimeMillisecondFieldElement(document, fieldOwner));
-    static MainThreadNeverDestroyed<const AtomString> millisecondPseudoId("-webkit-datetime-edit-millisecond-field"_s);
     ScriptDisallowedScope::EventAllowedScope eventAllowedScope { element };
-    element->initialize(millisecondPseudoId);
+    element->setPseudo(ShadowPseudoIds::webkitDatetimeEditMillisecondField());
     return element;
 }
 
@@ -197,9 +194,8 @@ DateTimeMinuteFieldElement::DateTimeMinuteFieldElement(Document& document, Field
 Ref<DateTimeMinuteFieldElement> DateTimeMinuteFieldElement::create(Document& document, FieldOwner& fieldOwner)
 {
     auto element = adoptRef(*new DateTimeMinuteFieldElement(document, fieldOwner));
-    static MainThreadNeverDestroyed<const AtomString> minutePseudoId("-webkit-datetime-edit-minute-field"_s);
     ScriptDisallowedScope::EventAllowedScope eventAllowedScope { element };
-    element->initialize(minutePseudoId);
+    element->setPseudo(ShadowPseudoIds::webkitDatetimeEditMinuteField());
     return element;
 }
 
@@ -224,9 +220,8 @@ DateTimeMonthFieldElement::DateTimeMonthFieldElement(Document& document, FieldOw
 Ref<DateTimeMonthFieldElement> DateTimeMonthFieldElement::create(Document& document, FieldOwner& fieldOwner)
 {
     auto element = adoptRef(*new DateTimeMonthFieldElement(document, fieldOwner));
-    static MainThreadNeverDestroyed<const AtomString> monthPseudoId("-webkit-datetime-edit-month-field"_s);
     ScriptDisallowedScope::EventAllowedScope eventAllowedScope { element };
-    element->initialize(monthPseudoId);
+    element->setPseudo(ShadowPseudoIds::webkitDatetimeEditMonthField());
     element->setAttributeWithoutSynchronization(HTMLNames::aria_labelAttr, AtomString { AXDateFieldMonthText() });
     element->setAttributeWithoutSynchronization(HTMLNames::roleAttr, AtomString { "spinbutton"_s });
     return element;
@@ -254,9 +249,8 @@ DateTimeSecondFieldElement::DateTimeSecondFieldElement(Document& document, Field
 Ref<DateTimeSecondFieldElement> DateTimeSecondFieldElement::create(Document& document, FieldOwner& fieldOwner)
 {
     auto element = adoptRef(*new DateTimeSecondFieldElement(document, fieldOwner));
-    static MainThreadNeverDestroyed<const AtomString> secondPseudoId("-webkit-datetime-edit-second-field"_s);
     ScriptDisallowedScope::EventAllowedScope eventAllowedScope { element };
-    element->initialize(secondPseudoId);
+    element->setPseudo(ShadowPseudoIds::webkitDatetimeEditSecondField());
     return element;
 }
 
@@ -281,9 +275,8 @@ DateTimeSymbolicMonthFieldElement::DateTimeSymbolicMonthFieldElement(Document& d
 Ref<DateTimeSymbolicMonthFieldElement> DateTimeSymbolicMonthFieldElement::create(Document& document, FieldOwner& fieldOwner, const Vector<String>& labels)
 {
     auto element = adoptRef(*new DateTimeSymbolicMonthFieldElement(document, fieldOwner, labels));
-    static MainThreadNeverDestroyed<const AtomString> monthPseudoId("-webkit-datetime-edit-month-field"_s);
     ScriptDisallowedScope::EventAllowedScope eventAllowedScope { element };
-    element->initialize(monthPseudoId);
+    element->setPseudo(ShadowPseudoIds::webkitDatetimeEditMonthField());
     element->setAttributeWithoutSynchronization(HTMLNames::aria_labelAttr, AtomString { AXDateFieldMonthText() });
     element->setAttributeWithoutSynchronization(HTMLNames::roleAttr, AtomString { "spinbutton"_s });
     return element;
@@ -310,9 +303,8 @@ DateTimeYearFieldElement::DateTimeYearFieldElement(Document& document, FieldOwne
 Ref<DateTimeYearFieldElement> DateTimeYearFieldElement::create(Document& document, FieldOwner& fieldOwner)
 {
     auto element = adoptRef(*new DateTimeYearFieldElement(document, fieldOwner));
-    static MainThreadNeverDestroyed<const AtomString> yearPseudoId("-webkit-datetime-edit-year-field"_s);
     ScriptDisallowedScope::EventAllowedScope eventAllowedScope { element };
-    element->initialize(yearPseudoId);
+    element->setPseudo(ShadowPseudoIds::webkitDatetimeEditYearField());
     element->setAttributeWithoutSynchronization(HTMLNames::aria_labelAttr, AtomString { AXDateFieldYearText() });
     element->setAttributeWithoutSynchronization(HTMLNames::roleAttr, AtomString { "spinbutton"_s });
     return element;

--- a/Source/WebCore/html/shadow/DateTimeNumericFieldElement.cpp
+++ b/Source/WebCore/html/shadow/DateTimeNumericFieldElement.cpp
@@ -107,11 +107,6 @@ bool DateTimeNumericFieldElement::hasValue() const
     return m_hasValue;
 }
 
-void DateTimeNumericFieldElement::initialize(const AtomString& pseudo)
-{
-    DateTimeFieldElement::initialize(pseudo);
-}
-
 void DateTimeNumericFieldElement::setEmptyValue(EventBehavior eventBehavior)
 {
     m_value = 0;

--- a/Source/WebCore/html/shadow/DateTimeNumericFieldElement.h
+++ b/Source/WebCore/html/shadow/DateTimeNumericFieldElement.h
@@ -54,7 +54,6 @@ protected:
 
     // DateTimeFieldElement functions:
     bool hasValue() const final;
-    void initialize(const AtomString&);
     void setEmptyValue(EventBehavior = DispatchNoEvent) final;
     void setValueAsInteger(int, EventBehavior = DispatchNoEvent) final;
     void stepDown() final;

--- a/Source/WebCore/html/shadow/DateTimeSymbolicFieldElement.cpp
+++ b/Source/WebCore/html/shadow/DateTimeSymbolicFieldElement.cpp
@@ -71,11 +71,6 @@ bool DateTimeSymbolicFieldElement::hasValue() const
     return m_selectedIndex >= 0;
 }
 
-void DateTimeSymbolicFieldElement::initialize(const AtomString& pseudo)
-{
-    DateTimeFieldElement::initialize(pseudo);
-}
-
 void DateTimeSymbolicFieldElement::setEmptyValue(EventBehavior eventBehavior)
 {
     m_selectedIndex = invalidIndex;

--- a/Source/WebCore/html/shadow/DateTimeSymbolicFieldElement.h
+++ b/Source/WebCore/html/shadow/DateTimeSymbolicFieldElement.h
@@ -39,7 +39,6 @@ protected:
     DateTimeSymbolicFieldElement(Document&, FieldOwner&, const Vector<String>&, int);
     size_t symbolsSize() const { return m_symbols.size(); }
     bool hasValue() const final;
-    void initialize(const AtomString& pseudo);
     void setEmptyValue(EventBehavior = DispatchNoEvent) final;
     void setValueAsInteger(int, EventBehavior = DispatchNoEvent) final;
     int valueAsInteger() const final;

--- a/Source/WebCore/html/shadow/ShadowPseudoIds.cpp
+++ b/Source/WebCore/html/shadow/ShadowPseudoIds.cpp
@@ -33,11 +33,13 @@ namespace WebCore {
 
 namespace ShadowPseudoIds {
 
+#if ENABLE(VIDEO)
 const AtomString& cue()
 {
     static MainThreadNeverDestroyed<const AtomString> cue("cue"_s);
     return cue;
 }
+#endif
 
 const AtomString& fileSelectorButton()
 {
@@ -111,16 +113,23 @@ const AtomString& webkitColorSwatchWrapper()
     return webkitColorSwatchWrapper;
 }
 
+#if ENABLE(DATE_AND_TIME_INPUT_TYPES)
+const AtomString& webkitDateAndTimeValue()
+{
+    static MainThreadNeverDestroyed<const AtomString> webkitDateAndTimeValue("-webkit-date-and-time-value"_s);
+    return webkitDateAndTimeValue;
+}
+
 const AtomString& webkitDatetimeEdit()
 {
     static MainThreadNeverDestroyed<const AtomString> webkitDatetimeEdit("-webkit-datetime-edit"_s);
     return webkitDatetimeEdit;
 }
 
-const AtomString& webkitDatetimeEditText()
+const AtomString& webkitDatetimeEditDayField()
 {
-    static MainThreadNeverDestroyed<const AtomString> webkitDatetimeEditText("-webkit-datetime-edit-text"_s);
-    return webkitDatetimeEditText;
+    static MainThreadNeverDestroyed<const AtomString> webkitDatetimeEditDayField("-webkit-datetime-edit-day-field"_s);
+    return webkitDatetimeEditDayField;
 }
 
 const AtomString& webkitDatetimeEditFieldsWrapper()
@@ -129,11 +138,54 @@ const AtomString& webkitDatetimeEditFieldsWrapper()
     return webkitDatetimeEditFieldsWrapper;
 }
 
-const AtomString& webkitDateAndTimeValue()
+const AtomString& webkitDatetimeEditHourField()
 {
-    static MainThreadNeverDestroyed<const AtomString> webkitDateAndTimeValue("-webkit-date-and-time-value"_s);
-    return webkitDateAndTimeValue;
+    static MainThreadNeverDestroyed<const AtomString> webkitDatetimeEditHourField("-webkit-datetime-edit-hour-field"_s);
+    return webkitDatetimeEditHourField;
 }
+
+const AtomString& webkitDatetimeEditMeridiemField()
+{
+    static MainThreadNeverDestroyed<const AtomString> webkitDatetimeEditMeridiemField("-webkit-datetime-edit-meridiem-field"_s);
+    return webkitDatetimeEditMeridiemField;
+}
+
+const AtomString& webkitDatetimeEditMillisecondField()
+{
+    static MainThreadNeverDestroyed<const AtomString> webkitDatetimeEditMillisecondField("-webkit-datetime-edit-millisecond-field"_s);
+    return webkitDatetimeEditMillisecondField;
+}
+
+const AtomString& webkitDatetimeEditMinuteField()
+{
+    static MainThreadNeverDestroyed<const AtomString> webkitDatetimeEditMinuteField("-webkit-datetime-edit-minute-field"_s);
+    return webkitDatetimeEditMinuteField;
+}
+
+const AtomString& webkitDatetimeEditMonthField()
+{
+    static MainThreadNeverDestroyed<const AtomString> webkitDatetimeEditMonthField("-webkit-datetime-edit-month-field"_s);
+    return webkitDatetimeEditMonthField;
+}
+
+const AtomString& webkitDatetimeEditSecondField()
+{
+    static MainThreadNeverDestroyed<const AtomString> webkitDatetimeEditSecondField("-webkit-datetime-edit-second-field"_s);
+    return webkitDatetimeEditSecondField;
+}
+
+const AtomString& webkitDatetimeEditText()
+{
+    static MainThreadNeverDestroyed<const AtomString> webkitDatetimeEditText("-webkit-datetime-edit-text"_s);
+    return webkitDatetimeEditText;
+}
+
+const AtomString& webkitDatetimeEditYearField()
+{
+    static MainThreadNeverDestroyed<const AtomString> webkitDatetimeEditYearField("-webkit-datetime-edit-year-field"_s);
+    return webkitDatetimeEditYearField;
+}
+#endif // ENABLE(DATE_AND_TIME_INPUT_TYPES)
 
 const AtomString& webkitDetailsMarker()
 {

--- a/Source/WebCore/html/shadow/ShadowPseudoIds.h
+++ b/Source/WebCore/html/shadow/ShadowPseudoIds.h
@@ -31,7 +31,9 @@ namespace WebCore {
 
 namespace ShadowPseudoIds {
 
+#if ENABLE(VIDEO)
 const AtomString& cue();
+#endif
 
 const AtomString& fileSelectorButton();
 
@@ -51,10 +53,20 @@ const AtomString& webkitCapsLockIndicator();
 const AtomString& webkitColorSwatch();
 const AtomString& webkitColorSwatchWrapper();
 
-const AtomString& webkitDatetimeEdit();
-const AtomString& webkitDatetimeEditText();
-const AtomString& webkitDatetimeEditFieldsWrapper();
+#if ENABLE(DATE_AND_TIME_INPUT_TYPES)
 const AtomString& webkitDateAndTimeValue();
+const AtomString& webkitDatetimeEdit();
+const AtomString& webkitDatetimeEditDayField();
+const AtomString& webkitDatetimeEditFieldsWrapper();
+const AtomString& webkitDatetimeEditHourField();
+const AtomString& webkitDatetimeEditMeridiemField();
+const AtomString& webkitDatetimeEditMillisecondField();
+const AtomString& webkitDatetimeEditMinuteField();
+const AtomString& webkitDatetimeEditMonthField();
+const AtomString& webkitDatetimeEditSecondField();
+const AtomString& webkitDatetimeEditText();
+const AtomString& webkitDatetimeEditYearField();
+#endif
 
 const AtomString& webkitDetailsMarker();
 


### PR DESCRIPTION
#### f8e7643db02e7e5c994fedf49333064c659dc2a4
<pre>
Make pseudo attribute values of DateTimeFieldElements proper ShadowPseudoIds
<a href="https://bugs.webkit.org/show_bug.cgi?id=266951">https://bugs.webkit.org/show_bug.cgi?id=266951</a>

Reviewed by Tim Nguyen.

This will enable us to have a central source of truth for
ShadowPseudoIds in due course.

Also call setPseudo() directly instead of using a somewhat useless
wrapper.

* Source/WebCore/html/shadow/DateTimeFieldElement.cpp:
(WebCore::DateTimeFieldElement::initialize): Deleted.
* Source/WebCore/html/shadow/DateTimeFieldElement.h:
* Source/WebCore/html/shadow/DateTimeFieldElements.cpp:
(WebCore::DateTimeDayFieldElement::create):
(WebCore::DateTimeHourFieldElement::create):
(WebCore::DateTimeMeridiemFieldElement::create):
(WebCore::DateTimeMillisecondFieldElement::create):
(WebCore::DateTimeMinuteFieldElement::create):
(WebCore::DateTimeMonthFieldElement::create):
(WebCore::DateTimeSecondFieldElement::create):
(WebCore::DateTimeSymbolicMonthFieldElement::create):
(WebCore::DateTimeYearFieldElement::create):
* Source/WebCore/html/shadow/DateTimeNumericFieldElement.cpp:
(WebCore::DateTimeNumericFieldElement::initialize): Deleted.
* Source/WebCore/html/shadow/DateTimeNumericFieldElement.h:
* Source/WebCore/html/shadow/DateTimeSymbolicFieldElement.cpp:
(WebCore::DateTimeSymbolicFieldElement::initialize): Deleted.
* Source/WebCore/html/shadow/DateTimeSymbolicFieldElement.h:
* Source/WebCore/html/shadow/ShadowPseudoIds.cpp:
(WebCore::ShadowPseudoIds::webkitDateAndTimeValue):
(WebCore::ShadowPseudoIds::webkitDatetimeEditDayField):
(WebCore::ShadowPseudoIds::webkitDatetimeEditHourField):
(WebCore::ShadowPseudoIds::webkitDatetimeEditMeridiemField):
(WebCore::ShadowPseudoIds::webkitDatetimeEditMillisecondField):
(WebCore::ShadowPseudoIds::webkitDatetimeEditMinuteField):
(WebCore::ShadowPseudoIds::webkitDatetimeEditMonthField):
(WebCore::ShadowPseudoIds::webkitDatetimeEditSecondField):
(WebCore::ShadowPseudoIds::webkitDatetimeEditText):
(WebCore::ShadowPseudoIds::webkitDatetimeEditYearField):
* Source/WebCore/html/shadow/ShadowPseudoIds.h:

Canonical link: <a href="https://commits.webkit.org/272550@main">https://commits.webkit.org/272550@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2626828c7db9798eabc4498d943a710c0a946c3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32065 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10783 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33852 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34608 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29060 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32894 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13140 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8006 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28644 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32464 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9103 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28661 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7896 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8069 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28576 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35952 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29164 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29031 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34176 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8178 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6136 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32035 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9819 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7491 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8825 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8703 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->