### PR TITLE
Revert 270416@main - Broke cmd-click navigation on fragment links.

### DIFF
--- a/LayoutTests/http/tests/navigation/fragment-navigation-policy-ignore-expected.txt
+++ b/LayoutTests/http/tests/navigation/fragment-navigation-policy-ignore-expected.txt
@@ -1,0 +1,11 @@
+Policy delegate: attempt to load http://127.0.0.1:8000/navigation/fragment-navigation-policy-ignore.html#test with navigation type 'other'
+Checks that the client can prevent a fragment navigation via the decidePolicyForNavigationAction delegate.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS window.location.href is "http://127.0.0.1:8000/navigation/fragment-navigation-policy-ignore.html"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/navigation/fragment-navigation-policy-ignore.html
+++ b/LayoutTests/http/tests/navigation/fragment-navigation-policy-ignore.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+</head>
+<body>
+<script>
+description("Checks that the client can prevent a fragment navigation via the decidePolicyForNavigationAction delegate.");
+jsTestIsAsync = true;
+
+if (window.testRunner) {
+    testRunner.setCustomPolicyDelegate(true, false);
+    if (testRunner.skipPolicyDelegateNotifyDone) { testRunner.skipPolicyDelegateNotifyDone() }
+}
+
+onload = function() {
+    location = "#test";
+    setTimeout(function() {
+        shouldBeEqualToString("window.location.href", "http://127.0.0.1:8000/navigation/fragment-navigation-policy-ignore.html");
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -113,7 +113,6 @@ enum class SDKAlignedBehavior {
     EvaluateJavaScriptWithoutTransientActivation,
     ResettingTransitionCancelsRunningTransitionQuirk,
     OnlyLoadWellKnownAboutURLs,
-    AsyncFragmentNavigationPolicyDecision,
     DoNotLoadStyleSheetIfHTTPStatusIsNotOK,
     ScrollViewSubclassImplementsAddGestureRecognizer,
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -41,10 +41,6 @@
 #include <WebCore/LocalFrame.h>
 #include <WebCore/PolicyChecker.h>
 
-#if PLATFORM(COCOA)
-#include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
-#endif
-
 #define WebFrameLoaderClient_PREFIX_PARAMETERS "%p - [webFrame=%p, webFrameID=%" PRIu64 ", webPage=%p, webPageID=%" PRIu64 "] WebFrameLoaderClient::"
 #define WebFrameLoaderClient_WEBFRAME (&webFrame())
 #define WebFrameLoaderClient_WEBFRAMEID (webFrame().frameID().object().toUInt64())
@@ -160,23 +156,16 @@ void WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction(const Navigat
 
     // Notify the UIProcess.
     if (policyDecisionMode == PolicyDecisionMode::Synchronous) {
-#if PLATFORM(COCOA)
-        if (!linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::AsyncFragmentNavigationPolicyDecision)) {
-            auto sendResult = webPage->sendSync(Messages::WebPageProxy::DecidePolicyForNavigationActionSync(m_frame->info(), documentLoader ? documentLoader->navigationID() : 0, navigationActionData, originatingFrameInfoData, originatingPageID, navigationAction.originalRequest(), request, IPC::FormDataReference { request.httpBody() }));
-            if (!sendResult.succeeded()) {
-                WebFrameLoaderClient_RELEASE_LOG_ERROR(Network, "dispatchDecidePolicyForNavigationAction: ignoring because of failing to send sync IPC with error %" PUBLIC_LOG_STRING, IPC::errorAsString(sendResult.error));
-                m_frame->didReceivePolicyDecision(listenerID, requestIdentifier, PolicyDecision { });
-                return;
-            }
-
-            auto [policyDecision] = sendResult.takeReply();
-            WebFrameLoaderClient_RELEASE_LOG(Network, "dispatchDecidePolicyForNavigationAction: Got policyAction %u from sync IPC", (unsigned)policyDecision.policyAction);
-            m_frame->didReceivePolicyDecision(listenerID, requestIdentifier, PolicyDecision { policyDecision.isNavigatingToAppBoundDomain, policyDecision.policyAction, 0, policyDecision.downloadID });
+        auto sendResult = webPage->sendSync(Messages::WebPageProxy::DecidePolicyForNavigationActionSync(m_frame->info(), documentLoader ? documentLoader->navigationID() : 0, navigationActionData, originatingFrameInfoData, originatingPageID, navigationAction.resourceRequest(), request, IPC::FormDataReference { request.httpBody() }));
+        if (!sendResult.succeeded()) {
+            WebFrameLoaderClient_RELEASE_LOG_ERROR(Network, "dispatchDecidePolicyForNavigationAction: ignoring because of failing to send sync IPC with error %" PUBLIC_LOG_STRING, IPC::errorAsString(sendResult.error));
+            m_frame->didReceivePolicyDecision(listenerID, requestIdentifier, PolicyDecision { });
             return;
         }
-#endif
-        webPage->sendWithAsyncReply(Messages::WebPageProxy::DecidePolicyForNavigationActionAsync(m_frame->info(), documentLoader ? documentLoader->navigationID() : 0, navigationActionData, originatingFrameInfoData, originatingPageID, navigationAction.originalRequest(), request, IPC::FormDataReference { request.httpBody() }), [] (PolicyDecision&&) { });
-        m_frame->didReceivePolicyDecision(listenerID, requestIdentifier, PolicyDecision { std::nullopt, PolicyAction::Use });
+
+        auto [policyDecision] = sendResult.takeReply();
+        WebFrameLoaderClient_RELEASE_LOG(Network, "dispatchDecidePolicyForNavigationAction: Got policyAction %u from sync IPC", (unsigned)policyDecision.policyAction);
+        m_frame->didReceivePolicyDecision(listenerID, requestIdentifier, PolicyDecision { policyDecision.isNavigatingToAppBoundDomain, policyDecision.policyAction, 0, policyDecision.downloadID });
         return;
     }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/StorageQuota.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/StorageQuota.mm
@@ -466,9 +466,7 @@ TEST(WebKit, QuotaDelegateNavigateFragment)
 
     receivedQuotaDelegateCalled = false;
     [webView loadRequest:server.request("/main.html#fragment"_s)];
-    [webView _test_waitForDidSameDocumentNavigation];
-
-    [webView evaluateJavaScript:@"doTestAgain()" completionHandler:nil];
+    [webView stringByEvaluatingJavaScript:@"doTestAgain()"];
 
     [messageHandler setExpectedMessage: @"start"];
     receivedMessage = false;

--- a/Tools/TestWebKitAPI/cocoa/TestNavigationDelegate.h
+++ b/Tools/TestWebKitAPI/cocoa/TestNavigationDelegate.h
@@ -38,7 +38,6 @@
 @property (nonatomic, copy) void (^didCommitNavigation)(WKWebView *, WKNavigation *);
 @property (nonatomic, copy) void (^didCommitLoadWithRequestInFrame)(WKWebView *, NSURLRequest *, WKFrameInfo *);
 @property (nonatomic, copy) void (^didFinishNavigation)(WKWebView *, WKNavigation *);
-@property (nonatomic, copy) void (^didSameDocumentNavigation)(WKWebView *, WKNavigation *);
 @property (nonatomic, copy) void (^renderingProgressDidChange)(WKWebView *, _WKRenderingProgressEvents);
 @property (nonatomic, copy) void (^webContentProcessDidTerminate)(WKWebView *);
 @property (nonatomic, copy) void (^didReceiveAuthenticationChallenge)(WKWebView *, NSURLAuthenticationChallenge *, void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential *));
@@ -50,7 +49,6 @@
 - (void)waitForDidStartProvisionalNavigation;
 - (void)waitForDidFinishNavigation;
 - (void)waitForDidFinishNavigationWithPreferences:(WKWebpagePreferences *)preferences;
-- (void)waitForDidSameDocumentNavigation;
 - (NSError *)waitForDidFailProvisionalNavigation;
 
 @end
@@ -58,7 +56,6 @@
 @interface WKWebView (TestWebKitAPIExtras)
 - (void)_test_waitForDidStartProvisionalNavigation;
 - (void)_test_waitForDidFinishNavigation;
-- (void)_test_waitForDidSameDocumentNavigation;
 - (void)_test_waitForDidFinishNavigationWithPreferences:(WKWebpagePreferences *)preferences;
 - (void)_test_waitForDidFinishNavigationWithoutPresentationUpdate;
 - (void)_test_waitForDidFinishNavigationWhileIgnoringSSLErrors;

--- a/Tools/TestWebKitAPI/cocoa/TestNavigationDelegate.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestNavigationDelegate.mm
@@ -85,12 +85,6 @@
         _didFinishNavigation(webView, navigation);
 }
 
-- (void)_webView:(WKWebView *)webView navigation:(WKNavigation *)navigation didSameDocumentNavigation:(_WKSameDocumentNavigationType)navigationType
-{
-    if (_didSameDocumentNavigation)
-        _didSameDocumentNavigation(webView, navigation);
-}
-
 - (void)webViewWebContentProcessDidTerminate:(WKWebView *)webView
 {
     if (_webContentProcessDidTerminate)
@@ -146,20 +140,6 @@
     TestWebKitAPI::Util::run(&finished);
 
     self.didFinishNavigation = nil;
-}
-
-- (void)waitForDidSameDocumentNavigation
-{
-    EXPECT_FALSE(self.didSameDocumentNavigation);
-
-    __block bool finished = false;
-    self.didSameDocumentNavigation = ^(WKWebView *, WKNavigation *) {
-        finished = true;
-    };
-
-    TestWebKitAPI::Util::run(&finished);
-
-    self.didSameDocumentNavigation = nil;
 }
 
 - (void)waitForWebContentProcessDidTerminate
@@ -288,17 +268,6 @@
     }];
     TestWebKitAPI::Util::run(&presentationUpdateHappened);
 #endif
-}
-
-- (void)_test_waitForDidSameDocumentNavigation
-{
-    EXPECT_FALSE(self.navigationDelegate);
-
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
-    self.navigationDelegate = navigationDelegate.get();
-    [navigationDelegate waitForDidSameDocumentNavigation];
-
-    self.navigationDelegate = nil;
 }
 
 - (void)_test_waitForDidFinishNavigationWhileIgnoringSSLErrors


### PR DESCRIPTION
#### 8bd38fa4b7e6b4ea6ac40368811c40595d0c1904
<pre>
Revert 270416@main - Broke cmd-click navigation on fragment links.
<a href="https://bugs.webkit.org/show_bug.cgi?id=267156">https://bugs.webkit.org/show_bug.cgi?id=267156</a>
<a href="https://rdar.apple.com/119079650">rdar://119079650</a>

Reviewed by NOBODY (OOPS!).

This change cause command-clicking on a fragment link to navigate the main page as well
and the page on the newly opened tab. Reverting until we find another solution that
doesn&apos;t cause this regression.

* LayoutTests/http/tests/navigation/fragment-navigation-policy-ignore-expected.txt: Added.
* LayoutTests/http/tests/navigation/fragment-navigation-policy-ignore.html: Added.
* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp:
(WebKit::WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/StorageQuota.mm:
* Tools/TestWebKitAPI/cocoa/TestNavigationDelegate.h:
* Tools/TestWebKitAPI/cocoa/TestNavigationDelegate.mm:
(-[TestNavigationDelegate _webView:navigation:didSameDocumentNavigation:]): Deleted.
(-[TestNavigationDelegate waitForDidSameDocumentNavigation]): Deleted.
(-[WKWebView _test_waitForDidSameDocumentNavigation]): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8bd38fa4b7e6b4ea6ac40368811c40595d0c1904

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32802 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11553 "Hash 8bd38fa4 for PR 22451 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34663 "Hash 8bd38fa4 for PR 22451 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35414 "Hash 8bd38fa4 for PR 22451 does not build (failure)") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29631 "Hash 8bd38fa4 for PR 22451 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33729 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13897 "Hash 8bd38fa4 for PR 22451 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8737 "Hash 8bd38fa4 for PR 22451 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/35414 "Hash 8bd38fa4 for PR 22451 does not build (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33245 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/13897 "Hash 8bd38fa4 for PR 22451 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/34663 "Hash 8bd38fa4 for PR 22451 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/35414 "Hash 8bd38fa4 for PR 22451 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/13897 "Hash 8bd38fa4 for PR 22451 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/34663 "Hash 8bd38fa4 for PR 22451 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36745 "Hash 8bd38fa4 for PR 22451 does not build (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/28069 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/13897 "Hash 8bd38fa4 for PR 22451 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/34663 "Hash 8bd38fa4 for PR 22451 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/36745 "Hash 8bd38fa4 for PR 22451 does not build (failure)") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/32808 "Built successfully and passed tests") | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8743 "Hash 8bd38fa4 for PR 22451 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/51/builds/8737 "Hash 8bd38fa4 for PR 22451 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/36745 "Hash 8bd38fa4 for PR 22451 does not build (failure)") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10431 "Hash 8bd38fa4 for PR 22451 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/34663 "Hash 8bd38fa4 for PR 22451 does not build (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/39276 "Built successfully") | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9354 "Hash 8bd38fa4 for PR 22451 does not build (failure)") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8279 "Passed tests") | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9362 "Hash 8bd38fa4 for PR 22451 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->