### PR TITLE
Revert removal of else branch in SelectorChecker::matchRecursively()

### DIFF
--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -294,21 +294,21 @@ SelectorChecker::MatchResult SelectorChecker::matchRecursively(CheckingContext& 
                     return MatchResult::fails(Match::SelectorFailsLocally);
             } else
                 return MatchResult::fails(Match::SelectorFailsLocally);
+        } else {
+            if (context.selector->pseudoElement() == CSSSelector::PseudoElement::WebKitUnknown)
+                return MatchResult::fails(Match::SelectorFailsLocally);
+
+            if (!context.pseudoElementEffective)
+                return MatchResult::fails(Match::SelectorFailsCompletely);
+
+            if (checkingContext.resolvingMode == Mode::QueryingRules)
+                return MatchResult::fails(Match::SelectorFailsCompletely);
+
+            auto pseudoId = CSSSelector::pseudoId(context.selector->pseudoElement());
+            if (pseudoId != PseudoId::None)
+                dynamicPseudoIdSet.add(pseudoId);
+            matchType = MatchType::VirtualPseudoElementOnly;
         }
-
-        if (context.selector->pseudoElement() == CSSSelector::PseudoElement::WebKitUnknown)
-            return MatchResult::fails(Match::SelectorFailsLocally);
-
-        if (!context.pseudoElementEffective)
-            return MatchResult::fails(Match::SelectorFailsCompletely);
-
-        if (checkingContext.resolvingMode == Mode::QueryingRules)
-            return MatchResult::fails(Match::SelectorFailsCompletely);
-
-        auto pseudoId = CSSSelector::pseudoId(context.selector->pseudoElement());
-        if (pseudoId != PseudoId::None)
-            dynamicPseudoIdSet.add(pseudoId);
-        matchType = MatchType::VirtualPseudoElementOnly;
     }
 
     // The rest of the selectors has to match


### PR DESCRIPTION
#### 5a57b47cbfbb4edbeeb22b65c1e91847f633bf47
<pre>
Revert removal of else branch in SelectorChecker::matchRecursively()
<a href="https://bugs.webkit.org/show_bug.cgi?id=267184">https://bugs.webkit.org/show_bug.cgi?id=267184</a>

Reviewed by Tim Nguyen.

272726@main (re-landed as 272729@main) removed the else branch under
the assumption that all paths had early returns. But that is not the
case. E.g., a user agent shadow root containing an element with a
matching pseudo attribute.

While I&apos;m not sure how to cover this with a test and no tests
regressed, it seems best to restore the status quo prior to that
commit.

* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::matchRecursively const):

Canonical link: <a href="https://commits.webkit.org/272738@main">https://commits.webkit.org/272738@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea025050e009897556928e080be1e26303f20f85

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32871 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11629 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34745 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35493 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29695 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33807 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13969 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8804 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29145 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33325 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9802 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29357 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8538 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8682 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29313 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36826 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29859 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29720 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34817 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8807 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6766 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32673 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10497 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7630 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9414 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9430 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->