### PR TITLE
Generate code to check pseudo-class/element argument

### DIFF
--- a/Source/WebCore/css/CSSPseudoSelectors.json
+++ b/Source/WebCore/css/CSSPseudoSelectors.json
@@ -7,6 +7,7 @@
             "status": "non-standard"
         },
         "-webkit-any": {
+            "argument": "required",
             "comment": "Alias of :is() with different specificity rules.",
             "status": "non-standard"
         },
@@ -73,7 +74,9 @@
         },
         "default": {},
         "defined": {},
-        "dir": {},
+        "dir": {
+            "argument": "required"
+        },
         "disabled": {},
         "double-button": {
             "comment": "For scrollbar styling.",
@@ -102,6 +105,7 @@
             "condition": "ENABLE(VIDEO)"
         },
         "has": {
+            "argument": "required",
             "settings-flag": "hasPseudoClassEnabled"
         },
         "has-attachment": {
@@ -112,7 +116,9 @@
             "comment": "For scrollbar styling.",
             "status": "non-standard"
         },
-        "host": {},
+        "host": {
+            "argument": "optional"
+        },
         "hover": {},
         "in-range": {},
         "increment": {
@@ -124,9 +130,12 @@
         "is": {
             "aliases": [
                 "matches"
-            ]
+            ],
+            "argument": "required"
         },
-        "lang": {},
+        "lang": {
+            "argument": "required"
+        },
         "last-child": {},
         "last-of-type": {},
         "link": {},
@@ -138,11 +147,21 @@
             "comment": "For scrollbar styling.",
             "status": "non-standard"
         },
-        "not": {},
-        "nth-child": {},
-        "nth-last-child": {},
-        "nth-last-of-type": {},
-        "nth-of-type": {},
+        "not": {
+            "argument": "required"
+        },
+        "nth-child": {
+            "argument": "required"
+        },
+        "nth-last-child": {
+            "argument": "required"
+        },
+        "nth-last-of-type": {
+            "argument": "required"
+        },
+        "nth-of-type": {
+            "argument": "required"
+        },
         "only-child": {},
         "only-of-type": {},
         "optional": {},
@@ -175,6 +194,7 @@
             "condition": "ENABLE(VIDEO)"
         },
         "state": {
+            "argument": "required",
             "settings-flag": "customStateSetEnabled"
         },
         "single-button": {
@@ -197,7 +217,9 @@
         "volume-locked": {
             "condition": "ENABLE(VIDEO)"
         },
-        "where": {},
+        "where": {
+            "argument": "required"
+        },
         "window-inactive": {
             "comment": "Standards track point towards a media query rather than a pseudo-class: https://github.com/w3c/csswg-drafts/issues/5828.",
             "status": "non-standard"
@@ -246,6 +268,7 @@
             "supports-single-colon-for-compatibility": true
         },
         "cue": {
+            "argument": "optional",
             "condition": "ENABLE(VIDEO)"
         },
         "file-selector-button": {
@@ -264,10 +287,13 @@
             "settings-flag": "grammarAndSpellingPseudoElementsEnabled"
         },
         "highlight": {
+            "argument": "required",
             "settings-flag": "highlightAPIEnabled"
         },
         "marker": {},
-        "part": {},
+        "part": {
+            "argument": "required"
+        },
         "placeholder": {
             "aliases": [
                 "-webkit-input-placeholder"
@@ -275,7 +301,9 @@
             "user-agent-part": true
         },
         "selection": {},
-        "slotted": {},
+        "slotted": {
+            "argument": "required"
+        },
         "spelling-error": {
             "settings-flag": "grammarAndSpellingPseudoElementsEnabled"
         },
@@ -291,15 +319,19 @@
             "settings-flag": "viewTransitionsEnabled"
         },
         "view-transition-group": {
+            "argument": "required",
             "settings-flag": "viewTransitionsEnabled"
         },
         "view-transition-image-pair": {
+            "argument": "required",
             "settings-flag": "viewTransitionsEnabled"
         },
         "view-transition-old": {
+            "argument": "required",
             "settings-flag": "viewTransitionsEnabled"
         },
         "view-transition-new": {
+            "argument": "required",
             "settings-flag": "viewTransitionsEnabled"
         }
     }

--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -516,6 +516,7 @@ String CSSSelector::selectorText(StringView separator, StringView rightSide) con
                 builder.append(')');
                 break;
             default:
+                ASSERT(!pseudoClassMayHaveArgument(cs->pseudoClass()), "Missing serialization for pseudo-class argument");
                 break;
             }
         } else if (cs->match() == Match::PseudoElement) {
@@ -559,6 +560,7 @@ String CSSSelector::selectorText(StringView separator, StringView rightSide) con
             }
 #endif
             default:
+                ASSERT(!pseudoElementMayHaveArgument(cs->pseudoElement()), "Missing serialization for pseudo-element argument");
                 builder.append("::");
                 serializeIdentifier(cs->serializingValue(), builder);
             }

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -118,6 +118,10 @@ public:
     static bool isPseudoElementEnabled(PseudoElement, StringView, const CSSSelectorParserContext&);
     static std::optional<PseudoElement> parsePseudoElement(StringView, const CSSSelectorParserContext&);
     static std::optional<PseudoId> parseStandalonePseudoElement(StringView, const CSSSelectorParserContext&);
+    static bool pseudoClassRequiresArgument(PseudoClass);
+    static bool pseudoElementRequiresArgument(PseudoElement);
+    static bool pseudoClassMayHaveArgument(PseudoClass);
+    static bool pseudoElementMayHaveArgument(PseudoElement);
 
     static const ASCIILiteral selectorTextForPseudoClass(PseudoClass);
     static const ASCIILiteral nameForShadowPseudoElementLegacyAlias(StringView);

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -698,52 +698,12 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumeAttribute(CSSParser
     if (attributeValue.type() != IdentToken && attributeValue.type() != StringToken)
         return nullptr;
     selector->setValue(attributeValue.value().toAtomString());
-    
+
     selector->setAttribute(qualifiedName, consumeAttributeFlags(block));
 
     if (!block.atEnd())
         return nullptr;
     return selector;
-}
-
-static bool isOnlyPseudoClassFunction(CSSSelector::PseudoClass pseudoClass)
-{
-    switch (pseudoClass) {
-    case CSSSelector::PseudoClass::Not:
-    case CSSSelector::PseudoClass::Is:
-    case CSSSelector::PseudoClass::Where:
-    case CSSSelector::PseudoClass::WebKitAny:
-    case CSSSelector::PseudoClass::Has:
-    case CSSSelector::PseudoClass::NthChild:
-    case CSSSelector::PseudoClass::NthLastChild:
-    case CSSSelector::PseudoClass::NthOfType:
-    case CSSSelector::PseudoClass::NthLastOfType:
-    case CSSSelector::PseudoClass::Lang:
-    case CSSSelector::PseudoClass::Dir:
-    case CSSSelector::PseudoClass::State:
-        return true;
-    default:
-        break;
-    }
-    return false;
-}
-    
-static bool isOnlyPseudoElementFunction(CSSSelector::PseudoElement pseudoElement)
-{
-    // Note that we omit ::cue since it can be either an ident or a function.
-    switch (pseudoElement) {
-    case CSSSelector::PseudoElement::Highlight:
-    case CSSSelector::PseudoElement::Part:
-    case CSSSelector::PseudoElement::Slotted:
-    case CSSSelector::PseudoElement::ViewTransitionGroup:
-    case CSSSelector::PseudoElement::ViewTransitionImagePair:
-    case CSSSelector::PseudoElement::ViewTransitionOld:
-    case CSSSelector::PseudoElement::ViewTransitionNew:
-        return true;
-    default:
-        break;
-    }
-    return false;
 }
 
 std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumePseudo(CSSParserTokenRange& range)
@@ -788,8 +748,8 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumePseudo(CSSParserTok
 
     if (token.type() == IdentToken) {
         range.consume();
-        if ((selector->match() == CSSSelector::Match::PseudoElement && isOnlyPseudoElementFunction(selector->pseudoElement()))
-            || (selector->match() == CSSSelector::Match::PseudoClass && isOnlyPseudoClassFunction(selector->pseudoClass())))
+        if ((selector->match() == CSSSelector::Match::PseudoElement && CSSSelector::pseudoElementRequiresArgument(selector->pseudoElement()))
+            || (selector->match() == CSSSelector::Match::PseudoClass && CSSSelector::pseudoClassRequiresArgument(selector->pseudoClass())))
             return nullptr;
         return selector;
     }


### PR DESCRIPTION
#### e0c29e7e482a4a452c92c394677358659c71eace
<pre>
Generate code to check pseudo-class/element argument
<a href="https://bugs.webkit.org/show_bug.cgi?id=267029">https://bugs.webkit.org/show_bug.cgi?id=267029</a>
<a href="https://rdar.apple.com/120404097">rdar://120404097</a>

Reviewed by Ryosuke Niwa.

Add a field in `CSSPseudoSelectors.json` that represents whether a pseudo takes a required or optional argument, and use it to:
- generate `isOnlyPseudoClassFunction` as `CSSSelector::pseudoClassRequiresArgument`
- generate `isOnlyPseudoElementFunction` as `CSSSelector::pseudoElementRequiresArgument`
- add ASSERTs when serialization code hasn&apos;t been provided for pseudos with an optional or required argument

* Source/WebCore/css/CSSPseudoSelectors.json:
* Source/WebCore/css/CSSSelector.cpp:
(WebCore::CSSSelector::selectorText const):
* Source/WebCore/css/CSSSelector.h:
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParser::consumeAttribute):
(WebCore::CSSSelectorParser::consumePseudo):
(WebCore::isOnlyPseudoClassFunction): Deleted.
(WebCore::isOnlyPseudoElementFunction): Deleted.
* Source/WebCore/css/process-css-pseudo-selectors.py:

Canonical link: <a href="https://commits.webkit.org/272601@main">https://commits.webkit.org/272601@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6766b478bd738af0713f87ad0cdd0f4d00ce3053

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32326 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11063 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34147 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34880 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/29265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33176 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13415 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8269 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/28814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32744 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9329 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28889 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8122 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8262 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28820 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36221 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29390 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29249 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/34388 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8391 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6337 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/32251 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10050 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/9022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4179 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8955 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->