### PR TITLE
_WKHitTestResult should expose a linkLocalDataMIMEType property

### DIFF
--- a/Source/WebCore/rendering/HitTestResult.cpp
+++ b/Source/WebCore/rendering/HitTestResult.cpp
@@ -671,6 +671,18 @@ URL HitTestResult::absoluteLinkURL() const
     return url;
 }
 
+bool HitTestResult::hasLocalDataForLinkURL() const
+{
+    auto linkURL = absoluteLinkURL();
+    if (linkURL.isEmpty())
+        return false;
+
+    if (RefPtr page = m_innerURLElement->document().page())
+        return page->hasLocalDataForURL(linkURL);
+
+    return false;
+}
+
 bool HitTestResult::isOverLink() const
 {
     return m_innerURLElement && m_innerURLElement->isLink();

--- a/Source/WebCore/rendering/HitTestResult.h
+++ b/Source/WebCore/rendering/HitTestResult.h
@@ -110,6 +110,7 @@ public:
     WEBCORE_EXPORT URL absolutePDFURL() const;
     WEBCORE_EXPORT URL absoluteMediaURL() const;
     WEBCORE_EXPORT URL absoluteLinkURL() const;
+    WEBCORE_EXPORT bool hasLocalDataForLinkURL() const;
     WEBCORE_EXPORT String textContent() const;
     bool isOverLink() const;
     WEBCORE_EXPORT bool isContentEditable() const;

--- a/Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.h
+++ b/Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.h
@@ -45,6 +45,7 @@ WK_CLASS_AVAILABLE(macos(10.12), ios(16.0))
 
 @property (nonatomic, readonly, copy) NSURL *absolutePDFURL;
 @property (nonatomic, readonly, copy) NSURL *absoluteLinkURL;
+@property (nonatomic, readonly, copy) NSString *linkLocalDataMIMEType WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 @property (nonatomic, readonly, copy) NSURL *absoluteMediaURL;
 
 @property (nonatomic, readonly, copy) NSString *linkLabel;

--- a/Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.mm
+++ b/Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.mm
@@ -65,6 +65,11 @@ static NSURL *URLFromString(const WTF::String& urlString)
     return URLFromString(_hitTestResult->absoluteLinkURL());
 }
 
+- (NSString *)linkLocalDataMIMEType
+{
+    return _hitTestResult->linkLocalDataMIMEType();
+}
+
 - (NSURL *)absoluteMediaURL
 {
     return URLFromString(_hitTestResult->absoluteMediaURL());

--- a/Source/WebKit/Shared/WebHitTestResultData.h
+++ b/Source/WebKit/Shared/WebHitTestResultData.h
@@ -96,6 +96,7 @@ struct WebHitTestResultData {
     RefPtr<SharedMemory> imageSharedMemory;
     RefPtr<ShareableBitmap> imageBitmap;
     String sourceImageMIMEType;
+    String linkLocalDataMIMEType;
 
 #if PLATFORM(MAC)
     WebHitTestResultPlatformData platformData;
@@ -112,7 +113,7 @@ struct WebHitTestResultData {
     WebHitTestResultData& operator=(const WebHitTestResultData&) = default;
     WebHitTestResultData(const WebCore::HitTestResult&, const String& toolTipText);
     WebHitTestResultData(const WebCore::HitTestResult&, bool includeImage);
-    WebHitTestResultData(const String& absoluteImageURL, const String& absolutePDFURL, const String& absoluteLinkURL, const String& absoluteMediaURL, const String& linkLabel, const String& linkTitle, const String& linkSuggestedFilename, bool isContentEditable, const WebCore::IntRect& elementBoundingBox, const WebKit::WebHitTestResultData::IsScrollbar&, bool isSelected, bool isTextNode, bool isOverTextInsideFormControlElement, bool isDownloadableMedia, bool mediaIsInFullscreen, const WebKit::WebHitTestResultData::ElementType&, std::optional<FrameInfoData>&&, const String& lookupText, const String& toolTipText, const String& imageText, std::optional<WebKit::SharedMemory::Handle>&& imageHandle, const RefPtr<WebKit::ShareableBitmap>& imageBitmap, const String& sourceImageMIMEType,
+    WebHitTestResultData(const String& absoluteImageURL, const String& absolutePDFURL, const String& absoluteLinkURL, const String& absoluteMediaURL, const String& linkLabel, const String& linkTitle, const String& linkSuggestedFilename, bool isContentEditable, const WebCore::IntRect& elementBoundingBox, const WebKit::WebHitTestResultData::IsScrollbar&, bool isSelected, bool isTextNode, bool isOverTextInsideFormControlElement, bool isDownloadableMedia, bool mediaIsInFullscreen, const WebKit::WebHitTestResultData::ElementType&, std::optional<FrameInfoData>&&, const String& lookupText, const String& toolTipText, const String& imageText, std::optional<WebKit::SharedMemory::Handle>&& imageHandle, const RefPtr<WebKit::ShareableBitmap>& imageBitmap, const String& sourceImageMIMEType, const String& linkLocalDataMIMEType,
 #if PLATFORM(MAC)
         const WebHitTestResultPlatformData&,
 #endif

--- a/Source/WebKit/Shared/WebHitTestResultData.serialization.in
+++ b/Source/WebKit/Shared/WebHitTestResultData.serialization.in
@@ -58,6 +58,7 @@ struct WebKit::WebHitTestResultData {
     std::optional<WebKit::SharedMemoryHandle> getImageSharedMemoryHandle();
     RefPtr<WebKit::ShareableBitmap> imageBitmap;
     String sourceImageMIMEType;
+    String linkLocalDataMIMEType;
     
 #if PLATFORM(MAC)
     WebKit::WebHitTestResultPlatformData platformData;

--- a/Source/WebKit/UIProcess/API/APIHitTestResult.h
+++ b/Source/WebKit/UIProcess/API/APIHitTestResult.h
@@ -56,6 +56,7 @@ public:
 
     WTF::String linkLabel() const { return m_data.linkLabel; }
     WTF::String linkTitle() const { return m_data.linkTitle; }
+    WTF::String linkLocalDataMIMEType() const { return m_data.linkLocalDataMIMEType; }
     WTF::String lookupText() const { return m_data.lookupText; }
     WTF::String sourceImageMIMEType() const { return m_data.sourceImageMIMEType; }
 

--- a/Tools/TestWebKitAPI/Tests/mac/ContextMenuTests.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/ContextMenuTests.mm
@@ -691,6 +691,27 @@ TEST(ContextMenuTests, HitTestResultImageMIMEType)
     Util::run(&gotProposedMenu);
 }
 
+TEST(ContextMenuTests, HitTestResultLinkLocalDataMIMEType)
+{
+    auto delegate = adoptNS([[TestUIDelegate alloc] init]);
+
+    __block bool gotProposedMenu = false;
+    [delegate setGetContextMenuFromProposedMenu:^(NSMenu *menu, _WKContextMenuElementInfo *elementInfo, id<NSSecureCoding>, void (^completion)(NSMenu *)) {
+        EXPECT_NOT_NULL(elementInfo.hitTestResult);
+        EXPECT_TRUE([elementInfo.hitTestResult.linkLocalDataMIMEType isEqualToString:@"image/jpeg"]);
+        completion(nil);
+        gotProposedMenu = true;
+    }];
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    [webView setUIDelegate:delegate.get()];
+    [webView synchronouslyLoadHTMLString:@"<a href='sunset-in-cupertino-600px.jpg'><img src='sunset-in-cupertino-600px.jpg'></img></a>"];
+
+    [webView mouseDownAtPoint:NSMakePoint(200, 200) simulatePressure:NO withFlags:0 eventType:NSEventTypeRightMouseDown];
+    [webView mouseUpAtPoint:NSMakePoint(200, 200) withFlags:0 eventType:NSEventTypeRightMouseUp];
+    Util::run(&gotProposedMenu);
+}
+
 } // namespace TestWebKitAPI
 
 #endif // PLATFORM(MAC)


### PR DESCRIPTION
#### 00a7a1e70c1a109781ddb1547e6e58c5e706211e
<pre>
_WKHitTestResult should expose a linkLocalDataMIMEType property
<a href="https://bugs.webkit.org/show_bug.cgi?id=266730">https://bugs.webkit.org/show_bug.cgi?id=266730</a>
<a href="https://rdar.apple.com/119404077">rdar://119404077</a>

Reviewed by Aditya Keerthi.

Add linkLocalDataMIMEType to WebHitTestResultData (and the underlying plumbing to support calculating
this string) and expose it via a property on _WKHitTestResult.

* Source/WebCore/rendering/HitTestResult.cpp:
(WebCore::HitTestResult::hasLocalDataForLinkURL const):
Added.

* Source/WebCore/rendering/HitTestResult.h:
Added hasLocalDataForLinkURL() and exported it so WebKit can use it.

* Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.h:
Added linkLocalDataMIMEType property.

* Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.mm:
(-[_WKHitTestResult linkLocalDataMIMEType]):
Added.

* Source/WebKit/Shared/WebHitTestResultData.cpp:
(WebKit::webFrameFromHitTestResult):
Refactored from frameInfoDataFromHitTestResult() so we can reuse this logic.

(WebKit::linkLocalDataMIMETypeFromHitTestResult):
Added.

(WebKit::WebHitTestResultData::WebHitTestResultData):
Initialize linkLocalDataMIMEType.

(WebKit::WebHitTestResultData::frameInfoDataFromHitTestResult):
Refactor some logic into webFrameFromHitTestResult().

* Source/WebKit/Shared/WebHitTestResultData.h:
Added linkLocalDataMIMEType.

* Source/WebKit/Shared/WebHitTestResultData.serialization.in:
Added linkLocalDataMIMEType.

* Source/WebKit/UIProcess/API/APIHitTestResult.h:
(API::HitTestResult::linkLocalDataMIMEType const):
Added.

* Tools/TestWebKitAPI/Tests/mac/ContextMenuTests.mm:
(TestWebKitAPI::TEST):
Added HitTestResultLinkLocalDataMIMEType, loads an image inside a link to itself and verifies that the
linkLocalDataMIMEType is &quot;image/jpeg&quot;.

Canonical link: <a href="https://commits.webkit.org/272600@main">https://commits.webkit.org/272600@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b6ae2321947cb3ca739bb280b12dc00ec68793a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32276 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11012 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34092 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34832 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29235 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33126 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13363 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8220 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28793 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32694 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9278 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28850 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8082 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8227 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28776 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36175 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29341 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29215 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34351 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8361 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6294 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32216 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10009 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7535 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8992 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8909 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->