### PR TITLE
Don't include Document.h and Quirks.h in EventNames.h

### DIFF
--- a/Source/WebCore/Modules/mediastream/RTCDtlsTransport.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCDtlsTransport.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(WEB_RTC)
 
 #include "Blob.h"
+#include "ContextDestructionObserverInlines.h"
 #include "EventNames.h"
 #include "Logging.h"
 #include "NotImplemented.h"

--- a/Source/WebCore/Modules/mediastream/RTCSctpTransport.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCSctpTransport.cpp
@@ -27,6 +27,7 @@
 
 #if ENABLE(WEB_RTC)
 
+#include "ContextDestructionObserverInlines.h"
 #include "EventNames.h"
 #include "Logging.h"
 #include "RTCDtlsTransport.h"

--- a/Source/WebCore/css/MediaQueryList.cpp
+++ b/Source/WebCore/css/MediaQueryList.cpp
@@ -26,6 +26,7 @@
 #include "MediaQueryEvaluator.h"
 #include "MediaQueryListEvent.h"
 #include "MediaQueryParser.h"
+#include "Quirks.h"
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/text/StringBuilder.h>
 

--- a/Source/WebCore/dom/EventNames.h
+++ b/Source/WebCore/dom/EventNames.h
@@ -21,14 +21,14 @@
 
 #pragma once
 
-#include "Document.h"
-#include "Quirks.h"
 #include "ThreadGlobalData.h"
 #include <array>
 #include <functional>
 #include <wtf/text/AtomString.h>
 
 namespace WebCore {
+
+class EventTarget;
 
 #if ENABLE(APPLE_PAY_COUPON_CODE)
 #define DOM_EVENT_NAME_APPLE_PAY_COUPON_CODE_CHANGED(macro) macro(couponcodechanged)
@@ -384,7 +384,6 @@ public:
     // We should choose one term and stick to it.
     bool isWheelEventType(const AtomString& eventType) const;
     bool isGestureEventType(const AtomString& eventType) const;
-    bool isTouchRelatedEventType(const AtomString& eventType, const EventTarget&) const;
     bool isTouchScrollBlockingEventType(const AtomString& eventType) const;
     bool isMouseClickRelatedEventType(const AtomString& eventType) const;
     bool isMouseMoveRelatedEventType(const AtomString& eventType) const;
@@ -421,30 +420,6 @@ inline bool EventNames::isTouchScrollBlockingEventType(const AtomString& eventTy
 {
     return eventType == touchstartEvent
         || eventType == touchmoveEvent;
-}
-
-inline bool EventNames::isTouchRelatedEventType(const AtomString& eventType, const EventTarget& target) const
-{
-#if ENABLE(TOUCH_EVENTS)
-    if (auto* targetNode = dynamicDowncast<Node>(target); targetNode && targetNode->document().quirks().shouldDispatchSimulatedMouseEvents(&target)) {
-        if (eventType == mousedownEvent || eventType == mousemoveEvent || eventType == mouseupEvent)
-            return true;
-    }
-#endif
-    UNUSED_PARAM(target);
-    return eventType == touchstartEvent
-        || eventType == touchmoveEvent
-        || eventType == touchendEvent
-        || eventType == touchcancelEvent
-        || eventType == touchforcechangeEvent
-        || eventType == pointeroverEvent
-        || eventType == pointerenterEvent
-        || eventType == pointerdownEvent
-        || eventType == pointermoveEvent
-        || eventType == pointerupEvent
-        || eventType == pointeroutEvent
-        || eventType == pointerleaveEvent
-        || eventType == pointercancelEvent;
 }
 
 inline bool EventNames::isWheelEventType(const AtomString& eventType) const

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -769,6 +769,8 @@ template<TreeType = Tree> std::partial_ordering treeOrder(const Node&, const Nod
 
 WEBCORE_EXPORT std::partial_ordering treeOrderForTesting(TreeType, const Node&, const Node&);
 
+bool isTouchRelatedEventType(const AtomString& eventType, const EventTarget&);
+
 #if ASSERT_ENABLED
 
 inline void adopted(Node* node)

--- a/Source/WebCore/dom/PointerEvent.h
+++ b/Source/WebCore/dom/PointerEvent.h
@@ -27,6 +27,7 @@
 
 #include "EventNames.h"
 #include "MouseEvent.h"
+#include "Node.h"
 #include "PointerEventTypeNames.h"
 #include "PointerID.h"
 #include <wtf/text/WTFString.h>

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -61,6 +61,7 @@
 #include "Navigator.h"
 #include "OffscreenCanvas.h"
 #include "PlaceholderRenderingContext.h"
+#include "Quirks.h"
 #include "RenderBoxInlines.h"
 #include "RenderElement.h"
 #include "RenderHTMLCanvas.h"

--- a/Source/WebCore/html/shadow/TextControlInnerElements.cpp
+++ b/Source/WebCore/html/shadow/TextControlInnerElements.cpp
@@ -38,6 +38,7 @@
 #include "LocalizedStrings.h"
 #include "MouseEvent.h"
 #include "PlatformMouseEvent.h"
+#include "Quirks.h"
 #include "RenderSearchField.h"
 #include "RenderStyleSetters.h"
 #include "RenderTextControl.h"

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -91,6 +91,7 @@
 #include "PointerCaptureController.h"
 #include "PointerEventTypeNames.h"
 #include "PseudoClassChangeInvalidation.h"
+#include "Quirks.h"
 #include "Range.h"
 #include "RemoteFrame.h"
 #include "RemoteFrameView.h"

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -95,6 +95,7 @@
 #include "PageTransitionEvent.h"
 #include "Performance.h"
 #include "PerformanceNavigationTiming.h"
+#include "Quirks.h"
 #include "RemoteFrame.h"
 #include "RequestAnimationFrameCallback.h"
 #include "ResourceLoadInfo.h"
@@ -2055,7 +2056,7 @@ bool LocalDOMWindow::addEventListener(const AtomString& eventType, Ref<EventList
         document->addListenerTypeIfNeeded(eventType);
         if (eventNames.isWheelEventType(eventType))
             document->didAddWheelEventHandler(*document);
-        else if (eventNames.isTouchRelatedEventType(eventType, *document))
+        else if (isTouchRelatedEventType(eventType, *document))
             document->didAddTouchEventHandler(*document);
         else if (eventType == eventNames.storageEvent)
             didAddStorageEventListener(*this);
@@ -2070,7 +2071,7 @@ bool LocalDOMWindow::addEventListener(const AtomString& eventType, Ref<EventList
         incrementScrollEventListenersCount();
 #endif
 #if ENABLE(IOS_TOUCH_EVENTS)
-    else if (document && eventNames.isTouchRelatedEventType(eventType, *document))
+    else if (document && isTouchRelatedEventType(eventType, *document))
         ++m_touchAndGestureEventListenerCount;
 #endif
 #if ENABLE(IOS_GESTURE_EVENTS)
@@ -2298,7 +2299,7 @@ bool LocalDOMWindow::removeEventListener(const AtomString& eventType, EventListe
     if (document) {
         if (eventNames.isWheelEventType(eventType))
             document->didRemoveWheelEventHandler(*document);
-        else if (eventNames.isTouchRelatedEventType(eventType, *document))
+        else if (isTouchRelatedEventType(eventType, *document))
             document->didRemoveTouchEventHandler(*document);
     }
 
@@ -2311,7 +2312,7 @@ bool LocalDOMWindow::removeEventListener(const AtomString& eventType, EventListe
         decrementScrollEventListenersCount();
 #endif
 #if ENABLE(IOS_TOUCH_EVENTS)
-    else if (document && eventNames.isTouchRelatedEventType(eventType, *document)) {
+    else if (document && isTouchRelatedEventType(eventType, *document)) {
         ASSERT(m_touchAndGestureEventListenerCount > 0);
         --m_touchAndGestureEventListenerCount;
     }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -206,6 +206,7 @@
 #include <WebCore/PermissionState.h>
 #include <WebCore/PlatformEvent.h>
 #include <WebCore/PublicSuffix.h>
+#include <WebCore/Quirks.h>
 #include <WebCore/RealtimeMediaSourceCenter.h>
 #include <WebCore/RemoteUserInputEventData.h>
 #include <WebCore/RenderEmbeddedObject.h>


### PR DESCRIPTION
#### 531b42b2128153c7f2b88ffe96444cfbc7971654
<pre>
Don&apos;t include Document.h and Quirks.h in EventNames.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=267118">https://bugs.webkit.org/show_bug.cgi?id=267118</a>

Reviewed by Tim Nguyen.

This PR moves isTouchRelatedEventType from EventNames.h to Node.cpp
so that EventNames.h no longer has to include Document.h and Quirks.h.

* Source/WebCore/Modules/mediastream/RTCSctpTransport.cpp:
* Source/WebCore/css/MediaQueryList.cpp:
* Source/WebCore/dom/EventNames.h:
(WebCore::EventNames::isTouchRelatedEventType const): Moved to Node.cpp
* Source/WebCore/dom/Node.cpp:
(WebCore::isTouchRelatedEventType): Added.
(WebCore::tryAddEventListener):
(WebCore::tryRemoveEventListener):
(WebCore::Node::defaultEventHandler):
(WebCore::Node::willRespondToTouchEvents const):
* Source/WebCore/dom/Node.h:
* Source/WebCore/html/HTMLCanvasElement.cpp:
* Source/WebCore/html/shadow/TextControlInnerElements.cpp:
* Source/WebCore/page/EventHandler.cpp:
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::addEventListener):
(WebCore::LocalDOMWindow::removeEventListener):

Canonical link: <a href="https://commits.webkit.org/272676@main">https://commits.webkit.org/272676@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3736ef62ee602ce9ebcc22eabcd2c5a48e6ab8fd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32682 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11434 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34536 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35253 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29530 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33605 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13781 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8622 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/29016 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33121 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9634 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29188 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8402 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/8528 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29140 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36589 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29696 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29548 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/34661 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8652 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6613 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/32528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10336 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9266 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4209 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9259 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->