### PR TITLE
WebGL is available in webworker but not available in sub webworker

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1392,6 +1392,7 @@ webkit.org/b/245334 [ Debug ] imported/w3c/web-platform-tests/html/canvas/offscr
 # This failure is related with (incomplete?) webgl support for OffscreenCanvas.
 webkit.org/b/245952 [ Debug ] imported/w3c/web-platform-tests/webcodecs/videoFrame-texImage.any.worker.html [ Failure Crash ]
 webgl/1.0.x/conformance/offscreencanvas/offscreencanvas-transfer-image-bitmap.html [ Failure Timeout Pass ]
+webkit.org/b/267218 webgl/webgl-worker.html [ Failure ]
 
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of OffscreenCanvas-related bugs

--- a/LayoutTests/webgl/resources/webgl-nested-worker.js
+++ b/LayoutTests/webgl/resources/webgl-nested-worker.js
@@ -1,0 +1,5 @@
+const result = [
+    `WebGL supported in nested Worker: ${new OffscreenCanvas(1, 1).getContext("webgl") !== null}`,
+    `WebGL2 supported in nested Worker: ${new OffscreenCanvas(1, 1).getContext("webgl2") !== null}`,
+];
+self.postMessage(result);

--- a/LayoutTests/webgl/resources/webgl-worker.js
+++ b/LayoutTests/webgl/resources/webgl-worker.js
@@ -1,0 +1,8 @@
+const worker = new Worker("./webgl-nested-worker.js");
+worker.addEventListener("message", (e) => {
+    const result = [
+        `WebGL supported in Worker: ${new OffscreenCanvas(1, 1).getContext("webgl") !== null}`,
+        `WebGL2 supported in Worker: ${new OffscreenCanvas(1, 1).getContext("webgl2") !== null}`
+    ];
+    self.postMessage(result.concat(e.data));
+});

--- a/LayoutTests/webgl/webgl-worker-expected.txt
+++ b/LayoutTests/webgl/webgl-worker-expected.txt
@@ -1,0 +1,7 @@
+WebGL supported in Worker: true
+
+WebGL2 supported in Worker: true
+
+WebGL supported in nested Worker: true
+
+WebGL2 supported in nested Worker: true

--- a/LayoutTests/webgl/webgl-worker.html
+++ b/LayoutTests/webgl/webgl-worker.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html><!-- webkit-test-runner [ UseGPUProcessForWebGLEnabled=true OffscreenCanvasEnabled=true ] -->
+<html>
+<body>
+<script>
+function runTest() {
+    if (!window.Worker) {
+        document.body.innerHTML +=  "<p>Workers not supported";
+        return;
+    }
+
+    if (window.testRunner) {
+        testRunner.waitUntilDone();
+        testRunner.dumpAsText();
+    }
+
+    const worker = new Worker("./resources/webgl-worker.js");
+    worker.addEventListener("message", (e) => {
+        for (result of e.data)
+            document.body.innerHTML += `<p>${result}` ;
+        if (window.testRunner)
+            testRunner.notifyDone();
+    });
+}
+runTest();
+ </script>
+</body>
+</html>

--- a/Source/WebCore/page/WorkerClient.h
+++ b/Source/WebCore/page/WorkerClient.h
@@ -28,6 +28,7 @@
 #include "GraphicsClient.h"
 #include <wtf/FastMalloc.h>
 #include <wtf/FunctionDispatcher.h>
+#include <wtf/UniqueRef.h>
 
 namespace WebCore {
 
@@ -35,7 +36,8 @@ class WorkerClient : public GraphicsClient {
     WTF_MAKE_FAST_ALLOCATED;
 public:
 
-    virtual std::unique_ptr<WorkerClient> clone(SerialFunctionDispatcher&) = 0;
+    // Used for constructing clients for nested workers. Created on the worker thread of the outer worker, and then transferred to the nested worker.
+    virtual UniqueRef<WorkerClient> createNestedWorkerClient(SerialFunctionDispatcher&) = 0;
 
     virtual ~WorkerClient() = default;
 };

--- a/Source/WebCore/workers/WorkerMessagingProxy.cpp
+++ b/Source/WebCore/workers/WorkerMessagingProxy.cpp
@@ -155,8 +155,8 @@ void WorkerMessagingProxy::startWorkerGlobalScope(const URL& scriptURL, PAL::Ses
 
     if (parentWorkerGlobalScope) {
         parentWorkerGlobalScope->thread().addChildThread(thread);
-        if (parentWorkerGlobalScope->thread().workerClient())
-            thread->setWorkerClient(parentWorkerGlobalScope->thread().workerClient()->clone(thread.get()));
+        if (auto* parentWorkerClient = parentWorkerGlobalScope->workerClient())
+            thread->setWorkerClient(parentWorkerClient->createNestedWorkerClient(thread.get()).moveToUniquePtr());
     } else if (is<Document>(m_scriptExecutionContext.get())) {
         auto& document = downcast<Document>(*m_scriptExecutionContext);
         if (auto* page = document.page()) {

--- a/Source/WebCore/workers/WorkerThread.h
+++ b/Source/WebCore/workers/WorkerThread.h
@@ -112,8 +112,7 @@ public:
 
     void clearProxies() override;
 
-    void setWorkerClient(std::unique_ptr<WorkerClient>&& client) { m_workerClient = WTFMove(client); }
-    WorkerClient* workerClient() { return m_workerClient.get(); }
+    void setWorkerClient(std::unique_ptr<WorkerClient> client) { m_workerClient = WTFMove(client); }
 protected:
     WorkerThread(const WorkerParameters&, const ScriptBuffer& sourceCode, WorkerLoaderProxy&, WorkerDebuggerProxy&, WorkerReportingProxy&, WorkerBadgeProxy&, WorkerThreadStartMode, const SecurityOrigin& topOrigin, IDBClient::IDBConnectionProxy*, SocketProvider*, JSC::RuntimeFlags);
 

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -98,7 +98,6 @@ template: enum class WebKit::RemoteMediaResourceIdentifierType
 template: enum class WebKit::RemoteMediaSourceIdentifierType
 template: enum class WebKit::RemoteRemoteCommandListenerIdentifierType
 template: enum class WebKit::RemoteSourceBufferIdentifierType
-template: enum class WebKit::RenderingBackendIdentifierType
 template: enum class WebKit::RetrieveRecordResponseBodyCallbackIdentifierType
 template: enum class WebKit::SampleBufferDisplayLayerIdentifierType
 template: enum class WebKit::ShapeDetectionIdentifierType
@@ -183,6 +182,7 @@ template: enum class WebKit::LegacyCustomProtocolIDType
 template: enum class WebKit::LibWebRTCResolverIdentifierType
 template: enum class WebKit::QuotaIncreaseRequestIdentifierType
 template: enum class WebKit::RemoteVideoFrameIdentifierType
+template: enum class WebKit::RenderingBackendIdentifierType
 template: enum class WebKit::VideoDecoderIdentifierType
 template: enum class WebKit::VideoEncoderIdentifierType
 template: enum class WebKit::WCContentBufferIdentifierType

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -58,7 +58,7 @@ using namespace WebCore;
 
 std::unique_ptr<RemoteRenderingBackendProxy> RemoteRenderingBackendProxy::create(WebPage& webPage)
 {
-    return std::unique_ptr<RemoteRenderingBackendProxy>(new RemoteRenderingBackendProxy({ RenderingBackendIdentifier::generate(), webPage.webPageProxyIdentifier(), webPage.identifier() }, RunLoop::main()));
+    return create({ RenderingBackendIdentifier::generate(), webPage.webPageProxyIdentifier(), webPage.identifier() }, RunLoop::main());
 }
 
 std::unique_ptr<RemoteRenderingBackendProxy> RemoteRenderingBackendProxy::create(const RemoteRenderingBackendCreationParameters& parameters, SerialFunctionDispatcher& dispatcher)

--- a/Source/WebKit/WebProcess/GPU/graphics/RenderingBackendIdentifier.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RenderingBackendIdentifier.h
@@ -32,7 +32,7 @@
 namespace WebKit {
 
 enum class RenderingBackendIdentifierType { };
-using RenderingBackendIdentifier = ObjectIdentifier<RenderingBackendIdentifierType>;
+using RenderingBackendIdentifier = AtomicObjectIdentifier<RenderingBackendIdentifierType>;
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1012,7 +1012,7 @@ RefPtr<ImageBuffer> WebChromeClient::sinkIntoImageBuffer(std::unique_ptr<Seriali
 
 std::unique_ptr<WebCore::WorkerClient> WebChromeClient::createWorkerClient(SerialFunctionDispatcher& dispatcher)
 {
-    return makeUnique<WebWorkerClient>(protectedPage().ptr(), dispatcher);
+    return WebWorkerClient::create(protectedPage(), dispatcher).moveToUniquePtr();
 }
 
 #if ENABLE(WEBGL)

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -1952,8 +1952,8 @@ template<typename IntegralType> bool encodeNumericType(IPC::Encoder& encoder, JS
 }
 
 #if ENABLE(GPU_PROCESS)
-template <typename ObjectIdentifierType>
-std::optional<ObjectIdentifier<ObjectIdentifierType>> getObjectIdentifierFromProperty(JSC::JSGlobalObject* globalObject, JSC::JSObject* jsObject, ASCIILiteral propertyName, JSC::CatchScope& scope)
+template <typename T>
+std::optional<T> getObjectIdentifierFromProperty(JSC::JSGlobalObject* globalObject, JSC::JSObject* jsObject, ASCIILiteral propertyName, JSC::CatchScope& scope)
 {
     auto jsPropertyValue = jsObject->get(globalObject, JSC::Identifier::fromString(globalObject->vm(), propertyName));
     if (scope.exception())
@@ -1961,20 +1961,20 @@ std::optional<ObjectIdentifier<ObjectIdentifierType>> getObjectIdentifierFromPro
     auto number = convertToUint64(jsPropertyValue);
     if (!number)
         return std::nullopt;
-    return ObjectIdentifier<ObjectIdentifierType>(*number);
+    return std::optional<T> { *number };
 }
 
 static bool encodeRemoteRenderingBackendCreationParameters(IPC::Encoder& encoder, JSC::JSGlobalObject* globalObject, JSC::JSObject* jsObject, JSC::CatchScope& scope)
 {
-    auto identifier = getObjectIdentifierFromProperty<RenderingBackendIdentifierType>(globalObject, jsObject, "identifier"_s, scope);
+    auto identifier = getObjectIdentifierFromProperty<RenderingBackendIdentifier>(globalObject, jsObject, "identifier"_s, scope);
     if (!identifier)
         return false;
 
-    auto pageProxyID = getObjectIdentifierFromProperty<WebPageProxyIdentifierType>(globalObject, jsObject, "pageProxyID"_s, scope);
+    auto pageProxyID = getObjectIdentifierFromProperty<WebPageProxyIdentifier>(globalObject, jsObject, "pageProxyID"_s, scope);
     if (!pageProxyID)
         return false;
 
-    auto pageID = getObjectIdentifierFromProperty<WebCore::PageIdentifierType>(globalObject, jsObject, "pageID"_s, scope);
+    auto pageID = getObjectIdentifierFromProperty<WebCore::PageIdentifier>(globalObject, jsObject, "pageID"_s, scope);
     if (!pageID)
         return false;
 


### PR DESCRIPTION
#### 9fb944e082ca85e9c509d60d879e898476822bd8
<pre>
WebGL is available in webworker but not available in sub webworker
<a href="https://bugs.webkit.org/show_bug.cgi?id=266825">https://bugs.webkit.org/show_bug.cgi?id=266825</a>
<a href="https://rdar.apple.com/120279728">rdar://120279728</a>

Reviewed by Matt Woodrow.

WorkerThread::setWorkerClient()
WorkerThread::m_workerClient
WorkerThread::workerClient()
These were part of constructor argument-like property used to store a
WorkerClient to WorkerThread::m_workerClient. The instance would be
moved from the WorkerThread to WorkerGlobalScope when WorkerGlobalScope
was instantiated. When creating a nested worker, the worker client used
as factory was looked up via
`parentWorkerGlobalScope-&gt;thread().workerClient()`. This was invalid, as
the property was always nullptr, since the parentWorkerGlobalScope is
the scope created by its thread and thus the property was moved to the
global scope. The intended accessor call was
`parentWorkerGlobalScope-&gt;workerClient()`.

Fix by calling the intended function and removing the errorneous
`WorkerThread::workerClient()`, as that is not needed.

WebWorkerClient would store
RemoteRenderingBackendCreationParameters. This is redundant, as the
intention is to not store the future RRB identifier. Instead, the
identifier should be generated when the instance is created. Otherwise
all nested WebWorkerClients would use the identifier genererated for the
top-level Worker. This would cause two RRB instantiations with same
identifier and thus assertions in GPUP.

Fix by storing just the page identifiers and generating the RRB
indentifier upon instantiation.

RenderingBackendIdentifier was not thread-safe, generation would assert
in nested Worker.

Fix by using AtomicObjectIdentifier, as the new id generation for a
nested Worker happens in the parent Worker, running in its own thread.

* LayoutTests/webgl/resources/webgl-nested-worker.js: Added.
* LayoutTests/webgl/resources/webgl-worker.js: Added.
* LayoutTests/webgl/webgl-worker-expected.txt: Added.
* LayoutTests/webgl/webgl-worker.html: Added.
* Source/WebCore/page/WorkerClient.h:
* Source/WebCore/workers/WorkerMessagingProxy.cpp:
(WebCore::WorkerMessagingProxy::startWorkerGlobalScope):
* Source/WebCore/workers/WorkerThread.h:
(WebCore::WorkerThread::setWorkerClient):
(WebCore::WorkerThread::workerClient): Deleted.
* Source/WebKit/Shared/WTFArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::create):
* Source/WebKit/WebProcess/GPU/graphics/RenderingBackendIdentifier.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::createWorkerClient):
* Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.cpp:
(WebKit::WebWorkerClient::create):
(WebKit::WebWorkerClient::WebWorkerClient):
(WebKit::WebWorkerClient::ensureRenderingBackend const):
(WebKit::WebWorkerClient::createNestedWorkerClient):
(WebKit::WebWorkerClient::clone): Deleted.
* Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.h:
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::getObjectIdentifierFromProperty):
(WebKit::IPCTestingAPI::encodeRemoteRenderingBackendCreationParameters):

Canonical link: <a href="https://commits.webkit.org/272765@main">https://commits.webkit.org/272765@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cac1a587f562e5d29b908fe8b985462d905caf6f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32971 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11737 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34865 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35608 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29790 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33935 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14080 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8909 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29230 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33439 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9891 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29453 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8625 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8773 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29409 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36941 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29948 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29820 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34907 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8908 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6852 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32762 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10600 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/29066 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7651 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9505 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9537 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->