### PR TITLE
Apple.com: Apple Events Video captions not working

### DIFF
--- a/Source/WebCore/platform/graphics/AudioTrackPrivate.h
+++ b/Source/WebCore/platform/graphics/AudioTrackPrivate.h
@@ -38,11 +38,6 @@ struct AudioInfo;
 
 class AudioTrackPrivate : public TrackPrivateBase {
 public:
-    static Ref<AudioTrackPrivate> create()
-    {
-        return adoptRef(*new AudioTrackPrivate);
-    }
-
     void setClient(AudioTrackPrivateClient& client) { m_client = client; }
     void clearClient() { m_client = nullptr; }
     AudioTrackPrivateClient* client() const override { return m_client.get(); }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/InbandTextTrackPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/InbandTextTrackPrivateAVFObjC.h
@@ -45,6 +45,8 @@ public:
 
     ~InbandTextTrackPrivateAVFObjC() = default;
 
+    TrackID id() const override;
+
     InbandTextTrackPrivate::Kind kind() const override;
     bool isClosedCaptions() const override;
     bool isSDH() const override;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/InbandTextTrackPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/InbandTextTrackPrivateAVFObjC.mm
@@ -42,6 +42,11 @@
 
 #import <pal/cocoa/AVFoundationSoftLink.h>
 
+@class AVMediaSelectionOption;
+@interface AVMediaSelectionOption (WebKitInternal)
+- (id)optionID;
+@end
+
 namespace WebCore {
 
 InbandTextTrackPrivateAVFObjC::InbandTextTrackPrivateAVFObjC(AVFInbandTrackParent* player, AVMediaSelectionGroup *group, AVMediaSelectionOption *selection, InbandTextTrackPrivate::CueFormat format)
@@ -56,6 +61,14 @@ void InbandTextTrackPrivateAVFObjC::disconnect()
     m_mediaSelectionGroup = 0;
     m_mediaSelectionOption = 0;
     InbandTextTrackPrivateAVF::disconnect();
+}
+
+TrackID InbandTextTrackPrivateAVFObjC::id() const
+{
+    if (m_mediaSelectionOption)
+        return [[m_mediaSelectionOption optionID] unsignedLongLongValue];
+    ASSERT_NOT_REACHED();
+    return 0;
 }
 
 InbandTextTrackPrivate::Kind InbandTextTrackPrivateAVFObjC::kind() const


### PR DESCRIPTION
#### 1314723e5732e1168a7bd6501cfa3295b54879b5
<pre>
Apple.com: Apple Events Video captions not working
<a href="https://bugs.webkit.org/show_bug.cgi?id=267160">https://bugs.webkit.org/show_bug.cgi?id=267160</a>
<a href="https://rdar.apple.com/119839950">rdar://119839950</a>

Reviewed by Jer Noble.

Currently, when an HLS video on the web has multiple text tracks to choose from, only the last
one in the list functions. This is because all of the text tracks have the same track ID, and
therefore override each other. They all have the same track ID because
InbandTextTrackPrivateAVFObjC does not override TrackPrivateBase&apos;s virtual id() function, and
so it always returns the default value 0.

To fix this, InbandTextTrackPrivateAVFObjC now implements id().

* Source/WebCore/platform/graphics/AudioTrackPrivate.h:
(WebCore::AudioTrackPrivate::create): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/InbandTextTrackPrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/InbandTextTrackPrivateAVFObjC.mm:
(WebCore::InbandTextTrackPrivateAVFObjC::id const):

Canonical link: <a href="https://commits.webkit.org/272784@main">https://commits.webkit.org/272784@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a06b0b782bd453ab5f1ff96fc19831276e480aba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33029 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11802 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34933 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35669 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29845 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34000 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14144 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8972 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/29274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33504 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9946 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29511 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8674 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/8825 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29471 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37004 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30003 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29877 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/34953 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8964 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6904 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32808 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10656 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7659 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/9553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9597 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->