### PR TITLE
Add more integer overflow tests for `enclosingIntRect` in FloatRectTests.cpp

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebCore/FloatRectTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/FloatRectTests.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2017 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -722,6 +723,41 @@ TEST(FloatRect, EnclosingIntRect)
     EXPECT_EQ(INT_MIN, enclosed2.y());
     EXPECT_EQ(INT_MAX, enclosed2.width());
     EXPECT_EQ(INT_MAX, enclosed2.height());
+
+    WebCore::FloatRect smallDimensionsRect(42.5f, 84.5f, std::numeric_limits<float>::epsilon(), std::numeric_limits<float>::epsilon());
+    EXPECT_EQ(WebCore::IntRect(42, 84, 1, 1), WebCore::enclosingIntRect(smallDimensionsRect));
+
+    WebCore::FloatRect integralRect(100, 150, 200, 350);
+    EXPECT_EQ(WebCore::IntRect(100, 150, 200, 350), WebCore::enclosingIntRect(integralRect));
+
+    WebCore::FloatRect fractionalPosRect(100.6f, 150.8f, 200, 350);
+    EXPECT_EQ(WebCore::IntRect(100, 150, 201, 351), WebCore::enclosingIntRect(fractionalPosRect));
+
+    WebCore::FloatRect fractionalDimensionsRect(100, 150, 200.6f, 350.4f);
+    EXPECT_EQ(WebCore::IntRect(100, 150, 201, 351), WebCore::enclosingIntRect(fractionalDimensionsRect));
+
+    WebCore::FloatRect fractionalBothRect1(100.6f, 150.8f, 200.4f, 350.2f);
+    EXPECT_EQ(WebCore::IntRect(100, 150, 201, 351), WebCore::enclosingIntRect(fractionalBothRect1));
+
+    WebCore::FloatRect fractionalBothRect2(100.6f, 150.8f, 200.3f, 350.3f);
+    EXPECT_EQ(WebCore::IntRect(100, 150, 201, 352), WebCore::enclosingIntRect(fractionalBothRect2));
+
+    WebCore::FloatRect fractionalBothRect3(100.6f, 150.8f, 200.5f, 350.3f);
+    EXPECT_EQ(WebCore::IntRect(100, 150, 202, 352), WebCore::enclosingIntRect(fractionalBothRect3));
+
+    WebCore::FloatRect fractionalNegposRect1(-100.4f, -150.8f, 200, 350);
+    EXPECT_EQ(WebCore::IntRect(-101, -151, 201, 351), WebCore::enclosingIntRect(fractionalNegposRect1));
+
+    WebCore::FloatRect fractionalNegposRect2(-100.4f, -150.8f, 199.4f, 350.3f);
+    EXPECT_EQ(WebCore::IntRect(-101, -151, 200, 351), WebCore::enclosingIntRect(fractionalNegposRect2));
+
+    WebCore::FloatRect fractionalNegposRect3(-100.6f, -150.8f, 199.6f, 350.3f);
+    EXPECT_EQ(WebCore::IntRect(-101, -151, 201, 351), WebCore::enclosingIntRect(fractionalNegposRect3));
+
+    constexpr int intMin = std::numeric_limits<int>::min();
+    constexpr int intMax = std::numeric_limits<int>::max();
+    WebCore::FloatRect maxRect(-std::numeric_limits<float>::max() / 2, -std::numeric_limits<float>::max() / 2, std::numeric_limits<float>::max(), std::numeric_limits<float>::max());
+    EXPECT_EQ(WebCore::IntRect(intMin, intMin, intMax, intMax), WebCore::enclosingIntRect(maxRect));
 }
 
 TEST(FloatRect, RoundedIntRect)


### PR DESCRIPTION
#### e73b8072d7b44b4246dd5a7dfdbad3de3b085d38
<pre>
Add more integer overflow tests for `enclosingIntRect` in FloatRectTests.cpp

<a href="https://bugs.webkit.org/show_bug.cgi?id=267162">https://bugs.webkit.org/show_bug.cgi?id=267162</a>

Reviewed by Antti Koivisto.

Partial Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/663b023cf7022eca119acc1b8b3a610cd8993da3">https://chromium.googlesource.com/chromium/src.git/+/663b023cf7022eca119acc1b8b3a610cd8993da3</a>

This PR adds additional test from Blink commit and the underlying bug was already fixed in 189573@main.

* Tools/TestWebKitAPI/Tests/WebCore/FloatRectTests.cpp:
(EnclosingIntRect):

Canonical link: <a href="https://commits.webkit.org/272779@main">https://commits.webkit.org/272779@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/947fbc4a34eac0a81090c38fc1aad5046726bd9f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33004 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11776 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34905 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35647 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29824 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33974 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14115 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8945 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29257 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33478 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9924 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29489 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8652 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8806 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29445 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36981 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29981 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29857 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34936 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8943 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6884 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32791 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10634 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7661 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9534 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9573 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->