### PR TITLE
GC can run during B3::generate now, causing UAF in patchpoints

### DIFF
--- a/JSTests/stress/gc-b3.js
+++ b/JSTests/stress/gc-b3.js
@@ -1,0 +1,27 @@
+function main() {
+    noDFG(main);
+
+    const object = {
+        opt: new Function('value', `
+            function inlinee(value) {
+                return [-value, -value, -value];
+            }
+
+            return inlinee(value);`)
+    };
+
+    for (let i = 0; i < 10000; i++) {
+        object.opt(BigInt(i));
+    }
+
+    setTimeout(() => {
+        object.opt = null;
+        gc();
+
+        setTimeout(() => {
+            print('Should\'ve crashed.');
+        }, 1000);
+    }, 300);
+}
+
+main();

--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -2284,6 +2284,12 @@ JSGlobalObject* CodeBlock::globalObjectFor(CodeOrigin codeOrigin)
     auto* inlineCallFrame = codeOrigin.inlineCallFrame();
     if (!inlineCallFrame)
         return globalObject();
+    // It is possible that the global object and/or other data relating to this origin
+    // was collected by GC, but we are still asking for this (ex: in a patchpoint generate() function).
+    // Plan::cancel should have cleared this in that case.
+    // Let's make sure we can continue to execute safely, even though we don't have a global object to give.
+    if (!inlineCallFrame->baselineCodeBlock)
+        return nullptr;
     return inlineCallFrame->baselineCodeBlock->globalObject();
 }
 

--- a/Source/JavaScriptCore/dfg/DFGPlan.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPlan.cpp
@@ -175,7 +175,10 @@ void Plan::cancel()
     m_mustHandleValues.clear();
     m_compilation = nullptr;
     m_finalizer = nullptr;
-    m_inlineCallFrames = nullptr;
+    if (m_inlineCallFrames) {
+        for (auto i : *m_inlineCallFrames)
+            i->baselineCodeBlock.clear();
+    }
     m_watchpoints = DesiredWatchpoints();
     m_identifiers = DesiredIdentifiers();
     m_weakReferences = DesiredWeakReferences();


### PR DESCRIPTION
#### cae26b36ccb9cf7c1e507b01dd8537efabd12194
<pre>
GC can run during B3::generate now, causing UAF in patchpoints
<a href="https://bugs.webkit.org/show_bug.cgi?id=267112">https://bugs.webkit.org/show_bug.cgi?id=267112</a>
<a href="https://rdar.apple.com/120195529">rdar://120195529</a>

Reviewed by Yusuke Suzuki.

Consider what happens when GC runs here:
{
    SetForScope disallowFreeze { state.graph.m_frozenValuesAreFinalized, true };
    GraphSafepoint safepoint(state.graph, safepointResult);

    // HERE

    B3::generate(*state.proc, jit);
}

We can see our global object and a bunch of plan state get collected.

Inside FTLLowerDFGToB3, we read the following pointers:

```
jit.codeBlock()-&gt;globalObjectFor(semanticNodeOrigin)
codeBlock()-&gt;inferredName() / hash(), which read ownerExecutable()
state-&gt;jitCode
``

The first case is fixed by this patch. The second case only happens when
dumping code. The third is not managed by the GC.

It is possible that we read more, but these were the cases that jumped out
to me.

We just add an early return to globalObjectFor to avoid reading the
freed value.

* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::globalObjectFor):
* Source/JavaScriptCore/dfg/DFGPlan.cpp:
(JSC::DFG::Plan::cancel):
* Source/JavaScriptCore/ftl/FTLCompile.cpp:
(JSC::FTL::compile):

Canonical link: <a href="https://commits.webkit.org/272710@main">https://commits.webkit.org/272710@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9583244dab63e60524908ce08692d4884813042

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32785 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11536 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34646 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35400 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29617 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13880 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8721 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/29080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33228 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9730 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29277 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/8471 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8611 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29229 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36708 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/28057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29787 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29635 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34727 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/32794 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8731 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6698 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32593 "Found 1 new API test failure: /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/cut-copy-paste/non-editable (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10417 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/39262 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7612 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9341 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8276 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9347 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->