### PR TITLE
[WGSL] Add support for f16 bitcast and constant function

### DIFF
--- a/Source/WebGPU/WGSL/tests/invalid/bitcast.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/bitcast.wgsl
@@ -26,3 +26,9 @@ fn testInvalidConversion()
     // CHECK: cannot bitcast from 'vec2<i32>' to 'i32'
     _ = bitcast<i32>(vec2(0));
 }
+
+fn testI32Overflow()
+{
+    // value 4294967295 cannot be represented as 'i32'
+    { const x: f32 = bitcast<f32>(4294967295); }
+}

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -1032,61 +1032,141 @@ fn testBitcast()
     let u = 0u;
     let i = 0i;
     let f = 0f;
+    let h = 0h;
 
-    // [T < Concrete32BitNumber, S < Concrete32BitNumber].(S) => T
+    // @const @must_use fn bitcast<T>(e : T) -> T
+    { const x: u32 = bitcast<u32>(5u); }
+    { const x: i32 = bitcast<i32>(5i); }
+    { const x: f32 = bitcast<f32>(5f); }
+    { const x: f16 = bitcast<f16>(5h); }
     { let x: u32 = bitcast<u32>(u); }
+    { let x: i32 = bitcast<i32>(i); }
+    { let x: f32 = bitcast<f32>(f); }
+    { let x: f16 = bitcast<f16>(h); }
+
+    // @const @must_use fn bitcast<T>(e : S) -> T
+    { const x: u32 = bitcast<u32>(5i); }
+    { const x: u32 = bitcast<u32>(5f); }
     { let x: u32 = bitcast<u32>(i); }
     { let x: u32 = bitcast<u32>(f); }
 
+    { const x: i32 = bitcast<i32>(5u); }
+    { const x: i32 = bitcast<i32>(5f); }
     { let x: i32 = bitcast<i32>(u); }
-    { let x: i32 = bitcast<i32>(i); }
     { let x: i32 = bitcast<i32>(f); }
 
+    { const x: f32 = bitcast<f32>(5u); }
+    { const x: f32 = bitcast<f32>(5i); }
     { let x: f32 = bitcast<f32>(u); }
     { let x: f32 = bitcast<f32>(i); }
-    { let x: f32 = bitcast<f32>(f); }
 
-    // [T < Concrete32BitNumber, S < Concrete32BitNumber, N].(vec[N][S]) => vec[N][T]
+    // @const @must_use fn bitcast<vecN<T>>(e : vecN<S>) -> T
+
     // vec2
+    { const x: vec2<u32> = bitcast<vec2<u32>>(vec2(5u)); }
+    { const x: vec2<u32> = bitcast<vec2<u32>>(vec2(5i)); }
+    { const x: vec2<u32> = bitcast<vec2<u32>>(vec2(5f)); }
     { let x: vec2<u32> = bitcast<vec2<u32>>(vec2(u)); }
     { let x: vec2<u32> = bitcast<vec2<u32>>(vec2(i)); }
     { let x: vec2<u32> = bitcast<vec2<u32>>(vec2(f)); }
 
+    { const x: vec2<i32> = bitcast<vec2<i32>>(vec2(5u)); }
+    { const x: vec2<i32> = bitcast<vec2<i32>>(vec2(5i)); }
+    { const x: vec2<i32> = bitcast<vec2<i32>>(vec2(5f)); }
     { let x: vec2<i32> = bitcast<vec2<i32>>(vec2(u)); }
     { let x: vec2<i32> = bitcast<vec2<i32>>(vec2(i)); }
     { let x: vec2<i32> = bitcast<vec2<i32>>(vec2(f)); }
 
+    { const x: vec2<f32> = bitcast<vec2<f32>>(vec2(5u)); }
+    { const x: vec2<f32> = bitcast<vec2<f32>>(vec2(5i)); }
+    { const x: vec2<f32> = bitcast<vec2<f32>>(vec2(5f)); }
     { let x: vec2<f32> = bitcast<vec2<f32>>(vec2(u)); }
     { let x: vec2<f32> = bitcast<vec2<f32>>(vec2(i)); }
     { let x: vec2<f32> = bitcast<vec2<f32>>(vec2(f)); }
 
     // vec3
+    { const x: vec3<u32> = bitcast<vec3<u32>>(vec3(5u)); }
+    { const x: vec3<u32> = bitcast<vec3<u32>>(vec3(5i)); }
+    { const x: vec3<u32> = bitcast<vec3<u32>>(vec3(5f)); }
     { let x: vec3<u32> = bitcast<vec3<u32>>(vec3(u)); }
     { let x: vec3<u32> = bitcast<vec3<u32>>(vec3(i)); }
     { let x: vec3<u32> = bitcast<vec3<u32>>(vec3(f)); }
 
+    { const x: vec3<i32> = bitcast<vec3<i32>>(vec3(5u)); }
+    { const x: vec3<i32> = bitcast<vec3<i32>>(vec3(5i)); }
+    { const x: vec3<i32> = bitcast<vec3<i32>>(vec3(5f)); }
     { let x: vec3<i32> = bitcast<vec3<i32>>(vec3(u)); }
     { let x: vec3<i32> = bitcast<vec3<i32>>(vec3(i)); }
     { let x: vec3<i32> = bitcast<vec3<i32>>(vec3(f)); }
 
+    { const x: vec3<f32> = bitcast<vec3<f32>>(vec3(5u)); }
+    { const x: vec3<f32> = bitcast<vec3<f32>>(vec3(5i)); }
+    { const x: vec3<f32> = bitcast<vec3<f32>>(vec3(5f)); }
     { let x: vec3<f32> = bitcast<vec3<f32>>(vec3(u)); }
     { let x: vec3<f32> = bitcast<vec3<f32>>(vec3(i)); }
     { let x: vec3<f32> = bitcast<vec3<f32>>(vec3(f)); }
 
     // vec4
+    { const x: vec4<u32> = bitcast<vec4<u32>>(vec4(5u)); }
+    { const x: vec4<u32> = bitcast<vec4<u32>>(vec4(5i)); }
+    { const x: vec4<u32> = bitcast<vec4<u32>>(vec4(5f)); }
     { let x: vec4<u32> = bitcast<vec4<u32>>(vec4(u)); }
     { let x: vec4<u32> = bitcast<vec4<u32>>(vec4(i)); }
     { let x: vec4<u32> = bitcast<vec4<u32>>(vec4(f)); }
 
+    { const x: vec4<i32> = bitcast<vec4<i32>>(vec4(5u)); }
+    { const x: vec4<i32> = bitcast<vec4<i32>>(vec4(5i)); }
+    { const x: vec4<i32> = bitcast<vec4<i32>>(vec4(5f)); }
     { let x: vec4<i32> = bitcast<vec4<i32>>(vec4(u)); }
     { let x: vec4<i32> = bitcast<vec4<i32>>(vec4(i)); }
     { let x: vec4<i32> = bitcast<vec4<i32>>(vec4(f)); }
 
+    { const x: vec4<f32> = bitcast<vec4<f32>>(vec4(5u)); }
+    { const x: vec4<f32> = bitcast<vec4<f32>>(vec4(5i)); }
+    { const x: vec4<f32> = bitcast<vec4<f32>>(vec4(5f)); }
     { let x: vec4<f32> = bitcast<vec4<f32>>(vec4(u)); }
     { let x: vec4<f32> = bitcast<vec4<f32>>(vec4(i)); }
     { let x: vec4<f32> = bitcast<vec4<f32>>(vec4(f)); }
 
-    // FIXME: add f16 overloads
+    // @const @must_use fn bitcast<u32>(e : AbstractInt) -> T
+    { const x: u32 = bitcast<u32>(4294967295); }
+
+    // @const @must_use fn bitcast<vecN<u32>>(e : vecN<AbstractInt>) -> T
+    { const x: vec2<u32> = bitcast<vec2<u32>>(vec2(4294967295)); }
+    { const x: vec3<u32> = bitcast<vec3<u32>>(vec3(4294967295)); }
+    { const x: vec4<u32> = bitcast<vec4<u32>>(vec4(4294967295)); }
+
+    // @const @must_use fn bitcast<T>(e : vec2<f16>) -> T
+    { const x: u32 = bitcast<u32>(vec2(5h)); }
+    { let x: u32 = bitcast<u32>(vec2(h)); }
+    { const x: i32 = bitcast<i32>(vec2(5h)); }
+    { let x: i32 = bitcast<i32>(vec2(h)); }
+    { const x: f32 = bitcast<f32>(vec2(5h)); }
+    { let x: f32 = bitcast<f32>(vec2(h)); }
+
+    // @const @must_use fn bitcast<vec2<T>>(e : vec4<f16>) -> vec2<T>
+    { const x: vec2<u32> = bitcast<vec2<u32>>(vec4(5h)); }
+    { let x: vec2<u32> = bitcast<vec2<u32>>(vec4(h)); }
+    { const x: vec2<i32> = bitcast<vec2<i32>>(vec4(5h)); }
+    { let x: vec2<i32> = bitcast<vec2<i32>>(vec4(h)); }
+    { const x: vec2<f32> = bitcast<vec2<f32>>(vec4(5h)); }
+    { let x: vec2<f32> = bitcast<vec2<f32>>(vec4(h)); }
+
+    // @const @must_use fn bitcast<vec2<f16>>(e : T) -> vec2<f16>
+    { const x: vec2<f16> = bitcast<vec2<f16>>(5u); }
+    { const x: vec2<f16> = bitcast<vec2<f16>>(5i); }
+    { const x: vec2<f16> = bitcast<vec2<f16>>(5f); }
+    { let x: vec2<f16> = bitcast<vec2<f16>>(u); }
+    { let x: vec2<f16> = bitcast<vec2<f16>>(i); }
+    { let x: vec2<f16> = bitcast<vec2<f16>>(f); }
+
+    // @const @must_use fn bitcast<vec4<f16>>(e : vec2<T>) -> vec4<f16>
+    { const x: vec4<f16> = bitcast<vec4<f16>>(vec2(5u)); }
+    { const x: vec4<f16> = bitcast<vec4<f16>>(vec2(5i)); }
+    { const x: vec4<f16> = bitcast<vec4<f16>>(vec2(5f)); }
+    { let x: vec4<f16> = bitcast<vec4<f16>>(vec2(u)); }
+    { let x: vec4<f16> = bitcast<vec4<f16>>(vec2(i)); }
+    { let x: vec4<f16> = bitcast<vec4<f16>>(vec2(f)); }
 }
 
 // 16.3. Logical Built-in Functions (https://www.w3.org/TR/WGSL/#logical-builtin-functions)


### PR DESCRIPTION
#### 75bb072eb384a932aff1db17c39183b66d85d6b1
<pre>
[WGSL] Add support for f16 bitcast and constant function
<a href="https://bugs.webkit.org/show_bug.cgi?id=267142">https://bugs.webkit.org/show_bug.cgi?id=267142</a>
<a href="https://rdar.apple.com/120555423">rdar://120555423</a>

Reviewed by Dan Glastonbury and Mike Wyrzykowski.

Extend the type checking implementation for bitcast to support f16, and also
add the constant evaluator for it.

* Source/WebGPU/WGSL/ConstantFunctions.h:
(WGSL::CONSTANT_FUNCTION):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visitVariable):
(WGSL::TypeChecker::bitcast):
* Source/WebGPU/WGSL/tests/invalid/bitcast.wgsl:
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/272757@main">https://commits.webkit.org/272757@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8bf0d86adfae8fca1b511cd839bafd5446299682

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32770 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11522 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34631 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35388 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29608 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13867 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8707 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29072 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33213 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9723 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29269 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8463 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8605 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36684 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29780 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29628 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34719 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8721 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6688 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32586 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10406 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7645 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9331 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9335 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->