### PR TITLE
Remove unused function `userPreferredLanguagesOverride` from Language.cpp|h

### DIFF
--- a/Source/WTF/wtf/Language.cpp
+++ b/Source/WTF/wtf/Language.cpp
@@ -107,12 +107,6 @@ String defaultLanguage(ShouldMinimizeLanguages shouldMinimizeLanguages)
     return emptyString();
 }
 
-Vector<String> userPreferredLanguagesOverride()
-{
-    Locker locker { languagesLock };
-    return preferredLanguagesOverride();
-}
-
 // This returns a reference to a Vector<String> protected by languagesLock.
 // Callers should not let it escape past the lock.
 static Vector<String>& computeUserPreferredLanguages(ShouldMinimizeLanguages shouldMinimizeLanguages) WTF_REQUIRES_LOCK(languagesLock)

--- a/Source/WTF/wtf/Language.h
+++ b/Source/WTF/wtf/Language.h
@@ -39,7 +39,6 @@ enum class ShouldMinimizeLanguages : bool { No, Yes };
 
 WTF_EXPORT_PRIVATE String defaultLanguage(ShouldMinimizeLanguages = ShouldMinimizeLanguages::Yes); // Thread-safe.
 WTF_EXPORT_PRIVATE Vector<String> userPreferredLanguages(ShouldMinimizeLanguages = ShouldMinimizeLanguages::Yes); // Thread-safe, returns BCP 47 language tags.
-WTF_EXPORT_PRIVATE Vector<String> userPreferredLanguagesOverride();
 WTF_EXPORT_PRIVATE void overrideUserPreferredLanguages(const Vector<String>&);
 WTF_EXPORT_PRIVATE size_t indexOfBestMatchingLanguageInList(const String& language, const Vector<String>& languageList, bool& exactMatch);
 WTF_EXPORT_PRIVATE bool userPrefersSimplifiedChinese();
@@ -66,7 +65,6 @@ RetainPtr<CFArrayRef> minimizedLanguagesFromLanguages(CFArrayRef);
 using WTF::ShouldMinimizeLanguages;
 using WTF::defaultLanguage;
 using WTF::userPreferredLanguages;
-using WTF::userPreferredLanguagesOverride;
 using WTF::overrideUserPreferredLanguages;
 using WTF::indexOfBestMatchingLanguageInList;
 using WTF::userPrefersSimplifiedChinese;


### PR DESCRIPTION
#### e98b9d978ece88c0f5932d8fd69ed60882a9aed7
<pre>
Remove unused function `userPreferredLanguagesOverride` from Language.cpp|h

<a href="https://bugs.webkit.org/show_bug.cgi?id=267086">https://bugs.webkit.org/show_bug.cgi?id=267086</a>

Reviewed by Sihui Liu.

This PR is to remove unused function `userPreferredLanguagesOverride` from Language.cpp|h.

* Source/WTF/wtf/Language.cpp:
(userPreferredLanguagesOverride): Removed
* Source/WTF/wtf/Language.h: Above function definition removed

Canonical link: <a href="https://commits.webkit.org/272658@main">https://commits.webkit.org/272658@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8162a69e7364587a0acbd0020e2f610e4bb91398

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32540 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11286 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34386 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35104 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29423 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13637 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8481 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28953 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32974 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9512 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29080 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8288 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8430 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29022 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36440 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/27924 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29576 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29444 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34553 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/32611 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8560 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6512 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32413 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10230 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/39041 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7576 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9173 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8240 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9145 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->