### PR TITLE
[JSC] Use cloning for Object.assign with empty object

### DIFF
--- a/JSTests/stress/object-assign-clone.js
+++ b/JSTests/stress/object-assign-clone.js
@@ -1,0 +1,61 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function shouldBeArray(actual, expected) {
+    shouldBe(actual.length, expected.length);
+    for (var i = 0; i < expected.length; ++i) {
+        try {
+            shouldBe(actual[i], expected[i]);
+        } catch(e) {
+            print(JSON.stringify(actual));
+            throw e;
+        }
+    }
+}
+
+{
+    let source = {};
+    Reflect.defineProperty(source, "hello", {
+        enumerable: false,
+        configurable: true,
+        writable: true,
+        value: 42,
+    });
+    let result = Object.assign({}, source);
+    shouldBe(Reflect.getOwnPropertyDescriptor(result, "hello"), undefined);
+}
+{
+    let source = {};
+    Reflect.defineProperty(source, "hello", {
+        enumerable: true,
+        configurable: false,
+        writable: true,
+        value: 42,
+    });
+    let result = Object.assign({}, source);
+    shouldBe(JSON.stringify(Reflect.getOwnPropertyDescriptor(result, "hello")), `{"value":42,"writable":true,"enumerable":true,"configurable":true}`);
+}
+{
+    let source = {};
+    Reflect.defineProperty(source, "hello", {
+        enumerable: true,
+        configurable: true,
+        writable: false,
+        value: 42,
+    });
+    let result = Object.assign({}, source);
+    shouldBe(JSON.stringify(Reflect.getOwnPropertyDescriptor(result, "hello")), `{"value":42,"writable":true,"enumerable":true,"configurable":true}`);
+}
+{
+    let source = {};
+    Reflect.defineProperty(source, "hello", {
+        enumerable: true,
+        configurable: true,
+        get() { return 42; },
+        set() { }
+    });
+    let result = Object.assign({}, source);
+    shouldBe(JSON.stringify(Reflect.getOwnPropertyDescriptor(result, "hello")), `{"value":42,"writable":true,"enumerable":true,"configurable":true}`);
+}

--- a/Source/JavaScriptCore/runtime/JSObject.h
+++ b/Source/JavaScriptCore/runtime/JSObject.h
@@ -1054,9 +1054,6 @@ public:
 
     DECLARE_EXPORT_INFO;
 
-    template<typename Functor>
-    bool fastForEachPropertyWithSideEffectFreeFunctor(VM&, const Functor&);
-
     bool getOwnNonIndexPropertySlot(VM&, Structure*, PropertyName, PropertySlot&);
     bool getNonIndexPropertySlot(JSGlobalObject*, PropertyName, PropertySlot&);
 

--- a/Source/JavaScriptCore/runtime/JSObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSObjectInlines.h
@@ -864,21 +864,6 @@ inline void JSObject::setPrivateBrand(JSGlobalObject* globalObject, JSValue bran
     this->setStructure(vm, newStructure);
 }
 
-template<typename Functor>
-bool JSObject::fastForEachPropertyWithSideEffectFreeFunctor(VM& vm, const Functor& functor)
-{
-    if (hasNonReifiedStaticProperties())
-        return false;
-
-    Structure* structure = this->structure();
-
-    if (!structure->canPerformFastPropertyEnumerationCommon())
-        return false;
-
-    structure->forEachProperty(vm, functor);
-    return true;
-}
-
 // Function forEachOwnIndexedProperty should only used in the fast path
 // for copying own non-GetterSetter indexed properties.
 template<JSObject::SortMode mode, typename Functor>

--- a/Source/JavaScriptCore/runtime/ObjectConstructorInlines.h
+++ b/Source/JavaScriptCore/runtime/ObjectConstructorInlines.h
@@ -63,7 +63,145 @@ ALWAYS_INLINE void objectAssignIndexedPropertiesFast(JSGlobalObject* globalObjec
     RETURN_IF_EXCEPTION(scope, void());
 }
 
-ALWAYS_INLINE bool objectAssignFast(JSGlobalObject* globalObject, JSObject* target, JSObject* source, Vector<RefPtr<UniquedStringImpl>, 8>& properties, MarkedArgumentBuffer& values)
+ALWAYS_INLINE bool objectCloneFast(VM& vm, JSFinalObject* target, JSObject* source)
+{
+    static constexpr bool verbose = false;
+
+    Structure* targetStructure = target->structure();
+    Structure* sourceStructure = source->structure();
+
+    ASSERT(sourceStructure->canPerformFastPropertyEnumerationCommon());
+
+    if (targetStructure->seenProperties().bits()) {
+        dataLogLnIf(verbose, "target already has properties");
+        return false;
+    }
+
+    auto checkStrucure = [&](Structure* structure) ALWAYS_INLINE_LAMBDA {
+        if (structure->typeInfo().type() != FinalObjectType) {
+            dataLogLnIf(verbose, "target is not final object");
+            return false;
+        }
+
+        if (structure->isDictionary()) {
+            dataLogLnIf(verbose, "target is dictionary");
+            return false;
+        }
+
+        if (hasIndexedProperties(structure->indexingType())) {
+            dataLogLnIf(verbose, "target has indexing mode");
+            return false;
+        }
+
+        if (structure->mayBePrototype()) {
+            dataLogLnIf(verbose, "target may be prototype");
+            return false;
+        }
+
+        if (structure->didPreventExtensions()) {
+            dataLogLnIf(verbose, "target has didPreventExtensions");
+            return false;
+        }
+
+        if (structure->hasBeenFlattenedBefore()) {
+            dataLogLnIf(verbose, "target has flattened before");
+            return false;
+        }
+
+        if (structure->hasBeenDictionary()) {
+            dataLogLnIf(verbose, "target has been dictionary");
+            return false;
+        }
+
+        if (structure->isBrandedStructure()) {
+            dataLogLnIf(verbose, "target has isBrandedStructure");
+            return false;
+        }
+
+        if (structure->hasPolyProto()) {
+            dataLogLnIf(verbose, "target has PolyProto");
+            return false;
+        }
+
+        if (structure->hasReadOnlyOrGetterSetterPropertiesExcludingProto()) {
+            dataLogLnIf(verbose, "target has non-writable properties");
+            return false;
+        }
+
+        if (structure->hasNonEnumerableProperties()) {
+            dataLogLnIf(verbose, "target has non-enumerable properties");
+            return false;
+        }
+
+        if (structure->hasNonConfigurableProperties()) {
+            dataLogLnIf(verbose, "target has non-configurable properties");
+            return false;
+        }
+
+        if (!structure->isQuickPropertyAccessAllowedForEnumeration()) {
+            dataLogLnIf(verbose, "target has symbol properties (right now we disable this optimization in this case since we cannot detect private symbol properties)");
+            return false;
+        }
+
+        return true;
+    };
+
+    if (!checkStrucure(targetStructure))
+        return false;
+
+    if (targetStructure->transitionWatchpointSetIsStillValid()) {
+        dataLogLnIf(verbose, "target transitionWatchpointSetIsStillValid");
+        return false;
+    }
+
+    // If the sourceStructure is frozen, we retrieve the last one before freezing.
+    if (sourceStructure->transitionKind() == TransitionKind::Freeze) {
+        dataLogLnIf(verbose, "source was frozen. Let's look into the previous structure");
+        sourceStructure = sourceStructure->previousID();
+        if (!sourceStructure)
+            return false;
+
+        dataLogLnIf(verbose, "source should have ArrayStorage since it was frozen. Let's see whether it is empty and we can quickly get the previous structure without ArrayStorage.");
+        if (sourceStructure->transitionKind() == TransitionKind::AllocateArrayStorage && !source->canHaveExistingOwnIndexedProperties()) {
+            sourceStructure = sourceStructure->previousID();
+            if (!sourceStructure)
+                return false;
+        }
+    }
+
+    if (!checkStrucure(sourceStructure))
+        return false;
+
+    if (targetStructure->inlineCapacity() != sourceStructure->inlineCapacity()) {
+        dataLogLnIf(verbose, "source and target has different inline capacity");
+        return false;
+    }
+
+    if (targetStructure->globalObject() != sourceStructure->globalObject()) {
+        dataLogLnIf(verbose, "source and target has different globalObject");
+        return false;
+    }
+
+    if (targetStructure->storedPrototype() != sourceStructure->storedPrototype()) {
+        dataLogLnIf(verbose, "__proto__ is different");
+        return false;
+    }
+
+    dataLogLnIf(verbose, "Use fast cloning!");
+
+    unsigned propertyCapacity = sourceStructure->outOfLineCapacity();
+    Butterfly* newButterfly = Butterfly::createUninitialized(vm, target, 0, propertyCapacity, /* hasIndexingHeader */ false, 0);
+    gcSafeMemcpy(newButterfly->propertyStorage() - propertyCapacity, source->butterfly()->propertyStorage() - propertyCapacity, propertyCapacity * sizeof(EncodedJSValue));
+    gcSafeMemcpy(target->inlineStorage(), source->inlineStorage(), sourceStructure->inlineCapacity() * sizeof(EncodedJSValue));
+    target->nukeStructureAndSetButterfly(vm, targetStructure->id(), newButterfly);
+    target->setStructure(vm, sourceStructure);
+
+    vm.writeBarrier(target);
+
+    return true;
+}
+
+ALWAYS_INLINE bool objectAssignFast(JSGlobalObject* globalObject, JSFinalObject* target, JSObject* source, Vector<RefPtr<UniquedStringImpl>, 8>& properties, MarkedArgumentBuffer& values)
 {
     // |source| Structure does not have any getters. And target can perform fast put.
     // So enumerating properties and putting properties are non observable.
@@ -84,9 +222,20 @@ ALWAYS_INLINE bool objectAssignFast(JSGlobalObject* globalObject, JSObject* targ
     properties.shrink(0);
     values.clear();
 
+    if (source->hasNonReifiedStaticProperties())
+        return false;
+
+    Structure* sourceStructure = source->structure();
+    if (!sourceStructure->canPerformFastPropertyEnumerationCommon())
+        return false;
+
+    if (objectCloneFast(vm, target, source))
+        return true;
+
     if (source->canHaveExistingOwnIndexedGetterSetterProperties())
         return false;
-    bool canUseFastPath = source->fastForEachPropertyWithSideEffectFreeFunctor(vm, [&](const PropertyTableEntry& entry) -> bool {
+
+    sourceStructure->forEachProperty(vm, [&](const PropertyTableEntry& entry) -> bool {
         if (entry.attributes() & PropertyAttribute::DontEnum)
             return true;
 
@@ -99,8 +248,6 @@ ALWAYS_INLINE bool objectAssignFast(JSGlobalObject* globalObject, JSObject* targ
 
         return true;
     });
-    if (!canUseFastPath)
-        return false;
 
     if (source->canHaveExistingOwnIndexedProperties()) {
         objectAssignIndexedPropertiesFast(globalObject, target, source);

--- a/Source/JavaScriptCore/runtime/Structure.h
+++ b/Source/JavaScriptCore/runtime/Structure.h
@@ -842,6 +842,7 @@ public:
     ConcurrentJSLock& lock() { return m_lock; }
 
     unsigned propertyHash() const { return m_propertyHash; }
+    SeenProperties seenProperties() const { return m_seenProperties; }
 
     static bool shouldConvertToPolyProto(const Structure* a, const Structure* b);
 
@@ -882,7 +883,7 @@ public:
     DEFINE_BITFIELD(bool, hasAnyKindOfGetterSetterProperties, HasAnyKindOfGetterSetterProperties, 1, 3);
     DEFINE_BITFIELD(bool, hasReadOnlyOrGetterSetterPropertiesExcludingProto, HasReadOnlyOrGetterSetterPropertiesExcludingProto, 1, 4);
     DEFINE_BITFIELD(bool, isQuickPropertyAccessAllowedForEnumeration, IsQuickPropertyAccessAllowedForEnumeration, 1, 5);
-    DEFINE_BITFIELD(TransitionPropertyAttributes, transitionPropertyAttributes, TransitionPropertyAttributes, 7, 6);
+    DEFINE_BITFIELD(bool, hasNonEnumerableProperties, HasNonEnumerableProperties, 1, 6);
     DEFINE_BITFIELD(TransitionKind, transitionKind, TransitionKind, 5, 13);
     DEFINE_BITFIELD(bool, isWatchingReplacement, IsWatchingReplacement, 1, 18); // This flag can be fliped on the main thread at any timing.
     DEFINE_BITFIELD(bool, mayBePrototype, MayBePrototype, 1, 19);
@@ -899,7 +900,6 @@ public:
     DEFINE_BITFIELD(bool, hasNonConfigurableProperties, HasNonConfigurableProperties, 1, 30);
     DEFINE_BITFIELD(bool, hasNonConfigurableReadOnlyOrGetterSetterProperties, HasNonConfigurableReadOnlyOrGetterSetterProperties, 1, 31);
 
-    static_assert(s_bitWidthOfTransitionPropertyAttributes <= sizeof(TransitionPropertyAttributes) * 8);
     static_assert(s_bitWidthOfTransitionKind <= sizeof(TransitionKind) * 8);
 
     static bool bitFieldFlagsCantBeChangedWithoutTransition(unsigned flags)
@@ -907,6 +907,7 @@ public:
         return flags == (flags & (
             s_didPreventExtensionsBits
             | s_isQuickPropertyAccessAllowedForEnumerationBits
+            | s_hasNonEnumerablePropertiesBits
             | s_hasAnyKindOfGetterSetterPropertiesBits
             | s_hasReadOnlyOrGetterSetterPropertiesExcludingProtoBits
             | s_hasUnderscoreProtoPropertyExcludingOriginalProtoBits
@@ -914,6 +915,9 @@ public:
             | s_hasNonConfigurableReadOnlyOrGetterSetterPropertiesBits
         ));
     }
+
+    TransitionPropertyAttributes transitionPropertyAttributes() const { return m_transitionPropertyAttributes; }
+    void setTransitionPropertyAttributes(TransitionPropertyAttributes transitionPropertyAttributes) { m_transitionPropertyAttributes = transitionPropertyAttributes; }
 
     int transitionCountEstimate() const
     {
@@ -1055,6 +1059,7 @@ private:
     ConcurrentJSLock m_lock;
 
     uint32_t m_bitField;
+    TransitionPropertyAttributes m_transitionPropertyAttributes { 0 };
 
     uint16_t m_transitionOffset;
     uint16_t m_maxOffset;

--- a/Source/JavaScriptCore/runtime/StructureInlines.h
+++ b/Source/JavaScriptCore/runtime/StructureInlines.h
@@ -478,6 +478,8 @@ inline PropertyOffset Structure::add(VM& vm, PropertyName propertyName, unsigned
     checkConsistency();
     if (attributes & PropertyAttribute::DontEnum || propertyName.isSymbol())
         setIsQuickPropertyAccessAllowedForEnumeration(false);
+    if (attributes & PropertyAttribute::DontEnum)
+        setHasNonEnumerableProperties(true);
     if (attributes & PropertyAttribute::DontDelete) {
         setHasNonConfigurableProperties(true);
         if (attributes & PropertyAttribute::ReadOnlyOrAccessorOrCustomAccessorOrValue)
@@ -573,8 +575,10 @@ inline PropertyOffset Structure::attributeChange(VM& vm, PropertyName propertyNa
     if (offset == invalidOffset)
         return offset;
 
-    if (attributes & PropertyAttribute::DontEnum)
+    if (attributes & PropertyAttribute::DontEnum) {
+        setHasNonEnumerableProperties(true);
         setIsQuickPropertyAccessAllowedForEnumeration(false);
+    }
     if (attributes & PropertyAttribute::DontDelete) {
         setHasNonConfigurableProperties(true);
         if (attributes & PropertyAttribute::ReadOnlyOrAccessorOrCustomAccessorOrValue)
@@ -630,6 +634,8 @@ ALWAYS_INLINE auto Structure::addOrReplacePropertyWithoutTransition(VM& vm, Prop
     checkConsistency();
     if (newAttributes & PropertyAttribute::DontEnum || propertyName.isSymbol())
         setIsQuickPropertyAccessAllowedForEnumeration(false);
+    if (newAttributes & PropertyAttribute::DontEnum)
+        setHasNonEnumerableProperties(true);
     if (newAttributes & PropertyAttribute::DontDelete) {
         setHasNonConfigurableProperties(true);
         if (newAttributes & PropertyAttribute::ReadOnlyOrAccessorOrCustomAccessorOrValue)


### PR DESCRIPTION
#### 11aee4671a9e0291cec87cf0ebeb615d3f6ac51c
<pre>
[JSC] Use cloning for Object.assign with empty object
<a href="https://bugs.webkit.org/show_bug.cgi?id=267239">https://bugs.webkit.org/show_bug.cgi?id=267239</a>
<a href="https://rdar.apple.com/120667395">rdar://120667395</a>

Reviewed by Justin Michaud.

This patch implements fast cloning path for `Object.assign({}, source)` case.
When conditions are met, we clone Butterfly in source, set it to the empty target object,
and use the source&apos;s Structure for target. This completely avoids iterating all object properties.

* JSTests/stress/object-assign-clone.js: Added.
(shouldBe):
(shouldBeArray):
(shouldBe.Reflect.getOwnPropertyDescriptor):
(shouldBe.set get let):
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/runtime/JSObject.h:
* Source/JavaScriptCore/runtime/JSObjectInlines.h:
(JSC::JSObject::fastForEachPropertyWithSideEffectFreeFunctor): Deleted.
* Source/JavaScriptCore/runtime/ObjectConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::toPropertyDescriptor):
(JSC::defineProperties):
* Source/JavaScriptCore/runtime/ObjectConstructorInlines.h:
(JSC::objectCloneFast):
(JSC::objectAssignFast):
* Source/JavaScriptCore/runtime/Structure.cpp:
(JSC::Structure::Structure):
(JSC::Structure::nonPropertyTransitionSlow):
* Source/JavaScriptCore/runtime/Structure.h:
(JSC::Structure::seenProperties const):
(JSC::Structure::bitFieldFlagsCantBeChangedWithoutTransition):
(JSC::Structure::transitionPropertyAttributes const):
(JSC::Structure::setTransitionPropertyAttributes):
* Source/JavaScriptCore/runtime/StructureInlines.h:
(JSC::Structure::add):
(JSC::Structure::attributeChange):
(JSC::Structure::addOrReplacePropertyWithoutTransition):

Canonical link: <a href="https://commits.webkit.org/272794@main">https://commits.webkit.org/272794@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36f8e92d286741ec4af2a04827f9cfe6c14fe191

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33101 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11878 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35011 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35742 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/29894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14220 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9045 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/29304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33576 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/10005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/29565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/8725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/8870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/29537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37073 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/28326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/30073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/29929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/34996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/33115 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/9015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/6952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/32850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/10716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/39573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/9602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/8317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4256 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/9659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->