### PR TITLE
Adopt dynamicDowncast<> in ImageLoader and RenderImage

### DIFF
--- a/Source/WebCore/loader/ImageLoader.cpp
+++ b/Source/WebCore/loader/ImageLoader.cpp
@@ -206,12 +206,11 @@ void ImageLoader::updateFromElement(RelevantMutation relevantMutation)
         options.loadedFromPluginElement = is<HTMLPlugInElement>(element()) ? LoadedFromPluginElement::Yes : LoadedFromPluginElement::No;
         options.sameOriginDataURLFlag = SameOriginDataURLFlag::Set;
         options.serviceWorkersMode = is<HTMLPlugInElement>(element()) ? ServiceWorkersMode::None : ServiceWorkersMode::All;
-        bool isImageElement = is<HTMLImageElement>(element());
-        if (isImageElement) {
-            auto& imageElement = downcast<HTMLImageElement>(element());
-            options.referrerPolicy = imageElement.referrerPolicy();
-            options.fetchPriorityHint = imageElement.fetchPriorityHint();
-            if (imageElement.usesSrcsetOrPicture())
+        RefPtr imageElement = dynamicDowncast<HTMLImageElement>(element());
+        if (imageElement) {
+            options.referrerPolicy = imageElement->referrerPolicy();
+            options.fetchPriorityHint = imageElement->fetchPriorityHint();
+            if (imageElement->usesSrcsetOrPicture())
                 options.initiator = Initiator::Imageset;
         }
 
@@ -244,9 +243,8 @@ void ImageLoader::updateFromElement(RelevantMutation relevantMutation)
 #if !LOG_DISABLED
             auto oldState = m_lazyImageLoadState;
 #endif
-            if (m_lazyImageLoadState == LazyImageLoadState::None && isImageElement) {
-                auto& imageElement = downcast<HTMLImageElement>(element());
-                if (imageElement.isLazyLoadable() && document.settings().lazyImageLoadingEnabled() && !canReuseFromListOfAvailableImages(request, document)) {
+            if (m_lazyImageLoadState == LazyImageLoadState::None && imageElement) {
+                if (imageElement->isLazyLoadable() && document.settings().lazyImageLoadingEnabled() && !canReuseFromListOfAvailableImages(request, document)) {
                     m_lazyImageLoadState = LazyImageLoadState::Deferred;
                     request.setIgnoreForRequestCount(true);
                 }
@@ -434,8 +432,8 @@ RenderImageResource* ImageLoader::renderImageResource()
 
     // We don't return style generated image because it doesn't belong to the ImageLoader.
     // See <https://bugs.webkit.org/show_bug.cgi?id=42840>
-    if (is<RenderImage>(*renderer) && !downcast<RenderImage>(*renderer).isGeneratedContent())
-        return &downcast<RenderImage>(*renderer).imageResource();
+    if (auto* renderImage = dynamicDowncast<RenderImage>(*renderer); renderImage && !renderImage->isGeneratedContent())
+        return &renderImage->imageResource();
 
     if (auto* svgImage = dynamicDowncast<LegacyRenderSVGImage>(renderer))
         return &svgImage->imageResource();
@@ -446,8 +444,8 @@ RenderImageResource* ImageLoader::renderImageResource()
 #endif
 
 #if ENABLE(VIDEO)
-    if (is<RenderVideo>(*renderer))
-        return &downcast<RenderVideo>(*renderer).imageResource();
+    if (auto* renderVideo = dynamicDowncast<RenderVideo>(*renderer))
+        return &renderVideo->imageResource();
 #endif
 
     return nullptr;
@@ -528,14 +526,12 @@ void ImageLoader::decode()
         return;
     }
 
-    Image* image = m_image->image();
-    if (!is<BitmapImage>(image)) {
+    RefPtr bitmapImage = dynamicDowncast<BitmapImage>(m_image->image());
+    if (!bitmapImage) {
         resolveDecodePromises();
         return;
     }
-
-    auto& bitmapImage = downcast<BitmapImage>(*image);
-    bitmapImage.decode([promises = WTFMove(m_decodingPromises)]() mutable {
+    bitmapImage->decode([promises = WTFMove(m_decodingPromises)]() mutable {
         resolvePromises(promises);
     });
 }
@@ -646,11 +642,8 @@ VisibleInViewportState ImageLoader::imageVisibleInViewport(const Document& docum
     if (&element().document() != &document)
         return VisibleInViewportState::No;
 
-    auto* renderer = element().renderer();
-    if (!is<RenderReplaced>(renderer))
-        return VisibleInViewportState::No;
-
-    return downcast<RenderReplaced>(*renderer).isContentLikelyVisibleInViewport() ? VisibleInViewportState::Yes : VisibleInViewportState::No;
+    auto* renderReplaced = dynamicDowncast<RenderReplaced>(element().renderer());
+    return renderReplaced && renderReplaced->isContentLikelyVisibleInViewport() ? VisibleInViewportState::Yes : VisibleInViewportState::No;
 }
 
 }


### PR DESCRIPTION
#### d4c1f6993b5637aef5023927054a1f8e0d95eb4f
<pre>
Adopt dynamicDowncast&lt;&gt; in ImageLoader and RenderImage
<a href="https://bugs.webkit.org/show_bug.cgi?id=267209">https://bugs.webkit.org/show_bug.cgi?id=267209</a>

Reviewed by Chris Dumez.

* Source/WebCore/loader/ImageLoader.cpp:
(WebCore::ImageLoader::updateFromElement):
(WebCore::ImageLoader::renderImageResource):
(WebCore::ImageLoader::decode):
(WebCore::ImageLoader::imageVisibleInViewport const):
* Source/WebCore/rendering/RenderImage.cpp:
(WebCore::RenderImage::RenderImage):
(WebCore::RenderImage::notifyFinished):
(WebCore::isDeferredImage):
(WebCore::RenderImage::paintAreaElementFocusRing):
(WebCore::RenderImage::paintIntoRect):
(WebCore::RenderImage::updateAltText):
(WebCore::RenderImage::computeIntrinsicRatioInformation const):
(WebCore::RenderImage::embeddedContentBox const):

Canonical link: <a href="https://commits.webkit.org/272781@main">https://commits.webkit.org/272781@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/573f2959ec2163b12d448c8d4cfc9af0cde9a8e0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33019 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11792 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34923 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35659 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29837 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33990 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14133 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8962 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/29268 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33494 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9938 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29502 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8664 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/8819 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29460 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36995 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29995 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29869 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/34946 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8954 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6895 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32801 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10646 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7655 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9545 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9587 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->