### PR TITLE
Update 'bogus-dropEffect-effectAllowed' to account for 'empty String', 'null' and 'undefined'

### DIFF
--- a/LayoutTests/fast/events/bogus-dropEffect-effectAllowed-expected.txt
+++ b/LayoutTests/fast/events/bogus-dropEffect-effectAllowed-expected.txt
@@ -19,6 +19,9 @@ PASS event.dataTransfer.effectAllowed is "uninitialized"
 PASS event.dataTransfer.effectAllowed is "uninitialized"
 PASS event.dataTransfer.effectAllowed is "uninitialized"
 PASS event.dataTransfer.effectAllowed is "uninitialized"
+PASS event.dataTransfer.effectAllowed is "uninitialized"
+PASS event.dataTransfer.effectAllowed is "uninitialized"
+PASS event.dataTransfer.effectAllowed is "uninitialized"
 PASS event.dataTransfer.dropEffect is "none"
 PASS event.dataTransfer.dropEffect is "copy"
 PASS event.dataTransfer.dropEffect is "copy"
@@ -36,6 +39,9 @@ PASS event.dataTransfer.dropEffect is "none"
 PASS event.dataTransfer.dropEffect is "none"
 PASS event.dataTransfer.dropEffect is "none"
 PASS event.dataTransfer.dropEffect is "none"
+PASS event.dataTransfer.dropEffect is "none"
+PASS event.dataTransfer.dropEffect is "none"
+PASS event.dataTransfer.dropEffect is "none"
 PASS event.dataTransfer.dropEffect is "copy"
 PASS event.dataTransfer.dropEffect is "copy"
 PASS event.dataTransfer.dropEffect is "copy"
@@ -51,6 +57,12 @@ PASS event.dataTransfer.dropEffect is "none"
 PASS event.dataTransfer.dropEffect is "none"
 PASS event.dataTransfer.dropEffect is "none"
 PASS event.dataTransfer.dropEffect is "none"
+PASS event.dataTransfer.dropEffect is "none"
+PASS event.dataTransfer.dropEffect is "none"
+PASS event.dataTransfer.dropEffect is "none"
+
+TEST COMPLETE
+PASS successfullyParsed is true
 
 TEST COMPLETE
 

--- a/LayoutTests/fast/events/bogus-dropEffect-effectAllowed.html
+++ b/LayoutTests/fast/events/bogus-dropEffect-effectAllowed.html
@@ -1,6 +1,7 @@
+<!DOCTYPE html>
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 <style>
 #dropTarget, #dragMe { text-align: center; display: table-cell; vertical-align: middle }
 #dropTarget {width: 256px; height: 256px; border: 1px dashed}
@@ -13,34 +14,34 @@
     var dropEffectElem;
     var consoleElm;
     var event;
-    
+
     window.onload = function()
     {
         dragMe = document.getElementById("dragMe");
         dropTarget = document.getElementById("dropTarget");
         consoleElm = document.getElementById("console");
-        
+
         if (!dragMe || !dropTarget || !consoleElm)
             return;
-        
+
         dragMe.ondragstart = dragStart;
         dragMe.ondragend = dragEnd;
-        
+
         dropTarget.ondragenter = dragEntered;
         dropTarget.ondragover = dragOver;
         dropTarget.ondrop = drop;
-        
+
         runTest();
     }
-    
+
     function dragStart(e)
     {
         var validEffectAllowedList = ["all", "copy", "copyLink", "copyMove", "link", "linkMove", "move", "none", "uninitialized"];
         var effectAllowedListToTest = ["all", "copy", "bogus", "copyLink", "wrong", "copyMove", "linkCopyMove", "link",
-            "linkMove", "move", "none", "uninitialized", "dummy", "bogus", "fake", "illegal"];
-        
+            "linkMove", "move", "none", "uninitialized", "dummy", "bogus", "fake", "illegal", null, undefined , ""];
+
         event = e;
-        
+
         for (var i = 0; i < effectAllowedListToTest.length; i++) {
             var effectAllowedBefore = e.dataTransfer.effectAllowed;
             e.dataTransfer.effectAllowed = effectAllowedListToTest[i];
@@ -49,33 +50,33 @@
             else
                 shouldBeEqualToString("event.dataTransfer.effectAllowed", effectAllowedBefore);
         }
-        
+
         e.dataTransfer.setData('Text', e.target.textContent);
     }
-    
+
     function dragEnd(e)
     {
         return;
     }
-    
+
     function dragEntered(e)
     {
         dragEnteredAndUpdated(e);
     }
-    
+
     function dragOver(e)
     {
         dragEnteredAndUpdated(e);
     }
-    
+
     function dragEnteredAndUpdated(e)
     {
         var validDropEffectList = ["none", "copy", "link", "move", "link"];
         var dropEffectListToTest = ["all", "copy", "bogus", "copyLink", "wrong", "copyMove", "linkCopyMove", "link",
-            "linkMove", "move", "none", "uninitialized", "dummy", "bogus", "fake", "illegal"];
-        
+            "linkMove", "move", "none", "uninitialized", "dummy", "bogus", "fake", "illegal", null, undefined , ""];
+
         event = e;
-        
+
         for (var i = 0; i < dropEffectListToTest.length; i++) {
             var dropEffectBefore = e.dataTransfer.dropEffect;
             e.dataTransfer.dropEffect = dropEffectListToTest[i];
@@ -89,12 +90,12 @@
 
         cancelDrag(e);
     }
-    
+
     function drop(e)
     {
         cancelDrag(e);
     }
-    
+
     function cancelDrag(e)
     {
         e.preventDefault();
@@ -104,15 +105,15 @@
     {
         if (!window.eventSender)
             return;
-            
+
         if (window.testRunner)
             testRunner.dumpAsText();
-            
+
         var startX = dragMe.offsetLeft + 10;
         var startY = dragMe.offsetTop + dragMe.offsetHeight / 2;
         var endX = dropTarget.offsetLeft + 10;
         var endY = dropTarget.offsetTop + dropTarget.offsetHeight / 2;
-        
+
         eventSender.mouseMoveTo(startX, startY);
         eventSender.mouseDown();
         eventSender.leapForward(100);


### PR DESCRIPTION
#### f6d4c6154380b7278662043aed49944d933b30ef
<pre>
Update &apos;bogus-dropEffect-effectAllowed&apos; to account for &apos;empty String&apos;, &apos;null&apos; and &apos;undefined&apos;

<a href="https://bugs.webkit.org/show_bug.cgi?id=267233">https://bugs.webkit.org/show_bug.cgi?id=267233</a>

Reviewed by Wenson Hsieh.

Merge: <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=197013

This test is to update &apos;bogus-dropEffect-effectAllowed&apos; test to account for &apos;empty String&apos;, &apos;null&apos;
and &apos;undefined&apos; results for m_dropEffect as none and m_effectAllowed as uninitialized.

* LayoutTests/fast/events/bogus-dropEffect-effectAllowed.html: Updated
* LayoutTests/fast/events/bogus-dropEffect-effectAllowed-expected.txt: Updated Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/272888@main">https://commits.webkit.org/272888@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7126945ae0735bf1ccaf02bb216d5d33e5681e91

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33056 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11831 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34963 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35695 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29863 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14172 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8999 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29287 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33531 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9969 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29531 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8692 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8845 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29497 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37027 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30032 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29898 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34972 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8983 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6922 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32829 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10681 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/29154 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7745 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9571 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9620 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->