### PR TITLE
Class selectors on pseudo elements should be forbidden

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/controls/text-tracks.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/text-tracks.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2016-2024 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -45,7 +45,7 @@ video::-webkit-media-text-track-container {
     -webkit-line-box-contain: block inline-box replaced;
 }
 
-video[controls]::-webkit-media-text-track-container.visible-controls-bar {
+video[controls][pseudo="-webkit-media-text-track-container"].visible-controls-bar {
     height: calc(100% - var(--inline-controls-bar-height) - var(--inline-controls-inside-margin));
 }
 

--- a/Source/WebCore/css/mediaControls.css
+++ b/Source/WebCore/css/mediaControls.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009, 2010, 2011, 2013, 2014 Apple Inc.  All rights reserved.
+ * Copyright (C) 2009-2024 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -157,10 +157,8 @@ video::-webkit-media-text-track-container {
     width: 100%;
     overflow: hidden;
     padding-bottom: 5px;
-
     text-align: center;
     color: rgba(255, 255, 255, 1);
-
     letter-spacing: normal;
     word-spacing: normal;
     text-transform: none;
@@ -169,9 +167,7 @@ video::-webkit-media-text-track-container {
     pointer-events: none;
     -webkit-user-select: none;
     word-break: break-word;
-
     flex: 1 1;
-
     -webkit-line-box-contain: block inline-box replaced;
 }
 
@@ -262,7 +258,7 @@ video::-webkit-media-text-track-region-container {
     flex-direction: column;
 }
 
-video::-webkit-media-text-track-region-container.scrolling {
+video[pseudo="-webkit-media-text-track-region-container"].scrolling {
     transition: top 433ms linear;
 }
 

--- a/Source/WebCore/inspector/InspectorStyleSheet.cpp
+++ b/Source/WebCore/inspector/InspectorStyleSheet.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2010, Google Inc. All rights reserved.
- * Copyright (C) 2021-2023, Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2024, Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -1690,11 +1690,6 @@ bool InspectorStyleSheet::ensureSourceData()
     auto ruleSourceDataResult = makeUnique<RuleSourceDataList>();
     
     CSSParserContext context(parserContextForDocument(m_pageStyleSheet->ownerDocument()));
-
-    // FIXME: <webkit.org/b/161747> Media control CSS uses out-of-spec selectors in inline user agent shadow root style
-    // element. See corresponding workaround in `CSSSelectorParser::extractCompoundFlags`.
-    if (auto* ownerNode = m_pageStyleSheet->ownerNode(); ownerNode && ownerNode->isInUserAgentShadowTree())
-        context.mode = UASheetMode;
     
     StyleSheetHandler handler(m_parsedStyleSheet->text(), m_pageStyleSheet->ownerDocument(), ruleSourceDataResult.get());
     CSSParser::parseSheetForInspector(context, newStyleSheet.ptr(), m_parsedStyleSheet->text(), handler);


### PR DESCRIPTION
<pre>
Class selectors on pseudo elements should be forbidden.
<a href="https://bugs.webkit.org/show_bug.cgi?id=161747">https://bugs.webkit.org/show_bug.cgi?id=161747</a>

Reviewed by NOBODY (OOPS!).

This patch is to remove workaround added which was to allow class selectors on
pseudo elements. It is done by updating 'mediaControls.css' UA stylesheet to match
other 'pseudo' codes (i.e., [pseudo="-webkit-media-text-track-display"] ) and
in addition also removing 'parserMode == UASheetMod' code.

This also undo '251738@main' and add workaround similar as above
for other UA stylesheet selectors.

* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(extractCompoundFlags):
(CSSSelectorParser::consumeComplexSelector):
* Source/WebCore/inspector/InspectorStyleSheet.cpp:
(InspectorStyleSheet::ensureSourceData): Undo '251738@main'
* Source/WebCore/css/mediaControls.css:
(-webkit-media-text-track-region-container.scrolling):
* Source/WebCore/Modules/modern-media-controls/controls/text-tracks.css:
(video[controls]::-webkit-media-text-track-container.visible-controls-bar):
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0757303374a7f2f7d601344d8218a481691d1ef

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32047 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10762 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33829 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34586 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29041 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32873 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13120 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7988 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28630 "Found 3 new test failures: imported/w3c/web-platform-tests/css/css-pseudo/parsing/tree-abiding-pseudo-elements.html, media/modern-media-controls/text-tracks/text-tracks-height-with-controls.html, media/modern-media-controls/tracks-support/captions-offset-with-controls-bar.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32442 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9090 "Found 1 new test failure: media/modern-media-controls/tracks-support/captions-offset-with-controls-bar.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28645 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7882 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8056 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-pseudo/parsing/tree-abiding-pseudo-elements.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28560 "Found 3 new test failures: imported/w3c/web-platform-tests/css/css-pseudo/parsing/tree-abiding-pseudo-elements.html, media/modern-media-controls/text-tracks/text-tracks-height-with-controls.html, svg/compositing/transform-change-repainting-viewBox.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35930 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29151 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29015 "Found 3 new test failures: imported/w3c/web-platform-tests/css/css-pseudo/parsing/tree-abiding-pseudo-elements.html, media/modern-media-controls/text-tracks/text-tracks-height-with-controls.html, media/modern-media-controls/tracks-support/captions-offset-with-controls-bar.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34161 "Found 3 new test failures: imported/w3c/web-platform-tests/css/css-pseudo/parsing/tree-abiding-pseudo-elements.html, media/modern-media-controls/text-tracks/text-tracks-height-with-controls.html, media/modern-media-controls/tracks-support/captions-offset-with-controls-bar.html (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8161 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6122 "Found 3 new test failures: imported/w3c/web-platform-tests/css/css-pseudo/parsing/tree-abiding-pseudo-elements.html, media/modern-media-controls/text-tracks/text-tracks-height-with-controls.html, media/modern-media-controls/tracks-support/captions-offset-with-controls-bar.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32019 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9802 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8808 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8684 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->