### PR TITLE
[WGSL] Implement dot4I8Packed and dot4U8Packed built-in functions

### DIFF
--- a/Source/WebGPU/WGSL/ConstantFunctions.h
+++ b/Source/WebGPU/WGSL/ConstantFunctions.h
@@ -979,6 +979,24 @@ CONSTANT_FUNCTION(Dot)
     return { { result } };
 }
 
+CONSTANT_FUNCTION(Dot4U8Packed)
+{
+    UNUSED_PARAM(resultType);
+    auto lhs = bitwise_cast<std::array<uint8_t, 4>>(std::get<uint32_t>(arguments[0]));
+    auto rhs = bitwise_cast<std::array<uint8_t, 4>>(std::get<uint32_t>(arguments[1]));
+    uint32_t result = lhs[0] * rhs[0] + lhs[1] * rhs[1] + lhs[2] * rhs[2] + lhs[3] * rhs[3];
+    return { { result } };
+}
+
+CONSTANT_FUNCTION(Dot4I8Packed)
+{
+    UNUSED_PARAM(resultType);
+    auto lhs = bitwise_cast<std::array<int8_t, 4>>(std::get<uint32_t>(arguments[0]));
+    auto rhs = bitwise_cast<std::array<int8_t, 4>>(std::get<uint32_t>(arguments[1]));
+    int32_t result = lhs[0] * rhs[0] + lhs[1] * rhs[1] + lhs[2] * rhs[2] + lhs[3] * rhs[3];
+    return { { result } };
+}
+
 CONSTANT_FUNCTION(Length)
 {
     ASSERT(arguments.size() == 1);

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -354,6 +354,30 @@ void FunctionDefinitionWriter::emitNecessaryHelpers()
         m_stringBuilder.append(m_indent, "}\n");
     }
 
+    if (m_callGraph.ast().usesDot4I8Packed()) {
+        m_stringBuilder.append(m_indent, "int __wgslDot4I8Packed(uint lhs, uint rhs)\n");
+        m_stringBuilder.append(m_indent, "{\n");
+        {
+            IndentationScope scope(m_indent);
+            m_stringBuilder.append(m_indent, "auto vec1 = as_type<packed_char4>(lhs);");
+            m_stringBuilder.append(m_indent, "auto vec2 = as_type<packed_char4>(rhs);");
+            m_stringBuilder.append(m_indent, "return vec1[0] * vec2[0] + vec1[1] * vec2[1] + vec1[2] * vec2[2] + vec1[3] * vec2[3];");
+        }
+        m_stringBuilder.append(m_indent, "}\n");
+    }
+
+    if (m_callGraph.ast().usesDot4U8Packed()) {
+        m_stringBuilder.append(m_indent, "uint __wgslDot4U8Packed(uint lhs, uint rhs)\n");
+        m_stringBuilder.append(m_indent, "{\n");
+        {
+            IndentationScope scope(m_indent);
+            m_stringBuilder.append(m_indent, "auto vec1 = as_type<packed_uchar4>(lhs);");
+            m_stringBuilder.append(m_indent, "auto vec2 = as_type<packed_uchar4>(rhs);");
+            m_stringBuilder.append(m_indent, "return vec1[0] * vec2[0] + vec1[1] * vec2[1] + vec1[2] * vec2[2] + vec1[3] * vec2[3];");
+        }
+        m_stringBuilder.append(m_indent, "}\n");
+    }
+
     if (m_callGraph.ast().usesFirstLeadingBit()) {
         m_stringBuilder.append(m_indent, "template<typename T>\n");
         m_stringBuilder.append(m_indent, "T __wgslFirstLeadingBit(T e)\n");
@@ -1833,6 +1857,8 @@ void FunctionDefinitionWriter::visit(const Type* type, AST::CallExpression& call
             { "countOneBits", "popcount"_s },
             { "countTrailingZeros", "ctz"_s },
             { "dot", "__wgslDot"_s },
+            { "dot4I8Packed", "__wgslDot4I8Packed"_s },
+            { "dot4U8Packed", "__wgslDot4U8Packed"_s },
             { "dpdx", "dfdx"_s },
             { "dpdxCoarse", "dfdx"_s },
             { "dpdxFine", "dfdx"_s },

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -1049,6 +1049,10 @@ void TypeChecker::visit(AST::CallExpression& call)
                 m_shaderModule.setUsesFirstTrailingBit();
             else if (targetName == "sign"_s)
                 m_shaderModule.setUsesSign();
+            else if (targetName == "dot4I8Packed"_s)
+                m_shaderModule.setUsesDot4I8Packed();
+            else if (targetName == "dot4U8Packed"_s)
+                m_shaderModule.setUsesDot4U8Packed();
             target.m_inferredType = result;
             return;
         }

--- a/Source/WebGPU/WGSL/TypeDeclarations.rb
+++ b/Source/WebGPU/WGSL/TypeDeclarations.rb
@@ -550,6 +550,23 @@ function :dot, {
     [T < Number, N].(vec[N][T], vec[N][T]) => T
 }
 
+# FIXME: new functions were added so the spec numbers changed
+# 16.5.21
+function :dot4U8Packed, {
+    must_use: true,
+    const: true,
+
+    [].(u32, u32) => u32
+}
+
+# 16.5.22
+function :dot4I8Packed, {
+    must_use: true,
+    const: true,
+
+    [].(u32, u32) => i32
+}
+
 # 16.5.21 & 16.5.22
 ["exp", "exp2"].each do |op|
     function :"#{op}", {

--- a/Source/WebGPU/WGSL/WGSLShaderModule.h
+++ b/Source/WebGPU/WGSL/WGSLShaderModule.h
@@ -117,6 +117,12 @@ public:
     bool usesSampleIndex() const { return m_usesSampleIndex; }
     void setUsesSampleIndex() { m_usesSampleIndex = true; }
 
+    bool usesDot4I8Packed() const { return m_usesDot4I8Packed; }
+    void setUsesDot4I8Packed() { m_usesDot4I8Packed = true; }
+
+    bool usesDot4U8Packed() const { return m_usesDot4U8Packed; }
+    void setUsesDot4U8Packed() { m_usesDot4U8Packed = true; }
+
     template<typename T>
     std::enable_if_t<std::is_base_of_v<AST::Node, T>, void> replace(T* current, T&& replacement)
     {
@@ -280,6 +286,8 @@ private:
     bool m_usesSampleMask { false };
     bool m_usesFrontFacing { false };
     bool m_usesSampleIndex { false };
+    bool m_usesDot4I8Packed { false };
+    bool m_usesDot4U8Packed { false };
     OptionSet<Extension> m_enabledExtensions;
     OptionSet<LanguageFeature> m_requiredFeatures;
     Configuration m_configuration;

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -2302,6 +2302,26 @@ fn testDot()
     }
 }
 
+// 16.5.21
+// RUN: %metal-compile testDot4U8Packed
+@compute @workgroup_size(1)
+fn testDot4U8Packed()
+{
+    let u = 0u;
+    { const x: u32 = dot4U8Packed(0u, 0u); }
+    { let x: u32 = dot4U8Packed(u, u); }
+}
+
+// 16.5.22
+// RUN: %metal-compile testDot4I8Packed
+@compute @workgroup_size(1)
+fn testDot4I8Packed()
+{
+    let u = 0u;
+    { const x: i32 = dot4I8Packed(0u, 0u); }
+    { let x: i32 = dot4I8Packed(u, u); }
+}
+
 // 16.5.21 & 16.5.22
 // RUN: %metal-compile testExpAndExp2
 @compute @workgroup_size(1)


### PR DESCRIPTION
#### 2d83031a0ec49431e02a7dafaf98ce9cf533d23c
<pre>
[WGSL] Implement dot4I8Packed and dot4U8Packed built-in functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=265343">https://bugs.webkit.org/show_bug.cgi?id=265343</a>
<a href="https://rdar.apple.com/118796882">rdar://118796882</a>

Reviewed by Mike Wyrzykowski.

These functions were recently added to the spec [1] &amp; [2].

[1]: <a href="https://www.w3.org/TR/WGSL/#dot4U8Packed-builtin">https://www.w3.org/TR/WGSL/#dot4U8Packed-builtin</a>
[2]: <a href="https://www.w3.org/TR/WGSL/#dot4I8Packed-builtin">https://www.w3.org/TR/WGSL/#dot4I8Packed-builtin</a>

* Source/WebGPU/WGSL/ConstantFunctions.h:
(WGSL::CONSTANT_FUNCTION):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::emitNecessaryHelpers):
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
* Source/WebGPU/WGSL/TypeDeclarations.rb:
* Source/WebGPU/WGSL/WGSLShaderModule.h:
(WGSL::ShaderModule::usesDot4I8Packed const):
(WGSL::ShaderModule::setUsesDot4I8Packed):
(WGSL::ShaderModule::usesDot4U8Packed const):
(WGSL::ShaderModule::setUsesDot4U8Packed):
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/272814@main">https://commits.webkit.org/272814@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d0a9e837e0f44b1444a2b2a94761181509fbf92

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33169 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11943 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35082 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35806 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29947 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14289 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9112 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/29353 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33644 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10071 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29632 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8780 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8927 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37138 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30139 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29989 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35044 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9056 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6996 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32903 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10776 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7687 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9643 "Built successfully") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9723 "Failed to checkout and rebase branch from PR 22508") | | | 
<!--EWS-Status-Bubble-End-->