### PR TITLE
Alias `:-webkit-full-screen` pseudo-class to `:fullscreen`

### DIFF
--- a/LayoutTests/fast/selectors/selector-aliases-expected.txt
+++ b/LayoutTests/fast/selectors/selector-aliases-expected.txt
@@ -1,0 +1,4 @@
+
+PASS ":-webkit-autofill" should be a valid selector
+PASS ":-webkit-full-screen" should be a valid selector
+

--- a/LayoutTests/fast/selectors/selector-aliases.html
+++ b/LayoutTests/fast/selectors/selector-aliases.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Selectors: pseudo-classes aliases are parse-time aliases</title>
+<link rel="help" href="https://drafts.csswg.org/selectors/#legacy-aliasing">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../imported/w3c/web-platform-tests/css/support/parsing-testcommon.js"></script>
+<script>
+test_valid_selector(":-webkit-autofill", ":autofill");
+test_valid_selector(":-webkit-full-screen", ":fullscreen");
+</script>

--- a/LayoutTests/fullscreen/full-screen-css-expected.txt
+++ b/LayoutTests/fullscreen/full-screen-css-expected.txt
@@ -9,7 +9,7 @@ EXPECTED (document.defaultView.getComputedStyle(document.documentElement, null).
 EVENT(webkitfullscreenchange)
 EXPECTED (document.webkitCurrentFullScreenElement == '[object HTMLSpanElement]') OK
 EXPECTED (document.defaultView.getComputedStyle(span, null).getPropertyValue('background-color') == 'rgb(0, 255, 0)') OK
-EXPECTED (document.defaultView.getComputedStyle(document.documentElement, null).getPropertyValue('background-color') == 'rgb(255, 0, 0)') OK
+EXPECTED (document.defaultView.getComputedStyle(document.documentElement, null).getPropertyValue('background-color') == 'rgb(0, 255, 0)') OK
 EXPECTED (document.defaultView.getComputedStyle(document.documentElement, null).getPropertyValue('color') == 'rgb(0, 0, 255)') OK
 END OF TEST
 

--- a/LayoutTests/fullscreen/full-screen-css.html
+++ b/LayoutTests/fullscreen/full-screen-css.html
@@ -3,7 +3,6 @@
 <style>
     :-webkit-full-screen { background: lime; }
     :-webkit-full-screen-document { color: blue; }
-    :root:-webkit-full-screen-document:not(:-webkit-full-screen) { background: red; }
 </style>
 <span></span>
 <script>
@@ -29,7 +28,7 @@
         var spanEnteredFullScreen = function(event) {
             testExpected("document.webkitCurrentFullScreenElement", span);
             testExpected("document.defaultView.getComputedStyle(span, null).getPropertyValue('background-color')", "rgb(0, 255, 0)");
-            testExpected("document.defaultView.getComputedStyle(document.documentElement, null).getPropertyValue('background-color')", "rgb(255, 0, 0)");
+            testExpected("document.defaultView.getComputedStyle(document.documentElement, null).getPropertyValue('background-color')", "rgb(0, 255, 0)");
             testExpected("document.defaultView.getComputedStyle(document.documentElement, null).getPropertyValue('color')", "rgb(0, 0, 255)");
         
             endTest();

--- a/Source/WebCore/css/CSSPseudoSelectors.json
+++ b/Source/WebCore/css/CSSPseudoSelectors.json
@@ -37,11 +37,6 @@
             "comment": "For UA stylesheet use.",
             "status": "non-standard"
         },
-        "-webkit-full-screen": {
-            "comment": "For compatibility.",
-            "condition": "ENABLE(FULLSCREEN_API)",
-            "status": "non-standard"
-        },
         "-webkit-full-screen-ancestor": {
             "comment": "For compatibility.",
             "condition": "ENABLE(FULLSCREEN_API)",
@@ -96,6 +91,9 @@
         "focus-visible": {},
         "focus-within": {},
         "fullscreen": {
+            "aliases": [
+                "-webkit-full-screen"
+            ],
             "condition": "ENABLE(FULLSCREEN_API)"
         },
         "future": {

--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -534,9 +534,6 @@ String CSSSelector::selectorText(StringView separator, StringView rightSide) con
             case CSSSelector::PseudoClass::Fullscreen:
                 builder.append(":fullscreen");
                 break;
-            case CSSSelector::PseudoClass::WebKitFullScreen:
-                builder.append(":-webkit-full-screen");
-                break;
             case CSSSelector::PseudoClass::WebKitFullScreenAncestor:
                 builder.append(":-webkit-full-screen-ancestor");
                 break;

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -167,7 +167,6 @@ struct PossiblyQuotedIdentifier {
             NoButton,
 #if ENABLE(FULLSCREEN_API)
             Fullscreen,
-            WebKitFullScreen,
             WebKitFullScreenDocument,
             WebKitFullScreenAncestor,
             WebKitAnimatingFullScreenTransition,

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -1047,8 +1047,6 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, const LocalCont
 #if ENABLE(FULLSCREEN_API)
         case CSSSelector::PseudoClass::Fullscreen:
             return matchesFullscreenPseudoClass(element);
-        case CSSSelector::PseudoClass::WebKitFullScreen:
-            return matchesWebkitFullScreenPseudoClass(element);
         case CSSSelector::PseudoClass::WebKitAnimatingFullScreenTransition:
             return matchesFullScreenAnimatingFullScreenTransitionPseudoClass(element);
         case CSSSelector::PseudoClass::WebKitFullScreenAncestor:

--- a/Source/WebCore/css/SelectorCheckerTestFunctions.h
+++ b/Source/WebCore/css/SelectorCheckerTestFunctions.h
@@ -416,19 +416,6 @@ ALWAYS_INLINE bool matchesFullscreenPseudoClass(const Element& element)
     return false;
 }
 
-ALWAYS_INLINE bool matchesWebkitFullScreenPseudoClass(const Element& element)
-{
-    // While a Document is in the fullscreen state, and the document's current fullscreen
-    // element is an element in the document, the 'full-screen' pseudoclass applies to
-    // that element. Also, an <iframe>, <object> or <embed> element whose child browsing
-    // context's Document is in the fullscreen state has the 'full-screen' pseudoclass applied.
-    if (is<HTMLFrameElementBase>(element) && element.hasFullscreenFlag())
-        return true;
-    if (!element.document().fullscreenManager().isFullscreen())
-        return false;
-    return &element == element.document().fullscreenManager().currentFullscreenElement();
-}
-
 ALWAYS_INLINE bool matchesFullScreenAnimatingFullScreenTransitionPseudoClass(const Element& element)
 {
     if (&element != element.document().fullscreenManager().currentFullscreenElement())

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -107,7 +107,6 @@ using PseudoClassesSet = HashSet<CSSSelector::PseudoClass, IntHash<CSSSelector::
     v(operationIsValid) \
     v(operationIsWindowInactive) \
     v(operationMatchesFullscreenPseudoClass) \
-    v(operationMatchesWebkitFullScreenPseudoClass) \
     v(operationMatchesFullScreenDocumentPseudoClass) \
     v(operationMatchesFullScreenAncestorPseudoClass) \
     v(operationMatchesFullScreenAnimatingFullScreenTransitionPseudoClass) \
@@ -258,7 +257,6 @@ static JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesDir, bool,
 static JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesLangPseudoClass, bool, (const Element&, const FixedVector<PossiblyQuotedIdentifier>&));
 #if ENABLE(FULLSCREEN_API)
 static JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesFullscreenPseudoClass, bool, (const Element&));
-static JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesWebkitFullScreenPseudoClass, bool, (const Element&));
 static JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesFullScreenDocumentPseudoClass, bool, (const Element&));
 static JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesFullScreenAncestorPseudoClass, bool, (const Element&));
 static JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesFullScreenAnimatingFullScreenTransitionPseudoClass, bool, (const Element&));
@@ -903,12 +901,6 @@ JSC_DEFINE_JIT_OPERATION(operationMatchesFullscreenPseudoClass, bool, (const Ele
     return matchesFullscreenPseudoClass(element);
 }
 
-JSC_DEFINE_JIT_OPERATION(operationMatchesWebkitFullScreenPseudoClass, bool, (const Element& element))
-{
-    COUNT_SELECTOR_OPERATION(operationMatchesWebkitFullScreenPseudoClass);
-    return matchesWebkitFullScreenPseudoClass(element);
-}
-
 JSC_DEFINE_JIT_OPERATION(operationMatchesFullScreenDocumentPseudoClass, bool, (const Element& element))
 {
     COUNT_SELECTOR_OPERATION(operationMatchesFullScreenDocumentPseudoClass);
@@ -1126,9 +1118,6 @@ static inline FunctionType addPseudoClassType(const CSSSelector& selector, Selec
 #if ENABLE(FULLSCREEN_API)
     case CSSSelector::PseudoClass::Fullscreen:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesFullscreenPseudoClass));
-        return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClass::WebKitFullScreen:
-        fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesWebkitFullScreenPseudoClass));
         return FunctionType::SimpleSelectorChecker;
     case CSSSelector::PseudoClass::WebKitFullScreenDocument:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesFullScreenDocumentPseudoClass));


### PR DESCRIPTION
#### c0e3ff49d701c24f709245fc4ed192bb9673a838
<pre>
Alias `:-webkit-full-screen` pseudo-class to `:fullscreen`
<a href="https://bugs.webkit.org/show_bug.cgi?id=266962">https://bugs.webkit.org/show_bug.cgi?id=266962</a>
<a href="https://rdar.apple.com/120335917">rdar://120335917</a>

Reviewed by Darin Adler.

The match functions for :fullscreen and :-webkit-full-screen are compatible with each other.
They differ in some very small edge cases, but for the most common cases they behave identically, alias them to clean up some code.

* LayoutTests/fast/selectors/selector-aliases-expected.txt: Added.
* LayoutTests/fast/selectors/selector-aliases.html: Added.
* LayoutTests/fullscreen/full-screen-css-expected.txt:
* LayoutTests/fullscreen/full-screen-css.html:
* Source/WebCore/css/CSSPseudoSelectors.json:
* Source/WebCore/css/CSSSelector.cpp:
(WebCore::CSSSelector::selectorText const):
* Source/WebCore/css/CSSSelector.h:
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::checkOne const):
* Source/WebCore/css/SelectorCheckerTestFunctions.h:
(WebCore::matchesWebkitFullScreenPseudoClass): Deleted.
* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::addPseudoClassType):

Canonical link: <a href="https://commits.webkit.org/272557@main">https://commits.webkit.org/272557@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de2872841cdb0ee27f4957dfe0d102b305861381

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32103 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10822 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33893 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34647 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29097 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32933 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13179 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8044 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/28674 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32503 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9131 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/28690 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7926 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/8096 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28605 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35991 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29191 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29061 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/34207 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8214 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/6165 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32066 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9855 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/28410 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7497 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8860 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8742 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->