### PR TITLE
Adopt new ServiceExtensions scroll view delegate API

### DIFF
--- a/Source/WebKit/Shared/ios/WebIOSEventFactory.h
+++ b/Source/WebKit/Shared/ios/WebIOSEventFactory.h
@@ -27,13 +27,17 @@
 
 #if PLATFORM(IOS_FAMILY)
 
+#import "WKSEDefinitions.h"
 #import "WebKeyboardEvent.h"
 #import "WebMouseEvent.h"
 #import "WebWheelEvent.h"
 #import <UIKit/UIKit.h>
+#import <WebCore/FloatSize.h>
 #import <WebCore/WebEvent.h>
 
-OBJC_CLASS UIScrollEvent;
+OBJC_CLASS WKSEScrollViewScrollUpdate;
+
+namespace WebKit {
 
 class WebIOSEventFactory {
 public:
@@ -41,11 +45,14 @@ public:
     static WebKit::WebMouseEvent createWebMouseEvent(::WebEvent *);
 
 #if HAVE(UISCROLLVIEW_ASYNCHRONOUS_SCROLL_EVENT_HANDLING)
-    static WebKit::WebWheelEvent createWebWheelEvent(UIScrollEvent *, UIView *contentView, std::optional<WebKit::WebWheelEvent::Phase> overridePhase = std::nullopt);
+    static WebKit::WebWheelEvent createWebWheelEvent(WKSEScrollViewScrollUpdate *, UIView *contentView, std::optional<WebKit::WebWheelEvent::Phase> overridePhase = std::nullopt);
+    static WebCore::FloatSize translationInView(WKSEScrollViewScrollUpdate *, UIView *);
 #endif
 
     static OptionSet<WebKit::WebEventModifier> webEventModifiersForUIKeyModifierFlags(UIKeyModifierFlags);
     static UIKeyModifierFlags toUIKeyModifierFlags(OptionSet<WebKit::WebEventModifier>);
 };
+
+} // namespace WebKit
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/Shared/ios/WebIOSEventFactory.mm
+++ b/Source/WebKit/Shared/ios/WebIOSEventFactory.mm
@@ -33,58 +33,60 @@
 #import <WebCore/PlatformEventFactoryIOS.h>
 #import <WebCore/Scrollbar.h>
 
-OptionSet<WebKit::WebEventModifier> WebIOSEventFactory::webEventModifiersForUIKeyModifierFlags(UIKeyModifierFlags modifierFlags)
+namespace WebKit {
+
+OptionSet<WebEventModifier> WebIOSEventFactory::webEventModifiersForUIKeyModifierFlags(UIKeyModifierFlags modifierFlags)
 {
-    OptionSet<WebKit::WebEventModifier> modifiers;
+    OptionSet<WebEventModifier> modifiers;
     if (modifierFlags & UIKeyModifierShift)
-        modifiers.add(WebKit::WebEventModifier::ShiftKey);
+        modifiers.add(WebEventModifier::ShiftKey);
     if (modifierFlags & UIKeyModifierControl)
-        modifiers.add(WebKit::WebEventModifier::ControlKey);
+        modifiers.add(WebEventModifier::ControlKey);
     if (modifierFlags & UIKeyModifierAlternate)
-        modifiers.add(WebKit::WebEventModifier::AltKey);
+        modifiers.add(WebEventModifier::AltKey);
     if (modifierFlags & UIKeyModifierCommand)
-        modifiers.add(WebKit::WebEventModifier::MetaKey);
+        modifiers.add(WebEventModifier::MetaKey);
     if (modifierFlags & UIKeyModifierAlphaShift)
-        modifiers.add(WebKit::WebEventModifier::CapsLockKey);
+        modifiers.add(WebEventModifier::CapsLockKey);
     return modifiers;
 }
 
-UIKeyModifierFlags WebIOSEventFactory::toUIKeyModifierFlags(OptionSet<WebKit::WebEventModifier> modifiers)
+UIKeyModifierFlags WebIOSEventFactory::toUIKeyModifierFlags(OptionSet<WebEventModifier> modifiers)
 {
     UIKeyModifierFlags modifierFlags = 0;
-    if (modifiers.contains(WebKit::WebEventModifier::ShiftKey))
+    if (modifiers.contains(WebEventModifier::ShiftKey))
         modifierFlags |= UIKeyModifierShift;
-    if (modifiers.contains(WebKit::WebEventModifier::ControlKey))
+    if (modifiers.contains(WebEventModifier::ControlKey))
         modifierFlags |= UIKeyModifierControl;
-    if (modifiers.contains(WebKit::WebEventModifier::AltKey))
+    if (modifiers.contains(WebEventModifier::AltKey))
         modifierFlags |= UIKeyModifierAlternate;
-    if (modifiers.contains(WebKit::WebEventModifier::MetaKey))
+    if (modifiers.contains(WebEventModifier::MetaKey))
         modifierFlags |= UIKeyModifierCommand;
-    if (modifiers.contains(WebKit::WebEventModifier::CapsLockKey))
+    if (modifiers.contains(WebEventModifier::CapsLockKey))
         modifierFlags |= UIKeyModifierAlphaShift;
     return modifierFlags;
 }
 
-static OptionSet<WebKit::WebEventModifier> modifiersForEvent(::WebEvent *event)
+static OptionSet<WebEventModifier> modifiersForEvent(::WebEvent *event)
 {
-    OptionSet<WebKit::WebEventModifier> modifiers;
+    OptionSet<WebEventModifier> modifiers;
     WebEventFlags eventModifierFlags = event.modifierFlags;
     if (eventModifierFlags & WebEventFlagMaskShiftKey)
-        modifiers.add(WebKit::WebEventModifier::ShiftKey);
+        modifiers.add(WebEventModifier::ShiftKey);
     if (eventModifierFlags & WebEventFlagMaskControlKey)
-        modifiers.add(WebKit::WebEventModifier::ControlKey);
+        modifiers.add(WebEventModifier::ControlKey);
     if (eventModifierFlags & WebEventFlagMaskOptionKey)
-        modifiers.add(WebKit::WebEventModifier::AltKey);
+        modifiers.add(WebEventModifier::AltKey);
     if (eventModifierFlags & WebEventFlagMaskCommandKey)
-        modifiers.add(WebKit::WebEventModifier::MetaKey);
+        modifiers.add(WebEventModifier::MetaKey);
     if (eventModifierFlags & WebEventFlagMaskLeftCapsLockKey)
-        modifiers.add(WebKit::WebEventModifier::CapsLockKey);
+        modifiers.add(WebEventModifier::CapsLockKey);
     return modifiers;
 }
 
-WebKit::WebKeyboardEvent WebIOSEventFactory::createWebKeyboardEvent(::WebEvent *event, bool handledByInputMethod)
+WebKeyboardEvent WebIOSEventFactory::createWebKeyboardEvent(::WebEvent *event, bool handledByInputMethod)
 {
-    WebKit::WebEventType type = (event.type == WebEventKeyUp) ? WebKit::WebEventType::KeyUp : WebKit::WebEventType::KeyDown;
+    WebEventType type = (event.type == WebEventKeyUp) ? WebEventType::KeyUp : WebEventType::KeyDown;
     String text;
     String unmodifiedText;
     bool autoRepeat;
@@ -127,16 +129,16 @@ WebKit::WebKeyboardEvent WebIOSEventFactory::createWebKeyboardEvent(::WebEvent *
         unmodifiedText = text;
     }
 
-    return WebKit::WebKeyboardEvent { { type, modifiers, WallTime::fromRawSeconds(timestamp) }, text, unmodifiedText, key, code, keyIdentifier, windowsVirtualKeyCode, nativeVirtualKeyCode, macCharCode, handledByInputMethod, autoRepeat, isKeypad, isSystemKey };
+    return WebKeyboardEvent { { type, modifiers, WallTime::fromRawSeconds(timestamp) }, text, unmodifiedText, key, code, keyIdentifier, windowsVirtualKeyCode, nativeVirtualKeyCode, macCharCode, handledByInputMethod, autoRepeat, isKeypad, isSystemKey };
 }
 
-WebKit::WebMouseEvent WebIOSEventFactory::createWebMouseEvent(::WebEvent *event)
+WebMouseEvent WebIOSEventFactory::createWebMouseEvent(::WebEvent *event)
 {
     // This currently only supports synthetic mouse moved events with no button pressed.
     ASSERT_ARG(event, event.type == WebEventMouseMoved);
 
-    auto type = WebKit::WebEventType::MouseMove;
-    auto button = WebKit::WebMouseEventButton::None;
+    auto type = WebEventType::MouseMove;
+    auto button = WebMouseEventButton::None;
     unsigned short buttons = 0;
     auto position = WebCore::IntPoint(event.locationInWindow);
     float deltaX = 0;
@@ -145,57 +147,71 @@ WebKit::WebMouseEvent WebIOSEventFactory::createWebMouseEvent(::WebEvent *event)
     int clickCount = 0;
     double timestamp = event.timestamp;
 
-    return WebKit::WebMouseEvent({ type, OptionSet<WebKit::WebEventModifier> { }, WallTime::fromRawSeconds(timestamp) }, button, buttons, position, position, deltaX, deltaY, deltaZ, clickCount);
+    return WebMouseEvent({ type, OptionSet<WebEventModifier> { }, WallTime::fromRawSeconds(timestamp) }, button, buttons, position, position, deltaX, deltaY, deltaZ, clickCount);
 }
 
 #if HAVE(UISCROLLVIEW_ASYNCHRONOUS_SCROLL_EVENT_HANDLING)
-static WebKit::WebWheelEvent::Phase toWebPhase(UIScrollPhase phase)
+static WebWheelEvent::Phase toWebPhase(WKSEScrollViewScrollUpdatePhase phase)
 {
     switch (phase) {
+#if !SERVICE_EXTENSIONS_SCROLL_VIEW_IS_AVAILABLE
     case UIScrollPhaseNone:
-        return WebKit::WebWheelEvent::PhaseNone;
+        return WebWheelEvent::PhaseNone;
     case UIScrollPhaseMayBegin:
-        return WebKit::WebWheelEvent::PhaseMayBegin;
-    case UIScrollPhaseBegan:
-        return WebKit::WebWheelEvent::PhaseBegan;
-    case UIScrollPhaseChanged:
-        return WebKit::WebWheelEvent::PhaseChanged;
-    case UIScrollPhaseEnded:
-        return WebKit::WebWheelEvent::PhaseEnded;
-    case UIScrollPhaseCancelled:
-        return WebKit::WebWheelEvent::PhaseCancelled;
+        return WebWheelEvent::PhaseMayBegin;
+#endif // !SERVICE_EXTENSIONS_SCROLL_VIEW_IS_AVAILABLE
+    case WKSEScrollViewScrollUpdatePhaseBegan:
+        return WebWheelEvent::PhaseBegan;
+    case WKSEScrollViewScrollUpdatePhaseChanged:
+        return WebWheelEvent::PhaseChanged;
+    case WKSEScrollViewScrollUpdatePhaseEnded:
+        return WebWheelEvent::PhaseEnded;
+    case WKSEScrollViewScrollUpdatePhaseCancelled:
+        return WebWheelEvent::PhaseCancelled;
     default:
         ASSERT_NOT_REACHED();
-        return WebKit::WebWheelEvent::PhaseNone;
+        return WebWheelEvent::PhaseNone;
     }
 }
 
-WebKit::WebWheelEvent WebIOSEventFactory::createWebWheelEvent(UIScrollEvent *event, UIView *contentView, std::optional<WebKit::WebWheelEvent::Phase> overridePhase)
+WebCore::FloatSize WebIOSEventFactory::translationInView(WKSEScrollViewScrollUpdate *update, UIView *view)
 {
-    WebCore::IntPoint scrollLocation = WebCore::roundedIntPoint([event locationInView:contentView]);
-    CGVector deltaVector = [event _adjustedAcceleratedDeltaInView:contentView];
-    WebCore::FloatSize delta(deltaVector.dx, deltaVector.dy);
+#if SERVICE_EXTENSIONS_SCROLL_VIEW_IS_AVAILABLE
+    auto delta = [update translationInView:view];
+    return { static_cast<float>(delta.x), static_cast<float>(delta.y) };
+#else
+    auto delta = [update _adjustedAcceleratedDeltaInView:view];
+    return { static_cast<float>(delta.dx), static_cast<float>(delta.dy) };
+#endif
+}
+
+WebWheelEvent WebIOSEventFactory::createWebWheelEvent(WKSEScrollViewScrollUpdate *update, UIView *contentView, std::optional<WebWheelEvent::Phase> overridePhase)
+{
+    WebCore::IntPoint scrollLocation = WebCore::roundedIntPoint([update locationInView:contentView]);
+    auto delta = translationInView(update, contentView);
     WebCore::FloatSize wheelTicks = delta;
     wheelTicks.scale(1. / static_cast<float>(WebCore::Scrollbar::pixelsPerLineStep()));
-    auto timestamp = MonotonicTime::fromRawSeconds(event.timestamp).approximateWallTime();
+    auto timestamp = MonotonicTime::fromRawSeconds(update.timestamp).approximateWallTime();
     return {
-        { WebKit::WebEventType::Wheel, OptionSet<WebKit::WebEventModifier> { }, timestamp },
+        { WebEventType::Wheel, OptionSet<WebEventModifier> { }, timestamp },
         scrollLocation,
         scrollLocation,
         delta,
         wheelTicks,
-        WebKit::WebWheelEvent::Granularity::ScrollByPixelWheelEvent,
+        WebWheelEvent::Granularity::ScrollByPixelWheelEvent,
         false,
-        overridePhase.value_or(toWebPhase(event.phase)),
-        WebKit::WebWheelEvent::PhaseNone,
+        overridePhase.value_or(toWebPhase(update.phase)),
+        WebWheelEvent::PhaseNone,
         true,
         1,
         delta,
         timestamp,
         { },
-        WebKit::WebWheelEvent::MomentumEndType::Unknown
+        WebWheelEvent::MomentumEndType::Unknown
     };
 }
 #endif
+
+} // namespace WebKit
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm
@@ -156,7 +156,7 @@ static WKSyntheticClickType toWKSyntheticClickType(WebKit::WebMouseEventSyntheti
 
 - (UIKeyModifierFlags)modifierFlags
 {
-    return WebIOSEventFactory::toUIKeyModifierFlags(_navigationAction->modifiers());
+    return WebKit::WebIOSEventFactory::toUIKeyModifierFlags(_navigationAction->modifiers());
 }
 
 #endif

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
@@ -31,7 +31,7 @@
 
 #import "UIKitSPI.h"
 
-@class UIScrollEvent;
+@class WKSEScrollViewScrollUpdate;
 
 namespace WebKit {
 enum class TapHandlingResult : uint8_t;
@@ -175,6 +175,10 @@ enum class TapHandlingResult : uint8_t;
 
 #if ENABLE(LOCKDOWN_MODE_API)
 + (void)_clearLockdownModeWarningNeeded;
+#endif
+
+#if HAVE(UISCROLLVIEW_ASYNCHRONOUS_SCROLL_EVENT_HANDLING)
+- (void)scrollView:(WKBaseScrollView *)scrollView handleScrollUpdate:(WKSEScrollViewScrollUpdate *)update completion:(void (^)(BOOL handled))completion;
 #endif
 
 - (UIColor *)_insertionPointColor;

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
@@ -302,7 +302,7 @@ void UIDelegate::UIClient::mouseDidMoveOverElement(WebPageProxy& page, const Web
 #if PLATFORM(MAC)
     auto modifierFlags = WebEventFactory::toNSEventModifierFlags(modifiers);
 #else
-    auto modifierFlags = WebIOSEventFactory::toUIKeyModifierFlags(modifiers);
+    auto modifierFlags = WebKit::WebIOSEventFactory::toUIKeyModifierFlags(modifiers);
 #endif
     [(id <WKUIDelegatePrivate>)delegate _webView:m_uiDelegate->m_webView.get().get() mouseDidMoveOverElement:wrapper(apiHitTestResult.get()) withFlags:modifierFlags userInfo:userInfo ? static_cast<id <NSSecureCoding>>(userInfo->wrapper()) : nil];
 }

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -57,6 +57,7 @@
 
 #if PLATFORM(COCOA)
 #include "WKFoundation.h"
+#include "WKSEDefinitions.h"
 
 #if PLATFORM(IOS_FAMILY)
 #include <WebCore/InspectorOverlay.h>
@@ -78,9 +79,9 @@ OBJC_CLASS NSObject;
 OBJC_CLASS NSSet;
 OBJC_CLASS NSTextAlternatives;
 OBJC_CLASS UIGestureRecognizer;
-OBJC_CLASS UIScrollEvent;
 OBJC_CLASS UIScrollView;
 OBJC_CLASS WKBaseScrollView;
+OBJC_CLASS WKSEScrollViewScrollUpdate;
 OBJC_CLASS _WKRemoteObjectRegistry;
 
 #if USE(APPKIT)
@@ -525,7 +526,7 @@ public:
     virtual void handleAutocorrectionContext(const WebAutocorrectionContext&) = 0;
 
 #if HAVE(UISCROLLVIEW_ASYNCHRONOUS_SCROLL_EVENT_HANDLING)
-    virtual void handleAsynchronousCancelableScrollEvent(WKBaseScrollView *, UIScrollEvent *, void (^completion)(BOOL handled)) = 0;
+    virtual void handleAsynchronousCancelableScrollEvent(WKBaseScrollView *, WKSEScrollViewScrollUpdate *, void (^completion)(BOOL handled)) = 0;
 #endif
 
     virtual WebCore::Color contentViewBackgroundColor() = 0;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.h
@@ -29,6 +29,8 @@
 #import "WKBaseScrollView.h"
 #import <wtf/OptionSet.h>
 
+OBJC_CLASS UIScrollView;
+
 namespace WebCore {
 class FloatRect;
 class IntPoint;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm
@@ -254,8 +254,8 @@ UIScrollView *findActingScrollParent(UIScrollView *scrollView, const RemoteLayer
         }
         if (auto* node = RemoteLayerTreeNode::forCALayer(view.layer)) {
             if (auto* actingParent = host.nodeForID(node->actingScrollContainerID())) {
-                if ([actingParent->uiView() isKindOfClass:[UIScrollView class]])
-                    return (UIScrollView *)actingParent->uiView();
+                if (auto scrollView = dynamic_objc_cast<UIScrollView>(actingParent->uiView()))
+                    return scrollView;
             }
 
             scrollersToSkip.add(node->stationaryScrollContainerIDs().begin(), node->stationaryScrollContainerIDs().end());

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.h
@@ -32,9 +32,10 @@
 #import <WebCore/ScrollingTreeScrollingNodeDelegate.h>
 
 @class CALayer;
-@class UIScrollEvent;
 @class UIScrollView;
 @class WKBaseScrollView;
+@class WKSEScrollViewScrollUpdate;
+@class WKSEScrollView;
 @class WKScrollingNodeScrollViewDelegate;
 
 namespace WebCore {
@@ -72,7 +73,7 @@ public:
     void repositionScrollingLayers();
 
 #if HAVE(UISCROLLVIEW_ASYNCHRONOUS_SCROLL_EVENT_HANDLING)
-    void handleAsynchronousCancelableScrollEvent(WKBaseScrollView *, UIScrollEvent *, void (^completion)(BOOL handled));
+    void handleAsynchronousCancelableScrollEvent(WKBaseScrollView *, WKSEScrollViewScrollUpdate *, void (^completion)(BOOL handled));
 #endif
 
     OptionSet<WebCore::TouchAction> activeTouchActions() const { return m_activeTouchActions; }

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -28,6 +28,7 @@
 #if PLATFORM(IOS_FAMILY)
 
 #import "PageClientImplCocoa.h"
+#import "WKSEDefinitions.h"
 #import "WebFullScreenManagerProxy.h"
 #import <WebCore/InspectorOverlay.h>
 #import <wtf/RetainPtr.h>
@@ -304,7 +305,7 @@ private:
     void showDictationAlternativeUI(const WebCore::FloatRect&, WebCore::DictationContext) final;
 
 #if HAVE(UISCROLLVIEW_ASYNCHRONOUS_SCROLL_EVENT_HANDLING)
-    void handleAsynchronousCancelableScrollEvent(WKBaseScrollView *, UIScrollEvent *, void (^completion)(BOOL handled)) final;
+    void handleAsynchronousCancelableScrollEvent(WKBaseScrollView *, WKSEScrollViewScrollUpdate *, void (^completion)(BOOL handled)) final;
 #endif
 
     WebCore::Color contentViewBackgroundColor() final;

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -1097,9 +1097,9 @@ void PageClientImpl::showMediaControlsContextMenu(FloatRect&& targetFrame, Vecto
 #endif // ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
 
 #if HAVE(UISCROLLVIEW_ASYNCHRONOUS_SCROLL_EVENT_HANDLING)
-void PageClientImpl::handleAsynchronousCancelableScrollEvent(WKBaseScrollView *scrollView, UIScrollEvent *scrollEvent, void (^completion)(BOOL handled))
+void PageClientImpl::handleAsynchronousCancelableScrollEvent(WKBaseScrollView *scrollView, WKSEScrollViewScrollUpdate *update, void (^completion)(BOOL handled))
 {
-    [webView() scrollView:scrollView handleScrollEvent:scrollEvent completion:completion];
+    [webView() scrollView:scrollView handleScrollUpdate:update completion:completion];
 }
 #endif
 

--- a/Source/WebKit/UIProcess/ios/WKBaseScrollView.h
+++ b/Source/WebKit/UIProcess/ios/WKBaseScrollView.h
@@ -30,19 +30,12 @@
 #import "WKSEDefinitions.h"
 #import <UIKit/UIKit.h>
 
-@class UIScrollEvent;
+@class WKSEScrollViewScrollUpdate;
 @class WKBaseScrollView;
 
 @protocol WKBaseScrollViewDelegate <NSObject>
 
 - (UIAxis)axesToPreventScrollingForPanGestureInScrollView:(WKBaseScrollView *)scrollView;
-
-#if HAVE(UISCROLLVIEW_ASYNCHRONOUS_SCROLL_EVENT_HANDLING)
-- (void)scrollView:(WKBaseScrollView *)scrollView handleScrollEvent:(UIScrollEvent *)event completion:(void(^)(BOOL handled))completion;
-#endif
-
-@optional
-- (UIScrollView *)actingParentScrollViewForScrollView:(WKBaseScrollView *)scrollView;
 
 @end
 

--- a/Source/WebKit/UIProcess/ios/WKBaseScrollView.mm
+++ b/Source/WebKit/UIProcess/ios/WKBaseScrollView.mm
@@ -49,7 +49,7 @@
     if (!(self = [super initWithFrame:frame]))
         return nil;
 
-#if HAVE(UISCROLLVIEW_ASYNCHRONOUS_SCROLL_EVENT_HANDLING) && !HAVE(UISCROLLVIEW_ASYNCHRONOUS_SCROLL_EVENT_SUBCLASS_HOOKS)
+#if HAVE(UISCROLLVIEW_ASYNCHRONOUS_SCROLL_EVENT_HANDLING) && !SERVICE_EXTENSIONS_SCROLL_VIEW_IS_AVAILABLE
     self._allowsAsyncScrollEvent = YES;
 #endif
 
@@ -140,36 +140,6 @@
     auto delegate = self.baseScrollViewDelegate;
     return delegate ? [delegate axesToPreventScrollingForPanGestureInScrollView:self] : UIAxisNeither;
 }
-
-#if HAVE(UISCROLLVIEW_ASYNCHRONOUS_SCROLL_EVENT_SUBCLASS_HOOKS)
-
-- (BOOL)_subclassHandlesAsyncScrollEvent
-{
-    return YES;
-}
-
-- (void)_asynchronouslyHandleScrollEvent:(UIScrollEvent *)event completion:(void (^)(BOOL handled))completion
-{
-    auto delegate = retainPtr(self.baseScrollViewDelegate);
-    if (!delegate)
-        return completion(NO);
-
-    [delegate scrollView:self handleScrollEvent:event completion:completion];
-}
-
-#endif // HAVE(UISCROLLVIEW_ASYNCHRONOUS_SCROLL_EVENT_SUBCLASS_HOOKS)
-
-#if HAVE(UI_SCROLL_VIEW_ACTING_PARENT_FOR_SCROLL_VIEW)
-
-- (UIScrollView *)_actingParentScrollView
-{
-    if (![self.baseScrollViewDelegate respondsToSelector:@selector(actingParentScrollViewForScrollView:)])
-        return nil;
-
-    return [self.baseScrollViewDelegate actingParentScrollViewForScrollView:self];
-}
-
-#endif // HAVE(UI_SCROLL_VIEW_ACTING_PARENT_FOR_SCROLL_VIEW)
 
 #pragma mark - UIGestureRecognizerDelegate
 

--- a/Source/WebKit/UIProcess/ios/WKMouseInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKMouseInteraction.mm
@@ -215,7 +215,7 @@ inline static String pointerType(UITouchType type)
     if (!type)
         return std::nullopt;
 
-    auto modifiers = WebIOSEventFactory::webEventModifiersForUIKeyModifierFlags(self._activeGesture.modifierFlags);
+    auto modifiers = WebKit::WebIOSEventFactory::webEventModifiersForUIKeyModifierFlags(self._activeGesture.modifierFlags);
     BOOL isRightButton = modifiers.contains(WebKit::WebEventModifier::ControlKey) || (_pressedButtonMask.value_or(0) & UIEventButtonMaskSecondary);
 
     auto button = [&] {

--- a/Source/WebKit/UIProcess/ios/WKSEDefinitions.h
+++ b/Source/WebKit/UIProcess/ios/WKSEDefinitions.h
@@ -31,14 +31,19 @@
 #endif
 
 #if USE(APPLE_INTERNAL_SDK)
-
 #import <WebKitAdditions/WKSEDefinitionsAdditions.h>
+#endif
 
-#else
-
-#define WKSEScrollViewDelegate UIScrollViewDelegate
-#define WKSEScrollView UIScrollView
-
+#ifndef SERVICE_EXTENSIONS_SCROLL_VIEW_IS_AVAILABLE
+#define SERVICE_EXTENSIONS_SCROLL_VIEW_IS_AVAILABLE 0
+#define WKSEScrollView                              UIScrollView
+#define WKSEScrollViewDelegate                      UIScrollViewDelegate
+#define WKSEScrollViewScrollUpdate                  UIScrollEvent
+#define WKSEScrollViewScrollUpdatePhase             UIScrollPhase
+#define WKSEScrollViewScrollUpdatePhaseBegan        UIScrollPhaseBegan
+#define WKSEScrollViewScrollUpdatePhaseChanged      UIScrollPhaseChanged
+#define WKSEScrollViewScrollUpdatePhaseEnded        UIScrollPhaseEnded
+#define WKSEScrollViewScrollUpdatePhaseCancelled    UIScrollPhaseCancelled
 #endif
 
 #ifndef SERVICE_EXTENSIONS_TEXT_INPUT_IS_AVAILABLE


### PR DESCRIPTION
#### 75f37688a521db96bf5943381c323eb9acb1f0c6
<pre>
Adopt new ServiceExtensions scroll view delegate API
<a href="https://bugs.webkit.org/show_bug.cgi?id=267214">https://bugs.webkit.org/show_bug.cgi?id=267214</a>
<a href="https://rdar.apple.com/120597428">rdar://120597428</a>

Reviewed by Tim Horton.

Adopt a couple of scroll view delegate APIs in `WKScrollingNodeScrollViewDelegate` and `WKWebView`:

```
-scrollView:handleScrollUpdate:completion:
-parentScrollViewForScrollView:
```

...instead of equivalent SPI subclassing hooks. To do this, we replace various UIKit SPI symbols
with equivalent declarations:

```
UIScrollEvent            →   WKSEScrollViewScrollUpdate
UIScrollPhase            →   WKSEScrollViewScrollUpdatePhase
UIScrollPhaseBegan       →   WKSEScrollViewScrollUpdatePhaseBegan
UIScrollPhaseChanged     →   WKSEScrollViewScrollUpdatePhaseChanged
UIScrollPhaseEnded       →   WKSEScrollViewScrollUpdatePhaseEnded
UIScrollPhaseCancelled   →   WKSEScrollViewScrollUpdatePhaseCancelled
```

See below for more details.

* Source/WebKit/Shared/ios/WebIOSEventFactory.h:
* Source/WebKit/Shared/ios/WebIOSEventFactory.mm:

Add a missing `WebKit` namespace around `WebIOSEventFactory`, and deploy the new WKSE-prefixed
scroll view symbols (see above).

(WebKit::WebIOSEventFactory::webEventModifiersForUIKeyModifierFlags):
(WebKit::WebIOSEventFactory::toUIKeyModifierFlags):
(WebKit::modifiersForEvent):
(WebKit::WebIOSEventFactory::createWebKeyboardEvent):
(WebKit::WebIOSEventFactory::createWebMouseEvent):
(WebKit::toWebPhase):

Note: since `UIScrollPhaseNone` and `UIScrollPhaseMayBegin` don&apos;t have WKSE-prefixed equivalents,
this codepath is limited to the non-ServiceExtensions case.

(WebKit::WebIOSEventFactory::translationInView):
(WebKit::WebIOSEventFactory::createWebWheelEvent):
(WebIOSEventFactory::webEventModifiersForUIKeyModifierFlags): Deleted.
(WebIOSEventFactory::toUIKeyModifierFlags): Deleted.
(modifiersForEvent): Deleted.
(WebIOSEventFactory::createWebKeyboardEvent): Deleted.
(WebIOSEventFactory::createWebMouseEvent): Deleted.
(toWebPhase): Deleted.
(WebIOSEventFactory::createWebWheelEvent): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm:
(-[WKNavigationAction modifierFlags]):
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _scrollView:asynchronouslyHandleScrollEvent:completion:]):
(-[WKWebView scrollView:handleScrollUpdate:completion:]):
(-[WKWebView scrollView:handleScrollEvent:completion:]): Deleted.

Add an implementation of `-scrollView:handleScrollUpdate:completion:`, and have the legacy SPI
delegate method call into this new method. Similarly, have `-_actingParentScrollViewForScrollView:`
call into the new `-parentScrollViewForScrollView:` method.

* Source/WebKit/UIProcess/Cocoa/UIDelegate.mm:
(WebKit::UIDelegate::UIClient::mouseDidMoveOverElement):
* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm:
(WebKit::findActingScrollParent):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm:
(-[WKScrollingNodeScrollViewDelegate _actingParentScrollViewForScrollView:]):
(-[WKScrollingNodeScrollViewDelegate parentScrollViewForScrollView:]):
(-[WKScrollingNodeScrollViewDelegate _scrollView:asynchronouslyHandleScrollEvent:completion:]):
(-[WKScrollingNodeScrollViewDelegate scrollView:handleScrollUpdate:completion:]):
(WebKit::ScrollingTreeScrollingNodeDelegateIOS::handleAsynchronousCancelableScrollEvent):
(WebKit::ScrollingTreeScrollingNodeDelegateIOS::findActingScrollParent):
(-[WKScrollingNodeScrollViewDelegate actingParentScrollViewForScrollView:]): Deleted.
(-[WKScrollingNodeScrollViewDelegate scrollView:handleScrollEvent:completion:]): Deleted.
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::handleAsynchronousCancelableScrollEvent):
* Source/WebKit/UIProcess/ios/WKBaseScrollView.h:
* Source/WebKit/UIProcess/ios/WKBaseScrollView.mm:
(-[WKBaseScrollView initWithFrame:]):
(-[WKBaseScrollView _subclassHandlesAsyncScrollEvent]): Deleted.
(-[WKBaseScrollView _asynchronouslyHandleScrollEvent:completion:]): Deleted.

Remove these subclass method implementations, which are no longer necessary after adopting the new
delegate methods.

(-[WKBaseScrollView _actingParentScrollView]): Deleted.
* Source/WebKit/UIProcess/ios/WKMouseInteraction.mm:
(-[WKMouseInteraction createMouseEventWithType:wasCancelled:]):
* Source/WebKit/UIProcess/ios/WKSEDefinitions.h:

Add fallback declarations for the new scroll-view-related `WKSE*` symbols.

* Tools/TestWebKitAPI/Tests/ios/WKScrollViewTests.mm:
(legacyScrollPhase):
(createScrollUpdate):

Update these API tests to call into the new delegate methods and create `WKSEScrollViewScrollUpdate`
instead of `UIScrollEvent` if needed.

Canonical link: <a href="https://commits.webkit.org/273026@main">https://commits.webkit.org/273026@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d6ff3f6c523d1f622371390ceb8e6a7ca42dd29

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34004 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12796 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35972 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36639 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30818 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35074 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15180 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9937 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29869 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34504 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10820 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30340 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9439 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9542 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30360 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37947 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30887 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30683 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35652 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9671 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7600 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33555 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11457 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7831 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10236 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10482 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->