### PR TITLE
`HasScope` should not be represented as a `PseudoClass` internally

### DIFF
--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -182,8 +182,6 @@ SelectorSpecificity simpleSelectorSpecificity(const CSSSelector& simpleSelector)
         case CSSSelector::PseudoClass::NthLastChild:
         case CSSSelector::PseudoClass::Host:
             return SelectorSpecificityIncrement::ClassB + maxSpecificity(simpleSelector.selectorList());
-        case CSSSelector::PseudoClass::HasScope:
-            return 0;
         default:
             return SelectorSpecificityIncrement::ClassB;
         }
@@ -206,6 +204,7 @@ SelectorSpecificity simpleSelectorSpecificity(const CSSSelector& simpleSelector)
         if (simpleSelector.pseudoElement() == CSSSelector::PseudoElement::Slotted)
             return maxSpecificity(simpleSelector.selectorList());
         return SelectorSpecificityIncrement::ClassC;
+    case CSSSelector::Match::HasScope:
     case CSSSelector::Match::Unknown:
     case CSSSelector::Match::ForgivingUnknown:
     case CSSSelector::Match::ForgivingUnknownNestContaining:
@@ -491,6 +490,9 @@ String CSSSelector::selectorText(StringView separator, StringView rightSide) con
             serializeIdentifier(cs->serializingValue(), builder);
         } else if (cs->match() == Match::ForgivingUnknown || cs->match() == Match::ForgivingUnknownNestContaining) {
             builder.append(cs->value());
+        } else if (cs->match() == Match::HasScope) {
+            // Remove the space from the start to generate a relative selector string like in ":has(> foo)".
+            return makeString(separator.substring(1), rightSide);
         } else if (cs->match() == Match::PseudoClass) {
             switch (cs->pseudoClass()) {
 #if ENABLE(FULLSCREEN_API)
@@ -769,9 +771,6 @@ String CSSSelector::selectorText(StringView separator, StringView rightSide) con
                 serializeIdentifier(cs->argument(), builder);
                 builder.append(')');
                 break;
-            case CSSSelector::PseudoClass::HasScope:
-                // Remove the space from the start to generate a relative selector string like in ":has(> foo)".
-                return makeString(separator.substring(1), rightSide);
             case CSSSelector::PseudoClass::SingleButton:
                 builder.append(":single-button");
                 break;

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -87,6 +87,7 @@ struct PossiblyQuotedIdentifier {
             End, // css3: E[foo$="bar"]
             PagePseudoClass,
             NestingParent, // &
+            HasScope, // matches the :has() scope
             ForgivingUnknown,
             ForgivingUnknownNestContaining
         };
@@ -152,7 +153,6 @@ struct PossiblyQuotedIdentifier {
             Root,
             Scope,
             State,
-            HasScope, // for internal use, matches the :has() scope
             WindowInactive,
             CornerPresent,
             Decrement,

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -364,8 +364,7 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumeRelativeScopeSelect
         end = end->tagHistory();
 
     auto scopeSelector = makeUnique<CSSParserSelector>();
-    scopeSelector->setMatch(CSSSelector::Match::PseudoClass);
-    scopeSelector->setPseudoClass(CSSSelector::PseudoClass::HasScope);
+    scopeSelector->setMatch(CSSSelector::Match::HasScope);
 
     end->setRelation(scopeCombinator);
     end->setTagHistory(WTFMove(scopeSelector));

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -1228,7 +1228,6 @@ static inline FunctionType addPseudoClassType(const CSSSelector& selector, Selec
     case CSSSelector::PseudoClass::NthLastOfType:
     case CSSSelector::PseudoClass::WebKitDrag:
     case CSSSelector::PseudoClass::Has:
-    case CSSSelector::PseudoClass::HasScope:
     case CSSSelector::PseudoClass::State:
         return FunctionType::CannotCompile;
 
@@ -1543,6 +1542,7 @@ static FunctionType constructFragmentsInternal(const CSSSelector* rootSelector, 
             return FunctionType::CannotMatchAnything;
         case CSSSelector::Match::ForgivingUnknown:
         case CSSSelector::Match::ForgivingUnknownNestContaining:
+        case CSSSelector::Match::HasScope:
             return FunctionType::CannotMatchAnything;
         }
 

--- a/Source/WebCore/style/RuleSet.cpp
+++ b/Source/WebCore/style/RuleSet.cpp
@@ -228,6 +228,7 @@ void RuleSet::addRule(RuleData&& ruleData, CascadeLayerIdentifier cascadeLayerId
         case CSSSelector::Match::Unknown:
         case CSSSelector::Match::ForgivingUnknown:
         case CSSSelector::Match::ForgivingUnknownNestContaining:
+        case CSSSelector::Match::HasScope:
         case CSSSelector::Match::NestingParent:
         case CSSSelector::Match::PagePseudoClass:
             break;


### PR DESCRIPTION
#### d7d7358f95b5061063be351b493abf41a1daa6b2
<pre>
`HasScope` should not be represented as a `PseudoClass` internally
<a href="https://bugs.webkit.org/show_bug.cgi?id=266949">https://bugs.webkit.org/show_bug.cgi?id=266949</a>
<a href="https://rdar.apple.com/120335193">rdar://120335193</a>

Reviewed by Darin Adler.

To make auto-generating the PseudoClass enum class from JSON easier, move PseudoClass::HasScope to CSSSelector::Match since it is not actually a pseudo-class even if behaves similarly.

This &quot;pseudo-class&quot; represents the hidden scope in relative selectors like :has(&gt; foo)`.

* Source/WebCore/css/CSSSelector.cpp:
(WebCore::simpleSelectorSpecificity):
(WebCore::CSSSelector::selectorText const):
* Source/WebCore/css/CSSSelector.h:
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::canMatchHoverOrActiveInQuirksMode):
(WebCore::SelectorChecker::checkOne const):
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParser::consumeRelativeScopeSelector):
* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::addPseudoClassType):
(WebCore::SelectorCompiler::constructFragmentsInternal):
* Source/WebCore/style/RuleSet.cpp:
(WebCore::Style::RuleSet::addRule):

Canonical link: <a href="https://commits.webkit.org/272554@main">https://commits.webkit.org/272554@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/262cc3c551f2d4ea6357b80c78c3751757de6b6e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32078 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10796 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/33874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34621 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29072 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32907 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13153 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8019 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28655 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32477 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9110 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28666 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7907 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8076 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28581 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35965 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29171 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29036 "Unexpected infrastructure issue, retrying build") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34184 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8189 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6145 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32043 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9830 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8835 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4165 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8716 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->