### PR TITLE
[macOS] Form controls with visual overflow and `writing-mode: vertical-rl` do not fully repaint

### DIFF
--- a/LayoutTests/fast/repaint/checkbox-overflow-vertical-rl-expected.txt
+++ b/LayoutTests/fast/repaint/checkbox-overflow-vertical-rl-expected.txt
@@ -1,0 +1,5 @@
+
+(repaint rects
+  (rect 10 21 10 11)
+)
+

--- a/LayoutTests/fast/repaint/checkbox-overflow-vertical-rl.html
+++ b/LayoutTests/fast/repaint/checkbox-overflow-vertical-rl.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/ui-helper.js"></script>
+</head>
+<body>
+    <input type="checkbox" style="width: 5px; height: 5px; writing-mode: vertical-rl">
+    <pre id="result"></pre>
+</body>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+(async () => {
+    if (window.internals)
+        internals.startTrackingRepaints();
+
+    document.querySelector("input").checked = true;
+
+    if (window.internals) {
+        let repaintRects = internals.repaintRectsAsText();
+        internals.stopTrackingRepaints();
+        result.textContent = repaintRects;
+    }
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+})();
+</script>
+</html>

--- a/LayoutTests/fast/repaint/switch-overflow-vertical-rl-expected.txt
+++ b/LayoutTests/fast/repaint/switch-overflow-vertical-rl-expected.txt
@@ -1,0 +1,5 @@
+
+(repaint rects
+  (rect 8 11 16 28)
+)
+

--- a/LayoutTests/fast/repaint/switch-overflow-vertical-rl.html
+++ b/LayoutTests/fast/repaint/switch-overflow-vertical-rl.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/ui-helper.js"></script>
+</head>
+<body>
+    <input type="checkbox" switch style="width: 10px; height: 10px; writing-mode: vertical-rl">
+    <pre id="result"></pre>
+</body>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+(async () => {
+    if (window.internals)
+        internals.startTrackingRepaints();
+
+    document.querySelector("input").checked = true;
+
+    if (window.internals) {
+        let repaintRects = internals.repaintRectsAsText();
+        internals.stopTrackingRepaints();
+        result.textContent = repaintRects;
+    }
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+})();
+</script>
+</html>

--- a/LayoutTests/platform/gtk/fast/repaint/checkbox-overflow-vertical-rl-expected.txt
+++ b/LayoutTests/platform/gtk/fast/repaint/checkbox-overflow-vertical-rl-expected.txt
@@ -1,0 +1,5 @@
+
+(repaint rects
+  (rect 10 21 5 5)
+)
+

--- a/LayoutTests/platform/gtk/fast/repaint/switch-overflow-vertical-rl-expected.txt
+++ b/LayoutTests/platform/gtk/fast/repaint/switch-overflow-vertical-rl-expected.txt
@@ -1,0 +1,5 @@
+
+(repaint rects
+  (rect 8 12 10 10)
+)
+

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -1276,7 +1276,7 @@ IntRect AccessibilityObject::boundingBoxForQuads(RenderObject* obj, const Vector
         FloatRect r = quad.enclosingBoundingBox();
         if (!r.isEmpty()) {
             if (obj->style().hasEffectiveAppearance())
-                obj->theme().adjustRepaintRect(*obj, r);
+                obj->theme().inflateRectForControlRenderer(*obj, r);
             result.unite(r);
         }
     }

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -135,7 +135,8 @@ public:
 
     // Some controls may spill out of their containers (e.g., the check on an OS X checkbox).  When these controls repaint,
     // the theme needs to communicate this inflated rect to the engine so that it can invalidate the whole control.
-    virtual void adjustRepaintRect(const RenderObject&, FloatRect&) { }
+    virtual void inflateRectForControlRenderer(const RenderObject&, FloatRect&) { }
+    virtual void adjustRepaintRect(const RenderBox&, FloatRect&) { }
 
     // This method is called whenever a relevant state changes on a particular themed object, e.g., the mouse becomes pressed
     // or a control becomes disabled.

--- a/Source/WebCore/rendering/RenderThemeMac.h
+++ b/Source/WebCore/rendering/RenderThemeMac.h
@@ -42,7 +42,8 @@ public:
     // A general method asking if any control tinting is supported at all.
     bool supportsControlTints() const final { return true; }
 
-    void adjustRepaintRect(const RenderObject&, FloatRect&) final;
+    void inflateRectForControlRenderer(const RenderObject&, FloatRect&) final;
+    void adjustRepaintRect(const RenderBox&, FloatRect&) final;
 
     bool isControlStyled(const RenderStyle&, const RenderStyle& userAgentStyle) const final;
 

--- a/Source/WebCore/rendering/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/RenderThemeMac.mm
@@ -777,7 +777,7 @@ static const int* popupButtonPadding(NSControlSize size, bool isRTL)
     return isRTL ? paddingRTL[size] : paddingLTR[size];
 }
 
-void RenderThemeMac::adjustRepaintRect(const RenderObject& renderer, FloatRect& rect)
+void RenderThemeMac::inflateRectForControlRenderer(const RenderObject& renderer, FloatRect& rect)
 {
     auto appearance = renderer.style().effectiveAppearance();
 
@@ -803,6 +803,14 @@ void RenderThemeMac::adjustRepaintRect(const RenderObject& renderer, FloatRect& 
     default:
         break;
     }
+}
+
+void RenderThemeMac::adjustRepaintRect(const RenderBox& renderer, FloatRect& rect)
+{
+    auto repaintRect = rect;
+    inflateRectForControlRenderer(renderer, repaintRect);
+    renderer.flipForWritingMode(repaintRect);
+    rect = repaintRect;
 }
 
 bool RenderThemeMac::controlSupportsTints(const RenderObject& o) const


### PR DESCRIPTION
#### 5cf446ee596f18fe1365d20d7bbe064667fb734d
<pre>
[macOS] Form controls with visual overflow and `writing-mode: vertical-rl` do not fully repaint
<a href="https://bugs.webkit.org/show_bug.cgi?id=266532">https://bugs.webkit.org/show_bug.cgi?id=266532</a>
<a href="https://rdar.apple.com/120066970">rdar://120066970</a>

Reviewed by Richard Robinson.

Due to AppKit&apos;s fixed sizes for controls, many controls in macOS WebKit have
visual overflow. For example, a checkbox with a 5px x 5px box size, will
actually paint a 10px x 10px control. In order to ensure that repaint works
correctly for these controls, the rect used for repaint is inflated to match
the control size.

Support for vertical form controls was recently turned on. However, the method
to adjust the repaint rect does not account for flipped block writing modes.
Instead, the method currently always returns a visual rect ignoring the block
direction. This is incorrect, as the rest of the visual overflow code expects a
visual rect account for the block direction.

Fix by flipping the inflated rect based on the block direction.

* LayoutTests/fast/repaint/checkbox-overflow-vertical-rl-expected.txt: Added.
* LayoutTests/fast/repaint/checkbox-overflow-vertical-rl.html: Added.
* LayoutTests/fast/repaint/switch-overflow-vertical-rl-expected.txt: Added.
* LayoutTests/fast/repaint/switch-overflow-vertical-rl.html: Added.
* LayoutTests/platform/gtk/fast/repaint/checkbox-overflow-vertical-rl-expected.txt: Added.
* LayoutTests/platform/gtk/fast/repaint/switch-overflow-vertical-rl-expected.txt: Added.
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::boundingBoxForQuads):

This accessibility method expects a rect ignoring the block direction.

* Source/WebCore/rendering/RenderTheme.h:
(WebCore::RenderTheme::inflateRectForControlRenderer):
(WebCore::RenderTheme::adjustRepaintRect):
* Source/WebCore/rendering/RenderThemeMac.h:
* Source/WebCore/rendering/RenderThemeMac.mm:
(WebCore::RenderThemeMac::inflateRectForControlRenderer):

Introduce a new method to inflate the rect ignoring block direction. This is
used directly by the accessibility code.

(WebCore::RenderThemeMac::adjustRepaintRect):

Flip the inflated rect based on the block direction.

Canonical link: <a href="https://commits.webkit.org/272799@main">https://commits.webkit.org/272799@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72ab233b53a0cdc04572fc7c6b786f8616874290

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33090 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11867 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35000 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35731 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29886 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34061 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14208 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9034 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29299 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33565 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9994 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29553 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8714 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8863 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29523 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37062 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30060 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29919 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34982 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9007 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6944 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32855 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10708 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/29181 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7668 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/9594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9650 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->