### PR TITLE
Make hits on overflow controls target RenderTextControlMultiline itself

### DIFF
--- a/LayoutTests/fast/css/resize-textarea-align-content-expected.txt
+++ b/LayoutTests/fast/css/resize-textarea-align-content-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Test for resizing a textarea control with align-content.
+

--- a/LayoutTests/fast/css/resize-textarea-align-content.html
+++ b/LayoutTests/fast/css/resize-textarea-align-content.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<!-- This test is derived from resize-below-min-size.html -->
+<html>
+<head>
+    <style>
+    body { margin: 0; padding: 0;}
+    #resizable {
+        box-sizing: border-box; /* to make the output width/height predictable */
+        align-content: center;
+        border: 3px solid;
+    }
+    </style>
+</head>
+<body>
+<div style="width:800px; height:800px">
+    <textarea id="resizable">resizable</textarea>
+</div>
+
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../imported/w3c/web-platform-tests/resources/testdriver.js"></script>
+<script src="../../imported/w3c/web-platform-tests/resources/testdriver-actions.js"></script>
+<script src="../../imported/w3c/web-platform-tests/resources/testdriver-vendor.js"></script>
+<script>
+function drag(startX, startY, destX, destY) {
+    const actions = new test_driver.Actions()
+        .pointerMove(startX - 6, startY - 7)
+        .pointerDown()
+        .pointerMove(destX - 6, destY - 7)
+        .pointerUp();
+    return actions.send();
+}
+
+async function testDragAndMove(box) {
+    const startX = box.getBoundingClientRect().right;
+    const startY = box.getBoundingClientRect().bottom;
+    await drag(startX, startY, startX - 350, startY - 350);
+}
+
+promise_test(async () => {
+    const box = document.getElementById("resizable");
+    box.style.width = "400px";
+    box.style.height = "400px";
+    box.style.minWidth = "200px";
+    box.style.minHeight = "200px";
+    await testDragAndMove(box);
+    assert_equals(box.style.width, "200px");
+    assert_equals(box.style.height, "200px");
+    box.style.width = "400px";
+    box.style.height = "400px";
+    box.style.minWidth = "15vw";
+    box.style.minHeight = "15vh";
+    await testDragAndMove(box);
+    assert_equals(box.style.width, (0.15 * window.innerWidth) + "px");
+    assert_equals(box.style.height, (0.15 * window.innerHeight) + "px");
+    box.style.width = "400px";
+    box.style.height = "400px";
+    box.style.minWidth = "10%";
+    box.style.minHeight = "10%";
+    await testDragAndMove(box);
+    assert_equals(box.style.width, "80px"); // 10% of container
+    assert_equals(box.style.height, "80px"); // 10% of container
+}, "Test for resizing a textarea control with align-content.");
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/gtk/fast/css/resize-corner-tracking-expected.txt
+++ b/LayoutTests/platform/gtk/fast/css/resize-corner-tracking-expected.txt
@@ -15,11 +15,11 @@ layer at (0,0) size 800x600
             text run at (403,0) width 318: "Resize corner does not track the mouse accurately"
         RenderText {#text} at (720,0) size 5x17
           text run at (720,0) width 5: "."
-      RenderBlock (anonymous) at (0,187) size 784x366
+      RenderBlock (anonymous) at (0,187) size 784x359
         RenderText {#text} at (0,0) size 0x0
-        RenderBR {BR} at (173,111) size 0x17
+        RenderBR {BR} at (169,107) size 0x17
         RenderText {#text} at (0,0) size 0x0
-        RenderBR {BR} at (223,177) size 0x17
+        RenderBR {BR} at (220,170) size 0x17
         RenderText {#text} at (0,0) size 0x0
 layer at (8,8) size 784x2 clip at (0,0) size 0x0
   RenderBlock {HR} at (0,0) size 784x2 [color=#808080] [border: (1px inset #808080)]
@@ -27,14 +27,14 @@ layer at (8,60) size 784x2 clip at (0,0) size 0x0
   RenderBlock {HR} at (0,52) size 784x2 [color=#808080] [border: (1px inset #808080)]
 layer at (8,70) size 173x125 clip at (10,72) size 169x121
   RenderBlock {DIV} at (0,62) size 173x125 [border: (2px solid #0000FF)]
-layer at (8,195) size 173x125 clip at (10,197) size 169x121
-  RenderTextControl {TEXTAREA} at (0,0) size 173x125 [bgcolor=#FFFFFF] [border: (2px solid #0000FF)]
-    RenderBlock {DIV} at (4,4) size 165x18
-layer at (8,320) size 223x66 clip at (9,321) size 221x64
-  RenderTextControl {TEXTAREA} at (0,125) size 223x66 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
-    RenderBlock {DIV} at (3,3) size 217x18
-layer at (8,386) size 323x175
-  RenderIFrame {IFRAME} at (0,191) size 323x175 [border: (2px inset #000000)]
+layer at (8,195) size 169x121 clip at (10,197) size 165x117
+  RenderTextControl {TEXTAREA} at (0,0) size 169x121 [bgcolor=#FFFFFF] [border: (2px solid #0000FF)]
+    RenderBlock {DIV} at (4,4) size 161x18
+layer at (8,316) size 220x63 clip at (9,317) size 218x61
+  RenderTextControl {TEXTAREA} at (0,121) size 220x63 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+    RenderBlock {DIV} at (3,3) size 214x18
+layer at (8,379) size 323x175
+  RenderIFrame {IFRAME} at (0,184) size 323x175 [border: (2px inset #000000)]
     layer at (0,0) size 319x171
       RenderView at (0,0) size 319x171
     layer at (0,0) size 319x171

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -1160,6 +1160,7 @@ fast/css/resize-corner-tracking.html [ Skip ]
 fast/css/resize-orthogonal-containing-block.html [ Skip ]
 fast/css/resize-rtl.html [ Skip ]
 fast/css/resize-single-axis.html [ Skip ]
+fast/css/resize-textarea-align-content.html [ Skip ]
 fast/events/mouse-events-on-textarea-resize.html [ Skip ]
 
 # The file-wrapper part of <attachment> is not yet working on iOS

--- a/LayoutTests/platform/wpe/fast/css/resize-corner-tracking-expected.txt
+++ b/LayoutTests/platform/wpe/fast/css/resize-corner-tracking-expected.txt
@@ -15,11 +15,11 @@ layer at (0,0) size 800x600
             text run at (403,0) width 318: "Resize corner does not track the mouse accurately"
         RenderText {#text} at (720,0) size 5x17
           text run at (720,0) width 5: "."
-      RenderBlock (anonymous) at (0,187) size 784x366
+      RenderBlock (anonymous) at (0,187) size 784x359
         RenderText {#text} at (0,0) size 0x0
-        RenderBR {BR} at (173,111) size 0x17
+        RenderBR {BR} at (169,107) size 0x17
         RenderText {#text} at (0,0) size 0x0
-        RenderBR {BR} at (203,177) size 0x17
+        RenderBR {BR} at (200,170) size 0x17
         RenderText {#text} at (0,0) size 0x0
 layer at (8,8) size 784x2 clip at (0,0) size 0x0
   RenderBlock {HR} at (0,0) size 784x2 [color=#808080] [border: (1px inset #808080)]
@@ -27,14 +27,14 @@ layer at (8,60) size 784x2 clip at (0,0) size 0x0
   RenderBlock {HR} at (0,52) size 784x2 [color=#808080] [border: (1px inset #808080)]
 layer at (8,70) size 173x125 clip at (10,72) size 169x121
   RenderBlock {DIV} at (0,62) size 173x125 [border: (2px solid #0000FF)]
-layer at (8,195) size 173x125 clip at (10,197) size 169x121
-  RenderTextControl {TEXTAREA} at (0,0) size 173x125 [bgcolor=#FFFFFF] [border: (2px solid #0000FF)]
-    RenderBlock {DIV} at (4,4) size 165x18
-layer at (8,320) size 203x66 clip at (9,321) size 201x64
-  RenderTextControl {TEXTAREA} at (0,125) size 203x66 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
-    RenderBlock {DIV} at (3,3) size 197x18
-layer at (8,386) size 323x175
-  RenderIFrame {IFRAME} at (0,191) size 323x175 [border: (2px inset #000000)]
+layer at (8,195) size 169x121 clip at (10,197) size 165x117
+  RenderTextControl {TEXTAREA} at (0,0) size 169x121 [bgcolor=#FFFFFF] [border: (2px solid #0000FF)]
+    RenderBlock {DIV} at (4,4) size 161x18
+layer at (8,316) size 200x63 clip at (9,317) size 198x61
+  RenderTextControl {TEXTAREA} at (0,121) size 200x63 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+    RenderBlock {DIV} at (3,3) size 194x18
+layer at (8,379) size 323x175
+  RenderIFrame {IFRAME} at (0,184) size 323x175 [border: (2px inset #000000)]
     layer at (0,0) size 319x171
       RenderView at (0,0) size 319x171
     layer at (0,0) size 319x171

--- a/Source/WebCore/rendering/RenderBlock.h
+++ b/Source/WebCore/rendering/RenderBlock.h
@@ -376,6 +376,8 @@ public:
     Node* nodeForHitTest() const override;
 
 protected:
+    virtual bool isPointInOverflowControl(HitTestResult&, const LayoutPoint& locationInContainer, const LayoutPoint& accumulatedOffset);
+
     virtual void addOverflowFromChildren();
     // FIXME-BLOCKFLOW: Remove virtualization when all callers have moved to RenderBlockFlow
     virtual void addOverflowFromInlineChildren() { }
@@ -431,8 +433,6 @@ private:
     virtual bool hitTestChildren(const HitTestRequest&, HitTestResult&, const HitTestLocation& locationInContainer, const LayoutPoint& adjustedLocation, HitTestAction);
     virtual bool hitTestInlineChildren(const HitTestRequest&, HitTestResult&, const HitTestLocation&, const LayoutPoint&, HitTestAction) { return false; }
     bool hitTestExcludedChildrenInBorder(const HitTestRequest&, HitTestResult&, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction);
-
-    virtual bool isPointInOverflowControl(HitTestResult&, const LayoutPoint& locationInContainer, const LayoutPoint& accumulatedOffset);
 
     void computeBlockPreferredLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const;
     

--- a/Source/WebCore/rendering/RenderTextControlMultiLine.cpp
+++ b/Source/WebCore/rendering/RenderTextControlMultiLine.cpp
@@ -27,6 +27,7 @@
 #include "LocalFrame.h"
 #include "RenderBoxInlines.h"
 #include "RenderBoxModelObjectInlines.h"
+#include "RenderLayerScrollableArea.h"
 #include "RenderStyleSetters.h"
 #include "ShadowRoot.h"
 #include "StyleInheritedData.h"
@@ -57,6 +58,10 @@ bool RenderTextControlMultiLine::nodeAtPoint(const HitTestRequest& request, HitT
 {
     if (!RenderTextControl::nodeAtPoint(request, result, locationInContainer, accumulatedOffset, hitTestAction))
         return false;
+
+    const LayoutPoint adjustedPoint(accumulatedOffset + location());
+    if (isPointInOverflowControl(result, locationInContainer.point(), adjustedPoint))
+        return true;
 
     if (result.innerNode() == &textAreaElement() || result.innerNode() == innerTextElement())
         hitInnerTextElement(result, locationInContainer.point(), accumulatedOffset);


### PR DESCRIPTION
#### 00e7f006e4094af8428002a407198255336fcceb
<pre>
Make hits on overflow controls target RenderTextControlMultiline itself
<a href="https://bugs.webkit.org/show_bug.cgi?id=266873">https://bugs.webkit.org/show_bug.cgi?id=266873</a>
<a href="https://rdar.apple.com/problem/120108102">rdar://problem/120108102</a>

Reviewed by Simon Fraser.

When align-content moves the textarea contents, the coordinates of the
inner text block no longer match those of the RenderTextControlMultiline,
so hit tests using the inner block&apos;s coordinates don&apos;t land on the resizer
properly. This patch captures these cases and associates them with the
textarea, rather than assuming they belong to the inner text block.

Side-effects of this patch include:
- Capturing hits correctly in the presence of borders/padding.
  <a href="https://bugs.webkit.org/show_bug.cgi?id=238193">https://bugs.webkit.org/show_bug.cgi?id=238193</a> &amp; <a href="https://rdar.apple.com/90639221">rdar://90639221</a>
- Using the correct cursor when hovering over the resize controls.
- Not jumping by the border-width when triggering a resize operation.
Test expectations on Linux are thus updated accordingly.

* Source/WebCore/rendering/RenderTextControlMultiLine.cpp:
(WebCore::RenderTextControlMultiLine::nodeAtPoint): Capture hits in overflow controls.
* LayoutTests/fast/css/resize-textarea-align-content-expected.txt: Added.
* LayoutTests/fast/css/resize-textarea-align-content.html: Added.
* LayoutTests/platform/gtk/fast/css/resize-corner-tracking-expected.txt: Use corrected expectations.
* LayoutTests/platform/ios/TestExpectations: Skip new test due to no resize support.
* LayoutTests/platform/wpe/fast/css/resize-corner-tracking-expected.txt: Use corrected expectations.

Canonical link: <a href="https://commits.webkit.org/272964@main">https://commits.webkit.org/272964@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12342611fc0b6dee85c6b5299565280d21f185f3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33718 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12491 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35652 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36333 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30571 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34766 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14863 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9644 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29648 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34195 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10532 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30060 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9189 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9284 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30074 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37656 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30600 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30394 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35416 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9425 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7370 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33304 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11205 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/29735 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7791 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10008 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10211 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->