### PR TITLE
Serialize CSSSupportsRule with URL replacement

### DIFF
--- a/Source/WebCore/css/CSSGroupingRule.cpp
+++ b/Source/WebCore/css/CSSGroupingRule.cpp
@@ -117,39 +117,46 @@ ExceptionOr<void> CSSGroupingRule::deleteRule(unsigned index)
     return { };
 }
 
-void CSSGroupingRule::appendCSSTextForItems(StringBuilder& builder) const
+void CSSGroupingRule::appendCSSTextForItemsInternal(StringBuilder& builder, StringBuilder& rules) const
 {
     builder.append(" {");
-
-    StringBuilder decls;
-    StringBuilder rules;
-    cssTextForDeclsAndRules(decls, rules);
-
-    if (decls.isEmpty() && rules.isEmpty()) {
+    if (rules.isEmpty()) {
         builder.append("\n}");
         return;
     }
 
-    if (rules.isEmpty()) {
-        builder.append(' ', static_cast<StringView>(decls), " }");
-        return;
-    }
-    
-    if (decls.isEmpty()) {
-        builder.append(static_cast<StringView>(rules), "\n}");
-        return;
-    }
-
-    builder.append('\n', "  ", static_cast<StringView>(decls), static_cast<StringView>(rules), "\n}");
-    return;
+    builder.append(static_cast<StringView>(rules), "\n}");
 }
 
-void CSSGroupingRule::cssTextForDeclsAndRules(StringBuilder&, StringBuilder& rules) const
+void CSSGroupingRule::appendCSSTextForItems(StringBuilder& builder) const
+{
+    StringBuilder rules;
+    cssTextForRules(rules);
+    appendCSSTextForItemsInternal(builder, rules);
+}
+
+void CSSGroupingRule::cssTextForRules(StringBuilder& rules) const
 {
     auto& childRules = m_groupRule->childRules();
     for (unsigned index = 0; index < childRules.size(); index++) {
         auto wrappedRule = item(index);
         rules.append("\n  ", wrappedRule->cssText());
+    }
+}
+
+void CSSGroupingRule::appendCSSTextWithReplacementURLsForItems(StringBuilder& builder, const HashMap<String, String>& replacementURLStrings, const HashMap<RefPtr<CSSStyleSheet>, String>& replacementURLStringsForCSSStyleSheet) const
+{
+    StringBuilder rules;
+    cssTextForRulesWithReplacementURLs(rules, replacementURLStrings, replacementURLStringsForCSSStyleSheet);
+    appendCSSTextForItemsInternal(builder, rules);
+}
+
+void CSSGroupingRule::cssTextForRulesWithReplacementURLs(StringBuilder& rules, const HashMap<String, String>& replacementURLStrings, const HashMap<RefPtr<CSSStyleSheet>, String>& replacementURLStringsForCSSStyleSheet) const
+{
+    auto& childRules = m_groupRule->childRules();
+    for (unsigned index = 0; index < childRules.size(); index++) {
+        auto wrappedRule = item(index);
+        rules.append("\n  ", wrappedRule->cssTextWithReplacementURLs(replacementURLStrings, replacementURLStringsForCSSStyleSheet));
     }
 }
 

--- a/Source/WebCore/css/CSSGroupingRule.h
+++ b/Source/WebCore/css/CSSGroupingRule.h
@@ -47,12 +47,14 @@ protected:
     StyleRuleGroup& groupRule() { return m_groupRule; }
     void reattach(StyleRuleBase&) override;
     void appendCSSTextForItems(StringBuilder&) const;
+    void appendCSSTextWithReplacementURLsForItems(StringBuilder&, const HashMap<String, String>&, const HashMap<RefPtr<CSSStyleSheet>, String>&) const;
     RefPtr<StyleRuleWithNesting> prepareChildStyleRuleForNesting(StyleRule&) override;
 
-    // https://drafts.csswg.org/cssom/#serialize-a-css-rule
-    void cssTextForDeclsAndRules(StringBuilder& decls, StringBuilder& rules) const;
-
 private:
+    void appendCSSTextForItemsInternal(StringBuilder&, StringBuilder&) const;
+    void cssTextForRules(StringBuilder&) const;
+    void cssTextForRulesWithReplacementURLs(StringBuilder&, const HashMap<String, String>&, const HashMap<RefPtr<CSSStyleSheet>, String>&) const;
+
     Ref<StyleRuleGroup> m_groupRule;
     mutable Vector<RefPtr<CSSRule>> m_childRuleCSSOMWrappers;
     mutable std::unique_ptr<CSSRuleList> m_ruleListCSSOMWrapper;

--- a/Source/WebCore/css/CSSSupportsRule.cpp
+++ b/Source/WebCore/css/CSSSupportsRule.cpp
@@ -56,6 +56,14 @@ String CSSSupportsRule::cssText() const
     return builder.toString();
 }
 
+String CSSSupportsRule::cssTextWithReplacementURLs(const HashMap<String, String>& replacementURLStrings, const HashMap<RefPtr<CSSStyleSheet>, String>& replacementURLStringsForCSSStyleSheet) const
+{
+    StringBuilder builder;
+    builder.append("@supports ", conditionText());
+    appendCSSTextWithReplacementURLsForItems(builder, replacementURLStrings, replacementURLStringsForCSSStyleSheet);
+    return builder.toString();
+}
+
 String CSSSupportsRule::conditionText() const
 {
     return downcast<StyleRuleSupports>(groupRule()).conditionText();

--- a/Source/WebCore/css/CSSSupportsRule.h
+++ b/Source/WebCore/css/CSSSupportsRule.h
@@ -41,6 +41,7 @@ public:
     static Ref<CSSSupportsRule> create(StyleRuleSupports&, CSSStyleSheet* parent);
 
     String cssText() const final;
+    String cssTextWithReplacementURLs(const HashMap<String, String>&, const HashMap<RefPtr<CSSStyleSheet>, String>&) const final;
     String conditionText() const final;
 
 private:


### PR DESCRIPTION
#### ecbf469afa265318eb7dc8f518c128ebeabdd49a
<pre>
Serialize CSSSupportsRule with URL replacement
<a href="https://bugs.webkit.org/show_bug.cgi?id=267088">https://bugs.webkit.org/show_bug.cgi?id=267088</a>
<a href="https://rdar.apple.com/119494689">rdar://119494689</a>

Reviewed by Ryosuke Niwa.

We need to replace URLs in CSSGroupingRule when saving style content to disk, just like what we did for CSSStyleRule.

API Test: WebArchive.SaveResourcesCSSSupportsRule

* Source/WebCore/css/CSSGroupingRule.cpp:
(WebCore::CSSGroupingRule::appendCSSTextForItemsInternal const):
(WebCore::CSSGroupingRule::appendCSSTextForItems const):
(WebCore::CSSGroupingRule::cssTextForRules const):
(WebCore::CSSGroupingRule::appendCSSTextWithReplacementURLsForItems const):
(WebCore::CSSGroupingRule::cssTextForRulesWithReplacementURLs const):
(WebCore::CSSGroupingRule::cssTextForDeclsAndRules const): Deleted. Replaced with cssTextForRules since declarations
parameter is unused.
* Source/WebCore/css/CSSGroupingRule.h:
* Source/WebCore/css/CSSSupportsRule.cpp:
(WebCore::CSSSupportsRule::cssTextWithReplacementURLs const): Overriding virtual function cssTextWithReplacementURLs of
CSSRule, which is invoked in CSSStyleSheet::cssTextWithReplacementURLs.
This is invoked via virtual function
.
* Source/WebCore/css/CSSSupportsRule.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/CreateWebArchive.mm:

Canonical link: <a href="https://commits.webkit.org/272661@main">https://commits.webkit.org/272661@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c88962173f74b2a07e234fee395dfe70334d9fc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32570 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11319 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34471 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35137 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29442 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33437 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13668 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8513 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28967 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33005 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9539 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/29139 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8317 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8449 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29086 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36473 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29602 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29502 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34573 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8580 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6532 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32440 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10255 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7579 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9191 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9173 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->