### PR TITLE
[css-grid] Rename GridBaselineAlignment's isBaselineAxis variables and GridBaselineAlignment::isHorizontalBaselineAxis.

### DIFF
--- a/Source/WebCore/rendering/GridBaselineAlignment.cpp
+++ b/Source/WebCore/rendering/GridBaselineAlignment.cpp
@@ -44,9 +44,9 @@ namespace WebCore {
 // axis to move the grid items so that they are baseline-aligned, we want their "horizontal" margin (right);
 // the same will happen when using the column-axis under vertical writing mode, we also want in this case the
 // 'right' margin.
-LayoutUnit GridBaselineAlignment::marginOverForChild(const RenderBox& child, GridAxis axis) const
+LayoutUnit GridBaselineAlignment::marginOverForChild(const RenderBox& child, GridAxis alignmentAxis) const
 {
-    return isHorizontalBaselineAxis(axis) ? child.marginRight() : child.marginTop();
+    return isVerticalAlignmentContext(alignmentAxis) ? child.marginRight() : child.marginTop();
 }
 
 // This function gives the margin 'under' based on the baseline-axis, since in grid we can can 2-dimensional
@@ -54,12 +54,12 @@ LayoutUnit GridBaselineAlignment::marginOverForChild(const RenderBox& child, Gri
 // axis to move the grid items so that they are baseline-aligned, we want their "horizontal" margin (left);
 // the same will happen when using the column-axis under vertical writing mode, we also want in this case the
 // 'left' margin.
-LayoutUnit GridBaselineAlignment::marginUnderForChild(const RenderBox& child, GridAxis axis) const
+LayoutUnit GridBaselineAlignment::marginUnderForChild(const RenderBox& child, GridAxis alignmentAxis) const
 {
-    return isHorizontalBaselineAxis(axis) ? child.marginLeft() : child.marginBottom();
+    return isVerticalAlignmentContext(alignmentAxis) ? child.marginLeft() : child.marginBottom();
 }
 
-LayoutUnit GridBaselineAlignment::logicalAscentForChild(const RenderBox& child, GridAxis baselineAxis, ItemPosition position) const
+LayoutUnit GridBaselineAlignment::logicalAscentForChild(const RenderBox& child, GridAxis alignmentAxis, ItemPosition position) const
 {
     auto hasOrthogonalAncestorSubgrids = [&] {
         for (auto& currentAncestorSubgrid : ancestorSubgridsOfGridItem(child, GridTrackSizingDirection::ForRows)) {
@@ -70,22 +70,22 @@ LayoutUnit GridBaselineAlignment::logicalAscentForChild(const RenderBox& child, 
     };
 
     ExtraMarginsFromSubgrids extraMarginsFromAncestorSubgrids;
-    if (baselineAxis == GridAxis::GridColumnAxis && !hasOrthogonalAncestorSubgrids())
+    if (alignmentAxis == GridAxis::GridColumnAxis && !hasOrthogonalAncestorSubgrids())
         extraMarginsFromAncestorSubgrids = GridLayoutFunctions::extraMarginForSubgridAncestors(GridTrackSizingDirection::ForRows, child);
 
-    LayoutUnit ascent = ascentForChild(child, baselineAxis, position) + extraMarginsFromAncestorSubgrids.extraTrackStartMargin();
-    return (isDescentBaselineForChild(child, baselineAxis) || position == ItemPosition::LastBaseline) ? descentForChild(child, ascent, baselineAxis, extraMarginsFromAncestorSubgrids) : ascent;
+    LayoutUnit ascent = ascentForChild(child, alignmentAxis, position) + extraMarginsFromAncestorSubgrids.extraTrackStartMargin();
+    return (isDescentBaselineForChild(child, alignmentAxis) || position == ItemPosition::LastBaseline) ? descentForChild(child, ascent, alignmentAxis, extraMarginsFromAncestorSubgrids) : ascent;
 }
 
-LayoutUnit GridBaselineAlignment::ascentForChild(const RenderBox& child, GridAxis baselineAxis, ItemPosition position) const
+LayoutUnit GridBaselineAlignment::ascentForChild(const RenderBox& child, GridAxis alignmentAxis, ItemPosition position) const
 {
     static const LayoutUnit noValidBaseline = LayoutUnit(-1);
 
     ASSERT(position == ItemPosition::Baseline || position == ItemPosition::LastBaseline);
     auto baseline = 0_lu;
-    LayoutUnit margin = isDescentBaselineForChild(child, baselineAxis) ? marginUnderForChild(child, baselineAxis) : marginOverForChild(child, baselineAxis);
+    LayoutUnit margin = isDescentBaselineForChild(child, alignmentAxis) ? marginUnderForChild(child, alignmentAxis) : marginOverForChild(child, alignmentAxis);
 
-    if (baselineAxis == GridAxis::GridColumnAxis) {
+    if (alignmentAxis == GridAxis::GridColumnAxis) {
         ASSERT(child.parentStyle());
         auto* parentStyle = child.parentStyle();
 
@@ -93,7 +93,7 @@ LayoutUnit GridBaselineAlignment::ascentForChild(const RenderBox& child, GridAxi
             return child.parentStyle()->isHorizontalWritingMode() ? LineDirectionMode::HorizontalLine : LineDirectionMode::VerticalLine;
         };
 
-        if (!isParallelToBaselineAxisForChild(child, baselineAxis))
+        if (!isParallelToAlignmentAxisForChild(child, alignmentAxis))
             return (parentStyle ? synthesizedBaseline(child, *child.parentStyle(), alignmentContextDirection(), BaselineSynthesisEdge::BorderBox) : 0_lu) + margin;
         auto ascent = position == ItemPosition::Baseline ? child.firstLineBaseline() : child.lastLineBaseline();
         if (!ascent)
@@ -101,11 +101,11 @@ LayoutUnit GridBaselineAlignment::ascentForChild(const RenderBox& child, GridAxi
         baseline = ascent.value();
     } else {
         auto computedBaselineValue = position == ItemPosition::Baseline ? child.firstLineBaseline() : child.lastLineBaseline();
-        baseline = isParallelToBaselineAxisForChild(child, baselineAxis) ? computedBaselineValue.value_or(noValidBaseline) : noValidBaseline;
+        baseline = isParallelToAlignmentAxisForChild(child, alignmentAxis) ? computedBaselineValue.value_or(noValidBaseline) : noValidBaseline;
         // We take border-box's under edge if no valid baseline.
         if (baseline == noValidBaseline) {
             ASSERT(!child.needsLayout());
-            if (isHorizontalBaselineAxis(baselineAxis))
+            if (isVerticalAlignmentContext(alignmentAxis))
                 return isFlippedWritingMode(m_blockFlow) ? child.size().width().toInt() + margin : margin;
             return child.size().height() + margin;
         }
@@ -114,24 +114,24 @@ LayoutUnit GridBaselineAlignment::ascentForChild(const RenderBox& child, GridAxi
     return margin + baseline;
 }
 
-LayoutUnit GridBaselineAlignment::descentForChild(const RenderBox& child, LayoutUnit ascent, GridAxis baselineAxis, ExtraMarginsFromSubgrids extraMarginsFromAncestorSubgrids) const
+LayoutUnit GridBaselineAlignment::descentForChild(const RenderBox& child, LayoutUnit ascent, GridAxis alignmentAxis, ExtraMarginsFromSubgrids extraMarginsFromAncestorSubgrids) const
 {
     ASSERT(!child.needsLayout());
-    if (isParallelToBaselineAxisForChild(child, baselineAxis))
+    if (isParallelToAlignmentAxisForChild(child, alignmentAxis))
         return extraMarginsFromAncestorSubgrids.extraTotalMargin() + child.marginLogicalHeight() + child.logicalHeight() - ascent;
     return child.marginLogicalWidth() + child.logicalWidth() - ascent;
 }
 
-bool GridBaselineAlignment::isDescentBaselineForChild(const RenderBox& child, GridAxis baselineAxis) const
+bool GridBaselineAlignment::isDescentBaselineForChild(const RenderBox& child, GridAxis alignmentAxis) const
 {
-    return isHorizontalBaselineAxis(baselineAxis)
+    return isVerticalAlignmentContext(alignmentAxis)
         && ((child.style().isFlippedBlocksWritingMode() && !isFlippedWritingMode(m_blockFlow))
             || (child.style().isFlippedLinesWritingMode() && isFlippedWritingMode(m_blockFlow)));
 }
 
-bool GridBaselineAlignment::isHorizontalBaselineAxis(GridAxis axis) const
+bool GridBaselineAlignment::isVerticalAlignmentContext(GridAxis alignmentAxis) const
 {
-    return axis == GridAxis::GridRowAxis ? isHorizontalWritingMode(m_blockFlow) : !isHorizontalWritingMode(m_blockFlow);
+    return alignmentAxis == GridAxis::GridRowAxis ? isHorizontalWritingMode(m_blockFlow) : !isHorizontalWritingMode(m_blockFlow);
 }
 
 bool GridBaselineAlignment::isOrthogonalChildForBaseline(const RenderBox& child) const
@@ -139,32 +139,32 @@ bool GridBaselineAlignment::isOrthogonalChildForBaseline(const RenderBox& child)
     return isHorizontalWritingMode(m_blockFlow) != child.isHorizontalWritingMode();
 }
 
-bool GridBaselineAlignment::isParallelToBaselineAxisForChild(const RenderBox& child, GridAxis axis) const
+bool GridBaselineAlignment::isParallelToAlignmentAxisForChild(const RenderBox& child, GridAxis alignmentAxis) const
 {
-    return axis == GridAxis::GridColumnAxis ? !isOrthogonalChildForBaseline(child) : isOrthogonalChildForBaseline(child);
+    return alignmentAxis == GridAxis::GridColumnAxis ? !isOrthogonalChildForBaseline(child) : isOrthogonalChildForBaseline(child);
 }
 
-const BaselineGroup& GridBaselineAlignment::baselineGroupForChild(ItemPosition preference, unsigned sharedContext, const RenderBox& child, GridAxis baselineAxis) const
+const BaselineGroup& GridBaselineAlignment::baselineGroupForChild(ItemPosition preference, unsigned sharedContext, const RenderBox& child, GridAxis alignmentAxis) const
 {
     ASSERT(isBaselinePosition(preference));
-    bool isRowAxisContext = baselineAxis == GridAxis::GridColumnAxis;
+    bool isRowAxisContext = alignmentAxis == GridAxis::GridColumnAxis;
     auto& baselineAlignmentStateMap = isRowAxisContext ? m_rowAxisBaselineAlignmentStates : m_colAxisBaselineAlignmentStates;
     auto* baselineAlignmentState = baselineAlignmentStateMap.get(sharedContext);
     ASSERT(baselineAlignmentState);
     return baselineAlignmentState->sharedGroup(child, preference);
 }
 
-void GridBaselineAlignment::updateBaselineAlignmentContext(ItemPosition preference, unsigned sharedContext, const RenderBox& child, GridAxis baselineAxis)
+void GridBaselineAlignment::updateBaselineAlignmentContext(ItemPosition preference, unsigned sharedContext, const RenderBox& child, GridAxis alignmentAxis)
 {
     ASSERT(isBaselinePosition(preference));
     ASSERT(!child.needsLayout());
 
     // Determine Ascent and Descent values of this child with respect to
     // its grid container.
-    LayoutUnit ascent = logicalAscentForChild(child, baselineAxis, preference);
+    LayoutUnit ascent = logicalAscentForChild(child, alignmentAxis, preference);
     // Looking up for a shared alignment context perpendicular to the
-    // baseline axis.
-    bool isRowAxisContext = baselineAxis == GridAxis::GridColumnAxis;
+    // alignment axis.
+    bool isRowAxisContext = alignmentAxis == GridAxis::GridColumnAxis;
     auto& baselineAlignmentStateMap = isRowAxisContext ? m_rowAxisBaselineAlignmentStates : m_colAxisBaselineAlignmentStates;
     // Looking for a compatible baseline-sharing group.
     if (auto* baselineAlignmentStateSearch = baselineAlignmentStateMap.get(sharedContext))
@@ -173,18 +173,18 @@ void GridBaselineAlignment::updateBaselineAlignmentContext(ItemPosition preferen
         baselineAlignmentStateMap.add(sharedContext, makeUnique<BaselineAlignmentState>(child, preference, ascent));
 }
 
-LayoutUnit GridBaselineAlignment::baselineOffsetForChild(ItemPosition preference, unsigned sharedContext, const RenderBox& child, GridAxis baselineAxis) const
+LayoutUnit GridBaselineAlignment::baselineOffsetForChild(ItemPosition preference, unsigned sharedContext, const RenderBox& child, GridAxis alignmentAxis) const
 {
     ASSERT(isBaselinePosition(preference));
-    auto& group = baselineGroupForChild(preference, sharedContext, child, baselineAxis);
+    auto& group = baselineGroupForChild(preference, sharedContext, child, alignmentAxis);
     if (group.computeSize() > 1)
-        return group.maxAscent() - logicalAscentForChild(child, baselineAxis, preference);
+        return group.maxAscent() - logicalAscentForChild(child, alignmentAxis, preference);
     return LayoutUnit();
 }
 
-void GridBaselineAlignment::clear(GridAxis baselineAxis)
+void GridBaselineAlignment::clear(GridAxis alignmentAxis)
 {
-    if (baselineAxis == GridAxis::GridColumnAxis)
+    if (alignmentAxis == GridAxis::GridColumnAxis)
         m_rowAxisBaselineAlignmentStates.clear();
     else
         m_colAxisBaselineAlignmentStates.clear();

--- a/Source/WebCore/rendering/GridBaselineAlignment.h
+++ b/Source/WebCore/rendering/GridBaselineAlignment.h
@@ -70,9 +70,9 @@ private:
     LayoutUnit ascentForChild(const RenderBox&, GridAxis, ItemPosition) const;
     LayoutUnit descentForChild(const RenderBox&, LayoutUnit, GridAxis, ExtraMarginsFromSubgrids) const;
     bool isDescentBaselineForChild(const RenderBox&, GridAxis) const;
-    bool isHorizontalBaselineAxis(GridAxis) const;
+    bool isVerticalAlignmentContext(GridAxis) const;
     bool isOrthogonalChildForBaseline(const RenderBox&) const;
-    bool isParallelToBaselineAxisForChild(const RenderBox&, GridAxis) const;
+    bool isParallelToAlignmentAxisForChild(const RenderBox&, GridAxis) const;
 
     typedef HashMap<unsigned, std::unique_ptr<BaselineAlignmentState>, DefaultHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>> BaselineAlignmentStateMap;
 


### PR DESCRIPTION
#### fcb681a31f038cac1be045d5b5491a53ec0f42dc
<pre>
[css-grid] Rename GridBaselineAlignment&apos;s isBaselineAxis variables and GridBaselineAlignment::isHorizontalBaselineAxis.
<a href="https://bugs.webkit.org/show_bug.cgi?id=266991">https://bugs.webkit.org/show_bug.cgi?id=266991</a>
<a href="https://rdar.apple.com/problem/120378682">rdar://problem/120378682</a>

Reviewed by Alan Baradlay.

There are spec terms that can be used to better represent what these
variables are capturing. The baselineAxis variables seem to be referring
to which direction in which alignment is occurring. The &quot;baseline axis,&quot;
is not a spec term, but the &quot;alignment axis&quot; is so we should use that
instead. I changed all instances of baselineAxis as well as various
function arguments that were just &quot;axis,&quot; since those were being passed
in baselineAxis anyway.

I also changed isHorizontalBaselineAxis to isVerticalAlignmentContext.
These are equivalent since whenever the axis of the alignment context is
vertical that means we have a horizontal alignment axis. It is better
to know the direction of the alignment context axis anyways since the
spec makes decisions based off of that.

<a href="https://drafts.csswg.org/css-align-3/">https://drafts.csswg.org/css-align-3/</a>
<a href="https://drafts.csswg.org/css-align-3/#baseline-rules">https://drafts.csswg.org/css-align-3/#baseline-rules</a>

* Source/WebCore/rendering/GridBaselineAlignment.cpp:
(WebCore::GridBaselineAlignment::marginOverForChild const):
(WebCore::GridBaselineAlignment::marginUnderForChild const):
(WebCore::GridBaselineAlignment::logicalAscentForChild const):
(WebCore::GridBaselineAlignment::ascentForChild const):
(WebCore::GridBaselineAlignment::descentForChild const):
(WebCore::GridBaselineAlignment::isDescentBaselineForChild const):
(WebCore::GridBaselineAlignment::isVerticalAlignmentContext const):
(WebCore::GridBaselineAlignment::isParallelToAlignmentAxisForChild const):
(WebCore::GridBaselineAlignment::baselineGroupForChild const):
(WebCore::GridBaselineAlignment::updateBaselineAlignmentContext):
(WebCore::GridBaselineAlignment::baselineOffsetForChild const):
(WebCore::GridBaselineAlignment::clear):
(WebCore::GridBaselineAlignment::isHorizontalBaselineAxis const): Deleted.
(WebCore::GridBaselineAlignment::isParallelToBaselineAxisForChild const): Deleted.
* Source/WebCore/rendering/GridBaselineAlignment.h:

Canonical link: <a href="https://commits.webkit.org/272579@main">https://commits.webkit.org/272579@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c179c6a7b6b2d1aedf9a0656e42dbb7038b5f4bc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32203 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10937 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34017 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34765 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29186 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33052 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13292 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8149 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28754 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32621 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9216 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28789 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8026 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8179 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28704 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36110 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29275 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29159 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34306 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8307 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/6248 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32167 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9948 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7516 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8939 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8844 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->