### PR TITLE
Avoid duplicate null check in ReplaceSelectionCommand::pastLastLeaf()

### DIFF
--- a/Source/WebCore/editing/ReplaceSelectionCommand.h
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2005, 2006, 2008 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2014 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -84,7 +85,7 @@ private:
         Node* pastLastLeaf() const
         {
             ASSERT(m_lastNodeInserted);
-            return NodeTraversal::next(*lastLeafInserted());
+            return NodeTraversal::next(*m_lastNodeInserted->lastDescendant());
         }
 
     private:


### PR DESCRIPTION
#### eed5354f0af639be61de79c2c1f00a8a1af496b1
<pre>
Avoid duplicate null check in ReplaceSelectionCommand::pastLastLeaf()

<a href="https://bugs.webkit.org/show_bug.cgi?id=267067">https://bugs.webkit.org/show_bug.cgi?id=267067</a>

Reviewed by Ryosuke Niwa.

Merge: <a href="https://chromium.googlesource.com/chromium/blink/+/4c63691bebc58be7ff827759a489286b71e6d314">https://chromium.googlesource.com/chromium/blink/+/4c63691bebc58be7ff827759a489286b71e6d314</a>

Avoid duplicate null check in ReplaceSelectionCommand::pastLastLeaf() by
calling m_lastNodeInserted-&gt;lastDescendant() directly instead of
lastLeafInserted(). This also makes it clearer by we are checking that
m_lastNodeInserted is not null as it is now explicitly use right after.
This avoid avoids dereferencing a pointer as we now get a reference
directly.

* Source/WebCore/editing/ReplaceSelectionCommand.h:
(pastLastLeaf):

Canonical link: <a href="https://commits.webkit.org/272659@main">https://commits.webkit.org/272659@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78cd5a326f1d3e6148312fb90a6fb4ebd100b65c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32573 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11322 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34422 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35140 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29445 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33440 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13671 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8516 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28971 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33008 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9542 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29108 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8323 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8452 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29051 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36476 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29605 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29472 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34578 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8583 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6534 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32438 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10258 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7578 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9194 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9176 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->