### PR TITLE
[UIAsyncTextInput] Fix several failing iOS API tests when async text input is enabled

### DIFF
--- a/Tools/TestWebKitAPI/Tests/ios/DragAndDropTestsIOS.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/DragAndDropTestsIOS.mm
@@ -39,6 +39,7 @@
 #import <MapKit/MapKit.h>
 #import <MobileCoreServices/MobileCoreServices.h>
 #import <UIKit/NSItemProvider+UIKitAdditions.h>
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 #import <WebKit/WKPreferencesPrivate.h>
 #import <WebKit/WKPreferencesRefPrivate.h>
 #import <WebKit/WKProcessPoolPrivate.h>
@@ -128,13 +129,16 @@ static void checkCGRectIsEqualToCGRectWithLogging(CGRect expected, CGRect observ
 
 static void checkRichTextTypePrecedesPlainTextType(DragAndDropSimulator *simulator)
 {
-    // At least one of "com.apple.flat-rtfd" or "public.rtf" is expected to have higher precedence than "public.utf8-plain-text".
     NSArray *registeredTypes = [simulator.sourceItemProviders.firstObject registeredTypeIdentifiers];
-    auto indexOfRTFType = [registeredTypes indexOfObject:(__bridge NSString *)kUTTypeRTF];
-    auto indexOfFlatRTFDType = [registeredTypes indexOfObject:(__bridge NSString *)kUTTypeFlatRTFD];
-    auto indexOfPlainTextType = [registeredTypes indexOfObject:(__bridge NSString *)kUTTypeUTF8PlainText];
+    auto indexOfHTMLType = [registeredTypes indexOfObject:UTTypeHTML.identifier];
+    auto indexOfRTFType = [registeredTypes indexOfObject:UTTypeRTF.identifier];
+    auto indexOfFlatRTFDType = [registeredTypes indexOfObject:UTTypeFlatRTFD.identifier];
+    auto indexOfPlainTextType = [registeredTypes indexOfObject:UTTypeUTF8PlainText.identifier];
     EXPECT_NE((NSInteger)indexOfPlainTextType, NSNotFound);
-    EXPECT_TRUE((indexOfRTFType != NSNotFound && indexOfRTFType < indexOfPlainTextType) || (indexOfFlatRTFDType != NSNotFound && indexOfFlatRTFDType < indexOfPlainTextType));
+    BOOL hasHighFidelityRTF = indexOfRTFType != NSNotFound && indexOfRTFType < indexOfPlainTextType;
+    BOOL hasHighFidelityFlatRTFD = indexOfFlatRTFDType != NSNotFound && indexOfFlatRTFDType < indexOfPlainTextType;
+    BOOL hasHighFidelityHTML = indexOfHTMLType != NSNotFound && indexOfHTMLType < indexOfPlainTextType;
+    EXPECT_TRUE(hasHighFidelityHTML || hasHighFidelityFlatRTFD || hasHighFidelityRTF);
 }
 
 static void checkFirstTypeIsPresentAndSecondTypeIsMissing(DragAndDropSimulator *simulator, CFStringRef firstType, CFStringRef secondType)


### PR DESCRIPTION
#### 1f6aecd2d6505d6ffb9bc1c379f806c1f76698c7
<pre>
[UIAsyncTextInput] Fix several failing iOS API tests when async text input is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=267064">https://bugs.webkit.org/show_bug.cgi?id=267064</a>
<a href="https://rdar.apple.com/120438466">rdar://120438466</a>

Reviewed by Megan Gardner.

Fix 4 failing API tests, when async text input is enabled:

• DragAndDropTests.ContentEditableToContentEditable
• DragAndDropTests.ContentEditableToTextarea

These two tests are failing because they expect WebKit to write RTF and/or FlatRTFD upon starting a
drag. This is no longer the case when this feature is enabled, since the system now takes care of
lazily coercing web archive and HTML data to RTF/FlatRTFD/`NSAttributedString` as needed.

As such, we simply adjust this test to pass as long as HTML data is placed at a higher type fidelity
than plain text.

• KeyboardInputTests.IsSingleLineDocument

This actually caught a real bug, where we&apos;re failing to actually set the `singleLineDocument`
property on the extended traits delegate (`WKSEExtendedTextInputTraits`), since the call site is
guarded by a `-respondsToSelector:` check for `-setIsSingleLineDocument:` (the legacy name on
private text input traits) instead of `-setSingleLineDocument:` (the new property name on the
extended traits).

Fix the test by fixing `-_updateTextInputTraits:`.

• KeyboardInputTests.EditableWebViewRequiresKeyboardWhenFirstResponder

This test failure is due to the fact that, for a fully-editable web view (i.e. if the embedder sets
`-[WKWebView _editable]` to `YES`), `-_requiresKeyboardWhenFirstResponder` now returns `YES` instead
of `NO` when focusing a `readonly` text field.

Address this and restore shipping behavior by only reverting to the superclass implementation in the
case where the web view is not fully editable.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _requiresKeyboardWhenFirstResponder]):
(-[WKContentView _updateTextInputTraits:]):
* Tools/TestWebKitAPI/Tests/ios/DragAndDropTestsIOS.mm:
(checkRichTextTypePrecedesPlainTextType):

Canonical link: <a href="https://commits.webkit.org/272638@main">https://commits.webkit.org/272638@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62b5641676e5cc6a3a479153ddef3e1df9280b11

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32463 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11199 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34296 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35016 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/29361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33318 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13549 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8398 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/28890 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32887 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9437 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29007 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8219 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/8357 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28940 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36352 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29499 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29365 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34483 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/8492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6441 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32344 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10156 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7561 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/9111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9068 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->