### PR TITLE
CRASH: Exception thrown from -[AVAssetResourceLoadingRequest finishLoading]

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm
@@ -39,6 +39,7 @@
 #import "UTIUtilities.h"
 #import <AVFoundation/AVAssetResourceLoader.h>
 #import <objc/runtime.h>
+#import <wtf/BlockObjCExceptions.h>
 #import <wtf/SoftLinking.h>
 #import <wtf/text/CString.h>
 
@@ -365,7 +366,9 @@ void WebCoreAVFResourceLoader::responseReceived(const ResourceResponse& response
             [contentInfo setEntireLengthAvailableOnDemand:YES];
 
         if (![m_avRequest dataRequest]) {
+            BEGIN_BLOCK_OBJC_EXCEPTIONS
             [m_avRequest finishLoading];
+            END_BLOCK_OBJC_EXCEPTIONS
             stopLoading();
         }
     }
@@ -384,7 +387,9 @@ void WebCoreAVFResourceLoader::loadFailed(const ResourceError& error)
 
 void WebCoreAVFResourceLoader::loadFinished()
 {
+    BEGIN_BLOCK_OBJC_EXCEPTIONS
     [m_avRequest finishLoading];
+    END_BLOCK_OBJC_EXCEPTIONS
     stopLoading();
 }
 
@@ -429,7 +434,9 @@ void WebCoreAVFResourceLoader::newDataStoredInSharedBuffer(const FragmentedShare
         return;
 
     if (dataRequest.currentOffset + dataRequest.requestedLength >= dataRequest.requestedOffset) {
+        BEGIN_BLOCK_OBJC_EXCEPTIONS
         [m_avRequest finishLoading];
+        END_BLOCK_OBJC_EXCEPTIONS
         stopLoading();
     }
 }


### PR DESCRIPTION
#### dd25322e371157212c618ce09a76040ddc25862a
<pre>
CRASH: Exception thrown from -[AVAssetResourceLoadingRequest finishLoading]
<a href="https://bugs.webkit.org/show_bug.cgi?id=267153">https://bugs.webkit.org/show_bug.cgi?id=267153</a>
<a href="https://rdar.apple.com/118422805">rdar://118422805</a>

Reviewed by Andy Estes.

AVAssetResourceLoadingRequest will throw an undocumented exception when -finishLoading is called,
provided a `contentType` present in the request, the `allowedContentTypes` readonly property is
non-nil, non-empty, and `contentType` is not present in the `allowedContentTypes` array.

`allowedContentTypes` is almost always nil, except under certain senarios involving AirPlay.

Protect against this undocument execption by wrapping -finishLoading in a try/catch block.

* Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm:
(WebCore::WebCoreAVFResourceLoader::responseReceived):
(WebCore::WebCoreAVFResourceLoader::loadFinished):
(WebCore::WebCoreAVFResourceLoader::newDataStoredInSharedBuffer):

Canonical link: <a href="https://commits.webkit.org/272715@main">https://commits.webkit.org/272715@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f8ab0bcabfb6c7868443579f735e8867d3dffa0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32795 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11546 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34656 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35407 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29624 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33722 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13890 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8730 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/29084 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33238 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9735 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29285 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8475 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8616 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29240 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36735 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29793 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29644 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34734 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8738 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6703 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32602 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10425 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7617 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9348 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9356 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->