### PR TITLE
Validate that `-apple-` prefixed pseudos are gated behind a setting

### DIFF
--- a/Source/WebCore/css/CSSPseudoSelectors.json
+++ b/Source/WebCore/css/CSSPseudoSelectors.json
@@ -22,7 +22,10 @@
                 "They internally map to `PseudoElement::UserAgentPart` or `PseudoElement::UserAgentPartLegacyAlias` for aliases."
             ]
         },
-        "notes": "Pseudos that start with `-internal-` will automatically be restricted to user agent stylesheets."
+        "notes": [
+            "Pseudos that start with `-apple-` require a 'settings-flag' field that points to a setting that is disabled to web content by default.",
+            "Pseudos that start with `-internal-` will automatically be restricted to user agent stylesheets."
+        ]
     },
     "pseudo-classes": {
         "-internal-html-document": {},

--- a/Source/WebCore/css/process-css-pseudo-selectors.py
+++ b/Source/WebCore/css/process-css-pseudo-selectors.py
@@ -65,6 +65,10 @@ class InputValidator:
 
     def validate_fields(self, input_data, pseudo_type):
         for pseudo_name, pseudo_data in input_data[pseudo_type].items():
+            # `-apple-` prefixed pseudos should be behind a flag that is disabled to web content by default.
+            if pseudo_name.startswith('-apple-') and 'settings-flag' not in pseudo_data:
+                raise Exception('"{}" should have a "settings-flag" that is disabled to web content by default.'.format(pseudo_name))
+
             for key, value in pseudo_data.items():
                 # Check for unknown fields.
                 if key not in KNOWN_KEY_TYPES[pseudo_type]:


### PR DESCRIPTION
#### c8d18f19f59873d7962e6de8008dc4bd1d12dbea
<pre>
Validate that `-apple-` prefixed pseudos are gated behind a setting
<a href="https://bugs.webkit.org/show_bug.cgi?id=267116">https://bugs.webkit.org/show_bug.cgi?id=267116</a>
<a href="https://rdar.apple.com/120505828">rdar://120505828</a>

Reviewed by Darin Adler.

Prevent accidental exposure of `-apple-` prefixed pseudos to web content by enforcing a &quot;settings-flag&quot; to be specified.

272538@main is an example of bug which this is meant to prevent.

* Source/WebCore/css/CSSPseudoSelectors.json:
* Source/WebCore/css/process-css-pseudo-selectors.py:
(InputValidator.validate_fields):

Canonical link: <a href="https://commits.webkit.org/272672@main">https://commits.webkit.org/272672@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/182cc2f7936f7dabf9df47399392afcc585b0581

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32650 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11404 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34504 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35222 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29513 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33560 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13750 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8590 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/29000 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33089 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9607 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29166 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8377 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8507 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29113 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36558 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29669 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/29527 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34633 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8636 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6590 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32497 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10317 "Built successfully") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/7586 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/9250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4208 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9239 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->