### PR TITLE
RemoteGPUProxy uses GPUProcessConnection in thread-unsafe manner

### DIFF
--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1034,7 +1034,7 @@ RefPtr<GraphicsContextGL> WebChromeClient::createGraphicsContextGL(const Graphic
 RefPtr<WebCore::WebGPU::GPU> WebChromeClient::createGPUForWebGPU() const
 {
 #if ENABLE(GPU_PROCESS)
-    return RemoteGPUProxy::create(WebProcess::singleton().ensureGPUProcessConnection(), WebGPU::DowncastConvertToBackingContext::create(), WebGPUIdentifier::generate(), protectedPage()->ensureRemoteRenderingBackendProxy().ensureBackendCreated());
+    return RemoteGPUProxy::create(WebProcess::singleton().ensureGPUProcessConnection().connection(), WebGPU::DowncastConvertToBackingContext::create(), WebGPUIdentifier::generate(), protectedPage()->ensureRemoteRenderingBackendProxy().ensureBackendCreated());
 #else
     return WebCore::WebGPU::create([](WebCore::WebGPU::WorkItem&& workItem) {
         callOnMainRunLoop(WTFMove(workItem));

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.cpp
@@ -49,8 +49,7 @@ using namespace WebCore;
 WebWorkerClient::WebWorkerClient(WebPage* page, SerialFunctionDispatcher& dispatcher)
     : m_dispatcher(dispatcher)
 #if ENABLE(GPU_PROCESS)
-    , m_gpuProcessConnection(WebProcess::singleton().ensureGPUProcessConnection())
-    , m_connection(m_gpuProcessConnection.connection())
+    , m_connection(WebProcess::singleton().ensureGPUProcessConnection().connection())
 #if ENABLE(VIDEO)
     , m_videoFrameObjectHeapProxy(WebProcess::singleton().ensureGPUProcessConnection().videoFrameObjectHeapProxy())
 #endif
@@ -66,16 +65,13 @@ WebWorkerClient::WebWorkerClient(WebPage* page, SerialFunctionDispatcher& dispat
 }
 
 #if ENABLE(GPU_PROCESS)
-WebWorkerClient::WebWorkerClient(GPUProcessConnection& gpuProcessConnection, IPC::Connection& connection, SerialFunctionDispatcher& dispatcher, RemoteRenderingBackendCreationParameters& creationParameters, WebCore::PlatformDisplayID& displayID
+WebWorkerClient::WebWorkerClient(Ref<IPC::Connection> connection, SerialFunctionDispatcher& dispatcher, RemoteRenderingBackendCreationParameters& creationParameters, WebCore::PlatformDisplayID& displayID
 #if ENABLE(VIDEO)
     , Ref<RemoteVideoFrameObjectHeapProxy>&& videoFrameObjectHeapProxy
 #endif
 )
     : m_dispatcher(dispatcher)
-#if ENABLE(GPU_PROCESS)
-    , m_gpuProcessConnection(gpuProcessConnection)
-#endif
-    , m_connection(connection)
+    , m_connection(WTFMove(connection))
     , m_creationParameters(creationParameters)
 #if ENABLE(VIDEO)
     , m_videoFrameObjectHeapProxy(WTFMove(videoFrameObjectHeapProxy))
@@ -103,7 +99,7 @@ std::unique_ptr<WorkerClient> WebWorkerClient::clone(SerialFunctionDispatcher& d
 {
     assertIsCurrent(m_dispatcher);
 #if ENABLE(GPU_PROCESS)
-    return makeUnique<WebWorkerClient>(m_gpuProcessConnection, m_connection, dispatcher, m_creationParameters, m_displayID
+    return makeUnique<WebWorkerClient>(m_connection, dispatcher, m_creationParameters, m_displayID
 #if ENABLE(VIDEO)
         , m_videoFrameObjectHeapProxy.copyRef()
 #endif
@@ -160,7 +156,7 @@ RefPtr<GraphicsContextGL> WebWorkerClient::createGraphicsContextGL(const Graphic
 RefPtr<WebCore::WebGPU::GPU> WebWorkerClient::createGPUForWebGPU() const
 {
 #if ENABLE(GPU_PROCESS)
-    return RemoteGPUProxy::create(m_gpuProcessConnection, WebGPU::DowncastConvertToBackingContext::create(), WebGPUIdentifier::generate(), ensureRenderingBackend().ensureBackendCreated());
+    return RemoteGPUProxy::create(m_connection, WebGPU::DowncastConvertToBackingContext::create(), WebGPUIdentifier::generate(), ensureRenderingBackend().ensureBackendCreated());
 #else
     return nullptr;
 #endif

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.h
@@ -37,7 +37,6 @@ class GPU;
 
 namespace WebKit {
 
-class GPUProcessConnection;
 class WebPage;
 class RemoteRenderingBackendProxy;
 
@@ -56,7 +55,7 @@ public:
     // nested worker.
 #if ENABLE(GPU_PROCESS)
 #if ENABLE(VIDEO)
-    WebWorkerClient(GPUProcessConnection&, IPC::Connection&, SerialFunctionDispatcher&, RemoteRenderingBackendCreationParameters&, WebCore::PlatformDisplayID&, Ref<RemoteVideoFrameObjectHeapProxy>&&);
+    WebWorkerClient(Ref<IPC::Connection>, SerialFunctionDispatcher&, RemoteRenderingBackendCreationParameters&, WebCore::PlatformDisplayID&, Ref<RemoteVideoFrameObjectHeapProxy>&&);
 #else
     WebWorkerClient(IPC::Connection&, SerialFunctionDispatcher&, RemoteRenderingBackendCreationParameters&, WebCore::PlatformDisplayID&);
 #endif
@@ -85,7 +84,6 @@ private:
 
     SerialFunctionDispatcher& m_dispatcher;
 #if ENABLE(GPU_PROCESS)
-    GPUProcessConnection& m_gpuProcessConnection;
     Ref<IPC::Connection> m_connection;
     mutable std::unique_ptr<RemoteRenderingBackendProxy> m_remoteRenderingBackendProxy;
     RemoteRenderingBackendCreationParameters m_creationParameters;


### PR DESCRIPTION
#### 11e984bdb5d873d6eb3ac961238482c9c721ad11
<pre>
RemoteGPUProxy uses GPUProcessConnection in thread-unsafe manner
<a href="https://bugs.webkit.org/show_bug.cgi?id=267128">https://bugs.webkit.org/show_bug.cgi?id=267128</a>
<a href="https://rdar.apple.com/120539209">rdar://120539209</a>

Reviewed by Mike Wyrzykowski.

GPUProcessConnection should not be stored in any member that might
be used in non-main threads. It is a main thread -only object and
as such useless in classes like RemoteGPUProxy.

Store the main GPUP IPC::Connection directly.
Listen to GPUP crashes via the RemoteGPUProxy stream connection,
similar to what RemoteGraphicsContextGLProxy and
RemoteRenderingBackendProxy do.

Make RemoteGPUProxy only ThreadSafeRefCounted, not
ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr. The weak ptrs
are not used when GPUProcessConnection::Client is not used.

* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp:
(WebKit::RemoteGPUProxy::create):
(WebKit::RemoteGPUProxy::RemoteGPUProxy):
(WebKit::RemoteGPUProxy::initializeIPC):
(WebKit::RemoteGPUProxy::disconnectGpuProcessIfNeeded):
(WebKit::RemoteGPUProxy::didClose):
(WebKit::RemoteGPUProxy::abandonGPUProcess):
(WebKit::RemoteGPUProxy::gpuProcessConnectionDidClose): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::createGPUForWebGPU const):
* Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.cpp:
(WebKit::WebWorkerClient::WebWorkerClient):
(WebKit::WebWorkerClient::clone):
(WebKit::WebWorkerClient::createGPUForWebGPU const):
* Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.h:

Canonical link: <a href="https://commits.webkit.org/272731@main">https://commits.webkit.org/272731@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96fbc259eb33462fd0534e80b3d829a1b479168b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32712 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11466 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34569 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35284 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29555 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13822 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8654 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29043 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33153 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9679 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29221 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8431 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8570 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36621 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29738 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29582 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34687 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8681 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6645 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32553 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10364 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7625 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9293 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9287 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->