### PR TITLE
[css-grid] Margins for grid item's ascent should be based off of the alignment context axis.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-001-expected.txt
@@ -15,10 +15,6 @@ PASS #target > div 1
 PASS #target > div 2
 PASS #target > div 3
 PASS #target > div 4
-FAIL #target > div 5 assert_equals:
-<div data-offset-x="35">line1<br>line2</div>
-offsetLeft expected 35 but got 15
-FAIL #target > div 6 assert_equals:
-<div data-offset-x="42">line1<br>line2</div>
-offsetLeft expected 42 but got 22
+PASS #target > div 5
+PASS #target > div 6
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-002-expected.txt
@@ -15,10 +15,6 @@ PASS #target > div 1
 PASS #target > div 2
 PASS #target > div 3
 PASS #target > div 4
-FAIL #target > div 5 assert_equals:
-<div data-offset-x="35">line1<br>line2</div>
-offsetLeft expected 35 but got 15
-FAIL #target > div 6 assert_equals:
-<div data-offset-x="42">line1<br>line2</div>
-offsetLeft expected 42 but got 22
+PASS #target > div 5
+PASS #target > div 6
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-002-expected.txt
@@ -21,10 +21,6 @@ FAIL #target > div 3 assert_equals:
 <div data-offset-x="126">line1<br>line2</div>
 offsetLeft expected 126 but got 42
 PASS #target > div 4
-FAIL #target > div 5 assert_equals:
-<div data-offset-x="35">line1<br>line2</div>
-offsetLeft expected 35 but got 15
-FAIL #target > div 6 assert_equals:
-<div data-offset-x="42">line1<br>line2</div>
-offsetLeft expected 42 but got 22
+PASS #target > div 5
+PASS #target > div 6
 

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -241,6 +241,9 @@ public:
         const RenderStyle* styleToUse = overrideStyle ? overrideStyle : &style();
         return m_marginBox.end(styleToUse->writingMode(), styleToUse->direction());
     }
+    LayoutUnit marginBlockStart(const WritingMode& writingMode) const { return m_marginBox.before(writingMode); }
+    LayoutUnit marginInlineStart(const WritingMode& writingMode) const { return m_marginBox.start(writingMode); }
+
     void setMarginBefore(LayoutUnit value, const RenderStyle* overrideStyle = nullptr) { m_marginBox.setBefore(value, (overrideStyle ? overrideStyle : &style())->writingMode()); }
     void setMarginAfter(LayoutUnit value, const RenderStyle* overrideStyle = nullptr) { m_marginBox.setAfter(value, (overrideStyle ? overrideStyle : &style())->writingMode()); }
     void setMarginStart(LayoutUnit value, const RenderStyle* overrideStyle = nullptr)


### PR DESCRIPTION
#### 6bdeb823e16e81ec11433826136fb738e1b00981
<pre>
[css-grid] Margins for grid item&apos;s ascent should be based off of the alignment context axis.
<a href="https://bugs.webkit.org/show_bug.cgi?id=260570">https://bugs.webkit.org/show_bug.cgi?id=260570</a>
<a href="https://rdar.apple.com/114299208">rdar://114299208</a>

Reviewed by Matt Woodrow.

The ascent value for a grid item needs to include its margin alongside
its baseline value since grid items are aligned by their margin box.

Currently code uses isDescentBaselineForChild to determine whether it
should get its margin using marginUnderForChild or marginOverForchild.
It is not super clear why these two functions are choosing certain
margins off the grid item&apos;s margin box.

Choosing which margin to use should just be a matter of checking which
direction the alignment context is in. If the alignment context
direction is in the grid&apos;s column axis (i.e. grid items are being
aligned in the grid&apos;s block direction), then that should be the grid
item&apos;s block-start margin according to the grid&apos;s writing mode.
Similarly, if the alignment context direction is in the row axis (i.e.
grid items are being aligned in the grid&apos;s inline direction), then that
should be the grid item&apos;s inline-start margin according to the grid&apos;s
writing mode.

I also renamed the variable &quot;margin,&quot; to &quot;gridItemMargin,&quot; to better
reflect what it corresponds to. Instances where this value was being
added to the grid item&apos;s baseline value have also been changed to be in
the form of &quot;gridItemMargin + gridItemBaseline&quot; since that is generally
the order in which we depict/imagine the structure of the ascent value.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-002-expected.txt:
* Source/WebCore/rendering/GridBaselineAlignment.cpp:
(WebCore::GridBaselineAlignment::ascentForChild const):
(WebCore::GridBaselineAlignment::marginOverForChild const): Deleted.
(WebCore::GridBaselineAlignment::marginUnderForChild const): Deleted.
* Source/WebCore/rendering/RenderBox.h:
(WebCore::RenderBox::marginBlockStart const):
(WebCore::RenderBox::marginInlineStart const):

Canonical link: <a href="https://commits.webkit.org/272860@main">https://commits.webkit.org/272860@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7de30d81d29748cd15528d615b1cb14fca8d07ea

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32549 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11295 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34395 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35113 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29427 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33415 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13646 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8490 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28957 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32983 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9521 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29087 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8298 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8437 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29029 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36449 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29585 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29451 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34559 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8565 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6518 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32423 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10237 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7726 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9177 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9153 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->