### PR TITLE
REGRESSION (270199@main): [iOS] Viewport units are incorrect in Safari after entering and exiting fullscreen

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -1699,7 +1699,7 @@ inline OptionSet<WebKit::FindOptions> toFindOptions(WKFindConfiguration *configu
     }
 
 #if PLATFORM(IOS_FAMILY)
-    if (_viewLayoutSizeOverride || _minimumUnobscuredSizeOverride || _maximumUnobscuredSizeOverride)
+    if (_overriddenLayoutParameters)
         return;
 #endif
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -127,6 +127,12 @@ struct LiveResizeParameters {
     CGPoint initialScrollPosition;
 };
 
+struct OverriddenLayoutParameters {
+    CGSize viewLayoutSize { CGSizeZero };
+    CGSize minimumUnobscuredSize { CGSizeZero };
+    CGSize maximumUnobscuredSize { CGSizeZero };
+};
+
 // This holds state that should be reset when the web process exits.
 struct PerWebProcessState {
     CGFloat viewportMetaTagWidth { WebCore::ViewportArguments::ValueAuto };
@@ -239,9 +245,7 @@ struct PerWebProcessState {
     
     PerWebProcessState _perProcessState;
 
-    std::optional<CGSize> _viewLayoutSizeOverride;
-    std::optional<CGSize> _minimumUnobscuredSizeOverride;
-    std::optional<CGSize> _maximumUnobscuredSizeOverride;
+    std::optional<OverriddenLayoutParameters> _overriddenLayoutParameters;
     CGRect _inputViewBoundsInWindow;
 
     BOOL _fastClickingIsDisabled;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
@@ -201,9 +201,6 @@ enum class TapHandlingResult : uint8_t;
 
 @property (nonatomic, readonly) BOOL _haveSetUnobscuredSafeAreaInsets;
 @property (nonatomic, readonly) BOOL _hasOverriddenLayoutParameters;
-@property (nonatomic, readonly) std::optional<CGSize> _viewLayoutSizeOverride;
-@property (nonatomic, readonly) std::optional<CGSize> _minimumUnobscuredSizeOverride;
-@property (nonatomic, readonly) std::optional<CGSize> _maximumUnobscuredSizeOverride;
 - (void)_resetContentOffset;
 - (void)_resetUnobscuredSafeAreaInsets;
 - (void)_resetObscuredInsets;

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -162,9 +162,8 @@ struct WKWebViewState {
     BOOL _savedHaveSetUnobscuredSafeAreaInsets = NO;
     UIEdgeInsets _savedUnobscuredSafeAreaInsets = UIEdgeInsetsZero;
     BOOL _savedHasOverriddenLayoutParameters = NO;
-    std::optional<CGSize> _savedMinimumUnobscuredSizeOverride;
-    std::optional<CGSize> _savedMaximumUnobscuredSizeOverride;
-
+    CGSize _savedMinimumUnobscuredSizeOverride = CGSizeZero;
+    CGSize _savedMaximumUnobscuredSizeOverride = CGSizeZero;
 
     void applyTo(WKWebView* webView)
     {
@@ -197,8 +196,8 @@ struct WKWebViewState {
         else
             [webView _resetUnobscuredSafeAreaInsets];
 
-        if (_savedHasOverriddenLayoutParameters && _savedMinimumUnobscuredSizeOverride && _savedMaximumUnobscuredSizeOverride)
-            [webView _overrideLayoutParametersWithMinimumLayoutSize:*_savedMinimumUnobscuredSizeOverride minimumUnobscuredSizeOverride:*_savedMinimumUnobscuredSizeOverride maximumUnobscuredSizeOverride:*_savedMaximumUnobscuredSizeOverride];
+        if (_savedHasOverriddenLayoutParameters)
+            [webView _overrideLayoutParametersWithMinimumLayoutSize:_savedMinimumUnobscuredSizeOverride minimumUnobscuredSizeOverride:_savedMinimumUnobscuredSizeOverride maximumUnobscuredSizeOverride:_savedMaximumUnobscuredSizeOverride];
         else
             [webView _clearOverrideLayoutParameters];
 

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1118,6 +1118,7 @@
 		E51A740E2B0442180047FEB1 /* ColorInputTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = E51A740D2B0442180047FEB1 /* ColorInputTests.mm */; };
 		E520A36B25AFB76C00526CB9 /* WKWebViewTitlebarSeparatorTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = E520A36A25AFB76C00526CB9 /* WKWebViewTitlebarSeparatorTests.mm */; };
 		E540058827B3A8B20005653A /* contenteditable-user-select-user-drag.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = E540058727B3A8320005653A /* contenteditable-user-select-user-drag.html */; };
+		E55999F72B476C2F00A3719F /* FullscreenOverriddenLayoutParameters.mm in Sources */ = {isa = PBXBuildFile; fileRef = E55999F62B476C2F00A3719F /* FullscreenOverriddenLayoutParameters.mm */; };
 		E57B44C129ABFB3B006069DE /* qr-code.png in Copy Resources */ = {isa = PBXBuildFile; fileRef = E57B44C029ABFAA4006069DE /* qr-code.png */; };
 		E589183C252BC90A0041DED5 /* DateTimeInputsAccessoryViewTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = E589183B252BC90A0041DED5 /* DateTimeInputsAccessoryViewTests.mm */; };
 		E5AA42F2259128AE00410A3D /* UserInterfaceIdiomUpdate.mm in Sources */ = {isa = PBXBuildFile; fileRef = E5AA42F1259128AE00410A3D /* UserInterfaceIdiomUpdate.mm */; };
@@ -3435,6 +3436,7 @@
 		E51A740D2B0442180047FEB1 /* ColorInputTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ColorInputTests.mm; sourceTree = "<group>"; };
 		E520A36A25AFB76C00526CB9 /* WKWebViewTitlebarSeparatorTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebViewTitlebarSeparatorTests.mm; sourceTree = "<group>"; };
 		E540058727B3A8320005653A /* contenteditable-user-select-user-drag.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "contenteditable-user-select-user-drag.html"; sourceTree = "<group>"; };
+		E55999F62B476C2F00A3719F /* FullscreenOverriddenLayoutParameters.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = FullscreenOverriddenLayoutParameters.mm; sourceTree = "<group>"; };
 		E57B44C029ABFAA4006069DE /* qr-code.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "qr-code.png"; sourceTree = "<group>"; };
 		E589183B252BC90A0041DED5 /* DateTimeInputsAccessoryViewTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = DateTimeInputsAccessoryViewTests.mm; sourceTree = "<group>"; };
 		E5AA42F1259128AE00410A3D /* UserInterfaceIdiomUpdate.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = UserInterfaceIdiomUpdate.mm; sourceTree = "<group>"; };
@@ -4548,6 +4550,7 @@
 				A11E7DA224A17C7D00026745 /* ElementActionTests.mm */,
 				F4CF327F2366552200D3AD07 /* EnterKeyHintTests.mm */,
 				F4BC0B132146C849002A0478 /* FocusPreservationTests.mm */,
+				E55999F62B476C2F00A3719F /* FullscreenOverriddenLayoutParameters.mm */,
 				CDA93DAC22F4EC2200490A69 /* FullscreenTouchSecheuristicTests.cpp */,
 				F4636A992A0DA61800C88CC0 /* GestureRecognizerTests.mm */,
 				F45E15722112CE2900307E82 /* KeyboardInputTestsIOS.mm */,
@@ -6515,6 +6518,7 @@
 				7CCE7EF61A411AE600447C4C /* FrameMIMETypeHTML.cpp in Sources */,
 				7CCE7EF71A411AE600447C4C /* FrameMIMETypePNG.cpp in Sources */,
 				CDB213BD24EF522800FDE301 /* FullscreenFocus.mm in Sources */,
+				E55999F72B476C2F00A3719F /* FullscreenOverriddenLayoutParameters.mm in Sources */,
 				CDE77D2525A6591C00D4115E /* FullscreenPointerLeave.mm in Sources */,
 				CDBFCC451A9FF45300A7B691 /* FullscreenZoomInitialFrame.mm in Sources */,
 				83DB79691EF63B3C00BFA5E5 /* Function.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/ios/FullscreenOverriddenLayoutParameters.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/FullscreenOverriddenLayoutParameters.mm
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if PLATFORM(IOS_FAMILY)
+
+#import "InstanceMethodSwizzler.h"
+#import "PlatformUtilities.h"
+#import "Test.h"
+#import "TestWKWebView.h"
+#import "WKWebViewConfigurationExtras.h"
+#import <WebKit/WKWebViewPrivate.h>
+#import <WebKit/_WKFullscreenDelegate.h>
+#import <wtf/BlockPtr.h>
+#import <wtf/RunLoop.h>
+
+static void swizzledPresentViewController(UIViewController *, SEL, UIViewController *, BOOL, dispatch_block_t completion)
+{
+    RunLoop::main().dispatch([completion = makeBlockPtr(completion)] {
+        if (completion)
+            completion();
+    });
+}
+
+@interface FullscreenOverriddenLayoutParametersWebView : TestWKWebView
+@end
+
+@implementation FullscreenOverriddenLayoutParametersWebView {
+    std::unique_ptr<InstanceMethodSwizzler> _viewControllerPresentationSwizzler;
+    bool _doneEnteringFullscreen;
+    bool _doneExitingFullscreen;
+}
+
+- (instancetype)initWithFrame:(CGRect)frame configuration:(WKWebViewConfiguration *)configuration
+{
+    if (!(self = [super initWithFrame:frame configuration:configuration]))
+        return nil;
+
+    // Since TestWebKitAPIApp is not a real UIApplication, -presentViewController:animated:completion:
+    // never calls the completion handler and we never transition into WKFullscreenStateInFullscreen.
+    // Work around that fact by swizzling the method.
+    _viewControllerPresentationSwizzler = WTF::makeUnique<InstanceMethodSwizzler>(
+        UIViewController.class,
+        @selector(presentViewController:animated:completion:),
+        reinterpret_cast<IMP>(swizzledPresentViewController)
+    );
+
+    return self;
+}
+
+- (void)enterFullscreen
+{
+    _doneEnteringFullscreen = false;
+    [self evaluateJavaScript:@"enterFullscreen()" completionHandler:nil];
+    TestWebKitAPI::Util::run(&_doneEnteringFullscreen);
+    [self waitForNextPresentationUpdate];
+}
+
+- (void)exitFullscreen
+{
+    _doneExitingFullscreen = false;
+    [self evaluateJavaScript:@"exitFullscreen()" completionHandler:nil];
+    TestWebKitAPI::Util::run(&_doneExitingFullscreen);
+    [self waitForNextPresentationUpdate];
+}
+
+- (void)didChangeValueForKey:(NSString *)key
+{
+    [super didChangeValueForKey:key];
+
+    if (![key isEqualToString:@"fullscreenState"])
+        return;
+
+    auto state = self.fullscreenState;
+    switch (state) {
+    case WKFullscreenStateNotInFullscreen:
+        _doneExitingFullscreen = true;
+        break;
+    case WKFullscreenStateInFullscreen:
+        _doneEnteringFullscreen = true;
+        break;
+    default:
+        break;
+    }
+}
+
+@end
+
+namespace TestWebKitAPI {
+
+TEST(Fullscreen, OverriddenLayoutParameters)
+{
+    auto configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
+    configuration.preferences.elementFullscreenEnabled = YES;
+    auto webView = adoptNS([[FullscreenOverriddenLayoutParametersWebView alloc] initWithFrame:CGRectMake(0, 0, 390, 800) configuration:configuration]);
+    [webView synchronouslyLoadTestPageNamed:@"element-fullscreen"];
+
+    auto layoutSize = CGSizeMake(390, 745);
+    [webView _overrideLayoutParametersWithMinimumLayoutSize:layoutSize minimumUnobscuredSizeOverride:layoutSize maximumUnobscuredSizeOverride:layoutSize];
+
+    [webView enterFullscreen];
+    [webView exitFullscreen];
+
+    EXPECT_TRUE(CGSizeEqualToSize([webView _minimumUnobscuredSizeOverride], layoutSize));
+    EXPECT_TRUE(CGSizeEqualToSize([webView _maximumUnobscuredSizeOverride], layoutSize));
+}
+
+} // namespace TestWebKitAPI
+
+#endif // PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### 53929a96966c93804cd8749b573b538503e1665c
<pre>
REGRESSION (270199@main): [iOS] Viewport units are incorrect in Safari after entering and exiting fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=267102">https://bugs.webkit.org/show_bug.cgi?id=267102</a>
<a href="https://rdar.apple.com/120496571">rdar://120496571</a>

Reviewed by Jer Noble.

Following 270199@main, entering and exiting fullscreen results in the overridden
layout parameters (viewLayoutSize, minimumUnobscuredSize, and maximumUnobscuredSize)
getting set to garbage values. This breaks viewport units in Safari, which are
derived from those values.

The intention of 270199@main was to reset these values as if they were never set
while in fullscreen. That change implemented the following methods on `WKWebView`:

```
- (std::optional&lt;CGSize&gt;)_minimumUnobscuredSizeOverride;
- (std::optional&lt;CGSize&gt;)_maximumUnobscuredSizeOverride;
```

However, those methods were already implemented as SPI in another `WKWebView`
category, with different return types:

```
- (CGSize)_minimumUnobscuredSizeOverride;
- (CGSize)_maximumUnobscuredSizeOverride;
```

The end result of implementing the same method twice with different returns
types, is that `std::optional&lt;CGSize&gt;` is treated as `CGSize`, giving garbage
data when these values are attempted to be restored.

Fix by removing the duplicate methods, and refactoring the code to make the
nature of these optionals less confusing. Previously the ivars were optionals,
but the exposed values were CGSize. Now, they are grouped into a single optional
struct.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _recalculateViewportSizesWithMinimumViewportInset:maximumViewportInset:throwOnInvalidInput:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:

The key idea behind the refactoring is that `_viewLayoutSizeOverride`,
`_minimumUnobscuredSizeOverride`, and `_maximumUnobscuredSizeOverride` are all
either `std::nullopt` or none of them are `std::nullopt`. This allows for leaving
the underlying type as `CGSize`, with only a single optional struct wrapping
the overridden parameters.

Ultimately, the confusion between methods and ivars with the same name but
different underlying types, which existed before 270199@main, is removed.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _updateScrollViewForTransaction:]):
(-[WKWebView activeViewLayoutSize:]):
(-[WKWebView _frameOrBoundsMayHaveChanged]):
(activeMinimumUnobscuredSize):
(activeMaximumUnobscuredSize):
(-[WKWebView _didStopDeferringGeometryUpdates]):
(-[WKWebView _setAvoidsUnsafeArea:]):
(-[WKWebView _hasOverriddenLayoutParameters]):
(-[WKWebView _minimumLayoutSizeOverride]):
(-[WKWebView _minimumUnobscuredSizeOverride]):
(-[WKWebView _maximumUnobscuredSizeOverride]):
(-[WKWebView _beginAnimatedResizeWithUpdates:]):
(-[WKWebView _overrideLayoutParametersWithMinimumLayoutSize:minimumUnobscuredSizeOverride:maximumUnobscuredSizeOverride:]):
(-[WKWebView _clearOverrideLayoutParameters]):
(-[WKWebView _viewLayoutSizeOverride]): Deleted.
(-[WKWebView _setViewLayoutSizeOverride:]): Deleted.
(-[WKWebView _setMinimumUnobscuredSizeOverride:]): Deleted.
(-[WKWebView _setMaximumUnobscuredSizeOverride:]): Deleted.
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(WebKit::WKWebViewState::applyTo):

The saved values do not need to be optionals, since there is already a check for
`hasOverriddenLayoutParameters`.

* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/ios/FullscreenOverriddenLayoutParameters.mm: Added.
(swizzledPresentViewController):
(-[FullscreenOverriddenLayoutParametersWebView initWithFrame:configuration:]):
(-[FullscreenOverriddenLayoutParametersWebView enterFullscreen]):
(-[FullscreenOverriddenLayoutParametersWebView exitFullscreen]):
(-[FullscreenOverriddenLayoutParametersWebView didChangeValueForKey:]):
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/272679@main">https://commits.webkit.org/272679@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93f4b154aec3187d615f2eeb81e3186ce9c43d33

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32620 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11373 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34474 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35192 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29486 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33518 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13719 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8560 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28989 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33059 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9583 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29144 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8360 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8492 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29091 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36528 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29645 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29507 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34614 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8615 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6570 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32475 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10296 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7592 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9229 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9216 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->