### PR TITLE
Use MutableCSSSelectorList alias in more places

### DIFF
--- a/Source/WebCore/css/CSSSelectorList.cpp
+++ b/Source/WebCore/css/CSSSelectorList.cpp
@@ -44,7 +44,7 @@ CSSSelectorList::CSSSelectorList(const CSSSelectorList& other)
         new (NotNull, &m_selectorArray[i]) CSSSelector(other.m_selectorArray[i]);
 }
 
-CSSSelectorList::CSSSelectorList(Vector<std::unique_ptr<MutableCSSSelector>>&& selectorVector)
+CSSSelectorList::CSSSelectorList(MutableCSSSelectorList&& selectorVector)
 {
     ASSERT_WITH_SECURITY_IMPLICATION(!selectorVector.isEmpty());
 

--- a/Source/WebCore/css/CSSSelectorList.h
+++ b/Source/WebCore/css/CSSSelectorList.h
@@ -32,6 +32,7 @@
 namespace WebCore {
 
 class MutableCSSSelector;
+using MutableCSSSelectorList = Vector<std::unique_ptr<MutableCSSSelector>>;
 
 class CSSSelectorList {
     WTF_MAKE_FAST_ALLOCATED;
@@ -39,7 +40,7 @@ public:
     CSSSelectorList() = default;
     CSSSelectorList(const CSSSelectorList&);
     CSSSelectorList(CSSSelectorList&&) = default;
-    explicit CSSSelectorList(Vector<std::unique_ptr<MutableCSSSelector>>&&);
+    explicit CSSSelectorList(MutableCSSSelectorList&&);
     explicit CSSSelectorList(UniqueArray<CSSSelector>&& array)
         : m_selectorArray(WTFMove(array)) { }
 

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -276,7 +276,7 @@ CSSSelectorList CSSParserImpl::parsePageSelector(CSSParserTokenRange range, Styl
     }
 
     selector->setForPage();
-    return CSSSelectorList { Vector<std::unique_ptr<MutableCSSSelector>>::from(WTFMove(selector)) };
+    return CSSSelectorList { MutableCSSSelectorList::from(WTFMove(selector)) };
 }
 
 Vector<double> CSSParserImpl::parseKeyframeKeyList(const String& keyList)
@@ -617,7 +617,7 @@ Ref<StyleRuleBase> CSSParserImpl::createNestingParentRule()
 {
     auto nestingParentSelector = makeUnique<MutableCSSSelector>();
     nestingParentSelector->setMatch(CSSSelector::Match::NestingParent);
-    Vector<std::unique_ptr<MutableCSSSelector>> selectorList;
+    MutableCSSSelectorList selectorList;
     selectorList.append(WTFMove(nestingParentSelector));
     auto properties = createStyleProperties(topContext().m_parsedProperties, m_context.mode);
     return StyleRuleWithNesting::create(WTFMove(properties), m_context.hasDocumentSecurityOrigin, CSSSelectorList { WTFMove(selectorList) }, { });

--- a/Source/WebCore/css/parser/CSSSelectorParser.h
+++ b/Source/WebCore/css/parser/CSSSelectorParser.h
@@ -44,8 +44,6 @@ class CSSSelectorList;
 class StyleSheetContents;
 class StyleRule;
 
-using MutableCSSSelectorList = Vector<std::unique_ptr<MutableCSSSelector>>;
-
 class CSSSelectorParser {
 public:
     CSSSelectorParser(const CSSSelectorParserContext&, StyleSheetContents*, CSSParserEnum::IsNestedContext = CSSParserEnum::IsNestedContext::No);

--- a/Source/WebCore/css/parser/MutableCSSSelector.cpp
+++ b/Source/WebCore/css/parser/MutableCSSSelector.cpp
@@ -124,7 +124,7 @@ MutableCSSSelector::~MutableCSSSelector()
     }
 }
 
-void MutableCSSSelector::adoptSelectorVector(Vector<std::unique_ptr<MutableCSSSelector>>&& selectorVector)
+void MutableCSSSelector::adoptSelectorVector(MutableCSSSelectorList&& selectorVector)
 {
     m_selector->setSelectorList(makeUnique<CSSSelectorList>(WTFMove(selectorVector)));
 }

--- a/Source/WebCore/css/parser/MutableCSSSelector.h
+++ b/Source/WebCore/css/parser/MutableCSSSelector.h
@@ -27,6 +27,9 @@ namespace WebCore {
 
 struct CSSSelectorParserContext;
 
+class MutableCSSSelector;
+using MutableCSSSelectorList = Vector<std::unique_ptr<MutableCSSSelector>>;
+
 class MutableCSSSelector {
     WTF_MAKE_FAST_ALLOCATED;
 public:
@@ -71,7 +74,7 @@ public:
     void setPseudoElement(CSSSelector::PseudoElement type) { m_selector->setPseudoElement(type); }
     void setPseudoClass(CSSSelector::PseudoClass type) { m_selector->setPseudoClass(type); }
 
-    void adoptSelectorVector(Vector<std::unique_ptr<MutableCSSSelector>>&&);
+    void adoptSelectorVector(MutableCSSSelectorList&&);
     void setArgumentList(FixedVector<PossiblyQuotedIdentifier>);
     void setSelectorList(std::unique_ptr<CSSSelectorList>);
 


### PR DESCRIPTION
#### 7dd32f2fb2b1df90c6c16e91d488b41b0b9dbc21
<pre>
Use MutableCSSSelectorList alias in more places
<a href="https://bugs.webkit.org/show_bug.cgi?id=267057">https://bugs.webkit.org/show_bug.cgi?id=267057</a>
<a href="https://rdar.apple.com/120431877">rdar://120431877</a>

Reviewed by Simon Fraser.

Move it out of CSSSelectorParser and start using it in more places.

* Source/WebCore/css/CSSSelectorList.cpp:
(WebCore::CSSSelectorList::CSSSelectorList):
* Source/WebCore/css/CSSSelectorList.h:
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::parsePageSelector):
(WebCore::CSSParserImpl::createNestingParentRule):
* Source/WebCore/css/parser/CSSSelectorParser.h:
* Source/WebCore/css/parser/MutableCSSSelector.cpp:
(WebCore::MutableCSSSelector::adoptSelectorVector):
* Source/WebCore/css/parser/MutableCSSSelector.h:

Canonical link: <a href="https://commits.webkit.org/272636@main">https://commits.webkit.org/272636@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/535e3696f14b23b02d97e30da58af083aa7e1e14

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32471 "Failed to checkout and rebase branch from PR 22365") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11207 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34305 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35024 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/29368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33326 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13559 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8406 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/28895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/32895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/9448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/29016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/8224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/8365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/28949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36360 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/29510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/29374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/34489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/8499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/6448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/32351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/10163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/9118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4195 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/9075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->