### PR TITLE
Input element with inherited display:ruby hits assert

### DIFF
--- a/LayoutTests/fast/ruby/input-with-inherited-ruby-display-expected.txt
+++ b/LayoutTests/fast/ruby/input-with-inherited-ruby-display-expected.txt
@@ -1,0 +1,1 @@
+  This test passes if it doesn't crash.

--- a/LayoutTests/fast/ruby/input-with-inherited-ruby-display.html
+++ b/LayoutTests/fast/ruby/input-with-inherited-ruby-display.html
@@ -1,0 +1,10 @@
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+</script>
+<style>
+input { display: inherit; }
+</style>
+<ruby>
+<input>
+This test passes if it doesn't crash.

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -379,6 +379,23 @@ static bool isRubyContainerOrInternalRubyBox(const RenderStyle& style)
         || display == DisplayType::RubyBase;
 }
 
+static bool hasUnsupportedRubyDisplay(DisplayType display, const Element* element)
+{
+    // Only allow ruby elements to have ruby display types for now.
+    switch (display) {
+    case DisplayType::Ruby:
+    case DisplayType::RubyBlock:
+        return !element || !element->hasTagName(rubyTag);
+    case DisplayType::RubyAnnotation:
+        return !element || !element->hasTagName(rtTag);
+    case DisplayType::RubyBase:
+        ASSERT_NOT_REACHED();
+        return false;
+    default:
+        return false;
+    }
+}
+
 // https://drafts.csswg.org/css-ruby-1/#bidi
 static UnicodeBidi forceBidiIsolationForRuby(UnicodeBidi unicodeBidi)
 {
@@ -424,6 +441,9 @@ void Adjuster::adjust(RenderStyle& style, const RenderStyle* userAgentAppearance
             if (m_element->hasTagName(legendTag))
                 style.setEffectiveDisplay(equivalentBlockDisplay(style));
         }
+
+        if (hasUnsupportedRubyDisplay(style.display(), m_element))
+            style.setEffectiveDisplay(style.display() == DisplayType::RubyBlock ? DisplayType::Block : DisplayType::Inline);
 
         // Top layer elements are always position: absolute; unless the position is set to fixed.
         // https://fullscreen.spec.whatwg.org/#new-stacking-layer


### PR DESCRIPTION
#### 4992ead0c2849d41bdb4195177e35836c5a54cdd
<pre>
Input element with inherited display:ruby hits assert
<a href="https://bugs.webkit.org/show_bug.cgi?id=267130">https://bugs.webkit.org/show_bug.cgi?id=267130</a>
<a href="https://rdar.apple.com/120496475">rdar://120496475</a>

Reviewed by Alan Baradlay.

We only support ruby display types with ruby elements for now.
They can be inherited to other elements though, leading to unexpected state.

* LayoutTests/fast/ruby/input-with-inherited-ruby-display-expected.txt: Added.
* LayoutTests/fast/ruby/input-with-inherited-ruby-display.html: Added.
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::hasUnsupportedRubyDisplay):
(WebCore::Style::Adjuster::adjust const):

Adjust the style to disallow non-ruby elements from having ruby display types.

Canonical link: <a href="https://commits.webkit.org/272693@main">https://commits.webkit.org/272693@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8fa00fe597d1b1fdea83590ed035dd9be341b4f0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32722 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11476 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34579 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35294 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29565 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33647 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13825 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8664 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29051 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33163 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9678 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29228 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8439 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8569 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29181 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36631 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29737 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/29589 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34695 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8691 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6655 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32561 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10374 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/28882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7598 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9303 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9297 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->