### PR TITLE
"Look Up" and "Copy Subject" context menu items are added after the menu is visible, which changes the current item under the cursor

### DIFF
--- a/Source/WebKit/Shared/WebContextMenuItemData.h
+++ b/Source/WebKit/Shared/WebContextMenuItemData.h
@@ -46,6 +46,7 @@ public:
     WebCore::ContextMenuAction action() const { return m_action; }
     const String& title() const { return m_title; }
     bool enabled() const { return m_enabled; }
+    void setEnabled(bool enabled) { m_enabled = enabled; }
     bool checked() const { return m_checked; }
     unsigned indentationLevel() const { return m_indentationLevel; }
     const Vector<WebContextMenuItemData>& submenu() const { return m_submenu; }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKElementAction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKElementAction.h
@@ -76,6 +76,7 @@ WK_CLASS_AVAILABLE(macos(10.10), ios(8.0))
 
 @property (nonatomic, readonly) _WKElementActionType type;
 @property (nonatomic, readonly) NSString* title;
+@property (nonatomic, readonly) BOOL disabled;
 @property (nonatomic, copy) WKElementActionDismissalHandler dismissalHandler;
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKElementActionInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKElementActionInternal.h
@@ -35,6 +35,7 @@ UIActionIdentifier elementActionTypeToUIActionIdentifier(_WKElementActionType);
 @interface _WKElementAction ()
 
 + (instancetype)_elementActionWithType:(_WKElementActionType)type info:(_WKActivatedElementInfo *)info assistant:(WKActionSheetAssistant *)assistant;
++ (instancetype)_elementActionWithType:(_WKElementActionType)type info:(_WKActivatedElementInfo *)info assistant:(WKActionSheetAssistant *)assistant disabled:(BOOL)disabled;
 + (instancetype)_elementActionWithType:(_WKElementActionType)type title:(NSString *)title actionHandler:(WKElementActionHandler)actionHandler;
 - (void)_runActionWithElementInfo:(_WKActivatedElementInfo *)info forActionSheetAssistant:(WKActionSheetAssistant *)assistant;
 

--- a/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm
+++ b/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm
@@ -611,15 +611,16 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     [defaultActions addObject:[_WKElementAction _elementActionWithType:_WKElementActionTypeCopy info:elementInfo assistant:self]];
 #if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)
-    if ([_delegate respondsToSelector:@selector(actionSheetAssistantShouldIncludeCopySubjectAction:)] && [_delegate actionSheetAssistantShouldIncludeCopySubjectAction:self])
-        [defaultActions addObject:[_WKElementAction _elementActionWithType:_WKElementActionTypeCopyCroppedImage info:elementInfo assistant:self]];
+    BOOL enableCopySubjectItem = [_delegate respondsToSelector:@selector(actionSheetAssistantShouldIncludeCopySubjectAction:)] && [_delegate actionSheetAssistantShouldIncludeCopySubjectAction:self];
+    [defaultActions addObject:[_WKElementAction _elementActionWithType:_WKElementActionTypeCopyCroppedImage info:elementInfo assistant:self disabled:!enableCopySubjectItem]];
 #endif
 
 #if ENABLE(IMAGE_ANALYSIS)
     if ([_delegate respondsToSelector:@selector(actionSheetAssistant:shouldIncludeShowTextActionForElement:)] && [_delegate actionSheetAssistant:self shouldIncludeShowTextActionForElement:elementInfo])
         [defaultActions addObject:[_WKElementAction _elementActionWithType:_WKElementActionTypeImageExtraction info:elementInfo assistant:self]];
-    if ([_delegate respondsToSelector:@selector(actionSheetAssistant:shouldIncludeLookUpImageActionForElement:)] && [_delegate actionSheetAssistant:self shouldIncludeLookUpImageActionForElement:elementInfo])
-        [defaultActions addObject:[_WKElementAction _elementActionWithType:_WKElementActionTypeRevealImage info:elementInfo assistant:self]];
+
+    BOOL enableLookUpItem = [_delegate respondsToSelector:@selector(actionSheetAssistant:shouldIncludeLookUpImageActionForElement:)] && [_delegate actionSheetAssistant:self shouldIncludeLookUpImageActionForElement:elementInfo];
+    [defaultActions addObject:[_WKElementAction _elementActionWithType:_WKElementActionTypeRevealImage info:elementInfo assistant:self disabled:!enableLookUpItem]];
 #endif
     [self _appendAnimationAction:defaultActions.get() elementInfo:elementInfo];
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -12298,14 +12298,28 @@ static BOOL shouldUseMachineReadableCodeMenuFromImageAnalysisResult(CocoaImageAn
             [replacements addObject:[elementAction uiActionForElementInfo:elementInfo]];
         };
 
-        if (foundCopyItem && self.copySubjectResultForImageContextMenu)
-            addAction(_WKElementActionTypeCopyCroppedImage);
+        for (UIMenuElement *child in adjustedChildren.get()) {
+            UIAction *action = dynamic_objc_cast<UIAction>(child);
+            if (!action)
+                continue;
+
+            if ([action.identifier isEqual:elementActionTypeToUIActionIdentifier(_WKElementActionTypeCopyCroppedImage)]) {
+                if (foundCopyItem && self.copySubjectResultForImageContextMenu)
+                    action.attributes &= ~UIMenuElementAttributesDisabled;
+
+                continue;
+            }
+
+            if ([action.identifier isEqual:revealImageIdentifier]) {
+                if (self.hasVisualSearchResultsForImageContextMenu)
+                    action.attributes &= ~UIMenuElementAttributesDisabled;
+
+                continue;
+            }
+        }
 
         if (self.hasSelectableTextForImageContextMenu)
             addAction(_WKElementActionTypeImageExtraction);
-
-        if (self.hasVisualSearchResultsForImageContextMenu)
-            addAction(_WKElementActionTypeRevealImage);
 
         if (UIMenu *subMenu = self.machineReadableCodeSubMenuForImageContextMenu)
             [replacements addObject:subMenu];


### PR DESCRIPTION
#### 4d608c217abcf334bf7ffd7b0848dece20489494
<pre>
&quot;Look Up&quot; and &quot;Copy Subject&quot; context menu items are added after the menu is visible, which changes the current item under the cursor
<a href="https://bugs.webkit.org/show_bug.cgi?id=267138">https://bugs.webkit.org/show_bug.cgi?id=267138</a>
<a href="https://rdar.apple.com/111049353">rdar://111049353</a>

Reviewed by Aditya Keerthi.

Show the items as disabled instead of hiding the &quot;Copy Subject&quot; and &quot;Look Up&quot; items until they are
ready to be used.

Note that this has the consequence that these items may never change from the disabled state to the
enabled state if it turns out an image isn&apos;t actually eligible for a given item.

* Source/WebKit/Platform/cocoa/ImageAnalysisUtilities.mm:
(WebKit::requestBackgroundRemoval):
* Source/WebKit/Shared/WebContextMenuItemData.h:
(WebKit::WebContextMenuItemData::setEnabled):
* Source/WebKit/UIProcess/API/Cocoa/_WKElementAction.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKElementAction.mm:
(-[_WKElementAction _initWithTitle:actionHandler:type:assistant:disabled:]):
(+[_WKElementAction elementActionWithTitle:actionHandler:]):
(+[_WKElementAction _elementActionWithType:title:actionHandler:]):
(+[_WKElementAction _elementActionWithType:customTitle:assistant:disabled:]):
(+[_WKElementAction _elementActionWithType:info:assistant:]):
(+[_WKElementAction _elementActionWithType:info:assistant:disabled:]):
(+[_WKElementAction elementActionWithType:customTitle:]):
(-[_WKElementAction uiActionForElementInfo:]):
(-[_WKElementAction _initWithTitle:actionHandler:type:assistant:]): Deleted.
(+[_WKElementAction _elementActionWithType:customTitle:assistant:]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/_WKElementActionInternal.h:
* Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm:
(-[WKActionSheetAssistant defaultActionsForLinkSheet:]):
(-[WKActionSheetAssistant defaultActionsForImageSheet:]):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _insertDynamicImageAnalysisContextMenuItemsIfPossible]):
* Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm:
(WebKit::WebContextMenuProxyMac::getContextMenuFromItems):

Canonical link: <a href="https://commits.webkit.org/272869@main">https://commits.webkit.org/272869@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1580a7efe1985795fb0f00ab576bd8ef17fc9038

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33416 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12187 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35329 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36042 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30365 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14537 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9329 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29496 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33889 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10281 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29830 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8972 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9100 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37372 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30347 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30166 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35220 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9223 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7158 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33088 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10975 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7732 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9808 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9947 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->