### PR TITLE
Fix MSVC build

### DIFF
--- a/Source/WebCore/PAL/pal/text/TextCodec.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodec.cpp
@@ -46,9 +46,9 @@ int TextCodec::getUnencodableReplacement(char32_t codePoint, UnencodableHandling
 
     switch (handling) {
     case UnencodableHandling::Entities:
-        return snprintf(replacement.data(), sizeof(UnencodableReplacementArray), "&#%u;", codePoint);
+        return snprintf(replacement.data(), sizeof(UnencodableReplacementArray), "&#%u;", static_cast<unsigned>(codePoint));
     case UnencodableHandling::URLEncodedEntities:
-        return snprintf(replacement.data(), sizeof(UnencodableReplacementArray), "%%26%%23%u%%3B", codePoint);
+        return snprintf(replacement.data(), sizeof(UnencodableReplacementArray), "%%26%%23%u%%3B", static_cast<unsigned>(codePoint));
     }
     ASSERT_NOT_REACHED();
     replacement.data()[0] = 0;

--- a/Source/WebKit/Scripts/generate-serializers.py
+++ b/Source/WebKit/Scripts/generate-serializers.py
@@ -1005,10 +1005,9 @@ def generate_impl(serialized_types, serialized_enums, headers, generating_webkit
             if member.condition is not None:
                 result.append('#endif')
         result.append('        return true;')
-        result.append('    default:')
-        result.append('        return false;')
         result.append('    }')
         result.append('IGNORE_WARNINGS_END')
+        result.append('    return false;')
         result.append('}')
         if type.condition is not None:
             result.append('#endif')

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
@@ -1236,10 +1236,9 @@ IGNORE_WARNINGS_BEGIN("switch-unreachable")
 #endif
     case IPC::WebCore_TimingFunction_Subclass::SpringTimingFunction:
         return true;
-    default:
-        return false;
     }
 IGNORE_WARNINGS_END
+    return false;
 }
 
 template<> bool isValidEnum<IPC::WebCore_MoveOnlyBaseClass_Subclass, void>(IPC::EncodedVariantIndex value)
@@ -1248,10 +1247,9 @@ IGNORE_WARNINGS_BEGIN("switch-unreachable")
     switch (static_cast<IPC::WebCore_MoveOnlyBaseClass_Subclass>(value)) {
     case IPC::WebCore_MoveOnlyBaseClass_Subclass::MoveOnlyDerivedClass:
         return true;
-    default:
-        return false;
     }
 IGNORE_WARNINGS_END
+    return false;
 }
 
 template<> bool isValidEnum<EnumWithoutNamespace, void>(uint8_t value)

--- a/Tools/TestWebKitAPI/Tests/WTF/DragonBoxTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/DragonBoxTest.cpp
@@ -179,7 +179,7 @@ TEST(WTF, DragonBox_perf)
 {
     DragonBoxTest t;
 
-    size_t size = 1e4;
+    constexpr size_t size = 1e4;
     double nums1[size];
     double nums2[size];
     double nums3[size];


### PR DESCRIPTION
#### 883e029e8b6852c5174b04c674ad0a149d1810d0
<pre>
Fix MSVC build
<a href="https://bugs.webkit.org/show_bug.cgi?id=267017">https://bugs.webkit.org/show_bug.cgi?id=267017</a>

Reviewed by Don Olmstead.

The default installation of MSVC is slightly different than what EWS is using.
These differences require a few small tweaks to get WebKit to compile.

* Source/WebCore/PAL/pal/text/TextCodec.cpp:
(PAL::TextCodec::getUnencodableReplacement):
%u in printf-like functions doesn&apos;t like char32_t in MSVC.  Just cast it to an unsigned.
* Source/WebKit/Scripts/generate-serializers.py:
(generate_impl):
IGNORE_WARNINGS_BEGIN(&quot;switch-unreachable&quot;) doesn&apos;t tell MSVC to ignore the right warning.
Instead, just make the generated code not have a default statement and exit the switch statement.
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
(WTF::void&gt;):
Update the generated code tests along with the generator.
* Tools/TestWebKitAPI/Tests/WTF/DragonBoxTest.cpp:
(TestWebKitAPI::TEST):
MSVC needs constexpr to be able to allocate arrays on the stack.

Canonical link: <a href="https://commits.webkit.org/272595@main">https://commits.webkit.org/272595@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0376fd4aec46f90160e601096d0086b6fa623463

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32295 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11032 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34114 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34851 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/29246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33145 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13382 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8239 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/28801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32713 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9296 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28862 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8094 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/32523 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/8236 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28787 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36193 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29359 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29224 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34365 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/8372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6309 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32228 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10024 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/9003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4176 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8926 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->