### PR TITLE
[css-animations] `animation` property should use shortest serialization rule

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/computed-style-animation-parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/computed-style-animation-parsing-expected.txt
@@ -1,6 +1,8 @@
 
 PASS Test animation name being empty.
 PASS Test a non-conflicting animation name.
+PASS Test an animation name that is the same as a possible animation timing-function.
+PASS Test an animation name that is the same as a possible animation iteration-count.
 PASS Test an animation name that is the same as a possible animation fill-mode.
 PASS Test an animation name that is the same as a possible animation direction.
 PASS Test an animation name that is the same as a possible running state.

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/computed-style-animation-parsing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/computed-style-animation-parsing.html
@@ -47,6 +47,23 @@ test(() => {
 }, "Test a non-conflicting animation name.");
 
 test(() => {
+  testAnimation("ease", "none");
+  testAnimation("ease-in", "none");
+  testAnimation("ease-in-out", "none");
+  testAnimation("ease-out", "none");
+  testAnimation("linear", "none");
+  testAnimation("step-end", "none");
+  testAnimation("step-start", "none");
+  testAnimation("ease ease", "ease");
+  testAnimation("ease linear", "linear");
+}, "Test an animation name that is the same as a possible animation timing-function.");
+
+test(() => {
+  testAnimation("infinite", "none");
+  testAnimation("infinite infinite", "infinite");
+}, "Test an animation name that is the same as a possible animation iteration-count.");
+
+test(() => {
   testAnimation("none", "none");
   testAnimation("forwards", "none");
   testAnimation("none forwards", "forwards");

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/animation-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/animation-computed-expected.txt
@@ -2,6 +2,7 @@
 PASS Default animation value
 PASS Property animation value '1s'
 PASS Property animation value 'cubic-bezier(0, -2, 1, 3)'
+PASS Property animation value 'ease-in-out'
 PASS Property animation value '1s -3s'
 PASS Property animation value '4'
 PASS Property animation value 'reverse'
@@ -11,4 +12,6 @@ PASS Property animation value 'none'
 PASS Property animation value 'anim'
 PASS Property animation value 'anim paused both reverse 4 1s -3s cubic-bezier(0, -2, 1, 3)'
 PASS Property animation value 'anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)'
+PASS Property animation value 'none, none'
+PASS Animation with a delay but no duration
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/animation-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/animation-computed.html
@@ -18,26 +18,35 @@
 // [ none | <keyframes-name> ]
 
 test(() => {
-  assert_equals(getComputedStyle(document.getElementById('target')).animation, "0s ease 0s 1 normal none running none");
+  assert_equals(getComputedStyle(document.getElementById('target')).animation, "none");
 }, "Default animation value");
 
-test_computed_value("animation", "1s", "1s ease 0s 1 normal none running none");
-test_computed_value("animation", "cubic-bezier(0, -2, 1, 3)", "0s cubic-bezier(0, -2, 1, 3) 0s 1 normal none running none");
-test_computed_value("animation", "1s -3s", "1s ease -3s 1 normal none running none");
-test_computed_value("animation", "4", "0s ease 0s 4 normal none running none");
-test_computed_value("animation", "reverse", "0s ease 0s 1 reverse none running none");
-test_computed_value("animation", "both", "0s ease 0s 1 normal both running none");
-test_computed_value("animation", "paused", "0s ease 0s 1 normal none paused none");
-test_computed_value("animation", "none", "0s ease 0s 1 normal none running none");
-test_computed_value("animation", "anim", "0s ease 0s 1 normal none running anim");
+test_computed_value("animation", "1s", "1s");
+test_computed_value("animation", "cubic-bezier(0, -2, 1, 3)", "cubic-bezier(0, -2, 1, 3)");
+test_computed_value("animation", "ease-in-out", "ease-in-out");
+test_computed_value("animation", "1s -3s", "1s -3s");
+test_computed_value("animation", "4", "4");
+test_computed_value("animation", "reverse", "reverse");
+test_computed_value("animation", "both", "both");
+test_computed_value("animation", "paused", "paused");
+test_computed_value("animation", "none", "none");
+test_computed_value("animation", "anim", "anim");
 
 test_computed_value("animation", "anim paused both reverse 4 1s -3s cubic-bezier(0, -2, 1, 3)",
   "1s cubic-bezier(0, -2, 1, 3) -3s 4 reverse both paused anim");
 
 test_computed_value("animation", "anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)",
-  "0s ease 0s 1 reverse both paused anim, 1s cubic-bezier(0, -2, 1, 3) -3s 4 normal none running none");
+  "reverse both paused anim, 1s cubic-bezier(0, -2, 1, 3) -3s 4");
 
-// TODO: Add test with a single timing-function keyword.
+test_computed_value("animation", "none, none", "none, none");
+
+test(() => {
+  const target = document.getElementById('target');
+  target.style.animation = "initial";
+  target.style.animationDelay = "1s";
+  assert_equals(getComputedStyle(target).animation, "0s 1s");
+}, "Animation with a delay but no duration");
+
 </script>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-shorthand-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-shorthand-expected.txt
@@ -19,11 +19,11 @@ FAIL e.style['animation'] = "1s linear 1s 2 reverse forwards paused anim1,\n   1
 PASS e.style['animation'] = "1s linear 1s 2 reverse forwards paused anim1,\n   1s linear 1s 2 reverse forwards paused anim2,\n   1s linear 1s 2 reverse forwards paused anim3" should set animation-timing-function
 PASS e.style['animation'] = "1s linear 1s 2 reverse forwards paused anim1,\n   1s linear 1s 2 reverse forwards paused anim2,\n   1s linear 1s 2 reverse forwards paused anim3" should not set unrelated longhands
 FAIL Animation shorthand can not represent non-initial timelines (specified) assert_equals: expected "" but got "1s anim"
-FAIL Animation shorthand can not represent non-initial timelines (computed) assert_equals: expected "" but got "1s ease 0s 1 normal none running anim"
+FAIL Animation shorthand can not represent non-initial timelines (computed) assert_equals: expected "" but got "1s anim --timeline"
 FAIL Animation shorthand can not represent non-initial animation-delay-end (specified) assert_equals: expected "" but got "1s anim"
-FAIL Animation shorthand can not represent non-initial animation-delay-end (computed) assert_equals: expected "" but got "1s ease 0s 1 normal none running anim"
+FAIL Animation shorthand can not represent non-initial animation-delay-end (computed) assert_equals: expected "" but got "1s anim"
 FAIL Animation shorthand can not represent non-initial animation-range-start (specified) assert_equals: expected "" but got "1s anim"
-FAIL Animation shorthand can not represent non-initial animation-range-start (computed) assert_equals: expected "" but got "1s ease 0s 1 normal none running anim"
+FAIL Animation shorthand can not represent non-initial animation-range-start (computed) assert_equals: expected "" but got "1s anim"
 FAIL Animation shorthand can not represent non-initial animation-range-end (specified) assert_equals: expected "" but got "1s anim"
-FAIL Animation shorthand can not represent non-initial animation-range-end (computed) assert_equals: expected "" but got "1s ease 0s 1 normal none running anim"
+FAIL Animation shorthand can not represent non-initial animation-range-end (computed) assert_equals: expected "" but got "1s anim"
 


### PR DESCRIPTION
#### 3b19eaa5f921647c3e95ffcd363d8bd59eed5bd5
<pre>
[css-animations] `animation` property should use shortest serialization rule
<a href="https://bugs.webkit.org/show_bug.cgi?id=267059">https://bugs.webkit.org/show_bug.cgi?id=267059</a>

Reviewed by Tim Nguyen.

We changed how we serialize the `transition` shorthand property in 272513@main to always
yield the shortest serialization. We now do the same for the `animation` property.

* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/computed-style-animation-parsing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/computed-style-animation-parsing.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/animation-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/animation-computed.html:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-shorthand-expected.txt:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::singleAnimationValue):
(WebCore::animationShorthandValue):
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle const):

Canonical link: <a href="https://commits.webkit.org/272629@main">https://commits.webkit.org/272629@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb01f6105ed53efd344d0722fc21f1565bd4b591

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32420 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11159 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34252 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34977 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29338 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33275 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13512 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8363 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/28876 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32844 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9410 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28978 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8197 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/8339 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28909 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36313 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29471 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29339 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/34462 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8467 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/6418 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/32324 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10130 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/28681 "Passed tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/9088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4191 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9039 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->