### PR TITLE
CSS linear() function not easing as expected

### DIFF
--- a/LayoutTests/webanimations/combining-transform-animations-with-different-acceleration-capabilities-7-expected.txt
+++ b/LayoutTests/webanimations/combining-transform-animations-with-different-acceleration-capabilities-7-expected.txt
@@ -1,0 +1,7 @@
+PASS successfullyParsed is true
+
+TEST COMPLETE
+PASS internals.acceleratedAnimationsForElement(element).length became 1
+PASS internals.acceleratedAnimationsForElement(element).length became 2
+PASS internals.acceleratedAnimationsForElement(element).length became 0
+

--- a/LayoutTests/webanimations/combining-transform-animations-with-different-acceleration-capabilities-7.html
+++ b/LayoutTests/webanimations/combining-transform-animations-with-different-acceleration-capabilities-7.html
@@ -1,0 +1,45 @@
+<style>
+
+#target {
+    animation: anim 1s infinite;
+}
+
+@keyframes anim {
+    to { scale: 2 }
+}
+
+</style>
+<div id="target" style="width: 100px; height: 100px; background-color: black;"></div>
+<script src="../resources/js-test.js"></script>
+<script>
+
+const element = document.getElementById("target");
+const timing = { duration: 1000, iterations: Infinity };
+
+const shouldBecomeEqualAsync = async (actual, expected) => new Promise(resolve => shouldBecomeEqual(actual, expected, resolve));
+
+(async () => {
+    if (!window.testRunner || !window.internals) {
+        debug("This test should be run in a test runner.");
+        return;
+    }
+
+    testRunner.waitUntilDone();
+
+    // First, check the initial transform-related CSS Animation can be accelerated.
+    await shouldBecomeEqualAsync("internals.acceleratedAnimationsForElement(element).length", "1");
+
+    // Now, start another transform-related animation that can also be accelerated.
+    const rotationAnimation = element.animate({ rotate: ["30deg", "60deg"] }, timing);
+    await shouldBecomeEqualAsync("internals.acceleratedAnimationsForElement(element).length", "2");
+
+    // Now, update the transform-related CSS Animation to a state that cannot be accelerated anymore
+    // due to using a linear() timing function. This should not only prevent this animation from
+    // running accelerated, but also make the second animation revert to a non-accelerated state.
+    element.style.animationTimingFunction = "linear(0 0%, 0.2 50%, 1 100%)";
+    await shouldBecomeEqualAsync("internals.acceleratedAnimationsForElement(element).length", "0");
+
+    testRunner.notifyDone();
+})();
+    
+</script>

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -1394,15 +1394,12 @@ void KeyframeEffect::computeSomeKeyframesUseStepsOrLinearTimingFunctionWithPoint
         if (defaultTimingFunctionIsSteps || defaultTimingFunctionIsLinearWithPoints) {
             for (auto& keyframe : m_blendingKeyframes) {
                 auto* timingFunction = keyframe.timingFunction();
-                if (!m_someKeyframesUseStepsTimingFunction) {
-                    if ((!timingFunction && defaultTimingFunctionIsSteps) || is<StepsTimingFunction>(timingFunction))
-                        m_someKeyframesUseStepsTimingFunction = true;
-                } else if (!m_someKeyframesUseLinearTimingFunctionWithPoints) {
-                    if ((!timingFunction && defaultTimingFunctionIsLinearWithPoints) || isLinearTimingFunctionWithPoints(timingFunction))
-                        m_someKeyframesUseStepsTimingFunction = true;
-                }
-                if (m_someKeyframesUseStepsTimingFunction && m_someKeyframesUseLinearTimingFunctionWithPoints)
-                    return;
+                if (defaultTimingFunctionIsSteps && !m_someKeyframesUseStepsTimingFunction)
+                    m_someKeyframesUseStepsTimingFunction = !timingFunction || is<StepsTimingFunction>(timingFunction);
+                else if (defaultTimingFunctionIsLinearWithPoints && !m_someKeyframesUseLinearTimingFunctionWithPoints)
+                    m_someKeyframesUseLinearTimingFunctionWithPoints = !timingFunction || isLinearTimingFunctionWithPoints(timingFunction);
+                if (defaultTimingFunctionIsSteps == m_someKeyframesUseStepsTimingFunction && defaultTimingFunctionIsLinearWithPoints == m_someKeyframesUseLinearTimingFunctionWithPoints)
+                    break;
             }
             return;
         }


### PR DESCRIPTION
#### 47204e7f6a588ff2f68bab665144c279e2c9354a
<pre>
CSS linear() function not easing as expected
<a href="https://bugs.webkit.org/show_bug.cgi?id=266848">https://bugs.webkit.org/show_bug.cgi?id=266848</a>
<a href="https://rdar.apple.com/120290721">rdar://120290721</a>

Reviewed by Simon Fraser.

While we attempted to make the use of `linear()` with accelerated properties work in 269594@main,
we neglected to test the case of a CSS Animation with a default `animation-timing-function` set
to a `linear()` easing.

We now address this by adding a dedicated test and ensuring the logic added in KeyframeEffect
is correct. Indeed, there were two issues:

1. we would only check for the absence of a timing function on a keyframe or an explicit `linear()`
value if `m_someKeyframesUseStepsTimingFunction` was `false`. Since that variable is `false` by default
and only ever `true` in case `steps()` values are involved, we would never hit the codepath required
to deal with `linear()` values.

2. due to some shoddy copy-pasting, we actually never set `m_someKeyframesUseLinearTimingFunctionWithPoints`!

We now correctly `m_someKeyframesUseLinearTimingFunctionWithPoints` such that the mechanisms
introduced in 269594@main work as expected.

* LayoutTests/webanimations/combining-transform-animations-with-different-acceleration-capabilities-7-expected.txt: Added.
* LayoutTests/webanimations/combining-transform-animations-with-different-acceleration-capabilities-7.html: Added.
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::computeSomeKeyframesUseStepsOrLinearTimingFunctionWithPoints):

Canonical link: <a href="https://commits.webkit.org/272613@main">https://commits.webkit.org/272613@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/503a9e90d64a83a6f60eb68be2671cec98c7591a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32362 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11102 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34189 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34920 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29296 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33214 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13455 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8308 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28838 "Found 1 new test failure: webanimations/combining-transform-animations-with-different-acceleration-capabilities-7.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32783 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9365 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28928 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8154 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8296 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28859 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36261 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29426 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29287 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34422 "Found 1 new test failure: webanimations/combining-transform-animations-with-different-acceleration-capabilities-7.html (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8427 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6375 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32285 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10086 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/28631 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9053 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4183 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8991 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->