### PR TITLE
Rename some pseudo-class/element parsing functions

### DIFF
--- a/Source/WebCore/animation/WebAnimationUtilities.cpp
+++ b/Source/WebCore/animation/WebAnimationUtilities.cpp
@@ -346,7 +346,7 @@ std::optional<PseudoId> pseudoIdFromString(const String& pseudoElement)
 
     // FIXME: This parserContext should include a document to get the proper settings.
     CSSSelectorParserContext parserContext { CSSParserContext { HTMLStandardMode } };
-    return CSSSelector::parseStandalonePseudoElement(pseudoElement, parserContext);
+    return CSSSelector::parsePseudoElement(pseudoElement, parserContext);
 }
 
 AtomString animatablePropertyAsString(AnimatableCSSProperty property)

--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -316,12 +316,12 @@ PseudoId CSSSelector::pseudoId(PseudoElement type)
     return PseudoId::None;
 }
 
-std::optional<CSSSelector::PseudoElement> CSSSelector::parsePseudoElement(StringView name, const CSSSelectorParserContext& context)
+std::optional<CSSSelector::PseudoElement> CSSSelector::parsePseudoElementName(StringView name, const CSSSelectorParserContext& context)
 {
     if (name.isEmpty())
         return std::nullopt;
 
-    auto type = parsePseudoElementString(name);
+    auto type = findPseudoElementName(name);
     if (!type) {
         // FIXME: Put all known UA parts in CSSPseudoSelectors.json and split out the unknown case (webkit.org/b/266947).
         if (name.startsWithIgnoringASCIICase("-webkit-"_s))
@@ -336,7 +336,7 @@ std::optional<CSSSelector::PseudoElement> CSSSelector::parsePseudoElement(String
 }
 
 // FIXME: We should eventually deduplicate this with CSSSelectorParser::consumePseudo() somehow.
-std::optional<PseudoId> CSSSelector::parseStandalonePseudoElement(const String& input, const CSSSelectorParserContext& context)
+std::optional<PseudoId> CSSSelector::parsePseudoElement(const String& input, const CSSSelectorParserContext& context)
 {
     // FIXME: Add support for FunctionToken (webkit.org/b/264103).
     auto tokenizer = CSSTokenizer { input };
@@ -348,7 +348,7 @@ std::optional<PseudoId> CSSSelector::parseStandalonePseudoElement(const String& 
     if (token.type() == IdentToken) {
         if (!range.atEnd())
             return std::nullopt;
-        auto pseudoClassOrElement = parsePseudoClassAndCompatibilityElementString(token.value());
+        auto pseudoClassOrElement = findPseudoClassAndCompatibilityElementName(token.value());
         if (!pseudoClassOrElement.compatibilityPseudoElement)
             return std::nullopt;
         ASSERT(CSSSelector::isPseudoElementEnabled(*pseudoClassOrElement.compatibilityPseudoElement, token.value(), context));
@@ -359,7 +359,7 @@ std::optional<PseudoId> CSSSelector::parseStandalonePseudoElement(const String& 
     token = range.consume();
     if (token.type() != IdentToken || !range.atEnd())
         return std::nullopt;
-    if (auto pseudoElement = parsePseudoElement(token.value(), context))
+    if (auto pseudoElement = parsePseudoElementName(token.value(), context))
         return pseudoId(*pseudoElement);
     return std::nullopt;
 }

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -118,8 +118,8 @@ public:
     static PseudoId pseudoId(PseudoElement);
     static bool isPseudoClassEnabled(PseudoClass, const CSSSelectorParserContext&);
     static bool isPseudoElementEnabled(PseudoElement, StringView, const CSSSelectorParserContext&);
-    static std::optional<PseudoElement> parsePseudoElement(StringView, const CSSSelectorParserContext&);
-    static std::optional<PseudoId> parseStandalonePseudoElement(const String&, const CSSSelectorParserContext&);
+    static std::optional<PseudoId> parsePseudoElement(const String&, const CSSSelectorParserContext&);
+    static std::optional<PseudoElement> parsePseudoElementName(StringView, const CSSSelectorParserContext&);
     static bool pseudoClassRequiresArgument(PseudoClass);
     static bool pseudoElementRequiresArgument(PseudoElement);
     static bool pseudoClassMayHaveArgument(PseudoClass);

--- a/Source/WebCore/css/SelectorPseudoTypeMap.h
+++ b/Source/WebCore/css/SelectorPseudoTypeMap.h
@@ -34,7 +34,7 @@ struct PseudoClassOrCompatibilityPseudoElement {
     std::optional<CSSSelector::PseudoElement> compatibilityPseudoElement;
 };
 
-PseudoClassOrCompatibilityPseudoElement parsePseudoClassAndCompatibilityElementString(StringView pseudoTypeString);
-std::optional<CSSSelector::PseudoElement> parsePseudoElementString(StringView pseudoTypeString);
+PseudoClassOrCompatibilityPseudoElement findPseudoClassAndCompatibilityElementName(StringView);
+std::optional<CSSSelector::PseudoElement> findPseudoElementName(StringView);
 
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -1186,7 +1186,7 @@ bool CSSSelectorParser::containsUnknownWebKitPseudoElements(const CSSSelector& c
                 continue;
 
             // FIXME: Stop attempting parsing once the unknown "-webkit" pseudo-elements are behind a different type. (webkit.org/b/266947)
-            if (!parsePseudoElementString(StringView(current->value())))
+            if (!findPseudoElementName(StringView(current->value())))
                 return true;
         }
     }

--- a/Source/WebCore/css/parser/MutableCSSSelector.cpp
+++ b/Source/WebCore/css/parser/MutableCSSSelector.cpp
@@ -53,7 +53,7 @@ std::unique_ptr<MutableCSSSelector> MutableCSSSelector::parsePagePseudoSelector(
 
 std::unique_ptr<MutableCSSSelector> MutableCSSSelector::parsePseudoElementSelector(StringView pseudoTypeString, const CSSSelectorParserContext& context)
 {
-    auto pseudoType = CSSSelector::parsePseudoElement(pseudoTypeString, context);
+    auto pseudoType = CSSSelector::parsePseudoElementName(pseudoTypeString, context);
     if (!pseudoType)
         return nullptr;
 
@@ -71,7 +71,7 @@ std::unique_ptr<MutableCSSSelector> MutableCSSSelector::parsePseudoElementSelect
 
 std::unique_ptr<MutableCSSSelector> MutableCSSSelector::parsePseudoClassSelector(StringView pseudoTypeString, const CSSSelectorParserContext& context)
 {
-    auto pseudoType = parsePseudoClassAndCompatibilityElementString(pseudoTypeString);
+    auto pseudoType = findPseudoClassAndCompatibilityElementName(pseudoTypeString);
     if (pseudoType.pseudoClass) {
         if (!CSSSelector::isPseudoClassEnabled(*pseudoType.pseudoClass, context))
             return nullptr;

--- a/Source/WebCore/css/process-css-pseudo-selectors.py
+++ b/Source/WebCore/css/process-css-pseudo-selectors.py
@@ -374,13 +374,13 @@ class GPerfOutputGenerator:
     def write_parsing_function_definitions_for_pseudo_class(self, writer):
         longest_keyword_length = len(max(self.mapping, key=len))
         writer.write_block("""
-        static inline const SelectorPseudoClassOrCompatibilityPseudoElementEntry* parsePseudoClassAndCompatibilityElementString(const LChar* characters, unsigned length)
+        static inline const SelectorPseudoClassOrCompatibilityPseudoElementEntry* findPseudoClassAndCompatibilityElementName(const LChar* characters, unsigned length)
         {
             return SelectorPseudoClassAndCompatibilityElementMapHash::in_word_set(reinterpret_cast<const char*>(characters), length);
         }""")
 
         writer.write_block("""
-        static inline const SelectorPseudoClassOrCompatibilityPseudoElementEntry* parsePseudoClassAndCompatibilityElementString(const UChar* characters, unsigned length)
+        static inline const SelectorPseudoClassOrCompatibilityPseudoElementEntry* findPseudoClassAndCompatibilityElementName(const UChar* characters, unsigned length)
         {{
             constexpr unsigned maxKeywordLength = {};
             LChar buffer[maxKeywordLength];
@@ -394,17 +394,17 @@ class GPerfOutputGenerator:
 
                 buffer[i] = static_cast<LChar>(character);
             }}
-            return parsePseudoClassAndCompatibilityElementString(buffer, length);
+            return findPseudoClassAndCompatibilityElementName(buffer, length);
         }}""".format(longest_keyword_length))
 
         writer.write_block("""
-        PseudoClassOrCompatibilityPseudoElement parsePseudoClassAndCompatibilityElementString(StringView pseudoTypeString)
+        PseudoClassOrCompatibilityPseudoElement findPseudoClassAndCompatibilityElementName(StringView name)
         {
             const SelectorPseudoClassOrCompatibilityPseudoElementEntry* entry;
-            if (pseudoTypeString.is8Bit())
-                entry = parsePseudoClassAndCompatibilityElementString(pseudoTypeString.characters8(), pseudoTypeString.length());
+            if (name.is8Bit())
+                entry = findPseudoClassAndCompatibilityElementName(name.characters8(), name.length());
             else
-                entry = parsePseudoClassAndCompatibilityElementString(pseudoTypeString.characters16(), pseudoTypeString.length());
+                entry = findPseudoClassAndCompatibilityElementName(name.characters16(), name.length());
 
             if (entry)
                 return entry->pseudoTypes;
@@ -414,7 +414,7 @@ class GPerfOutputGenerator:
     def write_parsing_function_definitions_for_pseudo_element(self, writer):
         longest_keyword_length = len(max(self.mapping, key=len))
         writer.write_block("""
-            static inline std::optional<CSSSelector::PseudoElement> parsePseudoElementString(const LChar* characters, unsigned length)
+            static inline std::optional<CSSSelector::PseudoElement> findPseudoElementName(const LChar* characters, unsigned length)
             {
                 if (const SelectorPseudoTypeEntry* entry = SelectorPseudoElementMapHash::in_word_set(reinterpret_cast<const char*>(characters), length))
                     return entry->type;
@@ -422,7 +422,7 @@ class GPerfOutputGenerator:
             }""")
 
         writer.write_block("""
-            static inline std::optional<CSSSelector::PseudoElement> parsePseudoElementString(const UChar* characters, unsigned length)
+            static inline std::optional<CSSSelector::PseudoElement> findPseudoElementName(const UChar* characters, unsigned length)
             {{
                 constexpr unsigned maxKeywordLength = {};
                 LChar buffer[maxKeywordLength];
@@ -436,15 +436,15 @@ class GPerfOutputGenerator:
 
                     buffer[i] = static_cast<LChar>(character);
                 }}
-                return parsePseudoElementString(buffer, length);
+                return findPseudoElementName(buffer, length);
             }}""".format(longest_keyword_length))
 
         writer.write_block("""
-            std::optional<CSSSelector::PseudoElement> parsePseudoElementString(StringView pseudoTypeString)
+            std::optional<CSSSelector::PseudoElement> findPseudoElementName(StringView name)
             {
-                if (pseudoTypeString.is8Bit())
-                    return parsePseudoElementString(pseudoTypeString.characters8(), pseudoTypeString.length());
-                return parsePseudoElementString(pseudoTypeString.characters16(), pseudoTypeString.length());
+                if (name.is8Bit())
+                    return findPseudoElementName(name.characters8(), name.length());
+                return findPseudoElementName(name.characters16(), name.length());
             }""")
 
     def write_end_ignore_warning(self, writer):

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -1685,7 +1685,7 @@ Ref<CSSStyleDeclaration> LocalDOMWindow::getComputedStyle(Element& element, cons
     std::optional<PseudoId> pseudoId = PseudoId::None;
     // FIXME: This does not work for pseudo-elements that take arguments (webkit.org/b/264103).
     if (pseudoElt.startsWith(":"_s))
-        pseudoId = CSSSelector::parseStandalonePseudoElement(pseudoElt, CSSSelectorParserContext { element.document() });
+        pseudoId = CSSSelector::parsePseudoElement(pseudoElt, CSSSelectorParserContext { element.document() });
     return CSSComputedStyleDeclaration::create(element, pseudoId);
 }
 
@@ -1696,7 +1696,7 @@ RefPtr<CSSRuleList> LocalDOMWindow::getMatchedCSSRules(Element* element, const S
 
     // FIXME: This parser context won't get the right settings without a document.
     auto parserContext = document() ? CSSSelectorParserContext { *document() } : CSSSelectorParserContext { CSSParserContext { HTMLStandardMode } };
-    auto optionalPseudoId = CSSSelector::parseStandalonePseudoElement(pseudoElement, parserContext);
+    auto optionalPseudoId = CSSSelector::parsePseudoElement(pseudoElement, parserContext);
     if (!optionalPseudoId && !pseudoElement.isEmpty())
         return nullptr;
     auto pseudoId = optionalPseudoId ? *optionalPseudoId : PseudoId::None;


### PR DESCRIPTION
#### 02d283970517a9c6d182e5748f0b60cfcccddc7c
<pre>
Rename some pseudo-class/element parsing functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=267084">https://bugs.webkit.org/show_bug.cgi?id=267084</a>
<a href="https://rdar.apple.com/120517489">rdar://120517489</a>

Reviewed by Antti Koivisto.

- Add &quot;Name&quot; suffix to functions that parse names without the colons.
- Change the map lookup functions to use the `find` prefix instead of `parse`, to prevent folks from mistakingly using them to parse strings
- Rename `parseStandalonePseudoElement` to `parsePseudoElement` since it parses a pseudo-element with the colons.

The end result is:
parsePseudoElement -&gt; parsePseudoElementName
parsePseudoElementString -&gt; findPseudoElementName
parseStandalonePseudoElement -&gt; parsePseudoElement
parsePseudoClassAndCompatibilityElementString -&gt; findPseudoClassAndCompatibilityElementName

* Source/WebCore/animation/WebAnimationUtilities.cpp:
(WebCore::pseudoIdFromString):
* Source/WebCore/css/CSSSelector.cpp:
(WebCore::CSSSelector::parsePseudoElementName):
(WebCore::CSSSelector::parsePseudoElement):
(WebCore::CSSSelector::parseStandalonePseudoElement): Deleted.
* Source/WebCore/css/CSSSelector.h:
* Source/WebCore/css/SelectorPseudoTypeMap.h:
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParser::containsUnknownWebKitPseudoElements):
* Source/WebCore/css/parser/MutableCSSSelector.cpp:
(WebCore::MutableCSSSelector::parsePseudoElementSelector):
(WebCore::MutableCSSSelector::parsePseudoClassSelector):
* Source/WebCore/css/process-css-pseudo-selectors.py:
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::getComputedStyle const):
(WebCore::LocalDOMWindow::getMatchedCSSRules const):

Canonical link: <a href="https://commits.webkit.org/272682@main">https://commits.webkit.org/272682@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da75f7207e0d3be336b97685619cf3215cc8455f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32696 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11449 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34552 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35267 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29539 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33620 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13797 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8637 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/29028 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33136 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/9649 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29205 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8416 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/8543 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29157 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36604 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29711 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/29566 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/34671 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8664 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6628 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32537 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10348 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7594 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9277 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9271 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->