### PR TITLE
[WGSL] Fix typos in tests and add extra validation to wgslc

### DIFF
--- a/Source/WebGPU/WGSL/tests/lit.cfg
+++ b/Source/WebGPU/WGSL/tests/lit.cfg
@@ -33,7 +33,7 @@ config.substitutions.append(('%not', 'eval !'))
 config.substitutions.append(('%metal-compile', (
     "function metal_compile() {"
     "     set -e -o pipefail;"
-    f"    {wgslc} --dump-generated-code '%s' \"$1\" > '%t.metal';"
+    f"    {wgslc} --dump-generated-code '%s' \"$1\" > '%t.metal' || exit 1;"
     f"    xcrun -sdk macosx metal -Werror {' '.join(ignored_warnings)} -c '%t.metal' -o /dev/null;"
     "};"
     "metal_compile ")))

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -4638,7 +4638,7 @@ fn testTextureSampleGrad()
 }
 
 // 16.7.13
-// RUN: %metal-compile testTexureSampleLevel
+// RUN: %metal-compile testTextureSampleLevel
 @compute @workgroup_size(1)
 fn testTextureSampleLevel()
 {
@@ -4770,7 +4770,7 @@ fn testAtomicReadWriteModify()
 }
 
 // 16.9. Data Packing Built-in Functions (https://www.w3.org/TR/WGSL/#pack-builtin-functions)
-// RUN: %metal-compile testDataPackingFunction
+// RUN: %metal-compile testDataPackingFunctions
 @compute @workgroup_size(1)
 fn testDataPackingFunctions()
 {

--- a/Source/WebGPU/WGSL/wgslc.cpp
+++ b/Source/WebGPU/WGSL/wgslc.cpp
@@ -132,6 +132,12 @@ static int runWGSL(const CommandLine& options)
 
     String entrypointName = String::fromLatin1(options.entrypoint());
     auto prepareResult = WGSL::prepare(shaderModule, entrypointName, std::nullopt);
+
+    if (entrypointName != "_"_s && !prepareResult.entryPoints.contains(entrypointName)) {
+        dataLogLn("WGSL source does not contain entrypoint named '", entrypointName, "'");
+        return EXIT_FAILURE;
+    }
+
     if (options.dumpASTAtEnd())
         WGSL::AST::dumpAST(shaderModule);
 


### PR DESCRIPTION
#### d1cf373824a82d210a44371b4f701ce2b89073ed
<pre>
[WGSL] Fix typos in tests and add extra validation to wgslc
<a href="https://bugs.webkit.org/show_bug.cgi?id=267227">https://bugs.webkit.org/show_bug.cgi?id=267227</a>
<a href="https://rdar.apple.com/120647630">rdar://120647630</a>

Reviewed by Mike Wyrzykowski.

In two instances there was a typo in the entrypoint name being passed to wgslc,
meaning that no code was actually being generated, so the metal test was no-op.
I added some extra validation to wgslc to ensure that the entrypoint exists, while
keeping the special case for `_`, which is currently used for tests that only care
about the type checking, so there&apos;s no need to generate code.

* Source/WebGPU/WGSL/tests/lit.cfg:
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:
* Source/WebGPU/WGSL/wgslc.cpp:
(runWGSL):

Canonical link: <a href="https://commits.webkit.org/272812@main">https://commits.webkit.org/272812@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e5354a2717630c408e338e35270f92c8ad75f06

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32995 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11767 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34942 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35638 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29816 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14105 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8937 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29252 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33469 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9915 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29515 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8647 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8797 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36972 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29972 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29880 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34930 "2 flakes 50 failures 1 missing results") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8935 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6876 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32785 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10626 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7682 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9528 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9564 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->