### PR TITLE
Deprecate _WKProcessPoolConfiguration.usesSingleWebProcess

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.h
@@ -35,7 +35,7 @@ WK_CLASS_AVAILABLE(macos(10.10), ios(8.0))
 @property (nonatomic, copy) NSURL *injectedBundleURL;
 @property (nonatomic, copy) NSSet<Class> *customClassesForParameterCoder WK_API_DEPRECATED("No longer supported", macos(10.15.4, 14.0), ios(13.4, 17.0));
 @property (nonatomic) NSUInteger maximumProcessCount WK_API_DEPRECATED("It is no longer possible to limit the number of processes", macos(10.0, 10.15), ios(1.0, 13.0));
-@property (nonatomic) BOOL usesSingleWebProcess WK_API_AVAILABLE(macos(10.15), ios(13.0));
+@property (nonatomic) BOOL usesSingleWebProcess WK_API_DEPRECATED("It is no longer possible to limit the number of processes", macos(10.15, WK_MAC_TBA), ios(13.0, WK_IOS_TBA));
 @property (nonatomic, nullable, copy) NSString *customWebContentServiceBundleIdentifier WK_API_DEPRECATED("No longer supported", macos(10.14.4, 14.0), ios(12.2, 17.0));
 
 @property (nonatomic) BOOL ignoreSynchronousMessagingTimeoutsForTesting WK_API_AVAILABLE(macos(10.12), ios(10.0));


### PR DESCRIPTION
#### 875b47cfa93d4f065a5edee77c540231ebea6cf1
<pre>
Deprecate _WKProcessPoolConfiguration.usesSingleWebProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=267105">https://bugs.webkit.org/show_bug.cgi?id=267105</a>
<a href="https://rdar.apple.com/120497660">rdar://120497660</a>

Reviewed by NOBODY (OOPS!).

usesSingleWebProcess should not be supported (for the same reasons that maximumProcessCount should not be supported)

* Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/875b47cfa93d4f065a5edee77c540231ebea6cf1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32617 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11370 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34470 "Hash 875b47cf for PR 22406 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35189 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29483 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13717 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8558 "Hash 875b47cf for PR 22406 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28986 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33056 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9582 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/34470 "Hash 875b47cf for PR 22406 does not build (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8357 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8491 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/34470 "Hash 875b47cf for PR 22406 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36525 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29644 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/34470 "Hash 875b47cf for PR 22406 does not build (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34612 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8613 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/51/builds/8558 "Hash 875b47cf for PR 22406 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32474 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10294 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/34470 "Hash 875b47cf for PR 22406 does not build (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9227 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9214 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->