### PR TITLE
[GStreamer] imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/audioworklet-registerprocessor-called-on-globalthis.https is flaky crash

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1235,9 +1235,6 @@ webkit.org/b/264708 [ Debug ] imported/w3c/web-platform-tests/media-source/media
 
 webkit.org/b/264708 media/media-source/media-webm-opus-partial-abort.html [ Pass Crash Failure ]
 
-webkit.org/b/264934 imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/audioworklet-registerprocessor-called-on-globalthis.https.html [ Pass Crash ]
-webkit.org/b/264934 http/wpt/webaudio/the-audio-api/the-audioworklet-interface/exposed-properties.https.html [ Pass Crash ]
-
 webkit.org/b/265205 imported/w3c/web-platform-tests/media-source/mediasource-remove-preserves-currentTime.html [ Pass Crash ]
 
 webkit.org/b/265206 media/encrypted-media/encrypted-media-append-encrypted-unencrypted.html [ Pass Crash ]
@@ -2027,8 +2024,7 @@ webkit.org/b/252878 fast/mediastream/mediastreamtrack-video-clone.html [ Crash F
 webkit.org/b/213202 fast/mediastream/getUserMedia-grant-persistency3.html [ Failure Pass ]
 webkit.org/b/252878 fast/mediastream/video-mediastream-restricted-invisible-autoplay-not-allowed.html [ Pass Timeout ]
 webkit.org/b/252878 fast/mediastream/video-mediastream-restricted-invisible-autoplay-user-click.html [ Pass Timeout ]
-# Uncomment when webkit.org/b/267126 is fixed
-#webkit.org/b/252878 http/tests/webrtc/video-mediastream-invisible-autoplay-detached.html [ Pass Timeout ]
+webkit.org/b/252878 http/tests/webrtc/video-mediastream-invisible-autoplay-detached.html [ Pass Timeout ]
 webkit.org/b/187064 webrtc/video-addTrack.html [ Failure Pass Timeout ]
 webkit.org/b/187064 webrtc/video-rotation.html [ Failure Timeout ]
 webkit.org/b/187064 webrtc/video-with-data-channel.html [ Failure ]
@@ -3760,8 +3756,6 @@ webkit.org/b/266708 imported/w3c/web-platform-tests/html/semantics/embedded-cont
 webkit.org/b/266719 fast/canvas/offscreen-giant.html [ ImageOnlyFailure ]
 
 webkit.org/b/266713 webrtc/processIceTransportStateChange-gc.html [ Skip ]
-
-webkit.org/b/267126 http/tests/webrtc/video-mediastream-invisible-autoplay-detached.html [ Pass Timeout Crash ]
 
 # End: Common failures between GTK and WPE.
 

--- a/Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp
@@ -122,7 +122,9 @@ AudioDestinationGStreamer::AudioDestinationGStreamer(AudioIOCallback& callback, 
     });
 
     m_src = GST_ELEMENT_CAST(g_object_new(WEBKIT_TYPE_WEB_AUDIO_SRC, "rate", sampleRate,
-        "bus", m_renderBus.get(), "destination", this, "frames", AudioUtilities::renderQuantumSize, nullptr));
+        "destination", this, "frames", AudioUtilities::renderQuantumSize, nullptr));
+
+    webkitWebAudioSourceSetBus(WEBKIT_WEB_AUDIO_SRC(m_src.get()), m_renderBus);
 
 #if PLATFORM(AMLOGIC)
     // autoaudiosink changes child element state to READY internally in auto detection phase

--- a/Source/WebCore/platform/audio/gstreamer/WebKitWebAudioSourceGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/WebKitWebAudioSourceGStreamer.cpp
@@ -59,7 +59,7 @@ static GstStaticPadTemplate srcTemplate = GST_STATIC_PAD_TEMPLATE("src",
 
 struct _WebKitWebAudioSrcPrivate {
     gfloat sampleRate;
-    AudioBus* bus;
+    RefPtr<AudioBus> bus;
     AudioDestinationGStreamer* destination;
     guint framesToPull;
     guint bufferSize;
@@ -102,7 +102,6 @@ struct _WebKitWebAudioSrcPrivate {
 
 enum {
     PROP_RATE = 1,
-    PROP_BUS,
     PROP_DESTINATION,
     PROP_FRAMES
 };
@@ -188,12 +187,6 @@ static void webkit_web_audio_src_class_init(WebKitWebAudioSrcClass* webKitWebAud
                                                        G_MINDOUBLE, G_MAXDOUBLE,
                                                        44100.0, flags));
 
-    g_object_class_install_property(objectClass,
-                                    PROP_BUS,
-                                    g_param_spec_pointer("bus",
-                                                         nullptr, nullptr,
-                                                         flags));
-
     g_object_class_install_property(objectClass, PROP_DESTINATION, g_param_spec_pointer("destination", "destination",
         "Destination", flags));
 
@@ -211,7 +204,6 @@ static void webKitWebAudioSrcConstructed(GObject* object)
     WebKitWebAudioSrc* src = WEBKIT_WEB_AUDIO_SRC(object);
     WebKitWebAudioSrcPrivate* priv = src->priv;
 
-    ASSERT(priv->bus);
     ASSERT(priv->destination);
     ASSERT(priv->sampleRate);
 
@@ -224,13 +216,9 @@ static void webKitWebAudioSrcConstructed(GObject* object)
     gst_task_set_lock(priv->task.get(), &priv->mutex);
 
     priv->source = makeGStreamerElement("appsrc", "webaudioSrc");
-    priv->caps = adoptGRef(getGStreamerAudioCaps(priv->sampleRate, priv->bus->numberOfChannels()));
-    gst_audio_info_from_caps(&priv->info, priv->caps.get());
 
     // Configure the appsrc for minimal latency.
-    g_object_set(priv->source.get(), "max-bytes", static_cast<guint64>(2 * priv->bufferSize * priv->bus->numberOfChannels()), "block", TRUE,
-        "blocksize", priv->bufferSize,
-        "format", GST_FORMAT_TIME, "caps", priv->caps.get(), nullptr);
+    g_object_set(priv->source.get(), "block", TRUE, "blocksize", priv->bufferSize, "format", GST_FORMAT_TIME, nullptr);
 
     gst_bin_add(GST_BIN(src), priv->source.get());
     // appsrc's src pad is the only visible pad of our element.
@@ -246,9 +234,6 @@ static void webKitWebAudioSrcSetProperty(GObject* object, guint propertyId, cons
     switch (propertyId) {
     case PROP_RATE:
         priv->sampleRate = g_value_get_float(value);
-        break;
-    case PROP_BUS:
-        priv->bus = static_cast<AudioBus*>(g_value_get_pointer(value));
         break;
     case PROP_DESTINATION:
         priv->destination = static_cast<AudioDestinationGStreamer*>(g_value_get_pointer(value));
@@ -271,9 +256,6 @@ static void webKitWebAudioSrcGetProperty(GObject* object, guint propertyId, GVal
     switch (propertyId) {
     case PROP_RATE:
         g_value_set_float(value, priv->sampleRate);
-        break;
-    case PROP_BUS:
-        g_value_set_pointer(value, priv->bus);
         break;
     case PROP_DESTINATION:
         g_value_set_pointer(value, priv->destination);
@@ -350,7 +332,8 @@ static void webKitWebAudioSrcRenderAndPushFrames(const GRefPtr<GstElement>& elem
     }
 
     // FIXME: Add support for local/live audio input.
-    priv->destination->callRenderCallback(nullptr, priv->bus, priv->framesToPull, outputTimestamp);
+    if (priv->bus)
+        priv->destination->callRenderCallback(nullptr, priv->bus.get(), priv->framesToPull, outputTimestamp);
 
     if (!priv->hasRenderedAudibleFrame && !priv->bus->isSilent()) {
         priv->destination->notifyIsPlaying(true);
@@ -462,6 +445,15 @@ static GstStateChangeReturn webKitWebAudioSrcChangeState(GstElement* element, Gs
     }
 
     return returnValue;
+}
+
+void webkitWebAudioSourceSetBus(WebKitWebAudioSrc* src, RefPtr<AudioBus> bus)
+{
+    auto priv = src->priv;
+    priv->bus = bus;
+    priv->caps = adoptGRef(getGStreamerAudioCaps(priv->sampleRate, priv->bus->numberOfChannels()));
+    gst_audio_info_from_caps(&priv->info, priv->caps.get());
+    g_object_set(priv->source.get(), "max-bytes", static_cast<guint64>(2 * priv->bufferSize * priv->bus->numberOfChannels()), "caps", priv->caps.get(), nullptr);
 }
 
 void webkitWebAudioSourceSetDispatchToRenderThreadFunction(WebKitWebAudioSrc* src, Function<void(Function<void()>&&)>&& function)

--- a/Source/WebCore/platform/audio/gstreamer/WebKitWebAudioSourceGStreamer.h
+++ b/Source/WebCore/platform/audio/gstreamer/WebKitWebAudioSourceGStreamer.h
@@ -20,6 +20,7 @@
 
 #if USE(GSTREAMER)
 
+#include "AudioBus.h"
 #include <gst/gst.h>
 #include <wtf/Forward.h>
 
@@ -30,7 +31,7 @@ typedef struct _WebKitWebAudioSrc WebKitWebAudioSrc;
 
 GType webkit_web_audio_src_get_type();
 
+void webkitWebAudioSourceSetBus(WebKitWebAudioSrc*, RefPtr<WebCore::AudioBus>);
 void webkitWebAudioSourceSetDispatchToRenderThreadFunction(WebKitWebAudioSrc*, Function<void(Function<void()>&&)>&&);
 
 #endif // USE(GSTREAMER)
-


### PR DESCRIPTION
#### 1fdb9251bb08acd8bd5ee06c652684cb9d4c9740
<pre>
[GStreamer] imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/audioworklet-registerprocessor-called-on-globalthis.https is flaky crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=264934">https://bugs.webkit.org/show_bug.cgi?id=264934</a>

Reviewed by Xabier Rodriguez-Calvar.

Store the AudioBus as a RefPtr in the GStreamer weaudiosrc element. Using a raw pointer provided no
guarantee the underlying data was still valid.

* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp:
(WebCore::AudioDestinationGStreamer::AudioDestinationGStreamer):
* Source/WebCore/platform/audio/gstreamer/WebKitWebAudioSourceGStreamer.cpp:
(webkit_web_audio_src_class_init):
(webKitWebAudioSrcConstructed):
(webKitWebAudioSrcSetProperty):
(webKitWebAudioSrcGetProperty):
(webKitWebAudioSrcRenderAndPushFrames):
(webkitWebAudioSourceSetBus):
* Source/WebCore/platform/audio/gstreamer/WebKitWebAudioSourceGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/272761@main">https://commits.webkit.org/272761@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e72be12a846e6f603f5358ca419125742318bdf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32855 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11610 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34746 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35473 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29679 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33787 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13951 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8788 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29128 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33305 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9788 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29358 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8522 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8668 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29314 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36806 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29845 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29721 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34797 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8790 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6754 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32657 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10480 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7650 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9399 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9412 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->