### PR TITLE
[cairo] freeze under WebCore::Cairo::fillRect at https://dev.orthologiq.net/

### DIFF
--- a/LayoutTests/fast/gradients/conic-stop-with-offset-zero-in-middle-expected.html
+++ b/LayoutTests/fast/gradients/conic-stop-with-offset-zero-in-middle-expected.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="fuzzy" content="maxDifference=0-1;totalPixels=900-2500" />
+    <style>
+        #box1 {
+            height: 50px;
+            width: 25px;
+            float: left;
+            background-color: green;
+        }
+        #box2 {
+            height: 50px;
+            width: 25px;
+            float: left;
+            background-color: red;
+        }
+    </style>
+</head>
+<body>
+    <div id="container">
+        <div id="box1"></div>
+        <div id="box2"></div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/fast/gradients/conic-stop-with-offset-zero-in-middle.html
+++ b/LayoutTests/fast/gradients/conic-stop-with-offset-zero-in-middle.html
@@ -1,0 +1,15 @@
+<html>
+<head>
+    <meta name="fuzzy" content="maxDifference=0-1;totalPixels=900-2500" />
+    <style>
+        #grad {
+            height: 50px;
+            width: 50px;
+            background: conic-gradient(from 0, blue, red 0, red 180deg, green 180deg, green 360deg);
+        }
+    </style>
+</head>
+<body>
+    <div id="grad"></div>
+</body>
+</html>

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2587,3 +2587,4 @@ imported/w3c/web-platform-tests/svg/animations/use-animate-display-none-symbol-2
 
 webkit.org/b/266996 imported/w3c/web-platform-tests/css/css-writing-modes/mongolian-orientation-002.html [ ImageOnlyFailure ]
 
+fast/gradients/conic-stop-with-offset-zero-in-middle.html [ ImageOnlyFailure ]

--- a/Source/WebCore/platform/graphics/cairo/GradientCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/GradientCairo.cpp
@@ -151,6 +151,20 @@ static void addConicSector(cairo_pattern_t *gradient, float cx, float cy, float 
 static RefPtr<cairo_pattern_t> createConic(float xo, float yo, float r, float angleRadians,
     GradientColorStops::StopVector stops, float globalAlpha)
 {
+    // Locate last stop with offset 0.
+    size_t i = stops.size() - 1;
+    for (; i > 0; i--) {
+        if (!stops[i].offset)
+            break;
+    }
+    // Remove stops with offset zero before last one.
+    if (i > 0) {
+        GradientColorStops::StopVector newStops;
+        for (; i < stops.size(); i++)
+            newStops.append(stops[i]);
+        stops = newStops;
+    }
+
     // Degenerated gradients with two stops at the same offset arrive with a single stop at 0.0
     // Add another point here so it can be interpolated properly below.
     if (stops.size() == 1)


### PR DESCRIPTION
#### 814c148a788c4d0f6eb9fa86a625ad7e13275b8d
<pre>
[cairo] freeze under WebCore::Cairo::fillRect at <a href="https://dev.orthologiq.net/">https://dev.orthologiq.net/</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=266160">https://bugs.webkit.org/show_bug.cgi?id=266160</a>

Reviewed by Fujii Hironori.

Stops with offset zero before last one must be ignored.

* LayoutTests/fast/gradients/conic-stop-with-offset-zero-in-middle-expected.html: Added.
* LayoutTests/fast/gradients/conic-stop-with-offset-zero-in-middle.html: Added.
* LayoutTests/platform/mac/TestExpectations: Mark new test as ImageOnlyFailure.
* Source/WebCore/platform/graphics/cairo/GradientCairo.cpp:
(WebCore::createConic):

Canonical link: <a href="https://commits.webkit.org/272730@main">https://commits.webkit.org/272730@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ccc7c2f63fbba947e0d002ba924fed7e0e2ee11c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32773 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11524 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34634 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35390 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29606 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33700 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13869 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8709 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29073 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33216 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9718 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29271 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8464 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8602 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29223 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36682 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29775 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29629 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34718 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8722 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6690 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32585 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10407 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/28898 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7624 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9332 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9336 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->