### PR TITLE
[UIAsyncTextInput] Keyboard incorrectly autocapitalizes after deleting backwards

### DIFF
--- a/LayoutTests/editing/deleting/ios/no-autoshift-after-deleting-character-in-word-expected.txt
+++ b/LayoutTests/editing/deleting/ios/no-autoshift-after-deleting-character-in-word-expected.txt
@@ -1,0 +1,10 @@
+Verifies that typing a word and then deleting backwards does not cause the keyboard to automatically enter shift state.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS isAutoShifted is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Hel

--- a/LayoutTests/editing/deleting/ios/no-autoshift-after-deleting-character-in-word.html
+++ b/LayoutTests/editing/deleting/ios/no-autoshift-after-deleting-character-in-word.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+body, html {
+    font-size: 20px;
+    font-family: system-ui;
+}
+
+#editor {
+    border: solid 1px tomato;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("Verifies that typing a word and then deleting backwards does not cause the keyboard to automatically enter shift state.");
+
+    await UIHelper.setHardwareKeyboardAttached(false);
+
+    const editor = document.getElementById("editor");
+    await UIHelper.activateElementAndWaitForInputSession(editor);
+
+    for (let character of [..."Hello"]) {
+        await UIHelper.typeCharacter(character);
+        await UIHelper.ensurePresentationUpdate();
+    }
+
+    await UIHelper.keyDown("delete");
+    await UIHelper.ensurePresentationUpdate();
+    await UIHelper.keyDown("delete");
+    await UIHelper.ensurePresentationUpdate();
+
+    isAutoShifted = await UIHelper.keyboardIsAutomaticallyShifted();
+    shouldBeFalse("isAutoShifted");
+
+    editor.blur();
+    await UIHelper.waitForKeyboardToHide();
+
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+<div contenteditable id="editor"><br></div>
+</body>
+</html>

--- a/Source/WebKit/Shared/DocumentEditingContext.mm
+++ b/Source/WebKit/Shared/DocumentEditingContext.mm
@@ -102,13 +102,14 @@ WKSETextDocumentContext *DocumentEditingContext::toPlatformContext(OptionSet<Doc
             contextAfter:contextAfter.nsAttributedString().get()
             markedText:markedText.nsAttributedString().get()
             selectedRangeInMarkedText:toNSRange(selectedRangeInMarkedText)]);
-    } else {
+    } else if (options.contains(DocumentEditingContextRequest::Options::Text)) {
         platformContext = adoptNS([[WKSETextDocumentContext alloc] initWithSelectedText:[selectedText.nsAttributedString() string]
             contextBefore:[contextBefore.nsAttributedString() string]
             contextAfter:[contextAfter.nsAttributedString() string]
             markedText:[markedText.nsAttributedString() string]
             selectedRangeInMarkedText:toNSRange(selectedRangeInMarkedText)]);
-    }
+    } else
+        ASSERT_NOT_REACHED_WITH_MESSAGE("%s expected at least Options::AttributedText or Options::Text", __PRETTY_FUNCTION__);
     setOptionalEditingContextProperties(*this, platformContext.get(), options);
     return platformContext.autorelease();
 #else

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -5925,9 +5925,9 @@ static void logTextInteraction(const char* methodName, UIGestureRecognizer *loup
 {
     [self _updateInternalStateBeforeSelectionChange];
 
-#if HAVE(UI_ASYNC_TEXT_INPUT_DELEGATE)
+#if HAVE(UI_ASYNC_TEXT_INTERACTION_DELEGATE)
     if (self.shouldUseAsyncInteractions)
-        [_asyncSystemInputDelegate selectionWillChange:self];
+        [_asyncSystemInputDelegate selectionWillChange:static_cast<id<UIAsyncTextInputClient>>(self)];
     else
 #endif
         [self.inputDelegate selectionWillChange:self];
@@ -5948,9 +5948,9 @@ static void logTextInteraction(const char* methodName, UIGestureRecognizer *loup
 
 - (void)_internalEndSelectionChange
 {
-#if HAVE(UI_ASYNC_TEXT_INPUT_DELEGATE)
+#if HAVE(UI_ASYNC_TEXT_INTERACTION_DELEGATE)
     if (self.shouldUseAsyncInteractions)
-        [_asyncSystemInputDelegate selectionDidChange:self];
+        [_asyncSystemInputDelegate selectionDidChange:static_cast<id<UIAsyncTextInputClient>>(self)];
     else
 #endif
         [self.inputDelegate selectionDidChange:self];
@@ -12627,7 +12627,7 @@ static BOOL shouldUseMachineReadableCodeMenuFromImageAnalysisResult(CocoaImageAn
             };
             break;
         }
-        completion(context.toPlatformContext({ }));
+        completion(context.toPlatformContext({ WebKit::DocumentEditingContextRequest::Options::Text }));
     }];
 }
 


### PR DESCRIPTION
#### 9bf259e8d9e0193d6bbe8bd66259bf9d853dd538
<pre>
[UIAsyncTextInput] Keyboard incorrectly autocapitalizes after deleting backwards
<a href="https://bugs.webkit.org/show_bug.cgi?id=267003">https://bugs.webkit.org/show_bug.cgi?id=267003</a>
<a href="https://rdar.apple.com/120381357">rdar://120381357</a>

Reviewed by Megan Gardner.

This bug was caused by the fact that autocorrection context requests with async text input enabled
broke after the changes in 272018@main — in particular, because we don&apos;t pass the `Text` request
flag when converting from `WebKit::DocumentEditingContext` to `WKSETextDocumentContext` in
`-requestTextContextForAutocorrectionWithCompletionHandler:`.

This happened to work in my testing when `SERVICE_EXTENSIONS_TEXT_INPUT_IS_AVAILABLE` is set,
because the logic in `DocumentEditingContext::toPlatformContext` assumes that `Text` is specified,
if `AttributedText` isn&apos;t set. This was an unintentional departure from the shipping behavior, which
checked:

```
    if (options.contains(DocumentEditingContextRequest::Options::AttributedText)) {

        …

    } else if (options.contains(DocumentEditingContextRequest::Options::Text)) {

        …

    }
```

As such, we fix this by making the `SERVICE_EXTENSIONS_TEXT_INPUT_IS_AVAILABLE` codepath consistent
with the above logic, and pass in `DocumentEditingContextRequest::Options::Text` when using
`toPlatformContext`, when returning an autocorrection context in
`-requestTextContextForAutocorrectionWithCompletionHandler:`.

* LayoutTests/editing/deleting/ios/no-autoshift-after-deleting-character-in-word-expected.txt: Added.
* LayoutTests/editing/deleting/ios/no-autoshift-after-deleting-character-in-word.html: Added.

Add a layout test to exercise the bug fix.

* Source/WebKit/Shared/DocumentEditingContext.mm:
(WebKit::DocumentEditingContext::toPlatformContext):

Make this only set non-attributed text context strings in the case where the `Text` request flag is
specified, to match shipping behavior.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView requestTextContextForAutocorrectionWithCompletionHandler:]):
* Tools/TestWebKitAPI/cocoa/TestWKWebView.mm:
(-[WKWebView autocorrectionRectsForString:]):
(-[WKWebView autocorrectionContext]):
(-[WKWebView effectiveTextInputTraits]):
(-[WKWebView replaceText:withText:shouldUnderline:completion:]):

Drive-by cleanup around API test infrastructure, with async text input enabled:

-   Some of these codepaths were using `UI_ASYNC_TEXT_INPUT` instead of `UI_ASYNC_TEXT_INTERACTION`,
    effectively becoming dead code.

-   A couple of codepaths related to autocorrection context and rects weren&apos;t actually calling into
    the async text input codepaths as intended.

(wrap):
(-[WKWebView synchronouslyAdjustSelectionWithDelta:]):
(-[WKWebView selectTextForContextMenuWithLocationInView:completion:]):
(-[WKWebView handleKeyEvent:completion:]):

Canonical link: <a href="https://commits.webkit.org/272594@main">https://commits.webkit.org/272594@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/734bd28c865a51fc739f287232b4c137b6fdb1e3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32254 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10989 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34069 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34812 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29220 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33104 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13384 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8198 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28783 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32672 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9300 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28832 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8068 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8240 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28754 "Found 1 new test failure: imported/w3c/web-platform-tests/content-security-policy/reporting-api/reporting-api-works-on-frame-src.https.sub.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36156 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29363 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29198 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34343 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8346 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6279 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32208 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9991 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/28522 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7531 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8977 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8890 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->