### PR TITLE
Fix warnings found by compiling with -Wmisleading-indentation

### DIFF
--- a/Source/WebCore/Scripts/SettingsTemplates/Settings.cpp.erb
+++ b/Source/WebCore/Scripts/SettingsTemplates/Settings.cpp.erb
@@ -214,7 +214,7 @@ void Settings::<%= @setting.setterFunctionName %>InspectorOverride(std::optional
 {
     if (m_values.<%= @setting.name %>InspectorOverride == <%= @setting.name %>InspectorOverride)
         return;
-        m_values.<%= @setting.name %>InspectorOverride = <%= @setting.name %>InspectorOverride;
+    m_values.<%= @setting.name %>InspectorOverride = <%= @setting.name %>InspectorOverride;
 <%- if @setting.condition -%>
 #if <%= @setting.condition %>
 <%- end -%>

--- a/Source/WebCore/platform/ios/wak/WKView.mm
+++ b/Source/WebCore/platform/ios/wak/WKView.mm
@@ -229,7 +229,7 @@ static void _WKViewAutoresizeCoord(bool bByHeight, unsigned int sizingMethod, co
             widthOrHeight = newSuperFrameWidthOrHeight - (origSuperFrameWidthOrHeight - widthOrHeight);
             if (widthOrHeight < 0.0f)
                 widthOrHeight = 0.0f;
-                break;
+            break;
         case NSViewWidthSizable | NSViewMaxXMargin:
             origWidthMinusMinMargin = origSuperFrameWidthOrHeight - xOrY;
             if (widthOrHeight) {
@@ -244,7 +244,7 @@ static void _WKViewAutoresizeCoord(bool bByHeight, unsigned int sizingMethod, co
                 widthOrHeight = ((newSuperFrameWidthOrHeight - xOrY)) * prop;
             if (widthOrHeight < 0.0f)
                 widthOrHeight = 0.0f;
-                break;
+            break;
         case NSViewMinXMargin:
             xOrY = newSuperFrameWidthOrHeight - (origSuperFrameWidthOrHeight - xOrY);
             if (xOrY < 0.0f)
@@ -268,7 +268,7 @@ static void _WKViewAutoresizeCoord(bool bByHeight, unsigned int sizingMethod, co
                 xOrY = ((newSuperFrameWidthOrHeight - widthOrHeight)) * prop;
             if (xOrY < 0.0f)
                 xOrY = 0.0f;
-                break;
+            break;
         case NSViewMinXMargin | NSViewWidthSizable:
             tmp = xOrY + widthOrHeight;
             if (tmp)
@@ -279,9 +279,9 @@ static void _WKViewAutoresizeCoord(bool bByHeight, unsigned int sizingMethod, co
             widthOrHeight  = newSuperFrameWidthOrHeight - (xOrY + (origSuperFrameWidthOrHeight - tmp));
             if (xOrY < 0.0f)
                 xOrY = 0.0f;
-                if (widthOrHeight < 0.0f)
-                    widthOrHeight = 0.0f;
-                    break;
+            if (widthOrHeight < 0.0f)
+                widthOrHeight = 0.0f;
+            break;
         case NSViewMinXMargin | NSViewWidthSizable | NSViewMaxXMargin:
             if (origSuperFrameWidthOrHeight)
                 prop = xOrY / origSuperFrameWidthOrHeight;


### PR DESCRIPTION
#### 27103d255680b06fcb2ec713f2844c14ac37312e
<pre>
Fix warnings found by compiling with -Wmisleading-indentation
<a href="https://bugs.webkit.org/show_bug.cgi?id=267196">https://bugs.webkit.org/show_bug.cgi?id=267196</a>
&lt;<a href="https://rdar.apple.com/120600518">rdar://120600518</a>&gt;

Reviewed by Darin Adler.

* Source/WebCore/Scripts/SettingsTemplates/Settings.cpp.erb:
- Fix indentation.  This regressed in 232425@main.
* Source/WebCore/platform/ios/wak/WKView.mm:
(_WKViewAutoresizeCoord):
- Fix some long-standing indentation issues that were upstreamed from
  the internal fork of iOS WebKit in 144613@main.

Canonical link: <a href="https://commits.webkit.org/272772@main">https://commits.webkit.org/272772@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff0066f6e8c4634f98a123dc18f9c4fe8608e900

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32901 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11659 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34778 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35525 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29726 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33849 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13999 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8835 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29168 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33357 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9823 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29380 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8560 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8704 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29336 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36857 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29880 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29745 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34841 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8836 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6788 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32695 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10527 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9441 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4249 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9460 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->