### PR TITLE
Background tabs often crash (null deref) under DynamicContentScalingBifurcatedImageBuffer::dynamicContentScalingDisplayList()

### DIFF
--- a/Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingBifurcatedImageBuffer.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingBifurcatedImageBuffer.mm
@@ -50,6 +50,8 @@ WebCore::GraphicsContext& DynamicContentScalingBifurcatedImageBuffer::context() 
 
 std::optional<WebCore::DynamicContentScalingDisplayList> DynamicContentScalingBifurcatedImageBuffer::dynamicContentScalingDisplayList()
 {
+    if (!m_dynamicContentScalingBackend)
+        return std::nullopt;
     auto* sharing = static_cast<WebCore::ImageBufferBackend&>(*m_dynamicContentScalingBackend).toBackendSharing();
     if (!is<ImageBufferBackendHandleSharing>(sharing))
         return std::nullopt;


### PR DESCRIPTION
#### 867fd6815a00b9b273ba4d9d0ed1c55e340d00dc
<pre>
Background tabs often crash (null deref) under DynamicContentScalingBifurcatedImageBuffer::dynamicContentScalingDisplayList()
<a href="https://bugs.webkit.org/show_bug.cgi?id=267246">https://bugs.webkit.org/show_bug.cgi?id=267246</a>
<a href="https://rdar.apple.com/120001661">rdar://120001661</a>

Reviewed by Richard Robinson and Wenson Hsieh.

* Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingBifurcatedImageBuffer.mm:
(WebKit::DynamicContentScalingBifurcatedImageBuffer::dynamicContentScalingDisplayList):
For a 0x0 layer, allocating the backend will fail (intentionally), and thus we
must not unconditionally dereference it when retrieving a display list.

Canonical link: <a href="https://commits.webkit.org/272792@main">https://commits.webkit.org/272792@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44a4980630ba4537c093c37ec588cb8fb4e12743

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33091 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11868 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35001 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35732 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/29887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14209 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9035 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/29300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33566 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/9998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/29554 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8715 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/8867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37063 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/30066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/29920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/34981 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/9008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/6946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/32837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/10709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/9595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4254 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/9651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->