### PR TITLE
[WebGPU] Calling GPUTexture.destroy() on the result of GPUCanvasContext.getCurrentTexture() is problematic

### DIFF
--- a/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
+++ b/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
@@ -121,6 +121,7 @@ void PresentationContextIOSurface::configure(Device& device, const WGPUSwapChain
         texture.label = fromAPI(descriptor.label);
         auto viewFormats = Vector<WGPUTextureFormat> { Texture::pixelFormat(descriptor.format) };
         auto parentTexture = Texture::create(texture, wgpuTextureDescriptor, WTFMove(viewFormats), device);
+        parentTexture->makeCanvasBacking();
         m_renderBuffers.append({ parentTexture, TextureView::create(texture, wgpuTextureViewDescriptor, { { width, height, 1 } }, parentTexture, device) });
     }
     ASSERT(m_ioSurfaces.count == m_renderBuffers.size());
@@ -143,7 +144,9 @@ void PresentationContextIOSurface::present()
 Texture* PresentationContextIOSurface::getCurrentTexture()
 {
     ASSERT(m_ioSurfaces.count == m_renderBuffers.size());
-    return m_renderBuffers[m_currentIndex].texture.ptr();
+    auto& texture = m_renderBuffers[m_currentIndex].texture;
+    texture->recreateIfNeeded();
+    return texture.ptr();
 }
 
 TextureView* PresentationContextIOSurface::getCurrentTextureView()

--- a/Source/WebGPU/WebGPU/Texture.h
+++ b/Source/WebGPU/WebGPU/Texture.h
@@ -109,6 +109,8 @@ public:
     static bool hasStorageBindingCapability(WGPUTextureFormat, const Device&, WGPUStorageTextureAccess = WGPUStorageTextureAccess_Undefined);
     static bool supportsMultisampling(WGPUTextureFormat, const Device&);
     static bool supportsBlending(WGPUTextureFormat, const Device&);
+    void recreateIfNeeded();
+    void makeCanvasBacking();
 
 private:
     Texture(id<MTLTexture>, const WGPUTextureDescriptor&, Vector<WGPUTextureFormat>&& viewFormats, Device&);
@@ -136,6 +138,7 @@ private:
     using ClearedToZeroContainer = HashMap<uint32_t, ClearedToZeroInnerContainer, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
     ClearedToZeroContainer m_clearedToZero;
     bool m_destroyed { false };
+    bool m_canvasBacking { false };
 };
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/Texture.mm
+++ b/Source/WebGPU/WebGPU/Texture.mm
@@ -2723,11 +2723,22 @@ Ref<TextureView> Texture::createView(const WGPUTextureViewDescriptor& inputDescr
     return TextureView::create(texture, *descriptor, renderExtent, *this, m_device);
 }
 
+void Texture::recreateIfNeeded()
+{
+    RELEASE_ASSERT(m_texture.iosurface && m_canvasBacking);
+    m_destroyed = false;
+}
+
+void Texture::makeCanvasBacking()
+{
+    m_canvasBacking = true;
+}
+
 void Texture::destroy()
 {
     // https://gpuweb.github.io/gpuweb/#dom-gputexture-destroy
-
-    m_texture = nil;
+    if (!m_canvasBacking)
+        m_texture = nil;
     m_destroyed = true;
 }
 


### PR DESCRIPTION
#### b6b15a92672c6f687c48ddaff2a646783e2bfe8a
<pre>
[WebGPU] Calling GPUTexture.destroy() on the result of GPUCanvasContext.getCurrentTexture() is problematic
<a href="https://bugs.webkit.org/show_bug.cgi?id=267098">https://bugs.webkit.org/show_bug.cgi?id=267098</a>
&lt;radar://120494910&gt;

Reviewed by Tadeu Zagallo.

Calling GPUTexture.destroy() on the result of GPUCanvasContext.getCurrentTexture() was
problematic because we don&apos;t continuously make new IOSurface backed MTLTexture instances
for the canvas.

We don&apos;t need to, we just need to ensure that calling destroy makes the Texture act
like an invalid texture and that calling getCurrentTexture() returns a non-destroyed
texture.

* Source/WebGPU/WebGPU/PresentationContextIOSurface.mm:
(WebGPU::PresentationContextIOSurface::configure):
(WebGPU::PresentationContextIOSurface::getCurrentTexture):
* Source/WebGPU/WebGPU/Texture.h:
* Source/WebGPU/WebGPU/Texture.mm:
(WebGPU::Texture::recreateIfNeeded):
(WebGPU::Texture::makeCanvasBacking):
(WebGPU::Texture::destroy):

Canonical link: <a href="https://commits.webkit.org/272711@main">https://commits.webkit.org/272711@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4bdbe510b309a4229d87493675f5565ed0f7db69

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32794 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11545 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34655 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35406 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29623 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13889 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8729 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/29081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33237 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9734 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29284 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8472 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/8615 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36736 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29792 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29643 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/34737 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8737 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6702 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32606 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10424 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7615 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9347 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9355 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->