### PR TITLE
Validate name prefixes in CSSPseudoSelectors.json

### DIFF
--- a/Source/WebCore/css/CSSPseudoSelectors.json
+++ b/Source/WebCore/css/CSSPseudoSelectors.json
@@ -28,8 +28,9 @@
             ]
         },
         "notes": [
-            "Pseudos that start with `-apple-` require a 'settings-flag' field that points to a setting that is disabled to web content by default.",
-            "Pseudos that start with `-internal-` will automatically be restricted to user agent stylesheets."
+            "Pseudos that start with `-apple-` require a 'settings-flag' field that points to a setting that is not exposed to web content.",
+            "Pseudos that start with `-internal-` will automatically be restricted to user agent stylesheets.",
+            "Please do not add new `-webkit-` pseudos. They exist mainly for historical and compatibility purposes. There is a mechanism to ensure no new ones are added."
         ]
     },
     "pseudo-classes": {


### PR DESCRIPTION
#### 0f1319b55b123c3139208eace470952f27fb33bf
<pre>
Validate name prefixes in CSSPseudoSelectors.json
<a href="https://bugs.webkit.org/show_bug.cgi?id=267170">https://bugs.webkit.org/show_bug.cgi?id=267170</a>
<a href="https://rdar.apple.com/120575956">rdar://120575956</a>

Reviewed by Darin Adler.

- Add a list of known prefixes and validate names against it.
- Add a mechanism to restrain the number of `-webkit-` prefixes and encourage the use of `-internal-` and `-apple-` or standardized pseudos instead.
- Add an allowlist for &quot;supports-single-colon-for-compatibility&quot;

* Source/WebCore/css/CSSPseudoSelectors.json:
* Source/WebCore/css/process-css-pseudo-selectors.py:
(InputValidator.__init__):
(InputValidator.validate_fields.is_known_prefix):
(InputValidator.validate_fields):
(InputValidator.check_webkit_prefix_count):

Canonical link: <a href="https://commits.webkit.org/272737@main">https://commits.webkit.org/272737@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d368bdd7db59c1ca8c2be609505779399778546

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32874 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11632 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34750 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35497 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29699 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33811 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13972 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8807 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/29149 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33329 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9805 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29362 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8541 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8685 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29318 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36830 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29862 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29725 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34822 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8811 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6769 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32676 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10501 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7629 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9417 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9433 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->