### PR TITLE
Fix role assignment for <header> inside <main> and sectioning elements

### DIFF
--- a/LayoutTests/accessibility/mac/html-section-elements-expected.txt
+++ b/LayoutTests/accessibility/mac/html-section-elements-expected.txt
@@ -8,6 +8,8 @@ Should be IGNORED because it's inside an article, so it should not be a landmark
 Should be IGNORED because it's inside an article, so it should not be a landmark
 Should be IGNORED because it's inside a section, so it should not be a landmark
 Should be IGNORED because it's inside a section, so it should not be a landmark
+Should be IGNORED because it's inside a main, so it should not be a landmark
+Should be IGNORED because it's inside a main, so it should not be a landmark
 This tests that the HTML5 section elements map to the correct AX roles.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
@@ -19,8 +21,26 @@ PASS body.childAtIndex(2).subrole is 'AXSubrole: '
 PASS body.childAtIndex(3).subrole is 'AXSubrole: AXDocumentArticle'
 PASS body.childAtIndex(4).subrole is 'AXSubrole: AXLandmarkNavigation'
 PASS body.childAtIndex(5).subrole is 'AXSubrole: AXLandmarkComplementary'
+PASS body.childAtIndex(6).domIdentifier is 'article'
+PASS body.childAtIndex(6).childAtIndex(0).domIdentifier is 'article_header'
+PASS body.childAtIndex(6).childAtIndex(0).role is 'AXRole: AXGroup'
 PASS body.childAtIndex(6).childAtIndex(0).subrole is 'AXSubrole: '
-PASS body.childAtIndex(7).role is 'AXRole: AXStaticText'
+PASS body.childAtIndex(6).childAtIndex(1).domIdentifier is 'article_footer'
+PASS body.childAtIndex(6).childAtIndex(1).role is 'AXRole: AXGroup'
+PASS body.childAtIndex(6).childAtIndex(1).subrole is 'AXSubrole: AXFooter'
+PASS body.childAtIndex(7).domIdentifier is 'section_header'
+PASS body.childAtIndex(7).role is 'AXRole: AXGroup'
+PASS body.childAtIndex(7).subrole is 'AXSubrole: '
+PASS body.childAtIndex(8).domIdentifier is 'section_footer'
+PASS body.childAtIndex(8).role is 'AXRole: AXGroup'
+PASS body.childAtIndex(8).subrole is 'AXSubrole: AXFooter'
+PASS body.childAtIndex(9).domIdentifier is 'main'
+PASS body.childAtIndex(9).childAtIndex(0).domIdentifier is 'main_header'
+PASS body.childAtIndex(9).childAtIndex(0).role is 'AXRole: AXGroup'
+PASS body.childAtIndex(9).childAtIndex(0).subrole is 'AXSubrole: '
+PASS body.childAtIndex(9).childAtIndex(1).domIdentifier is 'main_footer'
+PASS body.childAtIndex(9).childAtIndex(1).role is 'AXRole: AXGroup'
+PASS body.childAtIndex(9).childAtIndex(1).subrole is 'AXSubrole: AXFooter'
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/accessibility/mac/html-section-elements.html
+++ b/LayoutTests/accessibility/mac/html-section-elements.html
@@ -12,15 +12,20 @@
 <nav>nav</nav>
 <aside>aside</aside>
 
-<article>
-<header>Should be IGNORED because it's inside an article, so it should not be a landmark</header>
-<footer>Should be IGNORED because it's inside an article, so it should not be a landmark</footer>
+<article id="article">
+<header id="article_header">Should be IGNORED because it's inside an article, so it should not be a landmark</header>
+<footer id="article_footer">Should be IGNORED because it's inside an article, so it should not be a landmark</footer>
 </article>
 
-<section>
-<header>Should be IGNORED because it's inside a section, so it should not be a landmark</header>
-<footer>Should be IGNORED because it's inside a section, so it should not be a landmark</footer>
+<section id="section">
+<header id="section_header">Should be IGNORED because it's inside a section, so it should not be a landmark</header>
+<footer id="section_footer">Should be IGNORED because it's inside a section, so it should not be a landmark</footer>
 </section>
+
+<main id="main">
+<header id="main_header">Should be IGNORED because it's inside a main, so it should not be a landmark</header>
+<footer id="main_footer">Should be IGNORED because it's inside a main, so it should not be a landmark</footer>
+</main>
 
 <p id="description"></p>
 <div id="console"></div>
@@ -41,11 +46,33 @@
           shouldBe("body.childAtIndex(5).subrole", "'AXSubrole: AXLandmarkComplementary'");
 
           // When a header and footer are inside an article, they should not be landmarks.
+          shouldBe("body.childAtIndex(6).domIdentifier", "'article'");
+          shouldBe("body.childAtIndex(6).childAtIndex(0).domIdentifier", "'article_header'");
+          shouldBe("body.childAtIndex(6).childAtIndex(0).role", "'AXRole: AXGroup'");
           shouldBe("body.childAtIndex(6).childAtIndex(0).subrole", "'AXSubrole: '");
+          shouldBe("body.childAtIndex(6).childAtIndex(1).domIdentifier", "'article_footer'");
+          shouldBe("body.childAtIndex(6).childAtIndex(1).role", "'AXRole: AXGroup'");
+          shouldBe("body.childAtIndex(6).childAtIndex(1).subrole", "'AXSubrole: AXFooter'");
 
           // When a header and footer are inside a section, they should not be landmarks.
-          // Instead, expect only the static text inside to be exposed.
-          shouldBe("body.childAtIndex(7).role", "'AXRole: AXStaticText'");
+          shouldBe("body.childAtIndex(7).domIdentifier", "'section_header'");
+          shouldBe("body.childAtIndex(7).role", "'AXRole: AXGroup'");
+          shouldBe("body.childAtIndex(7).subrole", "'AXSubrole: '");
+
+          shouldBe("body.childAtIndex(8).domIdentifier", "'section_footer'");
+          shouldBe("body.childAtIndex(8).role", "'AXRole: AXGroup'");
+          // FIXME: AXSubrole of the footer should be empty.
+          shouldBe("body.childAtIndex(8).subrole", "'AXSubrole: AXFooter'");
+
+          // When a header and footer are inside a main, they should not be landmarks.
+          shouldBe("body.childAtIndex(9).domIdentifier", "'main'");
+          shouldBe("body.childAtIndex(9).childAtIndex(0).domIdentifier", "'main_header'");
+          shouldBe("body.childAtIndex(9).childAtIndex(0).role", "'AXRole: AXGroup'");
+          shouldBe("body.childAtIndex(9).childAtIndex(0).subrole", "'AXSubrole: '");
+          shouldBe("body.childAtIndex(9).childAtIndex(1).domIdentifier", "'main_footer'");
+          shouldBe("body.childAtIndex(9).childAtIndex(1).role", "'AXRole: AXGroup'");
+          // FIXME: AXSubrole of the footer should be empty.
+          shouldBe("body.childAtIndex(9).childAtIndex(1).subrole", "'AXSubrole: AXFooter'");
     }
 
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html-aam/roles-contextual-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html-aam/roles-contextual-expected.txt
@@ -13,6 +13,7 @@ x
 x
 x
 x
+x
 
 PASS el-a
 PASS el-aside-in-section-with-name
@@ -20,6 +21,7 @@ PASS el-aside-in-section-with-role
 PASS el-aside-ancestorbodymain
 PASS el-footer-ancestorbody
 PASS el-header-ancestorbody
+PASS el-header-ancestormain
 PASS el-section
 PASS el-a-no-href
 PASS el-aside-in-section-without-name

--- a/LayoutTests/imported/w3c/web-platform-tests/html-aam/roles-contextual.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html-aam/roles-contextual.html
@@ -40,6 +40,9 @@
   <header data-testname="el-header" aria-label="x" class="ex-generic">x</header>
 </nav>
 <header data-testname="el-header-ancestorbody" data-expectedrole="banner" class="ex">x</header>
+<main>
+  <header data-testname="el-header-ancestormain" data-expectedrole="generic" class="ex">x</header>
+</main>
 
 <!-- el-section -->
 <section data-testname="el-section" aria-label="x" data-expectedrole="region" class="ex">x</section>

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -473,8 +473,11 @@ AccessibilityRole AccessibilityNodeObject::determineAccessibilityRoleFromNode(Tr
 
     // There should only be one banner/contentInfo per page. If header/footer are being used within an article or section then it should not be exposed as whole page's banner/contentInfo.
     // https://w3c.github.io/html-aam/#el-header
-    if (node->hasTagName(headerTag) && !isDescendantOfElementType({ articleTag, asideTag, navTag, sectionTag }))
-        return AccessibilityRole::LandmarkBanner;
+    if (node->hasTagName(headerTag)) {
+        if (!isDescendantOfElementType({ articleTag, asideTag, mainTag, navTag, sectionTag }))
+            return AccessibilityRole::LandmarkBanner;
+        return AccessibilityRole::Generic;
+    }
 
     // http://webkit.org/b/190138 Footers should become contentInfo's if scoped to body (and consequently become a landmark).
     // It should remain a footer if scoped to main, sectioning elements (article, aside, nav, section) or root sectioning element (blockquote, details, dialog, fieldset, figure, td).


### PR DESCRIPTION
#### da3bbf117740b8052a9e28fe42d9f6aadd283c56
<pre>
Fix role assignment for &lt;header&gt; inside &lt;main&gt; and sectioning elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=242685">https://bugs.webkit.org/show_bug.cgi?id=242685</a>
&lt;<a href="https://rdar.apple.com/48370244">rdar://48370244</a>&gt;

Reviewed by Tyler Wilcock.

This change assigns a generic role to &lt;header&gt; elements when nested
within &lt;main&gt;, &lt;aside&gt;, &lt;article&gt;, &lt;section&gt;, or &lt;nav&gt; elements, aligning with
the W3C spec(<a href="https://w3c.github.io/html-aam/#el-header)">https://w3c.github.io/html-aam/#el-header)</a>

Previously, the &lt;main&gt; element was not included in these conditions.
The &lt;header&gt; element assumed an unknown role instead of a generic role in these
conditions.

* LayoutTests/accessibility/mac/html-section-elements-expected.txt:
* LayoutTests/accessibility/mac/html-section-elements.html:
* LayoutTests/imported/w3c/web-platform-tests/html-aam/roles-contextual-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html-aam/roles-contextual.html:
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::determineAccessibilityRoleFromNode const):

Canonical link: <a href="https://commits.webkit.org/273188@main">https://commits.webkit.org/273188@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64943fa286d12d5730a3e8ff87f4fd1d92bdb020

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34489 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13308 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36491 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37174 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31181 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35628 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15700 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10415 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30167 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35010 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11255 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30739 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9837 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9918 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30801 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38452 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31317 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31121 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35984 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10040 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7925 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33933 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11858 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/30425 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7948 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10596 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10901 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->