### PR TITLE
Recursively Determine Size of coresymbolicationd Cache When Pruning

### DIFF
--- a/Tools/CISupport/build-webkit-org/steps.py
+++ b/Tools/CISupport/build-webkit-org/steps.py
@@ -249,7 +249,7 @@ class PruneCoreSymbolicationdCacheIfTooLarge(shell.ShellCommandNewStyle):
     descriptionDone = ["pruned coresymbolicationd cache"]
     flunkOnFailure = False
     haltOnFailure = False
-    command = ["python3", "Tools/Scripts/delete-if-too-large",
+    command = ["sudo", "python3", "Tools/Scripts/delete-if-too-large",
                "/System/Library/Caches/com.apple.coresymbolicationd"]
 
 

--- a/Tools/Scripts/delete-if-too-large
+++ b/Tools/Scripts/delete-if-too-large
@@ -25,8 +25,8 @@
 
 import sys
 import os
+import subprocess
 from pathlib import Path
-
 
 def main():
      for directory in sys.argv[1:]:
@@ -41,13 +41,17 @@ def main():
             print(f'{directory} is not a directory')
             return 1
 
-        tenGigabytes = 1024 * 1024 * 1024 * 10
-        directorySize = sum(file.stat().st_size for file in directoryPath.rglob('*'))
-        if directorySize >= tenGigabytes:
-            os.remove(directory)
+        tenGigabytesInKiloBytes = 1024 * 1024  * 10
+        
+        # directorySize will be in kilobytes.
+        directorySize = int(subprocess.check_output(['sudo', 'du', '-sk', directoryPath]).decode().strip().split()[0])
+
+        if directorySize >= tenGigabytesInKiloBytes:
+            print(f'{directory} is {directorySize}K in size. Deleting') 
+            subprocess.call(['rm','-rf', directoryPath])
             print(f'Deleted {directory}')
         else:
-            print(f'{directory} is {directorySize}. Doing nothing') 
+            print(f'{directory} is {directorySize}K in size. Doing nothing') 
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
#### b16a3adebc84c911d70174523b0a238bfd47bd76
<pre>
Recursively Determine Size of coresymbolicationd Cache When Pruning
<a href="https://bugs.webkit.org/show_bug.cgi?id=267053">https://bugs.webkit.org/show_bug.cgi?id=267053</a>
<a href="https://rdar.apple.com/120428325">rdar://120428325</a>

Reviewed by Alexey Proskuryakov.

In the prune-coresymbolicationd-cache-if-too-large buildbot step, we should recursively walk the top-level directory when determining its size. We should also use sudo when attempting to delete the cache.
Failing to recursively determine size results in size always being 0 for /System/Library/Caches/com.apple.coresymbolicationd. Failing to use sudo prevents deletion of the same.

* Tools/CISupport/build-webkit-org/steps.py:
(PruneCoreSymbolicationdCacheIfTooLarge):
* Tools/Scripts/delete-if-too-large:
(main):

Canonical link: <a href="https://commits.webkit.org/272843@main">https://commits.webkit.org/272843@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2e1c894425975621c79413d81ba921072116194

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33202 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11976 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35116 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35839 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30243 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34173 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14323 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9146 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29377 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33677 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10105 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29663 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8806 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8956 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29636 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37170 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30172 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30017 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35065 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9087 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7024 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32926 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/33085 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10807 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7717 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9671 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9756 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->