### PR TITLE
Fix warnings found by compiling with -Wc99-designator and -Wreorder-init-list

### DIFF
--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp
@@ -165,7 +165,7 @@ Ref<ExternalTexture> DeviceImpl::importExternalTexture(const ExternalTextureDesc
     auto pixelBuffer = std::get_if<RetainPtr<CVPixelBufferRef>>(&descriptor.videoBacking);
     WGPUExternalTextureDescriptor backingDescriptor {
         .nextInChain = nullptr,
-        label.data(),
+        .label = label.data(),
         .pixelBuffer = pixelBuffer ? pixelBuffer->get() : nullptr,
         .colorSpace = convertToWGPUColorSpace(descriptor.colorSpace),
     };
@@ -246,7 +246,7 @@ Ref<BindGroup> DeviceImpl::createBindGroup(const BindGroupDescriptor& descriptor
     auto backingEntries = descriptor.entries.map([&convertToBackingContext = m_convertToBackingContext.get(), &chainedEntries](const auto& bindGroupEntry) {
         auto externalTexture = std::holds_alternative<std::reference_wrapper<ExternalTexture>>(bindGroupEntry.resource) ? convertToBackingContext.convertToBacking(std::get<std::reference_wrapper<ExternalTexture>>(bindGroupEntry.resource).get()) : nullptr;
         chainedEntries.append(WGPUBindGroupExternalTextureEntry {
-            {
+            .chain = {
                 .next = nullptr,
                 .sType = static_cast<WGPUSType>(WGPUSTypeExtended_BindGroupEntryExternalTexture)
             },

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -2684,12 +2684,12 @@ bool MediaPlayerPrivateAVFoundationObjC::updateLastPixelBuffer()
     if (m_isGatheringVideoFrameMetadata) {
         auto presentationTime = MonotonicTime::now().secondsSinceEpoch().seconds() - (currentTime - entry.displayTime).toDouble();
         m_videoFrameMetadata = {
-            .width = static_cast<unsigned>(CVPixelBufferGetWidth(m_lastPixelBuffer.get())),
-            .height = static_cast<unsigned>(CVPixelBufferGetHeight(m_lastPixelBuffer.get())),
-            .presentedFrames = static_cast<unsigned>(++m_sampleCount),
-            .mediaTime = entry.displayTime.toDouble(),
             .presentationTime = presentationTime,
             .expectedDisplayTime = presentationTime,
+            .width = static_cast<unsigned>(CVPixelBufferGetWidth(m_lastPixelBuffer.get())),
+            .height = static_cast<unsigned>(CVPixelBufferGetHeight(m_lastPixelBuffer.get())),
+            .mediaTime = entry.displayTime.toDouble(),
+            .presentedFrames = static_cast<unsigned>(++m_sampleCount),
         };
     }
 

--- a/Source/WebCore/platform/graphics/cocoa/AudioTrackPrivateWebM.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/AudioTrackPrivateWebM.cpp
@@ -164,11 +164,13 @@ void AudioTrackPrivateWebM::setFormatDescription(Ref<AudioInfo>&& formatDescript
 
 void AudioTrackPrivateWebM::updateConfiguration()
 {
+IGNORE_WARNINGS_BEGIN("c99-designator")
     PlatformAudioTrackConfiguration configuration {
         { .codec = codec() },
         .sampleRate = sampleRate(),
         .numberOfChannels = numberOfChannels(),
     };
+IGNORE_WARNINGS_END
     setConfiguration(WTFMove(configuration));
 }
 

--- a/Source/WebCore/platform/graphics/cocoa/VideoTrackPrivateWebM.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/VideoTrackPrivateWebM.cpp
@@ -176,13 +176,15 @@ PlatformVideoColorSpace VideoTrackPrivateWebM::colorSpace() const
 
 void VideoTrackPrivateWebM::updateConfiguration()
 {
+IGNORE_WARNINGS_BEGIN("c99-designator")
     PlatformVideoTrackConfiguration configuration {
         { .codec = codec() },
         .width = width(),
         .height = height(),
-        .framerate = framerate(),
         .colorSpace = colorSpace(),
+        .framerate = framerate(),
     };
+IGNORE_WARNINGS_END
     setConfiguration(WTFMove(configuration));
 }
 

--- a/Source/WebKit/Shared/mac/MediaFormatReader/MediaSampleCursor.h
+++ b/Source/WebKit/Shared/mac/MediaFormatReader/MediaSampleCursor.h
@@ -147,11 +147,11 @@ constexpr MediaSampleCursor::WrapperClass MediaSampleCursor::wrapperClass()
         .getSyncInfo = [](MTPluginSampleCursorRef sampleCursor, MTPluginSampleCursorSyncInfo* syncInfo) -> OSStatus {
             return unwrap(sampleCursor)->getSyncInfo(syncInfo);
         },
-        .copyFormatDescription = [](MTPluginSampleCursorRef sampleCursor, CMFormatDescriptionRef* formatDescription) {
-            return unwrap(sampleCursor)->copyFormatDescription(formatDescription);
-        },
         .copySampleLocation = [](MTPluginSampleCursorRef sampleCursor, MTPluginSampleCursorStorageRange* storageRange, MTPluginByteSourceRef* byteSource) {
             return unwrap(sampleCursor)->copySampleLocation(storageRange, byteSource);
+        },
+        .copyFormatDescription = [](MTPluginSampleCursorRef sampleCursor, CMFormatDescriptionRef* formatDescription) {
+            return unwrap(sampleCursor)->copyFormatDescription(formatDescription);
         },
 #if HAVE(MT_PLUGIN_SAMPLE_CURSOR_PLAYABLE_HORIZON)
         .getPlayableHorizon = [](MTPluginSampleCursorRef sampleCursor, CMTime* playableHorizon) {


### PR DESCRIPTION
#### b5982fde2d0abead10f14d4f0f142242c055be4a
<pre>
Fix warnings found by compiling with -Wc99-designator and -Wreorder-init-list
<a href="https://bugs.webkit.org/show_bug.cgi?id=267203">https://bugs.webkit.org/show_bug.cgi?id=267203</a>
&lt;<a href="https://rdar.apple.com/120609492">rdar://120609492</a>&gt;

Reviewed by Mike Wyrzykowski.

Every fix below is related to using designated initializers, and
initializing member fields in the same order that they are defined.  In
two cases, a struct inherits from another struct, and the designated
initializer syntax can&apos;t be used to initialize members in the base
struct, so IGNORE_WARNINGS_BEGIN/END is used instead.

* Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp:
(WebCore::WebGPU::DeviceImpl::importExternalTexture):
(WebCore::WebGPU::DeviceImpl::createBindGroup):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::updateLastPixelBuffer):
* Source/WebCore/platform/graphics/cocoa/AudioTrackPrivateWebM.cpp:
(WebCore::AudioTrackPrivateWebM::updateConfiguration):
- Use IGNORE_WARNINGS_BEGIN(&quot;c99-designator&quot;)/IGNORE_WARNINGS_END to
  suppress the -Wc99-designator warning.
* Source/WebCore/platform/graphics/cocoa/VideoTrackPrivateWebM.cpp:
(WebCore::VideoTrackPrivateWebM::updateConfiguration):
- Ditto.
* Source/WebKit/Shared/mac/MediaFormatReader/MediaSampleCursor.h:
(WebKit::MediaSampleCursor::wrapperClass):

Canonical link: <a href="https://commits.webkit.org/272764@main">https://commits.webkit.org/272764@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08985c0439981f78f437f762c918099ca1791dee

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32926 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11684 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34804 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35550 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29747 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33878 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14025 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8860 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29188 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33382 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9842 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29401 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8580 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8724 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29357 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36882 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29899 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29766 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34860 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8858 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6811 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32714 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10551 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9464 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4242 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9485 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->