### PR TITLE
[GStreamer][MediaStream] Do not initialize on teardown

### DIFF
--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp
@@ -32,6 +32,9 @@ namespace WebCore {
 GST_DEBUG_CATEGORY(webkitGStreamerCaptureDeviceManagerDebugCategory);
 #define GST_CAT_DEFAULT webkitGStreamerCaptureDeviceManagerDebugCategory
 
+static bool audioCaptureSingletonInitialized = false;
+static bool videoCaptureSingletonInitialized = false;
+
 static gint sortDevices(gconstpointer a, gconstpointer b)
 {
     GstDevice* adev = GST_DEVICE(a), *bdev = GST_DEVICE(b);
@@ -55,22 +58,28 @@ static gint sortDevices(gconstpointer a, gconstpointer b)
 GStreamerAudioCaptureDeviceManager& GStreamerAudioCaptureDeviceManager::singleton()
 {
     static NeverDestroyed<GStreamerAudioCaptureDeviceManager> manager;
+    audioCaptureSingletonInitialized = true;
     return manager;
 }
 
 GStreamerVideoCaptureDeviceManager& GStreamerVideoCaptureDeviceManager::singleton()
 {
     static NeverDestroyed<GStreamerVideoCaptureDeviceManager> manager;
+    videoCaptureSingletonInitialized = true;
     return manager;
 }
 
 void teardownGStreamerCaptureDeviceManagers()
 {
-    auto& audioManager = GStreamerAudioCaptureDeviceManager::singleton();
-    audioManager.teardown();
+    if (audioCaptureSingletonInitialized) {
+        auto& audioManager = GStreamerAudioCaptureDeviceManager::singleton();
+        audioManager.teardown();
+    }
 
-    auto& videoManager = GStreamerVideoCaptureDeviceManager::singleton();
-    videoManager.teardown();
+    if (videoCaptureSingletonInitialized) {
+        auto& videoManager = GStreamerVideoCaptureDeviceManager::singleton();
+        videoManager.teardown();
+    }
 }
 
 GStreamerCaptureDeviceManager::GStreamerCaptureDeviceManager()


### PR DESCRIPTION
#### 0af0ad4fe5bfc67d224672b4b2120493c3bd4483
<pre>
[GStreamer][MediaStream] Do not initialize on teardown
<a href="https://bugs.webkit.org/show_bug.cgi?id=267234">https://bugs.webkit.org/show_bug.cgi?id=267234</a>

Reviewed by Philippe Normand.

The capture device managers were created on exit, including possibly a full GStreamer init.

* Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp:
(WebCore::GStreamerAudioCaptureDeviceManager::singleton):
(WebCore::GStreamerVideoCaptureDeviceManager::singleton):
(WebCore::teardownGStreamerCaptureDeviceManagers):

Canonical link: <a href="https://commits.webkit.org/272804@main">https://commits.webkit.org/272804@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eef09af0532b73d10a49db12196eaeb83deda252

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33014 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11787 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34917 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35656 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29833 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33984 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14216 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8956 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29264 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33488 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9997 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29499 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8660 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8866 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29457 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36990 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30065 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29866 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34948 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8952 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6892 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32803 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10643 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7673 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9543 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9583 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->