### PR TITLE
[GStreamer][MediaStream] Capturer pipelines are leaking

### DIFF
--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCaptureSource.cpp
@@ -136,7 +136,7 @@ const RealtimeMediaSourceCapabilities& GStreamerAudioCaptureSource::capabilities
         return m_capabilities.value();
 
     uint i;
-    GRefPtr<GstCaps> caps = m_capturer->caps();
+    auto caps = m_capturer->caps();
     int minSampleRate = 0, maxSampleRate = 0;
     for (i = 0; i < gst_caps_get_size(caps.get()); i++) {
         int capabilityMinSampleRate = 0, capabilityMaxSampleRate = 0;

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDevice.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDevice.h
@@ -36,7 +36,7 @@ public:
     {
     }
 
-    GstCaps* caps() const { return gst_device_get_caps(m_device.get()); }
+    WARN_UNUSED_RETURN GRefPtr<GstCaps> caps() const { return adoptGRef(gst_device_get_caps(m_device.get())); }
     GstDevice* device() { return m_device.get(); }
 
 private:

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp
@@ -96,6 +96,9 @@ void GStreamerCaptureDeviceManager::teardown()
     GST_DEBUG_OBJECT(m_deviceMonitor.get(), "Tearing down");
     m_isTearingDown = true;
     stopMonitor();
+    for (auto& capturer : m_capturers)
+        capturer->stopDevice(true);
+    m_capturers.clear();
     RealtimeMediaSourceCenter::singleton().removeDevicesChangedObserver(*this);
     m_devices.clear();
     m_gstreamerDevices.clear();
@@ -127,11 +130,13 @@ void GStreamerCaptureDeviceManager::deviceWillBeRemoved(const String& persistent
 
 void GStreamerCaptureDeviceManager::registerCapturer(const RefPtr<GStreamerCapturer>& capturer)
 {
+    GST_DEBUG("Registering capturer for device %s", capturer->devicePersistentId().ascii().data());
     m_capturers.append(capturer);
 }
 
 void GStreamerCaptureDeviceManager::unregisterCapturer(const GStreamerCapturer& capturer)
 {
+    GST_DEBUG("Un-registering capturer for device %s", capturer.devicePersistentId().ascii().data());
     m_capturers.removeAllMatching([&](auto& item) -> bool {
         return item.get() == &capturer;
     });
@@ -140,14 +145,13 @@ void GStreamerCaptureDeviceManager::unregisterCapturer(const GStreamerCapturer& 
 void GStreamerCaptureDeviceManager::stopCapturing(const String& persistentId)
 {
     GST_DEBUG("Stopping capturer for device with persistent ID: %s", persistentId.ascii().data());
-    m_capturers.removeAllMatching([&persistentId](auto& capturer) -> bool {
+    for (auto& capturer : m_capturers) {
         GST_DEBUG("Checking capturer with device persistent ID: %s", capturer->devicePersistentId().ascii().data());
         if (capturer->devicePersistentId() != persistentId)
-            return false;
-
-        capturer->stopDevice();
-        return true;
-    });
+            continue;
+        capturer->stopDevice(false);
+        break;
+    }
 }
 
 std::optional<GStreamerCaptureDevice> GStreamerCaptureDeviceManager::gstreamerDeviceWithUID(const String& deviceID)
@@ -232,6 +236,7 @@ void GStreamerCaptureDeviceManager::refreshCaptureDevices()
     if (m_isTearingDown)
         return;
 
+    bool monitorBus = false;
     if (!m_deviceMonitor) {
         m_deviceMonitor = adoptGRef(gst_device_monitor_new());
 
@@ -260,6 +265,8 @@ void GStreamerCaptureDeviceManager::refreshCaptureDevices()
             m_deviceMonitor = nullptr;
             return;
         }
+
+        monitorBus = true;
     }
 
     GList* devices = g_list_sort(gst_device_monitor_get_devices(m_deviceMonitor.get()), sortDevices);
@@ -267,6 +274,9 @@ void GStreamerCaptureDeviceManager::refreshCaptureDevices()
         addDevice(adoptGRef(GST_DEVICE_CAST(devices->data)));
         devices = g_list_delete_link(devices, devices);
     }
+
+    if (!monitorBus)
+        return;
 
     auto bus = adoptGRef(gst_device_monitor_get_bus(m_deviceMonitor.get()));
 

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp
@@ -32,6 +32,7 @@
 #include <mutex>
 #include <wtf/HexNumber.h>
 #include <wtf/MonotonicTime.h>
+#include <wtf/PrintStream.h>
 
 GST_DEBUG_CATEGORY(webkit_capturer_debug);
 #define GST_CAT_DEFAULT webkit_capturer_debug
@@ -67,16 +68,31 @@ GStreamerCapturer::GStreamerCapturer(const char* sourceFactory, GRefPtr<GstCaps>
 
 GStreamerCapturer::~GStreamerCapturer()
 {
-    auto* sink = this->sink();
-    if (sink)
-        g_signal_handlers_disconnect_by_data(sink, this);
+    tearDown();
+}
 
-    if (!m_pipeline)
+void GStreamerCapturer::tearDown(bool disconnectSignals)
+{
+    GST_DEBUG("Disposing capture pipeline %" GST_PTR_FORMAT " (disconnecting signals: %s)", m_pipeline.get(), boolForPrinting(disconnectSignals));
+    if (disconnectSignals && m_sink)
+        g_signal_handlers_disconnect_by_data(m_sink.get(), this);
+
+    if (m_pipeline) {
+        if (disconnectSignals) {
+            unregisterPipeline(m_pipeline);
+            disconnectSimpleBusMessageCallback(pipeline());
+        }
+        gst_element_set_state(pipeline(), GST_STATE_NULL);
+    }
+
+    if (!disconnectSignals)
         return;
 
-    unregisterPipeline(m_pipeline);
-    disconnectSimpleBusMessageCallback(pipeline());
-    gst_element_set_state(pipeline(), GST_STATE_NULL);
+    m_sink = nullptr;
+    m_valve = nullptr;
+    m_src = nullptr;
+    m_capsfilter = nullptr;
+    m_pipeline = nullptr;
 }
 
 GStreamerCapturer::Observer::~Observer()
@@ -151,23 +167,25 @@ GstElement* GStreamerCapturer::createSource()
     return m_src.get();
 }
 
-GstCaps* GStreamerCapturer::caps()
+GRefPtr<GstCaps> GStreamerCapturer::caps()
 {
     if (m_sourceFactory) {
         GRefPtr<GstElement> element = makeElement(m_sourceFactory);
         auto pad = adoptGRef(gst_element_get_static_pad(element.get(), "src"));
 
-        return gst_pad_query_caps(pad.get(), nullptr);
+        return adoptGRef(gst_pad_query_caps(pad.get(), nullptr));
     }
 
     ASSERT(m_device);
-    return gst_device_get_caps(m_device->device());
+    return adoptGRef(gst_device_get_caps(m_device->device()));
 }
 
 void GStreamerCapturer::setupPipeline()
 {
-    if (m_pipeline)
+    if (m_pipeline) {
+        unregisterPipeline(m_pipeline);
         disconnectSimpleBusMessageCallback(pipeline());
+    }
 
     m_pipeline = makeElement("pipeline");
     registerActivePipeline(m_pipeline);
@@ -201,6 +219,9 @@ GstElement* GStreamerCapturer::makeElement(const char* factoryName)
 
 void GStreamerCapturer::start()
 {
+    if (!m_pipeline)
+        setupPipeline();
+
     ASSERT(m_pipeline);
     GST_INFO_OBJECT(pipeline(), "Starting");
     gst_element_set_state(pipeline(), GST_STATE_PLAYING);
@@ -208,10 +229,8 @@ void GStreamerCapturer::start()
 
 void GStreamerCapturer::stop()
 {
-    ASSERT(m_pipeline);
     GST_INFO_OBJECT(pipeline(), "Stopping");
-    unregisterPipeline(m_pipeline);
-    gst_element_set_state(pipeline(), GST_STATE_NULL);
+    tearDown(false);
 }
 
 bool GStreamerCapturer::isInterrupted() const
@@ -226,11 +245,16 @@ void GStreamerCapturer::setInterrupted(bool isInterrupted)
     g_object_set(m_valve.get(), "drop", isInterrupted, nullptr);
 }
 
-void GStreamerCapturer::stopDevice()
+void GStreamerCapturer::stopDevice(bool disconnectSignals)
 {
     forEachObserver([](auto& observer) {
         observer.captureEnded();
     });
+    if (disconnectSignals) {
+        m_device.reset();
+        m_caps = nullptr;
+    }
+    tearDown(disconnectSignals);
 }
 
 #undef GST_CAT_DEFAULT

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.h
@@ -47,6 +47,8 @@ public:
     GStreamerCapturer(const char* sourceFactory, GRefPtr<GstCaps>&&, CaptureDevice::DeviceType);
     virtual ~GStreamerCapturer();
 
+    void tearDown(bool disconnectSignals = true);
+
     void addObserver(Observer&);
     void removeObserver(Observer&);
     void forEachObserver(const Function<void(Observer&)>&);
@@ -54,7 +56,7 @@ public:
     void setupPipeline();
     void start();
     void stop();
-    GstCaps* caps();
+    WARN_UNUSED_RETURN GRefPtr<GstCaps> caps();
 
     GstElement* makeElement(const char* factoryName);
     virtual GstElement* createSource();
@@ -72,7 +74,7 @@ public:
     CaptureDevice::DeviceType deviceType() const { return m_deviceType; }
     const String& devicePersistentId() const { return m_device ? m_device->persistentId() : emptyString(); }
 
-    void stopDevice();
+    void stopDevice(bool disconnectSignals);
 
 protected:
     GRefPtr<GstElement> m_sink;

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
@@ -55,7 +55,7 @@ static GstStaticPadTemplate audioSrcTemplate = GST_STATIC_PAD_TEMPLATE("audio_sr
 GST_DEBUG_CATEGORY_STATIC(webkitMediaStreamSrcDebug);
 #define GST_CAT_DEFAULT webkitMediaStreamSrcDebug
 
-GRefPtr<GstTagList> mediaStreamTrackPrivateGetTags(const MediaStreamTrackPrivate& track)
+WARN_UNUSED_RETURN GRefPtr<GstTagList> mediaStreamTrackPrivateGetTags(const MediaStreamTrackPrivate& track)
 {
     auto tagList = adoptGRef(gst_tag_list_new_empty());
 
@@ -63,7 +63,7 @@ GRefPtr<GstTagList> mediaStreamTrackPrivateGetTags(const MediaStreamTrackPrivate
         gst_tag_list_add(tagList.get(), GST_TAG_MERGE_APPEND, GST_TAG_TITLE, track.label().utf8().data(), nullptr);
 
     GST_DEBUG("Track tags: %" GST_PTR_FORMAT, tagList.get());
-    return tagList.leakRef();
+    return tagList;
 }
 
 GstStream* webkitMediaStreamNew(const MediaStreamTrackPrivate& track)
@@ -88,7 +88,7 @@ GstStream* webkitMediaStreamNew(const MediaStreamTrackPrivate& track)
     auto trackId = builder.toString();
     auto* stream = gst_stream_new(trackId.ascii().data(), caps.get(), type, GST_STREAM_FLAG_SELECT);
     auto tags = mediaStreamTrackPrivateGetTags(track);
-    gst_stream_set_tags(stream, tags.leakRef());
+    gst_stream_set_tags(stream, tags.get());
     return stream;
 }
 

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp
@@ -183,9 +183,6 @@ void GStreamerVideoCaptureSource::captureEnded()
 
 void GStreamerVideoCaptureSource::startProducingData()
 {
-    if (m_capturer->pipeline())
-        return;
-
     m_capturer->setupPipeline();
 
     if (m_deviceType == CaptureDevice::DeviceType::Camera)
@@ -251,7 +248,7 @@ const RealtimeMediaSourceSettings& GStreamerVideoCaptureSource::settings()
 void GStreamerVideoCaptureSource::generatePresets()
 {
     Vector<VideoPreset> presets;
-    GRefPtr<GstCaps> caps = adoptGRef(m_capturer->caps());
+    auto caps = m_capturer->caps();
     for (unsigned i = 0; i < gst_caps_get_size(caps.get()); i++) {
         GstStructure* str = gst_caps_get_structure(caps.get(), i);
 

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
@@ -125,15 +125,6 @@ GstElement* GStreamerVideoCapturer::createConverter()
     return bin;
 }
 
-GstVideoInfo GStreamerVideoCapturer::getBestFormat()
-{
-    auto caps = adoptGRef(gst_caps_fixate(gst_device_get_caps(m_device->device())));
-    GstVideoInfo info;
-    gst_video_info_from_caps(&info, caps.get());
-
-    return info;
-}
-
 bool GStreamerVideoCapturer::setSize(int width, int height)
 {
     if (isCapturingDisplay()) {

--- a/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.cpp
@@ -122,6 +122,8 @@ void MockRealtimeAudioSourceGStreamer::stopProducingData()
 {
     m_capturer->stop();
     MockRealtimeAudioSource::stopProducingData();
+    m_caps = nullptr;
+    m_streamFormat.reset();
 }
 
 void MockRealtimeAudioSourceGStreamer::captureEnded()


### PR DESCRIPTION
#### ab8acb6fab4d5ef60e07f7a55cea2cae452cfca5
<pre>
[GStreamer][MediaStream] Capturer pipelines are leaking
<a href="https://bugs.webkit.org/show_bug.cgi?id=267043">https://bugs.webkit.org/show_bug.cgi?id=267043</a>

Reviewed by Xabier Rodriguez-Calvar.

Make sure to teardown all GStreamer objects held by capturers. Also in the capture device manager we
now ensure the GstBus is not being monitored by more than one observers. Several Caps and TagList
leaks were also fixed.

* Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCaptureSource.cpp:
(WebCore::GStreamerAudioCaptureSource::capabilities):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDevice.h:
(WebCore::GStreamerCaptureDevice::caps const):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp:
(WebCore::GStreamerCaptureDeviceManager::teardown):
(WebCore::GStreamerCaptureDeviceManager::registerCapturer):
(WebCore::GStreamerCaptureDeviceManager::unregisterCapturer):
(WebCore::GStreamerCaptureDeviceManager::refreshCaptureDevices):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp:
(WebCore::GStreamerCapturer::~GStreamerCapturer):
(WebCore::GStreamerCapturer::tearDown):
(WebCore::GStreamerCapturer::caps):
(WebCore::GStreamerCapturer::stop):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp:
(mediaStreamTrackPrivateGetTags):
(webkitMediaStreamNew):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp:
(WebCore::GStreamerVideoCaptureSource::generatePresets):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp:
(WebCore::GStreamerVideoCapturer::getBestFormat): Deleted.
* Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.cpp:
(WebCore::MockRealtimeAudioSourceGStreamer::stopProducingData):

Canonical link: <a href="https://commits.webkit.org/272776@main">https://commits.webkit.org/272776@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e53e765c4c4804592ebaa480fa58ea92bd32d27e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32522 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11266 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34365 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35083 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29405 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33385 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13617 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8461 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28938 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32953 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9497 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29063 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8271 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8415 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29003 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36419 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29561 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29426 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34536 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8542 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6495 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32396 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10211 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7656 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9155 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9126 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->