### PR TITLE
[WebGPU] webgpu:api,operation,resource_init,* does not pass

### DIFF
--- a/LayoutTests/http/tests/webgpu/webgpu/api/operation/resource_init/buffer-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/operation/resource_init/buffer-expected.txt
@@ -1,1 +1,25 @@
-(Populate me when we're ready to investigate this test)
+
+PASS :partial_write_buffer:
+PASS :map_whole_buffer:mapMode=1
+PASS :map_whole_buffer:mapMode=2
+PASS :map_partial_buffer:mapMode=1
+PASS :map_partial_buffer:mapMode=2
+PASS :mapped_at_creation_whole_buffer:bufferUsage=9
+PASS :mapped_at_creation_whole_buffer:bufferUsage=6
+PASS :mapped_at_creation_whole_buffer:bufferUsage=4
+PASS :mapped_at_creation_partial_buffer:bufferUsage=9
+PASS :mapped_at_creation_partial_buffer:bufferUsage=6
+PASS :mapped_at_creation_partial_buffer:bufferUsage=4
+PASS :copy_buffer_to_buffer_copy_source:
+PASS :copy_buffer_to_texture:
+PASS :resolve_query_set_to_partial_buffer:
+PASS :copy_texture_to_partial_buffer:
+PASS :uniform_buffer:
+PASS :readonly_storage_buffer:
+PASS :storage_buffer:
+PASS :vertex_buffer:
+PASS :index_buffer:
+PASS :indirect_buffer_for_draw_indirect:test_indexed_draw=true
+PASS :indirect_buffer_for_draw_indirect:test_indexed_draw=false
+PASS :indirect_buffer_for_dispatch_indirect:
+

--- a/Source/WebGPU/WebGPU/CommandEncoder.h
+++ b/Source/WebGPU/WebGPU/CommandEncoder.h
@@ -89,7 +89,7 @@ public:
     id<MTLBlitCommandEncoder> ensureBlitCommandEncoder();
     void finalizeBlitCommandEncoder();
 
-    void runClearEncoder(NSMutableDictionary<NSNumber*, TextureAndClearColor*> *attachmentsToClear, id<MTLTexture> depthStencilAttachmentToClear, bool depthAttachmentToClear, bool stencilAttachmentToClear, float depthClearValue = 0, uint32_t stencilClearValue = 0);
+    void runClearEncoder(NSMutableDictionary<NSNumber*, TextureAndClearColor*> *attachmentsToClear, id<MTLTexture> depthStencilAttachmentToClear, bool depthAttachmentToClear, bool stencilAttachmentToClear, float depthClearValue = 0, uint32_t stencilClearValue = 0, id<MTLRenderCommandEncoder> = nil);
     static void clearTexture(const WGPUImageCopyTexture&, NSUInteger, id<MTLDevice>, id<MTLBlitCommandEncoder>);
     void makeInvalid() { m_commandBuffer = nil; }
 


### PR DESCRIPTION
#### a33ef31297cfc2779c26322595583f7a722bccf7
<pre>
[WebGPU] webgpu:api,operation,resource_init,* does not pass
<a href="https://bugs.webkit.org/show_bug.cgi?id=264552">https://bugs.webkit.org/show_bug.cgi?id=264552</a>
&lt;radar://118217988&gt;

Reviewed by Tadeu Zagallo.

Correct how textures are cleared when attempting to load contents which
were not previously written, which gets all of resource_init,* passing.

* LayoutTests/http/tests/webgpu/webgpu/api/operation/resource_init/buffer-expected.txt:
Add passing expectations.

* Source/WebGPU/WebGPU/CommandEncoder.h:
* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::loadAction):
(WebGPU::storeAction):
(WebGPU::createSimplePso):
(WebGPU::CommandEncoder::runClearEncoder):
(WebGPU::CommandEncoder::beginRenderPass):
(WebGPU::CommandEncoder::finish):
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::endPass):

Canonical link: <a href="https://commits.webkit.org/272721@main">https://commits.webkit.org/272721@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14aa4f8df503e05bfb563c17280b34e6fa796903

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32591 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11344 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34444 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35162 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29461 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13692 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8535 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28977 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33030 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9560 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29122 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8339 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8470 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29067 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36498 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29623 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29488 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34593 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8597 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6550 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32603 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10275 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7619 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9209 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9194 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->