### PR TITLE
Fix warnings found by compiling with -Wfinal-dtor-non-final-class

### DIFF
--- a/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.h
+++ b/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.h
@@ -56,7 +56,7 @@ enum class WaitForServiceToExist : bool {
     Yes,
 };
 
-class Connection : public CanMakeWeakPtr<Connection>, public IPC::MessageSender {
+class Connection final : public CanMakeWeakPtr<Connection>, public IPC::MessageSender {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     static std::unique_ptr<Connection> create(std::optional<Action>, PreferTestService, Reconnect);


### PR DESCRIPTION
#### 5381539f603fb34434f0b6dcc88f19ab96947b0e
<pre>
Fix warnings found by compiling with -Wfinal-dtor-non-final-class
<a href="https://bugs.webkit.org/show_bug.cgi?id=267205">https://bugs.webkit.org/show_bug.cgi?id=267205</a>
&lt;<a href="https://rdar.apple.com/120609974">rdar://120609974</a>&gt;

Reviewed by Darin Adler.

* Source/WebKit/webpushd/webpushtool/WebPushToolConnection.h:
(WebPushTool::Connection):
- Mark class as final to fix the warning.

Canonical link: <a href="https://commits.webkit.org/272769@main">https://commits.webkit.org/272769@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48247ffea85156eac4c84a3abb4f37e258d475eb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32928 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11686 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34806 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35552 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29749 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14027 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8862 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29191 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33384 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9845 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29403 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8583 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8727 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36884 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29902 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29768 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34864 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8860 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6813 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32718 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10553 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9466 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4246 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9487 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->