### PR TITLE
[GStreamer][WebCodecs] Improve VPx encoding accuracy

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp
@@ -259,13 +259,9 @@ String GStreamerInternalVideoEncoder::initialize(const String& codecName, const 
     GRefPtr<GstCaps> encoderCaps;
     if (codecName == "vp8"_s)
         encoderCaps = adoptGRef(gst_caps_new_empty_simple("video/x-vp8"));
-    else if (codecName.startsWith("vp09"_s)) {
+    else if (codecName.startsWith("vp09"_s))
         encoderCaps = adoptGRef(gst_caps_new_empty_simple("video/x-vp9"));
-        if (auto profileId = GStreamerCodecUtilities::parseVP9Profile(codecName)) {
-            auto profile = makeString(profileId);
-            gst_caps_set_simple(encoderCaps.get(), "profile", G_TYPE_STRING, profile.ascii().data(), nullptr);
-        }
-    } else if (codecName.startsWith("avc1"_s)) {
+    else if (codecName.startsWith("avc1"_s)) {
         encoderCaps = adoptGRef(gst_caps_new_empty_simple("video/x-h264"));
         auto [profile, level] = GStreamerCodecUtilities::parseH264ProfileAndLevel(codecName);
         if (profile)
@@ -288,8 +284,9 @@ String GStreamerInternalVideoEncoder::initialize(const String& codecName, const 
         gst_caps_set_simple(encoderCaps.get(), "height", G_TYPE_INT, static_cast<int>(config.height), nullptr);
 
     // FIXME: Propagate config.frameRate to caps?
+    gst_caps_set_simple(encoderCaps.get(), "framerate", GST_TYPE_FRACTION, 1, 1, nullptr);
 
-    if (!videoEncoderSetFormat(WEBKIT_VIDEO_ENCODER(m_harness->element()), WTFMove(encoderCaps)))
+    if (!videoEncoderSetFormat(WEBKIT_VIDEO_ENCODER(m_harness->element()), WTFMove(encoderCaps), codecName))
         return "Unable to set encoder format"_s;
 
     if (config.bitRate > 1000)

--- a/Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.h
@@ -21,6 +21,8 @@
 
 #if USE(GSTREAMER)
 
+#include "GRefPtrGStreamer.h"
+
 #include <wtf/Forward.h>
 
 namespace WebCore {
@@ -29,7 +31,7 @@ namespace GStreamerCodecUtilities {
 
 std::pair<const char*, const char*> parseH264ProfileAndLevel(const String& codec);
 const char* parseHEVCProfile(const String& codec);
-uint8_t parseVP9Profile(const String& codec);
+std::pair<GRefPtr<GstCaps>, GRefPtr<GstCaps>> capsFromCodecString(const String&, unsigned width, unsigned height, int framerateNumerator, int framerateDenominator);
 
 } // namespace GStreamerCodecUtilities
 

--- a/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.h
+++ b/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.h
@@ -45,5 +45,5 @@ struct _WebKitVideoEncoderClass {
 GType webkit_video_encoder_get_type(void);
 
 bool videoEncoderSupportsFormat(WebKitVideoEncoder*, const GRefPtr<GstCaps>&);
-bool videoEncoderSetFormat(WebKitVideoEncoder*, GRefPtr<GstCaps>&&);
+bool videoEncoderSetFormat(WebKitVideoEncoder*, GRefPtr<GstCaps>&&, const String& = emptyString());
 void teardownVideoEncoderSingleton();


### PR DESCRIPTION
#### 71c6f87c37cc6d6d4b06f88d5281c7734712a6ec
<pre>
[GStreamer][WebCodecs] Improve VPx encoding accuracy
<a href="https://bugs.webkit.org/show_bug.cgi?id=266966">https://bugs.webkit.org/show_bug.cgi?id=266966</a>

Reviewed by Xabier Rodriguez-Calvar.

The codec string passed to the encoder is now parsed and converted to an input/output caps pair to
be used by the internal encoder. VPx encoders are now more accurately handling colorspace
informations. As follow-up, a similar approach can be used for avc and av1 cases.

* Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp:
(WebCore::GStreamerInternalVideoDecoder::GStreamerInternalVideoDecoder):
(WebCore::GStreamerInternalVideoDecoder::decode):
* Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp:
(WebCore::GStreamerInternalVideoEncoder::initialize):
* Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.cpp:
(WebCore::vpxCapsFromCodecString):
(WebCore::GStreamerCodecUtilities::capsFromCodecString):
(WebCore::GStreamerCodecUtilities::parseVP9Profile): Deleted.
* Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.h:
* Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp:
(videoEncoderSetEncoder):
(videoEncoderSetFormat):
(webkit_video_encoder_class_init):
* Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.h:
(videoEncoderSetFormat):

Canonical link: <a href="https://commits.webkit.org/272806@main">https://commits.webkit.org/272806@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e5e3625784c878c0bf1874d499bf5d66b4c809e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32999 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11771 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34900 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35642 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29819 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33969 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14109 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8940 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29256 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33473 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9918 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29483 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8651 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8800 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29439 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36976 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29975 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29851 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34934 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8938 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6879 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32789 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10629 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7674 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9530 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9568 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->