### PR TITLE
[css-grid] Rename GridBaselineAlignment's m_blockFlow to m_writingMode.

### DIFF
--- a/Source/WebCore/rendering/GridBaselineAlignment.cpp
+++ b/Source/WebCore/rendering/GridBaselineAlignment.cpp
@@ -106,7 +106,7 @@ LayoutUnit GridBaselineAlignment::ascentForChild(const RenderBox& child, GridAxi
         if (baseline == noValidBaseline) {
             ASSERT(!child.needsLayout());
             if (isVerticalAlignmentContext(alignmentAxis))
-                return isFlippedWritingMode(m_blockFlow) ? child.size().width().toInt() + margin : margin;
+                return isFlippedWritingMode(m_writingMode) ? child.size().width().toInt() + margin : margin;
             return child.size().height() + margin;
         }
     }
@@ -125,18 +125,18 @@ LayoutUnit GridBaselineAlignment::descentForChild(const RenderBox& child, Layout
 bool GridBaselineAlignment::isDescentBaselineForChild(const RenderBox& child, GridAxis alignmentAxis) const
 {
     return isVerticalAlignmentContext(alignmentAxis)
-        && ((child.style().isFlippedBlocksWritingMode() && !isFlippedWritingMode(m_blockFlow))
-            || (child.style().isFlippedLinesWritingMode() && isFlippedWritingMode(m_blockFlow)));
+        && ((child.style().isFlippedBlocksWritingMode() && !isFlippedWritingMode(m_writingMode))
+            || (child.style().isFlippedLinesWritingMode() && isFlippedWritingMode(m_writingMode)));
 }
 
 bool GridBaselineAlignment::isVerticalAlignmentContext(GridAxis alignmentAxis) const
 {
-    return alignmentAxis == GridAxis::GridRowAxis ? isHorizontalWritingMode(m_blockFlow) : !isHorizontalWritingMode(m_blockFlow);
+    return alignmentAxis == GridAxis::GridRowAxis ? isHorizontalWritingMode(m_writingMode) : !isHorizontalWritingMode(m_writingMode);
 }
 
 bool GridBaselineAlignment::isOrthogonalChildForBaseline(const RenderBox& child) const
 {
-    return isHorizontalWritingMode(m_blockFlow) != child.isHorizontalWritingMode();
+    return isHorizontalWritingMode(m_writingMode) != child.isHorizontalWritingMode();
 }
 
 bool GridBaselineAlignment::isParallelToAlignmentAxisForChild(const RenderBox& child, GridAxis alignmentAxis) const

--- a/Source/WebCore/rendering/GridBaselineAlignment.h
+++ b/Source/WebCore/rendering/GridBaselineAlignment.h
@@ -57,7 +57,7 @@ public:
 
     // Sets the Grid Container's writing-mode so that we can avoid the dependecy of the LayoutGrid class for
     // determining whether a grid item is orthogonal or not.
-    void setBlockFlow(WritingMode blockFlow) { m_blockFlow = blockFlow; };
+    void setWritingMode(WritingMode writingMode) { m_writingMode = writingMode; };
 
     // Clearing the Baseline Alignment context and their internal classes and data structures.
     void clear(GridAxis);
@@ -77,7 +77,7 @@ private:
     typedef HashMap<unsigned, std::unique_ptr<BaselineAlignmentState>, DefaultHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>> BaselineAlignmentStateMap;
 
     // Grid Container's WritingMode, used to determine grid item's orthogonality.
-    WritingMode m_blockFlow;
+    WritingMode m_writingMode;
     BaselineAlignmentStateMap m_rowAxisBaselineAlignmentStates;
     BaselineAlignmentStateMap m_colAxisBaselineAlignmentStates;
 };

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -1623,7 +1623,7 @@ void GridTrackSizingAlgorithm::computeBaselineAlignmentContext()
 {
     GridAxis axis = gridAxisForDirection(m_direction);
     m_baselineAlignment.clear(axis);
-    m_baselineAlignment.setBlockFlow(m_renderGrid->style().writingMode());
+    m_baselineAlignment.setWritingMode(m_renderGrid->style().writingMode());
     BaselineItemsCache& baselineItemsCache = axis == GridAxis::GridColumnAxis ? m_columnBaselineItemsMap : m_rowBaselineItemsMap;
     BaselineItemsCache tmpBaselineItemsCache = baselineItemsCache;
     for (auto* child : tmpBaselineItemsCache.keys()) {


### PR DESCRIPTION
#### 5e996b5167f06a420715b3718bdf05860eaa5b3e
<pre>
[css-grid] Rename GridBaselineAlignment&apos;s m_blockFlow to m_writingMode.
<a href="https://bugs.webkit.org/show_bug.cgi?id=266993">https://bugs.webkit.org/show_bug.cgi?id=266993</a>
<a href="https://rdar.apple.com/problem/120379902">rdar://problem/120379902</a>

Reviewed by Tim Nguyen.

This variable refers to the grid&apos;s writing mode and not its block flow
direction. We can get the block flow direction from the writing mode,
but we also need to know its writing mode since the spec will use it in
certain scenarions.

See: <a href="https://drafts.csswg.org/css-align-3/#baseline-export">https://drafts.csswg.org/css-align-3/#baseline-export</a>

* Source/WebCore/rendering/GridBaselineAlignment.cpp:
(WebCore::GridBaselineAlignment::ascentForChild const):
(WebCore::GridBaselineAlignment::isDescentBaselineForChild const):
(WebCore::GridBaselineAlignment::isHorizontalBaselineAxis const):
(WebCore::GridBaselineAlignment::isOrthogonalChildForBaseline const):
* Source/WebCore/rendering/GridBaselineAlignment.h:
(WebCore::GridBaselineAlignment::setWritingMode):
(WebCore::GridBaselineAlignment::setBlockFlow): Deleted.
* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::GridTrackSizingAlgorithm::computeBaselineAlignmentContext):

Canonical link: <a href="https://commits.webkit.org/272582@main">https://commits.webkit.org/272582@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d2a4fc1de36844818eb08b8fe4730920826b0ae

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32225 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10959 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34040 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34785 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29204 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33075 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13312 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8169 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/28766 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32643 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9240 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28812 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8045 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8200 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28730 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36130 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29300 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29177 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/34324 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8325 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6261 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32187 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9966 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7520 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8958 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8864 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->