### PR TITLE
Sync 'SVGTransform.idl' with WebIDL Specification

### DIFF
--- a/LayoutTests/svg/dom/SVGTransform-expected.txt
+++ b/LayoutTests/svg/dom/SVGTransform-expected.txt
@@ -75,30 +75,38 @@ PASS transform.setTranslate() threw exception TypeError: Not enough arguments.
 PASS transform.setTranslate(transform) threw exception TypeError: Not enough arguments.
 PASS transform.setTranslate(svgElement) threw exception TypeError: Not enough arguments.
 PASS transform.setTranslate('aString') threw exception TypeError: Not enough arguments.
-PASS transform.setTranslate(1, transform) is undefined.
-PASS transform.setTranslate(1, svgElement) is undefined.
-PASS transform.setTranslate(1, 'aString') is undefined.
-PASS transform.setTranslate(transform, 1) is undefined.
-PASS transform.setTranslate(svgElement, 1) is undefined.
-PASS transform.setTranslate('aString', 1) is undefined.
-PASS transform.setTranslate(transform, transform) is undefined.
-PASS transform.setTranslate(svgElement, svgElement) is undefined.
-PASS transform.setTranslate('aString', 'aString') is undefined.
+PASS transform.setTranslate(1, transform) threw exception TypeError: The provided value is non-finite.
+PASS transform.setTranslate(1, svgElement) threw exception TypeError: The provided value is non-finite.
+PASS transform.setTranslate(1, 'aString') threw exception TypeError: The provided value is non-finite.
+PASS transform.setTranslate(transform, 1) threw exception TypeError: The provided value is non-finite.
+PASS transform.setTranslate(svgElement, 1) threw exception TypeError: The provided value is non-finite.
+PASS transform.setTranslate('aString', 1) threw exception TypeError: The provided value is non-finite.
+PASS transform.setTranslate(transform, transform) threw exception TypeError: The provided value is non-finite.
+PASS transform.setTranslate(svgElement, svgElement) threw exception TypeError: The provided value is non-finite.
+PASS transform.setTranslate('aString', 'aString') threw exception TypeError: The provided value is non-finite.
+PASS transform.setTranslate(NaN, 1) threw exception TypeError: The provided value is non-finite.
+PASS transform.setTranslate(Infinity, 1) threw exception TypeError: The provided value is non-finite.
+PASS transform.setTranslate(1, NaN) threw exception TypeError: The provided value is non-finite.
+PASS transform.setTranslate(1, Infinity) threw exception TypeError: The provided value is non-finite.
 
 Check passing invalid arguments to 'setScale'
 PASS transform.setScale() threw exception TypeError: Not enough arguments.
 PASS transform.setScale(transform) threw exception TypeError: Not enough arguments.
 PASS transform.setScale(svgElement) threw exception TypeError: Not enough arguments.
 PASS transform.setScale('aString') threw exception TypeError: Not enough arguments.
-PASS transform.setScale(1, transform) is undefined.
-PASS transform.setScale(1, svgElement) is undefined.
-PASS transform.setScale(1, 'aString') is undefined.
-PASS transform.setScale(transform, 1) is undefined.
-PASS transform.setScale(svgElement, 1) is undefined.
-PASS transform.setScale('aString', 1) is undefined.
-PASS transform.setScale(transform, transform) is undefined.
-PASS transform.setScale(svgElement, svgElement) is undefined.
-PASS transform.setScale('aString', 'aString') is undefined.
+PASS transform.setScale(1, transform) threw exception TypeError: The provided value is non-finite.
+PASS transform.setScale(1, svgElement) threw exception TypeError: The provided value is non-finite.
+PASS transform.setScale(1, 'aString') threw exception TypeError: The provided value is non-finite.
+PASS transform.setScale(transform, 1) threw exception TypeError: The provided value is non-finite.
+PASS transform.setScale(svgElement, 1) threw exception TypeError: The provided value is non-finite.
+PASS transform.setScale('aString', 1) threw exception TypeError: The provided value is non-finite.
+PASS transform.setScale(transform, transform) threw exception TypeError: The provided value is non-finite.
+PASS transform.setScale(svgElement, svgElement) threw exception TypeError: The provided value is non-finite.
+PASS transform.setScale('aString', 'aString') threw exception TypeError: The provided value is non-finite.
+PASS transform.setScale(NaN, 1) threw exception TypeError: The provided value is non-finite.
+PASS transform.setScale(Infinity, 1) threw exception TypeError: The provided value is non-finite.
+PASS transform.setScale(1, NaN) threw exception TypeError: The provided value is non-finite.
+PASS transform.setScale(1, Infinity) threw exception TypeError: The provided value is non-finite.
 
 Check passing invalid arguments to 'setRotate'
 PASS transform.setRotate() threw exception TypeError: Not enough arguments.
@@ -108,21 +116,31 @@ PASS transform.setRotate('aString') threw exception TypeError: Not enough argume
 PASS transform.setRotate(1, transform) threw exception TypeError: Not enough arguments.
 PASS transform.setRotate(1, svgElement) threw exception TypeError: Not enough arguments.
 PASS transform.setRotate(1, 'aString') threw exception TypeError: Not enough arguments.
-PASS transform.setRotate(1, 1, transform) is undefined.
-PASS transform.setRotate(1, 1, svgElement) is undefined.
-PASS transform.setRotate(1, 1, 'aString') is undefined.
+PASS transform.setRotate(1, 1, transform) threw exception TypeError: The provided value is non-finite.
+PASS transform.setRotate(1, 1, svgElement) threw exception TypeError: The provided value is non-finite.
+PASS transform.setRotate(1, 1, 'aString') threw exception TypeError: The provided value is non-finite.
+PASS transform.setRotate(NaN, 1, 1) threw exception TypeError: The provided value is non-finite.
+PASS transform.setRotate(Infinity, 1, 1) threw exception TypeError: The provided value is non-finite.
+PASS transform.setRotate(1, NaN, 1) threw exception TypeError: The provided value is non-finite.
+PASS transform.setRotate(1, Infinity, 1) threw exception TypeError: The provided value is non-finite.
+PASS transform.setRotate(1, 1, NaN) threw exception TypeError: The provided value is non-finite.
+PASS transform.setRotate(1, 1, Infinity) threw exception TypeError: The provided value is non-finite.
 
 Check passing invalid arguments to 'setSkewX'
 PASS transform.setSkewX() threw exception TypeError: Not enough arguments.
-PASS transform.setSkewX(transform) is undefined.
-PASS transform.setSkewX(svgElement) is undefined.
-PASS transform.setSkewX('aString') is undefined.
+PASS transform.setSkewX(transform) threw exception TypeError: The provided value is non-finite.
+PASS transform.setSkewX(svgElement) threw exception TypeError: The provided value is non-finite.
+PASS transform.setSkewX('aString') threw exception TypeError: The provided value is non-finite.
+PASS transform.setSkewX(NaN) threw exception TypeError: The provided value is non-finite.
+PASS transform.setSkewX(Infinity) threw exception TypeError: The provided value is non-finite.
 
 Check passing invalid arguments to 'setSkewY'
 PASS transform.setSkewY() threw exception TypeError: Not enough arguments.
-PASS transform.setSkewY(transform) is undefined.
-PASS transform.setSkewY(svgElement) is undefined.
-PASS transform.setSkewY('aString') is undefined.
+PASS transform.setSkewY(transform) threw exception TypeError: The provided value is non-finite.
+PASS transform.setSkewY(svgElement) threw exception TypeError: The provided value is non-finite.
+PASS transform.setSkewY('aString') threw exception TypeError: The provided value is non-finite.
+PASS transform.setSkewY(NaN) threw exception TypeError: The provided value is non-finite.
+PASS transform.setSkewY(Infinity) threw exception TypeError: The provided value is non-finite.
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/svg/dom/SVGTransform.html
+++ b/LayoutTests/svg/dom/SVGTransform.html
@@ -1,7 +1,7 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE html>
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 </head>
 <body>
 <p id="description"></p>
@@ -89,15 +89,19 @@ shouldThrow("transform.setTranslate()");
 shouldThrow("transform.setTranslate(transform)");
 shouldThrow("transform.setTranslate(svgElement)");
 shouldThrow("transform.setTranslate('aString')");
-shouldBeUndefined("transform.setTranslate(1, transform)");
-shouldBeUndefined("transform.setTranslate(1, svgElement)");
-shouldBeUndefined("transform.setTranslate(1, 'aString')");
-shouldBeUndefined("transform.setTranslate(transform, 1)");
-shouldBeUndefined("transform.setTranslate(svgElement, 1)");
-shouldBeUndefined("transform.setTranslate('aString', 1)");
-shouldBeUndefined("transform.setTranslate(transform, transform)");
-shouldBeUndefined("transform.setTranslate(svgElement, svgElement)");
-shouldBeUndefined("transform.setTranslate('aString', 'aString')");
+shouldThrow("transform.setTranslate(1, transform)");
+shouldThrow("transform.setTranslate(1, svgElement)");
+shouldThrow("transform.setTranslate(1, 'aString')");
+shouldThrow("transform.setTranslate(transform, 1)");
+shouldThrow("transform.setTranslate(svgElement, 1)");
+shouldThrow("transform.setTranslate('aString', 1)");
+shouldThrow("transform.setTranslate(transform, transform)");
+shouldThrow("transform.setTranslate(svgElement, svgElement)");
+shouldThrow("transform.setTranslate('aString', 'aString')");
+shouldThrow("transform.setTranslate(NaN, 1)");
+shouldThrow("transform.setTranslate(Infinity, 1)");
+shouldThrow("transform.setTranslate(1, NaN)");
+shouldThrow("transform.setTranslate(1, Infinity)");
 
 debug("");
 debug("Check passing invalid arguments to 'setScale'");
@@ -105,15 +109,19 @@ shouldThrow("transform.setScale()");
 shouldThrow("transform.setScale(transform)");
 shouldThrow("transform.setScale(svgElement)");
 shouldThrow("transform.setScale('aString')");
-shouldBeUndefined("transform.setScale(1, transform)");
-shouldBeUndefined("transform.setScale(1, svgElement)");
-shouldBeUndefined("transform.setScale(1, 'aString')");
-shouldBeUndefined("transform.setScale(transform, 1)");
-shouldBeUndefined("transform.setScale(svgElement, 1)");
-shouldBeUndefined("transform.setScale('aString', 1)");
-shouldBeUndefined("transform.setScale(transform, transform)");
-shouldBeUndefined("transform.setScale(svgElement, svgElement)");
-shouldBeUndefined("transform.setScale('aString', 'aString')");
+shouldThrow("transform.setScale(1, transform)");
+shouldThrow("transform.setScale(1, svgElement)");
+shouldThrow("transform.setScale(1, 'aString')");
+shouldThrow("transform.setScale(transform, 1)");
+shouldThrow("transform.setScale(svgElement, 1)");
+shouldThrow("transform.setScale('aString', 1)");
+shouldThrow("transform.setScale(transform, transform)");
+shouldThrow("transform.setScale(svgElement, svgElement)");
+shouldThrow("transform.setScale('aString', 'aString')");
+shouldThrow("transform.setScale(NaN, 1)");
+shouldThrow("transform.setScale(Infinity, 1)");
+shouldThrow("transform.setScale(1, NaN)");
+shouldThrow("transform.setScale(1, Infinity)");
 
 debug("");
 debug("Check passing invalid arguments to 'setRotate'");
@@ -124,26 +132,34 @@ shouldThrow("transform.setRotate('aString')");
 shouldThrow("transform.setRotate(1, transform)");
 shouldThrow("transform.setRotate(1, svgElement)");
 shouldThrow("transform.setRotate(1, 'aString')");
-shouldBeUndefined("transform.setRotate(1, 1, transform)");
-shouldBeUndefined("transform.setRotate(1, 1, svgElement)");
-shouldBeUndefined("transform.setRotate(1, 1, 'aString')");
+shouldThrow("transform.setRotate(1, 1, transform)");
+shouldThrow("transform.setRotate(1, 1, svgElement)");
+shouldThrow("transform.setRotate(1, 1, 'aString')");
+shouldThrow("transform.setRotate(NaN, 1, 1)");
+shouldThrow("transform.setRotate(Infinity, 1, 1)");
+shouldThrow("transform.setRotate(1, NaN, 1)");
+shouldThrow("transform.setRotate(1, Infinity, 1)");
+shouldThrow("transform.setRotate(1, 1, NaN)");
+shouldThrow("transform.setRotate(1, 1, Infinity)");
 
 debug("");
 debug("Check passing invalid arguments to 'setSkewX'");
 shouldThrow("transform.setSkewX()");
-shouldBeUndefined("transform.setSkewX(transform)");
-shouldBeUndefined("transform.setSkewX(svgElement)");
-shouldBeUndefined("transform.setSkewX('aString')");
+shouldThrow("transform.setSkewX(transform)");
+shouldThrow("transform.setSkewX(svgElement)");
+shouldThrow("transform.setSkewX('aString')");
+shouldThrow("transform.setSkewX(NaN)");
+shouldThrow("transform.setSkewX(Infinity)");
 
 debug("");
 debug("Check passing invalid arguments to 'setSkewY'");
 shouldThrow("transform.setSkewY()");
-shouldBeUndefined("transform.setSkewY(transform)");
-shouldBeUndefined("transform.setSkewY(svgElement)");
-shouldBeUndefined("transform.setSkewY('aString')");
-
+shouldThrow("transform.setSkewY(transform)");
+shouldThrow("transform.setSkewY(svgElement)");
+shouldThrow("transform.setSkewY('aString')");
+shouldThrow("transform.setSkewY(NaN)");
+shouldThrow("transform.setSkewY(Infinity)");
 successfullyParsed = true;
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/Source/WebCore/svg/SVGTransform.idl
+++ b/Source/WebCore/svg/SVGTransform.idl
@@ -19,6 +19,8 @@
  * Boston, MA 02110-1301, USA.
  */
 
+// https://svgwg.org/svg2-draft/coords.html#InterfaceSVGTransform
+
 [
     ConstantsScope=SVGTransformValue,
     Exposed=Window
@@ -33,14 +35,14 @@
     const unsigned short SVG_TRANSFORM_SKEWY = 6;
 
     readonly attribute unsigned short type;
-    readonly attribute SVGMatrix matrix;
-    readonly attribute unrestricted float angle;
+    [SameObject] readonly attribute SVGMatrix matrix;
+    readonly attribute float angle;
 
-    undefined setMatrix(optional DOMMatrix2DInit matrix);
-    undefined setTranslate(unrestricted float tx, unrestricted float ty);
-    undefined setScale(unrestricted float sx, unrestricted float sy);
-    undefined setRotate(unrestricted float angle, unrestricted float cx, unrestricted float cy);
-    undefined setSkewX(unrestricted float angle);
-    undefined setSkewY(unrestricted float angle);
+    undefined setMatrix(optional DOMMatrix2DInit matrix = {});
+    undefined setTranslate(float tx, float ty);
+    undefined setScale(float sx, float sy);
+    undefined setRotate(float angle, float cx, float cy);
+    undefined setSkewX(float angle);
+    undefined setSkewY(float angle);
 };
 


### PR DESCRIPTION
#### be98f63ecae4c7e34c8293c6dc4f7c893d7e171e
<pre>
Sync &apos;SVGTransform.idl&apos; with WebIDL Specification

<a href="https://bugs.webkit.org/show_bug.cgi?id=267190">https://bugs.webkit.org/show_bug.cgi?id=267190</a>

Reviewed by Simon Fraser.

This patch is to align WebKit with Web-Specification [1]:

[1] <a href="https://svgwg.org/svg2-draft/coords.html#InterfaceSVGTransform">https://svgwg.org/svg2-draft/coords.html#InterfaceSVGTransform</a>

It removes &apos;unrestricted&apos; from multiple values and add [SameObject] as needed.

Additionally, the test is synced from below Blink commit (SVGTransform.js):

Commit: <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=190303

* Source/WebCore/svg/SVGTransform.idl:
* LayoutTests/svg/dom/SVGTransform.html: Updated from Blink / Chromium source
* LayoutTests/svg/dom/SVGTransform-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/272751@main">https://commits.webkit.org/272751@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a986a2bbde141648ba8be81aae2fe932fcda80f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32883 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11641 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34759 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35506 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29708 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33820 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13981 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8816 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29156 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33338 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9812 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29369 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8548 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8692 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29325 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36839 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29869 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29732 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34829 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8820 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6776 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32683 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10510 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/28982 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7638 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9426 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9442 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->