### PR TITLE
_WKHitTestResult should expose a linkSuggestedFilename property

### DIFF
--- a/Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.h
+++ b/Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.h
@@ -50,6 +50,7 @@ WK_CLASS_AVAILABLE(macos(10.12), ios(16.0))
 
 @property (nonatomic, readonly, copy) NSString *linkLabel;
 @property (nonatomic, readonly, copy) NSString *linkTitle;
+@property (nonatomic, readonly, copy) NSString *linkSuggestedFilename WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 @property (nonatomic, readonly, copy) NSString *lookupText;
 
 @property (nonatomic, readonly, getter=isContentEditable) BOOL contentEditable;

--- a/Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.mm
+++ b/Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.mm
@@ -90,6 +90,11 @@ static NSURL *URLFromString(const WTF::String& urlString)
     return _hitTestResult->lookupText();
 }
 
+- (NSString *)linkSuggestedFilename
+{
+    return _hitTestResult->linkSuggestedFilename();
+}
+
 - (NSString *)imageMIMEType
 {
     return _hitTestResult->sourceImageMIMEType();

--- a/Source/WebKit/UIProcess/API/APIHitTestResult.h
+++ b/Source/WebKit/UIProcess/API/APIHitTestResult.h
@@ -57,6 +57,7 @@ public:
     WTF::String linkLabel() const { return m_data.linkLabel; }
     WTF::String linkTitle() const { return m_data.linkTitle; }
     WTF::String linkLocalDataMIMEType() const { return m_data.linkLocalDataMIMEType; }
+    WTF::String linkSuggestedFilename() const { return m_data.linkSuggestedFilename; }
     WTF::String lookupText() const { return m_data.lookupText; }
     WTF::String sourceImageMIMEType() const { return m_data.sourceImageMIMEType; }
 

--- a/Tools/TestWebKitAPI/Tests/mac/ContextMenuTests.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/ContextMenuTests.mm
@@ -712,6 +712,27 @@ TEST(ContextMenuTests, HitTestResultLinkLocalDataMIMEType)
     Util::run(&gotProposedMenu);
 }
 
+TEST(ContextMenuTests, HitTestResultLinkSuggestedFilename)
+{
+    auto delegate = adoptNS([[TestUIDelegate alloc] init]);
+
+    __block bool gotProposedMenu = false;
+    [delegate setGetContextMenuFromProposedMenu:^(NSMenu *menu, _WKContextMenuElementInfo *elementInfo, id<NSSecureCoding>, void (^completion)(NSMenu *)) {
+        EXPECT_NOT_NULL(elementInfo.hitTestResult);
+        EXPECT_TRUE([elementInfo.hitTestResult.linkSuggestedFilename isEqualToString:@"Sunset.jpg"]);
+        completion(nil);
+        gotProposedMenu = true;
+    }];
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    [webView setUIDelegate:delegate.get()];
+    [webView synchronouslyLoadHTMLString:@"<a href='sunset-in-cupertino-600px.jpg' download='Sunset.jpg'><img src='sunset-in-cupertino-600px.jpg'></img></a>"];
+
+    [webView mouseDownAtPoint:NSMakePoint(200, 200) simulatePressure:NO withFlags:0 eventType:NSEventTypeRightMouseDown];
+    [webView mouseUpAtPoint:NSMakePoint(200, 200) withFlags:0 eventType:NSEventTypeRightMouseUp];
+    Util::run(&gotProposedMenu);
+}
+
 } // namespace TestWebKitAPI
 
 #endif // PLATFORM(MAC)


### PR DESCRIPTION
#### 84d3ec3073d62e1ced4c7a788050e6369dc5e4c6
<pre>
_WKHitTestResult should expose a linkSuggestedFilename property
<a href="https://bugs.webkit.org/show_bug.cgi?id=267050">https://bugs.webkit.org/show_bug.cgi?id=267050</a>
<a href="https://rdar.apple.com/120394017">rdar://120394017</a>

Reviewed by Aditya Keerthi.

Expose linkSuggestedFilename from API::HitTestResult and _WKHitTestResult.

* Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.h:
Added linkSuggestedFilename property.

* Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.mm:
(-[_WKHitTestResult linkSuggestedFilename]):
Added.

* Source/WebKit/UIProcess/API/APIHitTestResult.h:
(API::HitTestResult::linkSuggestedFilename const):
Added.

* Tools/TestWebKitAPI/Tests/mac/ContextMenuTests.mm:
(TestWebKitAPI::TEST):
Added HitTestResultLinkSuggestedFilename test which loads an image inside a link to itself that
includes a &apos;download&apos; attribute and verifies that the linkSuggestedFilename matches the name
specified by the attribute.

Canonical link: <a href="https://commits.webkit.org/272643@main">https://commits.webkit.org/272643@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f03f36327fe914ad1ceb212f2fb2507f5cff920

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32488 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11225 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34323 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35042 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29381 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33344 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13577 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8424 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28909 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32913 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9464 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29030 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8238 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8381 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28963 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36378 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29526 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29388 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34504 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8512 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6465 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32365 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10179 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7565 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9131 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9092 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->