### PR TITLE
Fix open-layout-test after 272281@main

### DIFF
--- a/Tools/Scripts/open-layout-test
+++ b/Tools/Scripts/open-layout-test
@@ -35,6 +35,7 @@ from webkitpy.common.host import Host
 from webkitpy.layout_tests.controllers.layout_test_finder_legacy import LayoutTestFinder
 from webkitpy.layout_tests.servers.run_webkit_httpd import run_server as run_webkit_httpd
 from webkitpy.layout_tests.servers.run_webkit_httpd import parse_args as parse_httpd_args
+from webkitpy.port import DriverInput
 
 def parse_args(args):
     description = """Open a layout test using the default browser. Script will make sure to start a server if test needs it."""
@@ -59,12 +60,13 @@ def main(argv, stdout, stderr):
     test_name = paths[0]
 
     needs_server = False
-    if driver.is_http_test(test_name) and not port.is_http_server_running():
+    driver_input = DriverInput(test_name, 1000, None, None)
+    if driver.is_http_test(driver_input) and not port.is_http_server_running():
         needs_server = not port.is_http_server_running()
     elif driver.is_web_platform_test(test_name) or driver.is_webkit_specific_web_platform_test(test_name):
         needs_server = not port.is_wpt_server_running()
 
-    test_url = driver.test_to_uri(test_name)
+    test_url = driver.test_to_uri(driver_input)
     if not needs_server:
         print("Opening %s" % test_url)
         subprocess.Popen(['open', test_url])


### PR DESCRIPTION
#### f9268d81b1a1e32b5707e0273b780c35e4cada80
<pre>
Fix open-layout-test after 272281@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=267242">https://bugs.webkit.org/show_bug.cgi?id=267242</a>
<a href="https://rdar.apple.com/120672699">rdar://120672699</a>

Reviewed by Jonathan Bedard.

* Tools/Scripts/open-layout-test:
(main):
Update calls to is_http_test and test_to_uri to take in a DriverInput.

This was already done for the test runner and tests in <a href="https://commits.webkit.org/272281@main">https://commits.webkit.org/272281@main</a>,
but the open-layout-test tool was not modified. This fixes that. I&apos;ve confirmed there&apos;s no other
callers of these two methods that need updating.

Canonical link: <a href="https://commits.webkit.org/274501@main">https://commits.webkit.org/274501@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/203261f050d16a35dc2c0592121c63e8f2c90898

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33067 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11843 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34975 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35707 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29871 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34037 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14184 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9011 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29291 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33542 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9978 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29543 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8698 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8851 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29511 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37039 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30041 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29910 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34971 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8991 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6930 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32828 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10690 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9579 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5139 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9630 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->