### PR TITLE
[scroll-anchoring] Weird scrolling effect when scrolling YouTube transcript panel

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/focused-element-nested-anchor-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/focused-element-nested-anchor-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Ensure there is no scroll anchoring adjustment in the main frame.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/focused-element-nested-anchor.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/focused-element-nested-anchor.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-scroll-anchoring/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+
+body { height: 4000px; }
+div { height: 100px; }
+
+.scroller {
+  overflow: scroll;
+  position: fixed;
+  width: 300px;
+  height: 300px;
+  background-color: green;
+}
+
+#posSticky {
+  top: 300px;
+  position: relative;
+  height: 50px;
+  width: 50px;
+  background-color: blue;
+}
+
+#content {
+  background-color: #D3D3D3;
+  height: 50px;
+  width: 50px;
+  position: relative;
+  top: 500px;
+}
+
+#anchor {
+  background-color: brown;
+  height: 50px;
+  width: 50px;
+  position: relative;
+  top: 200px;
+}
+
+</style>
+<div id="scroller" class="scroller">
+    <div id="content" tabindex="-1"></div>
+    <div id="anchor" tabindex="-1"></div>
+</div>
+
+<script>
+
+// Tests that a focused element doesn't become the
+// priority candidate of the main frame if it is
+// the anchor element of a subscroller
+
+promise_test(async function() {
+  var scroller = document.querySelector("#scroller");
+  var focusElement = document.querySelector("#anchor");
+  focusElement.focus();
+  scroller.scrollBy(0,150);
+  document.scrollingElement.scrollBy(0,100);
+
+  scroller.scrollBy(0, 50);
+  await new Promise(resolve => {
+     scroller.addEventListener("scroll", () => step_timeout(resolve, 0));
+   });
+
+  assert_equals(document.scrollingElement.scrollTop, 100);
+}, "Ensure there is no scroll anchoring adjustment in the main frame.");
+
+</script>

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.h
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.h
@@ -50,14 +50,14 @@ public:
     void adjustScrollPositionForAnchoring();
     void selectAnchorElement();
     void chooseAnchorElement(Document&);
+    CandidateExaminationResult examineAnchorCandidate(Element&);
     void updateAnchorElement();
     void notifyChildHadSuppressingStyleChange();
     bool isInScrollAnchoringAncestorChain(const RenderObject&);
-    Element* anchorElement() const { return m_anchorElement.get(); }
 
+    Element* anchorElement() const { return m_anchorElement.get(); }
 private:
     Element* findAnchorElementRecursive(Element*);
-    CandidateExaminationResult examineAnchorCandidate(Element&);
     bool didFindPriorityCandidate(Document&);
     FloatPoint computeOffsetFromOwningScroller(RenderObject& candidate);
     LocalFrameView& frameView();

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1026,7 +1026,7 @@ void RenderElement::styleDidChange(StyleDifference diff, const RenderStyle* oldS
     bool shouldCheckIfInAncestorChain = false;
     if (frame().settings().cssScrollAnchoringEnabled() && (style().outOfFlowPositionStyleDidChange(oldStyle) || (shouldCheckIfInAncestorChain = style().scrollAnchoringSuppressionStyleDidChange(oldStyle)))) {
         LOG_WITH_STREAM(ScrollAnchoring, stream << "RenderElement::styleDidChange() found node with style change: " << *this << " from: " << oldStyle->position() <<" to: " << style().position());
-        auto* controller = findScrollAnchoringControllerForRenderer(*this);
+        auto* controller = searchParentChainForScrollAnchoringController(*this);
         if (controller && (!shouldCheckIfInAncestorChain || (shouldCheckIfInAncestorChain && controller->isInScrollAnchoringAncestorChain(*this))))
             controller->notifyChildHadSuppressingStyleChange();
     }

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -2338,7 +2338,7 @@ Vector<FloatRect> RenderObject::clientBorderAndTextRects(const SimpleRange& rang
     return borderAndTextRects(range, CoordinateSpace::Client, { });
 }
 
-ScrollAnchoringController* RenderObject::findScrollAnchoringControllerForRenderer(const RenderObject& renderer)
+ScrollAnchoringController* RenderObject::searchParentChainForScrollAnchoringController(const RenderObject& renderer)
 {
     if (renderer.hasLayer()) {
         if (auto* scrollableArea = downcast<RenderLayerModelObject>(renderer).layer()->scrollableArea()) {

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -504,7 +504,7 @@ public:
 
     bool everHadLayout() const { return m_stateBitfields.hasFlag(StateFlag::EverHadLayout); }
 
-    static ScrollAnchoringController* findScrollAnchoringControllerForRenderer(const RenderObject&);
+    static ScrollAnchoringController* searchParentChainForScrollAnchoringController(const RenderObject&);
 
     bool childrenInline() const { return m_stateBitfields.hasFlag(StateFlag::ChildrenInline); }
     virtual void setChildrenInline(bool b) { m_stateBitfields.setFlag(StateFlag::ChildrenInline, b); }


### PR DESCRIPTION
#### bb9af3d426703c0dab09e5de39fe435eb6876f7f
<pre>
[scroll-anchoring] Weird scrolling effect when scrolling YouTube transcript panel
<a href="https://bugs.webkit.org/show_bug.cgi?id=267005">https://bugs.webkit.org/show_bug.cgi?id=267005</a>
<a href="https://rdar.apple.com/120378263">rdar://120378263</a>

Reviewed by Simon Fraser.

After <a href="https://commits.webkit.org/272277@main">https://commits.webkit.org/272277@main</a> we descend subscrollers that are not maintaining a
scroll anchor. We need to replicate the logic used in ScrollAnchoringController::examineAnchorCandidate
for ScrollAnchoringController::didFindPriorityCandidate, to ensure we don&apos;t end up choosing an anchor
element that is a descendant of a scrollable area that is maintaining a scroll anchor.

* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/focused-element-nested-anchor-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/focused-element-nested-anchor.html: Added.
* Source/WebCore/page/scrolling/ScrollAnchoringController.cpp:
(WebCore::scrollAnchoringControllerForElement):
(WebCore::ScrollAnchoringController::didFindPriorityCandidate):
(WebCore::canDescendIntoElement):
(WebCore::ScrollAnchoringController::isExcludedSubtree):
(WebCore::ScrollAnchoringController::examineAnchorCandidate):
(WebCore::ScrollAnchoringController::chooseAnchorElement):
(WebCore::ScrollAnchoringController::adjustScrollPositionForAnchoring):
* Source/WebCore/page/scrolling/ScrollAnchoringController.h:

Canonical link: <a href="https://commits.webkit.org/272616@main">https://commits.webkit.org/272616@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97959b7bbf7c61fb5e5c9fc202ffc136edb43ce9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32278 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11014 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34094 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34834 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29237 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33128 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13365 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8222 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28795 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32696 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9283 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28847 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8087 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8230 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28773 "Found 1 new test failure: imported/w3c/web-platform-tests/content-security-policy/reporting-api/reporting-api-works-on-frame-src.https.sub.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36177 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29346 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29211 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34354 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8363 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6295 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32218 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10011 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/28542 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8994 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4184 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8911 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->