### PR TITLE
Accumulating offsets to handle fixed position container has a transform-related property but not a transform.

### DIFF
--- a/LayoutTests/fast/block/positioning/fixed-position-transform-related-container-expected.txt
+++ b/LayoutTests/fast/block/positioning/fixed-position-transform-related-container-expected.txt
@@ -1,0 +1,1 @@
+PASS if no assert in Debug.

--- a/LayoutTests/fast/block/positioning/fixed-position-transform-related-container.html
+++ b/LayoutTests/fast/block/positioning/fixed-position-transform-related-container.html
@@ -1,0 +1,11 @@
+<div style="position:absolute; left:50px; transform:translateX(0)">
+    <div style="position:absolute; top:50px; transform-style:preserve-3d;">
+        <div style="position:fixed; left:5px; top:5px; width:50px; height:50px; background-color:green;">
+        </div>
+        PASS if no assert in Debug.
+    </div>
+</div>
+<script>
+    if (window.testRunner)
+        testRunner.dumpAsText();
+</script>


### PR DESCRIPTION
#### a3c2ba9f9c71c4d54675a9d5ca88f0a739c0b967
<pre>
Accumulating offsets to handle fixed position container has a transform-related property but not a transform.
<a href="https://bugs.webkit.org/show_bug.cgi?id=266976">https://bugs.webkit.org/show_bug.cgi?id=266976</a>
<a href="https://rdar.apple.com/120349843">rdar://120349843</a>

Reviewed by Simon Fraser.

Referring chromium fix: <a href="https://codereview.chromium.org/1111423002">https://codereview.chromium.org/1111423002</a>

* LayoutTests/fast/block/positioning/fixed-position-transform-related-container-expected.txt: Added.
* LayoutTests/fast/block/positioning/fixed-position-transform-related-container.html: Added.
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::accumulateOffsetTowardsAncestor):

Canonical link: <a href="https://commits.webkit.org/273161@main">https://commits.webkit.org/273161@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de3dbeacdc47adf1e442186d34bf0aed41cd69c2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34353 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13162 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36346 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37033 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31082 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35434 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15543 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10274 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30088 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34866 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11133 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30633 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9723 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9821 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30682 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38317 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31198 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31001 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35891 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9939 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7815 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33827 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11741 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/30305 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7929 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10495 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10782 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->