### PR TITLE
User command-clicks on fragment URLS should not navigate on current page.

### DIFF
--- a/LayoutTests/fast/dom/no-scroll-when-command-click-fragment-URL-expected.txt
+++ b/LayoutTests/fast/dom/no-scroll-when-command-click-fragment-URL-expected.txt
@@ -1,0 +1,3 @@
+Policy delegate: attempt to load no-scroll-when-command-click-fragment-URL.html with navigation type 'link clicked'
+Link to Fragment
+PASS: Page did not scroll.

--- a/LayoutTests/fast/dom/no-scroll-when-command-click-fragment-URL.html
+++ b/LayoutTests/fast/dom/no-scroll-when-command-click-fragment-URL.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>Fragment Navigation - ensure navigating to a fragment URL is preventable by a client.</title>
+<meta name="assert" content="This test checks command-clicking on a fragment URL does not navigate on the current page.">
+
+<head>
+<script src="../../resources/ui-helper.js"></script>
+
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.setCustomPolicyDelegate(true, false);
+    testRunner.skipPolicyDelegateNotifyDone();
+    testRunner.waitUntilDone();
+}
+
+async function runTest()
+{
+    if (!testRunner.runUIScript)
+        return;
+
+    var output = "";
+
+    var scrollOffset = window.pageYOffset;
+
+    await UIHelper.activateElement(document.getElementById("LinkToClick"), ["metaKey"]); // metaKey = commandKey
+
+    await UIHelper.ensurePresentationUpdate();
+
+    if (window.pageYOffset != scrollOffset)
+        output += "FAIL: Page should not scroll. - " + window.pageYOffset;
+    else
+        output += "PASS: Page did not scroll.";
+
+    var scrollOffset = window.pageYOffset;
+
+    var target = document.getElementById('target');
+    target.innerHTML = output;
+    target.style.paddingTop = "0px";
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+addEventListener('load', runTest);
+</script>
+</head>
+
+<body>
+    <a href="#fragment" id="LinkToClick">Link to Fragment</a>
+    <div id="target" style="padding-top: 10000px;">
+        <p>Scroll Point</p>
+        <div id="fragment"></div>
+    </div>
+</body>
+

--- a/LayoutTests/http/tests/navigation/fragment-navigation-policy-ignore-expected.txt
+++ b/LayoutTests/http/tests/navigation/fragment-navigation-policy-ignore-expected.txt
@@ -1,0 +1,11 @@
+Policy delegate: attempt to load http://127.0.0.1:8000/navigation/fragment-navigation-policy-ignore.html#test with navigation type 'other'
+Checks that the client does not prevent a fragment navigation on modern WebKit via the decidePolicyForNavigationAction delegate when activated via JavaScript. The opposite it true for legacy WebKit.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS window.location.href is "http://127.0.0.1:8000/navigation/fragment-navigation-policy-ignore.html#test"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/navigation/fragment-navigation-policy-ignore.html
+++ b/LayoutTests/http/tests/navigation/fragment-navigation-policy-ignore.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+</head>
+<body>
+<script>
+description("Checks that the client does not prevent a fragment navigation on modern WebKit via the decidePolicyForNavigationAction delegate when activated via JavaScript. The opposite it true for legacy WebKit.");
+jsTestIsAsync = true;
+
+if (window.testRunner) {
+    testRunner.setCustomPolicyDelegate(true, false);
+    if (testRunner.skipPolicyDelegateNotifyDone)
+        testRunner.skipPolicyDelegateNotifyDone()
+}
+
+onload = function() {
+    location = "#test";
+    setTimeout(function() {
+        if (testRunner.isWebKit2)
+            shouldBeEqualToString("window.location.href", "http://127.0.0.1:8000/navigation/fragment-navigation-policy-ignore.html#test");
+        else
+            shouldBeEqualToString("window.location.href", "http://127.0.0.1:8000/navigation/fragment-navigation-policy-ignore.html");
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -2677,3 +2677,5 @@ webkit.org/b/266204 [ Debug ] imported/w3c/web-platform-tests/scroll-animations/
 [ Debug ] imported/w3c/web-platform-tests/scroll-animations/css/animation-fill-outside-range-test.html [ Crash ]
 
 imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/mask-and-nested-clip-path.svg [ Failure ]
+
+fast/dom/no-scroll-when-command-click-fragment-URL.html [ Skip ]

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2747,3 +2747,8 @@ imported/w3c/web-platform-tests/dom/events/scrolling/iframe-chains.html [ Skip ]
 imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-for-user-scroll.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss.html [ Skip ]
 imported/w3c/web-platform-tests/pointerevents/pointerevent_touch-action-mouse.html [ Skip ]
+
+#test uses test helper functions not implemented on WK1
+fast/dom/no-scroll-when-command-click-fragment-URL.html [ Skip ]
+
+

--- a/LayoutTests/platform/mac-wk1/http/tests/navigation/fragment-navigation-policy-ignore-expected.txt
+++ b/LayoutTests/platform/mac-wk1/http/tests/navigation/fragment-navigation-policy-ignore-expected.txt
@@ -1,0 +1,11 @@
+Policy delegate: attempt to load http://127.0.0.1:8000/navigation/fragment-navigation-policy-ignore.html#test with navigation type 'other'
+Checks that the client does not prevent a fragment navigation on modern WebKit via the decidePolicyForNavigationAction delegate when activated via JavaScript. The opposite it true for legacy WebKit.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS window.location.href is "http://127.0.0.1:8000/navigation/fragment-navigation-policy-ignore.html"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -1714,3 +1714,5 @@ webkit.org/b/266711 webrtc/canvas-to-peer-connection.html  [ Failure Timeout Cra
 webkit.org/b/266711 webrtc/release-after-getting-track.html [ Pass Crash ]
 webkit.org/b/266711 fast/mediastream/applyConstraints-deviceId.html [ Pass Crash ]
 webkit.org/b/266711 fast/mediastream/MediaStream-video-element-enter-background.html [ Failure Pass Crash ]
+
+fast/dom/no-scroll-when-command-click-fragment-URL.html [ Failure ]

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -161,7 +161,7 @@ void WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction(const Navigat
     // Notify the UIProcess.
     if (policyDecisionMode == PolicyDecisionMode::Synchronous) {
 #if PLATFORM(COCOA)
-        if (!linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::AsyncFragmentNavigationPolicyDecision)) {
+        if (navigationAction.processingUserGesture() || !linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::AsyncFragmentNavigationPolicyDecision)) {
             auto sendResult = webPage->sendSync(Messages::WebPageProxy::DecidePolicyForNavigationActionSync(m_frame->info(), documentLoader ? documentLoader->navigationID() : 0, navigationActionData, originatingFrameInfoData, originatingPageID, navigationAction.originalRequest(), request, IPC::FormDataReference { request.httpBody() }));
             if (!sendResult.succeeded()) {
                 WebFrameLoaderClient_RELEASE_LOG_ERROR(Network, "dispatchDecidePolicyForNavigationAction: ignoring because of failing to send sync IPC with error %" PUBLIC_LOG_STRING, IPC::errorAsString(sendResult.error()));


### PR DESCRIPTION
#### b872b71975a2c60bb1496dbddf05dcaf987dc525
<pre>
User command-clicks on fragment URLS should not navigate on current page.
<a href="https://bugs.webkit.org/show_bug.cgi?id=267168">https://bugs.webkit.org/show_bug.cgi?id=267168</a>
<a href="https://rdar.apple.com/119079650">rdar://119079650</a>

Reviewed by Wenson Hsieh and Alex Christensen.

In <a href="https://commits.webkit.org/270416@main">https://commits.webkit.org/270416@main</a> a change was made for performance
to asynchronously  DecidePolicyForNavigationAction for fragment loading. While this is
a good speedup, it breaks the long-standing user interaction of command-clicking on
a fragment link to load that link in a background tab, while staying at the current
scroll location on the current page. This is a client behavior, and with this change, the
client no longer had control to keep the navigation to the fragment from happening.
We do not want to lose this speedup, so only revert to the previously synchronous behavior
when the fragment URL is being loaded from a user gesture.

* LayoutTests/fast/dom/no-scroll-when-command-click-fragment-URL-expected.txt: Added.
* LayoutTests/fast/dom/no-scroll-when-command-click-fragment-URL.html: Added.
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp:
(WebKit::WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction):

Canonical link: <a href="https://commits.webkit.org/272906@main">https://commits.webkit.org/272906@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b69fc4e25118dcfe0743eb76a5e55b4e5b9b6ff6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33467 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12238 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35385 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36091 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30401 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14683 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9386 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29525 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33942 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10375 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29866 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9017 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/9168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29857 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37415 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30442 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30206 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35264 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9259 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7200 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33139 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11014 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/29542 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7761 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9844 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9991 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->