### PR TITLE
[GStreamer] Crash in CachedResourceStreamingClient::dataReceived

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3750,8 +3750,6 @@ webkit.org/b/266465 [ Debug ] imported/w3c/web-platform-tests/editing/run/delete
 
 webkit.org/b/266636 fast/multicol/last-set-crash.html [ Skip ]
 
-webkit.org/b/266708 imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/loading-the-media-resource/resource-selection-currentSrc.html [ Pass Crash ]
-
 webkit.org/b/266719 fast/canvas/offscreen-giant.html [ ImageOnlyFailure ]
 
 webkit.org/b/266713 webrtc/processIceTransportStateChange-gc.html [ Skip ]

--- a/Source/WTF/wtf/PlatformGTK.cmake
+++ b/Source/WTF/wtf/PlatformGTK.cmake
@@ -5,6 +5,7 @@ list(APPEND WTF_PUBLIC_HEADERS
     glib/GMutexLocker.h
     glib/GRefPtr.h
     glib/GSocketMonitor.h
+    glib/GThreadSafeWeakPtr.h
     glib/GTypedefs.h
     glib/GUniquePtr.h
     glib/GWeakPtr.h

--- a/Source/WTF/wtf/PlatformWPE.cmake
+++ b/Source/WTF/wtf/PlatformWPE.cmake
@@ -3,6 +3,7 @@ list(APPEND WTF_PUBLIC_HEADERS
     glib/GMutexLocker.h
     glib/GRefPtr.h
     glib/GSocketMonitor.h
+    glib/GThreadSafeWeakPtr.h
     glib/GTypedefs.h
     glib/GUniquePtr.h
     glib/GWeakPtr.h

--- a/Source/WTF/wtf/glib/GThreadSafeWeakPtr.h
+++ b/Source/WTF/wtf/glib/GThreadSafeWeakPtr.h
@@ -1,0 +1,83 @@
+/*
+ *  Copyright (C) 2024 Igalia S.L.
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Library General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Library General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Library General Public License
+ *  along with this library; see the file COPYING.LIB.  If not, write to
+ *  the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ *  Boston, MA 02110-1301, USA.
+ *
+ */
+
+#pragma once
+
+#if USE(GLIB)
+
+#include "GRefPtr.h"
+
+#include <glib-object.h>
+#include <wtf/Noncopyable.h>
+
+namespace WTF {
+
+template <typename T> class GThreadSafeWeakPtr {
+    WTF_MAKE_NONCOPYABLE(GThreadSafeWeakPtr);
+public:
+    GThreadSafeWeakPtr()
+    {
+        g_weak_ref_init(&m_ref, nullptr);
+    }
+
+    explicit GThreadSafeWeakPtr(T* ptr)
+    {
+        RELEASE_ASSERT(!ptr || G_IS_OBJECT(ptr));
+        g_weak_ref_init(&m_ref, ptr);
+    }
+
+    GThreadSafeWeakPtr(GThreadSafeWeakPtr&& other)
+    {
+        auto strongRef = other.get();
+        g_weak_ref_set(&other.m_ref, nullptr);
+        g_weak_ref_init(&m_ref, strongRef.get());
+    }
+
+    ~GThreadSafeWeakPtr()
+    {
+        g_weak_ref_clear(&m_ref);
+    }
+
+    WARN_UNUSED_RETURN GRefPtr<T> get()
+    {
+        return adoptGRef(reinterpret_cast<T*>(g_weak_ref_get(&m_ref)));
+    }
+
+    void reset(T* ptr = nullptr)
+    {
+        RELEASE_ASSERT(!ptr || G_IS_OBJECT(ptr));
+        g_weak_ref_set(&m_ref, ptr);
+    }
+
+    GThreadSafeWeakPtr& operator=(std::nullptr_t)
+    {
+        reset();
+        return *this;
+    }
+
+private:
+    GWeakRef m_ref;
+};
+
+} // namespace WTF
+
+using WTF::GThreadSafeWeakPtr;
+
+#endif // USE(GLIB)

--- a/Tools/TestWebKitAPI/Tests/WTF/glib/GWeakPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/glib/GWeakPtr.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 
 #include "Test.h"
+#include <wtf/glib/GThreadSafeWeakPtr.h>
 #include <wtf/glib/GWeakPtr.h>
 
 namespace TestWebKitAPI {
@@ -128,6 +129,73 @@ TEST(WTF_GWeakPtr, Move)
         g_clear_object(&obj);
         EXPECT_NULL(weak2.get());
         EXPECT_FALSE(weak2);
+    }
+    EXPECT_NULL(obj);
+}
+
+TEST(WTF_GThreadSafeWeakPtr, Basic)
+{
+    GThreadSafeWeakPtr<GObject> empty;
+    EXPECT_NULL(empty.get());
+
+    GObject* obj = G_OBJECT(g_object_new(G_TYPE_OBJECT, nullptr));
+    GThreadSafeWeakPtr<GObject> weak(obj);
+    EXPECT_EQ(obj, weak.get());
+    g_clear_object(&obj);
+    EXPECT_NULL(weak.get());
+    EXPECT_NULL(obj);
+}
+
+TEST(WTF_GThreadSafeWeakPtr, Reset)
+{
+    GObject* obj = nullptr;
+    {
+        obj = G_OBJECT(g_object_new(G_TYPE_OBJECT, nullptr));
+        GThreadSafeWeakPtr<GObject> weak(obj);
+        EXPECT_EQ(obj, weak.get());
+        weak.reset();
+        EXPECT_NULL(weak.get());
+        g_clear_object(&obj);
+    }
+    EXPECT_NULL(obj);
+
+    {
+        obj = G_OBJECT(g_object_new(G_TYPE_OBJECT, nullptr));
+        GThreadSafeWeakPtr<GObject> weak(obj);
+        EXPECT_EQ(obj, weak.get());
+        weak = nullptr;
+        EXPECT_NULL(weak.get());
+        g_clear_object(&obj);
+    }
+    EXPECT_NULL(obj);
+
+    {
+        obj = G_OBJECT(g_object_new(G_TYPE_OBJECT, nullptr));
+        GThreadSafeWeakPtr<GObject> weak(obj);
+        EXPECT_EQ(obj, weak.get());
+        GObject* obj2 = G_OBJECT(g_object_new(G_TYPE_OBJECT, nullptr));
+        weak.reset(obj2);
+        EXPECT_EQ(obj2, weak.get());
+        g_clear_object(&obj);
+        EXPECT_EQ(obj2, weak.get());
+        g_object_unref(obj2);
+        EXPECT_NULL(weak.get());
+    }
+    EXPECT_NULL(obj);
+}
+
+TEST(WTF_GThreadSafeWeakPtr, Move)
+{
+    GObject* obj = nullptr;
+    {
+        obj = G_OBJECT(g_object_new(G_TYPE_OBJECT, nullptr));
+        GThreadSafeWeakPtr<GObject> weak(obj);
+        EXPECT_EQ(obj, weak.get());
+        GThreadSafeWeakPtr<GObject> weak2 = WTFMove(weak);
+        EXPECT_NULL(weak.get());
+        EXPECT_EQ(obj, weak2.get());
+        g_clear_object(&obj);
+        EXPECT_NULL(weak2.get());
     }
     EXPECT_NULL(obj);
 }


### PR DESCRIPTION
#### 6a9d7a164705ebaf78a158be71f97a5f520f9655
<pre>
[GStreamer] Crash in CachedResourceStreamingClient::dataReceived
<a href="https://bugs.webkit.org/show_bug.cgi?id=266973">https://bugs.webkit.org/show_bug.cgi?id=266973</a>

Reviewed by Michael Catanzaro, Carlos Garcia Campos and Xabier Rodriguez-Calvar.

Store the WebKitWebSrc pointer as a weak reference in the CachedResourceStreamingClient. Using a
const raw pointer was not sufficient, because nothing prevented other code to dispose the element,
thus making the pointer point to garbage. We can&apos;t use a strong reference because it would introduce
a reference cycle between WebKitWebSrc and the CachedResourceStreamingClient.

* Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp:
(webKitWebSrcMakeRequest):
(CachedResourceStreamingClient::CachedResourceStreamingClient):
(CachedResourceStreamingClient::~CachedResourceStreamingClient):
(CachedResourceStreamingClient::checkUpdateBlocksize):
(CachedResourceStreamingClient::responseReceived):
(CachedResourceStreamingClient::dataReceived):
(CachedResourceStreamingClient::accessControlCheckFailed):
(CachedResourceStreamingClient::loadFailed):
(CachedResourceStreamingClient::loadFinished):

Canonical link: <a href="https://commits.webkit.org/272807@main">https://commits.webkit.org/272807@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f945af303527332a58844c460d013e149531752c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32845 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11599 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34715 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35463 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29669 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33777 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13945 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8778 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29119 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33295 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9782 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29330 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8516 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8663 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29286 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36796 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/28105 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29840 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29691 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34784 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/32850 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8780 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6743 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32652 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10470 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/39317 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7677 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9389 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8282 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9402 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->