### PR TITLE
Rename *ShadowPseudoElement* to *UserAgentPart*

### DIFF
--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -186,7 +186,7 @@ void ElementRuleCollector::collectMatchingRules(CascadeLevel level)
         matchHostPseudoClassRules(level);
 
     if (element().isInShadowTree()) {
-        matchShadowPseudoElementRules(level);
+        matchUserAgentPartRules(level);
         matchPartPseudoElementRules(level);
     }
 }
@@ -198,7 +198,7 @@ void ElementRuleCollector::collectMatchingRules(const MatchRequest& matchRequest
     auto& element = this->element();
     auto* shadowRoot = element.containingShadowRoot();
     if (shadowRoot && shadowRoot->mode() == ShadowRootMode::UserAgent)
-        collectMatchingShadowPseudoElementRules(matchRequest);
+        collectMatchingUserAgentPartRules(matchRequest);
 
     bool isHTML = element.isHTMLElement() && element.document().isHTMLDocument();
 
@@ -295,20 +295,20 @@ bool ElementRuleCollector::matchesAnyAuthorRules()
     return !m_matchedRules.isEmpty();
 }
 
-void ElementRuleCollector::matchShadowPseudoElementRules(CascadeLevel level)
+void ElementRuleCollector::matchUserAgentPartRules(CascadeLevel level)
 {
     ASSERT(element().isInShadowTree());
     auto* shadowRoot = element().containingShadowRoot();
     if (!shadowRoot || shadowRoot->mode() != ShadowRootMode::UserAgent)
         return;
 
-    // Look up shadow pseudo elements also from the host scope style as they are web-exposed.
+    // Look up user agent parts also from the host scope style as they are web-exposed.
     auto* hostRules = Scope::forNode(*shadowRoot->host()).resolver().ruleSets().styleForCascadeLevel(level);
     if (!hostRules)
         return;
 
     MatchRequest hostRequest { *hostRules, ScopeOrdinal::ContainingHost };
-    collectMatchingShadowPseudoElementRules(hostRequest);
+    collectMatchingUserAgentPartRules(hostRequest);
 }
 
 void ElementRuleCollector::matchHostPseudoClassRules(CascadeLevel level)
@@ -355,9 +355,9 @@ void ElementRuleCollector::matchPartPseudoElementRules(CascadeLevel level)
     if (!element().containingShadowRoot())
         return;
 
-    bool isUAShadowPseudoElement = element().containingShadowRoot()->mode() == ShadowRootMode::UserAgent && !element().pseudo().isNull();
+    bool isUserAgentPart = element().containingShadowRoot()->mode() == ShadowRootMode::UserAgent && !element().pseudo().isNull();
 
-    auto& partMatchingElement = isUAShadowPseudoElement ? *element().shadowHost() : element();
+    auto& partMatchingElement = isUserAgentPart ? *element().shadowHost() : element();
     if (partMatchingElement.partNames().isEmpty() || !partMatchingElement.isInShadowTree())
         return;
 
@@ -392,7 +392,7 @@ void ElementRuleCollector::matchPartPseudoElementRulesForScope(const Element& pa
     }
 }
 
-void ElementRuleCollector::collectMatchingShadowPseudoElementRules(const MatchRequest& matchRequest)
+void ElementRuleCollector::collectMatchingUserAgentPartRules(const MatchRequest& matchRequest)
 {
     ASSERT(element().containingShadowRoot()->mode() == ShadowRootMode::UserAgent);
 
@@ -404,7 +404,7 @@ void ElementRuleCollector::collectMatchingShadowPseudoElementRules(const MatchRe
 #endif
     auto& partId = element().pseudo();
     if (!partId.isEmpty())
-        collectMatchingRulesForList(rules.shadowPseudoElementRules(partId), matchRequest);
+        collectMatchingRulesForList(rules.userAgentPartRules(partId), matchRequest);
 }
 
 void ElementRuleCollector::matchUserRules()

--- a/Source/WebCore/style/ElementRuleCollector.h
+++ b/Source/WebCore/style/ElementRuleCollector.h
@@ -108,13 +108,13 @@ private:
 
     void addElementInlineStyleProperties(bool includeSMILProperties);
 
-    void matchShadowPseudoElementRules(CascadeLevel);
+    void matchUserAgentPartRules(CascadeLevel);
     void matchHostPseudoClassRules(CascadeLevel);
     void matchSlottedPseudoElementRules(CascadeLevel);
     void matchPartPseudoElementRules(CascadeLevel);
     void matchPartPseudoElementRulesForScope(const Element& partMatchingElement, CascadeLevel);
 
-    void collectMatchingShadowPseudoElementRules(const MatchRequest&);
+    void collectMatchingUserAgentPartRules(const MatchRequest&);
 
     void collectMatchingRules(CascadeLevel);
     void collectMatchingRules(const MatchRequest&);

--- a/Source/WebCore/style/RuleSet.cpp
+++ b/Source/WebCore/style/RuleSet.cpp
@@ -272,7 +272,7 @@ void RuleSet::addRule(RuleData&& ruleData, CascadeLayerIdentifier cascadeLayerId
             return;
         }
 
-        addToRuleSet(customPseudoElementSelector->value(), m_shadowPseudoElementRules, ruleData);
+        addToRuleSet(customPseudoElementSelector->value(), m_userAgentPartRules, ruleData);
         return;
     }
 
@@ -341,7 +341,7 @@ void RuleSet::traverseRuleDatas(Function&& function)
     traverseMap(m_attributeLowercaseLocalNameRules);
     traverseMap(m_tagLocalNameRules);
     traverseMap(m_tagLowercaseLocalNameRules);
-    traverseMap(m_shadowPseudoElementRules);
+    traverseMap(m_userAgentPartRules);
     traverseVector(m_linkPseudoClassRules);
 #if ENABLE(VIDEO)
     traverseVector(m_cuePseudoRules);
@@ -433,7 +433,7 @@ void RuleSet::shrinkToFit()
     shrinkMapVectorsToFit(m_attributeLowercaseLocalNameRules);
     shrinkMapVectorsToFit(m_tagLocalNameRules);
     shrinkMapVectorsToFit(m_tagLowercaseLocalNameRules);
-    shrinkMapVectorsToFit(m_shadowPseudoElementRules);
+    shrinkMapVectorsToFit(m_userAgentPartRules);
 
     m_linkPseudoClassRules.shrinkToFit();
 #if ENABLE(VIDEO)

--- a/Source/WebCore/style/RuleSet.h
+++ b/Source/WebCore/style/RuleSet.h
@@ -92,7 +92,7 @@ public:
     const RuleDataVector* classRules(const AtomString& key) const { return m_classRules.get(key); }
     const RuleDataVector* attributeRules(const AtomString& key, bool isHTMLName) const;
     const RuleDataVector* tagRules(const AtomString& key, bool isHTMLName) const;
-    const RuleDataVector* shadowPseudoElementRules(const AtomString& key) const { return m_shadowPseudoElementRules.get(key); }
+    const RuleDataVector* userAgentPartRules(const AtomString& key) const { return m_userAgentPartRules.get(key); }
     const RuleDataVector* linkPseudoClassRules() const { return &m_linkPseudoClassRules; }
 #if ENABLE(VIDEO)
     const RuleDataVector& cuePseudoRules() const { return m_cuePseudoRules; }
@@ -108,7 +108,7 @@ public:
     unsigned ruleCount() const { return m_ruleCount; }
 
     bool hasAttributeRules() const { return !m_attributeLocalNameRules.isEmpty(); }
-    bool hasShadowPseudoElementRules() const { return !m_shadowPseudoElementRules.isEmpty(); }
+    bool hasUserAgentPartRules() const { return !m_userAgentPartRules.isEmpty(); }
     bool hasHostPseudoClassRulesMatchingInShadowTree() const { return m_hasHostPseudoClassRulesMatchingInShadowTree; }
 
     static constexpr auto cascadeLayerPriorityForPresentationalHints = std::numeric_limits<CascadeLayerPriority>::min();
@@ -187,7 +187,7 @@ private:
     AtomRuleMap m_attributeLowercaseLocalNameRules;
     AtomRuleMap m_tagLocalNameRules;
     AtomRuleMap m_tagLowercaseLocalNameRules;
-    AtomRuleMap m_shadowPseudoElementRules;
+    AtomRuleMap m_userAgentPartRules;
     RuleDataVector m_linkPseudoClassRules;
 #if ENABLE(VIDEO)
     RuleDataVector m_cuePseudoRules;

--- a/Source/WebCore/style/StyleInvalidationFunctions.h
+++ b/Source/WebCore/style/StyleInvalidationFunctions.h
@@ -70,7 +70,7 @@ inline void traverseRuleFeatures(Element& element, TraverseFunction&& function)
 
     auto mayAffectShadowTree = [&] {
         if (element.shadowRoot() && element.shadowRoot()->isUserAgentShadowRoot()) {
-            if (ruleSets.hasMatchingUserOrAuthorStyle([] (auto& style) { return style.hasShadowPseudoElementRules(); }))
+            if (ruleSets.hasMatchingUserOrAuthorStyle([] (auto& style) { return style.hasUserAgentPartRules(); }))
                 return true;
 #if ENABLE(VIDEO)
             if (element.isMediaElement() && ruleSets.hasMatchingUserOrAuthorStyle([] (auto& style) { return !style.cuePseudoRules().isEmpty(); }))

--- a/Source/WebCore/style/StyleInvalidator.cpp
+++ b/Source/WebCore/style/StyleInvalidator.cpp
@@ -123,8 +123,8 @@ Invalidator::RuleInformation Invalidator::collectRuleInformation()
             information.hasHostPseudoClassRules = true;
         if (ruleSet->hasHostPseudoClassRulesMatchingInShadowTree())
             information.hasHostPseudoClassRulesMatchingInShadowTree = true;
-        if (ruleSet->hasShadowPseudoElementRules())
-            information.hasShadowPseudoElementRules = true;
+        if (ruleSet->hasUserAgentPartRules())
+            information.hasUserAgentPartRules = true;
 #if ENABLE(VIDEO)
         if (!ruleSet->cuePseudoRules().isEmpty())
             information.hasCuePseudoElementRules = true;
@@ -415,7 +415,7 @@ void Invalidator::invalidateShadowParts(ShadowRoot& shadowRoot)
     }
 }
 
-void Invalidator::invalidateShadowPseudoElements(ShadowRoot& shadowRoot)
+void Invalidator::invalidateUserAgentParts(ShadowRoot& shadowRoot)
 {
     if (shadowRoot.mode() != ShadowRootMode::UserAgent)
         return;
@@ -425,7 +425,7 @@ void Invalidator::invalidateShadowPseudoElements(ShadowRoot& shadowRoot)
         if (!partId)
             continue;
         for (auto& ruleSet : m_ruleSets) {
-            if (ruleSet->shadowPseudoElementRules(partId))
+            if (ruleSet->userAgentPartRules(partId))
                 descendant.invalidateStyleInternal();
         }
     }
@@ -437,8 +437,8 @@ void Invalidator::invalidateInShadowTreeIfNeeded(Element& element)
     if (!shadowRoot)
         return;
 
-    if (m_ruleInformation.hasShadowPseudoElementRules)
-        invalidateShadowPseudoElements(*shadowRoot);
+    if (m_ruleInformation.hasUserAgentPartRules)
+        invalidateUserAgentParts(*shadowRoot);
 
     if (m_ruleInformation.hasHostPseudoClassRulesMatchingInShadowTree) {
         for (auto& child : childrenOfType<Element>(*shadowRoot)) {

--- a/Source/WebCore/style/StyleInvalidator.h
+++ b/Source/WebCore/style/StyleInvalidator.h
@@ -76,14 +76,14 @@ private:
     void invalidateStyleForTree(Element&, SelectorMatchingState*);
     void invalidateStyleForDescendants(Element&, SelectorMatchingState*);
     void invalidateInShadowTreeIfNeeded(Element&);
-    void invalidateShadowPseudoElements(ShadowRoot&);
+    void invalidateUserAgentParts(ShadowRoot&);
     void invalidateStyleWithMatchElement(Element&, MatchElement);
 
     struct RuleInformation {
         bool hasSlottedPseudoElementRules { false };
         bool hasHostPseudoClassRules { false };
         bool hasHostPseudoClassRulesMatchingInShadowTree { false };
-        bool hasShadowPseudoElementRules { false };
+        bool hasUserAgentPartRules { false };
         bool hasCuePseudoElementRules { false };
         bool hasPartPseudoElementRules { false };
     };


### PR DESCRIPTION
#### 7f449ab1aa4febc931204ba1fae1be83d0902013
<pre>
Rename *ShadowPseudoElement* to *UserAgentPart*
<a href="https://bugs.webkit.org/show_bug.cgi?id=267157">https://bugs.webkit.org/show_bug.cgi?id=267157</a>
<a href="https://rdar.apple.com/120563131">rdar://120563131</a>

Reviewed by Ryosuke Niwa.

Unify terminology across the codebase by renaming instances of ShadowPseudoElement to UserAgentPart.

* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::collectMatchingRules):
(WebCore::Style::ElementRuleCollector::matchUserAgentPartRules):
(WebCore::Style::ElementRuleCollector::matchPartPseudoElementRules):
(WebCore::Style::ElementRuleCollector::collectMatchingUserAgentPartRules):
(WebCore::Style::ElementRuleCollector::matchShadowPseudoElementRules): Deleted.
(WebCore::Style::ElementRuleCollector::collectMatchingShadowPseudoElementRules): Deleted.
* Source/WebCore/style/ElementRuleCollector.h:
* Source/WebCore/style/RuleSet.cpp:
(WebCore::Style::RuleSet::addRule):
(WebCore::Style::RuleSet::traverseRuleDatas):
(WebCore::Style::RuleSet::shrinkToFit):
* Source/WebCore/style/RuleSet.h:
(WebCore::Style::RuleSet::userAgentPartRules const):
(WebCore::Style::RuleSet::hasUserAgentPartRules const):
(WebCore::Style::RuleSet::shadowPseudoElementRules const): Deleted.
(WebCore::Style::RuleSet::hasShadowPseudoElementRules const): Deleted.
* Source/WebCore/style/StyleInvalidationFunctions.h:
(WebCore::Style::traverseRuleFeatures):
* Source/WebCore/style/StyleInvalidator.cpp:
(WebCore::Style::Invalidator::collectRuleInformation):
(WebCore::Style::Invalidator::invalidateUserAgentParts):
(WebCore::Style::Invalidator::invalidateInShadowTreeIfNeeded):
(WebCore::Style::Invalidator::invalidateShadowPseudoElements): Deleted.
* Source/WebCore/style/StyleInvalidator.h:

Canonical link: <a href="https://commits.webkit.org/272717@main">https://commits.webkit.org/272717@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/788c987e16322b6469eff1edddf83f2d1783919d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32814 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11564 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34675 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35426 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29638 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33740 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13907 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8747 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/29089 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33257 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9750 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/29296 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8487 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8631 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29251 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36757 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29808 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29655 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34751 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8748 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6719 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32621 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10437 "Built successfully") | [⏳ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/macOS-Release-WK2-Stress-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9359 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4231 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9370 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->