### PR TITLE
[JSC] Refactor AbstractValue Access in DFGAbstractInterpreterInlines.h for Efficiency

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -414,7 +414,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
             
     case GetLocal: {
         VariableAccessData* variableAccessData = node->variableAccessData();
-        AbstractValue value = m_state.operand(variableAccessData->operand());
+        AbstractValue& value = m_state.operand(variableAccessData->operand());
         // The value in the local should already be checked.
         DFG_ASSERT(m_graph, node, value.isType(typeFilterFor(variableAccessData->flushFormat())));
         if (value.value())
@@ -425,7 +425,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         
     case GetStack: {
         StackAccessData* data = node->stackAccessData();
-        AbstractValue value = m_state.operand(data->operand);
+        AbstractValue& value = m_state.operand(data->operand);
         // The value in the local should already be checked.
         DFG_ASSERT(m_graph, node, value.isType(typeFilterFor(data->format)));
         if (value.value())
@@ -1604,7 +1604,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
     case IsConstructor:
     case IsCellWithType:
     case IsTypedArrayView: {
-        AbstractValue child = forNode(node->child1());
+        AbstractValue& child = forNode(node->child1());
         if (child.value()) {
             bool constantWasSet = true;
             switch (node->op()) {
@@ -1928,7 +1928,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
     }
 
     case GlobalIsNaN: {
-        AbstractValue child = forNode(node->child1());
+        AbstractValue& child = forNode(node->child1());
         if (JSValue value = child.value(); value && value.isNumber()) {
             if (node->child1().useKind() != DoubleRepUse)
                 didFoldClobberWorld();
@@ -1942,7 +1942,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
     }
 
     case NumberIsNaN: {
-        AbstractValue child = forNode(node->child1());
+        AbstractValue& child = forNode(node->child1());
         if (JSValue value = child.value()) {
             setConstant(node, jsBoolean(value.isNumber() && std::isnan(value.asNumber())));
             break;
@@ -4275,7 +4275,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
 
     case GetWebAssemblyInstanceExports: {
 #if ENABLE(WEBASSEMBLY)
-        AbstractValue base = forNode(node->child1());
+        AbstractValue& base = forNode(node->child1());
         if (base.m_value) {
             if (auto* instance = jsDynamicCast<JSWebAssemblyInstance*>(base.m_value)) {
                 if (auto* moduleRecord = instance->moduleRecord()) {
@@ -4315,7 +4315,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         
     case GetGetterSetterByOffset: {
         StorageAccessData& data = node->storageAccessData();
-        AbstractValue base = forNode(node->child2());
+        AbstractValue& base = forNode(node->child2());
         JSValue result = m_graph.tryGetConstantProperty(base, data.offset);
         if (result && jsDynamicCast<GetterSetter*>(result)) {
             setConstant(node, *m_graph.freeze(result));
@@ -4340,7 +4340,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         // because of the effect on compile times, but this node is FTL-only.
         m_state.setShouldTryConstantFolding(true);
         
-        AbstractValue base = forNode(node->child1());
+        AbstractValue& base = forNode(node->child1());
         RegisteredStructureSet baseSet;
         AbstractValue result;
         for (const MultiGetByOffsetCase& getCase : node->multiGetByOffsetData().cases) {
@@ -4386,8 +4386,8 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         // because of the effect on compile times, but this node is FTL-only.
         m_state.setShouldTryConstantFolding(true);
         
-        AbstractValue base = forNode(node->child1());
-        AbstractValue originalValue = forNode(node->child2());
+        AbstractValue& base = forNode(node->child1());
+        AbstractValue& originalValue = forNode(node->child2());
         AbstractValue resultingValue;
         
         if (node->multiPutByOffsetData().writesStructures())
@@ -4400,7 +4400,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
             if (thisSet.isEmpty())
                 continue;
 
-            AbstractValue thisValue = originalValue;
+            AbstractValue& thisValue = originalValue;
             resultingValue.merge(thisValue);
             
             if (variant.kind() == PutByVariant::Transition) {
@@ -4438,7 +4438,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         // because of the effect on compile times, but this node is FTL-only.
         m_state.setShouldTryConstantFolding(true);
 
-        AbstractValue base = forNode(node->child1());
+        AbstractValue& base = forNode(node->child1());
 
         if (node->multiDeleteByOffsetData().writesStructures())
             didFoldClobberStructures();
@@ -4794,7 +4794,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         break;
         
     case MatchStructure: {
-        AbstractValue base = forNode(node->child1());
+        AbstractValue& base = forNode(node->child1());
         RegisteredStructureSet baseSet;
         
         BooleanLattice result = BooleanLattice::Bottom;
@@ -4999,7 +4999,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
     }
 
     case ParseInt: {
-        AbstractValue value = forNode(node->child1());
+        AbstractValue& value = forNode(node->child1());
         if (value.m_type && !(value.m_type & ~SpecInt32Only)) {
             JSValue radix;
             if (!node->child2())
@@ -5024,7 +5024,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
     }
 
     case ToIntegerOrInfinity: {
-        AbstractValue child = forNode(node->child1());
+        AbstractValue& child = forNode(node->child1());
         if (JSValue value = child.value(); value && value.isNumber()) {
             if (node->child1().useKind() == UntypedUse)
                 didFoldClobberWorld();
@@ -5039,7 +5039,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
     }
 
     case ToLength: {
-        AbstractValue child = forNode(node->child1());
+        AbstractValue& child = forNode(node->child1());
         if (JSValue value = child.value(); value && value.isNumber()) {
             if (node->child1().useKind() == UntypedUse)
                 didFoldClobberWorld();


### PR DESCRIPTION
#### 30602923c0fb7a39ab0c2393479b5f28a01490b1
<pre>
[JSC] Refactor AbstractValue Access in DFGAbstractInterpreterInlines.h for Efficiency
<a href="https://bugs.webkit.org/show_bug.cgi?id=267215">https://bugs.webkit.org/show_bug.cgi?id=267215</a>
<a href="https://rdar.apple.com/120618070">rdar://120618070</a>

Reviewed by Yusuke Suzuki.

Use variable references for accessing reference results of
InPlaceAbstractState::operand() and InPlaceAbstractState::forNode().

* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):

Canonical link: <a href="https://commits.webkit.org/272775@main">https://commits.webkit.org/272775@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d86ccbe314545dad507879a2d53d4bf1c385c51

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32947 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11707 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34830 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35575 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29765 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14048 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8883 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29209 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33407 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9864 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29424 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8604 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8746 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29380 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36907 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/28195 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29921 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29790 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34885 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/32954 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8878 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6830 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32740 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10572 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/39418 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7654 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9482 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8301 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9507 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->