### PR TITLE
Allow MediaStreamTrackPrivate to work out of main thread

### DIFF
--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivate.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivate.cpp
@@ -61,11 +61,11 @@ MediaRecorderPrivate::AudioVideoSelectedTracks MediaRecorderPrivate::selectTrack
 
 void MediaRecorderPrivate::checkTrackState(const MediaStreamTrackPrivate& track)
 {
-    if (&track.source() == m_audioSource.get()) {
+    if (track.hasSource(m_audioSource.get())) {
         m_shouldMuteAudio = track.muted() || !track.enabled();
         return;
     }
-    if (&track.source() == m_videoSource.get())
+    if (track.hasSource(m_videoSource.get()))
         m_shouldMuteVideo = track.muted() || !track.enabled();
 }
 

--- a/Source/WebCore/platform/mediastream/MediaConstraints.cpp
+++ b/Source/WebCore/platform/mediastream/MediaConstraints.cpp
@@ -34,6 +34,7 @@
 #if ENABLE(MEDIA_STREAM)
 #include "RealtimeMediaSourceCenter.h"
 #include "RealtimeMediaSourceSupportedConstraints.h"
+#include <wtf/CrossThreadCopier.h>
 #include <wtf/StdLibExtras.h>
 
 namespace WebCore {
@@ -477,6 +478,20 @@ void IntConstraint::logAsInt() const
     WTFLogAlways("IntConstraint %d, min %d, max %d, exact %d, ideal %d", static_cast<int>(constraintType()), m_min ? *m_min : -1, m_max ? *m_max : -1, m_exact ? *m_exact : -1, m_ideal ? *m_ideal : -1);
 }
 
+StringConstraint StringConstraint::isolatedCopy() const
+{
+    return StringConstraint({ name().isolatedCopy(), constraintType(), dataType() }, crossThreadCopy(m_exact), crossThreadCopy(m_ideal));
+}
+
+MediaTrackConstraintSetMap MediaTrackConstraintSetMap::isolatedCopy() const
+{
+    return { m_width, m_height, m_sampleRate, m_sampleSize, m_aspectRatio, m_frameRate, m_volume, m_echoCancellation, m_displaySurface, m_logicalSurface, crossThreadCopy(m_facingMode), crossThreadCopy(m_deviceId), crossThreadCopy(m_groupId), crossThreadCopy(m_whiteBalanceMode), m_zoom, m_torch };
+}
+
+MediaConstraints MediaConstraints::isolatedCopy() const
+{
+    return { crossThreadCopy(mandatoryConstraints), crossThreadCopy(advancedConstraints), isValid };
+}
 
 }
 

--- a/Source/WebCore/platform/mediastream/MediaConstraints.h
+++ b/Source/WebCore/platform/mediastream/MediaConstraints.h
@@ -586,6 +586,8 @@ public:
         });
     }
 
+    StringConstraint isolatedCopy() const;
+
 private:
     friend struct IPC::ArgumentCoder<StringConstraint, void>;
     
@@ -615,6 +617,27 @@ private:
 
 class MediaTrackConstraintSetMap {
 public:
+    MediaTrackConstraintSetMap() = default;
+    MediaTrackConstraintSetMap(std::optional<IntConstraint> width, std::optional<IntConstraint> height, std::optional<IntConstraint> sampleRate, std::optional<IntConstraint> sampleSize, std::optional<DoubleConstraint> aspectRatio, std::optional<DoubleConstraint> frameRate, std::optional<DoubleConstraint> volume, std::optional<BooleanConstraint> echoCancellation, std::optional<BooleanConstraint> displaySurface, std::optional<BooleanConstraint> logicalSurface, std::optional<StringConstraint>&& facingMode, std::optional<StringConstraint>&& deviceId, std::optional<StringConstraint>&& groupId, std::optional<StringConstraint>&& whiteBalanceMode, std::optional<DoubleConstraint> zoom, std::optional<BooleanConstraint> torch)
+        : m_width(width)
+        , m_height(height)
+        , m_sampleRate(sampleRate)
+        , m_sampleSize(sampleSize)
+        , m_aspectRatio(aspectRatio)
+        , m_frameRate(frameRate)
+        , m_volume(volume)
+        , m_echoCancellation(echoCancellation)
+        , m_displaySurface(displaySurface)
+        , m_logicalSurface(logicalSurface)
+        , m_facingMode(facingMode)
+        , m_deviceId(WTFMove(deviceId))
+        , m_groupId(WTFMove(groupId))
+        , m_whiteBalanceMode(WTFMove(whiteBalanceMode))
+        , m_zoom(zoom)
+        , m_torch(torch)
+    {
+    }
+
     WEBCORE_EXPORT void forEach(Function<void(const MediaConstraint&)>&&) const;
     void filter(const Function<bool(const MediaConstraint&)>&) const;
     bool isEmpty() const;
@@ -645,6 +668,8 @@ public:
     std::optional<StringConstraint> whiteBalanceMode() const { return m_whiteBalanceMode; }
     std::optional<DoubleConstraint> zoom() const { return m_zoom; }
     std::optional<BooleanConstraint> torch() const { return m_torch; }
+
+    MediaTrackConstraintSetMap isolatedCopy() const;
 
 private:
     friend struct IPC::ArgumentCoder<MediaTrackConstraintSetMap, void>;
@@ -818,8 +843,10 @@ struct MediaConstraints {
     MediaTrackConstraintSetMap mandatoryConstraints;
     Vector<MediaTrackConstraintSetMap> advancedConstraints;
     bool isValid { false };
+
+    MediaConstraints isolatedCopy() const;
 };
-    
+
 } // namespace WebCore
 
 #define SPECIALIZE_TYPE_TRAITS_MEDIACONSTRAINT(ConstraintType, predicate) \

--- a/Source/WebCore/platform/mediastream/MediaStreamPrivate.cpp
+++ b/Source/WebCore/platform/mediastream/MediaStreamPrivate.cpp
@@ -313,7 +313,7 @@ void MediaStreamPrivate::trackEnded(MediaStreamTrackPrivate& track)
 void MediaStreamPrivate::monitorOrientation(OrientationNotifier& notifier)
 {
     for (auto& track : m_trackSet.values()) {
-        if (track->source().isCaptureSource() && track->deviceType() == CaptureDevice::DeviceType::Camera)
+        if (track->isCaptureTrack() && track->deviceType() == CaptureDevice::DeviceType::Camera)
             track->source().monitorOrientation(notifier);
     }
 }

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp
@@ -34,6 +34,7 @@
 #include "IntRect.h"
 #include "Logging.h"
 #include "PlatformMediaSessionManager.h"
+#include <wtf/CrossThreadCopier.h>
 #include <wtf/NativePromise.h>
 #include <wtf/UUID.h>
 
@@ -47,44 +48,304 @@
 
 namespace WebCore {
 
-Ref<MediaStreamTrackPrivate> MediaStreamTrackPrivate::create(Ref<const Logger>&& logger, Ref<RealtimeMediaSource>&& source)
+Ref<MediaStreamTrackPrivate> MediaStreamTrackPrivate::create(Ref<const Logger>&& logger, Ref<RealtimeMediaSource>&& source, std::function<void(Function<void()>&&)>&& postTask)
 {
-    return create(WTFMove(logger), WTFMove(source), createVersion4UUIDString());
+    return create(WTFMove(logger), WTFMove(source), createVersion4UUIDString(), WTFMove(postTask));
 }
 
-Ref<MediaStreamTrackPrivate> MediaStreamTrackPrivate::create(Ref<const Logger>&& logger, Ref<RealtimeMediaSource>&& source, String&& id)
+Ref<MediaStreamTrackPrivate> MediaStreamTrackPrivate::create(Ref<const Logger>&& logger, Ref<RealtimeMediaSource>&& source, String&& id, std::function<void(Function<void()>&&)>&& postTask)
 {
-    return adoptRef(*new MediaStreamTrackPrivate(WTFMove(logger), WTFMove(source), WTFMove(id)));
+    auto privateTrack = adoptRef(*new MediaStreamTrackPrivate(WTFMove(logger), WTFMove(source), WTFMove(id), WTFMove(postTask)));
+    privateTrack->initialize();
+    return privateTrack;
 }
 
-MediaStreamTrackPrivate::MediaStreamTrackPrivate(Ref<const Logger>&& trackLogger, Ref<RealtimeMediaSource>&& source, String&& id)
-    : m_source(WTFMove(source))
+class MediaStreamTrackPrivateSourceObserver : public ThreadSafeRefCounted<MediaStreamTrackPrivateSourceObserver, WTF::DestructionThread::Main> {
+public:
+    static Ref<MediaStreamTrackPrivateSourceObserver> create(Ref<RealtimeMediaSource>&& source, std::function<void(Function<void()>&&)>&& postTask) { return adoptRef(*new MediaStreamTrackPrivateSourceObserver(WTFMove(source), WTFMove(postTask))); }
+
+    void initialize(MediaStreamTrackPrivate& privateTrack)
+    {
+        ensureOnMainThread([this, protectedThis = Ref { *this }, privateTrack = WeakPtr { privateTrack }, postTask = m_postTask, source = m_source, interrupted = privateTrack.interrupted(), muted = privateTrack.muted()] () mutable {
+            m_sourceProxy = makeUnique<SourceProxy>(WTFMove(privateTrack), WTFMove(source), WTFMove(postTask));
+            m_sourceProxy->initialize(interrupted, muted);
+        });
+    }
+
+    std::function<void(Function<void()>&&)> getPostTask()
+    {
+        return m_postTask;
+    }
+
+    RealtimeMediaSource& source() { return m_source.get(); }
+
+    void start()
+    {
+        ensureOnMainThread([protectedThis = Ref { *this }] {
+            protectedThis->m_sourceProxy->start();
+        });
+    }
+
+    void stop()
+    {
+        ensureOnMainThread([protectedThis = Ref { *this }] {
+            protectedThis->m_sourceProxy->stop();
+        });
+    }
+
+    void requestToEnd()
+    {
+        ensureOnMainThread([protectedThis = Ref { *this }] {
+            protectedThis->m_sourceProxy->requestToEnd();
+        });
+    }
+
+    void setMuted(bool muted)
+    {
+        ensureOnMainThread([protectedThis = Ref { *this }, muted] {
+            protectedThis->m_sourceProxy->setMuted(muted);
+        });
+    }
+
+    void close()
+    {
+        auto callbacks = std::exchange(m_applyConstraintsCallbacks, { });
+        for (auto& callback : callbacks.values())
+            callback(RealtimeMediaSource::ApplyConstraintsError { "applyConstraint cancelled"_s, ""_s }, { }, { });
+    }
+
+    using ApplyConstraintsHandler = CompletionHandler<void(std::optional<RealtimeMediaSource::ApplyConstraintsError>&&, RealtimeMediaSourceSettings&&, RealtimeMediaSourceCapabilities&&)>;
+    void applyConstraints(const MediaConstraints& constraints, ApplyConstraintsHandler&& completionHandler)
+    {
+        m_applyConstraintsCallbacks.add(++m_applyConstraintsCallbacksIdentifier, WTFMove(completionHandler));
+        ensureOnMainThread([this, protectedThis = Ref { *this }, constraints = crossThreadCopy(constraints), identifier = m_applyConstraintsCallbacksIdentifier] () mutable {
+            m_sourceProxy->applyConstraints(constraints, [weakObserver = WeakPtr { *m_sourceProxy }, protectedThis = WTFMove(protectedThis), identifier] (auto&& result) mutable {
+                if (!weakObserver)
+                    return;
+                weakObserver->postTask([protectedThis = WTFMove(protectedThis), result = crossThreadCopy(WTFMove(result)), settings = crossThreadCopy(weakObserver->settings()), capabilities = crossThreadCopy(weakObserver->capabilities()), identifier] () mutable {
+                    if (auto callback = protectedThis->m_applyConstraintsCallbacks.take(identifier))
+                        callback(WTFMove(result), WTFMove(settings), WTFMove(capabilities));
+                });
+            });
+        });
+    }
+
+private:
+    class SourceProxy final : public RealtimeMediaSource::Observer {
+        WTF_MAKE_FAST_ALLOCATED;
+    public:
+        SourceProxy(WeakPtr<MediaStreamTrackPrivate>&& privateTrack, Ref<RealtimeMediaSource>&& source, std::function<void(Function<void()>&&)>&& postTask)
+            : m_privateTrack(WTFMove(privateTrack))
+            , m_source(WTFMove(source))
+            , m_postTask(WTFMove(postTask))
+        {
+            ASSERT(m_postTask);
+            ASSERT(isMainThread());
+        }
+
+        std::function<void(Function<void()>&&)> getPostTask()
+        {
+            return m_postTask;
+        }
+
+        void initialize(bool interrupted, bool muted)
+        {
+            ASSERT(isMainThread());
+            if (m_source->isEnded()) {
+                sourceStopped();
+                return;
+            }
+
+            if (muted != m_source->muted() || interrupted != m_source->interrupted())
+                sourceMutedChanged();
+
+            // FIXME: We should check for settings capabilities changes.
+
+            m_isStarted = true;
+            m_source->addObserver(*this);
+        }
+
+        ~SourceProxy()
+        {
+            ASSERT(isMainThread());
+            if (m_isStarted)
+                m_source->removeObserver(*this);
+        }
+
+        const RealtimeMediaSourceCapabilities& capabilities()
+        {
+            ASSERT(isMainThread());
+            return m_source->capabilities();
+        }
+
+        const RealtimeMediaSourceSettings& settings()
+        {
+            ASSERT(isMainThread());
+            return m_source->settings();
+        }
+
+        void start()
+        {
+            m_source->start();
+        }
+
+        void stop()
+        {
+            m_source->stop();
+        }
+
+        void requestToEnd()
+        {
+            m_shouldPreventSourceFromEnding = false;
+            m_source->requestToEnd(*this);
+        }
+
+        void setMuted(bool muted)
+        {
+            m_source->setMuted(muted);
+        }
+
+        void applyConstraints(const MediaConstraints& constraints, RealtimeMediaSource::ApplyConstraintsHandler&& completionHandler)
+        {
+            m_source->applyConstraints(constraints, WTFMove(completionHandler));
+        }
+
+        void postTask(Function<void()>&& task)
+        {
+            m_postTask(WTFMove(task));
+        }
+
+    private:
+        void sourceStarted() final
+        {
+            sendToMediaStreamTrackPrivate([] (auto& privateTrack) {
+                privateTrack.sourceStarted();
+            });
+        }
+
+        void sourceStopped() final
+        {
+            sendToMediaStreamTrackPrivate([captureDidFail = m_source->captureDidFail()] (auto& privateTrack) {
+                privateTrack.sourceStopped(captureDidFail);
+            });
+        }
+
+        void sourceMutedChanged() final
+        {
+            sendToMediaStreamTrackPrivate([muted = m_source->muted(), interrupted = m_source->interrupted()] (auto& privateTrack) {
+                privateTrack.sourceMutedChanged(interrupted, muted);
+            });
+        }
+
+        void sourceSettingsChanged() final
+        {
+            sendToMediaStreamTrackPrivate([settings = crossThreadCopy(m_source->settings()), capabilities = crossThreadCopy(m_source->capabilities())] (auto& privateTrack) mutable {
+                privateTrack.sourceSettingsChanged(WTFMove(settings), WTFMove(capabilities));
+            });
+        }
+
+        void sourceConfigurationChanged() final
+        {
+            sendToMediaStreamTrackPrivate([name = crossThreadCopy(m_source->name()), settings = crossThreadCopy(m_source->settings()), capabilities = crossThreadCopy(m_source->capabilities())] (auto& privateTrack) mutable {
+                privateTrack.sourceConfigurationChanged(WTFMove(name), WTFMove(settings), WTFMove(capabilities));
+            });
+        }
+
+        void hasStartedProducingData() final
+        {
+            sendToMediaStreamTrackPrivate([] (auto& privateTrack) {
+                privateTrack.hasStartedProducingData();
+            });
+        }
+
+        void sendToMediaStreamTrackPrivate(Function<void(MediaStreamTrackPrivate&)>&& task)
+        {
+            m_postTask([task = WTFMove(task), privateTrack = m_privateTrack] () mutable {
+                if (RefPtr protectedPrivateTrack = privateTrack.get())
+                    task(*protectedPrivateTrack);
+            });
+        }
+
+        bool preventSourceFromEnding() { return m_shouldPreventSourceFromEnding; }
+
+        WeakPtr<MediaStreamTrackPrivate> m_privateTrack;
+        Ref<RealtimeMediaSource> m_source;
+        std::function<void(Function<void()>&&)> m_postTask;
+        bool m_shouldPreventSourceFromEnding { true };
+        bool m_isStarted { false };
+    };
+
+private:
+    MediaStreamTrackPrivateSourceObserver(Ref<RealtimeMediaSource>&& source, std::function<void(Function<void()>&&)>&& postTask)
+        : m_source(WTFMove(source))
+        , m_postTask(WTFMove(postTask))
+    {
+        ASSERT(m_postTask || isMainThread());
+        if (!m_postTask)
+            m_postTask = [] (Function<void()>&& function) { function(); };
+    }
+
+    Ref<RealtimeMediaSource> m_source;
+    std::unique_ptr<SourceProxy> m_sourceProxy;
+    std::function<void(Function<void()>&&)> m_postTask;
+    HashMap<uint64_t, ApplyConstraintsHandler> m_applyConstraintsCallbacks;
+    uint64_t m_applyConstraintsCallbacksIdentifier { 0 };
+};
+
+MediaStreamTrackPrivate::MediaStreamTrackPrivate(Ref<const Logger>&& trackLogger, Ref<RealtimeMediaSource>&& source, String&& id, std::function<void(Function<void()>&&)>&& postTask)
+    : m_sourceObserver(MediaStreamTrackPrivateSourceObserver::create(WTFMove(source), WTFMove(postTask)))
     , m_id(WTFMove(id))
+    , m_label(m_sourceObserver->source().name())
+    , m_type(m_sourceObserver->source().type())
+    , m_deviceType(m_sourceObserver->source().deviceType())
+    , m_isCaptureTrack(m_sourceObserver->source().isCaptureSource())
+    , m_captureDidFail(m_sourceObserver->source().captureDidFail())
     , m_logger(WTFMove(trackLogger))
 #if !RELEASE_LOG_DISABLED
     , m_logIdentifier(uniqueLogIdentifier())
 #endif
+    , m_isProducingData(m_sourceObserver->source().isProducingData())
+    , m_isMuted(m_sourceObserver->source().muted())
+    , m_isInterrupted(m_sourceObserver->source().interrupted())
+    , m_settings(m_sourceObserver->source().settings())
+    , m_capabilities(m_sourceObserver->source().capabilities())
+#if ASSERT_ENABLED
+    , m_creationThreadId(isMainThread() ? 0 : Thread::current().uid())
+#endif
 {
-    ASSERT(isMainThread());
     UNUSED_PARAM(trackLogger);
     ALWAYS_LOG(LOGIDENTIFIER);
+
 #if !RELEASE_LOG_DISABLED
-    m_source->setLogger(m_logger.copyRef(), m_logIdentifier);
+    if (isMainThread())
+        m_sourceObserver->source().setLogger(m_logger.copyRef(), m_logIdentifier);
 #endif
-    m_source->addObserver(*this);
+}
+
+void MediaStreamTrackPrivate::initialize()
+{
+    m_sourceObserver->initialize(*this);
 }
 
 MediaStreamTrackPrivate::~MediaStreamTrackPrivate()
 {
-    ASSERT(isMainThread());
+    ASSERT(isOnCreationThread());
 
     ALWAYS_LOG(LOGIDENTIFIER);
-    m_source->removeObserver(*this);
+
+    m_sourceObserver->close();
 }
+
+#if ASSERT_ENABLED
+bool MediaStreamTrackPrivate::isOnCreationThread()
+{
+    return m_creationThreadId ? m_creationThreadId == Thread::current().uid() : isMainThread();
+}
+#endif
 
 void MediaStreamTrackPrivate::forEachObserver(const Function<void(Observer&)>& apply)
 {
-    ASSERT(isMainThread());
+    ASSERT(isOnCreationThread());
     ASSERT(!m_observers.hasNullReferences());
     Ref protectedThis { *this };
     m_observers.forEach(apply);
@@ -92,43 +353,48 @@ void MediaStreamTrackPrivate::forEachObserver(const Function<void(Observer&)>& a
 
 void MediaStreamTrackPrivate::addObserver(MediaStreamTrackPrivate::Observer& observer)
 {
-    ASSERT(isMainThread());
+    ASSERT(isOnCreationThread());
     m_observers.add(observer);
 }
 
 void MediaStreamTrackPrivate::removeObserver(MediaStreamTrackPrivate::Observer& observer)
 {
-    ASSERT(isMainThread());
+    ASSERT(isOnCreationThread());
     m_observers.remove(observer);
-}
-
-const String& MediaStreamTrackPrivate::label() const
-{
-    return m_source->name();
 }
 
 void MediaStreamTrackPrivate::setContentHint(HintValue hintValue)
 {
     m_contentHint = hintValue;
 }
-    
-bool MediaStreamTrackPrivate::muted() const
+
+void MediaStreamTrackPrivate::startProducingData()
 {
-    return m_source->muted();
+    m_sourceObserver->start();
 }
 
-bool MediaStreamTrackPrivate::interrupted() const
+void MediaStreamTrackPrivate::stopProducingData()
 {
-    return m_source->interrupted();
+    m_sourceObserver->stop();
 }
 
-bool MediaStreamTrackPrivate::isCaptureTrack() const
+void MediaStreamTrackPrivate::setIsInBackground(bool value)
 {
-    return m_source->isCaptureSource();
+    ASSERT(isMainThread());
+    m_sourceObserver->source().setIsInBackground(value);
+}
+
+void MediaStreamTrackPrivate::setMuted(bool muted)
+{
+    ASSERT(isOnCreationThread());
+    m_isMuted = muted;
+
+    m_sourceObserver->setMuted(muted);
 }
 
 void MediaStreamTrackPrivate::setEnabled(bool enabled)
 {
+    ASSERT(isOnCreationThread());
     if (m_isEnabled == enabled)
         return;
 
@@ -144,6 +410,7 @@ void MediaStreamTrackPrivate::setEnabled(bool enabled)
 
 void MediaStreamTrackPrivate::endTrack()
 {
+    ASSERT(isOnCreationThread());
     if (m_isEnded)
         return;
 
@@ -155,7 +422,7 @@ void MediaStreamTrackPrivate::endTrack()
     m_isEnded = true;
     updateReadyState();
 
-    m_source->requestToEnd(*this);
+    m_sourceObserver->requestToEnd();
 
     forEachObserver([this](auto& observer) {
         observer.trackEnded(*this);
@@ -164,7 +431,10 @@ void MediaStreamTrackPrivate::endTrack()
 
 Ref<MediaStreamTrackPrivate> MediaStreamTrackPrivate::clone()
 {
-    auto clonedMediaStreamTrackPrivate = create(m_logger.copyRef(), m_source->clone());
+    ASSERT(isOnCreationThread());
+
+    auto postTask = m_sourceObserver->getPostTask();
+    auto clonedMediaStreamTrackPrivate = create(m_logger.copyRef(), m_sourceObserver->source().clone(), WTFMove(postTask));
 
     ALWAYS_LOG(LOGIDENTIFIER, clonedMediaStreamTrackPrivate->logIdentifier());
 
@@ -173,44 +443,57 @@ Ref<MediaStreamTrackPrivate> MediaStreamTrackPrivate::clone()
     clonedMediaStreamTrackPrivate->m_contentHint = this->m_contentHint;
     clonedMediaStreamTrackPrivate->updateReadyState();
 
-    if (m_source->isProducingData())
+    if (m_isProducingData)
         clonedMediaStreamTrackPrivate->startProducingData();
 
     return clonedMediaStreamTrackPrivate;
 }
 
-const RealtimeMediaSourceSettings& MediaStreamTrackPrivate::settings() const
+RealtimeMediaSource& MediaStreamTrackPrivate::source()
 {
-    return m_source->settings();
+    ASSERT(isMainThread());
+    return m_sourceObserver->source();
 }
 
-const RealtimeMediaSourceCapabilities& MediaStreamTrackPrivate::capabilities() const
+bool MediaStreamTrackPrivate::hasSource(const RealtimeMediaSource* source) const
 {
-    return m_source->capabilities();
+    ASSERT(isMainThread());
+    return &m_sourceObserver->source() == source;
 }
 
 Ref<RealtimeMediaSource::PhotoCapabilitiesNativePromise> MediaStreamTrackPrivate::getPhotoCapabilities()
 {
-    return m_source->getPhotoCapabilities();
+    ASSERT(isMainThread());
+    return m_sourceObserver->source().getPhotoCapabilities();
 }
 
 Ref<RealtimeMediaSource::PhotoSettingsNativePromise> MediaStreamTrackPrivate::getPhotoSettings()
 {
-    return m_source->getPhotoSettings();
+    ASSERT(isMainThread());
+    return m_sourceObserver->source().getPhotoSettings();
 }
 
 Ref<RealtimeMediaSource::TakePhotoNativePromise> MediaStreamTrackPrivate::takePhoto(PhotoSettings&& settings)
 {
-    return m_source->takePhoto(WTFMove(settings));
+    ASSERT(isMainThread());
+    return m_sourceObserver->source().takePhoto(WTFMove(settings));
 }
 
 void MediaStreamTrackPrivate::applyConstraints(const MediaConstraints& constraints, RealtimeMediaSource::ApplyConstraintsHandler&& completionHandler)
 {
-    m_source->applyConstraints(constraints, WTFMove(completionHandler));
+    MediaStreamTrackPrivateSourceObserver::ApplyConstraintsHandler callback = [weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler)] (auto&& result, auto&& settings, auto&& capabilities) mutable {
+        if (RefPtr protectedThis = weakThis.get()) {
+            protectedThis->m_settings = WTFMove(settings);
+            protectedThis->m_capabilities = WTFMove(capabilities);
+        }
+        completionHandler(WTFMove(result));
+    };
+    m_sourceObserver->applyConstraints(constraints, WTFMove(callback));
 }
 
 RefPtr<WebAudioSourceProvider> MediaStreamTrackPrivate::createAudioSourceProvider()
 {
+    ASSERT(isMainThread());
     ALWAYS_LOG(LOGIDENTIFIER);
 
 #if PLATFORM(COCOA)
@@ -224,21 +507,27 @@ RefPtr<WebAudioSourceProvider> MediaStreamTrackPrivate::createAudioSourceProvide
 
 void MediaStreamTrackPrivate::sourceStarted()
 {
+    ASSERT(isOnCreationThread());
     ALWAYS_LOG(LOGIDENTIFIER);
 
+    m_isProducingData = true;
     forEachObserver([this](auto& observer) {
         observer.trackStarted(*this);
     });
 }
 
-void MediaStreamTrackPrivate::sourceStopped()
+void MediaStreamTrackPrivate::sourceStopped(bool captureDidFail)
 {
+    ASSERT(isOnCreationThread());
+    m_isProducingData = false;
+
     if (m_isEnded)
         return;
 
     ALWAYS_LOG(LOGIDENTIFIER);
 
     m_isEnded = true;
+    m_captureDidFail = captureDidFail;
     updateReadyState();
 
     forEachObserver([this](auto& observer) {
@@ -246,44 +535,45 @@ void MediaStreamTrackPrivate::sourceStopped()
     });
 }
 
-void MediaStreamTrackPrivate::sourceMutedChanged()
+void MediaStreamTrackPrivate::sourceMutedChanged(bool interrupted, bool muted)
 {
+    ASSERT(isOnCreationThread());
     ALWAYS_LOG(LOGIDENTIFIER);
 
+    m_isInterrupted = interrupted;
+    m_isMuted = muted;
     forEachObserver([this](auto& observer) {
         observer.trackMutedChanged(*this);
     });
 }
 
-void MediaStreamTrackPrivate::sourceSettingsChanged()
+void MediaStreamTrackPrivate::sourceSettingsChanged(RealtimeMediaSourceSettings&& settings, RealtimeMediaSourceCapabilities&& capabilities)
 {
+    ASSERT(isOnCreationThread());
     ALWAYS_LOG(LOGIDENTIFIER);
 
+    m_settings = WTFMove(settings);
+    m_capabilities = WTFMove(capabilities);
     forEachObserver([this](auto& observer) {
         observer.trackSettingsChanged(*this);
     });
 }
-
-void MediaStreamTrackPrivate::sourceConfigurationChanged()
+void MediaStreamTrackPrivate::sourceConfigurationChanged(String&& label, RealtimeMediaSourceSettings&& settings, RealtimeMediaSourceCapabilities&& capabilities)
 {
+    ASSERT(isOnCreationThread());
     ALWAYS_LOG(LOGIDENTIFIER);
 
+    m_label = WTFMove(label);
+    m_settings = WTFMove(settings);
+    m_capabilities = WTFMove(capabilities);
     forEachObserver([this](auto& observer) {
         observer.trackConfigurationChanged(*this);
     });
 }
 
-bool MediaStreamTrackPrivate::preventSourceFromEnding()
-{
-    ALWAYS_LOG(LOGIDENTIFIER, m_isEnded);
-
-    // Do not allow the source to end if we are still using it.
-    return !m_isEnded;
-}
-
 void MediaStreamTrackPrivate::hasStartedProducingData()
 {
-    ASSERT(isMainThread());
+    ASSERT(isOnCreationThread());
     if (m_hasStartedProducingData)
         return;
     ALWAYS_LOG(LOGIDENTIFIER);
@@ -293,6 +583,7 @@ void MediaStreamTrackPrivate::hasStartedProducingData()
 
 void MediaStreamTrackPrivate::updateReadyState()
 {
+    ASSERT(isOnCreationThread());
     ReadyState state = ReadyState::None;
 
     if (m_isEnded)
@@ -309,12 +600,6 @@ void MediaStreamTrackPrivate::updateReadyState()
     forEachObserver([this](auto& observer) {
         observer.readyStateChanged(*this);
     });
-}
-
-void MediaStreamTrackPrivate::audioUnitWillStart()
-{
-    if (!m_isEnded)
-        PlatformMediaSessionManager::sharedManager().sessionCanProduceAudioChanged();
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/platform/mediastream/RealtimeIncomingVideoSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeIncomingVideoSource.h
@@ -93,6 +93,7 @@ private:
     std::optional<RealtimeMediaSourceSettings> m_currentSettings;
     rtc::scoped_refptr<webrtc::VideoTrackInterface> m_videoTrack;
 
+    double m_currentFrameRate { -1 };
     std::unique_ptr<FrameRateMonitor> m_frameRateMonitor;
 #if !RELEASE_LOG_DISABLED
     bool m_enableFrameRatedMonitoringLogging { false };

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
@@ -123,9 +123,8 @@ void RealtimeMediaSource::initializePersistentId()
     if (m_device.persistentId().isEmpty())
         m_device.setPersistentId(createVersion4UUIDString());
 
-    auto& center = RealtimeMediaSourceCenter::singleton();
-    m_hashedID = AtomString { center.hashStringWithSalt(m_device.persistentId(), m_idHashSalts.persistentDeviceSalt) };
-    m_ephemeralHashedID = AtomString { center.hashStringWithSalt(m_device.persistentId(), m_idHashSalts.ephemeralDeviceSalt) };
+    m_hashedID = RealtimeMediaSourceCenter::hashStringWithSalt(m_device.persistentId(), m_idHashSalts.persistentDeviceSalt);
+    m_ephemeralHashedID = RealtimeMediaSourceCenter::hashStringWithSalt(m_device.persistentId(), m_idHashSalts.ephemeralDeviceSalt);
 }
 
 void RealtimeMediaSource::addAudioSampleObserver(AudioSampleObserver& observer)
@@ -1426,7 +1425,7 @@ void RealtimeMediaSource::scheduleDeferredTask(Function<void()>&& function)
     });
 }
 
-const AtomString& RealtimeMediaSource::hashedId() const
+const String& RealtimeMediaSource::hashedId() const
 {
     ASSERT(!m_hashedID.isEmpty());
     ASSERT(!m_ephemeralHashedID.isEmpty());

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceCapabilities.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceCapabilities.h
@@ -33,7 +33,7 @@
 #include <wtf/NeverDestroyed.h>
 #include <wtf/RefCounted.h>
 #include <wtf/Vector.h>
-#include <wtf/text/AtomString.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
@@ -129,7 +129,7 @@ public:
         ReadWrite = 1,
     };
     
-    RealtimeMediaSourceCapabilities(CapabilityRange&& width, CapabilityRange&& height, CapabilityRange&& aspectRatio, CapabilityRange&& frameRate, Vector<VideoFacingMode>&& facingMode, CapabilityRange&& volume, CapabilityRange&& sampleRate, CapabilityRange&& sampleSize, EchoCancellation&& echoCancellation, AtomString&& deviceId, AtomString&& groupId, CapabilityRange&& focusDistance, Vector<MeteringMode>&& whiteBalanceModes, CapabilityRange&& zoom, bool torch, RealtimeMediaSourceSupportedConstraints&& supportedConstraints)
+    RealtimeMediaSourceCapabilities(CapabilityRange width, CapabilityRange height, CapabilityRange aspectRatio, CapabilityRange frameRate, Vector<VideoFacingMode>&& facingMode, CapabilityRange volume, CapabilityRange sampleRate, CapabilityRange sampleSize, EchoCancellation echoCancellation, String&& deviceId, String&& groupId, CapabilityRange focusDistance, Vector<MeteringMode>&& whiteBalanceModes, CapabilityRange zoom, bool torch, RealtimeMediaSourceSupportedConstraints&& supportedConstraints)
         : m_width(WTFMove(width))
         , m_height(WTFMove(height))
         , m_aspectRatio(WTFMove(aspectRatio))
@@ -194,12 +194,12 @@ public:
     void setEchoCancellation(EchoCancellation echoCancellation) { m_echoCancellation = echoCancellation; }
 
     bool supportsDeviceId() const { return m_supportedConstraints.supportsDeviceId(); }
-    const AtomString& deviceId() const { return m_deviceId; }
-    void setDeviceId(const AtomString& id)  { m_deviceId = id; }
+    const String& deviceId() const { return m_deviceId; }
+    void setDeviceId(const String& id)  { m_deviceId = id; }
 
     bool supportsGroupId() const { return m_supportedConstraints.supportsGroupId(); }
-    const AtomString& groupId() const { return m_groupId; }
-    void setGroupId(const AtomString& id)  { m_groupId = id; }
+    const String& groupId() const { return m_groupId; }
+    void setGroupId(const String& id)  { m_groupId = id; }
 
     bool supportsFocusDistance() const { return m_supportedConstraints.supportsFocusDistance(); }
     const CapabilityRange& focusDistance() const { return m_focusDistance; }
@@ -220,6 +220,8 @@ public:
     const RealtimeMediaSourceSupportedConstraints& supportedConstraints() const { return m_supportedConstraints; }
     void setSupportedConstraints(const RealtimeMediaSourceSupportedConstraints& constraints) { m_supportedConstraints = constraints; }
 
+    RealtimeMediaSourceCapabilities isolatedCopy() const { return { m_width, m_height, m_aspectRatio, m_frameRate, Vector<VideoFacingMode> { m_facingMode }, m_volume, m_sampleRate, m_sampleSize, m_echoCancellation, m_deviceId.isolatedCopy(), m_groupId.isolatedCopy(), m_focusDistance, Vector<MeteringMode> { m_whiteBalanceModes }, m_zoom, m_torch, RealtimeMediaSourceSupportedConstraints { m_supportedConstraints } }; }
+
 private:
     CapabilityRange m_width;
     CapabilityRange m_height;
@@ -230,8 +232,8 @@ private:
     CapabilityRange m_sampleRate;
     CapabilityRange m_sampleSize;
     EchoCancellation m_echoCancellation { EchoCancellation::ReadOnly };
-    AtomString m_deviceId;
-    AtomString m_groupId;
+    String m_deviceId;
+    String m_groupId;
     CapabilityRange m_focusDistance;
 
     Vector<MeteringMode> m_whiteBalanceModes;

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.h
@@ -96,7 +96,7 @@ public:
     WEBCORE_EXPORT void setDisplayCaptureFactory(DisplayCaptureFactory&);
     WEBCORE_EXPORT void unsetDisplayCaptureFactory(DisplayCaptureFactory&);
 
-    WEBCORE_EXPORT String hashStringWithSalt(const String& id, const String& hashSalt);
+    WEBCORE_EXPORT static String hashStringWithSalt(const String& id, const String& hashSalt);
 
     WEBCORE_EXPORT void addDevicesChangedObserver(Observer&);
     WEBCORE_EXPORT void removeDevicesChangedObserver(Observer&);

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.cpp
@@ -38,6 +38,11 @@
 
 namespace WebCore {
 
+RealtimeMediaSourceSettings RealtimeMediaSourceSettings::isolatedCopy() const
+{
+    return { m_width, m_height , m_frameRate, m_facingMode, m_volume , m_sampleRate, m_sampleSize, m_echoCancellation, m_deviceId.isolatedCopy(), m_groupId.isolatedCopy(), m_label.isolatedCopy(), m_displaySurface, m_logicalSurface, m_whiteBalanceMode, m_zoom, m_torch, RealtimeMediaSourceSupportedConstraints { m_supportedConstraints } };
+}
+
 VideoFacingMode RealtimeMediaSourceSettings::videoFacingModeEnum(const String& mode)
 {
     if (mode == "user"_s)

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.h
@@ -32,7 +32,7 @@
 #include <wtf/OptionSet.h>
 #include <wtf/RefCounted.h>
 #include <wtf/Vector.h>
-#include <wtf/text/AtomString.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
@@ -81,7 +81,7 @@ public:
     WEBCORE_EXPORT OptionSet<RealtimeMediaSourceSettings::Flag> difference(const RealtimeMediaSourceSettings&) const;
 
     RealtimeMediaSourceSettings() = default;
-    RealtimeMediaSourceSettings(uint32_t width, uint32_t height, float frameRate, VideoFacingMode facingMode, double volume, uint32_t sampleRate, uint32_t sampleSize, bool echoCancellation, AtomString&& deviceId, String&& groupId, AtomString&& label, DisplaySurfaceType displaySurface, bool logicalSurface, MeteringMode whiteBalanceMode, double zoom, bool torch, RealtimeMediaSourceSupportedConstraints&& supportedConstraints)
+    RealtimeMediaSourceSettings(uint32_t width, uint32_t height, float frameRate, VideoFacingMode facingMode, double volume, uint32_t sampleRate, uint32_t sampleSize, bool echoCancellation, String&& deviceId, String&& groupId, String&& label, DisplaySurfaceType displaySurface, bool logicalSurface, MeteringMode whiteBalanceMode, double zoom, bool torch, RealtimeMediaSourceSupportedConstraints&& supportedConstraints)
         : m_width(width)
         , m_height(height)
         , m_frameRate(frameRate)
@@ -137,8 +137,8 @@ public:
     void setEchoCancellation(bool echoCancellation) { m_echoCancellation = echoCancellation; }
 
     bool supportsDeviceId() const { return m_supportedConstraints.supportsDeviceId(); }
-    const AtomString& deviceId() const { return m_deviceId; }
-    void setDeviceId(const AtomString& deviceId) { m_deviceId = deviceId; }
+    const String& deviceId() const { return m_deviceId; }
+    void setDeviceId(const String& deviceId) { m_deviceId = deviceId; }
 
     bool supportsGroupId() const { return m_supportedConstraints.supportsGroupId(); }
     const String& groupId() const { return m_groupId; }
@@ -167,10 +167,12 @@ public:
     const RealtimeMediaSourceSupportedConstraints& supportedConstraints() const { return m_supportedConstraints; }
     void setSupportedConstraints(const RealtimeMediaSourceSupportedConstraints& supportedConstraints) { m_supportedConstraints = supportedConstraints; }
 
-    const AtomString& label() const { return m_label; }
-    void setLabel(const AtomString& label) { m_label = label; }
+    const String& label() const { return m_label; }
+    void setLabel(const String& label) { m_label = label; }
 
     static String convertFlagsToString(const OptionSet<RealtimeMediaSourceSettings::Flag>);
+
+    RealtimeMediaSourceSettings isolatedCopy() const;
 
 private:
     uint32_t m_width { 0 };
@@ -182,9 +184,9 @@ private:
     uint32_t m_sampleSize { 0 };
     bool m_echoCancellation { 0 };
 
-    AtomString m_deviceId;
+    String m_deviceId;
     String m_groupId;
-    AtomString m_label;
+    String m_label;
 
     DisplaySurfaceType m_displaySurface { DisplaySurfaceType::Invalid };
     bool m_logicalSurface { 0 };

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp
@@ -364,7 +364,7 @@ void CoreAudioCaptureSource::handleNewCurrentMicrophoneDevice(const CaptureDevic
     if (!isProducingData() || persistentID() == device.persistentId())
         return;
     
-    RELEASE_LOG_INFO(WebRTC, "CoreAudioCaptureSource switching from '%s' to '%s'", name().string().utf8().data(), device.label().utf8().data());
+    RELEASE_LOG_INFO(WebRTC, "CoreAudioCaptureSource switching from '%s' to '%s'", name().utf8().data(), device.label().utf8().data());
     
     setName(AtomString { device.label() });
     setPersistentId(device.persistentId());

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
@@ -579,7 +579,7 @@ void MockRealtimeVideoSource::drawText(GraphicsContext& context)
         context.drawText(drawingState.statsFont(), TextRun(string), statsLocation);
     } else if (!name().isNull()) {
         statsLocation.move(0, drawingState.statsFontSize());
-        context.drawText(drawingState.statsFont(), TextRun { name().string() }, statsLocation);
+        context.drawText(drawingState.statsFont(), TextRun { name() }, statsLocation);
     }
 
     FloatPoint bipBopLocation(captureSize.width() * .6, captureSize.height() * .6);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -5007,9 +5007,9 @@ class WebCore::RealtimeMediaSourceSettings {
     uint32_t sampleRate();
     uint32_t sampleSize();
     bool echoCancellation();
-    AtomString deviceId();
+    String deviceId();
     String groupId();
-    AtomString label();
+    String label();
     WebCore::DisplaySurfaceType displaySurface();
     bool logicalSurface();
     WebCore::MeteringMode whiteBalanceMode();
@@ -5072,8 +5072,8 @@ class WebCore::RealtimeMediaSourceCapabilities {
     WebCore::CapabilityRange sampleRate();
     WebCore::CapabilityRange sampleSize();
     WebCore::RealtimeMediaSourceCapabilities::EchoCancellation echoCancellation();
-    AtomString deviceId();
-    AtomString groupId();
+    String deviceId();
+    String groupId();
     WebCore::CapabilityRange focusDistance();
     Vector<WebCore::MeteringMode> whiteBalanceModes();
     WebCore::CapabilityRange zoom();

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
@@ -183,18 +183,20 @@ public:
 
             m_source->removeVideoFrameObserver(*this);
 
-            m_source->applyConstraints(WTFMove(constraints), [this, weakThis = WTFMove(weakThis), &constraints, callback = WTFMove(callback)](auto&& result) mutable {
+            m_source->applyConstraints(WTFMove(constraints), [this, weakThis = WTFMove(weakThis), &constraints, callback = WTFMove(callback)](auto&& error) mutable {
                 if (!weakThis) {
                     callback(RealtimeMediaSource::ApplyConstraintsError { { }, { } });
                     return;
                 }
 
-                if (!result && updateVideoConstraints(constraints))
+                if (!error) {
+                    updateVideoConstraints(constraints);
                     m_settings = { };
+                }
 
                 m_source->addVideoFrameObserver(*this, { m_widthConstraint, m_heightConstraint }, m_frameRateConstraint);
 
-                callback(WTFMove(result));
+                callback(WTFMove(error));
             });
 
             return GenericPromise::createAndResolve();


### PR DESCRIPTION
#### 9e81b99af3104473041f6334bc92810d5c66da8f
<pre>
Allow MediaStreamTrackPrivate to work out of main thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=267230">https://bugs.webkit.org/show_bug.cgi?id=267230</a>
<a href="https://rdar.apple.com/120652619">rdar://120652619</a>

Reviewed by Eric Carlson.

We want to allow MediaStreamTrack to live in worker contexts, to allow MediaStreamTrackProcessor et al.
We do a refactoring of MediaStreamTrackPrivate so that it can handle a RealtimeMediaSource even though interaction is happening in a worker.
We keep the RealtimeMediaSource model (everything is main thread, except for media data delivery).
We introduce MediaStreamTrackPrivateSourceObserverWrapper which will observe the RealtimeMediaSource so that:
- It hops to main thread whenever interacting with the source (for instance for starting or muting a source).
- It hops back to MediaStreamTrackPrivate thread when being notified by RealtimeMediaSource.

We thus have to store more state in MediaStreamTrackPrivate (muted, settings and so on) and we update these states based on RealtimeMediaSource observing callbacks.
We also start to update the code to more directly use track/privateTrack instead of source wherever possible to better isolate sources from JS code.

We update RealtimeIncomingVideoSource so that clients are notified of settings that change.
This was the case for width and height but not frame rate.

Drive-by fix in UserMediaCaptureManagerProxy::SourceProxy where we should grab fresh settings whenever applyConstraints succeeds.

* Source/WebCore/platform/mediarecorder/MediaRecorderPrivate.cpp:
(WebCore::MediaRecorderPrivate::checkTrackState):
* Source/WebCore/platform/mediastream/MediaConstraints.cpp:
(WebCore::StringConstraint::isolatedCopy const):
(WebCore::MediaTrackConstraintSetMap::isolatedCopy const):
(WebCore::MediaConstraints::isolatedCopy const):
* Source/WebCore/platform/mediastream/MediaConstraints.h:
(WebCore::MediaTrackConstraintSetMap::MediaTrackConstraintSetMap):
* Source/WebCore/platform/mediastream/MediaStreamPrivate.cpp:
(WebCore::MediaStreamPrivate::monitorOrientation):
* Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp:
(WebCore::MediaStreamTrackPrivate::create):
(WebCore::MediaStreamTrackPrivateSourceObserverWrapper::create):
(WebCore::MediaStreamTrackPrivateSourceObserverWrapper::initialize):
(WebCore::MediaStreamTrackPrivateSourceObserverWrapper::std::function&lt;void):
(WebCore::MediaStreamTrackPrivateSourceObserverWrapper::source):
(WebCore::MediaStreamTrackPrivateSourceObserverWrapper::start):
(WebCore::MediaStreamTrackPrivateSourceObserverWrapper::stop):
(WebCore::MediaStreamTrackPrivateSourceObserverWrapper::requestToEnd):
(WebCore::MediaStreamTrackPrivateSourceObserverWrapper::setMuted):
(WebCore::MediaStreamTrackPrivateSourceObserverWrapper::close):
(WebCore::MediaStreamTrackPrivateSourceObserverWrapper::applyConstraints):
(WebCore::MediaStreamTrackPrivateSourceObserverWrapper::MediaStreamTrackPrivateSourceObserverWrapper):
(WebCore::MediaStreamTrackPrivate::MediaStreamTrackPrivate):
(WebCore::MediaStreamTrackPrivate::initialize):
(WebCore::MediaStreamTrackPrivate::~MediaStreamTrackPrivate):
(WebCore::MediaStreamTrackPrivate::isOnCreationThread):
(WebCore::MediaStreamTrackPrivate::forEachObserver):
(WebCore::MediaStreamTrackPrivate::addObserver):
(WebCore::MediaStreamTrackPrivate::removeObserver):
(WebCore::MediaStreamTrackPrivate::setContentHint):
(WebCore::MediaStreamTrackPrivate::startProducingData):
(WebCore::MediaStreamTrackPrivate::stopProducingData):
(WebCore::MediaStreamTrackPrivate::setIsInBackground):
(WebCore::MediaStreamTrackPrivate::setMuted):
(WebCore::MediaStreamTrackPrivate::setEnabled):
(WebCore::MediaStreamTrackPrivate::endTrack):
(WebCore::MediaStreamTrackPrivate::clone):
(WebCore::MediaStreamTrackPrivate::source):
(WebCore::MediaStreamTrackPrivate::hasSource const):
(WebCore::MediaStreamTrackPrivate::getPhotoCapabilities):
(WebCore::MediaStreamTrackPrivate::getPhotoSettings):
(WebCore::MediaStreamTrackPrivate::takePhoto):
(WebCore::MediaStreamTrackPrivate::applyConstraints):
(WebCore::MediaStreamTrackPrivate::createAudioSourceProvider):
(WebCore::MediaStreamTrackPrivate::sourceStarted):
(WebCore::MediaStreamTrackPrivate::sourceStopped):
(WebCore::MediaStreamTrackPrivate::sourceMutedChanged):
(WebCore::MediaStreamTrackPrivate::sourceSettingsChanged):
(WebCore::MediaStreamTrackPrivate::sourceConfigurationChanged):
(WebCore::MediaStreamTrackPrivate::hasStartedProducingData):
(WebCore::MediaStreamTrackPrivate::updateReadyState):
(WebCore::MediaStreamTrackPrivate::label const): Deleted.
(WebCore::MediaStreamTrackPrivate::muted const): Deleted.
(WebCore::MediaStreamTrackPrivate::interrupted const): Deleted.
(WebCore::MediaStreamTrackPrivate::isCaptureTrack const): Deleted.
(WebCore::MediaStreamTrackPrivate::settings const): Deleted.
(WebCore::MediaStreamTrackPrivate::capabilities const): Deleted.
(WebCore::MediaStreamTrackPrivate::preventSourceFromEnding): Deleted.
(WebCore::MediaStreamTrackPrivate::audioUnitWillStart): Deleted.
* Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h:
* Source/WebCore/platform/mediastream/RealtimeIncomingVideoSource.cpp:
(WebCore::RealtimeIncomingVideoSource::settings):
(WebCore::RealtimeIncomingVideoSource::settingsDidChange):
(WebCore::RealtimeIncomingVideoSource::notifyNewFrame):
* Source/WebCore/platform/mediastream/RealtimeIncomingVideoSource.h:
* Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp:
(WebCore::RealtimeMediaSource::initializePersistentId):
(WebCore::RealtimeMediaSource::hashedId const):
* Source/WebCore/platform/mediastream/RealtimeMediaSource.h:
(WebCore::RealtimeMediaSource::setName):
(WebCore::RealtimeMediaSource::isVideoSource const): Deleted.
* Source/WebCore/platform/mediastream/RealtimeMediaSourceCapabilities.h:
(WebCore::RealtimeMediaSourceCapabilities::RealtimeMediaSourceCapabilities):
(WebCore::RealtimeMediaSourceCapabilities::deviceId const):
(WebCore::RealtimeMediaSourceCapabilities::setDeviceId):
(WebCore::RealtimeMediaSourceCapabilities::groupId const):
(WebCore::RealtimeMediaSourceCapabilities::setGroupId):
(WebCore::RealtimeMediaSourceCapabilities::isolatedCopy const):
* Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.h:
* Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.cpp:
(WebCore::RealtimeMediaSourceSettings::isolatedCopy const):
* Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.h:
(WebCore::RealtimeMediaSourceSettings::RealtimeMediaSourceSettings):
(WebCore::RealtimeMediaSourceSettings::deviceId const):
(WebCore::RealtimeMediaSourceSettings::setDeviceId):
(WebCore::RealtimeMediaSourceSettings::label const):
(WebCore::RealtimeMediaSourceSettings::setLabel):
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp:
(WebCore::CoreAudioCaptureSource::handleNewCurrentMicrophoneDevice):
* Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp:
(WebCore::MockRealtimeVideoSource::drawText):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp:
(WebKit::UserMediaCaptureManagerProxy::SourceProxy::applyConstraints):
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeVideoSource.cpp:
(WebKit::RemoteRealtimeVideoSource::clone):

Canonical link: <a href="https://commits.webkit.org/272844@main">https://commits.webkit.org/272844@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a41f1defd82a81928d5e500d84c48fafda6eff03

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33197 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11971 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35111 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35834 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30240 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34168 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14318 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9141 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29372 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33672 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10097 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29656 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8799 "Found 1 new API test failure: /WPE/TestResources:/webkit/WebKitWebView/sync-request-on-max-conns (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8950 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29630 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37166 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30164 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30012 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35066 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9084 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7018 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32927 "Found 2 new API test failures: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/proxy, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state-changed (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10804 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7718 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9668 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9752 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->