### PR TITLE
Unreviewed, fix the iOS build with some versions of the internal SDK

### DIFF
--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
@@ -166,8 +166,10 @@ static NSString *overrideBundleIdentifier(id, SEL)
 - (void)defineSelection
 {
 #if HAVE(UI_ASYNC_TEXT_INTERACTION)
-    if (self.hasAsyncTextInput)
-        return [self define:nil];
+    if (self.hasAsyncTextInput) {
+        [self define:nil];
+        return;
+    }
 #endif
     [self _lookup:nil];
 }
@@ -175,8 +177,10 @@ static NSString *overrideBundleIdentifier(id, SEL)
 - (void)shareSelection
 {
 #if HAVE(UI_ASYNC_TEXT_INTERACTION)
-    if (self.hasAsyncTextInput)
-        return [self share:nil];
+    if (self.hasAsyncTextInput) {
+        [self share:nil];
+        return;
+    }
 #endif
     [self _share:nil];
 }
@@ -202,8 +206,10 @@ static NSString *overrideBundleIdentifier(id, SEL)
 - (void)moveSelectionToStartOfParagraph
 {
 #if HAVE(UI_ASYNC_TEXT_INTERACTION)
-    if (id<WKSETextInput> asyncTextInput = self.asyncTextInput)
-        return [asyncTextInput moveInDirection:UITextStorageDirectionBackward byGranularity:UITextGranularityParagraph];
+    if (id<WKSETextInput> asyncTextInput = self.asyncTextInput) {
+        [asyncTextInput moveInDirection:UITextStorageDirectionBackward byGranularity:UITextGranularityParagraph];
+        return;
+    }
 #endif
     [self.textInputContentView _moveToStartOfParagraph:NO withHistory:nil];
 }
@@ -211,8 +217,10 @@ static NSString *overrideBundleIdentifier(id, SEL)
 - (void)extendSelectionToStartOfParagraph
 {
 #if HAVE(UI_ASYNC_TEXT_INTERACTION)
-    if (id<WKSETextInput> asyncTextInput = self.asyncTextInput)
-        return [asyncTextInput extendInDirection:UITextStorageDirectionBackward byGranularity:UITextGranularityParagraph];
+    if (id<WKSETextInput> asyncTextInput = self.asyncTextInput) {
+        [asyncTextInput extendInDirection:UITextStorageDirectionBackward byGranularity:UITextGranularityParagraph];
+        return;
+    }
 #endif
     [self.textInputContentView _moveToStartOfParagraph:YES withHistory:nil];
 }
@@ -220,8 +228,10 @@ static NSString *overrideBundleIdentifier(id, SEL)
 - (void)moveSelectionToEndOfParagraph
 {
 #if HAVE(UI_ASYNC_TEXT_INTERACTION)
-    if (id<WKSETextInput> asyncTextInput = self.asyncTextInput)
-        return [asyncTextInput moveInDirection:UITextStorageDirectionForward byGranularity:UITextGranularityParagraph];
+    if (id<WKSETextInput> asyncTextInput = self.asyncTextInput) {
+        [asyncTextInput moveInDirection:UITextStorageDirectionForward byGranularity:UITextGranularityParagraph];
+        return;
+    }
 #endif
     [self.textInputContentView _moveToEndOfParagraph:NO withHistory:nil];
 }
@@ -229,8 +239,10 @@ static NSString *overrideBundleIdentifier(id, SEL)
 - (void)extendSelectionToEndOfParagraph
 {
 #if HAVE(UI_ASYNC_TEXT_INTERACTION)
-    if (id<WKSETextInput> asyncTextInput = self.asyncTextInput)
-        return [asyncTextInput extendInDirection:UITextStorageDirectionForward byGranularity:UITextGranularityParagraph];
+    if (id<WKSETextInput> asyncTextInput = self.asyncTextInput) {
+        [asyncTextInput extendInDirection:UITextStorageDirectionForward byGranularity:UITextGranularityParagraph];
+        return;
+    }
 #endif
     [self.textInputContentView _moveToEndOfParagraph:YES withHistory:nil];
 }


### PR DESCRIPTION
#### 6f1c962a62eb99f5e30dd2c7e214ec5db632a460
<pre>
Unreviewed, fix the iOS build with some versions of the internal SDK

Remove some `void` early returns, and instead put the `return` on a separate line.

* Tools/TestWebKitAPI/cocoa/TestWKWebView.mm:
(-[WKWebView defineSelection]):
(-[WKWebView shareSelection]):
(-[WKWebView moveSelectionToStartOfParagraph]):
(-[WKWebView extendSelectionToStartOfParagraph]):
(-[WKWebView moveSelectionToEndOfParagraph]):
(-[WKWebView extendSelectionToEndOfParagraph]):

Canonical link: <a href="https://commits.webkit.org/272654@main">https://commits.webkit.org/272654@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb13f6e0deda3fd8f96d703155b24e3d3a74a314

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32576 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11325 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34425 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35143 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29448 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33443 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13674 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8519 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/28969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33011 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9543 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29110 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8321 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8453 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29054 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36479 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29606 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/29474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/34576 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8586 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/6536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/32437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10261 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9197 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4200 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9179 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->