### PR TITLE
Custom Highlights API painting does not invalidate properly when removing highlights

### DIFF
--- a/LayoutTests/fast/repaint/highlight-removed-when-cleared-expected.txt
+++ b/LayoutTests/fast/repaint/highlight-removed-when-cleared-expected.txt
@@ -1,0 +1,6 @@
+Highlight this first and then clear highlight.
+(repaint rects
+  (rect 8 8 784 37)
+  (rect 8 8 784 37)
+)
+When run, the first "this" should be highlighted, and then the highlight should be removed.

--- a/LayoutTests/fast/repaint/highlight-removed-when-cleared.html
+++ b/LayoutTests/fast/repaint/highlight-removed-when-cleared.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+html {
+    font-size: 24pt;
+}
+
+::highlight(yellowHighlight) {
+    background-color: yellow;
+}
+</style>
+<script src="../../resources/ui-helper.js"></script>
+</head>
+<body>
+    <div id="highlight_area">Highlight this first and then clear highlight.</div>
+    <pre id="result"></pre>
+    <p>When run, the first "this" should be highlighted, and then the highlight should be removed.</p>
+</body>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+(async () => {
+    if (window.internals)
+        internals.startTrackingRepaints();
+
+    let highlightRange = new Range();
+    let highlightOne = new Highlight(highlightRange);
+    CSS.highlights.set("yellowHighlight", highlightOne);
+    let highlightNode = highlight_area;
+
+    highlightRange.setStart(highlightNode.firstChild, 10);
+    highlightRange.setEnd(highlightNode.firstChild, 14);
+
+    await UIHelper.renderingUpdate();
+
+    CSS.highlights.clear();
+    if (window.internals) {
+        let repaintRects = internals.repaintRectsAsText();
+        internals.stopTrackingRepaints();
+        result.textContent = repaintRects;
+    }
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+})();
+</script>
+</html>

--- a/Source/WebCore/Modules/highlight/HighlightRegistry.cpp
+++ b/Source/WebCore/Modules/highlight/HighlightRegistry.cpp
@@ -49,8 +49,10 @@ void HighlightRegistry::setFromMapLike(AtomString&& key, Ref<Highlight>&& value)
 
 void HighlightRegistry::clear()
 {
-    m_map.clear();
     m_highlightNames.clear();
+    auto map = std::exchange(m_map, { });
+    for (auto& highlight : map.values())
+        highlight->clearFromSetLike();
 }
 
 bool HighlightRegistry::remove(const AtomString& key)


### PR DESCRIPTION
#### fd569defc022c2d1e03658764ac31816e0267ef1
<pre>
Custom Highlights API painting does not invalidate properly when removing highlights
<a href="https://bugs.webkit.org/show_bug.cgi?id=267136">https://bugs.webkit.org/show_bug.cgi?id=267136</a>
<a href="https://rdar.apple.com/119531671">rdar://119531671</a>

Reviewed by Tim Horton.

When clearing the entire highlight registry held on the document, we only
cleared the map of the highlights, which are sets of ranges. This did not
actually clear the highlight sets, and so the ranges were never flagged for
repainting. So when clearing the highlight registry, we need to ensure
that we are clearing each set of highlights specifically.

* LayoutTests/fast/repaint/highlight-removed-when-cleared-expected.txt: Added.
* LayoutTests/fast/repaint/highlight-removed-when-cleared.html: Added.
* Source/WebCore/Modules/highlight/HighlightRegistry.cpp:
(WebCore::HighlightRegistry::clear):

Canonical link: <a href="https://commits.webkit.org/272723@main">https://commits.webkit.org/272723@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/86605e6a4492c79789bc111b8519ad47cd149799

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32746 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11501 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34606 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35320 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29585 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33673 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13849 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8688 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29065 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33189 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9707 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29256 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8454 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8596 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29209 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36657 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29764 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29617 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34708 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8709 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6676 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32575 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10393 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/28891 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7621 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9320 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9318 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->