### PR TITLE
Improve code coverage of sdp_integration_fuzzer

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/webrtc/test/fuzzers/sdp_integration_fuzzer.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/test/fuzzers/sdp_integration_fuzzer.cc
@@ -10,8 +10,14 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#ifdef WEBRTC_WEBKIT_BUILD
+#include <stdlib.h>
+#endif
 
 #include "absl/strings/string_view.h"
+#ifdef WEBRTC_WEBKIT_BUILD
+#include "api/jsep.h"
+#endif
 #include "pc/test/integration_test_helpers.h"
 
 namespace webrtc {
@@ -21,7 +27,11 @@ class FuzzerTest : public PeerConnectionIntegrationBaseTest {
   FuzzerTest()
       : PeerConnectionIntegrationBaseTest(SdpSemantics::kUnifiedPlan) {}
 
+#ifdef WEBRTC_WEBKIT_BUILD
+  void RunNegotiateCycle(SdpType sdpType, absl::string_view message) {
+#else
   void RunNegotiateCycle(absl::string_view message) {
+#endif
     CreatePeerConnectionWrappers();
     // Note - we do not do test.ConnectFakeSignaling(); all signals
     // generated are discarded.
@@ -29,9 +39,14 @@ class FuzzerTest : public PeerConnectionIntegrationBaseTest {
     auto srd_observer =
         rtc::make_ref_counted<FakeSetRemoteDescriptionObserver>();
 
+#ifdef WEBRTC_WEBKIT_BUILD
+    std::unique_ptr<SessionDescriptionInterface> sdp(
+        CreateSessionDescription(sdpType, std::string(message)));
+#else
     SdpParseError error;
     std::unique_ptr<SessionDescriptionInterface> sdp(
         CreateSessionDescription("offer", std::string(message), &error));
+#endif
     caller()->pc()->SetRemoteDescription(std::move(sdp), srd_observer);
     // Wait a short time for observer to be called. Timeout is short
     // because the fuzzer should be trying many branches.
@@ -56,13 +71,53 @@ class FuzzerTest : public PeerConnectionIntegrationBaseTest {
 };
 
 void FuzzOneInput(const uint8_t* data, size_t size) {
+#ifdef WEBRTC_WEBKIT_BUILD
+  uint8_t* newData = const_cast<uint8_t*>(data);
+  size_t newSize = size;
+  uint8_t type = 0;
+
+  if (const char* var = getenv("SDP_TYPE")) {
+    if (size > 16384) {
+      return;
+    }
+    type = atoi(var);
+  } else {
+    if (size < 1 || size > 16385) {
+      return;
+    }
+    type = data[0];
+    newSize = size - 1;
+    newData = reinterpret_cast<uint8_t*>(malloc(newSize));
+    if (!newData)
+      return;
+    memcpy(newData, &data[1], newSize);
+  }
+
+  SdpType sdpType = SdpType::kOffer;
+  switch (type % 4) {
+    case 0: sdpType = SdpType::kOffer; break;
+    case 1: sdpType = SdpType::kPrAnswer; break;
+    case 2: sdpType = SdpType::kAnswer; break;
+    case 3: sdpType = SdpType::kRollback; break;
+  }
+#else
   if (size > 16384) {
     return;
   }
+#endif
 
   FuzzerTest test;
+#ifdef WEBRTC_WEBKIT_BUILD
+  test.RunNegotiateCycle(
+      sdpType,
+      absl::string_view(reinterpret_cast<const char*>(newData), newSize));
+
+  if (newData != data)
+      free(newData);
+#else
   test.RunNegotiateCycle(
       absl::string_view(reinterpret_cast<const char*>(data), size));
+#endif
 }
 
 }  // namespace webrtc

--- a/Source/ThirdParty/libwebrtc/WebKit/sdp_integration_fuzzer-libwebrtc.diff
+++ b/Source/ThirdParty/libwebrtc/WebKit/sdp_integration_fuzzer-libwebrtc.diff
@@ -1,39 +1,50 @@
 diff --git a/Source/ThirdParty/libwebrtc/Source/webrtc/test/fuzzers/sdp_integration_fuzzer.cc b/Source/ThirdParty/libwebrtc/Source/webrtc/test/fuzzers/sdp_integration_fuzzer.cc
-index ece4b50505d8..f66ed04a792f 100644
+index e39e89f6c616..19c8be014b4f 100644
 --- a/Source/ThirdParty/libwebrtc/Source/webrtc/test/fuzzers/sdp_integration_fuzzer.cc
 +++ b/Source/ThirdParty/libwebrtc/Source/webrtc/test/fuzzers/sdp_integration_fuzzer.cc
-@@ -10,8 +10,10 @@
+@@ -10,8 +10,14 @@
  
  #include <stddef.h>
  #include <stdint.h>
++#ifdef WEBRTC_WEBKIT_BUILD
 +#include <stdlib.h>
++#endif
  
  #include "absl/strings/string_view.h"
++#ifdef WEBRTC_WEBKIT_BUILD
 +#include "api/jsep.h"
++#endif
  #include "pc/test/integration_test_helpers.h"
  
  namespace webrtc {
-@@ -21,7 +23,7 @@ class FuzzerTest : public PeerConnectionIntegrationBaseTest {
+@@ -21,7 +27,11 @@ class FuzzerTest : public PeerConnectionIntegrationBaseTest {
    FuzzerTest()
        : PeerConnectionIntegrationBaseTest(SdpSemantics::kUnifiedPlan) {}
  
--  void RunNegotiateCycle(absl::string_view message) {
++#ifdef WEBRTC_WEBKIT_BUILD
 +  void RunNegotiateCycle(SdpType sdpType, absl::string_view message) {
++#else
+   void RunNegotiateCycle(absl::string_view message) {
++#endif
      CreatePeerConnectionWrappers();
      // Note - we do not do test.ConnectFakeSignaling(); all signals
      // generated are discarded.
-@@ -29,9 +31,8 @@ class FuzzerTest : public PeerConnectionIntegrationBaseTest {
+@@ -29,9 +39,14 @@ class FuzzerTest : public PeerConnectionIntegrationBaseTest {
      auto srd_observer =
          rtc::make_ref_counted<FakeSetRemoteDescriptionObserver>();
  
--    SdpParseError error;
-     std::unique_ptr<SessionDescriptionInterface> sdp(
--        CreateSessionDescription("offer", std::string(message), &error));
++#ifdef WEBRTC_WEBKIT_BUILD
++    std::unique_ptr<SessionDescriptionInterface> sdp(
 +        CreateSessionDescription(sdpType, std::string(message)));
++#else
+     SdpParseError error;
+     std::unique_ptr<SessionDescriptionInterface> sdp(
+         CreateSessionDescription("offer", std::string(message), &error));
++#endif
      caller()->pc()->SetRemoteDescription(std::move(sdp), srd_observer);
      // Wait a short time for observer to be called. Timeout is short
      // because the fuzzer should be trying many branches.
-@@ -44,8 +45,10 @@ class FuzzerTest : public PeerConnectionIntegrationBaseTest {
+@@ -44,8 +57,10 @@ class FuzzerTest : public PeerConnectionIntegrationBaseTest {
        caller()->pc()->SetLocalDescription(sld_observer);
        EXPECT_TRUE_WAIT(sld_observer->called(), 100);
      }
@@ -44,12 +55,11 @@ index ece4b50505d8..f66ed04a792f 100644
    }
  
    // This test isn't using the test definition macros, so we have to
-@@ -54,13 +57,42 @@ class FuzzerTest : public PeerConnectionIntegrationBaseTest {
+@@ -56,13 +71,53 @@ class FuzzerTest : public PeerConnectionIntegrationBaseTest {
  };
  
  void FuzzOneInput(const uint8_t* data, size_t size) {
--  if (size > 16384) {
--    return;
++#ifdef WEBRTC_WEBKIT_BUILD
 +  uint8_t* newData = const_cast<uint8_t*>(data);
 +  size_t newSize = size;
 +  uint8_t type = 0;
@@ -77,16 +87,25 @@ index ece4b50505d8..f66ed04a792f 100644
 +    case 1: sdpType = SdpType::kPrAnswer; break;
 +    case 2: sdpType = SdpType::kAnswer; break;
 +    case 3: sdpType = SdpType::kRollback; break;
++  }
++#else
+   if (size > 16384) {
+     return;
    }
++#endif
  
    FuzzerTest test;
-   test.RunNegotiateCycle(
--      absl::string_view(reinterpret_cast<const char*>(data), size));
++#ifdef WEBRTC_WEBKIT_BUILD
++  test.RunNegotiateCycle(
 +      sdpType,
 +      absl::string_view(reinterpret_cast<const char*>(newData), newSize));
 +
 +  if (newData != data)
 +      free(newData);
++#else
+   test.RunNegotiateCycle(
+       absl::string_view(reinterpret_cast<const char*>(data), size));
++#endif
  }
  
  }  // namespace webrtc


### PR DESCRIPTION
#### ea6d6f413312d763125e16f826e740d26ba0bdca
<pre>
Improve code coverage of sdp_integration_fuzzer
<a href="https://bugs.webkit.org/show_bug.cgi?id=267113">https://bugs.webkit.org/show_bug.cgi?id=267113</a>
&lt;<a href="https://rdar.apple.com/120503718">rdar://120503718</a>&gt;

Unreviewed re-land of changes from 269551@main.

* Source/ThirdParty/libwebrtc/Source/webrtc/test/fuzzers/sdp_integration_fuzzer.cc:
- Added WEBRTC_WEBKIT_BUILD guards to changes.
* Source/ThirdParty/libwebrtc/WebKit/sdp_integration_fuzzer-libwebrtc.diff:

Canonical link: <a href="https://commits.webkit.org/272671@main">https://commits.webkit.org/272671@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7adcfb10e892867d3cad73155edf4aa9a9a83cdf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32641 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11394 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34495 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35213 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29504 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13741 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8581 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28996 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33080 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9601 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29161 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8371 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8503 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29108 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36549 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29662 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29525 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34626 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8627 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6583 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32490 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10308 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9241 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4207 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9229 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->