### PR TITLE
[GStreamer] Leak fixes for GL display, registries and video encoder

### DIFF
--- a/Source/WebCore/platform/graphics/PlatformDisplay.h
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.h
@@ -141,6 +141,7 @@ public:
 #if ENABLE(VIDEO) && USE(GSTREAMER_GL)
     GstGLDisplay* gstGLDisplay() const;
     GstGLContext* gstGLContext() const;
+    void clearGStreamerGLState();
 #endif
 
 #if USE(LCMS)

--- a/Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp
@@ -133,13 +133,13 @@ std::optional<GRefPtr<GstContext>> requestGLContext(const char* contextType)
         return std::nullopt;
 
     if (!g_strcmp0(contextType, GST_GL_DISPLAY_CONTEXT_TYPE)) {
-        GRefPtr<GstContext> displayContext = adoptGRef(gst_context_new(GST_GL_DISPLAY_CONTEXT_TYPE, TRUE));
+        GRefPtr<GstContext> displayContext = adoptGRef(gst_context_new(GST_GL_DISPLAY_CONTEXT_TYPE, FALSE));
         gst_context_set_gl_display(displayContext.get(), gstGLDisplay);
         return displayContext;
     }
 
     if (!g_strcmp0(contextType, "gst.gl.app_context")) {
-        GRefPtr<GstContext> appContext = adoptGRef(gst_context_new("gst.gl.app_context", TRUE));
+        GRefPtr<GstContext> appContext = adoptGRef(gst_context_new("gst.gl.app_context", FALSE));
         GstStructure* structure = gst_context_writable_structure(appContext.get());
         gst_structure_set(structure, "context", GST_TYPE_GL_CONTEXT, gstGLContext, nullptr);
         return appContext;

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -108,7 +108,7 @@ GST_DEBUG_CATEGORY_STATIC(webkit_media_gst_registry_scanner_debug);
 
 static bool singletonInitialized = false;
 
-bool GStreamerRegistryScanner::singletonNeedsInitialization()
+bool GStreamerRegistryScanner::singletonWasInitialized()
 {
     return singletonInitialized;
 }
@@ -122,7 +122,7 @@ GStreamerRegistryScanner& GStreamerRegistryScanner::singleton()
 
 void teardownGStreamerRegistryScanner()
 {
-    if (GStreamerRegistryScanner::singletonNeedsInitialization())
+    if (!GStreamerRegistryScanner::singletonWasInitialized())
         return;
 
     auto& scanner = GStreamerRegistryScanner::singleton();

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h
@@ -42,7 +42,7 @@ void teardownGStreamerRegistryScanner();
 class GStreamerRegistryScanner {
     WTF_MAKE_NONCOPYABLE(GStreamerRegistryScanner)
 public:
-    static bool singletonNeedsInitialization();
+    static bool singletonWasInitialized();
     static GStreamerRegistryScanner& singleton();
     static void getSupportedDecodingTypes(HashSet<String>&);
 

--- a/Source/WebCore/platform/graphics/gstreamer/PlatformDisplayGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/PlatformDisplayGStreamer.cpp
@@ -74,6 +74,12 @@ GstGLContext* PlatformDisplay::gstGLContext() const
     return m_gstGLContext.get();
 }
 
+void PlatformDisplay::clearGStreamerGLState()
+{
+    m_gstGLDisplay = nullptr;
+    m_gstGLContext = nullptr;
+}
+
 } // namespace WebCore
 
 #endif

--- a/Source/WebCore/platform/graphics/gstreamer/mse/GStreamerRegistryScannerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/GStreamerRegistryScannerMSE.cpp
@@ -26,10 +26,22 @@
 
 namespace WebCore {
 
+static bool singletonInitialized = false;
+
 GStreamerRegistryScannerMSE& GStreamerRegistryScannerMSE::singleton()
 {
     static NeverDestroyed<GStreamerRegistryScannerMSE> sharedInstance;
+    singletonInitialized = true;
     return sharedInstance;
+}
+
+void teardownGStreamerRegistryScannerMSE()
+{
+    if (!singletonInitialized)
+        return;
+
+    auto& scanner = GStreamerRegistryScannerMSE::singleton();
+    scanner.teardown();
 }
 
 void GStreamerRegistryScannerMSE::getSupportedDecodingTypes(HashSet<String>& types)

--- a/Source/WebCore/platform/graphics/gstreamer/mse/GStreamerRegistryScannerMSE.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/GStreamerRegistryScannerMSE.h
@@ -27,6 +27,8 @@
 
 namespace WebCore {
 
+void teardownGStreamerRegistryScannerMSE();
+
 class GStreamerRegistryScannerMSE : public GStreamerRegistryScanner {
 public:
     static GStreamerRegistryScannerMSE& singleton();

--- a/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp
@@ -184,6 +184,11 @@ public:
     }
 };
 
+void teardownVideoEncoderSingleton()
+{
+    Encoders::singleton().clear();
+}
+
 /* Internal bin structure: videoconvert ! inputCapsFilter ! encoder ! outputCapsFilter ! (optional
    parser) ! capsFilter */
 struct _WebKitVideoEncoderPrivate {

--- a/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.h
+++ b/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.h
@@ -46,3 +46,4 @@ GType webkit_video_encoder_get_type(void);
 
 bool videoEncoderSupportsFormat(WebKitVideoEncoder*, const GRefPtr<GstCaps>&);
 bool videoEncoderSetFormat(WebKitVideoEncoder*, GRefPtr<GstCaps>&&);
+void teardownVideoEncoderSingleton();


### PR DESCRIPTION
#### c0c0cb347423417c4135f012632a0ba7f4c939b1
<pre>
[GStreamer] Leak fixes for GL display, registries and video encoder
<a href="https://bugs.webkit.org/show_bug.cgi?id=266964">https://bugs.webkit.org/show_bug.cgi?id=266964</a>

Reviewed by Carlos Garcia Campos.

The GL display and app contexts were persistent, so never destroyed, thus reported by the leak
tracer. The encoder was also leaking a GstElementFactory so its state is now cleared before
deinitialization. The MSE registry is also now cleaned-up as well.

* Source/WebCore/platform/graphics/PlatformDisplay.h:
* Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp:
(requestGLContext):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::registerWebKitGStreamerElements):
(WebCore::registerWebKitGStreamerVideoEncoder):
(WebCore::deinitializeGStreamer):
* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp:
(WebCore::GStreamerRegistryScanner::singletonWasInitialized):
(WebCore::teardownGStreamerRegistryScanner):
(WebCore::GStreamerRegistryScanner::singletonNeedsInitialization): Deleted.
* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h:
* Source/WebCore/platform/graphics/gstreamer/PlatformDisplayGStreamer.cpp:
(WebCore::PlatformDisplay::clearGStreamerGLState):
* Source/WebCore/platform/graphics/gstreamer/mse/GStreamerRegistryScannerMSE.cpp:
(WebCore::GStreamerRegistryScannerMSE::singleton):
(WebCore::teardownGStreamerRegistryScannerMSE):
* Source/WebCore/platform/graphics/gstreamer/mse/GStreamerRegistryScannerMSE.h:
* Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp:
(teardownVideoEncoderSingleton):
* Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/272551@main">https://commits.webkit.org/272551@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1ed807afff160cd7d47e1f989ea18b613a764d6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32080 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10798 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33867 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34623 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29074 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32909 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13155 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8021 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28654 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32479 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9113 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28672 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7906 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8079 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/28587 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35967 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29174 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29042 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34187 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8191 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6147 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32045 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9832 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7492 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8837 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8718 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->