### PR TITLE
Clean-ups to CSSParserSelector

### DIFF
--- a/Source/WebCore/css/parser/CSSParserSelector.h
+++ b/Source/WebCore/css/parser/CSSParserSelector.h
@@ -37,7 +37,7 @@ enum class CSSParserSelectorCombinator {
 class CSSParserSelector {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static std::unique_ptr<CSSParserSelector> parsePseudoClassSelector(StringView);
+    static std::unique_ptr<CSSParserSelector> parsePseudoClassSelector(StringView, const CSSSelectorParserContext&);
     static std::unique_ptr<CSSParserSelector> parsePseudoElementSelector(StringView, const CSSSelectorParserContext&);
     static std::unique_ptr<CSSParserSelector> parsePagePseudoSelector(StringView);
 
@@ -57,7 +57,7 @@ public:
     void setValue(const AtomString& value, bool matchLowerCase = false) { m_selector->setValue(value, matchLowerCase); }
 
     void setAttribute(const QualifiedName& value, CSSSelector::AttributeMatchType type) { m_selector->setAttribute(value, type); }
-    
+
     void setArgument(const AtomString& value) { m_selector->setArgument(value); }
     void setNth(int a, int b) { m_selector->setNth(a, b); }
     void setMatch(CSSSelector::Match value) { m_selector->setMatch(value); }
@@ -67,7 +67,7 @@ public:
     CSSSelector::Match match() const { return m_selector->match(); }
     CSSSelector::PseudoElement pseudoElement() const { return m_selector->pseudoElement(); }
     const CSSSelectorList* selectorList() const { return m_selector->selectorList(); }
-    
+
     void setPseudoElement(CSSSelector::PseudoElement type) { m_selector->setPseudoElement(type); }
     void setPseudoClass(CSSSelector::PseudoClass type) { m_selector->setPseudoClass(type); }
 
@@ -76,8 +76,6 @@ public:
     void setSelectorList(std::unique_ptr<CSSSelectorList>);
 
     CSSSelector::PseudoClass pseudoClass() const { return m_selector->pseudoClass(); }
-
-    bool isPseudoElementCueFunction() const;
 
     bool matchesPseudoElement() const;
 
@@ -120,15 +118,6 @@ inline bool CSSParserSelector::needsImplicitShadowCombinatorForMatching() const
             || pseudoElement() == CSSSelector::PseudoElement::Part
             || pseudoElement() == CSSSelector::PseudoElement::Slotted
             || pseudoElement() == CSSSelector::PseudoElement::UserAgentPartLegacyAlias);
-}
-
-inline bool CSSParserSelector::isPseudoElementCueFunction() const
-{
-#if ENABLE(VIDEO)
-    return m_selector->match() == CSSSelector::Match::PseudoElement && m_selector->pseudoElement() == CSSSelector::PseudoElement::Cue;
-#else
-    return false;
-#endif
 }
 
 }

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -723,13 +723,9 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumePseudo(CSSParserTok
 
     std::unique_ptr<CSSParserSelector> selector;
 
-    if (colons == 1) {
-        selector = CSSParserSelector::parsePseudoClassSelector(token.value());
-        if (!selector)
-            return nullptr;
-        if (selector->match() == CSSSelector::Match::PseudoClass && !CSSSelector::isPseudoClassEnabled(selector->pseudoClass(), m_context))
-            return nullptr;
-    } else {
+    if (colons == 1)
+        selector = CSSParserSelector::parsePseudoClassSelector(token.value(), m_context);
+    else {
         selector = CSSParserSelector::parsePseudoElementSelector(token.value(), m_context);
 #if ENABLE(VIDEO)
         // Treat the ident version of cue as PseudoElement::UserAgentPart.


### PR DESCRIPTION
#### aec9d2a42db65e9db3152d3e3dfdf00d5ee1750f
<pre>
Clean-ups to CSSParserSelector
<a href="https://bugs.webkit.org/show_bug.cgi?id=267034">https://bugs.webkit.org/show_bug.cgi?id=267034</a>
<a href="https://rdar.apple.com/120410898">rdar://120410898</a>

Reviewed by Darin Adler.

- Move settings check to `CSSParserSelector::parsePseudoClassSelector` for consistency with `parsePseudoElementSelector`
- Remove unused `CSSParserSelector::isPseudoElementCueFunction`

* Source/WebCore/css/parser/CSSParserSelector.cpp:
(WebCore::CSSParserSelector::parsePseudoClassSelector):
* Source/WebCore/css/parser/CSSParserSelector.h:
(WebCore::CSSParserSelector::isPseudoElementCueFunction const): Deleted.
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParser::consumePseudo):

Canonical link: <a href="https://commits.webkit.org/272608@main">https://commits.webkit.org/272608@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a46ed0d016af715d68a11e3bd6fdf5928b62c4bf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32352 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11089 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34175 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34907 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29284 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33201 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13443 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8295 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28827 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32770 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9356 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28914 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8142 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8287 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28845 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36248 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29417 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29273 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34411 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8414 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6361 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32276 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10073 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7542 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9043 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8978 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->