### PR TITLE
Introduce StyleFontData to store the FontCascade object

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2369,6 +2369,8 @@ imported/w3c/web-platform-tests/svg/text/reftests/xml-lang-attribute.svg [ Image
 imported/w3c/web-platform-tests/svg/text/reftests/textpath-side-001.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/text/reftests/text-font-face-load-image.html [ Skip ]
 
+webkit.org/b/283954 imported/w3c/web-platform-tests/svg/text/reftests/transform-dynamic-change-root.html [ ImageOnlyFailure ]
+
 [ Debug ] fast/loader/document-with-fragment-url-3.html [ Pass Timeout ]
 [ Debug ] fast/loader/document-with-fragment-url-4.html [ Pass Timeout ]
 

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2564,6 +2564,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     rendering/style/StyleDeprecatedFlexibleBoxData.h
     rendering/style/StyleFilterData.h
     rendering/style/StyleFlexibleBoxData.h
+    rendering/style/StyleFontData.h
     rendering/style/StyleGridData.h
     rendering/style/StyleGridItemData.h
     rendering/style/StyleImage.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2955,6 +2955,7 @@ rendering/style/StyleDeprecatedFlexibleBoxData.cpp
 rendering/style/StyleFilterData.cpp
 rendering/style/StyleFilterImage.cpp
 rendering/style/StyleFlexibleBoxData.cpp
+rendering/style/StyleFontData.cpp
 rendering/style/StyleGeneratedImage.cpp
 rendering/style/StyleGradientImage.cpp
 rendering/style/StyleGridData.cpp

--- a/Source/WebCore/platform/graphics/FontCascadeDescription.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeDescription.cpp
@@ -170,6 +170,7 @@ TextStream& operator<<(TextStream& ts, const FontCascadeDescription& fontCascade
     }
 
     ts << ", specified size " << fontCascadeDescription.specifiedSize();
+    ts << ", computed size " << fontCascadeDescription.computedSize();
     ts << ", is absolute size " << fontCascadeDescription.isAbsoluteSize();
     if (fontCascadeDescription.kerning() != Kerning::Auto)
         ts << ", kerning " << fontCascadeDescription.kerning();

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -557,7 +557,7 @@ unsigned RenderStyle::hashForTextAutosizing() const
     hash ^= m_rareInheritedData->nbspMode;
     hash ^= m_rareInheritedData->lineBreak;
     hash ^= WTF::FloatHash<float>::hash(m_inheritedData->specifiedLineHeight.value());
-    hash ^= computeFontHash(m_inheritedData->fontCascade);
+    hash ^= computeFontHash(m_inheritedData->fontData->fontCascade);
     hash ^= WTF::FloatHash<float>::hash(m_inheritedData->horizontalBorderSpacing);
     hash ^= WTF::FloatHash<float>::hash(m_inheritedData->verticalBorderSpacing);
     hash ^= m_inheritedFlags.boxDirection;
@@ -579,7 +579,7 @@ bool RenderStyle::equalForTextAutosizing(const RenderStyle& other) const
         && m_rareInheritedData->lineBreak == other.m_rareInheritedData->lineBreak
         && m_rareInheritedData->textSecurity == other.m_rareInheritedData->textSecurity
         && m_inheritedData->specifiedLineHeight == other.m_inheritedData->specifiedLineHeight
-        && m_inheritedData->fontCascade.equalForTextAutoSizing(other.m_inheritedData->fontCascade)
+        && m_inheritedData->fontData->fontCascade.equalForTextAutoSizing(other.m_inheritedData->fontData->fontCascade)
         && m_inheritedData->horizontalBorderSpacing == other.m_inheritedData->horizontalBorderSpacing
         && m_inheritedData->verticalBorderSpacing == other.m_inheritedData->verticalBorderSpacing
         && m_inheritedFlags.boxDirection == other.m_inheritedFlags.boxDirection
@@ -1025,9 +1025,11 @@ bool RenderStyle::changeRequiresLayout(const RenderStyle& other, OptionSet<Style
 #if ENABLE(TEXT_AUTOSIZING)
             || m_inheritedData->specifiedLineHeight != other.m_inheritedData->specifiedLineHeight
 #endif
-            || m_inheritedData->fontCascade != other.m_inheritedData->fontCascade
             || m_inheritedData->horizontalBorderSpacing != other.m_inheritedData->horizontalBorderSpacing
             || m_inheritedData->verticalBorderSpacing != other.m_inheritedData->verticalBorderSpacing)
+            return true;
+
+        if (m_inheritedData->fontData != other.m_inheritedData->fontData)
             return true;
     }
 
@@ -1982,7 +1984,7 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
             changingProperties.m_properties.set(CSSPropertyLineHeight);
 #endif
 
-        if (first.fontCascade != second.fontCascade) {
+        if (first.fontData != second.fontData) {
             changingProperties.m_properties.set(CSSPropertyWordSpacing);
             changingProperties.m_properties.set(CSSPropertyLetterSpacing);
             changingProperties.m_properties.set(CSSPropertyTextRendering);
@@ -2716,17 +2718,17 @@ AnimationList& RenderStyle::ensureTransitions()
 
 const FontCascade& RenderStyle::fontCascade() const
 {
-    return m_inheritedData->fontCascade;
+    return m_inheritedData->fontData->fontCascade;
 }
 
 const FontMetrics& RenderStyle::metricsOfPrimaryFont() const
 {
-    return m_inheritedData->fontCascade.metricsOfPrimaryFont();
+    return m_inheritedData->fontData->fontCascade.metricsOfPrimaryFont();
 }
 
 const FontCascadeDescription& RenderStyle::fontDescription() const
 {
-    return m_inheritedData->fontCascade.fontDescription();
+    return m_inheritedData->fontData->fontCascade.fontDescription();
 }
 
 float RenderStyle::specifiedFontSize() const
@@ -2764,7 +2766,7 @@ void RenderStyle::setFontCascade(FontCascade&& fontCascade)
     if (fontCascade == this->fontCascade())
         return;
 
-    m_inheritedData.access().fontCascade = fontCascade;
+    m_inheritedData.access().fontData.access().fontCascade = fontCascade;
 }
 
 void RenderStyle::setFontDescription(FontCascadeDescription&& description)
@@ -2785,7 +2787,7 @@ bool RenderStyle::setFontDescriptionWithoutUpdate(FontCascadeDescription&& descr
     if (fontDescription() == description)
         return false;
 
-    auto& cascade = m_inheritedData.access().fontCascade;
+    auto& cascade = m_inheritedData.access().fontData.access().fontCascade;
     cascade = { WTFMove(description), cascade };
     return true;
 }
@@ -2864,7 +2866,7 @@ void RenderStyle::setLetterSpacing(Length&& spacing)
         return;
 
     bool oldShouldDisableLigatures = fontDescription().shouldDisableLigaturesForSpacing();
-    m_inheritedData.access().fontCascade.setLetterSpacing(WTFMove(spacing));
+    m_inheritedData.access().fontData.access().fontCascade.setLetterSpacing(WTFMove(spacing));
 
     // Switching letter-spacing between zero and non-zero requires updating fonts (to enable/disable ligatures)
     bool shouldDisableLigatures = fontCascade().letterSpacing();
@@ -2881,7 +2883,7 @@ void RenderStyle::setWordSpacing(Length&& spacing)
     if (fontCascade().computedWordSpacing() == spacing)
         return;
 
-    m_inheritedData.access().fontCascade.setWordSpacing(WTFMove(spacing));
+    m_inheritedData.access().fontData.access().fontCascade.setWordSpacing(WTFMove(spacing));
 }
 
 void RenderStyle::setTextSpacingTrim(TextSpacingTrim value)

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -43,6 +43,7 @@
 #include "StyleDeprecatedFlexibleBoxData.h"
 #include "StyleFilterData.h"
 #include "StyleFlexibleBoxData.h"
+#include "StyleFontData.h"
 #include "StyleGridData.h"
 #include "StyleGridItemData.h"
 #include "StyleInheritedData.h"
@@ -558,7 +559,7 @@ inline const StyleContentAlignmentData& RenderStyle::justifyContent() const { re
 inline const StyleSelfAlignmentData& RenderStyle::justifyItems() const { return m_nonInheritedData->miscData->justifyItems; }
 inline const StyleSelfAlignmentData& RenderStyle::justifySelf() const { return m_nonInheritedData->miscData->justifySelf; }
 inline const Length& RenderStyle::left() const { return m_nonInheritedData->surroundData->offset.left(); }
-inline float RenderStyle::letterSpacing() const { return m_inheritedData->fontCascade.letterSpacing(); }
+inline float RenderStyle::letterSpacing() const { return m_inheritedData->fontData->fontCascade.letterSpacing(); }
 inline LineAlign RenderStyle::lineAlign() const { return static_cast<LineAlign>(m_rareInheritedData->lineAlign); }
 inline OptionSet<LineBoxContain> RenderStyle::lineBoxContain() const { return OptionSet<LineBoxContain>::fromRaw(m_rareInheritedData->lineBoxContain); }
 inline LineBreak RenderStyle::lineBreak() const { return static_cast<LineBreak>(m_rareInheritedData->lineBreak); }
@@ -785,7 +786,7 @@ inline const Length& RenderStyle::width() const { return m_nonInheritedData->box
 inline WillChangeData* RenderStyle::willChange() const { return m_nonInheritedData->rareData->willChange.get(); }
 inline bool RenderStyle::willChangeCreatesStackingContext() const { return willChange() && willChange()->canCreateStackingContext(); }
 inline WordBreak RenderStyle::wordBreak() const { return static_cast<WordBreak>(m_rareInheritedData->wordBreak); }
-inline float RenderStyle::wordSpacing() const { return m_inheritedData->fontCascade.wordSpacing(); }
+inline float RenderStyle::wordSpacing() const { return m_inheritedData->fontData->fontCascade.wordSpacing(); }
 constexpr LengthType RenderStyle::zeroLength() { return LengthType::Fixed; }
 inline float RenderStyle::zoom() const { return m_nonInheritedData->rareData->zoom; }
 

--- a/Source/WebCore/rendering/style/StyleFontData.cpp
+++ b/Source/WebCore/rendering/style/StyleFontData.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#include "config.h"
+#include "StyleFontData.h"
+
+namespace WebCore {
+
+StyleFontData::StyleFontData() = default;
+
+StyleFontData::StyleFontData(const StyleFontData& o)
+    : fontCascade(o.fontCascade)
+{
+}
+
+Ref<StyleFontData> StyleFontData::copy() const
+{
+    return adoptRef(*new StyleFontData(*this));
+}
+
+bool StyleFontData::operator==(const StyleFontData& o) const
+{
+    return fontCascade == o.fontCascade;
+}
+
+#if !LOG_DISABLED
+void StyleFontData::dumpDifferences(TextStream& ts, const StyleFontData& other) const
+{
+    if (fontCascade != other.fontCascade)
+        ts << "fontCascade differs:\n  " << fontCascade << "\n  " << other.fontCascade;
+}
+#endif
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/style/StyleFontData.h
+++ b/Source/WebCore/rendering/style/StyleFontData.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#pragma once
+
+#include "FontCascade.h"
+#include <wtf/DataRef.h>
+
+namespace WTF {
+class TextStream;
+}
+
+namespace WebCore {
+
+class StyleFontData : public RefCounted<StyleFontData> {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    static Ref<StyleFontData> create() { return adoptRef(*new StyleFontData); }
+    Ref<StyleFontData> copy() const;
+
+    bool operator==(const StyleFontData&) const;
+
+#if !LOG_DISABLED
+    void dumpDifferences(TextStream&, const StyleFontData&) const;
+#endif
+
+    FontCascade fontCascade;
+
+private:
+    StyleFontData();
+    StyleFontData(const StyleFontData&);
+    void operator=(const StyleFontData&) = delete;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/style/StyleInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleInheritedData.cpp
@@ -24,6 +24,7 @@
 
 #include "RenderStyleInlines.h"
 #include "RenderStyleDifference.h"
+#include "StyleFontData.h"
 
 namespace WebCore {
 
@@ -36,6 +37,7 @@ StyleInheritedData::StyleInheritedData()
 #if ENABLE(TEXT_AUTOSIZING)
     , specifiedLineHeight(RenderStyle::initialLineHeight())
 #endif
+    , fontData(StyleFontData::create())
     , color(RenderStyle::initialColor())
     , visitedLinkColor(RenderStyle::initialColor())
 {
@@ -49,7 +51,7 @@ inline StyleInheritedData::StyleInheritedData(const StyleInheritedData& o)
 #if ENABLE(TEXT_AUTOSIZING)
     , specifiedLineHeight(o.specifiedLineHeight)
 #endif
-    , fontCascade(o.fontCascade)
+    , fontData(o.fontData)
     , color(o.color)
     , visitedLinkColor(o.visitedLinkColor)
 {
@@ -80,7 +82,7 @@ bool StyleInheritedData::nonFastPathInheritedEqual(const StyleInheritedData& oth
 #if ENABLE(TEXT_AUTOSIZING)
         && specifiedLineHeight == other.specifiedLineHeight
 #endif
-        && fontCascade == other.fontCascade
+        && fontData == other.fontData
         && horizontalBorderSpacing == other.horizontalBorderSpacing
         && verticalBorderSpacing == other.verticalBorderSpacing;
 }
@@ -94,6 +96,8 @@ void StyleInheritedData::fastPathInheritFrom(const StyleInheritedData& inheritPa
 #if !LOG_DISABLED
 void StyleInheritedData::dumpDifferences(TextStream& ts, const StyleInheritedData& other) const
 {
+    fontData->dumpDifferences(ts, *other.fontData);
+
     LOG_IF_DIFFERENT(horizontalBorderSpacing);
     LOG_IF_DIFFERENT(verticalBorderSpacing);
     LOG_IF_DIFFERENT(lineHeight);
@@ -101,10 +105,6 @@ void StyleInheritedData::dumpDifferences(TextStream& ts, const StyleInheritedDat
 #if ENABLE(TEXT_AUTOSIZING)
     LOG_IF_DIFFERENT(specifiedLineHeight);
 #endif
-
-    // fontCascade is complex, so gets special dumping.
-    if (fontCascade != other.fontCascade)
-        ts << "fontCascade differs:\n  " << fontCascade << "\n  " << other.fontCascade;
 
     LOG_IF_DIFFERENT(color);
     LOG_IF_DIFFERENT(visitedLinkColor);

--- a/Source/WebCore/rendering/style/StyleInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleInheritedData.h
@@ -27,12 +27,15 @@
 #include "FontCascade.h"
 #include "Length.h"
 #include "StyleColor.h"
+#include <wtf/DataRef.h>
 
 namespace WTF {
 class TextStream;
 }
 
 namespace WebCore {
+
+class StyleFontData;
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleInheritedData);
 class StyleInheritedData : public RefCounted<StyleInheritedData> {
@@ -59,7 +62,7 @@ public:
     Length specifiedLineHeight;
 #endif
 
-    FontCascade fontCascade;
+    DataRef<StyleFontData> fontData;
     Color color;
     Color visitedLinkColor;
 


### PR DESCRIPTION
#### 035afb7932796efbe52c82c55242711cd739ed61
<pre>
Introduce StyleFontData to store the FontCascade object
<a href="https://bugs.webkit.org/show_bug.cgi?id=267252">https://bugs.webkit.org/show_bug.cgi?id=267252</a>
<a href="https://rdar.apple.com/120688639">rdar://120688639</a>

Reviewed by Cameron McCormack.

FontCascade::operator== shows up on profiles under RenderStyle::diff() in the Design subtest
of MotionMark, which is animating the `color` property on many elements. `color` and
`fontCascade` are both members of `StyleInheritedData`, so we end up copying and comparing
`StyleInheritedData` a lot.

But FontCascade is large (232 bytes) and expensive to compare, so we can optimize by moving
it into its own ref-counted class that `StyleInheritedData` can own via a `DataRef`. This
approach was chosen, rather than making `FontCascade` directly ref-counted, because it&apos;s
used on the stack in various places.

Now RenderStyle can test for `fontData` pointer equality in various places before doing more
expensive checks.

* LayoutTests/TestExpectations:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/FontCascadeDescription.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::hashForTextAutosizing const):
(WebCore::RenderStyle::equalForTextAutosizing const):
(WebCore::RenderStyle::changeRequiresLayout const):
(WebCore::RenderStyle::conservativelyCollectChangedAnimatableProperties const):
(WebCore::RenderStyle::fontCascade const):
(WebCore::RenderStyle::metricsOfPrimaryFont const):
(WebCore::RenderStyle::fontDescription const):
(WebCore::RenderStyle::setFontCascade):
(WebCore::RenderStyle::setFontDescription):
(WebCore::RenderStyle::setLetterSpacing):
(WebCore::RenderStyle::setWordSpacing):
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::letterSpacing const):
(WebCore::RenderStyle::wordSpacing const):
* Source/WebCore/rendering/style/StyleFontData.cpp: Added.
(WebCore::StyleFontData::StyleFontData):
(WebCore::StyleFontData::copy const):
(WebCore::StyleFontData::operator== const):
(WebCore::StyleFontData::dumpDifferences const):
* Source/WebCore/rendering/style/StyleFontData.h: Added.
(WebCore::StyleFontData::create):
* Source/WebCore/rendering/style/StyleInheritedData.cpp:
(WebCore::StyleInheritedData::StyleInheritedData):
(WebCore::StyleInheritedData::nonFastPathInheritedEqual const):
(WebCore::StyleInheritedData::dumpDifferences const):
* Source/WebCore/rendering/style/StyleInheritedData.h:

Canonical link: <a href="https://commits.webkit.org/287648@main">https://commits.webkit.org/287648@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd9786ecb79c23abfc3a5f0d370264e399c7e437

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80432 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59438 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34090 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/84953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/31414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82543 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68500 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7741 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/84953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/31414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83501 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/52938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/73231 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/84953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/50247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27387 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29873 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/71387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27907 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86387 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7657 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/5406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/71132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7832 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69069 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/70372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17520 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/14377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/13325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7619 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/13139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/7458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/10978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9264 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->