### PR TITLE
Make ServerTrust API tests more tolerant of multiple connections

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Challenge.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Challenge.mm
@@ -586,6 +586,7 @@ static void verifyCertificateAndPublicKey(SecTrustRef trust)
 
 - (void)webView:(WKWebView *)webView didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition disposition, NSURLCredential *credential))completionHandler
 {
+    EXPECT_WK_STREQ(challenge.protectionSpace.authenticationMethod, NSURLAuthenticationMethodServerTrust);
     _authenticationChallengeCount++;
     SecTrustRef trust = challenge.protectionSpace.serverTrust;
     verifyCertificateAndPublicKey(trust);
@@ -608,7 +609,7 @@ TEST(WebKit, ServerTrust)
     [delegate waitForDidFinishNavigation];
 
     verifyCertificateAndPublicKey([webView serverTrust]);
-    EXPECT_EQ([delegate authenticationChallengeCount], 1u);
+    EXPECT_GT([delegate authenticationChallengeCount], 0u);
 }
 
 TEST(WebKit, FastServerTrust)
@@ -623,7 +624,7 @@ TEST(WebKit, FastServerTrust)
     [webView setNavigationDelegate:delegate.get()];
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"https://localhost:%d/", server.port()]]]];
     [delegate waitForDidFinishNavigation];
-    EXPECT_EQ([delegate authenticationChallengeCount], 1ull);
+    EXPECT_GT([delegate authenticationChallengeCount], 0u);
 }
 
 TEST(WebKit, ErrorSecureCoding)


### PR DESCRIPTION
#### d0deb6d3a89ef661a4ec6a89954b7cac4d486716
<pre>
Make ServerTrust API tests more tolerant of multiple connections
<a href="https://bugs.webkit.org/show_bug.cgi?id=266995">https://bugs.webkit.org/show_bug.cgi?id=266995</a>
<a href="https://rdar.apple.com/119839895">rdar://119839895</a>

Reviewed by Ryosuke Niwa.

Bots indicate that sometimes these tests will make 2 TCP connections to the server,
which is ok and expected.  The tests only need to verify that more than 0 TLS handshakes
happened successfully.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/Challenge.mm:
(-[ServerTrustDelegate webView:didReceiveAuthenticationChallenge:completionHandler:]):
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/272617@main">https://commits.webkit.org/272617@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3142911b432e1f0b4e053a2ba68e6536d3678780

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32214 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10948 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34028 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34774 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29193 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33064 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13301 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8158 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28760 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32632 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9227 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28798 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8035 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8187 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28716 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36119 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29287 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29165 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34314 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8314 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6251 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32177 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9955 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8946 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4185 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8853 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->