### PR TITLE
imported/w3c/web-platform-tests/webrtc-stats are failing with GStreamer

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1886,11 +1886,14 @@ webkit.org/b/187603 fast/mediastream/media-stream-track-source-failure.html [ Ti
 
 webkit.org/b/264803 fast/mediastream/mediastreamtrack-video-resize-event.html [ Failure ]
 
-webkit.org/b/262989 imported/w3c/web-platform-tests/webrtc-stats/getStats-remote-candidate-address.html [ Failure ]
-webkit.org/b/262989 imported/w3c/web-platform-tests/webrtc-stats/outbound-rtp.https.html [ Failure ]
-webkit.org/b/262989 imported/w3c/web-platform-tests/webrtc-stats/rtp-stats-creation.html [ Failure ]
-webkit.org/b/262989 imported/w3c/web-platform-tests/webrtc-stats/supported-stats.https.html [ Failure ]
-webkit.org/b/262989 imported/w3c/web-platform-tests/webrtc-stats/hardware-capability-stats.https.html [ Failure ]
+# Adding transceivers without tracks is broken.
+webkit.org/b/265865 imported/w3c/web-platform-tests/webrtc-stats/rtp-stats-creation.html [ Skip ]
+
+# [GStreamer][WebRTC] Missing support for non-trickle ICE handshake
+webkit.org/b/265860 imported/w3c/web-platform-tests/webrtc-stats/supported-stats.https.html [ Skip ]
+
+# Pass Slow Failure with GStreamer 1.23. Skip (too many bugs) with GStreamer 1.22.
+webkit.org/b/262989 imported/w3c/web-platform-tests/webrtc-stats/hardware-capability-stats.https.html [ Skip ]
 
 # This ends up calling WKPageTriggerMockMicrophoneConfigurationChange which is specific to GPUProcess.
 fast/mediastream/mediastreamtrack-configurationchange.html [ Skip ]
@@ -1994,6 +1997,7 @@ webkit.org/b/235885 webrtc/video.html [ Failure ]
 
 # webrtcbin emits no ICE candidate stats for a PeerConnection managing only one data-channel.
 webkit.org/b/235885 webrtc/candidate-stats.html [ Failure ]
+webkit.org/b/262989 imported/w3c/web-platform-tests/webrtc-stats/getStats-remote-candidate-address.html [ Failure ]
 
 # Pending investigation.
 webkit.org/b/235885 fast/mediastream/RTCPeerConnection-addIceCandidate.html [ Failure ]

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h
@@ -139,8 +139,10 @@ private:
 
     MediaStream& mediaStreamFromRTCStream(String mediaStreamId);
 
-    void addRemoteStream(GstPad*);
+    String addRemoteStream(GstPad*);
     void removeRemoteStream(GstPad*);
+
+    void startRemoteStream(GstPad*, const String&);
 
     int pickAvailablePayloadType();
 

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp
@@ -192,6 +192,8 @@ static inline void fillInboundRTPStreamStats(RTCStatsReport::InboundRtpStreamSta
     if (gst_structure_get_uint64(structure, "bytes-received", &bytesReceived))
         stats.bytesReceived = bytesReceived;
 
+    stats.decoderImplementation = "GStreamer"_s;
+
     if (!additionalStats)
         return;
 
@@ -222,7 +224,6 @@ static inline void fillInboundRTPStreamStats(RTCStatsReport::InboundRtpStreamSta
 
 static inline void fillOutboundRTPStreamStats(RTCStatsReport::OutboundRtpStreamStats& stats, const GstStructure* structure, const GstStructure* additionalStats)
 {
-    fillRTCRTPStreamStats(stats, structure);
     fillSentRTPStreamStats(stats, structure);
 
     unsigned firCount;

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -1111,6 +1111,30 @@ void configureVideoDecoderForHarnessing(const GRefPtr<GstElement>& element)
         g_object_set(element.get(), "output-corrupt", FALSE, nullptr);
 }
 
+void configureMediaStreamVideoDecoder(GstElement* element)
+{
+    if (gstObjectHasProperty(element, "automatic-request-sync-points"))
+        g_object_set(element, "automatic-request-sync-points", TRUE, nullptr);
+
+    if (gstObjectHasProperty(element, "discard-corrupted-frames"))
+        g_object_set(element, "discard-corrupted-frames", TRUE, nullptr);
+
+    if (gstObjectHasProperty(element, "output-corrupt"))
+        g_object_set(element, "output-corrupt", FALSE, nullptr);
+
+    if (gstObjectHasProperty(element, "max-errors"))
+        g_object_set(element, "max-errors", -1, nullptr);
+}
+
+void configureVideoRTPDepayloader(GstElement* element)
+{
+    if (gstObjectHasProperty(element, "request-keyframe"))
+        g_object_set(element, "request-keyframe", TRUE, nullptr);
+
+    if (gstObjectHasProperty(element, "wait-for-keyframe"))
+        g_object_set(element, "wait-for-keyframe", TRUE, nullptr);
+}
+
 static bool gstObjectHasProperty(GstObject* gstObject, const char* name)
 {
     return g_object_class_find_property(G_OBJECT_GET_CLASS(gstObject), name);

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -391,6 +391,9 @@ void fillVideoInfoColorimetryFromColorSpace(GstVideoInfo*, const PlatformVideoCo
 void configureAudioDecoderForHarnessing(const GRefPtr<GstElement>&);
 void configureVideoDecoderForHarnessing(const GRefPtr<GstElement>&);
 
+void configureMediaStreamVideoDecoder(GstElement*);
+void configureVideoRTPDepayloader(GstElement*);
+
 bool gstObjectHasProperty(GstElement*, const char* name);
 bool gstObjectHasProperty(GstPad*, const char* name);
 

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -3132,14 +3132,7 @@ void MediaPlayerPrivateGStreamer::configureVideoDecoder(GstElement* decoder)
     if (!isMediaStreamPlayer())
         return;
 
-    if (gstObjectHasProperty(decoder, "automatic-request-sync-points"))
-        g_object_set(decoder, "automatic-request-sync-points", TRUE, nullptr);
-    if (gstObjectHasProperty(decoder, "discard-corrupted-frames"))
-        g_object_set(decoder, "discard-corrupted-frames", TRUE, nullptr);
-    if (gstObjectHasProperty(decoder, "output-corrupt"))
-        g_object_set(decoder, "output-corrupt", FALSE, nullptr);
-    if (gstObjectHasProperty(decoder, "max-errors"))
-        g_object_set(decoder, "max-errors", -1, nullptr);
+    configureMediaStreamVideoDecoder(decoder);
 
     auto pad = adoptGRef(gst_element_get_static_pad(decoder, "src"));
     gst_pad_add_probe(pad.get(), static_cast<GstPadProbeType>(GST_PAD_PROBE_TYPE_QUERY_DOWNSTREAM | GST_PAD_PROBE_TYPE_BUFFER), [](GstPad*, GstPadProbeInfo* info, gpointer userData) -> GstPadProbeReturn {

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.h
@@ -34,6 +34,8 @@ public:
 
     GstElement* bin() { return m_bin.get(); }
 
+    virtual void configureForInputCaps(const GRefPtr<GstCaps>&) { createParser(); }
+
     int registerClient(GRefPtr<GstElement>&&);
     void unregisterClient(int);
 
@@ -42,6 +44,11 @@ public:
 
 protected:
     RealtimeIncomingSourceGStreamer(const CaptureDevice&);
+
+    void createParser();
+
+    GRefPtr<GstElement> m_valve;
+    GRefPtr<GstElement> m_tee;
 
 private:
     // RealtimeMediaSource API
@@ -52,8 +59,6 @@ private:
     virtual void dispatchSample(GRefPtr<GstSample>&&) { }
 
     GRefPtr<GstElement> m_bin;
-    GRefPtr<GstElement> m_valve;
-    GRefPtr<GstElement> m_tee;
     GQuark m_clientQuark { 0 };
     HashMap<int, GRefPtr<GstElement>> m_clients;
 };

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingVideoSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingVideoSourceGStreamer.h
@@ -36,6 +36,8 @@ public:
 
     const GstStructure* stats();
 
+    void configureForInputCaps(const GRefPtr<GstCaps>&) final;
+
 protected:
     RealtimeIncomingVideoSourceGStreamer(AtomString&&);
 
@@ -47,8 +49,16 @@ private:
     // RealtimeIncomingSourceGStreamer API
     void dispatchSample(GRefPtr<GstSample>&&) final;
 
+    void ensureSizeAndFramerate(const GRefPtr<GstCaps>&);
+
     std::optional<RealtimeMediaSourceSettings> m_currentSettings;
     GUniquePtr<GstStructure> m_stats;
+
+    bool m_isDecoding { false };
+    FloatSize m_videoSize;
+    uint64_t m_decodedVideoFrames { 0 };
+    GRefPtr<GstElement> m_queue;
+    GRefPtr<GstElement> m_fakeVideoSink;
 };
 
 } // namespace WebCore

--- a/Tools/Scripts/webkitpy/port/glib.py
+++ b/Tools/Scripts/webkitpy/port/glib.py
@@ -110,6 +110,7 @@ class GLibPort(Port):
             environment['GST_PLUGIN_FEATURE_RANK'] += ',%s' % gst_feature_rank_override
 
         environment['WEBKIT_GST_ALLOW_PLAYBACK_OF_INVISIBLE_VIDEOS'] = '1'
+        environment['WEBKIT_GST_WEBRTC_FORCE_EARLY_VIDEO_DECODING'] = '1'
 
         if self.get_option("leaks"):
             # Turn off GLib memory optimisations https://wiki.gnome.org/Valgrind.


### PR DESCRIPTION
#### 41ce5164a75ae8558a06100e1969f0e9fe94ed21
<pre>
imported/w3c/web-platform-tests/webrtc-stats are failing with GStreamer
<a href="https://bugs.webkit.org/show_bug.cgi?id=262989">https://bugs.webkit.org/show_bug.cgi?id=262989</a>

Reviewed by Xabier Rodriguez-Calvar.

Some stats related with video decoding/rendering were available only if the incoming MediaStream was
associated with a &lt;video&gt; element and the WPT tests added recently are not in that runtime scenario,
they expect video decoder stats without &lt;video&gt; element. We still want to decode only when
rendering, because that&apos;s how hardware-accelerated decoders work best, when there is a downstream GL
or DMABuf sink. For tests purpose a new environment variable is then introduced, that allows to
perform decoding without needing a &lt;video&gt; element. Decoded frames go to a fakevideosink, within the
WebRTC pipeline.

* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::initializePipeline):
(WebCore::GStreamerMediaEndpoint::addRemoteStream):
(WebCore::GStreamerMediaEndpoint::startRemoteStream):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp:
(WebCore::fillInboundRTPStreamStats):
(WebCore::fillOutboundRTPStreamStats):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::getVideoResolutionFromCaps):
(WebCore::configureMediaStreamVideoDecoder):
(WebCore::configureVideoRTPDepayloader):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h:
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::configureVideoDecoder):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.h:
(WebCore::GStreamerCapturer::Observer::sourceCapsChanged):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp:
(WebCore::GStreamerVideoCaptureSource::sourceCapsChanged):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.h:
* Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.cpp:
(WebCore::RealtimeIncomingSourceGStreamer::RealtimeIncomingSourceGStreamer):
(WebCore::RealtimeIncomingSourceGStreamer::createParser):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.h:
(WebCore::RealtimeIncomingSourceGStreamer::configureForInputCaps):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingVideoSourceGStreamer.cpp:
(WebCore::RealtimeIncomingVideoSourceGStreamer::configureForInputCaps):
(WebCore::RealtimeIncomingVideoSourceGStreamer::ensureSizeAndFramerate):
(WebCore::RealtimeIncomingVideoSourceGStreamer::dispatchSample):
(WebCore::RealtimeIncomingVideoSourceGStreamer::stats):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingVideoSourceGStreamer.h:
* Tools/Scripts/webkitpy/port/glib.py:
(GLibPort.setup_environ_for_server):

Canonical link: <a href="https://commits.webkit.org/272813@main">https://commits.webkit.org/272813@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/055f87d03bf71a1affbfd838e2801419bd217b7f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33163 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11937 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35076 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35800 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29940 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34134 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14282 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9106 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/29352 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33638 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10065 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29626 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8779 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/33438 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8921 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29601 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37132 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30133 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29984 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/35043 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9050 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6990 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32902 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10770 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7676 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9637 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9717 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->