### PR TITLE
[GStreamer] GRefPtr template specialization for GstObject

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GRefPtrGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GRefPtrGStreamer.cpp
@@ -59,6 +59,25 @@ template<> void derefGPtr<GstMiniObject>(GstMiniObject* ptr)
         gst_mini_object_unref(ptr);
 }
 
+template<> GRefPtr<GstObject> adoptGRef(GstObject* ptr)
+{
+    return GRefPtr<GstObject>(ptr, GRefPtrAdopt);
+}
+
+template<> GstObject* refGPtr<GstObject>(GstObject* ptr)
+{
+    if (ptr)
+        gst_object_ref(ptr);
+
+    return ptr;
+}
+
+template<> void derefGPtr<GstObject>(GstObject* ptr)
+{
+    if (ptr)
+        gst_object_unref(ptr);
+}
+
 template <> GRefPtr<GstElement> adoptGRef(GstElement* ptr)
 {
     ASSERT(!ptr || !g_object_is_floating(ptr));

--- a/Source/WebCore/platform/graphics/gstreamer/GRefPtrGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GRefPtrGStreamer.h
@@ -64,6 +64,10 @@ template<> GRefPtr<GstMiniObject> adoptGRef(GstMiniObject* ptr);
 template<> GstMiniObject* refGPtr<GstMiniObject>(GstMiniObject* ptr);
 template<> void derefGPtr<GstMiniObject>(GstMiniObject* ptr);
 
+template<> GRefPtr<GstObject> adoptGRef(GstObject* ptr);
+template<> GstObject* refGPtr<GstObject>(GstObject* ptr);
+template<> void derefGPtr<GstObject>(GstObject* ptr);
+
 template<> GRefPtr<GstElement> adoptGRef(GstElement* ptr);
 template<> GstElement* refGPtr<GstElement>(GstElement* ptr);
 template<> void derefGPtr<GstElement>(GstElement* ptr);


### PR DESCRIPTION
#### 39f515330ba663c2806b9a1fe0d1da15c02cabd7
<pre>
[GStreamer] GRefPtr template specialization for GstObject
<a href="https://bugs.webkit.org/show_bug.cgi?id=266967">https://bugs.webkit.org/show_bug.cgi?id=266967</a>

Reviewed by Carlos Garcia Campos.

Without this the leak tracer might report leaks from MediaPlayerPrivateGStreamer::updateTracks()
that uses a GRefPtr&lt;GstObject&gt;. I don&apos;t think it&apos;s a real one, because without this patch GRefPtr
would fallback to the default GObject ref/unref, which is also OK, but not tracked by the leak tracer.

* Source/WebCore/platform/graphics/gstreamer/GRefPtrGStreamer.cpp:
(WTF::adoptGRef):
(WTF::refGPtr&lt;GstObject&gt;):
(WTF::derefGPtr&lt;GstObject&gt;):
* Source/WebCore/platform/graphics/gstreamer/GRefPtrGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/272553@main">https://commits.webkit.org/272553@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6ede75a0d89ef98d5aff902d5d9ae23e176d8dc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32086 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10804 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33873 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34629 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29080 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32915 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13161 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8027 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/28660 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32485 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9119 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28677 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7912 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8085 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28592 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-tables/tentative/table-fixed-minmax.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35973 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29180 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29047 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34192 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8197 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6153 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32050 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9838 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7494 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8843 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8724 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->