### PR TITLE
Make most CSSSelector setters only available to MutableCSSSelector

### DIFF
--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -76,7 +76,7 @@ static void appendImplicitSelectorPseudoClassScopeIfNeeded(MutableCSSSelector& s
         auto scopeSelector = makeUnique<MutableCSSSelector>();
         scopeSelector->setMatch(CSSSelector::Match::PseudoClass);
         scopeSelector->setPseudoClass(CSSSelector::PseudoClass::Scope);
-        scopeSelector->selector()->setImplicit();
+        scopeSelector->setImplicit();
         selector.appendTagHistoryAsRelative(WTFMove(scopeSelector));
     }
 }
@@ -615,11 +615,10 @@ void CSSParserImpl::runInNewNestingContext(auto&& run)
 
 Ref<StyleRuleBase> CSSParserImpl::createNestingParentRule()
 {
-    CSSSelector nestingParentSelector;
-    nestingParentSelector.setMatch(CSSSelector::Match::NestingParent);
-    auto parserSelector = makeUnique<MutableCSSSelector>(nestingParentSelector);
+    auto nestingParentSelector = makeUnique<MutableCSSSelector>();
+    nestingParentSelector->setMatch(CSSSelector::Match::NestingParent);
     Vector<std::unique_ptr<MutableCSSSelector>> selectorList;
-    selectorList.append(WTFMove(parserSelector));
+    selectorList.append(WTFMove(nestingParentSelector));
     auto properties = createStyleProperties(topContext().m_parsedProperties, m_context.mode);
     return StyleRuleWithNesting::create(WTFMove(properties), m_context.hasDocumentSecurityOrigin, CSSSelectorList { WTFMove(selectorList) }, { });
 }

--- a/Source/WebCore/css/parser/MutableCSSSelector.h
+++ b/Source/WebCore/css/parser/MutableCSSSelector.h
@@ -75,6 +75,8 @@ public:
     void setArgumentList(FixedVector<PossiblyQuotedIdentifier>);
     void setSelectorList(std::unique_ptr<CSSSelectorList>);
 
+    void setImplicit() { m_selector->setImplicit(); }
+
     CSSSelector::PseudoClass pseudoClass() const { return m_selector->pseudoClass(); }
 
     bool matchesPseudoElement() const;


### PR DESCRIPTION
#### 4a02d79b3e9c11ebe226d266f3527c1a3929d0ed
<pre>
Make most CSSSelector setters only available to MutableCSSSelector
<a href="https://bugs.webkit.org/show_bug.cgi?id=267060">https://bugs.webkit.org/show_bug.cgi?id=267060</a>
<a href="https://rdar.apple.com/120434084">rdar://120434084</a>

Reviewed by Simon Fraser.

CSSSelector isn&apos;t meant to be mutated in the majority of cases, restrict most setters to MutableCSSSelector.

* Source/WebCore/css/CSSSelector.h:
(WebCore::CSSSelector::hasDescendantRelation const):
(WebCore::CSSSelector::relation const):
(WebCore::CSSSelector::match const):
(WebCore::CSSSelector::isLastInSelectorList const):
(WebCore::CSSSelector::isFirstInTagHistory const):
(WebCore::CSSSelector::setLastInSelectorList):
(WebCore::CSSSelector::setNotFirstInTagHistory):
(WebCore::CSSSelector::setNotLastInTagHistory):
(WebCore::CSSSelector::isForPage const):
(WebCore::CSSSelector::setForPage):
(WebCore::CSSSelector::setImplicit):
(WebCore::CSSSelector::tagHistory):
(WebCore::CSSSelector::setNotLastInSelectorList): Deleted.
(WebCore::CSSSelector::setLastInTagHistory): Deleted.
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::appendImplicitSelectorPseudoClassScopeIfNeeded):
(WebCore::CSSParserImpl::createNestingParentRule):
* Source/WebCore/css/parser/MutableCSSSelector.h:
(WebCore::MutableCSSSelector::setImplicit):

Canonical link: <a href="https://commits.webkit.org/272635@main">https://commits.webkit.org/272635@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12a63a1c2c7493b6a25347cc675ca705b88864c5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32458 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11195 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34291 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35012 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/29357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33313 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13545 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8394 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/28888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32882 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9438 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29003 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8217 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/8358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28936 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36348 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29500 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/29361 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/34482 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/8488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6436 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32343 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/10152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/7559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/9107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4193 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9064 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->