### PR TITLE
Disable AES-CFB.

### DIFF
--- a/LayoutTests/crypto/subtle/aes-cbc-cfb-decrypt-malformed-parameters.html
+++ b/LayoutTests/crypto/subtle/aes-cbc-cfb-decrypt-malformed-parameters.html
@@ -17,6 +17,9 @@ var extractable = false;
 var cipherText = hexStringToUint8Array("2ffa4618784dfd414b22c40c6330d022");
 var rawKey = asciiToUint8Array("jnOw99oOZFLIEPMr");
 
+if (window.internals)
+  internals.settings.setDeprecateAESCFBWebCryptoEnabled(false);
+  
 crypto.subtle.importKey("raw", rawKey, "aes-cbc", extractable, ["decrypt"]).then(function(result) {
     key = result;
     // Wrong iv length

--- a/LayoutTests/crypto/subtle/aes-cbc-cfb-encrypt-malformed-parameters.html
+++ b/LayoutTests/crypto/subtle/aes-cbc-cfb-encrypt-malformed-parameters.html
@@ -17,6 +17,9 @@ var extractable = false;
 var plainText = asciiToUint8Array("Hello, World!");
 var rawKey = asciiToUint8Array("jnOw99oOZFLIEPMr");
 
+if (window.internals)
+  internals.settings.setDeprecateAESCFBWebCryptoEnabled(false);
+ 
 crypto.subtle.importKey("raw", rawKey, "aes-cbc", extractable, ["encrypt"]).then(function(result) {
     key = result;
     // Malformed AlgorithmIdentifiers

--- a/LayoutTests/crypto/subtle/aes-cfb-generate-export-key-jwk-length-128.html
+++ b/LayoutTests/crypto/subtle/aes-cfb-generate-export-key-jwk-length-128.html
@@ -15,6 +15,9 @@ jsTestIsAsync = true;
 
 var extractable = true;
 
+if (window.internals)
+  internals.settings.setDeprecateAESCFBWebCryptoEnabled(false);
+ 
 debug("Generating a key...");
 crypto.subtle.generateKey({name: "aes-cfb-8", length: 128}, extractable, ["encrypt", "decrypt", "wrapKey", "unwrapKey"]).then(function(key) {
     debug("Exporting a key...");

--- a/LayoutTests/crypto/subtle/aes-cfb-generate-export-key-jwk-length-192.html
+++ b/LayoutTests/crypto/subtle/aes-cfb-generate-export-key-jwk-length-192.html
@@ -15,6 +15,9 @@ jsTestIsAsync = true;
 
 var extractable = true;
 
+if (window.internals)
+  internals.settings.setDeprecateAESCFBWebCryptoEnabled(false);
+ 
 debug("Generating a key...");
 crypto.subtle.generateKey({name: "aes-cfb-8", length: 192}, extractable, ["encrypt", "decrypt", "wrapKey", "unwrapKey"]).then(function(key) {
     debug("Exporting a key...");

--- a/LayoutTests/crypto/subtle/aes-cfb-generate-export-key-jwk-length-256.html
+++ b/LayoutTests/crypto/subtle/aes-cfb-generate-export-key-jwk-length-256.html
@@ -15,6 +15,9 @@ jsTestIsAsync = true;
 
 var extractable = true;
 
+if (window.internals)
+  internals.settings.setDeprecateAESCFBWebCryptoEnabled(false);
+ 
 debug("Generating a key...");
 crypto.subtle.generateKey({name: "aes-cfb-8", length: 256}, extractable, ["encrypt", "decrypt", "wrapKey", "unwrapKey"]).then(function(key) {
     debug("Exporting a key...");

--- a/LayoutTests/crypto/subtle/aes-cfb-generate-export-raw-key.html
+++ b/LayoutTests/crypto/subtle/aes-cfb-generate-export-raw-key.html
@@ -15,6 +15,9 @@ jsTestIsAsync = true;
 
 var extractable = true;
 
+if (window.internals)
+  internals.settings.setDeprecateAESCFBWebCryptoEnabled(false);
+ 
 debug("Generating a key...");
 crypto.subtle.generateKey({name: "aes-cfb-8", length: 256}, extractable, ["encrypt", "decrypt", "wrapKey", "unwrapKey"]).then(function(key) {
     debug("Exporting a key...");

--- a/LayoutTests/crypto/subtle/aes-cfb-generate-key-encrypt-decrypt.html
+++ b/LayoutTests/crypto/subtle/aes-cfb-generate-key-encrypt-decrypt.html
@@ -18,6 +18,9 @@ var aesCfbParams = {
     iv: asciiToUint8Array("jnOw99oOZFLIEPMr"),
 }
 
+if (window.internals)
+  internals.settings.setDeprecateAESCFBWebCryptoEnabled(false);
+ 
 debug("Generating a key...");
 crypto.subtle.generateKey({name: "aes-cfb-8", length: 256}, true, ["decrypt", "encrypt"]).then(function(result) {
     key = result;

--- a/LayoutTests/crypto/subtle/aes-cfb-generate-key.html
+++ b/LayoutTests/crypto/subtle/aes-cfb-generate-key.html
@@ -13,6 +13,9 @@ description("Test generating an AES key with length 128 using AES-CFB algorithm.
 
 jsTestIsAsync = true;
 
+if (window.internals)
+  internals.settings.setDeprecateAESCFBWebCryptoEnabled(false);
+ 
 debug("Generating a key...");
 crypto.subtle.generateKey({name: "aes-cfb-8", length: 128}, true, ["encrypt", "decrypt", "unwrapKey", "wrapKey"]).then(function(result) {
     key = result;

--- a/LayoutTests/crypto/subtle/aes-cfb-import-jwk-key-length-128.html
+++ b/LayoutTests/crypto/subtle/aes-cfb-import-jwk-key-length-128.html
@@ -20,6 +20,9 @@ var jwkKey = {
 };
 var extractable = true;
 
+if (window.internals)
+  internals.settings.setDeprecateAESCFBWebCryptoEnabled(false);
+ 
 debug("Importing a key...");
 crypto.subtle.importKey("jwk", jwkKey, "aes-cfb-8", extractable, ["encrypt", "decrypt", "wrapKey", "unwrapKey"]).then(function(result) {
     key = result;

--- a/LayoutTests/crypto/subtle/aes-cfb-import-jwk-key-length-192.html
+++ b/LayoutTests/crypto/subtle/aes-cfb-import-jwk-key-length-192.html
@@ -20,6 +20,9 @@ var jwkKey = {
 };
 var extractable = true;
 
+if (window.internals)
+  internals.settings.setDeprecateAESCFBWebCryptoEnabled(false);
+ 
 debug("Importing a key...");
 crypto.subtle.importKey("jwk", jwkKey, "aes-cfb-8", extractable, ["encrypt", "decrypt", "wrapKey", "unwrapKey"]).then(function(result) {
     key = result;

--- a/LayoutTests/crypto/subtle/aes-cfb-import-jwk-key-length-256.html
+++ b/LayoutTests/crypto/subtle/aes-cfb-import-jwk-key-length-256.html
@@ -20,6 +20,9 @@ var jwkKey = {
 };
 var extractable = true;
 
+if (window.internals)
+  internals.settings.setDeprecateAESCFBWebCryptoEnabled(false);
+ 
 debug("Importing a key...");
 crypto.subtle.importKey("jwk", jwkKey, "aes-cfb-8", extractable, ["encrypt", "decrypt", "wrapKey", "unwrapKey"]).then(function(result) {
     key = result;

--- a/LayoutTests/crypto/subtle/aes-cfb-import-key-decrypt.html
+++ b/LayoutTests/crypto/subtle/aes-cfb-import-key-decrypt.html
@@ -22,6 +22,9 @@ var aesCfbParams = {
 var rawKey = asciiToUint8Array("jnOw99oOZFLIEPMr");
 var expectedPlainText = "Hello, World!";
 
+if (window.internals)
+  internals.settings.setDeprecateAESCFBWebCryptoEnabled(false);
+ 
 crypto.subtle.importKey("raw", rawKey, "aes-cfb-8", extractable, ["decrypt"]).then(function(key) {
     return crypto.subtle.decrypt(aesCfbParams, key, cipherText);
 }).then(function(result) {

--- a/LayoutTests/crypto/subtle/aes-cfb-import-key-encrypt.html
+++ b/LayoutTests/crypto/subtle/aes-cfb-import-key-encrypt.html
@@ -22,6 +22,9 @@ var aesCfbParams = {
 var rawKey = asciiToUint8Array("jnOw99oOZFLIEPMr");
 var expectedCipherText = "a572525a0baef88e6f5b198c6f";
 
+if (window.internals)
+  internals.settings.setDeprecateAESCFBWebCryptoEnabled(false);
+ 
 crypto.subtle.importKey("raw", rawKey, "aes-cfb-8", extractable, ["encrypt"]).then(function(key) {
     return crypto.subtle.encrypt(aesCfbParams, key, plainText);
 }).then(function(result) {

--- a/LayoutTests/crypto/subtle/aes-cfb-import-key-unwrap-jwk-key.html
+++ b/LayoutTests/crypto/subtle/aes-cfb-import-key-unwrap-jwk-key.html
@@ -29,7 +29,9 @@ var aesCfbParams = {
 }
 var wrappedKey = hexStringToUint8Array("96a1740c58cb039ce9d3f77c4031efc6e3c16adbc1ce9a1b0d5bc5b953e2d9de3f5413b01b940477fd80cee9f49e09c38ce965c2040a3fc1449ba4f2b6c03386acd2b2a145e335e1890c4ac351b4702d07b6ea330cce9d44af7e2a");
 
-
+if (window.internals)
+  internals.settings.setDeprecateAESCFBWebCryptoEnabled(false);
+ 
 crypto.subtle.importKey("raw", rawKey, "aes-cfb-8", extractable, ["unwrapKey"]).then(function(unwrappingKey) {
     return crypto.subtle.unwrapKey("jwk", wrappedKey, unwrappingKey, aesCfbParams, {name: "aes-cbc"}, extractable, ["encrypt"]);
 }).then(function(cryptoKey) {

--- a/LayoutTests/crypto/subtle/aes-cfb-import-key-unwrap-raw-key.html
+++ b/LayoutTests/crypto/subtle/aes-cfb-import-key-unwrap-raw-key.html
@@ -22,6 +22,9 @@ var aesCfbParams = {
 }
 var wrappedKey = hexStringToUint8Array("8707ee311f6e8ed157885a7fc25f0ee7");
 
+if (window.internals)
+  internals.settings.setDeprecateAESCFBWebCryptoEnabled(false);
+ 
 
 crypto.subtle.importKey("raw", rawKey, "aes-cfb-8", extractable, ["unwrapKey"]).then(function(unwrappingKey) {
     return crypto.subtle.unwrapKey("raw", wrappedKey, unwrappingKey, aesCfbParams, {name: "aes-cbc"}, extractable, ["encrypt"]);

--- a/LayoutTests/crypto/subtle/aes-cfb-import-key-wrap-jwk-key.html
+++ b/LayoutTests/crypto/subtle/aes-cfb-import-key-wrap-jwk-key.html
@@ -21,6 +21,9 @@ var aesCfbParams = {
 }
 var expectWrappedKey = "96a17ede3414d990741d2fe5f1d93e74999ed6ca6071db6dc0cf0bcf9178b1ac037076d18ffe0e247ee570c2d551bc7621b0d791df9c7bc7c021ea1fda83e4c41d8704112777a86413dd7b20088479a615b83942d3903ef08f81f4";
 
+if (window.internals)
+  internals.settings.setDeprecateAESCFBWebCryptoEnabled(false);
+ 
 crypto.subtle.importKey("raw", rawKey, "aes-cfb-8", extractable, ["wrapKey"]).then(function(result) {
     wrappingKey = result;
     return crypto.subtle.importKey("raw", rawKey, "aes-cbc", extractable, ["encrypt"]);

--- a/LayoutTests/crypto/subtle/aes-cfb-import-key-wrap-raw-key.html
+++ b/LayoutTests/crypto/subtle/aes-cfb-import-key-wrap-raw-key.html
@@ -21,6 +21,9 @@ var aesCfbParams = {
 }
 var expectWrappedKey = "8707ee311f6e8ed157885a7fc25f0ee7";
 
+if (window.internals)
+  internals.settings.setDeprecateAESCFBWebCryptoEnabled(false);
+ 
 crypto.subtle.importKey("raw", rawKey, "aes-cfb-8", extractable, ["wrapKey"]).then(function(result) {
     wrappingKey = result;
     return crypto.subtle.importKey("raw", rawKey, "aes-cbc", extractable, ["encrypt"]);

--- a/LayoutTests/crypto/subtle/aes-cfb-import-raw-key.html
+++ b/LayoutTests/crypto/subtle/aes-cfb-import-raw-key.html
@@ -16,6 +16,9 @@ jsTestIsAsync = true;
 var rawKey = asciiToUint8Array("jnOw99oOZFLIEPMr");
 var extractable = true;
 
+if (window.internals)
+  internals.settings.setDeprecateAESCFBWebCryptoEnabled(false);
+ 
 debug("Importing a key...");
 crypto.subtle.importKey("raw", rawKey, "aes-cfb-8", extractable, ["encrypt", "decrypt", "wrapKey", "unwrapKey"]).then(function(result) {
     key = result;

--- a/LayoutTests/crypto/subtle/aes-export-key-malformed-parameters.html
+++ b/LayoutTests/crypto/subtle/aes-export-key-malformed-parameters.html
@@ -15,6 +15,9 @@ jsTestIsAsync = true;
 
 var extractable = true;
 
+if (window.internals)
+  internals.settings.setDeprecateAESCFBWebCryptoEnabled(false);
+
 crypto.subtle.generateKey({name: "aes-cbc", length: 128}, extractable, ["decrypt", "encrypt", "unwrapKey", "wrapKey"]).then(function(result) {
     key = result;
 

--- a/LayoutTests/crypto/subtle/aes-generate-key-malformed-parameters.html
+++ b/LayoutTests/crypto/subtle/aes-generate-key-malformed-parameters.html
@@ -13,6 +13,9 @@ description("Test generating an AES key with malformed-paramters.");
 
 var extractable = true;
 
+if (window.internals)
+  internals.settings.setDeprecateAESCFBWebCryptoEnabled(false);
+
 // Malformed AlgorithmIdentifiers
 shouldReject('crypto.subtle.generateKey("aes-cbc", extractable, ["encrypt", "decrypt"])');
 shouldReject('crypto.subtle.generateKey({name: "aes-cbc"}, extractable, ["encrypt", "decrypt"])');

--- a/LayoutTests/crypto/subtle/aes-import-key-malformed-parameters.html
+++ b/LayoutTests/crypto/subtle/aes-import-key-malformed-parameters.html
@@ -16,6 +16,9 @@ var k192 = "A72FD48989ED7E92A3B3A080F74FA80B";
 var k256 = "YWJjZGVmZ2gxMjM0NTY3OGFiY2RlZmdoMTIzNDU2Nzg";
 var extractable = true;
 
+if (window.internals)
+  internals.settings.setDeprecateAESCFBWebCryptoEnabled(false);
+
 // Raw: wrong length
 shouldReject('crypto.subtle.importKey("raw", asciiToUint8Array("jnOw97"), "aes-cbc", extractable, ["encrypt", "decrypt", "wrapKey", "unwrapKey"])');
 // Jwk: Wrong kty

--- a/LayoutTests/crypto/subtle/aes-kw-wrap-key-malformed-parameters.html
+++ b/LayoutTests/crypto/subtle/aes-kw-wrap-key-malformed-parameters.html
@@ -16,6 +16,9 @@ jsTestIsAsync = true;
 var extractable = true;
 var rawKey = asciiToUint8Array("jnOw99oOZFLIEPMr");
 
+if (window.internals)
+  internals.settings.setDeprecateAESCFBWebCryptoEnabled(false);
+  
 crypto.subtle.importKey("raw", rawKey, "aes-kw", extractable, ["wrapKey", "unwrapKey"]).then(function(result) {
     wrappingKey = result;
     return crypto.subtle.importKey("raw", rawKey, "aes-cbc", extractable, ["encrypt", "decrypt"]);

--- a/LayoutTests/crypto/workers/subtle/aes-cfb-import-key-decrypt.html
+++ b/LayoutTests/crypto/workers/subtle/aes-cfb-import-key-decrypt.html
@@ -5,6 +5,10 @@
 </head>
 <body>
     <script>
+
+        if (window.internals)
+          internals.settings.setDeprecateAESCFBWebCryptoEnabled(false);
+
         worker = startWorker('resources/aes-cfb-import-key-decrypt.js');
     </script>
     <script src="../../../resources/js-test-post.js"></script>

--- a/LayoutTests/crypto/workers/subtle/aes-cfb-import-key-encrypt.html
+++ b/LayoutTests/crypto/workers/subtle/aes-cfb-import-key-encrypt.html
@@ -5,6 +5,10 @@
 </head>
 <body>
     <script>
+
+        if (window.internals)
+          internals.settings.setDeprecateAESCFBWebCryptoEnabled(false);
+
         worker = startWorker('resources/aes-cfb-import-key-encrypt.js');
     </script>
     <script src="../../../resources/js-test-post.js"></script>

--- a/LayoutTests/crypto/workers/subtle/aes-cfb-import-key-unwrap-key.html
+++ b/LayoutTests/crypto/workers/subtle/aes-cfb-import-key-unwrap-key.html
@@ -5,6 +5,10 @@
 </head>
 <body>
     <script>
+
+        if (window.internals)
+          internals.settings.setDeprecateAESCFBWebCryptoEnabled(false);
+
         worker = startWorker('resources/aes-cfb-import-key-unwrap-key.js');
     </script>
     <script src="../../../resources/js-test-post.js"></script>

--- a/LayoutTests/crypto/workers/subtle/aes-cfb-import-key-wrap-key.html
+++ b/LayoutTests/crypto/workers/subtle/aes-cfb-import-key-wrap-key.html
@@ -5,6 +5,10 @@
 </head>
 <body>
     <script>
+
+        if (window.internals)
+          internals.settings.setDeprecateAESCFBWebCryptoEnabled(false);
+
         worker = startWorker('resources/aes-cfb-import-key-wrap-key.js');
     </script>
     <script src="../../../resources/js-test-post.js"></script>

--- a/LayoutTests/crypto/workers/subtle/aes-ctr-import-key-decrypt.html
+++ b/LayoutTests/crypto/workers/subtle/aes-ctr-import-key-decrypt.html
@@ -5,6 +5,10 @@
 </head>
 <body>
     <script>
+
+        if (window.internals)
+          internals.settings.setDeprecateAESCFBWebCryptoEnabled(false);
+
         worker = startWorker('resources/aes-ctr-import-key-decrypt.js');
     </script>
     <script src="../../../resources/js-test-post.js"></script>

--- a/LayoutTests/crypto/workers/subtle/resources/aes-cfb-import-key-unwrap-key.js
+++ b/LayoutTests/crypto/workers/subtle/resources/aes-cfb-import-key-unwrap-key.js
@@ -14,7 +14,6 @@ var aesCfbParams = {
 }
 var wrappedKey = hexStringToUint8Array("8707ee311f6e8ed157885a7fc25f0ee7");
 
-
 crypto.subtle.importKey("raw", rawKey, "aes-cfb-8", extractable, ["unwrapKey"]).then(function(unwrappingKey) {
     return crypto.subtle.unwrapKey("raw", wrappedKey, unwrappingKey, aesCfbParams, {name: "aes-cbc"}, extractable, ["encrypt"]);
 }).then(function(cryptoKey) {

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2216,6 +2216,20 @@ DefaultTextEncodingName:
     WebCore:
       default: '{ }'
 
+DeprecateAESCFBWebCryptoEnabled:
+  type: bool
+  status: stable
+  category: dom
+  humanReadableName: "Deprecate AES-CFB Web Crypto"
+  humanReadableDescription: "Enable Deprecation of AES-CFB from Web Crypto"
+  defaultValue:
+    WebKitLegacy:
+      default: true
+    WebKit:
+      default: true
+    WebCore:
+      default: true
+
 DeprecateRSAESPKCSWebCryptoEnabled:
   type: bool
   status: stable


### PR DESCRIPTION
#### 572fec1979ec18aa50fda2389fc9768459851535
<pre>
Disable AES-CFB.
<a href="https://bugs.webkit.org/show_bug.cgi?id=266990">https://bugs.webkit.org/show_bug.cgi?id=266990</a>
radar://120000331

Reviewed by Pascoe.

It&apos;s been removed from the standard since 2016.
This change will disable AES-CFB by default.
Following the same pattern as:
<a href="https://github.com/WebKit/WebKit/pull/8392">https://github.com/WebKit/WebKit/pull/8392</a>

* LayoutTests/crypto/subtle/aes-cbc-cfb-decrypt-malformed-parameters.html:
* LayoutTests/crypto/subtle/aes-cbc-cfb-encrypt-malformed-parameters.html:
* LayoutTests/crypto/subtle/aes-cfb-generate-export-key-jwk-length-128.html:
* LayoutTests/crypto/subtle/aes-cfb-generate-export-key-jwk-length-192.html:
* LayoutTests/crypto/subtle/aes-cfb-generate-export-key-jwk-length-256.html:
* LayoutTests/crypto/subtle/aes-cfb-generate-export-raw-key.html:
* LayoutTests/crypto/subtle/aes-cfb-generate-key-encrypt-decrypt.html:
* LayoutTests/crypto/subtle/aes-cfb-generate-key.html:
* LayoutTests/crypto/subtle/aes-cfb-import-jwk-key-length-128.html:
* LayoutTests/crypto/subtle/aes-cfb-import-jwk-key-length-192.html:
* LayoutTests/crypto/subtle/aes-cfb-import-jwk-key-length-256.html:
* LayoutTests/crypto/subtle/aes-cfb-import-key-decrypt.html:
* LayoutTests/crypto/subtle/aes-cfb-import-key-encrypt.html:
* LayoutTests/crypto/subtle/aes-cfb-import-key-unwrap-jwk-key.html:
* LayoutTests/crypto/subtle/aes-cfb-import-key-unwrap-raw-key.html:
* LayoutTests/crypto/subtle/aes-cfb-import-key-wrap-jwk-key.html:
* LayoutTests/crypto/subtle/aes-cfb-import-raw-key.html:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/crypto/SubtleCrypto.cpp:
(WebCore::isAESCFBWebCryptoDeprecated):
(WebCore::normalizeCryptoAlgorithmParameters):
(WebCore::isSupportedExportKey):

Canonical link: <a href="https://commits.webkit.org/272615@main">https://commits.webkit.org/272615@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9b27a2e13e812ac10cf05d6fb9a36bc7b4595ff

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32311 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11048 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34132 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34865 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29254 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33161 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13399 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8254 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28809 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32729 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9314 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28874 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8111 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8249 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28805 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36206 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/27756 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29376 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29236 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34379 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/32401 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8380 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6322 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32241 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10035 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/28579 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/38824 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7544 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9011 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8212 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8940 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->