### PR TITLE
Factor PDF JS evaluation out of PDFPlugin

### DIFF
--- a/LayoutTests/compositing/plugins/pdf/pdf-plugin-printing-expected.txt
+++ b/LayoutTests/compositing/plugins/pdf/pdf-plugin-printing-expected.txt
@@ -1,0 +1,12 @@
+Basic testing for automatic PDF printing
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+* Received beforeprint event
+* Received afterprint event
+PASS receivedBeforePrintEvent is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/compositing/plugins/pdf/pdf-plugin-printing.html
+++ b/LayoutTests/compositing/plugins/pdf/pdf-plugin-printing.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ UnifiedPDFEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+<script>
+description("Basic testing for automatic PDF printing");
+jsTestIsAsync = true;
+let receivedBeforePrintEvent = false;
+
+addEventListener("beforeprint", () => {
+    debug("* Received beforeprint event");
+    receivedBeforePrintEvent = true;
+});
+
+addEventListener("afterprint", () => {
+    debug("* Received afterprint event");
+    shouldBeTrue("receivedBeforePrintEvent");
+    finishJSTest();
+});
+</script>
+<embed src="../../../resources/auto-print.pdf"></embed>
+</body>
+</html>

--- a/LayoutTests/resources/auto-print.pdf
+++ b/LayoutTests/resources/auto-print.pdf
@@ -1,0 +1,46 @@
+%PDF-1.7
+1 0 obj
+<<
+    /Type /Catalog
+    /Pages 2 0 R
+    /Names << 
+        /JavaScript <<
+            /Names [
+                /Name << 
+                    /S /JavaScript
+                    /JS (this.print())
+                >>
+            ]
+        >>
+    >>
+>>
+endobj
+2 0 obj
+<<
+    /Type /Pages
+    /MediaBox [0 0 100 100]
+    /Count 1
+    /Kids [3 0 R]
+>>
+endobj
+3 0 obj
+<<
+    /Type /Page
+    /Parent 2 0 R
+    /MediaBox [0 0 100 100]
+>>
+endobj
+xref
+0 4
+0000000000 65535 f 
+0000000009 00000 n 
+0000000276 00000 n 
+0000000373 00000 n 
+trailer
+<<
+    /Size 4
+    /Root 1 0 R
+>>
+startxref
+456
+%%EOF

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -684,6 +684,7 @@ WebProcess/Plugins/PDF/PDFPluginAnnotation.mm
 WebProcess/Plugins/PDF/PDFPluginChoiceAnnotation.mm
 WebProcess/Plugins/PDF/PDFPluginPasswordField.mm
 WebProcess/Plugins/PDF/PDFPluginTextAnnotation.mm
+WebProcess/Plugins/PDF/PDFScriptEvaluator.mm
 WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
 WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -4595,6 +4595,8 @@
 		2DC18001D90DDD15FC6991A9 /* SharedBufferReference.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SharedBufferReference.cpp; sourceTree = "<group>"; };
 		2DC18FB1218A6E9E0025A88D /* RemoteLayerTreeViews.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RemoteLayerTreeViews.h; sourceTree = "<group>"; };
 		2DC18FB2218A6E9E0025A88D /* RemoteLayerTreeViews.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RemoteLayerTreeViews.mm; sourceTree = "<group>"; };
+		2DC2515E2AFE0E8F00EB4EC5 /* PDFScriptEvaluator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = PDFScriptEvaluator.h; path = PDF/PDFScriptEvaluator.h; sourceTree = "<group>"; };
+		2DC2515F2AFE0E9000EB4EC5 /* PDFScriptEvaluator.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = PDFScriptEvaluator.mm; path = PDF/PDFScriptEvaluator.mm; sourceTree = "<group>"; };
 		2DC4CF7A1D2DE24B00ECCC94 /* WebPageCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebPageCocoa.mm; sourceTree = "<group>"; };
 		2DC6D9C118C44A610043BAD4 /* WKWebViewContentProviderRegistry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKWebViewContentProviderRegistry.h; sourceTree = "<group>"; };
 		2DC6D9C218C44A610043BAD4 /* WKWebViewContentProviderRegistry.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebViewContentProviderRegistry.mm; sourceTree = "<group>"; };
@@ -14853,6 +14855,8 @@
 				2D429BFB1721E2BA00EC681F /* PDFPluginPasswordField.mm */,
 				2D2ADF0516362DC700197E47 /* PDFPluginTextAnnotation.h */,
 				2D2ADF0616362DC700197E47 /* PDFPluginTextAnnotation.mm */,
+				2DC2515E2AFE0E8F00EB4EC5 /* PDFScriptEvaluator.h */,
+				2DC2515F2AFE0E9000EB4EC5 /* PDFScriptEvaluator.mm */,
 			);
 			name = PDF;
 			sourceTree = "<group>";

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
@@ -55,11 +55,6 @@ OBJC_CLASS PDFSelection;
 OBJC_CLASS WKPDFLayerControllerDelegate;
 OBJC_CLASS WKPDFPluginAccessibilityObject;
 
-typedef const struct OpaqueJSContext* JSContextRef;
-typedef struct OpaqueJSValue* JSObjectRef;
-typedef const struct OpaqueJSValue* JSValueRef;
-typedef struct OpaqueJSClass* JSClassRef;
-
 namespace WebCore {
 class AXObjectCache;
 class Element;
@@ -166,7 +161,6 @@ private:
     bool isComposited() const override { return true; }
 
     void installPDFDocument() override;
-    void tryRunScriptsInPDFDocument() override;
 
     CGFloat scaleFactor() const override;
 
@@ -223,10 +217,6 @@ private:
     void createPasswordEntryForm();
 
     NSData *liveData() const;
-    JSObjectRef makeJSPDFDoc(JSContextRef);
-    static JSClassRef jsPDFDocClass();
-    static JSValueRef jsPDFDocPrint(JSContextRef, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception);
-
 
     bool m_pdfDocumentWasMutated { false };
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -30,6 +30,7 @@
 #include "DataReference.h"
 #include "FrameInfoData.h"
 #include "PDFPluginIdentifier.h"
+#include "PDFScriptEvaluator.h"
 #include <WebCore/AffineTransform.h>
 #include <WebCore/FindOptions.h>
 #include <WebCore/FloatRect.h>
@@ -67,13 +68,17 @@ class WebMouseEvent;
 class WebWheelEvent;
 struct WebHitTestResultData;
 
-class PDFPluginBase : public ThreadSafeRefCounted<PDFPluginBase>, public WebCore::ScrollableArea {
+class PDFPluginBase : public ThreadSafeRefCounted<PDFPluginBase>, public WebCore::ScrollableArea, public PDFScriptEvaluator::Client {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(PDFPluginBase);
 public:
     static WebCore::PluginInfo pluginInfo();
 
     virtual ~PDFPluginBase();
+
+    using WebKit::PDFScriptEvaluator::Client::weakPtrFactory;
+    using WebKit::PDFScriptEvaluator::Client::WeakValueType;
+    using WebKit::PDFScriptEvaluator::Client::WeakPtrImplType;
 
     void destroy();
 
@@ -181,7 +186,7 @@ protected:
 
     void createPDFDocument();
     virtual void installPDFDocument() = 0;
-    virtual void tryRunScriptsInPDFDocument() { }
+    void tryRunScriptsInPDFDocument();
 
     virtual void incrementalPDFStreamDidReceiveData(const WebCore::SharedBuffer&) { }
     virtual bool incrementalPDFStreamDidFinishLoading() { return false; }
@@ -195,6 +200,8 @@ protected:
     void addArchiveResource();
 
     void invalidateRect(const WebCore::IntRect&);
+
+    void print() override;
 
     // ScrollableArea functions.
     WebCore::IntRect scrollCornerRect() const final;
@@ -266,6 +273,7 @@ protected:
     bool m_documentFinishedLoading { false };
     bool m_isBeingDestroyed { false };
     bool m_hasBeenDestroyed { false };
+    bool m_didRunScripts { false };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -233,6 +233,15 @@ void PDFPluginBase::addArchiveResource()
     m_view->frame()->document()->loader()->addArchiveResource(resource.releaseNonNull());
 }
 
+void PDFPluginBase::tryRunScriptsInPDFDocument()
+{
+    if (!m_pdfDocument || !m_documentFinishedLoading || m_didRunScripts)
+        return;
+
+    PDFScriptEvaluator::runScripts([m_pdfDocument documentRef], *this);
+    m_didRunScripts = true;
+}
+
 void PDFPluginBase::geometryDidChange(const IntSize& pluginSize, const AffineTransform& pluginToRootViewTransform)
 {
     m_size = pluginSize;
@@ -560,6 +569,12 @@ void PDFPluginBase::destroyScrollbar(ScrollbarOrientation orientation)
     willRemoveScrollbar(scrollbar.get(), orientation);
     scrollbar->removeFromParent();
     scrollbar = nullptr;
+}
+
+void PDFPluginBase::print()
+{
+    if (RefPtr page = this->page())
+        page->chrome().print(*m_frame->coreLocalFrame());
 }
 
 #if ENABLE(PDF_HUD)

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginScriptEvaluator.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginScriptEvaluator.mm
@@ -1,0 +1,217 @@
+/*
+ * Copyright (C) 2009-2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "PDFScriptEvaluator.h"
+
+#if ENABLE(PDF_PLUGIN)
+
+#import <JavaScriptCore/JSContextRef.h>
+#import <JavaScriptCore/JSObjectRef.h>
+#import <JavaScriptCore/OpaqueJSString.h>
+
+namespace WebKit {
+
+static void appendValuesInPDFNameSubtreeToVector(RetainPtr<CGPDFDictionaryRef> subtree, Vector<RetainPtr<CGPDFObjectRef>>& values)
+{
+    CGPDFArrayRef names = nullptr;
+    if (CGPDFDictionaryGetArray(subtree.get(), "Names", &names)) {
+        size_t nameCount = CGPDFArrayGetCount(names) / 2;
+        for (size_t i = 0; i < nameCount; ++i) {
+            CGPDFObjectRef object = nullptr;
+            CGPDFArrayGetObject(names, 2 * i + 1, &object);
+            values.append(object);
+        }
+        return;
+    }
+
+    CGPDFArrayRef kids = nullptr;
+    if (!CGPDFDictionaryGetArray(subtree.get(), "Kids", &kids))
+        return;
+
+    size_t kidCount = CGPDFArrayGetCount(kids);
+    for (size_t i = 0; i < kidCount; ++i) {
+        CGPDFDictionaryRef kid = nullptr;
+        if (!CGPDFArrayGetDictionary(kids, i, &kid))
+            continue;
+        appendValuesInPDFNameSubtreeToVector(kid, values);
+    }
+}
+
+static void getAllScriptsInPDFDocument(RetainPtr<CGPDFDocumentRef> pdfDocument, Vector<RetainPtr<CFStringRef>>& scripts)
+{
+    if (!pdfDocument)
+        return;
+
+    CGPDFDictionaryRef pdfCatalog = CGPDFDocumentGetCatalog(pdfDocument.get());
+    if (!pdfCatalog)
+        return;
+
+    // Get the dictionary of all document-level name trees.
+    CGPDFDictionaryRef namesDictionary = nullptr;
+    if (!CGPDFDictionaryGetDictionary(pdfCatalog, "Names", &namesDictionary))
+        return;
+
+    // Get the document-level "JavaScript" name tree.
+    CGPDFDictionaryRef javaScriptNameTree = nullptr;
+    if (!CGPDFDictionaryGetDictionary(namesDictionary, "JavaScript", &javaScriptNameTree))
+        return;
+
+    // The names are arbitrary. We are only interested in the values.
+    Vector<RetainPtr<CGPDFObjectRef>> objects;
+    appendValuesInPDFNameSubtreeToVector(javaScriptNameTree, objects);
+
+    for (auto object : objects) {
+        CGPDFDictionaryRef javaScriptAction = nullptr;
+        if (!CGPDFObjectGetValue(object.get(), kCGPDFObjectTypeDictionary, &javaScriptAction))
+            continue;
+
+        // A JavaScript action must have an action type of "JavaScript".
+        const char* actionType = nullptr;
+        if (!CGPDFDictionaryGetName(javaScriptAction, "S", &actionType) || strcmp(actionType, "JavaScript"))
+            continue;
+
+        auto scriptFromBytes = [](const UInt8* bytes, CFIndex length) {
+            CFStringEncoding encoding = (length > 1 && bytes[0] == 0xFE && bytes[1] == 0xFF) ? kCFStringEncodingUnicode : kCFStringEncodingUTF8;
+            return adoptCF(CFStringCreateWithBytes(kCFAllocatorDefault, bytes, length, encoding, true));
+        };
+
+        auto scriptFromStream = [&]() -> RetainPtr<CFStringRef> {
+            CGPDFStreamRef stream = nullptr;
+            if (!CGPDFDictionaryGetStream(javaScriptAction, "JS", &stream))
+                return nullptr;
+            CGPDFDataFormat format;
+            RetainPtr<CFDataRef> data = adoptCF(CGPDFStreamCopyData(stream, &format));
+            if (!data)
+                return nullptr;
+            return scriptFromBytes(CFDataGetBytePtr(data.get()), CFDataGetLength(data.get()));
+        };
+
+        auto scriptFromString = [&]() -> RetainPtr<CFStringRef> {
+            CGPDFStringRef string = nullptr;
+            if (!CGPDFDictionaryGetString(javaScriptAction, "JS", &string))
+                return nullptr;
+            return scriptFromBytes(CGPDFStringGetBytePtr(string), CGPDFStringGetLength(string));
+        };
+
+        RetainPtr<CFStringRef> script = scriptFromStream() ?: scriptFromString();
+        if (!script)
+            continue;
+
+        scripts.append(script);
+    }
+}
+
+static void jsPDFDocInitialize(JSContextRef ctx, JSObjectRef object)
+{
+    PDFScriptEvaluator* evaluator = static_cast<PDFScriptEvaluator*>(JSObjectGetPrivate(object));
+    evaluator->ref();
+}
+
+static void jsPDFDocFinalize(JSObjectRef object)
+{
+    PDFScriptEvaluator* evaluator = static_cast<PDFScriptEvaluator*>(JSObjectGetPrivate(object));
+    evaluator->deref();
+}
+
+JSClassRef PDFScriptEvaluator::jsPDFDocClass()
+{
+    static const JSStaticFunction jsPDFDocStaticFunctions[] = {
+        { "print", jsPDFDocPrint, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
+        { 0, 0, 0 },
+    };
+
+    static const JSClassDefinition jsPDFDocClassDefinition = {
+        0,
+        kJSClassAttributeNone,
+        "Doc",
+        0,
+        0,
+        jsPDFDocStaticFunctions,
+        jsPDFDocInitialize, jsPDFDocFinalize, 0, 0, 0, 0, 0, 0, 0, 0, 0
+    };
+
+    static JSClassRef jsPDFDocClass = JSClassCreate(&jsPDFDocClassDefinition);
+    return jsPDFDocClass;
+}
+
+JSValueRef PDFScriptEvaluator::jsPDFDocPrint(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
+{
+    if (!JSValueIsObjectOfClass(ctx, thisObject, jsPDFDocClass()))
+        return JSValueMakeUndefined(ctx);
+
+    RefPtr evaluator = static_cast<PDFScriptEvaluator*>(JSObjectGetPrivate(thisObject));
+    evaluator->print();
+
+    return JSValueMakeUndefined(ctx);
+}
+
+void PDFScriptEvaluator::runScripts(CGPDFDocumentRef document, Client& client)
+{
+    ASSERT(isMainRunLoop());
+
+    Ref evaluator = PDFScriptEvaluator::create(document, client);
+
+    auto completionHandler = [evaluator = WTFMove(evaluator)] (Vector<RetainPtr<CFStringRef>>&& scripts) mutable {
+        if (scripts.isEmpty())
+            return;
+
+        JSGlobalContextRef ctx = JSGlobalContextCreate(nullptr);
+        JSObjectRef jsPDFDoc = JSObjectMake(ctx, jsPDFDocClass(), evaluator.ptr());
+        for (auto& script : scripts)
+            JSEvaluateScript(ctx, OpaqueJSString::tryCreate(script.get()).get(), jsPDFDoc, nullptr, 1, nullptr);
+        JSGlobalContextRelease(ctx);
+    };
+
+#if HAVE(INCREMENTAL_PDF_APIS)
+    auto scriptUtilityQueue = WorkQueue::create("PDF script utility");
+    auto& rawQueue = scriptUtilityQueue.get();
+    rawQueue.dispatch([scriptUtilityQueue = WTFMove(scriptUtilityQueue), completionHandler = WTFMove(completionHandler), document = WTFMove(document)] () mutable {
+        ASSERT(!isMainRunLoop());
+
+        Vector<RetainPtr<CFStringRef>> scripts;
+        getAllScriptsInPDFDocument(document, scripts);
+
+        callOnMainRunLoop([completionHandler = WTFMove(completionHandler), scripts = WTFMove(scripts)] () mutable {
+            completionHandler(WTFMove(scripts));
+        });
+    });
+#else
+    Vector<RetainPtr<CFStringRef>> scripts;
+    getAllScriptsInPDFDocument(document, scripts);
+    completionHandler(WTFMove(scripts));
+#endif
+}
+
+void PDFScriptEvaluator::print()
+{
+    if (!m_client)
+        return;
+    m_client->print();
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(PDF_PLUGIN)

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFScriptEvaluator.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFScriptEvaluator.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2011-2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(PDF_PLUGIN)
+
+#include <wtf/Noncopyable.h>
+#include <wtf/RefCounted.h>
+#include <wtf/WeakPtr.h>
+
+typedef const struct OpaqueJSContext* JSContextRef;
+typedef struct OpaqueJSValue* JSObjectRef;
+typedef const struct OpaqueJSValue* JSValueRef;
+typedef struct OpaqueJSClass* JSClassRef;
+
+namespace WebKit {
+
+class PDFScriptEvaluator : public RefCounted<PDFScriptEvaluator> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_NONCOPYABLE(PDFScriptEvaluator);
+public:
+    class Client : public CanMakeWeakPtr<Client> {
+    public:
+        virtual ~Client() = default;
+
+        virtual void print() = 0;
+    };
+
+    static void runScripts(CGPDFDocumentRef, Client&);
+
+private:
+    PDFScriptEvaluator() = delete;
+    PDFScriptEvaluator(CGPDFDocumentRef pdfDocument, Client& client)
+        : m_pdfDocument(pdfDocument)
+        , m_client(client)
+    {
+    }
+
+    static Ref<PDFScriptEvaluator> create(CGPDFDocumentRef pdfDocument, Client& client)
+    {
+        return adoptRef(*new PDFScriptEvaluator(pdfDocument, client));
+    }
+
+    static JSClassRef jsPDFDocClass();
+    static JSValueRef jsPDFDocPrint(JSContextRef, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception);
+
+    void print();
+
+    RetainPtr<CGPDFDocumentRef> m_pdfDocument;
+    WeakPtr<Client> m_client;
+};
+
+}
+
+#endif // ENABLE(PDF_PLUGIN)

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFScriptEvaluator.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFScriptEvaluator.mm
@@ -1,0 +1,217 @@
+/*
+ * Copyright (C) 2009-2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "PDFScriptEvaluator.h"
+
+#if ENABLE(PDF_PLUGIN)
+
+#import <JavaScriptCore/JSContextRef.h>
+#import <JavaScriptCore/JSObjectRef.h>
+#import <JavaScriptCore/OpaqueJSString.h>
+
+namespace WebKit {
+
+static void appendValuesInPDFNameSubtreeToVector(RetainPtr<CGPDFDictionaryRef> subtree, Vector<RetainPtr<CGPDFObjectRef>>& values)
+{
+    CGPDFArrayRef names = nullptr;
+    if (CGPDFDictionaryGetArray(subtree.get(), "Names", &names)) {
+        size_t nameCount = CGPDFArrayGetCount(names) / 2;
+        for (size_t i = 0; i < nameCount; ++i) {
+            CGPDFObjectRef object = nullptr;
+            CGPDFArrayGetObject(names, 2 * i + 1, &object);
+            values.append(object);
+        }
+        return;
+    }
+
+    CGPDFArrayRef kids = nullptr;
+    if (!CGPDFDictionaryGetArray(subtree.get(), "Kids", &kids))
+        return;
+
+    size_t kidCount = CGPDFArrayGetCount(kids);
+    for (size_t i = 0; i < kidCount; ++i) {
+        CGPDFDictionaryRef kid = nullptr;
+        if (!CGPDFArrayGetDictionary(kids, i, &kid))
+            continue;
+        appendValuesInPDFNameSubtreeToVector(kid, values);
+    }
+}
+
+static void getAllScriptsInPDFDocument(RetainPtr<CGPDFDocumentRef> pdfDocument, Vector<RetainPtr<CFStringRef>>& scripts)
+{
+    if (!pdfDocument)
+        return;
+
+    CGPDFDictionaryRef pdfCatalog = CGPDFDocumentGetCatalog(pdfDocument.get());
+    if (!pdfCatalog)
+        return;
+
+    // Get the dictionary of all document-level name trees.
+    CGPDFDictionaryRef namesDictionary = nullptr;
+    if (!CGPDFDictionaryGetDictionary(pdfCatalog, "Names", &namesDictionary))
+        return;
+
+    // Get the document-level "JavaScript" name tree.
+    CGPDFDictionaryRef javaScriptNameTree = nullptr;
+    if (!CGPDFDictionaryGetDictionary(namesDictionary, "JavaScript", &javaScriptNameTree))
+        return;
+
+    // The names are arbitrary. We are only interested in the values.
+    Vector<RetainPtr<CGPDFObjectRef>> objects;
+    appendValuesInPDFNameSubtreeToVector(javaScriptNameTree, objects);
+
+    for (auto object : objects) {
+        CGPDFDictionaryRef javaScriptAction = nullptr;
+        if (!CGPDFObjectGetValue(object.get(), kCGPDFObjectTypeDictionary, &javaScriptAction))
+            continue;
+
+        // A JavaScript action must have an action type of "JavaScript".
+        const char* actionType = nullptr;
+        if (!CGPDFDictionaryGetName(javaScriptAction, "S", &actionType) || strcmp(actionType, "JavaScript"))
+            continue;
+
+        auto scriptFromBytes = [](const UInt8* bytes, CFIndex length) {
+            CFStringEncoding encoding = (length > 1 && bytes[0] == 0xFE && bytes[1] == 0xFF) ? kCFStringEncodingUnicode : kCFStringEncodingUTF8;
+            return adoptCF(CFStringCreateWithBytes(kCFAllocatorDefault, bytes, length, encoding, true));
+        };
+
+        auto scriptFromStream = [&]() -> RetainPtr<CFStringRef> {
+            CGPDFStreamRef stream = nullptr;
+            if (!CGPDFDictionaryGetStream(javaScriptAction, "JS", &stream))
+                return nullptr;
+            CGPDFDataFormat format;
+            RetainPtr<CFDataRef> data = adoptCF(CGPDFStreamCopyData(stream, &format));
+            if (!data)
+                return nullptr;
+            return scriptFromBytes(CFDataGetBytePtr(data.get()), CFDataGetLength(data.get()));
+        };
+
+        auto scriptFromString = [&]() -> RetainPtr<CFStringRef> {
+            CGPDFStringRef string = nullptr;
+            if (!CGPDFDictionaryGetString(javaScriptAction, "JS", &string))
+                return nullptr;
+            return scriptFromBytes(CGPDFStringGetBytePtr(string), CGPDFStringGetLength(string));
+        };
+
+        RetainPtr<CFStringRef> script = scriptFromStream() ?: scriptFromString();
+        if (!script)
+            continue;
+
+        scripts.append(script);
+    }
+}
+
+static void jsPDFDocInitialize(JSContextRef ctx, JSObjectRef object)
+{
+    PDFScriptEvaluator* evaluator = static_cast<PDFScriptEvaluator*>(JSObjectGetPrivate(object));
+    evaluator->ref();
+}
+
+static void jsPDFDocFinalize(JSObjectRef object)
+{
+    PDFScriptEvaluator* evaluator = static_cast<PDFScriptEvaluator*>(JSObjectGetPrivate(object));
+    evaluator->deref();
+}
+
+JSClassRef PDFScriptEvaluator::jsPDFDocClass()
+{
+    static const JSStaticFunction jsPDFDocStaticFunctions[] = {
+        { "print", jsPDFDocPrint, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
+        { 0, 0, 0 },
+    };
+
+    static const JSClassDefinition jsPDFDocClassDefinition = {
+        0,
+        kJSClassAttributeNone,
+        "Doc",
+        0,
+        0,
+        jsPDFDocStaticFunctions,
+        jsPDFDocInitialize, jsPDFDocFinalize, 0, 0, 0, 0, 0, 0, 0, 0, 0
+    };
+
+    static JSClassRef jsPDFDocClass = JSClassCreate(&jsPDFDocClassDefinition);
+    return jsPDFDocClass;
+}
+
+JSValueRef PDFScriptEvaluator::jsPDFDocPrint(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
+{
+    if (!JSValueIsObjectOfClass(ctx, thisObject, jsPDFDocClass()))
+        return JSValueMakeUndefined(ctx);
+
+    RefPtr evaluator = static_cast<PDFScriptEvaluator*>(JSObjectGetPrivate(thisObject));
+    evaluator->print();
+
+    return JSValueMakeUndefined(ctx);
+}
+
+void PDFScriptEvaluator::runScripts(CGPDFDocumentRef document, Client& client)
+{
+    ASSERT(isMainRunLoop());
+
+    Ref evaluator = PDFScriptEvaluator::create(document, client);
+
+    auto completionHandler = [evaluator = WTFMove(evaluator)] (Vector<RetainPtr<CFStringRef>>&& scripts) mutable {
+        if (scripts.isEmpty())
+            return;
+
+        JSGlobalContextRef ctx = JSGlobalContextCreate(nullptr);
+        JSObjectRef jsPDFDoc = JSObjectMake(ctx, jsPDFDocClass(), evaluator.ptr());
+        for (auto& script : scripts)
+            JSEvaluateScript(ctx, OpaqueJSString::tryCreate(script.get()).get(), jsPDFDoc, nullptr, 1, nullptr);
+        JSGlobalContextRelease(ctx);
+    };
+
+#if HAVE(INCREMENTAL_PDF_APIS)
+    auto scriptUtilityQueue = WorkQueue::create("PDF script utility");
+    auto& rawQueue = scriptUtilityQueue.get();
+    rawQueue.dispatch([scriptUtilityQueue = WTFMove(scriptUtilityQueue), completionHandler = WTFMove(completionHandler), document = WTFMove(document)] () mutable {
+        ASSERT(!isMainRunLoop());
+
+        Vector<RetainPtr<CFStringRef>> scripts;
+        getAllScriptsInPDFDocument(document, scripts);
+
+        callOnMainRunLoop([completionHandler = WTFMove(completionHandler), scripts = WTFMove(scripts)] () mutable {
+            completionHandler(WTFMove(scripts));
+        });
+    });
+#else
+    Vector<RetainPtr<CFStringRef>> scripts;
+    getAllScriptsInPDFDocument(document, scripts);
+    completionHandler(WTFMove(scripts));
+#endif
+}
+
+void PDFScriptEvaluator::print()
+{
+    if (!m_client)
+        return;
+    m_client->print();
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(PDF_PLUGIN)

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteHost.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteHost.mm
@@ -26,9 +26,11 @@
 #import "config.h"
 #import "PlatformCALayerRemoteHost.h"
 
+#import "RemoteLayerTreeContext.h"
+
 namespace WebKit {
 
-Ref<PlatformCALayerRemote> PlatformCALayerRemoteHost::create(WebCore::LayerHostingContextIdentifier identifier, PlatformCALayerClient* owner, RemoteLayerTreeContext& context)
+Ref<PlatformCALayerRemote> PlatformCALayerRemoteHost::create(WebCore::LayerHostingContextIdentifier identifier, WebCore::PlatformCALayerClient* owner, RemoteLayerTreeContext& context)
 {
     auto layer = adoptRef(*new PlatformCALayerRemoteHost(identifier, owner, context));
     context.layerDidEnterContext(layer.get(), layer->layerType());

--- a/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
+++ b/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
@@ -737,6 +737,12 @@ static BOOL areEssentiallyEqual(double a, double b)
     return WKDragDestinationActionAny;
 }
 
+- (void)_webView:(WKWebView *)webView printFrame:(_WKFrameHandle *)frame pdfFirstPageSize:(CGSize)size completionHandler:(void (^)(void))completionHandler
+{
+    [[_webView printOperationWithPrintInfo:[NSPrintInfo sharedPrintInfo]] runOperationModalForWindow:self.window delegate:nil didRunSelector:nil contextInfo:nil];
+    completionHandler();
+}
+
 - (void)updateTextFieldFromURL:(NSURL *)URL
 {
     if (!URL)


### PR DESCRIPTION
#### 0474d6003056297ae8a98eff1172eae36be468c7
<pre>
Factor PDF JS evaluation out of PDFPlugin
<a href="https://bugs.webkit.org/show_bug.cgi?id=267091">https://bugs.webkit.org/show_bug.cgi?id=267091</a>
<a href="https://rdar.apple.com/118550726">rdar://118550726</a>

Reviewed by Simon Fraser.

Separate PDF JS evaluation code (for auto-printing) out of PDFPlugin.

By virtue of doing this, also enable it in UnifiedPDFPlugin.

And add a test! And make window.print work in MiniBrowser!

* LayoutTests/compositing/plugins/pdf/pdf-plugin-printing-expected.txt: Added.
* LayoutTests/compositing/plugins/pdf/pdf-plugin-printing.html: Added.
* LayoutTests/resources/auto-print.pdf: Added.
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(WebKit::appendValuesInPDFNameSubtreeToVector): Deleted.
(WebKit::getAllValuesInPDFNameTree): Deleted.
(WebKit::getAllScriptsInPDFDocument): Deleted.
(WebKit::jsPDFDocInitialize): Deleted.
(WebKit::jsPDFDocFinalize): Deleted.
(WebKit::PDFPlugin::jsPDFDocClass): Deleted.
(WebKit::PDFPlugin::jsPDFDocPrint): Deleted.
(WebKit::PDFPlugin::makeJSPDFDoc): Deleted.
(WebKit::PDFPlugin::tryRunScriptsInPDFDocument): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
(WebKit::PDFPluginBase::tryRunScriptsInPDFDocument): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::tryRunScriptsInPDFDocument):
(WebKit::PDFPluginBase::print):
Avoid double-running PDF scripts with a &quot;did run&quot; bit (this appears to be broken in shipping Safari).

* Source/WebKit/WebProcess/Plugins/PDF/PDFScriptEvaluator.h: Added.
(WebKit::PDFScriptEvaluator::PDFScriptEvaluator):
(WebKit::PDFScriptEvaluator::create):
* Source/WebKit/WebProcess/Plugins/PDF/PDFScriptEvaluator.mm: Added.
(WebKit::appendValuesInPDFNameSubtreeToVector):
(WebKit::getAllValuesInPDFNameTree):
(WebKit::getAllScriptsInPDFDocument):
(WebKit::jsPDFDocInitialize):
(WebKit::jsPDFDocFinalize):
(WebKit::PDFScriptEvaluator::jsPDFDocClass):
(WebKit::PDFScriptEvaluator::jsPDFDocPrint):
(WebKit::PDFScriptEvaluator::runScripts):
(WebKit::PDFScriptEvaluator::print):
Factor this code out of PDFPlugin.

* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteHost.mm:
(WebKit::PlatformCALayerRemoteHost::create):
Unified sources fixes.

* Tools/MiniBrowser/mac/WK2BrowserWindowController.m:
(-[WK2BrowserWindowController _webView:printFrame:pdfFirstPageSize:completionHandler:]):
Hook up the printing UI delegate in MiniBrowser.

Canonical link: <a href="https://commits.webkit.org/272706@main">https://commits.webkit.org/272706@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d29e3f4fdc18a6a120dc7f7351614dd38f66852

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32781 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11532 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34641 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/35397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/29614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33708 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13876 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8717 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/35397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33224 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9725 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/29274 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/35397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8607 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29226 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36697 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29782 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29632 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34724 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/8728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6694 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32590 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10413 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/28900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7613 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9338 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9343 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->