### PR TITLE
Remove Element::userAgentPartId() in favor of pseudo()

### DIFF
--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -287,7 +287,7 @@ SelectorChecker::MatchResult SelectorChecker::matchRecursively(CheckingContext& 
             if (context.inFunctionalPseudoClass)
                 return MatchResult::fails(Match::SelectorFailsCompletely);
             if (ShadowRoot* root = context.element->containingShadowRoot()) {
-                if (context.element->userAgentPartId() != context.selector->value())
+                if (context.element->pseudo() != context.selector->value())
                     return MatchResult::fails(Match::SelectorFailsLocally);
 
                 if (root->mode() != ShadowRootMode::UserAgent)

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3124,11 +3124,6 @@ CustomElementDefaultARIA* Element::customElementDefaultARIAIfExists()
     return isPrecustomizedOrDefinedCustomElement() && hasRareData() ? elementRareData()->customElementDefaultARIA() : nullptr;
 }
 
-const AtomString& Element::userAgentPartId() const
-{
-    return pseudo();
-}
-
 bool Element::childTypeAllowed(NodeType type) const
 {
     switch (type) {

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -374,9 +374,6 @@ public:
     CheckedRef<CustomElementDefaultARIA> checkedCustomElementDefaultARIA();
     CustomElementDefaultARIA* customElementDefaultARIAIfExists();
 
-    // FIXME: This should not be virtual. Please do not add additional overrides of this function.
-    virtual const AtomString& userAgentPartId() const;
-
     bool isInActiveChain() const { return isUserActionElement() && isUserActionElementInActiveChain(); }
     bool active() const { return isUserActionElement() && isUserActionElementActive(); }
     bool hovered() const { return isUserActionElement() && isUserActionElementHovered(); }
@@ -495,7 +492,7 @@ public:
  
     virtual String title() const;
 
-    const AtomString& pseudo() const;
+    WEBCORE_EXPORT const AtomString& pseudo() const;
     WEBCORE_EXPORT void setPseudo(const AtomString&);
 
     // Use Document::registerForDocumentActivationCallbacks() to subscribe to these

--- a/Source/WebCore/html/TextFieldInputType.cpp
+++ b/Source/WebCore/html/TextFieldInputType.cpp
@@ -880,7 +880,7 @@ void TextFieldInputType::updateAutoFillButton()
         if (!m_autoFillButton)
             createAutoFillButton(autoFillButtonType);
 
-        const AtomString& attribute = m_autoFillButton->attributeWithoutSynchronization(pseudoAttr);
+        const AtomString& attribute = m_autoFillButton->pseudo();
         bool shouldUpdateAutoFillButtonType = isAutoFillButtonTypeChanged(attribute, autoFillButtonType);
         if (shouldUpdateAutoFillButtonType) {
             m_autoFillButton->setPseudo(autoFillButtonTypeToAutoFillButtonPseudoClassName(autoFillButtonType));

--- a/Source/WebCore/html/shadow/DateTimeEditElement.cpp
+++ b/Source/WebCore/html/shadow/DateTimeEditElement.cpp
@@ -263,11 +263,11 @@ void DateTimeEditElement::layout(const LayoutParameters& layoutParameters)
     }
 
     if (focusedField) {
-        auto& focusedFieldId = focusedField->userAgentPartId();
+        auto& focusedFieldId = focusedField->pseudo();
 
         auto foundFieldToFocus = false;
         for (auto& field : m_fields) {
-            if (field->userAgentPartId() == focusedFieldId) {
+            if (field->pseudo() == focusedFieldId) {
                 foundFieldToFocus = true;
                 field->focus();
                 break;

--- a/Source/WebCore/html/shadow/YouTubeEmbedShadowElement.cpp
+++ b/Source/WebCore/html/shadow/YouTubeEmbedShadowElement.cpp
@@ -27,7 +27,6 @@
 #include "YouTubeEmbedShadowElement.h"
 
 #include "RenderBlockFlow.h"
-#include "UserAgentPartIds.h"
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -362,7 +362,7 @@ StyleAppearance RenderTheme::autoAppearanceForElement(RenderStyle& style, const 
 #endif
 
     if (element->isInUserAgentShadowTree()) {
-        auto& part = element->userAgentPartId();
+        auto& part = element->pseudo();
 
 #if ENABLE(DATALIST_ELEMENT)
         if (part == UserAgentPartIds::webkitListButton())

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -355,7 +355,7 @@ void ElementRuleCollector::matchPartPseudoElementRules(CascadeLevel level)
     if (!element().containingShadowRoot())
         return;
 
-    bool isUAShadowPseudoElement = element().containingShadowRoot()->mode() == ShadowRootMode::UserAgent && !element().userAgentPartId().isNull();
+    bool isUAShadowPseudoElement = element().containingShadowRoot()->mode() == ShadowRootMode::UserAgent && !element().pseudo().isNull();
 
     auto& partMatchingElement = isUAShadowPseudoElement ? *element().shadowHost() : element();
     if (partMatchingElement.partNames().isEmpty() || !partMatchingElement.isInShadowTree())
@@ -402,7 +402,7 @@ void ElementRuleCollector::collectMatchingShadowPseudoElementRules(const MatchRe
     if (element().isWebVTTElement() || element().isWebVTTRubyElement() || element().isWebVTTRubyTextElement())
         collectMatchingRulesForList(&rules.cuePseudoRules(), matchRequest);
 #endif
-    auto& partId = element().userAgentPartId();
+    auto& partId = element().pseudo();
     if (!partId.isEmpty())
         collectMatchingRulesForList(rules.shadowPseudoElementRules(partId), matchRequest);
 }

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -562,7 +562,7 @@ void Adjuster::adjust(RenderStyle& style, const RenderStyle* userAgentAppearance
             style.setTextSecurity(style.inputSecurity() == InputSecurity::Auto ? TextSecurity::Disc : TextSecurity::None);
 
         // Disallow -webkit-user-modify on :pseudo and ::pseudo elements.
-        if (!m_element->userAgentPartId().isNull())
+        if (!m_element->pseudo().isNull())
             style.setUserModify(UserModify::ReadOnly);
 
         if (is<HTMLMarqueeElement>(*m_element)) {

--- a/Source/WebCore/style/StyleInvalidator.cpp
+++ b/Source/WebCore/style/StyleInvalidator.cpp
@@ -421,7 +421,7 @@ void Invalidator::invalidateShadowPseudoElements(ShadowRoot& shadowRoot)
         return;
 
     for (auto& descendant : descendantsOfType<Element>(shadowRoot)) {
-        auto& partId = descendant.userAgentPartId();
+        auto& partId = descendant.pseudo();
         if (!partId)
             continue;
         for (auto& ruleSet : m_ruleSets) {

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -582,7 +582,7 @@ static bool elementTypeHasAppearanceFromUAStyle(const Element& element)
         || localName == HTMLNames::progressTag
         || localName == HTMLNames::selectTag
         || localName == HTMLNames::meterTag
-        || (element.isInUserAgentShadowTree() && element.userAgentPartId() == UserAgentPartIds::webkitListButton());
+        || (element.isInUserAgentShadowTree() && element.pseudo() == UserAgentPartIds::webkitListButton());
 }
 
 void Resolver::invalidateMatchedDeclarationsCache()

--- a/Source/WebCore/style/StyleSharingResolver.cpp
+++ b/Source/WebCore/style/StyleSharingResolver.cpp
@@ -216,7 +216,7 @@ bool SharingResolver::canShareStyleWithElement(const Context& context, const Sty
         return false;
     if (candidateElement.isBeingDragged() != element.isBeingDragged())
         return false;
-    if (candidateElement.userAgentPartId() != element.userAgentPartId())
+    if (candidateElement.pseudo() != element.pseudo())
         return false;
     if (element.isInShadowTree() && candidateElement.partNames() != element.partNames())
         return false;

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1425,7 +1425,7 @@ ExceptionOr<String> Internals::shadowRootType(const Node& root) const
 
 const AtomString& Internals::userAgentPartId(Element& element)
 {
-    return element.userAgentPartId();
+    return element.pseudo();
 }
 
 void Internals::setUserAgentPartId(Element& element, const AtomString& id)


### PR DESCRIPTION
#### a9f625b0b81f3e6dd73f16c2504a40f58fcec8cf
<pre>
Remove Element::userAgentPartId() in favor of pseudo()
<a href="https://bugs.webkit.org/show_bug.cgi?id=267030">https://bugs.webkit.org/show_bug.cgi?id=267030</a>

Reviewed by Tim Nguyen.

This virtual method was never overridden and didn&apos;t do anything beyond
calling pseudo() directly.

Also remove an obsolete include in YouTubeEmbedShadowElement and use
pseudo() instead of directly invoking the attribute getter in
TextFieldInputType.

* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::matchRecursively const):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::userAgentPartId const): Deleted.
* Source/WebCore/dom/Element.h:
* Source/WebCore/html/shadow/DateTimeEditElement.cpp:
(WebCore::DateTimeEditElement::layout):
* Source/WebCore/html/shadow/YouTubeEmbedShadowElement.cpp:
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::autoAppearanceForElement const):
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::matchPartPseudoElementRules):
(WebCore::Style::ElementRuleCollector::collectMatchingShadowPseudoElementRules):
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjust const):
* Source/WebCore/style/StyleInvalidator.cpp:
(WebCore::Style::Invalidator::invalidateShadowPseudoElements):
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::elementTypeHasAppearanceFromUAStyle):
* Source/WebCore/style/StyleSharingResolver.cpp:
(WebCore::Style::SharingResolver::canShareStyleWithElement const):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::userAgentPartId):

Canonical link: <a href="https://commits.webkit.org/272604@main">https://commits.webkit.org/272604@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/603e9300f6b4753d5aaa4b5f75a516cb58410403

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32333 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11070 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34155 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34887 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29270 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33183 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13423 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8276 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/28819 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32751 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9336 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28896 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/8131 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8269 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28827 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36228 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29397 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29256 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/34400 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8398 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6345 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32263 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10057 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7538 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9028 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8962 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->