### PR TITLE
Only call HTMLInputElement::didFinishInsertingNode on radio buttons

### DIFF
--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -1709,7 +1709,7 @@ Node::InsertedIntoAncestorResult HTMLInputElement::insertedIntoAncestor(Insertio
         document().addElementWithPendingUserAgentShadowTreeUpdate(*this);
         m_hasPendingUserAgentShadowTreeUpdate = true;
     }
-    return InsertedIntoAncestorResult::NeedsPostInsertionCallback;
+    return isRadioButton() ? InsertedIntoAncestorResult::NeedsPostInsertionCallback : InsertedIntoAncestorResult::Done;
 }
 
 void HTMLInputElement::updateUserAgentShadowTree()
@@ -1722,6 +1722,7 @@ void HTMLInputElement::updateUserAgentShadowTree()
 
 void HTMLInputElement::didFinishInsertingNode()
 {
+    ASSERT(isRadioButton());
     HTMLTextFormControlElement::didFinishInsertingNode();
     if (isInTreeScope() && !form())
         addToRadioButtonGroup();


### PR DESCRIPTION
#### f77fadbf3d41387d6dc849e453bb29f8f0c48468
<pre>
Only call HTMLInputElement::didFinishInsertingNode on radio buttons
<a href="https://bugs.webkit.org/show_bug.cgi?id=267049">https://bugs.webkit.org/show_bug.cgi?id=267049</a>

Reviewed by NOBODY (OOPS!).

This PR eliminates most calls to HTMLInputElement::didFinishInsertingNode since it only needs
to be called on radio buttons.

* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::insertedIntoAncestor):
(WebCore::HTMLInputElement::didFinishInsertingNode):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f77fadbf3d41387d6dc849e453bb29f8f0c48468

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32388 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11130 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34219 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34949 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/29320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33243 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13483 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8335 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/28860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32812 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9390 "Found 60 new test failures: dom/xhtml/level2/html/HTMLFormElement01.xhtml, dom/xhtml/level2/html/HTMLFormElement02.xhtml, dom/xhtml/level2/html/HTMLInputElement03.xhtml, dom/xhtml/level2/html/HTMLLabelElement01.xhtml, editing/selection/ios/selection-handles-in-iframe.html, fast/css/pseudo-invalid-form-and-fieldset-basics.html, fast/css/pseudo-invalid-form-basics.html, fast/css/pseudo-invalid-form-dynamically-created-basics.html, fast/css/pseudo-invalid-form-invalidation-optimization.html, fast/css/pseudo-valid-form-and-fieldset-basics.html ... (failure)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/28960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/8178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/8321 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/28891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36290 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29451 "4 api tests failed or timed out") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/29320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/34447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/8450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6398 "Found 60 new test failures: dom/xhtml/level2/html/HTMLFormElement01.xhtml, dom/xhtml/level2/html/HTMLFormElement02.xhtml, dom/xhtml/level2/html/HTMLInputElement03.xhtml, dom/xhtml/level2/html/HTMLLabelElement01.xhtml, fast/css/aspect-ratio-min-height-replaced.html, fast/css/pseudo-invalid-form-and-fieldset-basics.html, fast/css/pseudo-invalid-form-basics.html, fast/css/pseudo-invalid-form-dynamically-created-basics.html, fast/css/pseudo-invalid-form-invalidation-optimization.html, fast/css/pseudo-valid-form-and-fieldset-basics.html ... (failure)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/32310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10108 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/9072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9015 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->