### PR TITLE
Fix warnings found by compiling with -Wdeprecated-enum-float-conversion

### DIFF
--- a/Source/WebCore/rendering/style/TextSizeAdjustment.h
+++ b/Source/WebCore/rendering/style/TextSizeAdjustment.h
@@ -28,23 +28,27 @@ namespace WebCore {
 
 class RenderStyle;
 
-enum TextSizeAdjustmentType { AutoTextSizeAdjustment = -1, NoTextSizeAdjustment = -2 };
-
 class TextSizeAdjustment {
 public:
-    constexpr TextSizeAdjustment() : m_value(AutoTextSizeAdjustment) { }
-    constexpr TextSizeAdjustment(float value) : m_value(value) { }
+    static constexpr TextSizeAdjustment autoAdjust() { return TextSizeAdjustment(true); }
+    static constexpr TextSizeAdjustment none() { return TextSizeAdjustment(false); }
 
-    constexpr float percentage() const { return m_value; }
-    constexpr float multiplier() const { return m_value / 100; }
+    constexpr TextSizeAdjustment() : m_value(Auto) { }
+    constexpr TextSizeAdjustment(float value) : m_value(value) { ASSERT_UNDER_CONSTEXPR_CONTEXT(m_value >= 0); }
 
-    constexpr bool isAuto() const { return m_value == AutoTextSizeAdjustment; }
-    constexpr bool isNone() const { return m_value == NoTextSizeAdjustment; }
+    constexpr float percentage() const { ASSERT_UNDER_CONSTEXPR_CONTEXT(m_value >= 0); return m_value; }
+    constexpr float multiplier() const { ASSERT_UNDER_CONSTEXPR_CONTEXT(m_value >= 0); return m_value / 100; }
+
+    constexpr bool isAuto() const { return m_value == Auto; }
+    constexpr bool isNone() const { return m_value == None; }
     constexpr bool isPercentage() const { return m_value >= 0; }
 
     friend constexpr bool operator==(TextSizeAdjustment, TextSizeAdjustment) = default;
 
 private:
+    static constexpr float Auto = -1;
+    static constexpr float None = -2;
+    constexpr TextSizeAdjustment(bool isAuto) : m_value(isAuto ? Auto : None) { }
     float m_value;
 };
 

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -820,9 +820,9 @@ inline void BuilderCustom::applyValueWebkitTextSizeAdjust(BuilderState& builderS
 {
     auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
     if (primitiveValue.valueID() == CSSValueAuto)
-        builderState.style().setTextSizeAdjust(TextSizeAdjustment(AutoTextSizeAdjustment));
+        builderState.style().setTextSizeAdjust(TextSizeAdjustment::autoAdjust());
     else if (primitiveValue.valueID() == CSSValueNone)
-        builderState.style().setTextSizeAdjust(TextSizeAdjustment(NoTextSizeAdjustment));
+        builderState.style().setTextSizeAdjust(TextSizeAdjustment::none());
     else
         builderState.style().setTextSizeAdjust(TextSizeAdjustment(primitiveValue.floatValue()));
 

--- a/Source/WebCore/style/StyleResolveForDocument.cpp
+++ b/Source/WebCore/style/StyleResolveForDocument.cpp
@@ -67,7 +67,7 @@ RenderStyle resolveForDocument(const Document& document)
     documentStyle.setUserModify(document.inDesignMode() ? UserModify::ReadWrite : UserModify::ReadOnly);
 #if PLATFORM(IOS_FAMILY)
     if (document.inDesignMode())
-        documentStyle.setTextSizeAdjust(TextSizeAdjustment(NoTextSizeAdjustment));
+        documentStyle.setTextSizeAdjust(TextSizeAdjustment::none());
 #endif
 
     Adjuster::adjustEventListenerRegionTypesForRootStyle(documentStyle, document);


### PR DESCRIPTION
#### c5050dfe582460a512d647870889778fcdb4604d
<pre>
Fix warnings found by compiling with -Wdeprecated-enum-float-conversion
<a href="https://bugs.webkit.org/show_bug.cgi?id=267206">https://bugs.webkit.org/show_bug.cgi?id=267206</a>
&lt;<a href="https://rdar.apple.com/120610023">rdar://120610023</a>&gt;

Reviewed by Tim Nguyen and Darin Adler.

The fix for the warning is to replace the TextSizeAdjustmentType enum
with helper methods that use internal float constants within the class.
The remaining changes are to add some debug assertions and to update the
code to use the new helper methods.

* Source/WebCore/rendering/style/TextSizeAdjustment.h:
(WebCore::TextSizeAdjustmentType): Remove.
(WebCore::TextSizeAdjustment::autoAdjust): Add.
(WebCore::TextSizeAdjustment::none): Add.
- Add static helper methods to replace enum values.
(WebCore::TextSizeAdjustment::TextSizeAdjustment):
- Add debug assertion when setting a float value to make sure it is not
  negative.
- Add private, overloaded constructor that takes a bool parameter to
  implement autoAdjust() and none().
(WebCore::TextSizeAdjustment::percentage const):
(WebCore::TextSizeAdjustment::multiplier const):
- Add debug assertions that m_value is not negative when calling
  percentage() and multiplier().
(WebCore::TextSizeAdjustment::isAuto const):
(WebCore::TextSizeAdjustment::isNone const):
(WebCore::TextSizeAdjustment::Auto): Add.
(WebCore::TextSizeAdjustment::None): Add.
- Private constant float values to implement autoAdjust() and none().

* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::BuilderCustom::applyValueWebkitTextSizeAdjust):
* Source/WebCore/style/StyleResolveForDocument.cpp:
(WebCore::Style::resolveForDocument):

Canonical link: <a href="https://commits.webkit.org/272819@main">https://commits.webkit.org/272819@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb3f927be0cf4c910cba158cf12a17c3405f3c48

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33124 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11898 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35034 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35761 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29911 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34095 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14266 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9067 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29318 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33599 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10049 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29585 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8745 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8905 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29559 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37093 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30117 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29943 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35006 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9028 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6968 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32861 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10733 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9615 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4266 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9678 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->