### PR TITLE
NEW TEST (271821@main): [ iOS17 macOS Debug ] TestWebKitAPI.ResourceLoadStatistics.StorageAccessOnRedirectSitesWithQuirk is a consistent timeout

### DIFF
--- a/Source/WebCore/platform/network/OrganizationStorageAccessPromptQuirk.h
+++ b/Source/WebCore/platform/network/OrganizationStorageAccessPromptQuirk.h
@@ -61,7 +61,7 @@ inline void add(Hasher& hasher, const OrganizationStorageAccessPromptQuirk& quir
 
 struct OrganizationStorageAccessPromptQuirkHashTraits : SimpleClassHashTraits<OrganizationStorageAccessPromptQuirk> {
     static const bool hasIsEmptyValueFunction = true;
-    static const bool emptyValueIsZero = true;
+    static const bool emptyValueIsZero = false;
     static bool isEmptyValue(const OrganizationStorageAccessPromptQuirk& quirk) { return quirk.organizationName.isNull(); }
 };
 


### PR DESCRIPTION
#### b9a84a32b25ef5eb6d4c179c00880ffbb4cb6201
<pre>
NEW TEST (271821@main): [ iOS17 macOS Debug ] TestWebKitAPI.ResourceLoadStatistics.StorageAccessOnRedirectSitesWithQuirk is a consistent timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=266602">https://bugs.webkit.org/show_bug.cgi?id=266602</a>
<a href="https://rdar.apple.com/119833423">rdar://119833423</a>

Reviewed by John Wilander.

I incorrectly defined OrganizationStorageAccessPromptQuirkHashTraits&apos;s
emptyValueIsZero as true in 271821@main. This causes a crash in the
NetworkProcess when adding a new entry in the hashtable.

* Source/WebCore/platform/network/OrganizationStorageAccessPromptQuirk.h:

Canonical link: <a href="https://commits.webkit.org/272621@main">https://commits.webkit.org/272621@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/081a7206c28f16d821dc7d298af09896a9ca8dd0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32312 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11049 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34133 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34866 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29255 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33162 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13400 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8255 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28806 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32730 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9312 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28875 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8105 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8248 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28806 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36207 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29374 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29237 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34373 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8381 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6321 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32235 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10036 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7549 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9012 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8941 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->