### PR TITLE
REGRESSION (270199@main): [visionOS] YouTube.com live chat flashes blank when exiting fullscreen

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -154,6 +154,8 @@ struct PerWebProcessState {
 
     WebCore::Color scrollViewBackgroundColor;
 
+    BOOL isAnimatingFullScreenExit { NO };
+
     BOOL invokingUIScrollViewDelegateCallback { NO };
 
     BOOL didDeferUpdateVisibleContentRectsForUIScrollViewDelegateCallback { NO };

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
@@ -160,6 +160,9 @@ enum class TapHandlingResult : uint8_t;
 - (void)_updateScrollViewInsetAdjustmentBehavior;
 - (void)_resetScrollViewInsetAdjustmentBehavior;
 
+- (void)_beginAnimatedFullScreenExit;
+- (void)_endAnimatedFullScreenExit;
+
 - (BOOL)_effectiveAppearanceIsDark;
 - (BOOL)_effectiveUserInterfaceLevelIsElevated;
 

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -2543,7 +2543,7 @@ static bool scrollViewCanScroll(UIScrollView *scrollView)
 
 - (BOOL)_shouldDeferGeometryUpdates
 {
-    return _perProcessState.liveResizeParameters || _perProcessState.dynamicViewportUpdateMode != WebKit::DynamicViewportUpdateMode::NotResizing;
+    return _perProcessState.liveResizeParameters || _perProcessState.dynamicViewportUpdateMode != WebKit::DynamicViewportUpdateMode::NotResizing || _perProcessState.isAnimatingFullScreenExit;
 }
 
 - (void)_updateVisibleContentRects
@@ -3048,6 +3048,19 @@ static WebCore::IntDegrees activeOrientation(WKWebView *webView)
 - (BOOL)_haveSetObscuredInsets
 {
     return _haveSetObscuredInsets;
+}
+
+- (void)_beginAnimatedFullScreenExit
+{
+    _perProcessState.isAnimatingFullScreenExit = YES;
+}
+
+- (void)_endAnimatedFullScreenExit
+{
+    if (std::exchange(_perProcessState.isAnimatingFullScreenExit, NO)) {
+        if (!self._shouldDeferGeometryUpdates)
+            [self _didStopDeferringGeometryUpdates];
+    }
 }
 
 #if ENABLE(FULLSCREEN_API)

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -1153,6 +1153,9 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
         _exitRequested = YES;
         return;
     }
+
+    [self._webView _beginAnimatedFullScreenExit];
+
     _fullScreenState = WebKit::WaitingToExitFullScreen;
     _exitingFullScreen = YES;
 
@@ -1224,6 +1227,8 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
 
     [webView setNeedsLayout];
     [webView layoutIfNeeded];
+
+    [webView _endAnimatedFullScreenExit];
 
     [CATransaction commit];
 }


### PR DESCRIPTION
#### 09322c4c8222987d5be229bf661b5c3ae4420664
<pre>
REGRESSION (270199@main): [visionOS] YouTube.com live chat flashes blank when exiting fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=267144">https://bugs.webkit.org/show_bug.cgi?id=267144</a>
<a href="https://rdar.apple.com/119210895">rdar://119210895</a>

Reviewed by Tim Horton.

In order to let the safe area insets determine viewport layout parameters,
270199@main removed the call to `-[WKWebView _overrideLayoutParametersWithMinimumLayoutSize:maximumUnobscuredSizeOverride:]`
in `-[WKFullScreenWindowController enterFullScreen:]`. While this change remains
desirable, that method call also served to ensure that viewport layout parameters
were stable until fullscreen exit was completed, when the original parameters were
restored in `-[WKFullScreenWindowController _reinsertWebViewUnderPlaceholder]`.

Specifically, with the removal of that method call, the web view&apos;s frame and safe
area insets are now always used to determine layout parameters while transitioning
into and out of fullscreen. This means that if a client were to change the frame
of the web view during the transition, the view layout size in the web process
would be updated.

Safari sets the frame of the web view back to the original size during the transition.
While this is not ideal client behavior, there is nothing stopping any client from
modifying the web view&apos;s frame. This results in the view layout size mismatching
with the other fullscreen specific overrides, which are only restored once the
transition is complete. The mismatch ultimately results in layout happening with an
incorrect viewport configuration, which is then fixed when the transition is fully
complete. This results in a flash, as YouTube&apos;s content is viewport size dependent.

Previously, setting the frame during the transition had no effect, as the overridden size
was used up until it was restored, when the transition was complete.

To fix without removing the intent of 270199@main, defer all geometry updates
while the fullscreen exit transition is happening. This ensures that used
viewport configuration remains stable during the transition.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:

Introduce a new fullscreen-specific bit that will be used to defer geometry updates.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _shouldDeferGeometryUpdates]):
(-[WKWebView _beginAnimatedFullScreenExit]):
(-[WKWebView _endAnimatedFullScreenExit]):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController exitFullScreen]):
(-[WKFullScreenWindowController _reinsertWebViewUnderPlaceholder]):

Stop deferring geometry updates once the original state of the web view has
fully been restored.

Canonical link: <a href="https://commits.webkit.org/272750@main">https://commits.webkit.org/272750@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/885d4486408b7cf3cd1c259ced334283638bbbb7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32783 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11534 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34643 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35398 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29615 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13878 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8719 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29077 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33226 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9727 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29276 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8468 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8609 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36714 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29784 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29634 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34729 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8729 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6696 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32595 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10415 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7637 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9339 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9345 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->