### PR TITLE
Negative SVGTransform scale values should be correctly stringified

### DIFF
--- a/LayoutTests/svg/transforms/negative-scale-value-expected.txt
+++ b/LayoutTests/svg/transforms/negative-scale-value-expected.txt
@@ -1,0 +1,10 @@
+SVG scale transform with negative scale values should be correctly converted to strings.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS g.getAttribute('transform') is "scale(-2 -4)"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/svg/transforms/negative-scale-value.html
+++ b/LayoutTests/svg/transforms/negative-scale-value.html
@@ -1,0 +1,15 @@
+<!DOCTYPE HTML>
+<script src='../../resources/js-test.js'></script>
+<script>
+description("SVG scale transform with negative scale values should be correctly converted to strings.");
+
+var svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+var g = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+var transform = svg.createSVGTransform();
+transform.setScale(-2, -4);
+
+var list = g.transform.baseVal;
+list.appendItem(transform);
+
+shouldBeEqualToString("g.getAttribute('transform')", "scale(-2 -4)");
+</script>

--- a/Source/WebCore/svg/SVGTransformValue.h
+++ b/Source/WebCore/svg/SVGTransformValue.h
@@ -1,7 +1,8 @@
 /*
  * Copyright (C) 2004, 2005, 2008 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005 Rob Buis <buis@kde.org>
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2014 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -264,7 +265,7 @@ private:
 
     void appendScale(StringBuilder& builder) const
     {
-        appendFixedPrecisionNumbers(builder, m_matrix->value().xScale(), m_matrix->value().yScale());
+        appendFixedPrecisionNumbers(builder, m_matrix->a(), m_matrix->d());
     }
 
     void appendRotate(StringBuilder& builder) const


### PR DESCRIPTION
#### 2efdea0ba354c2758bfa2a8c6a262e411fc6c4f8
<pre>
Negative SVGTransform scale values should be correctly stringified

<a href="https://bugs.webkit.org/show_bug.cgi?id=264752">https://bugs.webkit.org/show_bug.cgi?id=264752</a>
<a href="https://rdar.apple.com/problem/118656892">rdar://problem/118656892</a>

Reviewed by Said Abou-Hallawa.

This patch is to align WebKit with Blink / Chromium and partially with Gecko / Firefox.

Merge: <a href="https://chromium.googlesource.com/chromium/blink/+/8a7252a2602bd8067c83d48c8fd525ef322708c2">https://chromium.googlesource.com/chromium/blink/+/8a7252a2602bd8067c83d48c8fd525ef322708c2</a>

Before this patch, SVGTransformValue::appendScale used AffineTransform::{x,y}Scale},
which computed transform scale values by computing norm of projected unit vectors.
However, that would always return positive values, even if negative scale values were specified.

This patch changes the implementation to use `a` and `d` values instead. This is valid,
as the scale matrix is guaranteed to be in the below simple form when the transform has
type `SVG_TRANSFORM_SCALE`.

|xscale    0   0|
|   0   yscale 0|

* Source/WebCore/svg/SVGTransformValue.h:
(appendScale):
* LayoutTests/svg/transforms/negative-scale-value.html: Add Test Case
* LayoutTests/svg/transforms/negative-scale-value-expected.txt: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/272885@main">https://commits.webkit.org/272885@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6aa0b1b3f7c6acd6f3175379ee81ee1df2872479

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32887 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11644 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34763 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35510 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29712 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33824 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13984 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8820 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29160 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33342 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9814 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29372 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8552 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8715 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29328 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36842 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29871 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29735 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34832 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8823 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6779 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32686 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10514 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/28985 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7746 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9429 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9445 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->