### PR TITLE
[webkitbugspy] Implement ability to relate radars

### DIFF
--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py
@@ -466,17 +466,11 @@ class Tracker(GenericTracker):
 
         return result
 
-    def issues_to_ids(self, issues):
-        if not isinstance(issues, (list, tuple)):
-            raise TypeError('Input should be a list of Issue objects.')
-        issue_ids = []
-        for i in issues:
-            issue_id = i.link
-            if isinstance(i.tracker, Tracker):
-                issue_ids.append(i.id)
-            else:
-                raise TypeError('Cannot relate issues of different types.')
-        return issue_ids
+    def related_issue_id(self, issue):
+        if isinstance(issue.tracker, Tracker):
+            return issue.id
+        else:
+            raise TypeError('Cannot relate issues of different types.')
 
     def relate(self, issue, depends_on=None, blocks=None, regressed_by=None, regressions=None, **relations):
         if relations:
@@ -485,13 +479,13 @@ class Tracker(GenericTracker):
         update_dict = dict()
         update_dict['ids'] = [issue.id]
         if depends_on:
-            update_dict['depends_on'] = {'add': self.issues_to_ids(depends_on)}
+            update_dict['depends_on'] = {'add': [self.related_issue_id(depends_on)]}
         if blocks:
-            update_dict['blocks'] = {'add': self.issues_to_ids(blocks)}
+            update_dict['blocks'] = {'add': [self.related_issue_id(blocks)]}
         if regressed_by:
-            update_dict['regressed_by'] = {'add': self.issues_to_ids(regressed_by)}
+            update_dict['regressed_by'] = {'add': [self.related_issue_id(regressed_by)]}
         if regressions:
-            update_dict['regressions'] = {'add': self.issues_to_ids(regressions)}
+            update_dict['regressions'] = {'add': [self.related_issue_id(regressions)]}
 
         response = None
         try:
@@ -512,13 +506,13 @@ class Tracker(GenericTracker):
             self.populate(issue, 'related')
         else:
             if depends_on:
-                issue._related['depends_on'] += depends_on
+                issue._related['depends_on'].append(depends_on)
             if blocks:
-                issue._related['blocks'] += blocks
+                issue._related['blocks'].append(blocks)
             if regressed_by:
-                issue._related['regressed_by'] += regressed_by
+                issue._related['regressed_by'].append(regressed_by)
             if regressions:
-                issue._related['regressions'] += regressions
+                issue._related['regressions'].append(regressions)
         return issue
 
     @property

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py
@@ -600,7 +600,7 @@ What component in 'WebKit' should the bug be associated with?:
             issue = tracker.issue(1)
 
             self.assertEqual(issue.related, {'depends_on': [], 'blocks': [], 'regressions': [], 'regressed_by': []})
-            issue.relate(depends_on=[tracker.issue(2)])
+            issue.relate(depends_on=tracker.issue(2))
             self.assertEqual(issue.related['depends_on'], [tracker.issue(2)])
             self.assertEqual(issue.related['blocks'], [])
 
@@ -613,7 +613,7 @@ What component in 'WebKit' should the bug be associated with?:
             issue = tracker.issue(1)
 
             self.assertEqual(issue.related, {'depends_on': [], 'blocks': [], 'regressions': [], 'regressed_by': []})
-            issue.relate(depends_on=[tracker.issue(2)], blocks=[tracker.issue(3)])
+            issue.relate(depends_on=tracker.issue(2), blocks=tracker.issue(3))
             self.assertEqual(issue.related['depends_on'], [tracker.issue(2)])
             self.assertEqual(issue.related['blocks'], [tracker.issue(3)])
 
@@ -628,7 +628,7 @@ What component in 'WebKit' should the bug be associated with?:
 
             self.assertEqual(issue.related, {'depends_on': [], 'blocks': [], 'regressions': [], 'regressed_by': []})
             with self.assertRaises(TypeError) as c:
-                issue.relate(fake_relation=[0])
+                issue.relate(fake_relation=0)
             self.assertEqual('\'fake_relation\' is an invalid relation', str(c.exception))
             self.assertEqual(issue.related, {'depends_on': [], 'blocks': [], 'regressions': [], 'regressed_by': []})
 
@@ -637,14 +637,14 @@ What component in 'WebKit' should the bug be associated with?:
                 BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
                 BUGS_EXAMPLE_COM_PASSWORD='password',
         ), users=mocks.USERS, issues=mocks.ISSUES):
-            bugzilla_tracker = bugzilla.Tracker(self.URL)
+            tracker = bugzilla.Tracker(self.URL)
 
-            issue = bugzilla_tracker.issue(1)
+            issue = tracker.issue(1)
 
             self.assertEqual(issue.related, {'depends_on': [], 'blocks': [], 'regressions': [], 'regressed_by': []})
             with self.assertRaises(AttributeError) as c:
-                issue.relate(blocks=[0])
-            self.assertEqual('\'int\' object has no attribute \'link\'', str(c.exception))
+                issue.relate(blocks=17)
+            self.assertEqual('\'int\' object has no attribute \'tracker\'', str(c.exception))
             self.assertEqual(issue.related, {'depends_on': [], 'blocks': [], 'regressions': [], 'regressed_by': []})
 
     def test_relate_fail_radar(self):
@@ -659,6 +659,6 @@ What component in 'WebKit' should the bug be associated with?:
 
             self.assertEqual(issue.related, {'depends_on': [], 'blocks': [], 'regressions': [], 'regressed_by': []})
             with self.assertRaises(TypeError) as c:
-                issue.relate(blocks=[radar_tracker.issue(1)])
+                issue.relate(blocks=radar_tracker.issue(1))
             self.assertEqual('Cannot relate issues of different types.', str(c.exception))
             self.assertEqual(issue.related, {'depends_on': [], 'blocks': [], 'regressions': [], 'regressed_by': []})


### PR DESCRIPTION
#### d7bdf653cbd118b1081198813b8ea6c16bd6a4ae
<pre>
[webkitbugspy] Implement ability to relate radars
<a href="https://rdar.apple.com/120013230">rdar://120013230</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=266790">https://bugs.webkit.org/show_bug.cgi?id=266790</a>

Reviewed by Jonathan Bedard.

You can now create and modify relationships between radars using radarclient!
Added mocks for testing. Aligned bugzilla.relate functionality with radar.relate.

* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/radar.py:
(RadarModel.__init__):
(RadarModel.relationships):
(RadarModel.add_relationship):
(Radar.Relationship):
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py:
(Tracker):
(Tracker.populate):
(Tracker.create_relationship):
(Tracker.relate):
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py:

Canonical link: <a href="https://commits.webkit.org/273248@main">https://commits.webkit.org/273248@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd2e0c7f4c3a525906e29818ee3db6e0b9e6f2b1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34707 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13524 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36710 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37389 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31326 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35848 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15920 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10609 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30284 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35232 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11440 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30906 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10003 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/35074 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10072 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30982 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38652 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31499 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31320 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36122 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10191 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8082 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34085 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12015 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7994 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10739 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11071 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->