### PR TITLE
[bmalloc] Weaken memory order of getSlowCase()

### DIFF
--- a/Source/bmalloc/bmalloc/StaticPerProcess.h
+++ b/Source/bmalloc/bmalloc/StaticPerProcess.h
@@ -81,11 +81,11 @@ private:
     {
         using Storage = typename StaticPerProcessStorageTraits<T>::Storage;
         LockHolder lock(Storage::s_mutex);
-        if (!Storage::s_object.load(std::memory_order_consume)) {
+        if (!Storage::s_object.load(std::memory_order_relaxed)) {
             T* t = new (&Storage::s_memory) T(lock);
-            Storage::s_object.store(t, std::memory_order_release);
+            Storage::s_object.store(t, std::memory_order_relaxed);
         }
-        return Storage::s_object.load(std::memory_order_consume);
+        return Storage::s_object.load(std::memory_order_relaxed);
     }
 };
 


### PR DESCRIPTION
<pre>
[bmalloc] Weaken memory order of getSlowCase()
https://bugs.webkit.org/show_bug.cgi?id=266970

Reviewed by NOBODY (OOPS!).

getSlowCase()'s accesses to Storage::s_object can safely be relaxed as
the method is not inline and is not subject to data races.

* Source/bmalloc/bmalloc/StaticPerProcess.h:
  (bmalloc::StaticPerProcess::getSlowCase): Weaken memory order for 
  accessing Storage::s_object.
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6572548984241bf6b92f069a1e13e4cb4c538337

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/63101 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/42457 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/15697 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/67122 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/13705 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/50144 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/13989 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/67122 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/13705 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/66170 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/50144 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/15697 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/67122 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/50144 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/15697 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/12581 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/56211 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/50144 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/15697 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/68817 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/62344 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/7047 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/13989 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/68817 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/7079 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/15697 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/68817 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/84107 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/38277 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/84107 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/39357 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/40468 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/39099 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->