### PR TITLE
[css-flexbox] Start storing flex line structure as the output of flex layout.

### DIFF
--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -460,7 +460,8 @@ void RenderFlexibleBox::layoutBlock(bool relayoutChildren, LayoutUnit)
         ChildFrameRects oldChildRects;
         appendChildFrameRects(oldChildRects);
 
-        layoutFlexItems(relayoutChildren);
+        m_flexLines.clear();
+        m_flexLines = layoutFlexItems(relayoutChildren);
 
         endAndCommitUpdateScrollInfoAfterLayoutTransaction();
 
@@ -1297,10 +1298,14 @@ LayoutUnit RenderFlexibleBox::computeFlexBaseSizeForChild(RenderBox& child, Layo
     return mainAxisExtent - mainAxisBorderAndPadding;
 }
 
-void RenderFlexibleBox::layoutFlexItems(bool relayoutChildren)
+RenderFlexibleBox::FlexLineStates RenderFlexibleBox::layoutFlexItems(bool relayoutChildren)
 {
-    if (LayoutIntegration::canUseForFlexLayout(*this))
-        return layoutUsingFlexFormattingContext();
+    ASSERT(m_flexLines.isEmpty());
+    if (LayoutIntegration::canUseForFlexLayout(*this)) {
+        layoutUsingFlexFormattingContext();
+        return { };
+    }
+
     FlexLineStates lineStates;
     LayoutUnit sumFlexBaseSize;
     double totalFlexGrow;
@@ -1377,7 +1382,6 @@ void RenderFlexibleBox::layoutFlexItems(bool relayoutChildren)
         // This will std::move lineItems into a newly-created LineState.
         layoutAndPlaceChildren(crossAxisOffset, lineItems, remainingFreeSpace, relayoutChildren, lineStates, gapBetweenItems);
     }
-
     if (hasLineIfEmpty()) {
         // Even if computeNextFlexLine returns true, the flexbox might not have
         // a line because all our children might be out of flow positioned.
@@ -1393,6 +1397,7 @@ void RenderFlexibleBox::layoutFlexItems(bool relayoutChildren)
 
     updateLogicalHeight();
     repositionLogicalHeightDependentFlexItems(lineStates, gapBetweenLines);
+    return lineStates;
 }
 
 LayoutUnit RenderFlexibleBox::autoMarginOffsetInMainAxis(const FlexItems& flexItems, LayoutUnit& availableFreeSpace)

--- a/Source/WebCore/rendering/RenderFlexibleBox.h
+++ b/Source/WebCore/rendering/RenderFlexibleBox.h
@@ -209,7 +209,7 @@ private:
     bool useChildOverridingCrossSizeForPercentageResolution(const RenderBox&);
     bool useChildOverridingMainSizeForPercentageResolution(const RenderBox&);
 
-    void layoutFlexItems(bool relayoutChildren);
+    FlexLineStates layoutFlexItems(bool relayoutChildren);
     LayoutUnit autoMarginOffsetInMainAxis(const FlexItems&, LayoutUnit& availableFreeSpace);
     void updateAutoMarginsInMainAxis(RenderBox& child, LayoutUnit autoMarginOffset);
     void initializeMarginTrimState(); 
@@ -262,6 +262,8 @@ private:
     void resetHasDefiniteHeight() { m_hasDefiniteHeight = SizeDefiniteness::Unknown; }
 
     void layoutUsingFlexFormattingContext();
+
+    FlexLineStates m_flexLines;
 
     // This is used to cache the preferred size for orthogonal flow children so we
     // don't have to relayout to get it


### PR DESCRIPTION
#### fae339a9faf2d8788df88ac77878710a1488aef9
<pre>
[css-flexbox] Start storing flex line structure as the output of flex layout.
<a href="https://bugs.webkit.org/show_bug.cgi?id=267006">https://bugs.webkit.org/show_bug.cgi?id=267006</a>
<a href="https://rdar.apple.com/problem/120390262">rdar://problem/120390262</a>

Reviewed by NOBODY (OOPS!).

This is a precursor to various bugs related to determining the baselines
of flexboxes. The spec determines the flex item that will be used to
best represent the baseline of flexbox using the structure of the flex
lines. At that point we no longer have the knowledge of the structure of
the flex lines so we should start keeping track of them at the end of
layout.

Unfortunately reconstructing the flex lines is not a trivial process
because:

1.) Creating a flex item via constructFlexItem is not a const operation
so we risk mutating the renderers
2.) Attempting to create the flex lines by querying the renderers
directly and checking the flexbox&apos;s style is also error prone. Any
oversights could result in an invalid structure of the flex line

* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::layoutBlock):
(WebCore::RenderFlexibleBox::layoutFlexItems):
* Source/WebCore/rendering/RenderFlexibleBox.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fae339a9faf2d8788df88ac77878710a1488aef9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33254 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12030 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35168 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35891 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30272 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34225 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14377 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9202 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29405 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33729 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10150 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29704 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8844 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8995 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29681 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37222 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30215 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30059 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35110 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9119 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7066 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32973 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10849 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9702 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9806 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->