### PR TITLE
REGRESSION(268038@main): poor performance with :has(+ :not(.class)) pseudo-class selector

### DIFF
--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -5005,6 +5005,7 @@ void Element::resetComputedStyle()
 void Element::resetStyleRelations()
 {
     clearStyleFlags(NodeStyleFlag::StyleAffectedByEmpty);
+    clearStyleFlags(NodeStyleFlag::AffectedByHasWithPositionalPseudoClass);
     if (!hasRareData())
         return;
     elementRareData()->setChildIndex(0);

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -430,6 +430,7 @@ public:
     bool descendantsAffectedByBackwardPositionalRules() const { return hasStyleFlag(NodeStyleFlag::DescendantsAffectedByBackwardPositionalRules); }
     bool affectsNextSiblingElementStyle() const { return hasStyleFlag(NodeStyleFlag::AffectsNextSiblingElementStyle); }
     bool styleIsAffectedByPreviousSibling() const { return hasStyleFlag(NodeStyleFlag::StyleIsAffectedByPreviousSibling); }
+    bool affectedByHasWithPositionalPseudoClass() const { return hasStyleFlag(NodeStyleFlag::AffectedByHasWithPositionalPseudoClass); }
     unsigned childIndex() const { return hasRareData() ? rareDataChildIndex() : 0; }
 
     bool hasFlagsSetDuringStylingOfChildren() const;
@@ -444,6 +445,7 @@ public:
     void setDescendantsAffectedByBackwardPositionalRules() { setStyleFlag(NodeStyleFlag::DescendantsAffectedByBackwardPositionalRules); }
     void setAffectsNextSiblingElementStyle() { setStyleFlag(NodeStyleFlag::AffectsNextSiblingElementStyle); }
     void setStyleIsAffectedByPreviousSibling() { setStyleFlag(NodeStyleFlag::StyleIsAffectedByPreviousSibling); }
+    void setAffectedByHasWithPositionalPseudoClass() { setStyleFlag(NodeStyleFlag::AffectedByHasWithPositionalPseudoClass); }
     void setChildIndex(unsigned);
 
     const AtomString& effectiveLang() const;

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -919,7 +919,7 @@ void Node::adjustStyleValidity(Style::Validity validity, Style::InvalidationMode
         break;
     case Style::InvalidationMode::RebuildRenderer:
     case Style::InvalidationMode::InsertedIntoAncestor:
-        setStyleFlag(NodeStyleFlag::HasInvalidRenderer);
+        setStateFlag(StateFlag::HasInvalidRenderer);
         break;
     };
 }

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -348,7 +348,7 @@ public:
     bool inRenderedDocument() const;
     bool needsStyleRecalc() const { return styleValidity() != Style::Validity::Valid || hasInvalidRenderer(); }
     Style::Validity styleValidity() const { return styleBitfields().styleValidity(); }
-    bool hasInvalidRenderer() const { return hasStyleFlag(NodeStyleFlag::HasInvalidRenderer); }
+    bool hasInvalidRenderer() const { return hasStateFlag(StateFlag::HasInvalidRenderer); }
     bool styleResolutionShouldRecompositeLayer() const { return hasStyleFlag(NodeStyleFlag::StyleResolutionShouldRecompositeLayer); }
     bool childNeedsStyleRecalc() const { return hasStyleFlag(NodeStyleFlag::DescendantNeedsStyleResolution); }
     bool isEditingText() const { return isTextNode() && hasTypeFlag(TypeFlag::IsSpecialInternalNode); }
@@ -610,6 +610,7 @@ protected:
 #if ENABLE(FULLSCREEN_API)
         IsFullscreen = 1 << 9,
 #endif
+        HasInvalidRenderer = 1 << 10,
     };
 
     enum class TabIndexState : uint8_t {
@@ -660,8 +661,8 @@ protected:
         DescendantNeedsStyleResolution                          = 1 << 0,
         DirectChildNeedsStyleResolution                         = 1 << 1,
         StyleResolutionShouldRecompositeLayer                   = 1 << 2,
-        HasInvalidRenderer                                      = 1 << 3,
 
+        AffectedByHasWithPositionalPseudoClass                  = 1 << 3,
         ChildrenAffectedByFirstChildRules                       = 1 << 4,
         ChildrenAffectedByLastChildRules                        = 1 << 5,
         AffectsNextSiblingElementStyle                          = 1 << 6,
@@ -869,9 +870,10 @@ inline void Node::setHasValidStyle()
 {
     auto bitfields = styleBitfields();
     bitfields.setStyleValidity(Style::Validity::Valid);
-    bitfields.clearFlags({ NodeStyleFlag::HasInvalidRenderer, NodeStyleFlag::StyleResolutionShouldRecompositeLayer });
+    bitfields.clearFlag(NodeStyleFlag::StyleResolutionShouldRecompositeLayer);
     setStyleBitfields(bitfields);
     clearStateFlag(StateFlag::IsComputedStyleInvalidFlag);
+    clearStateFlag(StateFlag::HasInvalidRenderer);
 }
 
 inline void Node::setTreeScopeRecursively(TreeScope& newTreeScope)

--- a/Source/WebCore/style/ChildChangeInvalidation.cpp
+++ b/Source/WebCore/style/ChildChangeInvalidation.cpp
@@ -127,6 +127,10 @@ void ChildChangeInvalidation::invalidateForHasBeforeMutation()
         invalidateForChangedElement(changedElement, matchingHasSelectors, ChangedElementRelation::SelfOrDescendant);
     });
 
+    // :empty is affected by text changes.
+    if (m_childChange.type == ContainerNode::ChildChange::Type::TextRemoved || m_childChange.type == ContainerNode::ChildChange::Type::AllChildrenRemoved)
+        invalidateForChangedElement(parentElement(), matchingHasSelectors, ChangedElementRelation::SelfOrDescendant);
+
     auto firstChildStateWillStopMatching = [&] {
         if (!m_childChange.nextSiblingElement)
             return false;
@@ -153,7 +157,7 @@ void ChildChangeInvalidation::invalidateForHasBeforeMutation()
         return false;
     };
 
-    if (parentElement().childrenAffectedByForwardPositionalRules() || parentElement().childrenAffectedByBackwardPositionalRules()) {
+    if (parentElement().affectedByHasWithPositionalPseudoClass()) {
         traverseRemainingExistingSiblings([&](auto& changedElement) {
             invalidateForChangedElement(changedElement, matchingHasSelectors, ChangedElementRelation::Sibling);
         });
@@ -177,6 +181,10 @@ void ChildChangeInvalidation::invalidateForHasAfterMutation()
     traverseAddedElements([&](auto& changedElement) {
         invalidateForChangedElement(changedElement, matchingHasSelectors, ChangedElementRelation::SelfOrDescendant);
     });
+
+    // :empty is affected by text changes.
+    if (m_childChange.type == ContainerNode::ChildChange::Type::TextInserted && m_wasEmpty)
+        invalidateForChangedElement(parentElement(), matchingHasSelectors, ChangedElementRelation::SelfOrDescendant);
 
     auto firstChildStateWillStartMatching = [&](Element* elementAfterChange) {
         if (!elementAfterChange)
@@ -204,7 +212,7 @@ void ChildChangeInvalidation::invalidateForHasAfterMutation()
         return false;
     };
 
-    if (parentElement().childrenAffectedByForwardPositionalRules() || parentElement().childrenAffectedByBackwardPositionalRules()) {
+    if (parentElement().affectedByHasWithPositionalPseudoClass()) {
         traverseRemainingExistingSiblings([&](auto& changedElement) {
             invalidateForChangedElement(changedElement, matchingHasSelectors, ChangedElementRelation::Sibling);
         });

--- a/Source/WebCore/style/ChildChangeInvalidation.h
+++ b/Source/WebCore/style/ChildChangeInvalidation.h
@@ -61,13 +61,15 @@ private:
 
     const bool m_isEnabled;
     const bool m_needsHasInvalidation;
+    const bool m_wasEmpty;
 };
 
 inline ChildChangeInvalidation::ChildChangeInvalidation(ContainerNode& container, const ContainerNode::ChildChange& childChange)
     : m_parentElement(dynamicDowncast<Element>(container))
     , m_childChange(childChange)
-    , m_isEnabled(m_parentElement ? m_parentElement->needsStyleInvalidation() : false)
+    , m_isEnabled(m_parentElement && m_parentElement->needsStyleInvalidation())
     , m_needsHasInvalidation(m_isEnabled && Scope::forNode(*m_parentElement).usesHasPseudoClass())
+    , m_wasEmpty(!container.firstChild())
 {
     if (!m_isEnabled)
         return;

--- a/Source/WebCore/style/StyleRelations.cpp
+++ b/Source/WebCore/style/StyleRelations.cpp
@@ -75,6 +75,7 @@ std::unique_ptr<Relations> commitRelationsToRenderStyle(RenderStyle& style, cons
         case Relation::ChildrenAffectedByFirstChildRules:
         case Relation::ChildrenAffectedByLastChildRules:
         case Relation::NthChildIndex:
+        case Relation::AffectedByHasWithPositionalPseudoClass:
             appendStyleRelation(relation);
             break;
         }
@@ -121,6 +122,9 @@ void commitRelations(std::unique_ptr<Relations> relations, Update& update)
             break;
         case Relation::ChildrenAffectedByLastChildRules:
             element.setChildrenAffectedByLastChildRules();
+            break;
+        case Relation::AffectedByHasWithPositionalPseudoClass:
+            element.setAffectedByHasWithPositionalPseudoClass();
             break;
         case Relation::FirstChild:
             if (auto* style = update.elementStyle(element))

--- a/Source/WebCore/style/StyleRelations.h
+++ b/Source/WebCore/style/StyleRelations.h
@@ -53,6 +53,7 @@ struct Relation {
         LastChild,
         NthChildIndex,
         Unique,
+        AffectedByHasWithPositionalPseudoClass,
     };
     const Element* element;
     Type type;


### PR DESCRIPTION
#### 9b67f95c4810d05d68b047eb9e84b48f7826783d
<pre>
REGRESSION(268038@main): poor performance with :has(+ :not(.class)) pseudo-class selector
<a href="https://bugs.webkit.org/show_bug.cgi?id=267078">https://bugs.webkit.org/show_bug.cgi?id=267078</a>
<a href="https://rdar.apple.com/119819247">rdar://119819247</a>

Reviewed by Cameron McCormack.

The selector gets misclassified as scope breaking.
Fixing the issue reveals it was hiding other invalidation bugs.

* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::matchHasPseudoClass const):

Add a new flag for the case where element is affected by :has() containing :nth-child() and similar.
The use of existing flags didn&apos;t work correctly in all situations because they would get wiped at
wrong time.

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::resetStyleRelations):
* Source/WebCore/dom/Element.h:
(WebCore::Element::affectedByHasWithPositionalPseudoClass const):
(WebCore::Element::setAffectedByHasWithPositionalPseudoClass):
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::adjustStyleValidity):
* Source/WebCore/dom/Node.h:
(WebCore::Node::hasInvalidRenderer const):
(WebCore::Node::setHasValidStyle):

Juggle the flags around to make space.

* Source/WebCore/style/ChildChangeInvalidation.cpp:
(WebCore::Style::ChildChangeInvalidation::invalidateForHasBeforeMutation):
(WebCore::Style::ChildChangeInvalidation::invalidateForHasAfterMutation):

Handle text node insertions and removals since they may affect :empty state within :has().
Test for the new :nth-child() flag instead of the old ones.

* Source/WebCore/style/ChildChangeInvalidation.h:
(WebCore::Style::ChildChangeInvalidation::ChildChangeInvalidation):
* Source/WebCore/style/RuleFeature.cpp:
(WebCore::Style::RuleFeatureSet::recursivelyCollectFeaturesFromSelector):

Break out of the loop if the current selector is the leftmost one before computing
MatchElement/IsScopeBreaking. Selector :not(.class) would get computed as scope breaking
even though there is nothing on the left of .class. Also stop CanBreakScope::Yes from affecting
subsequent selectors after the one that can actually leak the scope.

* Source/WebCore/style/StyleRelations.cpp:
(WebCore::Style::commitRelationsToRenderStyle):
(WebCore::Style::commitRelations):
* Source/WebCore/style/StyleRelations.h:

Canonical link: <a href="https://commits.webkit.org/272678@main">https://commits.webkit.org/272678@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96a552c6d5f6b36ddaa227994f6b9f7f1b32901d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32684 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11436 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34538 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35255 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/29531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33607 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13783 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8624 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/29018 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33123 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9636 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29191 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8405 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8530 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29143 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36591 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29698 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/29552 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/34662 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8653 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6615 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32527 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10338 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7590 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9267 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9260 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->