### PR TITLE
Generate EventNames.h and EventNames.cpp from a JSON file

### DIFF
--- a/Source/WebCore/dom/make-event-names.py
+++ b/Source/WebCore/dom/make-event-names.py
@@ -36,7 +36,7 @@ def main():
     parser.add_argument('--event-names')
     args = parser.parse_args()
 
-    with open(args.event_names, "r", encoding="utf-8") as event_names_file:
+    with open(args.event_names, 'r', encoding='utf-8') as event_names_file:
         event_names_input = json.load(event_names_file)
 
     with open('EventNames.h', 'w') as output_file:
@@ -44,9 +44,9 @@ def main():
             output_file.write(text)
 
         def writeln(text):
-            write(text + "\n")
+            write(text + '\n')
 
-        writeln("""/*
+        writeln('''/*
  * Copyright (C) 2005-2024 Apple Inc. All rights reserved.
  * Copyright (C) 2006 Jon Shier (jshier@iastate.edu)
  *
@@ -79,37 +79,37 @@ namespace WebCore {
 struct EventNames {
     WTF_MAKE_NONCOPYABLE(EventNames); WTF_MAKE_FAST_ALLOCATED;
 
-public:""")
+public:''')
         type_map = {}
         for name in sorted(event_names_input.keys()):
             entry = event_names_input[name]
             conditional = entry.get('conditional', None)
             if conditional:
-                writeln(f"#if {conditional}")
-            writeln(f"    const AtomString {name}Event;")
+                writeln(f'#if {conditional}')
+            writeln(f'    const AtomString {name}Event;')
             for event_type in entry.get('types', []):
                 type_map.setdefault(event_type, [])
                 type_map[event_type].append(name)
             if conditional:
-                writeln("#endif")
+                writeln('#endif')
 
-        writeln("""
+        writeln('''
     template<class... Args>
     static std::unique_ptr<EventNames> create(Args&&... args)
     {
         return std::unique_ptr<EventNames>(new EventNames(std::forward<Args>(args)...));
-    }""")
+    }''')
 
         for event_type in sorted(type_map.keys()):
-            writeln("")
-            writeln(f"    inline bool is{event_type}EventType(const AtomString&) const;")
+            writeln('')
+            writeln(f'    inline bool is{event_type}EventType(const AtomString&) const;')
             name_count = len(type_map[event_type])
-            writeln(f"    inline std::array<const AtomString, {name_count}> {lowercase_first_letter(event_type)}EventNames() const;")
+            writeln(f'    inline std::array<const AtomString, {name_count}> {lowercase_first_letter(event_type)}EventNames() const;')
 
-        writeln("")
-        writeln(f"    inline std::array<const AtomString, {len(event_names_input)}> allEventNames() const;")
+        writeln('')
+        writeln(f'    inline std::array<const AtomString, {len(event_names_input)}> allEventNames() const;')
 
-        writeln("""
+        writeln('''
 private:
     EventNames();
 };
@@ -119,61 +119,61 @@ const EventNames& eventNames();
 inline const EventNames& eventNames()
 {
     return threadGlobalData().eventNames();
-}""")
+}''')
 
         for event_type in sorted(type_map.keys()):
             names = type_map[event_type]
             name_count = len(type_map[event_type])
-            writeln("")
-            writeln(f"inline bool EventNames::is{event_type}EventType(const AtomString& type) const")
-            writeln("{")
+            writeln('')
+            writeln(f'inline bool EventNames::is{event_type}EventType(const AtomString& type) const')
+            writeln('{')
             # FIXME: Support conditionals in the first or the last item.
-            writeln(f"    return type == {names[0]}Event")
+            writeln(f'    return type == {names[0]}Event')
             for name in names[1:-1]:
                 conditional = event_names_input[name].get('conditional', None)
                 if conditional:
-                    writeln(f"#if {conditional}")
-                writeln(f"        || type == {name}Event")
+                    writeln(f'#if {conditional}')
+                writeln(f'        || type == {name}Event')
                 if conditional:
-                    writeln(f"#endif")
+                    writeln(f'#endif')
             if len(names) >= 2:
-                writeln(f"        || type == {names[-1]}Event;")
-            writeln("}")
-            writeln("")
-            writeln(f"inline std::array<const AtomString, {name_count}> EventNames::{lowercase_first_letter(event_type)}EventNames() const")
-            writeln("{")
-            writeln("    return { {")
+                writeln(f'        || type == {names[-1]}Event;')
+            writeln('}')
+            writeln('')
+            writeln(f'inline std::array<const AtomString, {name_count}> EventNames::{lowercase_first_letter(event_type)}EventNames() const')
+            writeln('{')
+            writeln('    return { {')
             for name in names:
                 conditional = event_names_input[name].get('conditional', None)
                 if conditional:
-                    writeln(f"#if {conditional}")
-                writeln(f"        {name}Event,")
+                    writeln(f'#if {conditional}')
+                writeln(f'        {name}Event,')
                 if conditional:
-                    writeln(f"#endif")
-            writeln("    } };")
-            writeln("}")
+                    writeln(f'#endif')
+            writeln('    } };')
+            writeln('}')
 
-        writeln("")
+        writeln('')
 
-        writeln(f"inline std::array<const AtomString, {len(event_names_input)}> EventNames::allEventNames() const")
-        writeln("{")
-        writeln("    return { {")
+        writeln(f'inline std::array<const AtomString, {len(event_names_input)}> EventNames::allEventNames() const')
+        writeln('{')
+        writeln('    return { {')
         for name in sorted(event_names_input.keys()):
             conditional = event_names_input[name].get('conditional', None)
             if conditional:
-                writeln(f"#if {conditional}")
-            writeln(f"        {name}Event,")
+                writeln(f'#if {conditional}')
+            writeln(f'        {name}Event,')
             if conditional:
-                writeln(f"#endif")
-        writeln("    } };")
-        writeln("}")
-        writeln("")
-        writeln("} // namespace WebCore")
+                writeln(f'#endif')
+        writeln('    } };')
+        writeln('}')
+        writeln('')
+        writeln('} // namespace WebCore')
 
     with open('EventNames.cpp', 'w') as output_file:
         def writeln(text):
-            output_file.write(text + "\n")
-        writeln("""/*
+            output_file.write(text + '\n')
+        writeln('''/*
  * Copyright (C) 2005-2024 Apple Inc.
  *
  * This library is free software; you can redistribute it and/or
@@ -198,22 +198,22 @@ inline const EventNames& eventNames()
 
 namespace WebCore {
 
-EventNames::EventNames()""")
+EventNames::EventNames()''')
 
         delimiter = ':'
         for name in sorted(event_names_input.keys()):
             conditional = event_names_input[name].get('conditional', None)
             if conditional:
-                writeln(f"#if {conditional}")
-            writeln(f"    {delimiter} {name}Event(\"{name}\"_s)")
+                writeln(f'#if {conditional}')
+            writeln(f'    {delimiter} {name}Event(\"{name}\"_s)')
             delimiter = ','
             if conditional:
-                writeln("#endif")
+                writeln('#endif')
 
-        writeln("""{ }
+        writeln('''{ }
 
-} // namespace WebCore""")
+} // namespace WebCore''')
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()


### PR DESCRIPTION
#### 35e8669975bf202d642116aa238bbc38c74bec5b
<pre>
Generate EventNames.h and EventNames.cpp from a JSON file
<a href="https://bugs.webkit.org/show_bug.cgi?id=267125">https://bugs.webkit.org/show_bug.cgi?id=267125</a>

Unreviewed. Address Tim Nguyen&apos;s review comment.

* Source/WebCore/dom/make-event-names.py:
(main):
(main.writeln):

Canonical link: <a href="https://commits.webkit.org/272712@main">https://commits.webkit.org/272712@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ed0dc8da30e8e0188fef7f9bebf01b8b7e12f223

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32797 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11548 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34658 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35409 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29626 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33724 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13892 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8732 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/29085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33240 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9737 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/29287 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8476 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8618 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29242 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36740 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29795 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/29646 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/34738 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8740 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/6705 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32607 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10427 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9350 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4228 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9358 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->