### PR TITLE
[JSC] Use MarkedArgumentBuffer::ensureCapacity

### DIFF
--- a/Source/JavaScriptCore/API/JSObjectRef.cpp
+++ b/Source/JavaScriptCore/API/JSObjectRef.cpp
@@ -142,6 +142,7 @@ JSObjectRef JSObjectMakeFunction(JSContextRef ctx, JSStringRef name, unsigned pa
     Identifier nameID = name ? name->identifier(&vm) : Identifier::fromString(vm, "anonymous"_s);
     
     MarkedArgumentBuffer args;
+    args.ensureCapacity(parameterCount + 1);
     for (unsigned i = 0; i < parameterCount; i++)
         args.append(jsString(vm, parameterNames[i]->string()));
     args.append(jsString(vm, body->string()));
@@ -173,6 +174,7 @@ JSObjectRef JSObjectMakeArray(JSContextRef ctx, size_t argumentCount, const JSVa
     JSObject* result;
     if (argumentCount) {
         MarkedArgumentBuffer argList;
+        argList.ensureCapacity(argumentCount);
         for (size_t i = 0; i < argumentCount; ++i)
             argList.append(toJS(globalObject, arguments[i]));
         if (UNLIKELY(argList.hasOverflowed())) {
@@ -204,6 +206,7 @@ JSObjectRef JSObjectMakeDate(JSContextRef ctx, size_t argumentCount, const JSVal
     auto scope = DECLARE_CATCH_SCOPE(vm);
 
     MarkedArgumentBuffer argList;
+    argList.ensureCapacity(argumentCount);
     for (size_t i = 0; i < argumentCount; ++i)
         argList.append(toJS(globalObject, arguments[i]));
     if (UNLIKELY(argList.hasOverflowed())) {
@@ -254,6 +257,7 @@ JSObjectRef JSObjectMakeRegExp(JSContextRef ctx, size_t argumentCount, const JSV
     auto scope = DECLARE_CATCH_SCOPE(vm);
 
     MarkedArgumentBuffer argList;
+    argList.ensureCapacity(argumentCount);
     for (size_t i = 0; i < argumentCount; ++i)
         argList.append(toJS(globalObject, arguments[i]));
     if (UNLIKELY(argList.hasOverflowed())) {
@@ -717,6 +721,7 @@ JSValueRef JSObjectCallAsFunction(JSContextRef ctx, JSObjectRef object, JSObject
         jsThisObject = globalObject->globalThis();
 
     MarkedArgumentBuffer argList;
+    argList.ensureCapacity(argumentCount);
     for (size_t i = 0; i < argumentCount; i++)
         argList.append(toJS(globalObject, arguments[i]));
     if (UNLIKELY(argList.hasOverflowed())) {
@@ -763,6 +768,7 @@ JSObjectRef JSObjectCallAsConstructor(JSContextRef ctx, JSObjectRef object, size
         return nullptr;
 
     MarkedArgumentBuffer argList;
+    argList.ensureCapacity(argumentCount);
     for (size_t i = 0; i < argumentCount; i++)
         argList.append(toJS(globalObject, arguments[i]));
     if (UNLIKELY(argList.hasOverflowed())) {

--- a/Source/JavaScriptCore/runtime/ArgList.h
+++ b/Source/JavaScriptCore/runtime/ArgList.h
@@ -84,7 +84,7 @@ protected:
 
     Status expandCapacity();
     Status expandCapacity(int newCapacity);
-    Status slowEnsureCapacity(size_t requestedCapacity);
+    JS_EXPORT_PRIVATE Status slowEnsureCapacity(size_t requestedCapacity);
 
     void addMarkSet(JSValue);
 
@@ -215,18 +215,31 @@ public:
         ensureCapacity(count);
         if (OverflowHandler::hasOverflowed())
             return;
-        if (LIKELY(!m_markSet)) {
-            m_markSet = &vm.heap.markListSet();
-            m_markSet->add(this);
+        if (!isUsingInlineBuffer()) {
+            if (LIKELY(!m_markSet)) {
+                m_markSet = &vm.heap.markListSet();
+                m_markSet->add(this);
+            }
         }
         m_size = count;
         auto* buffer = reinterpret_cast<JSValue*>(&slotFor(0));
+
+        // This clearing does not need to consider about concurrent marking from GC since MarkedVector
+        // gets marked only while mutator is stopping. So, while clearing in the mutator, concurrent
+        // marker will not see the buffer.
+#if USE(JSVALUE64)
+        memset(bitwise_cast<void*>(buffer), 0, sizeof(JSValue) * count);
+#else
         for (unsigned i = 0; i < count; ++i)
             buffer[i] = JSValue();
+#endif
+
         func(buffer);
     }
 
 private:
+    bool isUsingInlineBuffer() const { return m_buffer == m_inlineBuffer; }
+
     EncodedJSValue m_inlineBuffer[inlineCapacity] { };
 };
 

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -4072,8 +4072,11 @@ JSC_DEFINE_HOST_FUNCTION(functionCallFromCPP, (JSGlobalObject* globalObject, Cal
         return JSValue::encode(jsUndefined());
 
     MarkedArgumentBuffer arguments;
-    for (unsigned i = 2; i < callFrame->argumentCount(); ++i)
-        arguments.append(callFrame->argument(i));
+    if (callFrame->argumentCount() > 2) {
+        arguments.ensureCapacity(callFrame->argumentCount() - 2);
+        for (unsigned i = 2; i < callFrame->argumentCount(); ++i)
+            arguments.append(callFrame->argument(i));
+    }
     ASSERT(!arguments.hasOverflowed());
     RETURN_IF_EXCEPTION(scope, { });
 

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -675,6 +675,7 @@ JSC_DEFINE_JIT_OPERATION(operationIterateResults, void, (Instance* instance, con
 
     unsigned iterationCount = 0;
     MarkedArgumentBuffer buffer;
+    buffer.ensureCapacity(signature->returnCount());
     JSValue result = JSValue::decode(encResult);
     forEachInIterable(globalObject, result, [&] (VM&, JSGlobalObject*, JSValue value) -> void {
         if (buffer.size() < signature->returnCount()) {

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyExceptionConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyExceptionConstructor.cpp
@@ -61,7 +61,9 @@ JSC_DEFINE_HOST_FUNCTION(constructJSWebAssemblyException, (JSGlobalObject* globa
     if (!tag)
         return throwVMTypeError(globalObject, scope, "WebAssembly.Exception constructor expects the first argument to be a WebAssembly.Tag"_s);
 
+    const auto& tagFunctionType = tag->type();
     MarkedArgumentBuffer values;
+    values.ensureCapacity(tagFunctionType.argumentCount());
     forEachInIterable(globalObject, tagParameters, [&] (VM&, JSGlobalObject*, JSValue nextValue) {
         values.append(nextValue);
         if (UNLIKELY(values.hasOverflowed()))
@@ -69,7 +71,6 @@ JSC_DEFINE_HOST_FUNCTION(constructJSWebAssemblyException, (JSGlobalObject* globa
     });
     RETURN_IF_EXCEPTION(scope, { });
 
-    const auto& tagFunctionType = tag->type();
     if (values.size() != tagFunctionType.argumentCount())
         return throwVMTypeError(globalObject, scope, "WebAssembly.Exception constructor expects the number of paremeters in WebAssembly.Tag to match the tags parameter count."_s);
 

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyTagPrototype.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyTagPrototype.cpp
@@ -103,6 +103,7 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyTagProtoFuncType, (JSGlobalObject* globalObj
     const Wasm::Tag& tag = jsTag->tag();
 
     MarkedArgumentBuffer argList;
+    argList.ensureCapacity(tag.parameterCount());
     for (size_t i = 0; i < tag.parameterCount(); ++i)
         argList.append(Wasm::typeToString(vm, tag.parameter(i).kind));
 

--- a/Source/WebCore/bindings/js/JSDOMConvertSequences.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertSequences.h
@@ -381,6 +381,7 @@ template<typename T> struct JSConverter<IDLSequence<T>> {
         JSC::VM& vm = JSC::getVM(&lexicalGlobalObject);
         auto scope = DECLARE_THROW_SCOPE(vm);
         JSC::MarkedArgumentBuffer list;
+        list.ensureCapacity(vector.size());
         for (auto& element : vector) {
             auto jsValue = toJS<T>(lexicalGlobalObject, globalObject, element);
             RETURN_IF_EXCEPTION(scope, { });
@@ -418,6 +419,7 @@ template<typename T> struct JSConverter<IDLFrozenArray<T>> {
         JSC::VM& vm = JSC::getVM(&lexicalGlobalObject);
         auto scope = DECLARE_THROW_SCOPE(vm);
         JSC::MarkedArgumentBuffer list;
+        list.ensureCapacity(vector.size());
         for (auto& element : vector) {
             auto jsValue = toJS<T>(lexicalGlobalObject, globalObject, element);
             RETURN_IF_EXCEPTION(scope, { });

--- a/Source/WebCore/bindings/js/JSDOMConvertWebGL.cpp
+++ b/Source/WebCore/bindings/js/JSDOMConvertWebGL.cpp
@@ -175,18 +175,21 @@ JSValue convertToJSValue(JSGlobalObject& lexicalGlobalObject, JSDOMGlobalObject&
             return jsStringWithCache(lexicalGlobalObject.vm(), value);
         }, [&] (const Vector<bool>& values) -> JSValue {
             MarkedArgumentBuffer list;
+            list.ensureCapacity(values.size());
             for (auto& value : values)
                 list.append(jsBoolean(value));
             RELEASE_ASSERT(!list.hasOverflowed());
             return constructArray(&globalObject, static_cast<JSC::ArrayAllocationProfile*>(nullptr), list);
         }, [&] (const Vector<int>& values) -> JSValue {
             MarkedArgumentBuffer list;
+            list.ensureCapacity(values.size());
             for (auto& value : values)
                 list.append(jsNumber(value));
             RELEASE_ASSERT(!list.hasOverflowed());
             return constructArray(&globalObject, static_cast<JSC::ArrayAllocationProfile*>(nullptr), list);
         }, [&] (const Vector<unsigned>& values) -> JSValue {
             MarkedArgumentBuffer list;
+            list.ensureCapacity(values.size());
             for (auto& value : values)
                 list.append(jsNumber(value));
             RELEASE_ASSERT(!list.hasOverflowed());

--- a/Source/WebCore/bindings/js/JSDOMMapLike.cpp
+++ b/Source/WebCore/bindings/js/JSDOMMapLike.cpp
@@ -91,6 +91,7 @@ JSC::JSValue forwardFunctionCallToBackingMap(JSC::JSGlobalObject& lexicalGlobalO
     ASSERT(callData.type != JSC::CallData::Type::None);
 
     JSC::MarkedArgumentBuffer arguments;
+    arguments.ensureCapacity(callFrame.argumentCount());
     for (size_t cptr = 0; cptr < callFrame.argumentCount(); ++cptr)
         arguments.append(callFrame.uncheckedArgument(cptr));
     ASSERT(!arguments.hasOverflowed());
@@ -109,6 +110,7 @@ JSC::JSValue forwardForEachCallToBackingMap(JSDOMGlobalObject& globalObject, JSC
     ASSERT(callData.type != JSC::CallData::Type::None);
 
     JSC::MarkedArgumentBuffer arguments;
+    arguments.ensureCapacity(callFrame.argumentCount() + 1);
     arguments.append(&result.second.get());
     for (size_t cptr = 0; cptr < callFrame.argumentCount(); ++cptr)
         arguments.append(callFrame.uncheckedArgument(cptr));

--- a/Source/WebCore/bindings/js/JSDOMSetLike.cpp
+++ b/Source/WebCore/bindings/js/JSDOMSetLike.cpp
@@ -93,6 +93,7 @@ JSC::JSValue forwardFunctionCallToBackingSet(JSC::JSGlobalObject& lexicalGlobalO
     auto callData = JSC::getCallData(function);
     ASSERT(callData.type != JSC::CallData::Type::None);
     JSC::MarkedArgumentBuffer arguments;
+    arguments.ensureCapacity(callFrame.argumentCount());
     for (size_t cptr = 0; cptr < callFrame.argumentCount(); ++cptr)
         arguments.append(callFrame.uncheckedArgument(cptr));
     ASSERT(!arguments.hasOverflowed());
@@ -111,6 +112,7 @@ JSC::JSValue forwardForEachCallToBackingSet(JSDOMGlobalObject& globalObject, JSC
     ASSERT(callData.type != JSC::CallData::Type::None);
 
     JSC::MarkedArgumentBuffer arguments;
+    arguments.ensureCapacity(callFrame.argumentCount() + 1);
     arguments.append(&result.second.get());
     for (size_t cptr = 0; cptr < callFrame.argumentCount(); ++cptr)
         arguments.append(callFrame.uncheckedArgument(cptr));

--- a/Source/WebCore/bindings/js/JSIDBRequestCustom.cpp
+++ b/Source/WebCore/bindings/js/JSIDBRequestCustom.cpp
@@ -80,6 +80,7 @@ JSC::JSValue JSIDBRequest::result(JSC::JSGlobalObject& lexicalGlobalObject) cons
             auto& values = getAllResult.values();
             auto& keyPath = getAllResult.keyPath();
             JSC::MarkedArgumentBuffer list;
+            list.ensureCapacity(values.size());
             for (unsigned i = 0; i < values.size(); i ++) {
                 auto result = deserializeIDBValueWithKeyInjection(lexicalGlobalObject, values[i], keys[i], keyPath);
                 if (!result)

--- a/Source/WebCore/bindings/js/JSNavigatorCustom.cpp
+++ b/Source/WebCore/bindings/js/JSNavigatorCustom.cpp
@@ -51,6 +51,7 @@ JSC::JSValue JSNavigator::getUserMedia(JSC::JSGlobalObject& lexicalGlobalObject,
     auto callData = JSC::getCallData(function);
     ASSERT(callData.type != JSC::CallData::Type::None);
     JSC::MarkedArgumentBuffer arguments;
+    arguments.ensureCapacity(callFrame.argumentCount());
     for (size_t cptr = 0; cptr < callFrame.argumentCount(); ++cptr)
         arguments.append(callFrame.uncheckedArgument(cptr));
     ASSERT(!arguments.hasOverflowed());

--- a/Source/WebCore/bindings/js/JSPluginElementFunctions.cpp
+++ b/Source/WebCore/bindings/js/JSPluginElementFunctions.cpp
@@ -131,6 +131,7 @@ JSC_DEFINE_HOST_FUNCTION(callPlugin, (JSGlobalObject* lexicalGlobalObject, CallF
 
     size_t argumentCount = callFrame->argumentCount();
     MarkedArgumentBuffer argumentList;
+    argumentList.ensureCapacity(argumentCount);
     for (size_t i = 0; i < argumentCount; i++)
         argumentList.append(callFrame->argument(i));
     ASSERT(!argumentList.hasOverflowed());

--- a/Source/WebCore/bindings/js/ScheduledAction.cpp
+++ b/Source/WebCore/bindings/js/ScheduledAction.cpp
@@ -109,6 +109,7 @@ void ScheduledAction::executeFunctionInContext(JSGlobalObject* globalObject, JSV
     JSGlobalObject* lexicalGlobalObject = globalObject;
 
     MarkedArgumentBuffer arguments;
+    arguments.ensureCapacity(m_arguments.size());
     for (auto& argument : m_arguments)
         arguments.append(argument.get());
     if (UNLIKELY(arguments.hasOverflowed())) {


### PR DESCRIPTION
#### e96e2b57c54ddda5ebe9a6caebffe32fec899ef9
<pre>
[JSC] Use MarkedArgumentBuffer::ensureCapacity
<a href="https://bugs.webkit.org/show_bug.cgi?id=267194">https://bugs.webkit.org/show_bug.cgi?id=267194</a>
<a href="https://rdar.apple.com/120598941">rdar://120598941</a>

Reviewed by Justin Michaud.

Use ensureCapacity for MarkedArgumentBuffer to avoid repeated allocations.

* Source/JavaScriptCore/API/JSObjectRef.cpp:
(JSObjectMakeFunction):
(JSObjectMakeArray):
(JSObjectMakeDate):
(JSObjectMakeRegExp):
(JSObjectCallAsFunction):
(JSObjectCallAsConstructor):
* Source/JavaScriptCore/runtime/ArgList.h:
(JSC::MarkedVector::fill):
(JSC::MarkedVector::isUsingInlineBuffer const):
* Source/JavaScriptCore/tools/JSDollarVM.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/wasm/js/WebAssemblyExceptionConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/wasm/js/WebAssemblyTagPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/WebCore/bindings/js/JSDOMConvertSequences.h:
(WebCore::JSConverter&lt;IDLSequence&lt;T&gt;&gt;::convert):
(WebCore::JSConverter&lt;IDLFrozenArray&lt;T&gt;&gt;::convert):
* Source/WebCore/bindings/js/JSDOMConvertWebGL.cpp:
(WebCore::convertToJSValue):
* Source/WebCore/bindings/js/JSDOMMapLike.cpp:
(WebCore::forwardFunctionCallToBackingMap):
(WebCore::forwardForEachCallToBackingMap):
* Source/WebCore/bindings/js/JSDOMSetLike.cpp:
(WebCore::forwardFunctionCallToBackingSet):
(WebCore::forwardForEachCallToBackingSet):
* Source/WebCore/bindings/js/JSIDBRequestCustom.cpp:
(WebCore::JSIDBRequest::result const):
* Source/WebCore/bindings/js/JSNavigatorCustom.cpp:
(WebCore::JSNavigator::getUserMedia):
* Source/WebCore/bindings/js/JSPluginElementFunctions.cpp:
(WebCore::JSC_DEFINE_HOST_FUNCTION):
* Source/WebCore/bindings/js/ScheduledAction.cpp:
(WebCore::ScheduledAction::executeFunctionInContext):
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
(GenerateCallbackImplementationContent):

Canonical link: <a href="https://commits.webkit.org/272785@main">https://commits.webkit.org/272785@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/981ff6dfc43c7c642d79831f6bb38e5af8acd891

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33022 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11795 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34926 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35662 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29840 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33993 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14136 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8965 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/29280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33497 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9942 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29505 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8684 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8822 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29463 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36998 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/28273 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29999 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29871 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/34950 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/33039 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8957 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6899 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/32805 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10649 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/39491 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9548 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8308 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4251 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9590 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->