### PR TITLE
Incremental build fix for "[Xcode] Add support for setting CC/CPLUSPLUS variables when using make"

### DIFF
--- a/Makefile.shared
+++ b/Makefile.shared
@@ -94,7 +94,9 @@ endif
 endif
 
 ifneq ($(CC),)
+ifneq ($(CC),cc)  # Default value without -R flag
 XCODE_OPTIONS += CC=$(CC)
+endif
 endif
 
 ifneq ($(CPLUSPLUS),)


### PR DESCRIPTION
#### e76ab16dac6e54b1113149a3fe941dbaf72a6546
<pre>
Incremental build fix for &quot;[Xcode] Add support for setting CC/CPLUSPLUS variables when using make&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=267020">https://bugs.webkit.org/show_bug.cgi?id=267020</a>
<a href="https://rdar.apple.com/120398180">rdar://120398180</a>

Unreviewed.

By default, Make sets CC=cc, causing us to always pass a &quot;CC&quot; build
setting to xcodebuild and invalidating incremental builds between Make
and Xcode. Change to only overriding the setting when something other
than &quot;cc&quot; is set.

* Makefile.shared:

Canonical link: <a href="https://commits.webkit.org/272640@main">https://commits.webkit.org/272640@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80b2439b73b3e5c77ba4306fc00d42a0ae643031

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32472 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11208 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34306 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35025 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/29369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13560 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8407 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/28896 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32896 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9449 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/29017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8225 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8366 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36361 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/27872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/29511 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/29375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/34490 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/32547 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/8500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6449 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32352 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10164 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/38972 "Built successfully") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/7563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/9119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8232 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4196 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9076 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->