### PR TITLE
Fix (wide-)attachment-element-gpu-process.html

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1785,10 +1785,6 @@ webkit.org/b/260113 [ arm64 ] http/wpt/webauthn/ctap-hid-failure.https.html [ Pa
 [ Sonoma+ ] compositing/images/direct-image-object-fit.html [ Skip ]
 [ Sonoma+ ] compositing/reflections/direct-image-object-fit-reflected.html [ Skip ]
 
-# rdar://107294589 ([UI-side compositing] fast/attachment/mac/attachment-element-gpu-process.html and fast/attachment/mac/wide-attachment-element-gpu-process.html fails)
-[ Sonoma+ ] fast/attachment/mac/attachment-element-gpu-process.html [ ImageOnlyFailure ]
-[ Sonoma+ ] fast/attachment/mac/wide-attachment-element-gpu-process.html [ ImageOnlyFailure ]
-
 # rdar://107294843 ([UI-side compositing] fast/events/wheel/wheel-events-become-non-cancelable.html fails)
 [ Sonoma+ ] fast/events/wheel/wheel-events-become-non-cancelable.html [ Failure ]
 


### PR DESCRIPTION
#### c124d59d0edf701359ff588a1829f1bcb7769ec0
<pre>
Fix (wide-)attachment-element-gpu-process.html
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

DRAFT patch to first force testing, to see the issue in EWS,
not linking direct to radar 107294589 just yet.
Try #3.

* LayoutTests/platform/mac-wk2/TestExpectations:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c124d59d0edf701359ff588a1829f1bcb7769ec0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32313 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11050 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34134 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34867 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29256 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13428 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8256 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28807 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32731 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9341 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28877 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8108 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8274 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28808 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36208 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29402 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29238 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34377 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8382 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6323 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32239 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10037 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9013 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8942 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->