### PR TITLE
[WebGPU] dynamic bind group indices continue to be incorrect

### DIFF
--- a/Source/WebGPU/WebGPU/BindGroupLayout.h
+++ b/Source/WebGPU/WebGPU/BindGroupLayout.h
@@ -112,6 +112,7 @@ public:
     static bool isPresent(const WGPUStorageTextureBindingLayout&);
 
     const EntriesContainer& entries() const { return m_bindGroupLayoutEntries; }
+    const Vector<const Entry*> sortedEntries() const;
     uint32_t sizeOfVertexDynamicOffsets() const;
     uint32_t sizeOfFragmentDynamicOffsets() const;
     uint32_t sizeOfComputeDynamicOffsets() const;
@@ -137,6 +138,7 @@ private:
     const id<MTLArgumentEncoder> m_computeArgumentEncoder { nil };
 
     const EntriesContainer m_bindGroupLayoutEntries;
+    Vector<const Entry*> m_sortedEntries;
     const bool m_valid { true };
     const size_t m_sizeOfVertexDynamicOffsets { 0 };
     const size_t m_sizeOfFragmentDynamicOffsets { 0 };

--- a/Source/WebGPU/WebGPU/PipelineLayout.mm
+++ b/Source/WebGPU/WebGPU/PipelineLayout.mm
@@ -211,15 +211,16 @@ const Vector<uint32_t>* PipelineLayout::offsetVectorForBindGroup(uint32_t bindGr
         auto& container = it->value;
         uint32_t stageOffsetIndex = 0;
         auto& bindGroupLayout = bindGroupLayouts[bindGroupIndex];
-        for (auto& entryKvp : bindGroupLayout->entries()) {
-            auto& entry = entryKvp.value;
+        for (auto* entryPtr : bindGroupLayout->sortedEntries()) {
+            auto& entry = *entryPtr;
             bool hasDynamicOffset = entry.vertexDynamicOffset || entry.fragmentDynamicOffset || entry.computeDynamicOffset;
             if (!hasDynamicOffset)
                 continue;
 
             if (entry.visibility & stage) {
-                RELEASE_ASSERT(container.size() > stageOffsetIndex && dynamicOffsets.size() > entry.dynamicOffsetsIndex);
-                container[stageOffsetIndex] = dynamicOffsets[entry.dynamicOffsetsIndex];
+                auto dynamicOffsetsIndex = entry.dynamicOffsetsIndex;
+                RELEASE_ASSERT(container.size() > stageOffsetIndex && dynamicOffsets.size() > dynamicOffsetsIndex);
+                container[stageOffsetIndex] = dynamicOffsets[dynamicOffsetsIndex];
                 ++stageOffsetIndex;
             }
         }


### PR DESCRIPTION
#### b5c493976ba54c2bcbfa55c8b7b329226fb67af9
<pre>
[WebGPU] dynamic bind group indices continue to be incorrect
<a href="https://bugs.webkit.org/show_bug.cgi?id=267119">https://bugs.webkit.org/show_bug.cgi?id=267119</a>
&lt;radar://120510255&gt;

Reviewed by Tadeu Zagallo.

The copy in PipelineLayout assumed the bind group
indices were linearly increasing but this was not guaranteed as
they were stored in a HashMap.

Build a shadow sorted container to address this as the data does
not change after creation.

* Source/WebGPU/WebGPU/BindGroupLayout.h:
* Source/WebGPU/WebGPU/BindGroupLayout.mm:
(WebGPU::Device::createBindGroupLayout):
This was being sorted uncessarily each iteration, correct this.

(WebGPU::BindGroupLayout::BindGroupLayout):
(WebGPU:: const):
* Source/WebGPU/WebGPU/PipelineLayout.mm:
(WebGPU::PipelineLayout::offsetVectorForBindGroup):

Canonical link: <a href="https://commits.webkit.org/272687@main">https://commits.webkit.org/272687@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/357152f04ac041e5f86ed30a2bf977454e7bc3b9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32678 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11430 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34532 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35249 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29529 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13776 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8618 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29015 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33117 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9626 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29182 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8400 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8522 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36585 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29688 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29543 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34654 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8651 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6607 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32517 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10334 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7597 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9265 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9256 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->