### PR TITLE
Use CSS tokenizer for parsing standalone pseudo-elements

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-pseudo-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-pseudo-expected.txt
@@ -4,7 +4,7 @@ PASS Resolution of width is correct when pseudo-element argument is ignored (due
 PASS Resolution of width is correct when pseudo-element argument is invalid (due to a trailing token)
 PASS Resolution of width is correct for ::before and ::after pseudo-elements (single-colon)
 PASS Resolution of width is correct for ::before and ::after pseudo-elements (double-colon)
-FAIL Pseudo-elements can use the full range of CSS syntax assert_equals: expected "50px" but got ""
+PASS Pseudo-elements can use the full range of CSS syntax
 PASS Resolution of width is correct for ::before and ::after pseudo-elements of display: contents elements
 PASS Resolution of nonexistent pseudo-element styles
 PASS Resolution of pseudo-element styles in display: none elements

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -119,7 +119,7 @@ public:
     static bool isPseudoClassEnabled(PseudoClass, const CSSSelectorParserContext&);
     static bool isPseudoElementEnabled(PseudoElement, StringView, const CSSSelectorParserContext&);
     static std::optional<PseudoElement> parsePseudoElement(StringView, const CSSSelectorParserContext&);
-    static std::optional<PseudoId> parseStandalonePseudoElement(StringView, const CSSSelectorParserContext&);
+    static std::optional<PseudoId> parseStandalonePseudoElement(const String&, const CSSSelectorParserContext&);
     static bool pseudoClassRequiresArgument(PseudoClass);
     static bool pseudoElementRequiresArgument(PseudoElement);
     static bool pseudoClassMayHaveArgument(PseudoClass);


### PR DESCRIPTION
#### 6fc1d6cf00094896d8b7a58d7dcd0aa1efdee97c
<pre>
Use CSS tokenizer for parsing standalone pseudo-elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=266979">https://bugs.webkit.org/show_bug.cgi?id=266979</a>

Reviewed by Tim Nguyen.

This ensures we do the correct thing for CSS escapes and also paves the
path for supporting FunctionToken and potentially deduplicating with
CSSSelectorParser::consumePseudo() in the future.

272607@main added additional test coverage for various token inputs.

* LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-pseudo-expected.txt:
* Source/WebCore/css/CSSSelector.cpp:
(WebCore::CSSSelector::parseStandalonePseudoElement):
* Source/WebCore/css/CSSSelector.h:

Canonical link: <a href="https://commits.webkit.org/272649@main">https://commits.webkit.org/272649@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc2edbc598f6a331c3abb15368190871520d8d4b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32496 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11234 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34332 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35051 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29390 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33353 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13587 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8433 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28916 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32922 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9491 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29037 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8245 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8389 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28970 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36387 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29534 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29395 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34518 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8521 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6474 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32372 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10188 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7570 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9140 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9101 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->