### PR TITLE
Sync 'SVGAngle.idl' with WebIDL Specification

### DIFF
--- a/LayoutTests/svg/dom/SVGAngle-expected.txt
+++ b/LayoutTests/svg/dom/SVGAngle-expected.txt
@@ -47,20 +47,24 @@ PASS angle.newValueSpecifiedUnits(SVGAngle.SVG_ANGLETYPE_UNKNOWN, 50) threw exce
 PASS angle.newValueSpecifiedUnits(-1, 50) threw exception NotSupportedError: The operation is not supported..
 PASS angle.newValueSpecifiedUnits(5, 50) threw exception NotSupportedError: The operation is not supported..
 PASS angle.newValueSpecifiedUnits(SVGAngle.SVG_ANGLETYPE_DEG) threw exception TypeError: Not enough arguments.
-PASS angle.newValueSpecifiedUnits(SVGAngle.SVG_ANGLETYPE_DEG, 'aString') is undefined.
-PASS angle.value is NaN
+PASS angle.newValueSpecifiedUnits(SVGAngle.SVG_ANGLETYPE_DEG, 'aString') threw exception TypeError: The provided value is non-finite.
+PASS angle.value is 0
 PASS angle.newValueSpecifiedUnits(SVGAngle.SVG_ANGLETYPE_DEG, 0) is undefined.
-PASS angle.newValueSpecifiedUnits(SVGAngle.SVG_ANGLETYPE_DEG, angle) is undefined.
-PASS angle.value is NaN
-PASS angle.newValueSpecifiedUnits(SVGAngle.SVG_ANGLETYPE_DEG, svgElement) is undefined.
-PASS angle.value is NaN
+PASS angle.newValueSpecifiedUnits(SVGAngle.SVG_ANGLETYPE_DEG, angle) threw exception TypeError: The provided value is non-finite.
+PASS angle.value is 0
+PASS angle.newValueSpecifiedUnits(SVGAngle.SVG_ANGLETYPE_DEG, svgElement) threw exception TypeError: The provided value is non-finite.
+PASS angle.value is 0
+PASS angle.newValueSpecifiedUnits(SVGAngle.SVG_ANGLETYPE_DEG, NaN) threw exception TypeError: The provided value is non-finite.
+PASS angle.value is 0
+PASS angle.newValueSpecifiedUnits(SVGAngle.SVG_ANGLETYPE_DEG, Infinity) threw exception TypeError: The provided value is non-finite.
+PASS angle.value is 0
 PASS angle.newValueSpecifiedUnits(SVGAngle.SVG_ANGLETYPE_DEG) threw exception TypeError: Not enough arguments.
 PASS angle.newValueSpecifiedUnits('aString', 4) threw exception NotSupportedError: The operation is not supported..
 PASS angle.newValueSpecifiedUnits(angle, 4) threw exception NotSupportedError: The operation is not supported..
 PASS angle.newValueSpecifiedUnits(svgElement, 4) threw exception NotSupportedError: The operation is not supported..
-PASS angle.newValueSpecifiedUnits('aString', 'aString') threw exception NotSupportedError: The operation is not supported..
-PASS angle.newValueSpecifiedUnits(angle, angle) threw exception NotSupportedError: The operation is not supported..
-PASS angle.newValueSpecifiedUnits(svgElement, svgElement) threw exception NotSupportedError: The operation is not supported..
+PASS angle.newValueSpecifiedUnits('aString', 'aString') threw exception TypeError: The provided value is non-finite.
+PASS angle.newValueSpecifiedUnits(angle, angle) threw exception TypeError: The provided value is non-finite.
+PASS angle.newValueSpecifiedUnits(svgElement, svgElement) threw exception TypeError: The provided value is non-finite.
 PASS angle.newValueSpecifiedUnits() threw exception TypeError: Not enough arguments.
 PASS angle.unitType is SVGAngle.SVG_ANGLETYPE_DEG
 
@@ -118,26 +122,34 @@ PASS angle.valueInSpecifiedUnits is 0
 PASS angle.unitType is SVGAngle.SVG_ANGLETYPE_UNSPECIFIED
 
 Check setting invalid 'valueInSpecifiedUnits' arguments
-PASS angle.valueInSpecifiedUnits = 'test' is 'test'
-PASS angle.value is NaN
-PASS angle.valueInSpecifiedUnits is NaN
+PASS angle.valueInSpecifiedUnits = 'test' threw exception TypeError: The provided value is non-finite.
+PASS angle.value is 0
+PASS angle.valueInSpecifiedUnits is 0
 PASS angle.unitType is SVGAngle.SVG_ANGLETYPE_UNSPECIFIED
 PASS angle.valueInSpecifiedUnits = 0 is 0
-PASS angle.valueInSpecifiedUnits = angle is angle
-PASS angle.value is NaN
-PASS angle.valueInSpecifiedUnits is NaN
+PASS angle.valueInSpecifiedUnits = angle threw exception TypeError: The provided value is non-finite.
+PASS angle.value is 0
+PASS angle.valueInSpecifiedUnits = NaN threw exception TypeError: The provided value is non-finite.
+PASS angle.value is 0
+PASS angle.valueInSpecifiedUnits = Infinity threw exception TypeError: The provided value is non-finite.
+PASS angle.value is 0
+PASS angle.valueInSpecifiedUnits is 0
 PASS angle.unitType is SVGAngle.SVG_ANGLETYPE_UNSPECIFIED
 
 Check setting invalid 'value' arguments
 PASS angle.value = 0 is 0
-PASS angle.value = 'test' is 'test'
-PASS angle.value is NaN
-PASS angle.valueInSpecifiedUnits is NaN
+PASS angle.value = 'test' threw exception TypeError: The provided value is non-finite.
+PASS angle.value is 0
+PASS angle.valueInSpecifiedUnits is 0
 PASS angle.unitType is SVGAngle.SVG_ANGLETYPE_UNSPECIFIED
 PASS angle.value = 0 is 0
-PASS angle.value = angle is angle
-PASS angle.value is NaN
-PASS angle.valueInSpecifiedUnits is NaN
+PASS angle.value = angle threw exception TypeError: The provided value is non-finite.
+PASS angle.value is 0
+PASS angle.value = NaN threw exception TypeError: The provided value is non-finite.
+PASS angle.value is 0
+PASS angle.value = Infinity threw exception TypeError: The provided value is non-finite.
+PASS angle.value is 0
+PASS angle.valueInSpecifiedUnits is 0
 PASS angle.unitType is SVGAngle.SVG_ANGLETYPE_UNSPECIFIED
 
 Reset to angle in degree units

--- a/LayoutTests/svg/dom/SVGAngle.html
+++ b/LayoutTests/svg/dom/SVGAngle.html
@@ -1,7 +1,7 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE html>
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 </head>
 <body>
 <p id="description"></p>
@@ -68,13 +68,17 @@ shouldThrow("angle.newValueSpecifiedUnits(SVGAngle.SVG_ANGLETYPE_UNKNOWN, 50)");
 shouldThrow("angle.newValueSpecifiedUnits(-1, 50)");
 shouldThrow("angle.newValueSpecifiedUnits(5, 50)");
 shouldThrow("angle.newValueSpecifiedUnits(SVGAngle.SVG_ANGLETYPE_DEG)");
-shouldBeUndefined("angle.newValueSpecifiedUnits(SVGAngle.SVG_ANGLETYPE_DEG, 'aString')");
-shouldBe("angle.value", "NaN");
+shouldThrow("angle.newValueSpecifiedUnits(SVGAngle.SVG_ANGLETYPE_DEG, 'aString')");
+shouldBe("angle.value", "0");
 shouldBeUndefined("angle.newValueSpecifiedUnits(SVGAngle.SVG_ANGLETYPE_DEG, 0)");
-shouldBeUndefined("angle.newValueSpecifiedUnits(SVGAngle.SVG_ANGLETYPE_DEG, angle)");
-shouldBe("angle.value", "NaN");
-shouldBeUndefined("angle.newValueSpecifiedUnits(SVGAngle.SVG_ANGLETYPE_DEG, svgElement)");
-shouldBe("angle.value", "NaN");
+shouldThrow("angle.newValueSpecifiedUnits(SVGAngle.SVG_ANGLETYPE_DEG, angle)");
+shouldBe("angle.value", "0");
+shouldThrow("angle.newValueSpecifiedUnits(SVGAngle.SVG_ANGLETYPE_DEG, svgElement)");
+shouldBe("angle.value", "0");
+shouldThrow("angle.newValueSpecifiedUnits(SVGAngle.SVG_ANGLETYPE_DEG, NaN)");
+shouldBe("angle.value", "0");
+shouldThrow("angle.newValueSpecifiedUnits(SVGAngle.SVG_ANGLETYPE_DEG, Infinity)");
+shouldBe("angle.value", "0");
 shouldThrow("angle.newValueSpecifiedUnits(SVGAngle.SVG_ANGLETYPE_DEG)");
 // All of the following unitType arguments convert to 0 (SVG_ANGLETYPE_UNKNOWN).
 shouldThrow("angle.newValueSpecifiedUnits('aString', 4)");
@@ -153,29 +157,37 @@ shouldBe("angle.unitType", "SVGAngle.SVG_ANGLETYPE_UNSPECIFIED");
 
 debug("");
 debug("Check setting invalid 'valueInSpecifiedUnits' arguments");
-shouldBe("angle.valueInSpecifiedUnits = 'test'", "'test'");
-shouldBe("angle.value", "NaN");
-shouldBe("angle.valueInSpecifiedUnits", "NaN");
+shouldThrow("angle.valueInSpecifiedUnits = 'test'");
+shouldBe("angle.value", "0");
+shouldBe("angle.valueInSpecifiedUnits", "0");
 shouldBe("angle.unitType", "SVGAngle.SVG_ANGLETYPE_UNSPECIFIED");
 shouldBe("angle.valueInSpecifiedUnits = 0", "0");
 
-shouldBe("angle.valueInSpecifiedUnits = angle", "angle");
-shouldBe("angle.value", "NaN");
-shouldBe("angle.valueInSpecifiedUnits", "NaN");
+shouldThrow("angle.valueInSpecifiedUnits = angle");
+shouldBe("angle.value", "0");
+shouldThrow("angle.valueInSpecifiedUnits = NaN");
+shouldBe("angle.value", "0");
+shouldThrow("angle.valueInSpecifiedUnits = Infinity");
+shouldBe("angle.value", "0");
+shouldBe("angle.valueInSpecifiedUnits", "0");
 shouldBe("angle.unitType", "SVGAngle.SVG_ANGLETYPE_UNSPECIFIED");
 
 debug("");
 debug("Check setting invalid 'value' arguments");
 shouldBe("angle.value = 0", "0");
-shouldBe("angle.value = 'test'", "'test'");
-shouldBe("angle.value", "NaN");
-shouldBe("angle.valueInSpecifiedUnits", "NaN");
+shouldThrow("angle.value = 'test'");
+shouldBe("angle.value", "0");
+shouldBe("angle.valueInSpecifiedUnits", "0");
 shouldBe("angle.unitType", "SVGAngle.SVG_ANGLETYPE_UNSPECIFIED");
 
 shouldBe("angle.value = 0", "0");
-shouldBe("angle.value = angle", "angle");
-shouldBe("angle.value", "NaN");
-shouldBe("angle.valueInSpecifiedUnits", "NaN");
+shouldThrow("angle.value = angle");
+shouldBe("angle.value", "0");
+shouldThrow("angle.value = NaN");
+shouldBe("angle.value", "0");
+shouldThrow("angle.value = Infinity");
+shouldBe("angle.value", "0");
+shouldBe("angle.valueInSpecifiedUnits", "0");
 shouldBe("angle.unitType", "SVGAngle.SVG_ANGLETYPE_UNSPECIFIED");
 
 debug("");
@@ -237,6 +249,5 @@ shouldBe("angle.unitType", "SVGAngle.SVG_ANGLETYPE_DEG");
 
 successfullyParsed = true;
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/Source/WebCore/svg/SVGAngle.idl
+++ b/Source/WebCore/svg/SVGAngle.idl
@@ -20,6 +20,8 @@
  * Boston, MA 02110-1301, USA.
  */
 
+// https://svgwg.org/svg2-draft/types.html#InterfaceSVGAngle
+
 [
     ConstantsScope=SVGAngleValue,
     Exposed=Window
@@ -32,11 +34,10 @@
     const unsigned short SVG_ANGLETYPE_GRAD = 4;
 
     readonly attribute unsigned short unitType;
-    [ImplementedAs=valueForBindings] attribute unrestricted float value;
-    attribute unrestricted float valueInSpecifiedUnits;
-
+    [ImplementedAs=valueForBindings] attribute float value;
+    attribute float valueInSpecifiedUnits;
     attribute DOMString valueAsString;
 
-    undefined newValueSpecifiedUnits(unsigned short unitType, unrestricted float valueInSpecifiedUnits);
+    undefined newValueSpecifiedUnits(unsigned short unitType, float valueInSpecifiedUnits);
     undefined convertToSpecifiedUnits(unsigned short unitType);
 };


### PR DESCRIPTION
#### 105fea294b3d6d23cd87708a567c2089230d678a
<pre>
Sync &apos;SVGAngle.idl&apos; with WebIDL Specification

<a href="https://bugs.webkit.org/show_bug.cgi?id=267182">https://bugs.webkit.org/show_bug.cgi?id=267182</a>

Reviewed by Tim Nguyen.

This patch is to align WebKit with Web-Specification [1]:

[1] <a href="https://svgwg.org/svg2-draft/types.html#InterfaceSVGAngle">https://svgwg.org/svg2-draft/types.html#InterfaceSVGAngle</a>

It removes &apos;unrestricted&apos; from `value` and `valueInSpecifiedUnits` and uses.

Additionally, the test is synced from below Blink commit (SVGAngle.js):

Commit: <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=190303

* Source/WebCore/svg/SVGAngle.idl:
* LayoutTests/svg/dom/SVGAngle.html: Rebaselined
* LayoutTests/svg/dom/SVGAngle-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/272739@main">https://commits.webkit.org/272739@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7fd9e6c9a855c59e3a9a7ead0d43e9f522e1e0b6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32864 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11620 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34736 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35484 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29687 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33798 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13960 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8797 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29140 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33316 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9797 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29352 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8532 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8677 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29308 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36817 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29854 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29715 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34811 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8799 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6763 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32668 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10489 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/28965 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7631 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9407 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9421 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->