### PR TITLE
Various minor RenderStyle::diff() optimizations

### DIFF
--- a/Source/WebCore/platform/graphics/transforms/RotateTransformOperation.cpp
+++ b/Source/WebCore/platform/graphics/transforms/RotateTransformOperation.cpp
@@ -49,7 +49,7 @@ bool RotateTransformOperation::operator==(const TransformOperation& other) const
     if (!isSameType(other))
         return false;
     const RotateTransformOperation& r = downcast<RotateTransformOperation>(other);
-    return m_x == r.m_x && m_y == r.m_y && m_z == r.m_z && m_angle == r.m_angle;
+    return m_angle == r.m_angle && m_x == r.m_x && m_y == r.m_y && m_z == r.m_z;
 }
 
 Ref<TransformOperation> RotateTransformOperation::blend(const TransformOperation* from, const BlendingContext& context, bool blendToIdentity)

--- a/Source/WebCore/rendering/style/BorderData.cpp
+++ b/Source/WebCore/rendering/style/BorderData.cpp
@@ -28,13 +28,14 @@
 
 #include "OutlineValue.h"
 #include "RenderStyle.h"
+#include <wtf/PointerComparison.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
 
 bool BorderData::isEquivalentForPainting(const BorderData& other, bool currentColorDiffers) const
 {
-    if (*this != other)
+    if (!arePointingToEqualData(this, &other))
         return false;
 
     if (!currentColorDiffers)


### PR DESCRIPTION
#### a507875fc8cfde9df318e7927e16f540da28c41c
<pre>
Various minor RenderStyle::diff() optimizations
<a href="https://bugs.webkit.org/show_bug.cgi?id=267004">https://bugs.webkit.org/show_bug.cgi?id=267004</a>
<a href="https://rdar.apple.com/120390005">rdar://120390005</a>

Reviewed by Tim Nguyen.

Various minor optimizations, detailed below.

* Source/WebCore/platform/graphics/transforms/RotateTransformOperation.cpp:
(WebCore::RotateTransformOperation::operator== const):
Check the angle first, because it&apos;s more common to animate the angle than the origin.
* Source/WebCore/rendering/style/BorderData.cpp:
(WebCore::BorderData::isEquivalentForPainting const):
Use arePointingToEqualData() to check for pointer equality first.
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::changeRequiresLayout const):
Check for m_svgStyle pointer equality first.
(WebCore::RenderStyle::changeRequiresRepaint const):
Check for m_svgStyle pointer equality first.
(WebCore::RenderStyle::changeRequiresRepaintIfText const):
Check for pointer equality of the various classes before checking their members.

Canonical link: <a href="https://commits.webkit.org/272645@main">https://commits.webkit.org/272645@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68b3c697975e566e70ed504d4372c08418caba44

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32256 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10991 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34128 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34814 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29222 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33106 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13343 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8200 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28785 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32674 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9267 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28871 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8072 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8219 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28802 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36158 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29328 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29235 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8348 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6281 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9993 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7566 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8979 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8892 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->