### PR TITLE
Rename `WebKitCustom` and `WebKitCustomLegacyPrefixed` in `PseudoElement`

### DIFF
--- a/Source/WebCore/css/CSSPseudoSelectors.json
+++ b/Source/WebCore/css/CSSPseudoSelectors.json
@@ -208,7 +208,7 @@
             "comment": "For use in Apple internal apps.",
             "condition": "ENABLE(SERVICE_CONTROLS)",
             "settings-flag": "imageControlsEnabled",
-            "shadow": true
+            "user-agent-part": true
         },
         "-webkit-resizer": {
             "comment": "For scrollbar styling.",
@@ -252,7 +252,7 @@
             "aliases": [
                 "-webkit-file-upload-button"
             ],
-            "shadow": true
+            "user-agent-part": true
         },
         "first-letter": {
             "supports-single-colon-for-compatibility": true
@@ -272,7 +272,7 @@
             "aliases": [
                 "-webkit-input-placeholder"
             ],
-            "shadow": true
+            "user-agent-part": true
         },
         "selection": {},
         "slotted": {},
@@ -281,11 +281,11 @@
         },
         "thumb": {
             "settings-flag": "thumbAndTrackPseudoElementsEnabled",
-            "shadow": true
+            "user-agent-part": true
         },
         "track": {
             "settings-flag": "thumbAndTrackPseudoElementsEnabled",
-            "shadow": true
+            "user-agent-part": true
         },
         "view-transition": {
             "settings-flag": "viewTransitionsEnabled"

--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -306,8 +306,8 @@ PseudoId CSSSelector::pseudoId(PseudoElement type)
 #endif
     case PseudoElement::Slotted:
     case PseudoElement::Part:
-    case PseudoElement::WebKitCustom:
-    case PseudoElement::WebKitCustomLegacyPrefixed:
+    case PseudoElement::UserAgentPart:
+    case PseudoElement::UserAgentPartLegacyAlias:
         return PseudoId::None;
     }
 
@@ -322,8 +322,9 @@ std::optional<CSSSelector::PseudoElement> CSSSelector::parsePseudoElement(String
 
     auto type = parsePseudoElementString(name);
     if (!type) {
+        // FIXME: Put all known UA parts in CSSPseudoSelectors.json and split out the unknown case (webkit.org/b/266947).
         if (name.startsWithIgnoringASCIICase("-webkit-"_s))
-            return PseudoElement::WebKitCustom;
+            return PseudoElement::UserAgentPart;
         return type;
     }
 

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -166,7 +166,7 @@ public:
     void setPagePseudoClass(PagePseudoClass);
 
     bool matchesPseudoElement() const;
-    bool isWebKitCustomPseudoElement() const;
+    bool isUserAgentPartPseudoElement() const;
     bool isSiblingSelector() const;
     bool isAttributeSelector() const;
 
@@ -268,9 +268,9 @@ inline bool CSSSelector::matchesPseudoElement() const
     return match() == Match::PseudoElement;
 }
 
-inline bool CSSSelector::isWebKitCustomPseudoElement() const
+inline bool CSSSelector::isUserAgentPartPseudoElement() const
 {
-    return pseudoElement() == PseudoElement::WebKitCustom || pseudoElement() == PseudoElement::WebKitCustomLegacyPrefixed;
+    return pseudoElement() == PseudoElement::UserAgentPart || pseudoElement() == PseudoElement::UserAgentPartLegacyAlias;
 }
 
 static inline bool pseudoClassIsRelativeToSiblings(CSSSelector::PseudoClass type)

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -281,7 +281,7 @@ SelectorChecker::MatchResult SelectorChecker::matchRecursively(CheckingContext& 
         return MatchResult::fails(Match::SelectorFailsLocally);
 
     if (context.selector->match() == CSSSelector::Match::PseudoElement) {
-        if (context.selector->isWebKitCustomPseudoElement()) {
+        if (context.selector->isUserAgentPartPseudoElement()) {
             // In functional pseudo class, custom pseudo elements are always disabled.
             // FIXME: We should accept custom pseudo elements inside :is()/:matches().
             if (context.inFunctionalPseudoClass)

--- a/Source/WebCore/css/parser/CSSParserSelector.cpp
+++ b/Source/WebCore/css/parser/CSSParserSelector.cpp
@@ -61,7 +61,7 @@ std::unique_ptr<CSSParserSelector> CSSParserSelector::parsePseudoElementSelector
     selector->m_selector->setMatch(CSSSelector::Match::PseudoElement);
     selector->m_selector->setPseudoElement(*pseudoType);
     AtomString name;
-    if (*pseudoType == CSSSelector::PseudoElement::WebKitCustomLegacyPrefixed)
+    if (*pseudoType == CSSSelector::PseudoElement::UserAgentPartLegacyAlias)
         name = CSSSelector::nameForShadowPseudoElementLegacyAlias(pseudoTypeString);
     else
         name = pseudoTypeString.convertToASCIILowercaseAtom();

--- a/Source/WebCore/css/parser/CSSParserSelector.h
+++ b/Source/WebCore/css/parser/CSSParserSelector.h
@@ -113,13 +113,13 @@ private:
 inline bool CSSParserSelector::needsImplicitShadowCombinatorForMatching() const
 {
     return match() == CSSSelector::Match::PseudoElement
-        && (pseudoElement() == CSSSelector::PseudoElement::WebKitCustom
+        && (pseudoElement() == CSSSelector::PseudoElement::UserAgentPart
 #if ENABLE(VIDEO)
             || pseudoElement() == CSSSelector::PseudoElement::Cue
 #endif
             || pseudoElement() == CSSSelector::PseudoElement::Part
             || pseudoElement() == CSSSelector::PseudoElement::Slotted
-            || pseudoElement() == CSSSelector::PseudoElement::WebKitCustomLegacyPrefixed);
+            || pseudoElement() == CSSSelector::PseudoElement::UserAgentPartLegacyAlias);
 }
 
 inline bool CSSParserSelector::isPseudoElementCueFunction() const

--- a/Source/WebCore/css/process-css-pseudo-selectors.py
+++ b/Source/WebCore/css/process-css-pseudo-selectors.py
@@ -204,15 +204,15 @@ class GPerfMappingGenerator:
             if not is_pseudo_selector_enabled(pseudo_element, self.webcore_defines):
                 continue
 
-            if key_is_true(pseudo_element, 'shadow'):
-                self.map[pseudo_element_name] = 'WebKitCustom'
+            if key_is_true(pseudo_element, 'user-agent-part'):
+                self.map[pseudo_element_name] = 'UserAgentPart'
             else:
                 self.map[pseudo_element_name] = format_name_for_enum_class(pseudo_element_name)
 
             if 'aliases' in pseudo_element:
                 for alias in pseudo_element['aliases']:
-                    if key_is_true(pseudo_element, 'shadow'):
-                        self.map[alias] = 'WebKitCustomLegacyPrefixed'
+                    if key_is_true(pseudo_element, 'user-agent-part'):
+                        self.map[alias] = 'UserAgentPartLegacyAlias'
                     else:
                         self.map[alias] = format_name_for_enum_class(pseudo_element_name)
 
@@ -454,13 +454,13 @@ class CSSSelectorEnumGenerator:
             write_pragma_once(writer)
             open_namespace_webcore(writer)
             self.write_enum_class(writer, "PseudoClass", self.pseudo_enum_values(pseudo_classes))
-            self.write_enum_class(writer, "PseudoElement", self.pseudo_enum_values(pseudo_elements) + [('WebKitCustom', None), ('WebKitCustomLegacyPrefixed', None)])
+            self.write_enum_class(writer, "PseudoElement", self.pseudo_enum_values(pseudo_elements) + [('UserAgentPart', None), ('UserAgentPartLegacyAlias', None)])
             close_namespace_webcore(writer)
 
     def pseudo_enum_values(self, values):
         enum_values = []
         for pseudo_name, pseudo_data in values.items():
-            if key_is_true(pseudo_data, 'shadow'):
+            if key_is_true(pseudo_data, 'user-agent-part'):
                 continue
             if 'condition' in pseudo_data:
                 enum_values.append((format_name_for_enum_class(pseudo_name), pseudo_data['condition']))
@@ -576,7 +576,7 @@ class CSSSelectorInlinesGenerator:
             settings_flag = pseudo_data['settings-flag'] if 'settings-flag' in pseudo_data else None
             enablement_condition = self.format_enablement_condition(settings_flag, is_internal_pseudo)
 
-            if key_is_true(pseudo_data, 'shadow'):
+            if key_is_true(pseudo_data, 'user-agent-part'):
                 if 'condition' in pseudo_data:
                     shadow_map[pseudo_name] = (enablement_condition, pseudo_data['condition'])
                 else:
@@ -627,11 +627,11 @@ class CSSSelectorInlinesGenerator:
                 writer.write('return true;')
 
         with writer.indent():
-            writer.write('case PseudoElement::WebKitCustom:')
+            writer.write('case PseudoElement::UserAgentPart:')
         write_condition_cases_for_shadow_elements(shadow_map)
 
         with writer.indent():
-            writer.write('case PseudoElement::WebKitCustomLegacyPrefixed:')
+            writer.write('case PseudoElement::UserAgentPartLegacyAlias:')
         write_condition_cases_for_shadow_elements(shadow_alias_map)
 
         with writer.indent():
@@ -679,7 +679,7 @@ class CSSSelectorInlinesGenerator:
             {""")
 
         for pseudo_name, pseudo_data in pseudo_elements.items():
-            if not key_is_true(pseudo_data, 'shadow'):
+            if not key_is_true(pseudo_data, 'user-agent-part'):
                 continue
             if 'aliases' not in pseudo_data:
                 continue

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -1473,8 +1473,8 @@ static FunctionType constructFragmentsInternal(const CSSSelector* rootSelector, 
             case CSSSelector::PseudoElement::Selection:
             case CSSSelector::PseudoElement::SpellingError:
             case CSSSelector::PseudoElement::ViewTransition:
-            case CSSSelector::PseudoElement::WebKitCustom:
-            case CSSSelector::PseudoElement::WebKitCustomLegacyPrefixed:
+            case CSSSelector::PseudoElement::UserAgentPart:
+            case CSSSelector::PseudoElement::UserAgentPartLegacyAlias:
                 ASSERT(!fragment->pseudoElementSelector);
                 fragment->pseudoElementSelector = selector;
                 break;

--- a/Source/WebCore/style/RuleSet.cpp
+++ b/Source/WebCore/style/RuleSet.cpp
@@ -187,8 +187,8 @@ void RuleSet::addRule(RuleData&& ruleData, CascadeLayerIdentifier cascadeLayerId
             break;
         case CSSSelector::Match::PseudoElement:
             switch (selector->pseudoElement()) {
-            case CSSSelector::PseudoElement::WebKitCustom:
-            case CSSSelector::PseudoElement::WebKitCustomLegacyPrefixed:
+            case CSSSelector::PseudoElement::UserAgentPart:
+            case CSSSelector::PseudoElement::UserAgentPartLegacyAlias:
                 customPseudoElementSelector = selector;
                 break;
             case CSSSelector::PseudoElement::Slotted:


### PR DESCRIPTION
#### 94f262ba04598cefdff4859e5864c971273348ec
<pre>
Rename `WebKitCustom` and `WebKitCustomLegacyPrefixed` in `PseudoElement`
<a href="https://bugs.webkit.org/show_bug.cgi?id=267016">https://bugs.webkit.org/show_bug.cgi?id=267016</a>
<a href="https://rdar.apple.com/120395761">rdar://120395761</a>

Reviewed by Ryosuke Niwa.

They don&apos;t necessarily represent `-webkit-` prefixed things. They just represent elements in UA shadow trees (like ::placeholder, ::file-selector-button, ::thumb or ::track),
which is effectively similar to the functionality ::part() provides in non-UA shadow trees (represented by `PseudoElement::Part`).

- Rename `PseudoElement::WebKitCustom` to `PseudoElement::UserAgentPart`
- Rename `PseudoElement::WebKitCustomLegacyPrefixed` to `PseudoElement::UserAgentPartLegacyAlias`

webkit.org/b/266947 will take care of mapping unknown `-webkit-` pseudo-elements to a different type (`PseudoElement::WebKitUnknown`).

* Source/WebCore/css/CSSPseudoSelectors.json:
* Source/WebCore/css/CSSSelector.cpp:
(WebCore::CSSSelector::pseudoId):
(WebCore::CSSSelector::parsePseudoElement):
* Source/WebCore/css/CSSSelector.h:
(WebCore::CSSSelector::isUserAgentPartPseudoElement const):
(WebCore::CSSSelector::isWebKitCustomPseudoElement const): Deleted.
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::matchRecursively const):
* Source/WebCore/css/parser/CSSParserSelector.cpp:
(WebCore::CSSParserSelector::parsePseudoElementSelector):
* Source/WebCore/css/parser/CSSParserSelector.h:
(WebCore::CSSParserSelector::needsImplicitShadowCombinatorForMatching const):
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::extractCompoundFlags):
(WebCore::isPseudoClassValidAfterPseudoElement):
(WebCore::CSSSelectorParser::consumePseudo):
(WebCore::CSSSelectorParser::containsUnknownWebKitPseudoElements):
* Source/WebCore/css/process-css-pseudo-selectors.py:
* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::constructFragmentsInternal):
* Source/WebCore/style/RuleSet.cpp:
(WebCore::Style::RuleSet::addRule):

Canonical link: <a href="https://commits.webkit.org/272593@main">https://commits.webkit.org/272593@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61e0ae54e070344d25a452259c004769e557f8ac

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32304 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11041 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34124 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/34859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/29252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33154 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/13392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8248 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/34859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32722 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/9305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/28868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/34859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/8243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/28798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/36200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/29367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/29232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/36200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/8378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/6313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/36200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/10030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/9009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4175 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/8934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->