### PR TITLE
Rename CSSParserSelector to MutableCSSSelector

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -878,11 +878,11 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     css/parser/CSSParserContext.h
     css/parser/CSSParserEnum.h
     css/parser/CSSParserMode.h
-    css/parser/CSSParserSelector.h
     css/parser/CSSParserToken.h
     css/parser/CSSParserTokenRange.h
     css/parser/CSSSelectorParser.h
     css/parser/CSSSelectorParserContext.h
+    css/parser/MutableCSSSelector.h
 
     css/query/GenericMediaQueryTypes.h
     css/query/MediaQuery.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -959,7 +959,6 @@ css/parser/CSSParserFastPaths.cpp
 css/parser/CSSParserIdioms.cpp
 css/parser/CSSParserImpl.cpp
 css/parser/CSSParserObserverWrapper.cpp
-css/parser/CSSParserSelector.cpp
 css/parser/CSSParserToken.cpp
 css/parser/CSSParserTokenRange.cpp
 css/parser/CSSPropertyParser.cpp
@@ -972,6 +971,7 @@ css/parser/CSSTokenizer.cpp
 css/parser/CSSTokenizerInputStream.cpp
 css/parser/CSSVariableParser.cpp
 css/parser/MediaQueryBlockWatcher.cpp
+css/parser/MutableCSSSelector.cpp
 css/parser/SizesAttributeParser.cpp
 css/parser/SizesCalcParser.cpp
 css/query/ContainerQueryFeatures.cpp

--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -27,12 +27,12 @@
 #include "CSSSelector.h"
 
 #include "CSSMarkup.h"
-#include "CSSParserSelector.h"
 #include "CSSSelectorInlines.h"
 #include "CSSSelectorList.h"
 #include "CSSSelectorParserContext.h"
 #include "CommonAtomStrings.h"
 #include "HTMLNames.h"
+#include "MutableCSSSelector.h"
 #include "SelectorPseudoTypeMap.h"
 #include <memory>
 #include <queue>

--- a/Source/WebCore/css/CSSSelectorList.cpp
+++ b/Source/WebCore/css/CSSSelectorList.cpp
@@ -27,8 +27,8 @@
 #include "config.h"
 #include "CSSSelectorList.h"
 
-#include "CSSParserSelector.h"
 #include "CommonAtomStrings.h"
+#include "MutableCSSSelector.h"
 #include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
@@ -44,21 +44,21 @@ CSSSelectorList::CSSSelectorList(const CSSSelectorList& other)
         new (NotNull, &m_selectorArray[i]) CSSSelector(other.m_selectorArray[i]);
 }
 
-CSSSelectorList::CSSSelectorList(Vector<std::unique_ptr<CSSParserSelector>>&& selectorVector)
+CSSSelectorList::CSSSelectorList(Vector<std::unique_ptr<MutableCSSSelector>>&& selectorVector)
 {
     ASSERT_WITH_SECURITY_IMPLICATION(!selectorVector.isEmpty());
 
     size_t flattenedSize = 0;
     for (size_t i = 0; i < selectorVector.size(); ++i) {
-        for (CSSParserSelector* selector = selectorVector[i].get(); selector; selector = selector->tagHistory())
+        for (auto* selector = selectorVector[i].get(); selector; selector = selector->tagHistory())
             ++flattenedSize;
     }
     ASSERT(flattenedSize);
     m_selectorArray = makeUniqueArray<CSSSelector>(flattenedSize);
     size_t arrayIndex = 0;
     for (size_t i = 0; i < selectorVector.size(); ++i) {
-        CSSParserSelector* first = selectorVector[i].get();
-        CSSParserSelector* current = first;
+        auto* first = selectorVector[i].get();
+        auto* current = first;
         while (current) {
             {
                 // Move item from the parser selector vector into m_selectorArray without invoking destructor (Ugh.)

--- a/Source/WebCore/css/CSSSelectorList.h
+++ b/Source/WebCore/css/CSSSelectorList.h
@@ -31,7 +31,7 @@
 
 namespace WebCore {
 
-class CSSParserSelector;
+class MutableCSSSelector;
 
 class CSSSelectorList {
     WTF_MAKE_FAST_ALLOCATED;
@@ -39,7 +39,7 @@ public:
     CSSSelectorList() = default;
     CSSSelectorList(const CSSSelectorList&);
     CSSSelectorList(CSSSelectorList&&) = default;
-    explicit CSSSelectorList(Vector<std::unique_ptr<CSSParserSelector>>&&);
+    explicit CSSSelectorList(Vector<std::unique_ptr<MutableCSSSelector>>&&);
     explicit CSSSelectorList(UniqueArray<CSSSelector>&& array)
         : m_selectorArray(WTFMove(array)) { }
 

--- a/Source/WebCore/css/StyleRule.cpp
+++ b/Source/WebCore/css/StyleRule.cpp
@@ -36,7 +36,6 @@
 #include "CSSMediaRule.h"
 #include "CSSNamespaceRule.h"
 #include "CSSPageRule.h"
-#include "CSSParserSelector.h"
 #include "CSSPropertyRule.h"
 #include "CSSScopeRule.h"
 #include "CSSStyleRule.h"

--- a/Source/WebCore/css/parser/CSSParserImpl.h
+++ b/Source/WebCore/css/parser/CSSParserImpl.h
@@ -205,7 +205,7 @@ private:
         Scope,
     };
     Vector<AncestorRuleType, 16> m_ancestorRuleTypeStack;
-    static void appendImplicitSelectorIfNeeded(CSSParserSelector&, AncestorRuleType);
+    static void appendImplicitSelectorIfNeeded(MutableCSSSelector&, AncestorRuleType);
 
     Vector<NestingContext> m_nestingContextStack { NestingContext { } };
     const CSSParserContext& m_context;

--- a/Source/WebCore/css/parser/CSSSelectorParser.h
+++ b/Source/WebCore/css/parser/CSSSelectorParser.h
@@ -31,10 +31,10 @@
 
 #include "CSSParserContext.h"
 #include "CSSParserEnum.h"
-#include "CSSParserSelector.h"
 #include "CSSParserTokenRange.h"
 #include "CSSSelectorList.h"
 #include "CSSSelectorParserContext.h"
+#include "MutableCSSSelector.h"
 #include "StyleSheetContents.h"
 
 namespace WebCore {
@@ -44,44 +44,44 @@ class CSSSelectorList;
 class StyleSheetContents;
 class StyleRule;
 
-using CSSParserSelectorList = Vector<std::unique_ptr<CSSParserSelector>>;
+using MutableCSSSelectorList = Vector<std::unique_ptr<MutableCSSSelector>>;
 
 class CSSSelectorParser {
 public:
     CSSSelectorParser(const CSSSelectorParserContext&, StyleSheetContents*, CSSParserEnum::IsNestedContext = CSSParserEnum::IsNestedContext::No);
 
-    CSSParserSelectorList consumeComplexSelectorList(CSSParserTokenRange&);
-    CSSParserSelectorList consumeNestedSelectorList(CSSParserTokenRange&);
-    CSSParserSelectorList consumeComplexForgivingSelectorList(CSSParserTokenRange&);
-    CSSParserSelectorList consumeNestedComplexForgivingSelectorList(CSSParserTokenRange&);
+    MutableCSSSelectorList consumeComplexSelectorList(CSSParserTokenRange&);
+    MutableCSSSelectorList consumeNestedSelectorList(CSSParserTokenRange&);
+    MutableCSSSelectorList consumeComplexForgivingSelectorList(CSSParserTokenRange&);
+    MutableCSSSelectorList consumeNestedComplexForgivingSelectorList(CSSParserTokenRange&);
 
     static bool supportsComplexSelector(CSSParserTokenRange, const CSSSelectorParserContext&, CSSParserEnum::IsNestedContext);
     static CSSSelectorList resolveNestingParent(const CSSSelectorList& nestedSelectorList, const CSSSelectorList* parentResolvedSelectorList);
 
 private:
-    template<typename ConsumeSelector> CSSParserSelectorList consumeSelectorList(CSSParserTokenRange&, ConsumeSelector&&);
-    template<typename ConsumeSelector> CSSParserSelectorList consumeForgivingSelectorList(CSSParserTokenRange&, ConsumeSelector&&);
+    template<typename ConsumeSelector> MutableCSSSelectorList consumeSelectorList(CSSParserTokenRange&, ConsumeSelector&&);
+    template<typename ConsumeSelector> MutableCSSSelectorList consumeForgivingSelectorList(CSSParserTokenRange&, ConsumeSelector&&);
 
-    CSSParserSelectorList consumeCompoundSelectorList(CSSParserTokenRange&);
-    CSSParserSelectorList consumeRelativeSelectorList(CSSParserTokenRange&);
+    MutableCSSSelectorList consumeCompoundSelectorList(CSSParserTokenRange&);
+    MutableCSSSelectorList consumeRelativeSelectorList(CSSParserTokenRange&);
 
-    std::unique_ptr<CSSParserSelector> consumeComplexSelector(CSSParserTokenRange&);
-    std::unique_ptr<CSSParserSelector> consumeNestedComplexSelector(CSSParserTokenRange&);
-    std::unique_ptr<CSSParserSelector> consumeCompoundSelector(CSSParserTokenRange&);
-    std::unique_ptr<CSSParserSelector> consumeRelativeScopeSelector(CSSParserTokenRange&);
-    std::unique_ptr<CSSParserSelector> consumeRelativeNestedSelector(CSSParserTokenRange&);
+    std::unique_ptr<MutableCSSSelector> consumeComplexSelector(CSSParserTokenRange&);
+    std::unique_ptr<MutableCSSSelector> consumeNestedComplexSelector(CSSParserTokenRange&);
+    std::unique_ptr<MutableCSSSelector> consumeCompoundSelector(CSSParserTokenRange&);
+    std::unique_ptr<MutableCSSSelector> consumeRelativeScopeSelector(CSSParserTokenRange&);
+    std::unique_ptr<MutableCSSSelector> consumeRelativeNestedSelector(CSSParserTokenRange&);
 
     // This doesn't include element names, since they're handled specially.
-    std::unique_ptr<CSSParserSelector> consumeSimpleSelector(CSSParserTokenRange&);
+    std::unique_ptr<MutableCSSSelector> consumeSimpleSelector(CSSParserTokenRange&);
 
     bool consumeName(CSSParserTokenRange&, AtomString& name, AtomString& namespacePrefix);
 
     // These will return nullptr when the selector is invalid.
-    std::unique_ptr<CSSParserSelector> consumeId(CSSParserTokenRange&);
-    std::unique_ptr<CSSParserSelector> consumeClass(CSSParserTokenRange&);
-    std::unique_ptr<CSSParserSelector> consumePseudo(CSSParserTokenRange&);
-    std::unique_ptr<CSSParserSelector> consumeAttribute(CSSParserTokenRange&);
-    std::unique_ptr<CSSParserSelector> consumeNesting(CSSParserTokenRange&);
+    std::unique_ptr<MutableCSSSelector> consumeId(CSSParserTokenRange&);
+    std::unique_ptr<MutableCSSSelector> consumeClass(CSSParserTokenRange&);
+    std::unique_ptr<MutableCSSSelector> consumePseudo(CSSParserTokenRange&);
+    std::unique_ptr<MutableCSSSelector> consumeAttribute(CSSParserTokenRange&);
+    std::unique_ptr<MutableCSSSelector> consumeNesting(CSSParserTokenRange&);
 
     CSSSelector::Relation consumeCombinator(CSSParserTokenRange&);
     CSSSelector::Match consumeAttributeMatch(CSSParserTokenRange&);
@@ -89,8 +89,8 @@ private:
 
     const AtomString& defaultNamespace() const;
     const AtomString& determineNamespace(const AtomString& prefix);
-    void prependTypeSelectorIfNeeded(const AtomString& namespacePrefix, const AtomString& elementName, CSSParserSelector&);
-    static std::unique_ptr<CSSParserSelector> splitCompoundAtImplicitShadowCrossingCombinator(std::unique_ptr<CSSParserSelector> compoundSelector, const CSSSelectorParserContext&);
+    void prependTypeSelectorIfNeeded(const AtomString& namespacePrefix, const AtomString& elementName, MutableCSSSelector&);
+    static std::unique_ptr<MutableCSSSelector> splitCompoundAtImplicitShadowCrossingCombinator(std::unique_ptr<MutableCSSSelector> compoundSelector, const CSSSelectorParserContext&);
     static bool containsUnknownWebKitPseudoElements(const CSSSelector& complexSelector);
 
     class DisallowPseudoElementsScope;
@@ -111,6 +111,6 @@ private:
 };
 
 std::optional<CSSSelectorList> parseCSSSelectorList(CSSParserTokenRange, const CSSSelectorParserContext&, StyleSheetContents* = nullptr, CSSParserEnum::IsNestedContext = CSSParserEnum::IsNestedContext::No);
-CSSParserSelectorList parseCSSParserSelectorList(CSSParserTokenRange&, const CSSSelectorParserContext&, StyleSheetContents*, CSSParserEnum::IsNestedContext, CSSParserEnum::IsForgiving);
+MutableCSSSelectorList parseMutableCSSSelectorList(CSSParserTokenRange&, const CSSSelectorParserContext&, StyleSheetContents*, CSSParserEnum::IsNestedContext, CSSParserEnum::IsForgiving);
 
 } // namespace WebCore

--- a/Source/WebCore/css/parser/MutableCSSSelector.h
+++ b/Source/WebCore/css/parser/MutableCSSSelector.h
@@ -27,28 +27,28 @@ namespace WebCore {
 
 struct CSSSelectorParserContext;
 
-enum class CSSParserSelectorCombinator {
-    Child,
-    DescendantSpace,
-    DirectAdjacent,
-    IndirectAdjacent
-};
-
-class CSSParserSelector {
+class MutableCSSSelector {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static std::unique_ptr<CSSParserSelector> parsePseudoClassSelector(StringView, const CSSSelectorParserContext&);
-    static std::unique_ptr<CSSParserSelector> parsePseudoElementSelector(StringView, const CSSSelectorParserContext&);
-    static std::unique_ptr<CSSParserSelector> parsePagePseudoSelector(StringView);
+    enum class Combinator {
+        Child,
+        DescendantSpace,
+        DirectAdjacent,
+        IndirectAdjacent
+    };
 
-    CSSParserSelector();
+    static std::unique_ptr<MutableCSSSelector> parsePseudoClassSelector(StringView, const CSSSelectorParserContext&);
+    static std::unique_ptr<MutableCSSSelector> parsePseudoElementSelector(StringView, const CSSSelectorParserContext&);
+    static std::unique_ptr<MutableCSSSelector> parsePagePseudoSelector(StringView);
+
+    MutableCSSSelector();
 
     // Recursively copy the selector chain.
-    CSSParserSelector(const CSSSelector&);
+    MutableCSSSelector(const CSSSelector&);
 
-    explicit CSSParserSelector(const QualifiedName&);
+    explicit MutableCSSSelector(const QualifiedName&);
 
-    ~CSSParserSelector();
+    ~MutableCSSSelector();
 
     std::unique_ptr<CSSSelector> releaseSelector() { return WTFMove(m_selector); }
     const CSSSelector* selector() const { return m_selector.get(); };
@@ -71,7 +71,7 @@ public:
     void setPseudoElement(CSSSelector::PseudoElement type) { m_selector->setPseudoElement(type); }
     void setPseudoClass(CSSSelector::PseudoClass type) { m_selector->setPseudoClass(type); }
 
-    void adoptSelectorVector(Vector<std::unique_ptr<CSSParserSelector>>&&);
+    void adoptSelectorVector(Vector<std::unique_ptr<MutableCSSSelector>>&&);
     void setArgumentList(FixedVector<PossiblyQuotedIdentifier>);
     void setSelectorList(std::unique_ptr<CSSSelectorList>);
 
@@ -90,25 +90,25 @@ public:
     // special case, since it will be covered by this function once again.
     bool needsImplicitShadowCombinatorForMatching() const;
 
-    CSSParserSelector* tagHistory() const { return m_tagHistory.get(); }
-    CSSParserSelector* leftmostSimpleSelector();
-    const CSSParserSelector* leftmostSimpleSelector() const;
+    MutableCSSSelector* tagHistory() const { return m_tagHistory.get(); }
+    MutableCSSSelector* leftmostSimpleSelector();
+    const MutableCSSSelector* leftmostSimpleSelector() const;
     bool startsWithExplicitCombinator() const;
-    void setTagHistory(std::unique_ptr<CSSParserSelector> selector) { m_tagHistory = WTFMove(selector); }
+    void setTagHistory(std::unique_ptr<MutableCSSSelector> selector) { m_tagHistory = WTFMove(selector); }
     void clearTagHistory() { m_tagHistory.reset(); }
-    void insertTagHistory(CSSSelector::Relation before, std::unique_ptr<CSSParserSelector>, CSSSelector::Relation after);
-    void appendTagHistory(CSSSelector::Relation, std::unique_ptr<CSSParserSelector>);
-    void appendTagHistory(CSSParserSelectorCombinator, std::unique_ptr<CSSParserSelector>);
-    void appendTagHistoryAsRelative(std::unique_ptr<CSSParserSelector>);
+    void insertTagHistory(CSSSelector::Relation before, std::unique_ptr<MutableCSSSelector>, CSSSelector::Relation after);
+    void appendTagHistory(CSSSelector::Relation, std::unique_ptr<MutableCSSSelector>);
+    void appendTagHistory(Combinator, std::unique_ptr<MutableCSSSelector>);
+    void appendTagHistoryAsRelative(std::unique_ptr<MutableCSSSelector>);
     void prependTagSelector(const QualifiedName&, bool tagIsForNamespaceRule = false);
-    std::unique_ptr<CSSParserSelector> releaseTagHistory();
+    std::unique_ptr<MutableCSSSelector> releaseTagHistory();
 
 private:
     std::unique_ptr<CSSSelector> m_selector;
-    std::unique_ptr<CSSParserSelector> m_tagHistory;
+    std::unique_ptr<MutableCSSSelector> m_tagHistory;
 };
 
-inline bool CSSParserSelector::needsImplicitShadowCombinatorForMatching() const
+inline bool MutableCSSSelector::needsImplicitShadowCombinatorForMatching() const
 {
     return match() == CSSSelector::Match::PseudoElement
         && (pseudoElement() == CSSSelector::PseudoElement::UserAgentPart

--- a/Source/WebCore/css/process-css-pseudo-selectors.py
+++ b/Source/WebCore/css/process-css-pseudo-selectors.py
@@ -252,7 +252,7 @@ class GPerfOutputGenerator:
         writer.write('#include "SelectorPseudoTypeMap.h"')
         if generator_type == GeneratorTypes['PSEUDO_CLASS_AND_COMPATIBILITY']:
             writer.newline()
-            writer.write('#include "CSSParserSelector.h"')
+            writer.write('#include "MutableCSSSelector.h"')
 
     def write_ignore_implicit_fallthrough(self, writer):
         writer.newline()


### PR DESCRIPTION
#### ac784c090ce396d3b17092ca7ad4ac8968c48f8f
<pre>
Rename CSSParserSelector to MutableCSSSelector
<a href="https://bugs.webkit.org/show_bug.cgi?id=267037">https://bugs.webkit.org/show_bug.cgi?id=267037</a>
<a href="https://rdar.apple.com/120412070">rdar://120412070</a>

Reviewed by Antti Koivisto.

The current name is confusing, especially with the presence of CSSSelectorParser. Rename to MutableCSSSelector to actually represent its purpose.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSSelector.cpp:
* Source/WebCore/css/CSSSelectorList.cpp:
(WebCore::CSSSelectorList::CSSSelectorList):
* Source/WebCore/css/CSSSelectorList.h:
* Source/WebCore/css/StyleRule.cpp:
* Source/WebCore/css/parser/MutableCSSSelector.cpp: Renamed from Source/WebCore/css/parser/CSSParserSelector.cpp.
(WebCore::MutableCSSSelector::parsePagePseudoSelector):
(WebCore::MutableCSSSelector::parsePseudoElementSelector):
(WebCore::MutableCSSSelector::parsePseudoClassSelector):
(WebCore::MutableCSSSelector::MutableCSSSelector):
(WebCore::MutableCSSSelector::~MutableCSSSelector):
(WebCore::MutableCSSSelector::adoptSelectorVector):
(WebCore::MutableCSSSelector::setArgumentList):
(WebCore::MutableCSSSelector::setSelectorList):
(WebCore::MutableCSSSelector::leftmostSimpleSelector const):
(WebCore::MutableCSSSelector::leftmostSimpleSelector):
(WebCore::MutableCSSSelector::hasExplicitNestingParent const):
(WebCore::MutableCSSSelector::hasExplicitPseudoClassScope const):
(WebCore::selectorListMatchesPseudoElement):
(WebCore::MutableCSSSelector::matchesPseudoElement const):
(WebCore::MutableCSSSelector::insertTagHistory):
(WebCore::MutableCSSSelector::appendTagHistory):
(WebCore::MutableCSSSelector::appendTagHistoryAsRelative):
(WebCore::MutableCSSSelector::prependTagSelector):
(WebCore::MutableCSSSelector::releaseTagHistory):
(WebCore::MutableCSSSelector::isHostPseudoSelector const):
(WebCore::MutableCSSSelector::startsWithExplicitCombinator const):
* Source/WebCore/css/parser/MutableCSSSelector.h: Renamed from Source/WebCore/css/parser/CSSParserSelector.h.
(WebCore::MutableCSSSelector::releaseSelector):
(WebCore::MutableCSSSelector::selector const):
(WebCore::MutableCSSSelector::selector):
(WebCore::MutableCSSSelector::setValue):
(WebCore::MutableCSSSelector::setAttribute):
(WebCore::MutableCSSSelector::setArgument):
(WebCore::MutableCSSSelector::setNth):
(WebCore::MutableCSSSelector::setMatch):
(WebCore::MutableCSSSelector::setRelation):
(WebCore::MutableCSSSelector::setForPage):
(WebCore::MutableCSSSelector::match const):
(WebCore::MutableCSSSelector::pseudoElement const):
(WebCore::MutableCSSSelector::selectorList const):
(WebCore::MutableCSSSelector::setPseudoElement):
(WebCore::MutableCSSSelector::setPseudoClass):
(WebCore::MutableCSSSelector::pseudoClass const):
(WebCore::MutableCSSSelector::tagHistory const):
(WebCore::MutableCSSSelector::setTagHistory):
(WebCore::MutableCSSSelector::clearTagHistory):
(WebCore::MutableCSSSelector::needsImplicitShadowCombinatorForMatching const):
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::appendImplicitSelectorPseudoClassScopeIfNeeded):
(WebCore::appendImplicitSelectorNestingParentIfNeeded):
(WebCore::CSSParserImpl::appendImplicitSelectorIfNeeded):
(WebCore::CSSParserImpl::parsePageSelector):
(WebCore::CSSParserImpl::createNestingParentRule):
(WebCore::CSSParserImpl::consumeScopeRule):
(WebCore::CSSParserImpl::consumeStyleRule):
* Source/WebCore/css/parser/CSSParserImpl.h:
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::parseMutableCSSSelectorList):
(WebCore::parseCSSSelectorList):
(WebCore::CSSSelectorParser::consumeSelectorList):
(WebCore::CSSSelectorParser::consumeComplexSelectorList):
(WebCore::CSSSelectorParser::consumeRelativeSelectorList):
(WebCore::CSSSelectorParser::consumeNestedSelectorList):
(WebCore::CSSSelectorParser::consumeForgivingSelectorList):
(WebCore::CSSSelectorParser::consumeComplexForgivingSelectorList):
(WebCore::CSSSelectorParser::consumeNestedComplexForgivingSelectorList):
(WebCore::CSSSelectorParser::supportsComplexSelector):
(WebCore::CSSSelectorParser::consumeCompoundSelectorList):
(WebCore::extractCompoundFlags):
(WebCore::CSSSelectorParser::consumeNestedComplexSelector):
(WebCore::CSSSelectorParser::consumeComplexSelector):
(WebCore::CSSSelectorParser::consumeRelativeScopeSelector):
(WebCore::CSSSelectorParser::consumeRelativeNestedSelector):
(WebCore::isSimpleSelectorValidAfterPseudoElement):
(WebCore::CSSSelectorParser::consumeCompoundSelector):
(WebCore::CSSSelectorParser::consumeSimpleSelector):
(WebCore::CSSSelectorParser::consumeId):
(WebCore::CSSSelectorParser::consumeClass):
(WebCore::CSSSelectorParser::consumeNesting):
(WebCore::CSSSelectorParser::consumeAttribute):
(WebCore::CSSSelectorParser::consumePseudo):
(WebCore::CSSSelectorParser::prependTypeSelectorIfNeeded):
(WebCore::CSSSelectorParser::splitCompoundAtImplicitShadowCrossingCombinator):
(WebCore::CSSSelectorParser::resolveNestingParent):
(WebCore::parseCSSParserSelectorList): Deleted.
* Source/WebCore/css/parser/CSSSelectorParser.h:
* Source/WebCore/css/process-css-pseudo-selectors.py:

Canonical link: <a href="https://commits.webkit.org/272620@main">https://commits.webkit.org/272620@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab09edaa1ac414b33362459043d4f62fbec70d9e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32409 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11150 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34241 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/34968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/29334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33264 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13503 "Failed to checkout and rebase branch from PR 22350") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/8354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/28867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32833 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/13503 "Failed to checkout and rebase branch from PR 22350") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/28971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/8185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/13503 "Failed to checkout and rebase branch from PR 22350") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/28902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/36306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/13503 "Failed to checkout and rebase branch from PR 22350") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/29332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/36306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/8463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/8354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/36306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/10124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/9084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4188 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/9033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->