### PR TITLE
[WebRTC] Extract BaseTarget-libaom.xcconfig from libaom.xcconfig

### DIFF
--- a/Source/ThirdParty/libwebrtc/Configurations/BaseTarget-libaom.xcconfig
+++ b/Source/ThirdParty/libwebrtc/Configurations/BaseTarget-libaom.xcconfig
@@ -21,22 +21,25 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "BaseTarget-libaom.xcconfig"
+CLANG_WARN_BOOL_CONVERSION = YES;
+CLANG_WARN_ENUM_CONVERSION = YES;
+CLANG_WARN_INT_CONVERSION = YES;
+CLANG_WARN_STRICT_PROTOTYPES = NO;
+CLANG_WARN_IMPLICIT_FUNCTION_DECLARATION = NO;
+GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
+ENABLE_STRICT_OBJC_MSGSEND = YES;
+GCC_WARN_UNUSED_FUNCTION = NO;
 
-PRODUCT_NAME = aom;
+WARNING_CFLAGS = $(inherited) -Wno-implicit-function-declaration -Wno-strict-prototypes -Wno-unused-function;
 
-COMBINE_HIDPI_IMAGES = NO;
+// FIXME: Enable x86 optimization
+HEADER_SEARCH_PATHS[arch=x86_64] = $(inherited) Source/third_party/libaom/source/config/linux/generic Source/third_party/libaom/source/libaom Source/third_party/libaom/source/config;
+HEADER_SEARCH_PATHS[arch=arm64*] = $(inherited) Source/third_party/libaom/source/config/linux/arm64-cpu-detect Source/third_party/libaom/source/libaom Source/third_party/libaom/source/config;
 
-INSTALL_PATH = $(INSTALL_PATH_PREFIX)$(WK_LIBRARY_INSTALL_PATH);
-PUBLIC_HEADERS_FOLDER_PATH = $(INSTALL_PATH_PREFIX)$(WK_LIBRARY_HEADERS_FOLDER_PATH)/libwebrtc;
+USE_HEADERMAP = NO;
 
-ARM_FILES = *_neon.c arm_cpudetect.c *_arm.c hash_arm_crc32.c *_neon_dotprod.c *_neon.c
-X86_FILES = *_sse2.c *_ssse3.c *_sse4.c *_avx2.c *_avx2.cc *_avx.c *.asm
+GCC_PREPROCESSOR_DEFINITIONS = $(inherited) CONFIG_REALTIME_ONLY=1 WEBRTC_WEBKIT_BUILD CONFIG_TUNE_VMAF=0
 
-EXCLUDED_SOURCE_FILE_NAMES[arch=x86_64] = $(ARM_FILES) $(EXCLUDED_SOURCE_FILE_NAMES_$(WK_IS_CATALYST));
-EXCLUDED_SOURCE_FILE_NAMES_YES = *_sse4.c *_avx.c;
-EXCLUDED_SOURCE_FILE_NAMES[arch=arm64*] = $(X86_FILES) *_mmx.c
-EXCLUDED_SOURCE_FILE_NAMES[sdk=iphonesimulator*][arch=x86_64] = $(ARM_FILES) $(X86_FILES)
-EXCLUDED_SOURCE_FILE_NAMES[sdk=iphoneos*] =  $(X86_FILES) *_mmx.c hash_arm_crc32.c *_neon_dotprod.c
-
-OTHER_LDFLAGS = $(inherited) $(SOURCE_VERSION_LDFLAGS);
+GCC_PREPROCESSOR_DEFINITIONS[sdk=iphonesimulator*] = $(inherited);
+GCC_PREPROCESSOR_DEFINITIONS[sdk=macosx*] = $(inherited) $(GCC_PREPROCESSOR_DEFINITIONS_$(WK_IS_CATALYST))
+GCC_PREPROCESSOR_DEFINITIONS_YES = WEBRTC_WEBKIT_MAC_CATALIST

--- a/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj
+++ b/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj
@@ -9429,6 +9429,7 @@
 		44E751A72AC73EA700828AC4 /* scoped_key_value_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = scoped_key_value_config.h; sourceTree = "<group>"; };
 		44E751AB2AC73F8800828AC4 /* field_trial.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = field_trial.cc; sourceTree = "<group>"; };
 		44E751B32AC73F8800828AC4 /* field_trial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = field_trial.h; sourceTree = "<group>"; };
+		44F99B2E2B2E9DCA00BE6517 /* BaseTarget-libaom.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "BaseTarget-libaom.xcconfig"; sourceTree = "<group>"; };
 		44FD166E2AEA16CC003636CB /* vp8_replay_fuzzer.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = vp8_replay_fuzzer.xcconfig; sourceTree = "<group>"; };
 		44FD16732AEA1F36003636CB /* json.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = json.h; sourceTree = "<group>"; };
 		44FD16752AEA3562003636CB /* null_transport.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = null_transport.cc; sourceTree = "<group>"; };
@@ -19826,6 +19827,7 @@
 				449187232AB3800D007266F2 /* Base-libvpx.xcconfig */,
 				44871D222AC69336007538BC /* Base-libwebrtc.xcconfig */,
 				5D7C59C61208C68B001C873E /* Base.xcconfig */,
+				44F99B2E2B2E9DCA00BE6517 /* BaseTarget-libaom.xcconfig */,
 				5C4B43B01E42877A002651C8 /* boringssl.xcconfig */,
 				5D7C59C71208C68B001C873E /* DebugRelease.xcconfig */,
 				448A76AD2AF054F400C0A67C /* h264_depacketizer_fuzzer.xcconfig */,


### PR DESCRIPTION
#### f67a9fb1e5fff1909406a6c3e7f6d19261f10e41
<pre>
[WebRTC] Extract BaseTarget-libaom.xcconfig from libaom.xcconfig
<a href="https://bugs.webkit.org/show_bug.cgi?id=267022">https://bugs.webkit.org/show_bug.cgi?id=267022</a>
&lt;<a href="https://rdar.apple.com/120399649">rdar://120399649</a>&gt;

Reviewed by Elliott Williams.

* Source/ThirdParty/libwebrtc/Configurations/BaseTarget-libaom.xcconfig: Add.
- Extract settings from libaom.xcconfig.
(WARNING_CFLAGS):
- Add missing $(inherited) to define warning flags consistently.
- Add -Wno-unused-function to fix the build after adding $(inherited).
* Source/ThirdParty/libwebrtc/Configurations/libaom.xcconfig:
- Include BaseTarget-libaom.xcconfig after extracting settings.
* Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj:
- Add BaseTarget-libaom.xcconfig to the project.

Canonical link: <a href="https://commits.webkit.org/272641@main">https://commits.webkit.org/272641@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e9573ccd1d6c4b5491fb2ad0ec02d328ba9f1904

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32315 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11052 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34136 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34869 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29258 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13403 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8258 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28808 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32733 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9316 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28878 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8110 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8250 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28809 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36210 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29378 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29239 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34375 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8384 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6325 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32237 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10039 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9015 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4197 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8944 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->