### PR TITLE
[scroll-anchoring] Keyboard scrolling into a rubberband leaves the page stuck at a bad scroll offset

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5488,7 +5488,8 @@ userscripts/user-script-plugin-document.html [ Skip ]
 
 webkit.org/b/242983 imported/w3c/web-platform-tests/css/css-scroll-anchoring/fullscreen-crash.html [ Skip ]
 webkit.org/b/261849 imported/w3c/web-platform-tests/css/css-scroll-anchoring/heuristic-with-offset-update-from-scroll-event-listener.html [ Skip ]
-webkit.org/b/261849  imported/w3c/web-platform-tests/css/css-scroll-anchoring/zero-scroll-offset.html [ Skip ]
+webkit.org/b/261849 imported/w3c/web-platform-tests/css/css-scroll-anchoring/zero-scroll-offset.html [ Skip ]
+webkit.org/b/261849 imported/w3c/web-platform-tests/css/css-scroll-anchoring/start-edge-in-block-layout-direction.html [ Skip ]
 
 # These tests are image failures
 imported/w3c/web-platform-tests/css/css-scroll-anchoring/vertical-rl-viewport-size-change-000.html [ Skip ]

--- a/LayoutTests/fast/scrolling/mac/keyboard-rubberband-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/keyboard-rubberband-expected.txt
@@ -1,0 +1,5 @@
+PASS window.pageYOffset < 0 is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/mac/keyboard-rubberband.html
+++ b/LayoutTests/fast/scrolling/mac/keyboard-rubberband.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ScrollAnimatorEnabled=true ] -->
+<html>
+<head>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script src="../../../resources/js-test.js"></script>
+    <meta name="viewport" content="initial-scale=1.5, user-scalable=no">
+    <script>
+        jsTestIsAsync = true;
+        
+        async function runTest()
+        {
+            if (window.eventSender) {
+                const delay = ms => new Promise(res => setTimeout(res, ms));
+                await UIHelper.startMonitoringWheelEvents();
+                await UIHelper.rawKeyDown("upArrow");
+                await UIHelper.waitForCondition(() => { return window.pageYOffset < -16 });
+                shouldBeTrue('window.pageYOffset < 0');
+                finishJSTest();
+            }
+        }
+    </script>
+</head>
+<body onload="runTest()">
+    <div style="height: 5000px;">
+    </div>
+</body>
+
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/start-edge-in-block-layout-direction-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/start-edge-in-block-layout-direction-expected.txt
@@ -2,7 +2,7 @@
 
 FAIL Horizontal LTR. assert_equals: expected 150 but got 120
 FAIL Horizontal RTL. assert_equals: expected 130 but got 150
-FAIL Vertical-LR LTR. assert_equals: expected 120 but got 150
+FAIL Vertical-LR LTR. assert_equals: expected 120 but got 135
 FAIL Vertical-LR RTL. assert_equals: expected 120 but got 150
 FAIL Vertical-RL LTR. assert_equals: expected -120 but got -150
 FAIL Vertical-RL RTL. assert_equals: expected -120 but got -150

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
@@ -368,11 +368,6 @@ void ScrollAnchoringController::adjustScrollPositionForAnchoring()
             return;
         }
 #endif
-        if (m_owningScrollableArea.isRubberBandInProgress()) {
-            invalidateAnchorElement();
-            updateAnchorElement();
-            return;
-        }
         auto newScrollPosition = m_owningScrollableArea.scrollPosition() + IntPoint(adjustment.width(), adjustment.height());
         LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController::updateScrollPosition() for frame: " << frameView() << " for scroller: " << m_owningScrollableArea << " adjusting from: " << m_owningScrollableArea.scrollPosition() << " to: " << newScrollPosition);
         auto options = ScrollPositionChangeOptions::createProgrammatic();

--- a/Source/WebCore/platform/ScrollAnimator.cpp
+++ b/Source/WebCore/platform/ScrollAnimator.cpp
@@ -231,6 +231,12 @@ bool ScrollAnimator::handleTouchEvent(const PlatformTouchEvent&)
 }
 #endif
 
+static void notifyScrollAnchoringControllerOfScroll(ScrollableArea& scrollableArea)
+{
+    scrollableArea.invalidateScrollAnchoringElement();
+    scrollableArea.updateScrollAnchoringElement();
+}
+
 void ScrollAnimator::setCurrentPosition(const FloatPoint& position, NotifyScrollableArea notify)
 {
     // FIXME: An early return here if the position is not changing triggers test failures because of adjustForIOSCaretWhenScrolling()
@@ -240,7 +246,9 @@ void ScrollAnimator::setCurrentPosition(const FloatPoint& position, NotifyScroll
     
     if (notify == NotifyScrollableArea::Yes)
         notifyPositionChanged(delta);
-    
+    else
+        notifyScrollAnchoringControllerOfScroll(m_scrollableArea);
+
     updateActiveScrollSnapIndexForOffset();
 }
 


### PR DESCRIPTION
#### 50c9dcae73447ac8e649a07dd246b227fc3dfd65
<pre>
[scroll-anchoring] Keyboard scrolling into a rubberband leaves the page stuck at a bad scroll offset
<a href="https://bugs.webkit.org/show_bug.cgi?id=267061">https://bugs.webkit.org/show_bug.cgi?id=267061</a>
<a href="https://rdar.apple.com/120053910">rdar://120053910</a>

Reviewed by Simon Fraser.

After <a href="https://commits.webkit.org/271957@main">https://commits.webkit.org/271957@main</a> we disabled scroll anchoring adjustments while
m_owningScrollableArea.isRubberBandInProgress() is true. However, this is not true during a
keyboard scroll. A better solution to this is to invalidate the scroll anchoring element in
ScrollAnimator::setCurrentPosition itself. Normally scroll position changes here would be sent
down into the scrollable area via setScrollPositionFromAnimation, however while rubberbanding
notify is NotifyScrollableArea::No, so we don&apos;t propagate the scroll position change to the
scrollable area. Now that we properly notfiy the scroll anchoring controller of the scroll
position change while rubberbanding, we can remove the old solution.

* Source/WebCore/page/scrolling/ScrollAnchoringController.cpp:
(WebCore::ScrollAnchoringController::adjustScrollPositionForAnchoring):
* Source/WebCore/platform/ScrollAnimator.cpp:
(WebCore::notifyScrollAnchoringControllerOfScroll):
(WebCore::ScrollAnimator::setCurrentPosition):

Canonical link: <a href="https://commits.webkit.org/272657@main">https://commits.webkit.org/272657@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d19359f21bfe3a32c4dd21990d569b28ed01790

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32564 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11312 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34412 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35130 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29436 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33430 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13661 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8506 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28961 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32998 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9535 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29102 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8308 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8446 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29043 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36466 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29598 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29465 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34572 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8573 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6526 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32431 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10248 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/28785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9185 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4202 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9166 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->