### PR TITLE
Resync web-platform-tests/tools from upstream 080b865ef

### DIFF
--- a/LayoutTests/imported/w3c/resources/config.json
+++ b/LayoutTests/imported/w3c/resources/config.json
@@ -10,7 +10,7 @@
           {"url-path": "/webkit-test-resources/", "local-dir":"../../../resources/"},
           {"url-path": "/WebKit/", "local-dir":"../../../http/wpt/"}],
  "check_subdomains": false,
- "log_level":"debug",
+ "logging": { "level": "debug" },
  "bind_address": true,
  "ssl": {"type": "openssl",
          "encrypt_after_connect": false,

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/serve/serve.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/serve/serve.py
@@ -633,7 +633,7 @@ class ServerProc:
         # in the logging module unlocked
         importlib.reload(logging)
 
-        logger = get_logger(config.log_level, log_handlers)
+        logger = get_logger(config.logging["level"], log_handlers)
 
         if sys.platform == "darwin":
             # on Darwin, NOFILE starts with a very low limit (256), so bump it up a little
@@ -1003,7 +1003,6 @@ class ConfigBuilder(config.ConfigBuilder):
             "webtransport-h3": ["auto"],
         },
         "check_subdomains": True,
-        "log_level": "info",
         "bind_address": True,
         "ssl": {
             "type": "pregenerated",
@@ -1022,7 +1021,11 @@ class ConfigBuilder(config.ConfigBuilder):
             },
             "none": {}
         },
-        "aliases": []
+        "aliases": [],
+        "logging": {
+            "level": "info",
+            "suppress_handler_traceback": False
+        }
     }
 
     computed_properties = ["ws_doc_root"] + config.ConfigBuilder.computed_properties
@@ -1082,7 +1085,7 @@ def build_config(logger, override_path=None, config_cls=ConfigBuilder, **kwargs)
             raise ValueError("Config path %s does not exist" % other_path)
 
     if kwargs.get("verbose"):
-        rv.log_level = "debug"
+        rv.logging["level"] = "DEBUG"
 
     setattr(rv, "inject_script", kwargs.get("inject_script"))
 
@@ -1174,7 +1177,7 @@ def run(config_cls=ConfigBuilder, route_builder=None, mp_context=None, log_handl
                       config_cls=config_cls,
                       **kwargs) as config:
         # This sets the right log level
-        logger = get_logger(config.log_level, log_handlers)
+        logger = get_logger(config.logging["level"], log_handlers)
 
         bind_address = config["bind_address"]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/wave/www/css/bulma-0.7.5/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/wave/www/css/bulma-0.7.5/w3c-import.log
@@ -9,8 +9,8 @@ Do NOT modify or remove this file.
 
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
-user-select
 text-size-adjust
+user-select
 Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/wptrunner/wptrunner/environment.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/wptrunner/wptrunner/environment.py
@@ -93,7 +93,8 @@ class TestEnvironment:
     websockets servers"""
     def __init__(self, test_paths, testharness_timeout_multipler,
                  pause_after_test, debug_test, debug_info, options, ssl_config, env_extras,
-                 enable_webtransport=False, mojojs_path=None, inject_script=None):
+                 enable_webtransport=False, mojojs_path=None, inject_script=None,
+                 suppress_handler_traceback=None):
 
         self.test_paths = test_paths
         self.server = None
@@ -117,6 +118,7 @@ class TestEnvironment:
         self.enable_webtransport = enable_webtransport
         self.mojojs_path = mojojs_path
         self.inject_script = inject_script
+        self.suppress_handler_traceback = suppress_handler_traceback
 
     def __enter__(self):
         server_log_handler = self.server_logging_ctx.__enter__()
@@ -212,6 +214,9 @@ class TestEnvironment:
         config.server_host = self.options.get("server_host", None)
         config.doc_root = serve_path(self.test_paths)
         config.inject_script = self.inject_script
+
+        if self.suppress_handler_traceback is not None:
+            config.logging["suppress_handler_traceback"] = self.suppress_handler_traceback
 
         return config
 

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/wptrunner/wptrunner/wptcommandline.py
@@ -261,6 +261,11 @@ scheme host and port.""")
                               help="Don't run browser in headless mode")
     config_group.add_argument("--instrument-to-file", action="store",
                               help="Path to write instrumentation logs to")
+    config_group.add_argument("--suppress-handler-traceback", action="store_true", default=None,
+                              help="Don't write the stacktrace for exceptions in server handlers")
+    config_group.add_argument("--no-suppress-handler-traceback", action="store_false",
+                              dest="supress_handler_traceback",
+                              help="Write the stacktrace for exceptions in server handlers")
 
     build_type = parser.add_mutually_exclusive_group()
     build_type.add_argument("--debug-build", dest="debug", action="store_true",

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/wptrunner/wptrunner/wptrunner.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/wptrunner/wptrunner/wptrunner.py
@@ -413,7 +413,8 @@ def run_tests(config, test_paths, product, **kwargs):
                                  env_extras,
                                  kwargs["enable_webtransport_h3"],
                                  mojojs_path,
-                                 inject_script) as test_environment:
+                                 inject_script,
+                                 kwargs["suppress_handler_traceback"]) as test_environment:
             recording.set(["startup", "ensure_environment"])
             try:
                 test_environment.ensure_started()

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/wptserve/tests/functional/test_response.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/wptserve/tests/functional/test_response.py
@@ -207,14 +207,16 @@ class TestH2Response(TestUsingH2Server):
     def test_set_error(self):
         @wptserve.handlers.handler
         def handler(request, response):
-            response.set_error(503, message="Test error")
+            response.set_error(503, "Test error")
 
         route = ("GET", "/h2test/test_set_error", handler)
         self.server.router.register(*route)
         resp = self.client.get(route[1])
 
         assert resp.status_code == 503
-        assert json.loads(resp.content) == json.loads("{\"error\": {\"message\": \"Test error\", \"code\": 503}}")
+        error = json.loads(resp.content)["error"]
+        assert error["code"] == 503
+        assert "Test error" in error["message"]
 
     def test_file_like_response(self):
         @wptserve.handlers.handler

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/wptserve/wptserve/config.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/wptserve/wptserve/config.py
@@ -133,7 +133,6 @@ class ConfigBuilder:
         "server_host": None,
         "ports": {"http": [8000]},
         "check_subdomains": True,
-        "log_level": "debug",
         "bind_address": True,
         "ssl": {
             "type": "none",
@@ -152,14 +151,18 @@ class ConfigBuilder:
                 "host_cert_path": None,
             },
         },
-        "aliases": []
+        "aliases": [],
+        "logging": {
+            "level": "debug",
+            "suppress_handler_traceback": False,
+        }
     }
     default_config_cls = Config
 
     # Configuration properties that are computed. Each corresponds to a method
     # _get_foo, which is called with the current data dictionary. The properties
     # are computed in the order specified in the list.
-    computed_properties = ["log_level",
+    computed_properties = ["logging",
                            "paths",
                            "server_host",
                            "ports",
@@ -209,6 +212,12 @@ class ConfigBuilder:
         else:
             self.__dict__[key] = value
 
+    def __getattr__(self, key):
+        if not key[0] == "_":
+            return self._data[key]
+        else:
+            return self.__dict__[key]
+
     def update(self, override):
         """Load an overrides dict to override config values"""
         override = override.copy()
@@ -251,8 +260,10 @@ class ConfigBuilder:
         self._ssl_env.__exit__(*args)
         self._ssl_env = None
 
-    def _get_log_level(self, data):
-        return data["log_level"].upper()
+    def _get_logging(self, data):
+        logging = data["logging"]
+        logging["level"] = logging["level"].upper()
+        return logging
 
     def _get_paths(self, data):
         return {"doc_root": data["doc_root"]}

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/wptserve/wptserve/handlers.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/wptserve/wptserve/handlers.py
@@ -2,7 +2,6 @@
 
 import json
 import os
-import traceback
 from collections import defaultdict
 
 from urllib.parse import quote, unquote, urljoin
@@ -361,9 +360,8 @@ class FunctionHandler:
             rv = self.func(request, response)
         except HTTPException:
             raise
-        except Exception:
-            msg = traceback.format_exc()
-            raise HTTPException(500, message=msg)
+        except Exception as e:
+            raise HTTPException(500) from e
         if rv is not None:
             if isinstance(rv, tuple):
                 if len(rv) == 3:

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/wptserve/wptserve/response.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/wptserve/wptserve/response.py
@@ -1,10 +1,11 @@
 # mypy: allow-untyped-defs
 
+import json
+import uuid
+import traceback
 from collections import OrderedDict
 from datetime import datetime, timedelta
 from io import BytesIO
-import json
-import uuid
 
 from hpack.struct import HeaderTuple
 from http.cookies import BaseCookie, Morsel
@@ -238,27 +239,46 @@ class Response:
         self.write_status_headers()
         self.write_content()
 
-    def set_error(self, code, message=""):
+    def set_error(self, code, err=None):
         """Set the response status headers and return a JSON error object:
 
         {"error": {"code": code, "message": message}}
         code is an int (HTTP status code), and message is a text string.
         """
-        err = {"code": code,
-               "message": message}
-        data = json.dumps({"error": err})
+        if 500 <= code < 600:
+            message = self._format_server_error(err)
+            self.logger.warning(message)
+        else:
+            if err is None:
+                message = ""
+            else:
+                message = str(err)
+
+        data = json.dumps({"error": {
+            "code": code,
+            "message": message}
+        })
         self.status = code
         self.headers = [("Content-Type", "application/json"),
                         ("Content-Length", len(data))]
         self.content = data
-        if code == 500:
-            if isinstance(message, str) and message:
-                first_line = message.splitlines()[0]
-            else:
-                first_line = "<no message given>"
-            self.logger.error("Exception loading %s: %s" % (self.request.url,
-                                                            first_line))
-            self.logger.info(message)
+
+    def _format_server_error(self, err):
+        if err is None:
+            suffix = "<no traceback>"
+        elif isinstance(err, str):
+            suffix = err
+        elif self.request.server.config.logging["suppress_handler_traceback"]:
+            frame = traceback.extract_tb(err.__traceback__)[-1]
+            suffix = (f"""File "{frame.filename}", line {frame.lineno} """
+                      f"""in {frame.name} (traceback suppressed)""")
+        else:
+            tb = "\n".join(f"  {line}"
+                           for line in traceback.format_tb(err.__traceback__))
+            suffix = f"""Traceback (most recent call last):
+{tb}  {type(err).__name__}: {err}
+"""
+        return f"Internal server error loading {self.request.url}:\n  {suffix}"
 
 
 class MultipartContent:

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/wptserve/wptserve/server.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/wptserve/wptserve/server.py
@@ -4,7 +4,6 @@ import errno
 import http.server
 import os
 import socket
-from socketserver import ThreadingMixIn
 import ssl
 import sys
 import threading
@@ -33,7 +32,7 @@ from .logger import get_logger
 from .request import Server, Request, H2Request
 from .response import Response, H2Response
 from .router import Router
-from .utils import HTTPException, isomorphic_decode, isomorphic_encode
+from .utils import HTTPException, get_error_cause, isomorphic_decode, isomorphic_encode
 from .constants import h2_headers
 from .ws_h2_handshake import WsH2Handshaker
 
@@ -129,7 +128,7 @@ class RequestRewriter:
                 request_handler.path = new_url
 
 
-class WebTestServer(ThreadingMixIn, http.server.HTTPServer):
+class WebTestServer(http.server.ThreadingHTTPServer):
     allow_reuse_address = True
     acceptable_errors = (errno.EPIPE, errno.ECONNABORTED)
     request_queue_size = 2000
@@ -190,7 +189,7 @@ class WebTestServer(ThreadingMixIn, http.server.HTTPServer):
         else:
             hostname_port = ("",server_address[1])
 
-        http.server.HTTPServer.__init__(self, hostname_port, request_handler_cls, **kwargs)
+        super().__init__(hostname_port, request_handler_cls)
 
         if config is not None:
             Server.config = config
@@ -243,7 +242,7 @@ class BaseWebTestRequestHandler(http.server.BaseHTTPRequestHandler):
 
     def __init__(self, *args, **kwargs):
         self.logger = get_logger()
-        http.server.BaseHTTPRequestHandler.__init__(self, *args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def finish_handling_h1(self, request_line_is_valid):
 
@@ -288,12 +287,10 @@ class BaseWebTestRequestHandler(http.server.BaseHTTPRequestHandler):
             try:
                 handler(request, response)
             except HTTPException as e:
-                if 500 <= e.code < 600:
-                    self.logger.warning("HTTPException in handler: %s" % e)
-                    self.logger.warning(traceback.format_exc())
-                response.set_error(e.code, str(e))
+                exc = get_error_cause(e) if 500 <= e.code < 600 else e
+                response.set_error(e.code, exc)
             except Exception as e:
-                self.respond_with_error(response, e)
+                response.set_error(500, e)
         self.logger.debug("%i %s %s (%s) %i" % (response.status[0],
                                                 request.method,
                                                 request.request_path,
@@ -331,15 +328,6 @@ class BaseWebTestRequestHandler(http.server.BaseHTTPRequestHandler):
                                            server_side=True)
             self.setup()
         return
-
-    def respond_with_error(self, response, e):
-        message = str(e)
-        if message:
-            err = [message]
-        else:
-            err = []
-        err.append(traceback.format_exc())
-        response.set_error(500, "\n".join(err))
 
 
 class Http2WebTestRequestHandler(BaseWebTestRequestHandler):
@@ -490,8 +478,8 @@ class Http2WebTestRequestHandler(BaseWebTestRequestHandler):
             try:
                 handshaker.do_handshake()
             except HandshakeException as e:
-                self.logger.info('Handshake failed for error: %s' % e)
-                h2response.set_error(e.status)
+                self.logger.info("Handshake failed")
+                h2response.set_error(e.status, e)
                 h2response.write()
                 return
             except AbortedByUserException:
@@ -643,10 +631,11 @@ class Http2WebTestRequestHandler(BaseWebTestRequestHandler):
         try:
             return handler.frame_handler(request)
         except HTTPException as e:
-            response.set_error(e.code, str(e))
+            exc = get_error_cause(e) if 500 <= e.code < 600 else e
+            response.set_error(exc.code, exc)
             response.write()
         except Exception as e:
-            self.respond_with_error(response, e)
+            response.set_error(500, e)
             response.write()
 
 
@@ -726,10 +715,9 @@ class Http1WebTestRequestHandler(BaseWebTestRequestHandler):
             self.close_connection = True
             return
 
-        except Exception:
-            err = traceback.format_exc()
+        except Exception as e:
             if response:
-                response.set_error(500, err)
+                response.set_error(500, e)
                 response.write()
 
     def get_request_line(self):

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/wptserve/wptserve/utils.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/wptserve/wptserve/utils.py
@@ -193,3 +193,12 @@ def http2_compatible() -> bool:
             (ssl_v[0] == 1 and
              (ssl_v[1] == 1 or
               (ssl_v[1] == 0 and ssl_v[2] >= 2))))
+
+
+def get_error_cause(exc: BaseException) -> BaseException:
+    """Get the parent cause/context from an exception"""
+    if exc.__cause__ is not None:
+        return exc.__cause__
+    if exc.__context__ is not None:
+        return exc.__context__
+    return exc


### PR DESCRIPTION
#### 998129fba1e0363368d1ec6cc58261131a08258c
<pre>
Resync web-platform-tests/tools from upstream 080b865ef
<a href="https://bugs.webkit.org/show_bug.cgi?id=267256">https://bugs.webkit.org/show_bug.cgi?id=267256</a>

Reviewed by Tim Nguyen.

<a href="https://github.com/web-platform-tests/wpt/commit/080b865ef9e42c5ce85ab355586c2d087a1bf015">https://github.com/web-platform-tests/wpt/commit/080b865ef9e42c5ce85ab355586c2d087a1bf015</a>

A config property &apos;log_level&apos; was renamed to &apos;logging.level&apos;.

* LayoutTests/imported/w3c/resources/config.json: Renamed the config property.
* LayoutTests/imported/w3c/web-platform-tests/tools/*: Updated.

Canonical link: <a href="https://commits.webkit.org/272808@main">https://commits.webkit.org/272808@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e70ca72a1af58ea561f3551fe556d7708316b67

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33144 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11918 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35054 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35781 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29924 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34115 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14262 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9087 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29327 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33619 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10042 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29604 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8754 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8898 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29578 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37113 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30110 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29961 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35019 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9037 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6975 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32875 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10751 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7678 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9624 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9698 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->