### PR TITLE
[iOS] -setSelectedTextRange: crashes with a nil range when async text input is enabled

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -3837,6 +3837,11 @@ static void cancelPotentialTapIfNecessary(WKContentView* contentView)
 {
     RELEASE_ASSERT_ASYNC_TEXT_INTERACTIONS_DISABLED();
 
+    [self _internalClearSelection];
+}
+
+- (void)_internalClearSelection
+{
     [self _elementDidBlur];
     _page->clearSelection();
 }
@@ -6136,7 +6141,7 @@ static NSArray<WKTextSelectionRect *> *textSelectionRects(const Vector<WebCore::
     if (!self._hasFocusedElement)
         return;
 #endif
-    [self clearSelection];
+    [self _internalClearSelection];
 }
 
 - (BOOL)hasMarkedText

--- a/Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm
@@ -665,6 +665,26 @@ TEST(KeyboardInputTests, OverrideTextInputTraits)
     EXPECT_EQ(keyboardType, [webView effectiveTextInputTraits].keyboardType);
 }
 
+TEST(KeyboardInputTests, ClearSelectedTextRange)
+{
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    [inputDelegate setFocusStartsInputSessionPolicyHandler:[&] (WKWebView *, id<_WKFocusedElementInfo>) -> _WKFocusStartsInputSessionPolicy {
+        return _WKFocusStartsInputSessionPolicyAllow;
+    }];
+
+    [webView _setInputDelegate:inputDelegate.get()];
+    [webView synchronouslyLoadHTMLString:@"<input id='textField' value='hello' />"];
+    [webView evaluateJavaScriptAndWaitForInputSessionToChange:@"textField.focus()"];
+    [webView objectByEvaluatingJavaScript:@"textField.select()"];
+    auto selectedTextBeforeClearing = [webView selectedText];
+    EXPECT_WK_STREQ(selectedTextBeforeClearing, "hello");
+
+    [webView textInputContentView].selectedTextRange = nil;
+    auto selectedTextAfterClearing = [webView selectedText];
+    EXPECT_WK_STREQ(selectedTextAfterClearing, "");
+}
+
 TEST(KeyboardInputTests, DisableSpellChecking)
 {
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);


### PR DESCRIPTION
#### db2541f704074d51642b6a6eada42ede259496b5
<pre>
[iOS] -setSelectedTextRange: crashes with a nil range when async text input is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=267164">https://bugs.webkit.org/show_bug.cgi?id=267164</a>
<a href="https://rdar.apple.com/120553527">rdar://120553527</a>

Reviewed by Aditya Keerthi.

Ensure that we don&apos;t hit legacy UIKit method assertions from within our own code, when async text
input is enabled, by moving the logic in `clearSelection` into `_internalClearSelection`, limiting
the assertion to `clearSelection`, and then using `_internalClearSelection` instead of the former.

Test: KeyboardInputTests.ClearSelectedTextRange

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView clearSelection]):
(-[WKContentView _internalClearSelection]):
(-[WKContentView setSelectedTextRange:]):
* Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm:

Canonical link: <a href="https://commits.webkit.org/272722@main">https://commits.webkit.org/272722@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37ee95ed89c4060363355d1b3683bc07e400bcba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32823 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11572 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34685 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35434 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29646 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33749 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13915 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8755 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/29096 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33266 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9757 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/29310 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8496 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/8638 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29267 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36765 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29815 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29671 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34758 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8756 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6725 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32631 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10445 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7620 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9367 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9378 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->