### PR TITLE
[Content-visibility][repaint] Boxes with "content-visibility: hidden" lingers around

### DIFF
--- a/LayoutTests/fast/repaint/content-visibility-hidden-container-with-abs-pos-c-v-auto-child-expected.txt
+++ b/LayoutTests/fast/repaint/content-visibility-hidden-container-with-abs-pos-c-v-auto-child-expected.txt
@@ -1,0 +1,5 @@
+PASS window.internals.repaintRectsAsText().indexOf('50 50') is not -1
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/repaint/content-visibility-hidden-container-with-abs-pos-c-v-auto-child.html
+++ b/LayoutTests/fast/repaint/content-visibility-hidden-container-with-abs-pos-c-v-auto-child.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<script>jsTestIsAsync = true;</script>
+<script src="../../resources/js-test-pre.js"></script>
+<head>
+<title>This tests that we don't leave bits behind, when an absolute positioned content-visibility: auto child is hidden due to content-visibility: hidden.</title>
+<style>
+#container {
+    height: 100px;
+    width: 100px;
+}
+
+#content {
+    position: absolute;
+    height: 50px;
+    width: 50px;
+    background: green;
+    content-visibility: auto;
+}
+</style>
+</head>
+<body>
+<div id=container>
+    <div id=content></div>
+</div>
+<script>
+setTimeout(
+    function() {
+        if (window.internals)
+            internals.startTrackingRepaints();
+        document.getElementById("container").style.contentVisibility = "hidden";
+        document.body.offsetWidth;
+
+        if (window.internals) {
+            shouldNotBe("window.internals.repaintRectsAsText().indexOf('50 50')", "-1");
+            internals.stopTrackingRepaints();
+        }
+        finishJSTest();
+	}, 0);
+</script>
+</body>
+<script src="../../resources/js-test-post.js"></script>
+</html>

--- a/LayoutTests/fast/repaint/content-visibility-hidden-container-with-abs-pos-child-expected.txt
+++ b/LayoutTests/fast/repaint/content-visibility-hidden-container-with-abs-pos-child-expected.txt
@@ -1,0 +1,5 @@
+PASS window.internals.repaintRectsAsText().indexOf('50 50') is not -1
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/repaint/content-visibility-hidden-container-with-abs-pos-child.html
+++ b/LayoutTests/fast/repaint/content-visibility-hidden-container-with-abs-pos-child.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<script>jsTestIsAsync = true;</script>
+<script src="../../resources/js-test-pre.js"></script>
+<head>
+<title>This tests that we don't leave bits behind, when an absolute positioned child is hidden due to content-visibility: hidden.</title>
+<style>
+#container {
+    height: 100px;
+    width: 100px;
+}
+
+#content {
+    position: absolute;
+    height: 50px;
+    width: 50px;
+    background: green;
+}
+</style>
+</head>
+<body>
+<div id=container>
+    <div id=content></div>
+</div>
+<script>
+setTimeout(
+    function() {
+        if (window.internals)
+            internals.startTrackingRepaints();
+        document.getElementById("container").style.contentVisibility = "hidden";
+        document.body.offsetWidth;
+
+        if (window.internals) {
+            shouldNotBe("window.internals.repaintRectsAsText().indexOf('50 50')", "-1");
+            internals.stopTrackingRepaints();
+        }
+        finishJSTest();
+	}, 0);
+</script>
+</body>
+<script src="../../resources/js-test-post.js"></script>
+</html>

--- a/LayoutTests/fast/repaint/position-relative-container-with-abs-pos-child-expected.txt
+++ b/LayoutTests/fast/repaint/position-relative-container-with-abs-pos-child-expected.txt
@@ -1,0 +1,5 @@
+PASS window.internals.repaintRectsAsText().indexOf('0 0 50 50') is not -1
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/repaint/position-relative-container-with-abs-pos-child.html
+++ b/LayoutTests/fast/repaint/position-relative-container-with-abs-pos-child.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<script>jsTestIsAsync = true;</script>
+<script src="../../resources/js-test-pre.js"></script>
+<head>
+<title>This tests that we don't leave bits behind, when an absolute positioned child is hidden and at the same time is positioned against a different container.</title>
+<style>
+#container {
+    height: 100px;
+    width: 100px;
+}
+
+#content {
+    position: absolute;
+    height: 50px;
+    width: 50px;
+    left: 0px;
+    top: 0px;
+    background: green;
+}
+</style>
+</head>
+<body>
+<div id=container>
+    <div id=content></div>
+</div>
+<script>
+setTimeout(
+    function() {
+        if (window.internals)
+            internals.startTrackingRepaints();
+        document.getElementById("container").style.position = "relative";
+        document.getElementById("content").style.visibility = "hidden";
+        document.body.offsetWidth;
+
+        if (window.internals) {
+            shouldNotBe("window.internals.repaintRectsAsText().indexOf('0 0 50 50')", "-1");
+            internals.stopTrackingRepaints();
+        }
+        finishJSTest();
+    }, 0);
+</script>
+</body>
+<script src="../../resources/js-test-post.js"></script>
+</html>


### PR DESCRIPTION
#### b96b33ee6c4c6dde7bf51c3744d6ccbc19a517e8
<pre>
[Content-visibility][repaint] Boxes with &quot;content-visibility: hidden&quot; lingers around
<a href="https://bugs.webkit.org/show_bug.cgi?id=264173">https://bugs.webkit.org/show_bug.cgi?id=264173</a>

Reviewed by Simon Fraser.

When skipped content becomes hidden, a repaint should be issued to clear it, before the style change is processed.
Add repaint logic for that similar to what is done when the visibility property changes to hidden on an element.

However, absolute positioned elements are not always repainted correctly when hidden and the container
changes. First, after layout repaints will have no effect since it is skipped for layers with hidden content.
For the repaint before style change, the newly calculated clipped overflow rectangle can be empty, causing the
artefact. Fix this by always using the cached clipped overflow (&quot;old&quot;) rectangle for out of flow elements, if
it is available, in before style change repainting.

* LayoutTests/fast/repaint/content-visibility-hidden-container-with-abs-pos-c-v-auto-child-expected.txt: Added.
* LayoutTests/fast/repaint/content-visibility-hidden-container-with-abs-pos-c-v-auto-child.html: Added.
* LayoutTests/fast/repaint/content-visibility-hidden-container-with-abs-pos-child-expected.txt: Added.
* LayoutTests/fast/repaint/content-visibility-hidden-container-with-abs-pos-child.html: Added.
* LayoutTests/fast/repaint/position-relative-container-with-abs-pos-child-expected.txt: Added.
* LayoutTests/fast/repaint/position-relative-container-with-abs-pos-child.html: Added.
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::repaintBeforeStyleChange):
(WebCore::RenderElement::styleWillChange):

Canonical link: <a href="https://commits.webkit.org/273602@main">https://commits.webkit.org/273602@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/06b8056c5c46f08d21455c76d43d0c9a91b5f749

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35197 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14130 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37323 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37952 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31767 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36359 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16511 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11197 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30672 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35742 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11953 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31388 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10480 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10533 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31493 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39200 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32015 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31824 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36523 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10661 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8590 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34533 "Found 1 new API test failure: /WebKitGTK/TestSSL:/webkit/WebKitWebView/load-failed-with-tls-errors (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12433 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/31147 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8194 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11185 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11494 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->