### PR TITLE
Replace const char* with ASCIILiteral in CSSSelector

### DIFF
--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -387,7 +387,7 @@ static void appendLangArgumentList(StringBuilder& builder, const FixedVector<Pos
         else
             serializeString(list[i].identifier, builder);
         if (i != size - 1)
-            builder.append(", ");
+            builder.append(", "_s);
     }
 }
 
@@ -423,7 +423,7 @@ static void outputNthChildAnPlusB(const CSSSelector& selector, StringBuilder& bu
         builder.append('n', b);
     } else {
         outputFirstTerm(a);
-        builder.append("n+", b);
+        builder.append("n+"_s, b);
     }
 }
 
@@ -561,7 +561,7 @@ String CSSSelector::selectorText(StringView separator, StringView rightSide) con
 #endif
             default:
                 ASSERT(!pseudoElementMayHaveArgument(cs->pseudoElement()), "Missing serialization for pseudo-element argument");
-                builder.append("::");
+                builder.append("::"_s);
                 serializeIdentifier(cs->serializingValue(), builder);
             }
         } else if (cs->isAttributeSelector()) {
@@ -580,19 +580,19 @@ String CSSSelector::selectorText(StringView separator, StringView rightSide) con
                 builder.append(']');
                 break;
             case Match::List:
-                builder.append("~=");
+                builder.append("~="_s);
                 break;
             case Match::Hyphen:
-                builder.append("|=");
+                builder.append("|="_s);
                 break;
             case Match::Begin:
-                builder.append("^=");
+                builder.append("^="_s);
                 break;
             case Match::End:
-                builder.append("$=");
+                builder.append("$="_s);
                 break;
             case Match::Contain:
-                builder.append("*=");
+                builder.append("*="_s);
                 break;
             default:
                 break;
@@ -600,20 +600,20 @@ String CSSSelector::selectorText(StringView separator, StringView rightSide) con
             if (cs->match() != Match::Set) {
                 serializeString(cs->serializingValue(), builder);
                 if (cs->attributeValueMatchingIsCaseInsensitive())
-                    builder.append(" i]");
+                    builder.append(" i]"_s);
                 else
                     builder.append(']');
             }
         } else if (cs->match() == Match::PagePseudoClass) {
             switch (cs->pagePseudoClass()) {
             case PagePseudoClass::First:
-                builder.append(":first");
+                builder.append(":first"_s);
                 break;
             case PagePseudoClass::Left:
-                builder.append(":left");
+                builder.append(":left"_s);
                 break;
             case PagePseudoClass::Right:
-                builder.append(":right");
+                builder.append(":right"_s);
                 break;
             }
         }


### PR DESCRIPTION
#### cfc789a751bf89803540c0cec6424aa99c379e81
<pre>
Replace const char* with ASCIILiteral in CSSSelector
<a href="https://bugs.webkit.org/show_bug.cgi?id=267032">https://bugs.webkit.org/show_bug.cgi?id=267032</a>
<a href="https://rdar.apple.com/120408392">rdar://120408392</a>

Reviewed by Ryosuke Niwa.

For consistency with the rest of the file and to match recommended practices.

* Source/WebCore/css/CSSSelector.cpp:
(WebCore::appendLangArgumentList):
(WebCore::outputNthChildAnPlusB):
(WebCore::CSSSelector::selectorText const):

Canonical link: <a href="https://commits.webkit.org/272603@main">https://commits.webkit.org/272603@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ccf41069553027393c8bd5f850f610530d8338c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32331 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11068 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34153 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34885 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/29268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33181 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13421 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8274 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/28816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32749 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/9333 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28894 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/8126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8266 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28825 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36226 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29394 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29254 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34393 "Failed to checkout and rebase branch from PR 22346") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8396 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6343 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32256 "Failed to checkout and rebase branch from PR 22346") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10055 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9026 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4180 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8960 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->