### PR TITLE
lh unit is sometimes computed before line-height is resolved

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/lh-unit-same-element-font-size-dependency-expected.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/lh-unit-same-element-font-size-dependency-expected.xht
@@ -1,0 +1,19 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
+  <style type="text/css"><![CDATA[
+  div
+  {
+  background-color: green;
+  height: 100px;
+  width: 100px;
+  }
+  ]]></style>
+ </head>
+ <body>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+  <div></div>
+ </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/lh-unit-same-element-font-size-dependency.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/lh-unit-same-element-font-size-dependency.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<title>Test same-element font-size dependency with lh unit</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-values/#font-relative-lengths">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-5000">
+<style>
+div {
+    background-image: linear-gradient(green, green);
+    background-repeat: no-repeat;
+    background-size: 100px 1lh;
+    line-height: 2em;
+    font-size: 50px;
+    width: 100px;
+    color: transparent;
+}
+</style>
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div>.</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/lh-unit-same-element-line-height-dependency-expected.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/lh-unit-same-element-line-height-dependency-expected.xht
@@ -1,0 +1,19 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
+  <style type="text/css"><![CDATA[
+  div
+  {
+  background-color: green;
+  height: 100px;
+  width: 100px;
+  }
+  ]]></style>
+ </head>
+ <body>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+  <div></div>
+ </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/lh-unit-same-element-line-height-dependency.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/lh-unit-same-element-line-height-dependency.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<title>Test same-element line-height dependency with lh unit</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-values/#font-relative-lengths">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-5000">
+<style>
+div {
+    background-image: linear-gradient(green, green);
+    background-repeat: no-repeat;
+    background-size: 100px 1lh;
+    line-height: 100px;
+    width: 100px;
+    color: transparent;
+}
+</style>
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div>.</div>

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -114,6 +114,8 @@ void Builder::applyHighPriorityProperties()
 {
     applyProperties(firstHighPriorityProperty, lastHighPriorityProperty);
     m_state.updateFont();
+    // This needs to apply before other properties for the `lh` unit, but after updating the font.
+    applyProperties(CSSPropertyLineHeight, CSSPropertyLineHeight);
 }
 
 void Builder::applyNonHighPriorityProperties()


### PR DESCRIPTION
#### 6220d3d8995a515d5fb13351683645f59153e603
<pre>
lh unit is sometimes computed before line-height is resolved
<a href="https://bugs.webkit.org/show_bug.cgi?id=265287">https://bugs.webkit.org/show_bug.cgi?id=265287</a>
<a href="https://rdar.apple.com/118983248">rdar://118983248</a>

Reviewed by Darin Adler.

Compute `line-height` before other properties, but after updating the font, since `line-height` can itself depend on `font-size` if it uses `em` units.

Note that there is no circular dependency with font-size since using `lh` in `font` properties will resolve against the parent style per-spec:

&gt; Similarly, when lh or rlh units are used in the value of the line-height property or font-* properties on the element they refer to,
&gt; they resolve against the computed line-height and font metrics of the parent element -or the computed metrics corresponding to the
&gt; initial values of the font and line-height properties, if the element has no parent.

<a href="https://drafts.csswg.org/css-values/#font-relative-lengths">https://drafts.csswg.org/css-values/#font-relative-lengths</a>

In the long run, the {top/high/low/sink} property setup should be cleaned up since it is quite fragile.

* LayoutTests/imported/w3c/web-platform-tests/css/css-values/lh-unit-same-element-font-size-dependency-expected.xht: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/lh-unit-same-element-font-size-dependency.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/lh-unit-same-element-line-height-dependency-expected.xht: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/lh-unit-same-element-line-height-dependency.html: Added.
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::applyHighPriorityProperties):

Canonical link: <a href="https://commits.webkit.org/281795@main">https://commits.webkit.org/281795@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58b52f1a91e6e3f4a38b2b74b73e59c2538c0caa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60991 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40350 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13599 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64924 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11538 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63121 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48026 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11813 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49305 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7998 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/63025 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37557 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52865 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30123 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34248 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10089 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10451 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/56073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10384 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66654 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4935 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10187 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56662 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4957 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52828 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56852 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13614 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4082 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/36156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37239 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38333 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/36983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->