### PR TITLE
Isolated iframes that crash during load should not delay load event of parent

### DIFF
--- a/LayoutTests/http/tests/site-isolation/iframe-process-termination-expected.html
+++ b/LayoutTests/http/tests/site-isolation/iframe-process-termination-expected.html
@@ -1,0 +1,2 @@
+<body bgcolor=blue>
+</body>

--- a/LayoutTests/http/tests/site-isolation/iframe-process-termination.html
+++ b/LayoutTests/http/tests/site-isolation/iframe-process-termination.html
@@ -1,0 +1,4 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<body bgcolor=blue>
+<iframe src="http://localhost:8000/site-isolation/resources/iframe-terminate-process-when-loaded.html" frameborder=0></iframe>
+</body>

--- a/LayoutTests/http/tests/site-isolation/resources/iframe-terminate-process-when-loaded.html
+++ b/LayoutTests/http/tests/site-isolation/resources/iframe-terminate-process-when-loaded.html
@@ -1,0 +1,2 @@
+<script> onload = () => { window.internals.terminateWebContentProcess() } </script>
+<body style='background-color:green'/>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -4576,6 +4576,7 @@ webkit.org/b/257904 http/tests/site-isolation/double-iframe.html [ Skip ]
 webkit.org/b/257904 http/tests/site-isolation/draw-after-navigation.html [ Skip ]
 webkit.org/b/257904 http/tests/site-isolation/selection-focus.html [ Skip ]
 webkit.org/b/257904 http/tests/site-isolation/basic-iframe-render-output.html [ Failure Timeout Pass ]
+webkit.org/b/257904 http/tests/site-isolation/iframe-process-termination.html [ Skip ]
 
 # This test can't be enabled on iOS until EventSenderProxyIOS::keyDown() is implemented.
 http/tests/site-isolation/key-events.html [ Skip ]

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -6184,6 +6184,11 @@ void Internals::whenServiceWorkerIsTerminated(ServiceWorker& worker, DOMPromiseD
     });
 }
 
+NO_RETURN_DUE_TO_CRASH void Internals::terminateWebContentProcess()
+{
+    exit(0);
+}
+
 #if ENABLE(APPLE_PAY)
 MockPaymentCoordinator& Internals::mockPaymentCoordinator(Document& document)
 {

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1016,6 +1016,7 @@ public:
     void hasServiceWorkerRegistration(const String& clientURL, HasRegistrationPromise&&);
     void terminateServiceWorker(ServiceWorker&, DOMPromiseDeferred<void>&&);
     void whenServiceWorkerIsTerminated(ServiceWorker&, DOMPromiseDeferred<void>&&);
+    void terminateWebContentProcess();
 
 #if ENABLE(APPLE_PAY)
     MockPaymentCoordinator& mockPaymentCoordinator(Document&);

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1124,6 +1124,7 @@ typedef (FetchRequest or FetchResponse) FetchObject;
     Promise<boolean> hasServiceWorkerRegistration(DOMString scopeURL);
     Promise<undefined> terminateServiceWorker(ServiceWorker worker);
     Promise<undefined> whenServiceWorkerIsTerminated(ServiceWorker worker);
+    undefined terminateWebContentProcess();
 
 #if defined(ENABLE_APPLE_PAY) && ENABLE_APPLE_PAY
     [CallWith=CurrentDocument, Conditional=APPLE_PAY] readonly attribute MockPaymentCoordinator mockPaymentCoordinator;

--- a/Source/WebKit/UIProcess/RemotePageProxy.cpp
+++ b/Source/WebKit/UIProcess/RemotePageProxy.cpp
@@ -89,6 +89,22 @@ void RemotePageProxy::injectPageIntoNewProcess()
     m_process->send(Messages::WebProcess::CreateWebPage(m_webPageID, WTFMove(parameters)), 0);
 }
 
+void RemotePageProxy::processDidTerminate()
+{
+    for (auto& frame : m_frames)
+        frame.remoteProcessDidTerminate();
+}
+
+void RemotePageProxy::addFrame(WebFrameProxy& frame)
+{
+    m_frames.add(frame);
+}
+
+void RemotePageProxy::removeFrame(WebFrameProxy& frame)
+{
+    m_frames.remove(frame);
+}
+
 RemotePageProxy::~RemotePageProxy()
 {
     m_process->removeRemotePageProxy(*this);

--- a/Source/WebKit/UIProcess/RemotePageProxy.h
+++ b/Source/WebKit/UIProcess/RemotePageProxy.h
@@ -32,6 +32,7 @@
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/PageIdentifier.h>
 #include <WebCore/RegistrableDomain.h>
+#include <wtf/WeakHashSet.h>
 
 namespace IPC {
 class Connection;
@@ -71,6 +72,8 @@ public:
 
     WebPageProxy* page() const;
     RefPtr<WebPageProxy> protectedPage() const;
+    void addFrame(WebFrameProxy&);
+    void removeFrame(WebFrameProxy&);
 
     template<typename M> void send(M&&);
     template<typename M> IPC::ConnectionSendSyncResult<M> sendSync(M&& message);
@@ -78,6 +81,7 @@ public:
     template<typename M, typename C> void sendWithAsyncReply(M&&, C&&, const ObjectIdentifierGenericBase&);
 
     void injectPageIntoNewProcess();
+    void processDidTerminate();
 
     WebPageProxyMessageReceiverRegistration& messageReceiverRegistration() { return m_messageReceiverRegistration; }
 
@@ -105,6 +109,7 @@ private:
     std::unique_ptr<RemotePageDrawingAreaProxy> m_drawingArea;
     std::unique_ptr<RemotePageVisitedLinkStoreRegistration> m_visitedLinkStoreRegistration;
     WebPageProxyMessageReceiverRegistration m_messageReceiverRegistration;
+    WeakHashSet<WebFrameProxy> m_frames;
 };
 
 template<typename M> void RemotePageProxy::send(M&& message)

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -165,6 +165,9 @@ public:
     ProvisionalFrameProxy* provisionalFrame() { return m_provisionalFrame.get(); }
     std::unique_ptr<ProvisionalFrameProxy> takeProvisionalFrame();
     RefPtr<RemotePageProxy> remotePageProxy();
+    void remoteProcessDidTerminate();
+    std::optional<WebCore::PageIdentifier> webPageIDInCurrentProcess();
+    void notifyParentOfLoadCompletion(WebProcessProxy&);
 
     bool isFocused() const;
 
@@ -175,7 +178,6 @@ private:
 
     WeakPtr<WebPageProxy> m_page;
     Ref<WebProcessProxy> m_process;
-    WebCore::PageIdentifier m_webPageID;
 
     FrameLoadState m_frameLoadState;
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -1159,6 +1159,9 @@ void WebProcessProxy::processDidTerminateOrFailedToLaunch(ProcessTerminationReas
 
     for (auto& page : pages)
         page->dispatchProcessDidTerminate(reason);
+
+    for (auto& remotePage : m_remotePages)
+        remotePage.processDidTerminate();
 }
 
 void WebProcessProxy::didReceiveInvalidMessage(IPC::Connection& connection, IPC::MessageName messageName)


### PR DESCRIPTION
#### fa35998e9caf2c45f333bdd7bfff310af2c06e56
<pre>
Isolated iframes that crash during load should not delay load event of parent
<a href="https://bugs.webkit.org/show_bug.cgi?id=267089">https://bugs.webkit.org/show_bug.cgi?id=267089</a>

Reviewed by Pascoe.

To accomplish this, I need to have each RemotePageProxy be informed when a process crashes,
and have each RemotePageProxy keep track of which WebFrameProxies are using it.  Then, we
need to send Messages::WebPage::DidFinishLoadInAnotherProcess to the parent process when a child
crashes if it has not already been sent.

I removed WebFrameProxy&apos;s m_webPageID because it was not used and not updated correctly when
the process of a frame changes, which likely causes a different PageIdentifier to be used in
the new process.

I moved the sending of the DidFinishLoadInAnotherProcess message to a shared function to reduce
duplicate code.

I removed the clearing of m_remotePageProxy in WebFrameProxy::prepareForProvisionalNavigationInProcess
because it would&apos;ve needed some updating of frame content management with an additional removeFrame
call, but that is actually the wrong place to be clearing the RemotePageProxy.
WebFrameProxy::commitProvisionalFrame is the right time to be updating that.

* LayoutTests/http/tests/site-isolation/iframe-process-termination-expected.html: Added.
* LayoutTests/http/tests/site-isolation/iframe-process-termination.html: Added.
* LayoutTests/http/tests/site-isolation/resources/iframe-terminate-process-when-loaded.html: Added.
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::terminateWebContentProcess):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/UIProcess/RemotePageProxy.cpp:
(WebKit::RemotePageProxy::processDidTerminate):
(WebKit::RemotePageProxy::addFrame):
(WebKit::RemotePageProxy::removeFrame):
* Source/WebKit/UIProcess/RemotePageProxy.h:
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::WebFrameProxy):
(WebKit::WebFrameProxy::prepareForProvisionalNavigationInProcess):
(WebKit::WebFrameProxy::commitProvisionalFrame):
(WebKit::WebFrameProxy::remoteProcessDidTerminate):
(WebKit::WebFrameProxy::notifyParentOfLoadCompletion):
(WebKit::WebFrameProxy::webPageIDInCurrentProcess):
* Source/WebKit/UIProcess/WebFrameProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didFailProvisionalLoadForFrameShared):
(WebKit::WebPageProxy::didFinishLoadForFrame):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::processDidTerminateOrFailedToLaunch):

Canonical link: <a href="https://commits.webkit.org/272656@main">https://commits.webkit.org/272656@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66b7bfa25cf746e5489cd32c10c2296b2d2a52b5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32553 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11300 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34400 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35118 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29429 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33419 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13650 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8494 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28958 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32987 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9522 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29091 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8299 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8438 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29033 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36454 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29586 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29455 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34560 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8566 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6522 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32436 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10239 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/28779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9178 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4201 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9156 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->