### PR TITLE
Cache "containsOnlyASCIIWhitespace" on Node

### DIFF
--- a/Source/WebCore/dom/CharacterData.h
+++ b/Source/WebCore/dom/CharacterData.h
@@ -34,11 +34,13 @@ public:
 
     WEBCORE_EXPORT void setData(const String&);
     unsigned length() const { return m_data.length(); }
-    WEBCORE_EXPORT ExceptionOr<String> substringData(unsigned offset, unsigned count);
+    WEBCORE_EXPORT ExceptionOr<String> substringData(unsigned offset, unsigned count) const;
     WEBCORE_EXPORT void appendData(const String&);
     WEBCORE_EXPORT ExceptionOr<void> insertData(unsigned offset, const String&);
     WEBCORE_EXPORT ExceptionOr<void> deleteData(unsigned offset, unsigned count);
     WEBCORE_EXPORT ExceptionOr<void> replaceData(unsigned offset, unsigned count, const String&);
+
+    bool containsOnlyASCIIWhitespace() const;
 
     // Like appendData, but optimized for the parser (e.g., no mutation events).
     void parserAppendData(StringView);
@@ -54,11 +56,8 @@ protected:
 
     ~CharacterData();
 
-    void setDataWithoutUpdate(const String& data)
-    {
-        ASSERT(!data.isNull());
-        m_data = data;
-    }
+    void setDataWithoutUpdate(const String&);
+
     void dispatchModifiedEvent(const String& oldValue);
 
     enum class UpdateLiveRanges : bool { No, Yes };

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -611,6 +611,8 @@ protected:
         IsFullscreen = 1 << 9,
 #endif
         HasInvalidRenderer = 1 << 10,
+        ContainsOnlyASCIIWhitespace = 1 << 11, // Only used on CharacterData.
+        ContainsOnlyASCIIWhitespaceIsValid = 1 << 12, // Only used on CharacterData.
     };
 
     enum class TabIndexState : uint8_t {

--- a/Source/WebCore/html/HTMLObjectElement.cpp
+++ b/Source/WebCore/html/HTMLObjectElement.cpp
@@ -215,7 +215,7 @@ bool HTMLObjectElement::hasFallbackContent() const
     for (RefPtr<Node> child = firstChild(); child; child = child->nextSibling()) {
         // Ignore whitespace-only text, and <param> tags, any other content is fallback content.
         if (auto* textChild = dynamicDowncast<Text>(*child)) {
-            if (!textChild->data().containsOnly<isASCIIWhitespace>())
+            if (!textChild->containsOnlyASCIIWhitespace())
                 return true;
         } else if (!is<HTMLParamElement>(*child))
             return true;
@@ -375,7 +375,7 @@ static inline bool preventsParentObjectFromExposure(const Node& child)
     if (auto* childElement = dynamicDowncast<Element>(child))
         return preventsParentObjectFromExposure(*childElement);
     if (auto* childText = dynamicDowncast<Text>(child))
-        return !childText->data().containsOnly<isASCIIWhitespace>();
+        return !childText->containsOnlyASCIIWhitespace();
     return true;
 }
 

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -2490,7 +2490,7 @@ Ref<Protocol::DOM::AccessibilityProperties> InspectorDOMAgent::buildObjectForAcc
 static bool containsOnlyASCIIWhitespace(Node* node)
 {
     // FIXME: Respect ignoreWhitespace setting from inspector front end?
-    return is<Text>(node) && downcast<Text>(*node).data().containsOnly<isASCIIWhitespace>();
+    return is<Text>(node) && downcast<Text>(*node).containsOnlyASCIIWhitespace();
 }
 
 Node* InspectorDOMAgent::innerFirstChild(Node* node)

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -231,7 +231,7 @@ void RenderTreeUpdater::updateRenderTree(ContainerNode& root)
         if (auto* text = dynamicDowncast<Text>(node)) {
             auto* textUpdate = m_styleUpdate->textUpdate(*text);
             bool didCreateParent = parent().update && parent().update->change == Style::Change::Renderer;
-            bool mayNeedUpdateWhitespaceOnlyRenderer = renderingParent().didCreateOrDestroyChildRenderer && text->data().containsOnly<isASCIIWhitespace>();
+            bool mayNeedUpdateWhitespaceOnlyRenderer = renderingParent().didCreateOrDestroyChildRenderer && text->containsOnlyASCIIWhitespace();
             if (didCreateParent || textUpdate || mayNeedUpdateWhitespaceOnlyRenderer)
                 updateTextRenderer(*text, textUpdate);
 
@@ -520,7 +520,7 @@ bool RenderTreeUpdater::textRendererIsNeeded(const Text& textNode)
         return true;
     if (!textNode.length())
         return false;
-    if (!textNode.data().containsOnly<isASCIIWhitespace>())
+    if (!textNode.containsOnlyASCIIWhitespace())
         return true;
     if (is<RenderText>(renderingParent.previousChildRenderer))
         return true;

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -863,7 +863,7 @@ void TreeResolver::resolveComposedTree()
                 m_update->addText(*text, parent.element, WTFMove(textUpdate));
             }
 
-            if (!text->data().containsOnly<isASCIIWhitespace>())
+            if (!text->containsOnlyASCIIWhitespace())
                 parent.resolvedFirstLineAndLetterChild = true;
 
             text->setHasValidStyle();


### PR DESCRIPTION
#### ef19f93eea992586bc6636a05d1445d0200ca626
<pre>
Cache &quot;containsOnlyASCIIWhitespace&quot; on Node
<a href="https://bugs.webkit.org/show_bug.cgi?id=267010">https://bugs.webkit.org/show_bug.cgi?id=267010</a>
<a href="https://rdar.apple.com/120391238">rdar://120391238</a>

Reviewed by Ryosuke Niwa.

The call to `text-&gt;containsOnlyASCIIWhitespace()` in TreeResolver::resolveComposedTree() shows up on MotionMark
profiles (in the Design subtest). We can cache this state for Text nodes by using two bits from Node&apos;s StateFlags.

The &quot;known&quot; state is cleared by functions on CharacterData that mutate the content.

* Source/WebCore/dom/CharacterData.cpp:
(WebCore::CharacterData::substringData const):
(WebCore::CharacterData::parserAppendData):
(WebCore::CharacterData::setDataWithoutUpdate):
(WebCore::CharacterData::setDataAndUpdate):
(WebCore::CharacterData::containsOnlyASCIIWhitespace const):
(WebCore::CharacterData::substringData): Deleted.
* Source/WebCore/dom/CharacterData.h:
(WebCore::CharacterData::setDataWithoutUpdate): Deleted.
* Source/WebCore/dom/Node.h:
* Source/WebCore/html/HTMLObjectElement.cpp:
(WebCore::HTMLObjectElement::hasFallbackContent const):
(WebCore::preventsParentObjectFromExposure):
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::containsOnlyASCIIWhitespace):
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(WebCore::RenderTreeUpdater::updateRenderTree):
(WebCore::RenderTreeUpdater::textRendererIsNeeded):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::resolveComposedTree):

Canonical link: <a href="https://commits.webkit.org/272724@main">https://commits.webkit.org/272724@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c419d59e2b439055c4562ff8654f0910a6729b8d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32804 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11555 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34665 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35416 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29632 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33731 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13898 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8738 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29090 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33247 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9740 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/29313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8488 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8621 "Found 1 new test failure: imported/w3c/web-platform-tests/webrtc-extensions/RTCRtpSynchronizationSource-senderCaptureTimeOffset.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29248 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36747 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29798 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29652 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34752 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8744 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6710 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32622 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10432 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7622 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9355 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9363 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->