### PR TITLE
REGRESSION (268251@main): 2D contexts fail after GPUP IOSurface limits have been exceeded

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7445,3 +7445,6 @@ http/wpt/opener/parent-access-child-via-windowproxy.html [ Skip ]
 webkit.org/b/266477 compositing/layer-creation/scale-rotation-transition-overlap.html [ Failure Timeout ]
 
 webkit.org/b/266986 imported/w3c/web-platform-tests/css/css-pseudo/highlight-pseudos-computed.html [ Failure ]
+
+# At the time of writing this test consumes all available IOSurfaces. If the next test is image-buffer-backend-variants.html, that will fail.
+fast/canvas/2d.context.many.small.html [ Slow Skip ]

--- a/LayoutTests/fast/canvas/2d.context.many.small-expected.html
+++ b/LayoutTests/fast/canvas/2d.context.many.small-expected.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+body {
+    margin: 0;
+}
+#container {
+    width: 700px;
+    height: 715px;
+    background: lime;
+}
+</style>
+</head>
+<body>
+<div id="container">
+</div>
+</body>
+</html>

--- a/LayoutTests/fast/canvas/2d.context.many.small.html
+++ b/LayoutTests/fast/canvas/2d.context.many.small.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html><!-- webkit-test-runner [ runSingly=true ] -->
+<html>
+<head>
+<style>
+body {
+    margin: 0;
+}
+canvas {
+    width: 5px;
+    height: 5px;
+    vertical-align: top;
+}
+#container {
+    width: 700px;
+    line-height: 5px;
+}
+</style>
+</head>
+<body>
+<div id="container"></div>
+<script>
+function runTest() {
+    const count = 20020;
+    for (let i = 0; i < count; ++i) {
+        let canvas = document.createElement("canvas");
+        canvas.width = 25;
+        canvas.height = 25;
+        let ctx = canvas.getContext("2d");
+        ctx.fillStyle = "lime";
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+        container.appendChild(canvas);
+    }
+}
+runTest();
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/canvas/image-buffer-backend-variants-expected.txt
+++ b/LayoutTests/fast/canvas/image-buffer-backend-variants-expected.txt
@@ -223,146 +223,160 @@ Testing 100x0 (area: 0)
 PASS Context was lost
 Testing 1x1 forced 'Accelerated' (area: 1)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 1x1000 forced 'Accelerated' (area: 1000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 1x2048 forced 'Accelerated' (area: 2048)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 1x4096 forced 'Accelerated' (area: 4096)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 1x8192 forced 'Accelerated' (area: 8192)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 1x16384 forced 'Accelerated' (area: 16384)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 1x32768 forced 'Accelerated' (area: 32768)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 1x32769 forced 'Accelerated' (area: 32769)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 1000x1 forced 'Accelerated' (area: 1000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 1000x1000 forced 'Accelerated' (area: 1000000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 1000x2048 forced 'Accelerated' (area: 2048000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 1000x4096 forced 'Accelerated' (area: 4096000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 1000x8192 forced 'Accelerated' (area: 8192000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 1000x16384 forced 'Accelerated' (area: 16384000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 1000x32768 forced 'Accelerated' (area: 32768000)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 1000x32769 forced 'Accelerated' (area: 32769000)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 2048x1 forced 'Accelerated' (area: 2048)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 2048x1000 forced 'Accelerated' (area: 2048000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 2048x2048 forced 'Accelerated' (area: 4194304)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 2048x4096 forced 'Accelerated' (area: 8388608)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 2048x8192 forced 'Accelerated' (area: 16777216)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 2048x16384 forced 'Accelerated' (area: 33554432)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 2048x32768 forced 'Accelerated' (area: 67108864)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 2048x32769 forced 'Accelerated' (area: 67110912)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 4096x1 forced 'Accelerated' (area: 4096)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 4096x1000 forced 'Accelerated' (area: 4096000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 4096x2048 forced 'Accelerated' (area: 8388608)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 4096x4096 forced 'Accelerated' (area: 16777216)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 4096x8192 forced 'Accelerated' (area: 33554432)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 4096x16384 forced 'Accelerated' (area: 67108864)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 4096x32768 forced 'Accelerated' (area: 134217728)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 4096x32769 forced 'Accelerated' (area: 134221824)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 8192x1 forced 'Accelerated' (area: 8192)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 8192x1000 forced 'Accelerated' (area: 8192000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 8192x2048 forced 'Accelerated' (area: 16777216)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 8192x4096 forced 'Accelerated' (area: 33554432)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 8192x8192 forced 'Accelerated' (area: 67108864)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 8192x16384 forced 'Accelerated' (area: 134217728)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 8192x32768 forced 'Accelerated' (area: 268435456)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 8192x32769 forced 'Accelerated' (area: 268443648)
 PASS Context was lost
 Testing 16384x1 forced 'Accelerated' (area: 16384)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 16384x1000 forced 'Accelerated' (area: 16384000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 16384x2048 forced 'Accelerated' (area: 33554432)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 16384x4096 forced 'Accelerated' (area: 67108864)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 16384x8192 forced 'Accelerated' (area: 134217728)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 16384x16384 forced 'Accelerated' (area: 268435456)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 16384x32768 forced 'Accelerated' (area: 536870912)
 PASS Context was lost
 Testing 16384x32769 forced 'Accelerated' (area: 536887296)
 PASS Context was lost
 Testing 32768x1 forced 'Accelerated' (area: 32768)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 32768x1000 forced 'Accelerated' (area: 32768000)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 32768x2048 forced 'Accelerated' (area: 67108864)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 32768x4096 forced 'Accelerated' (area: 134217728)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 32768x8192 forced 'Accelerated' (area: 268435456)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 32768x16384 forced 'Accelerated' (area: 536870912)
 PASS Context was lost
 Testing 32768x32768 forced 'Accelerated' (area: 1073741824)
@@ -370,13 +384,17 @@ PASS Context was lost
 Testing 32768x32769 forced 'Accelerated' (area: 1073774592)
 PASS Context was lost
 Testing 32769x1 forced 'Accelerated' (area: 32769)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 32769x1000 forced 'Accelerated' (area: 32769000)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 32769x2048 forced 'Accelerated' (area: 67110912)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 32769x4096 forced 'Accelerated' (area: 134221824)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 32769x8192 forced 'Accelerated' (area: 268443648)
 PASS Context was lost
 Testing 32769x16384 forced 'Accelerated' (area: 536887296)
@@ -393,160 +411,160 @@ Testing 100x0 forced 'Accelerated' (area: 0)
 PASS Context was lost
 Testing 1x1 forced 'Unaccelerated' (area: 1)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1x1000 forced 'Unaccelerated' (area: 1000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1x2048 forced 'Unaccelerated' (area: 2048)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1x4096 forced 'Unaccelerated' (area: 4096)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1x8192 forced 'Unaccelerated' (area: 8192)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1x16384 forced 'Unaccelerated' (area: 16384)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1x32768 forced 'Unaccelerated' (area: 32768)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1x32769 forced 'Unaccelerated' (area: 32769)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1000x1 forced 'Unaccelerated' (area: 1000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1000x1000 forced 'Unaccelerated' (area: 1000000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1000x2048 forced 'Unaccelerated' (area: 2048000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1000x4096 forced 'Unaccelerated' (area: 4096000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1000x8192 forced 'Unaccelerated' (area: 8192000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1000x16384 forced 'Unaccelerated' (area: 16384000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1000x32768 forced 'Unaccelerated' (area: 32768000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1000x32769 forced 'Unaccelerated' (area: 32769000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 2048x1 forced 'Unaccelerated' (area: 2048)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 2048x1000 forced 'Unaccelerated' (area: 2048000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 2048x2048 forced 'Unaccelerated' (area: 4194304)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 2048x4096 forced 'Unaccelerated' (area: 8388608)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 2048x8192 forced 'Unaccelerated' (area: 16777216)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 2048x16384 forced 'Unaccelerated' (area: 33554432)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 2048x32768 forced 'Unaccelerated' (area: 67108864)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 2048x32769 forced 'Unaccelerated' (area: 67110912)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 4096x1 forced 'Unaccelerated' (area: 4096)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 4096x1000 forced 'Unaccelerated' (area: 4096000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 4096x2048 forced 'Unaccelerated' (area: 8388608)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 4096x4096 forced 'Unaccelerated' (area: 16777216)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 4096x8192 forced 'Unaccelerated' (area: 33554432)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 4096x16384 forced 'Unaccelerated' (area: 67108864)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 4096x32768 forced 'Unaccelerated' (area: 134217728)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 4096x32769 forced 'Unaccelerated' (area: 134221824)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 8192x1 forced 'Unaccelerated' (area: 8192)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 8192x1000 forced 'Unaccelerated' (area: 8192000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 8192x2048 forced 'Unaccelerated' (area: 16777216)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 8192x4096 forced 'Unaccelerated' (area: 33554432)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 8192x8192 forced 'Unaccelerated' (area: 67108864)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 8192x16384 forced 'Unaccelerated' (area: 134217728)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 8192x32768 forced 'Unaccelerated' (area: 268435456)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 8192x32769 forced 'Unaccelerated' (area: 268443648)
 PASS Context was lost
 Testing 16384x1 forced 'Unaccelerated' (area: 16384)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 16384x1000 forced 'Unaccelerated' (area: 16384000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 16384x2048 forced 'Unaccelerated' (area: 33554432)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 16384x4096 forced 'Unaccelerated' (area: 67108864)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 16384x8192 forced 'Unaccelerated' (area: 134217728)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 16384x16384 forced 'Unaccelerated' (area: 268435456)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 16384x32768 forced 'Unaccelerated' (area: 536870912)
 PASS Context was lost
 Testing 16384x32769 forced 'Unaccelerated' (area: 536887296)
 PASS Context was lost
 Testing 32768x1 forced 'Unaccelerated' (area: 32768)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 32768x1000 forced 'Unaccelerated' (area: 32768000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 32768x2048 forced 'Unaccelerated' (area: 67108864)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 32768x4096 forced 'Unaccelerated' (area: 134217728)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 32768x8192 forced 'Unaccelerated' (area: 268435456)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 32768x16384 forced 'Unaccelerated' (area: 536870912)
 PASS Context was lost
 Testing 32768x32768 forced 'Unaccelerated' (area: 1073741824)
@@ -555,16 +573,16 @@ Testing 32768x32769 forced 'Unaccelerated' (area: 1073774592)
 PASS Context was lost
 Testing 32769x1 forced 'Unaccelerated' (area: 32769)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 32769x1000 forced 'Unaccelerated' (area: 32769000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 32769x2048 forced 'Unaccelerated' (area: 67110912)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 32769x4096 forced 'Unaccelerated' (area: 134221824)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 32769x8192 forced 'Unaccelerated' (area: 268443648)
 PASS Context was lost
 Testing 32769x16384 forced 'Unaccelerated' (area: 536887296)

--- a/LayoutTests/fast/canvas/image-buffer-backend-variants.html
+++ b/LayoutTests/fast/canvas/image-buffer-backend-variants.html
@@ -58,10 +58,9 @@ for (var subcase of subcases) {
     } 
     shouldBe("imageData.data", "red");
     if (typeof context.getEffectiveRenderingModeForTesting !== "undefined") {
-        if (subcase.renderingMode)
-            shouldBe("context.getEffectiveRenderingModeForTesting()", `'${"" + subcase.renderingMode}'`);
-        else
-            debug(`Effective renderingMode: ${context.getEffectiveRenderingModeForTesting()}`);
+        // Currently we do not require that the rendering mode request is adhered to.
+        // This is because Accelerated has run-time limitations, global IOSurface count limits.
+        debug(`Effective renderingMode: ${context.getEffectiveRenderingModeForTesting()}`);
     }
 }
 </script>

--- a/LayoutTests/platform/glib/fast/canvas/image-buffer-backend-variants-expected.txt
+++ b/LayoutTests/platform/glib/fast/canvas/image-buffer-backend-variants-expected.txt
@@ -205,132 +205,132 @@ Testing 100x0 (area: 0)
 PASS Context was lost
 Testing 1x1 forced 'Accelerated' (area: 1)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 1x1000 forced 'Accelerated' (area: 1000)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 1x2048 forced 'Accelerated' (area: 2048)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 1x4096 forced 'Accelerated' (area: 4096)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 1x8192 forced 'Accelerated' (area: 8192)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 1x16384 forced 'Accelerated' (area: 16384)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 1x32768 forced 'Accelerated' (area: 32768)
 PASS Context was lost
 Testing 1x32769 forced 'Accelerated' (area: 32769)
 PASS Context was lost
 Testing 1000x1 forced 'Accelerated' (area: 1000)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 1000x1000 forced 'Accelerated' (area: 1000000)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 1000x2048 forced 'Accelerated' (area: 2048000)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 1000x4096 forced 'Accelerated' (area: 4096000)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 1000x8192 forced 'Accelerated' (area: 8192000)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 1000x16384 forced 'Accelerated' (area: 16384000)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 1000x32768 forced 'Accelerated' (area: 32768000)
 PASS Context was lost
 Testing 1000x32769 forced 'Accelerated' (area: 32769000)
 PASS Context was lost
 Testing 2048x1 forced 'Accelerated' (area: 2048)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 2048x1000 forced 'Accelerated' (area: 2048000)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 2048x2048 forced 'Accelerated' (area: 4194304)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 2048x4096 forced 'Accelerated' (area: 8388608)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 2048x8192 forced 'Accelerated' (area: 16777216)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 2048x16384 forced 'Accelerated' (area: 33554432)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 2048x32768 forced 'Accelerated' (area: 67108864)
 PASS Context was lost
 Testing 2048x32769 forced 'Accelerated' (area: 67110912)
 PASS Context was lost
 Testing 4096x1 forced 'Accelerated' (area: 4096)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 4096x1000 forced 'Accelerated' (area: 4096000)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 4096x2048 forced 'Accelerated' (area: 8388608)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 4096x4096 forced 'Accelerated' (area: 16777216)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 4096x8192 forced 'Accelerated' (area: 33554432)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 4096x16384 forced 'Accelerated' (area: 67108864)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 4096x32768 forced 'Accelerated' (area: 134217728)
 PASS Context was lost
 Testing 4096x32769 forced 'Accelerated' (area: 134221824)
 PASS Context was lost
 Testing 8192x1 forced 'Accelerated' (area: 8192)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 8192x1000 forced 'Accelerated' (area: 8192000)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 8192x2048 forced 'Accelerated' (area: 16777216)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 8192x4096 forced 'Accelerated' (area: 33554432)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 8192x8192 forced 'Accelerated' (area: 67108864)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 8192x16384 forced 'Accelerated' (area: 134217728)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 8192x32768 forced 'Accelerated' (area: 268435456)
 PASS Context was lost
 Testing 8192x32769 forced 'Accelerated' (area: 268443648)
 PASS Context was lost
 Testing 16384x1 forced 'Accelerated' (area: 16384)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 16384x1000 forced 'Accelerated' (area: 16384000)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 16384x2048 forced 'Accelerated' (area: 33554432)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 16384x4096 forced 'Accelerated' (area: 67108864)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 16384x8192 forced 'Accelerated' (area: 134217728)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 16384x16384 forced 'Accelerated' (area: 268435456)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 16384x32768 forced 'Accelerated' (area: 536870912)
 PASS Context was lost
 Testing 16384x32769 forced 'Accelerated' (area: 536887296)
@@ -375,132 +375,132 @@ Testing 100x0 forced 'Accelerated' (area: 0)
 PASS Context was lost
 Testing 1x1 forced 'Unaccelerated' (area: 1)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1x1000 forced 'Unaccelerated' (area: 1000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1x2048 forced 'Unaccelerated' (area: 2048)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1x4096 forced 'Unaccelerated' (area: 4096)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1x8192 forced 'Unaccelerated' (area: 8192)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1x16384 forced 'Unaccelerated' (area: 16384)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1x32768 forced 'Unaccelerated' (area: 32768)
 PASS Context was lost
 Testing 1x32769 forced 'Unaccelerated' (area: 32769)
 PASS Context was lost
 Testing 1000x1 forced 'Unaccelerated' (area: 1000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1000x1000 forced 'Unaccelerated' (area: 1000000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1000x2048 forced 'Unaccelerated' (area: 2048000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1000x4096 forced 'Unaccelerated' (area: 4096000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1000x8192 forced 'Unaccelerated' (area: 8192000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1000x16384 forced 'Unaccelerated' (area: 16384000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1000x32768 forced 'Unaccelerated' (area: 32768000)
 PASS Context was lost
 Testing 1000x32769 forced 'Unaccelerated' (area: 32769000)
 PASS Context was lost
 Testing 2048x1 forced 'Unaccelerated' (area: 2048)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 2048x1000 forced 'Unaccelerated' (area: 2048000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 2048x2048 forced 'Unaccelerated' (area: 4194304)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 2048x4096 forced 'Unaccelerated' (area: 8388608)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 2048x8192 forced 'Unaccelerated' (area: 16777216)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 2048x16384 forced 'Unaccelerated' (area: 33554432)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 2048x32768 forced 'Unaccelerated' (area: 67108864)
 PASS Context was lost
 Testing 2048x32769 forced 'Unaccelerated' (area: 67110912)
 PASS Context was lost
 Testing 4096x1 forced 'Unaccelerated' (area: 4096)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 4096x1000 forced 'Unaccelerated' (area: 4096000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 4096x2048 forced 'Unaccelerated' (area: 8388608)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 4096x4096 forced 'Unaccelerated' (area: 16777216)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 4096x8192 forced 'Unaccelerated' (area: 33554432)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 4096x16384 forced 'Unaccelerated' (area: 67108864)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 4096x32768 forced 'Unaccelerated' (area: 134217728)
 PASS Context was lost
 Testing 4096x32769 forced 'Unaccelerated' (area: 134221824)
 PASS Context was lost
 Testing 8192x1 forced 'Unaccelerated' (area: 8192)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 8192x1000 forced 'Unaccelerated' (area: 8192000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 8192x2048 forced 'Unaccelerated' (area: 16777216)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 8192x4096 forced 'Unaccelerated' (area: 33554432)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 8192x8192 forced 'Unaccelerated' (area: 67108864)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 8192x16384 forced 'Unaccelerated' (area: 134217728)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 8192x32768 forced 'Unaccelerated' (area: 268435456)
 PASS Context was lost
 Testing 8192x32769 forced 'Unaccelerated' (area: 268443648)
 PASS Context was lost
 Testing 16384x1 forced 'Unaccelerated' (area: 16384)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 16384x1000 forced 'Unaccelerated' (area: 16384000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 16384x2048 forced 'Unaccelerated' (area: 33554432)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 16384x4096 forced 'Unaccelerated' (area: 67108864)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 16384x8192 forced 'Unaccelerated' (area: 134217728)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 16384x16384 forced 'Unaccelerated' (area: 268435456)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 16384x32768 forced 'Unaccelerated' (area: 536870912)
 PASS Context was lost
 Testing 16384x32769 forced 'Unaccelerated' (area: 536887296)

--- a/LayoutTests/platform/ios/fast/canvas/image-buffer-backend-variants-expected.txt
+++ b/LayoutTests/platform/ios/fast/canvas/image-buffer-backend-variants-expected.txt
@@ -271,61 +271,65 @@ Testing 100x0 (area: 0)
 PASS Context was lost
 Testing 1x1 forced 'Accelerated' (area: 1)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 1x1000 forced 'Accelerated' (area: 1000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 1x2048 forced 'Accelerated' (area: 2048)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 1x4096 forced 'Accelerated' (area: 4096)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 1x8192 forced 'Accelerated' (area: 8192)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 1x16384 forced 'Accelerated' (area: 16384)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 1x32768 forced 'Accelerated' (area: 32768)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 1x32769 forced 'Accelerated' (area: 32769)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 1000x1 forced 'Accelerated' (area: 1000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 1000x1000 forced 'Accelerated' (area: 1000000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 1000x2048 forced 'Accelerated' (area: 2048000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 1000x4096 forced 'Accelerated' (area: 4096000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 1000x8192 forced 'Accelerated' (area: 8192000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 1000x16384 forced 'Accelerated' (area: 16384000)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 1000x32768 forced 'Accelerated' (area: 32768000)
 PASS Context was lost
 Testing 1000x32769 forced 'Accelerated' (area: 32769000)
 PASS Context was lost
 Testing 2048x1 forced 'Accelerated' (area: 2048)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 2048x1000 forced 'Accelerated' (area: 2048000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 2048x2048 forced 'Accelerated' (area: 4194304)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 2048x4096 forced 'Accelerated' (area: 8388608)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 2048x8192 forced 'Accelerated' (area: 16777216)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 2048x16384 forced 'Accelerated' (area: 33554432)
 PASS Context was lost
 Testing 2048x32768 forced 'Accelerated' (area: 67108864)
@@ -334,16 +338,16 @@ Testing 2048x32769 forced 'Accelerated' (area: 67110912)
 PASS Context was lost
 Testing 4096x1 forced 'Accelerated' (area: 4096)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 4096x1000 forced 'Accelerated' (area: 4096000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 4096x2048 forced 'Accelerated' (area: 8388608)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 4096x4096 forced 'Accelerated' (area: 16777216)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 4096x8192 forced 'Accelerated' (area: 33554432)
 PASS Context was lost
 Testing 4096x16384 forced 'Accelerated' (area: 67108864)
@@ -354,13 +358,13 @@ Testing 4096x32769 forced 'Accelerated' (area: 134221824)
 PASS Context was lost
 Testing 8192x1 forced 'Accelerated' (area: 8192)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 8192x1000 forced 'Accelerated' (area: 8192000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 8192x2048 forced 'Accelerated' (area: 16777216)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 8192x4096 forced 'Accelerated' (area: 33554432)
 PASS Context was lost
 Testing 8192x8192 forced 'Accelerated' (area: 67108864)
@@ -372,9 +376,11 @@ PASS Context was lost
 Testing 8192x32769 forced 'Accelerated' (area: 268443648)
 PASS Context was lost
 Testing 16384x1 forced 'Accelerated' (area: 16384)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 16384x1000 forced 'Accelerated' (area: 16384000)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 16384x2048 forced 'Accelerated' (area: 33554432)
 PASS Context was lost
 Testing 16384x4096 forced 'Accelerated' (area: 67108864)
@@ -388,7 +394,8 @@ PASS Context was lost
 Testing 16384x32769 forced 'Accelerated' (area: 536887296)
 PASS Context was lost
 Testing 32768x1 forced 'Accelerated' (area: 32768)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 32768x1000 forced 'Accelerated' (area: 32768000)
 PASS Context was lost
 Testing 32768x2048 forced 'Accelerated' (area: 67108864)
@@ -404,7 +411,8 @@ PASS Context was lost
 Testing 32768x32769 forced 'Accelerated' (area: 1073774592)
 PASS Context was lost
 Testing 32769x1 forced 'Accelerated' (area: 32769)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 32769x1000 forced 'Accelerated' (area: 32769000)
 PASS Context was lost
 Testing 32769x2048 forced 'Accelerated' (area: 67110912)
@@ -427,65 +435,65 @@ Testing 100x0 forced 'Accelerated' (area: 0)
 PASS Context was lost
 Testing 1x1 forced 'Unaccelerated' (area: 1)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1x1000 forced 'Unaccelerated' (area: 1000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1x2048 forced 'Unaccelerated' (area: 2048)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1x4096 forced 'Unaccelerated' (area: 4096)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1x8192 forced 'Unaccelerated' (area: 8192)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1x16384 forced 'Unaccelerated' (area: 16384)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1x32768 forced 'Unaccelerated' (area: 32768)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1x32769 forced 'Unaccelerated' (area: 32769)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1000x1 forced 'Unaccelerated' (area: 1000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1000x1000 forced 'Unaccelerated' (area: 1000000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1000x2048 forced 'Unaccelerated' (area: 2048000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1000x4096 forced 'Unaccelerated' (area: 4096000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1000x8192 forced 'Unaccelerated' (area: 8192000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1000x16384 forced 'Unaccelerated' (area: 16384000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1000x32768 forced 'Unaccelerated' (area: 32768000)
 PASS Context was lost
 Testing 1000x32769 forced 'Unaccelerated' (area: 32769000)
 PASS Context was lost
 Testing 2048x1 forced 'Unaccelerated' (area: 2048)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 2048x1000 forced 'Unaccelerated' (area: 2048000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 2048x2048 forced 'Unaccelerated' (area: 4194304)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 2048x4096 forced 'Unaccelerated' (area: 8388608)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 2048x8192 forced 'Unaccelerated' (area: 16777216)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 2048x16384 forced 'Unaccelerated' (area: 33554432)
 PASS Context was lost
 Testing 2048x32768 forced 'Unaccelerated' (area: 67108864)
@@ -494,16 +502,16 @@ Testing 2048x32769 forced 'Unaccelerated' (area: 67110912)
 PASS Context was lost
 Testing 4096x1 forced 'Unaccelerated' (area: 4096)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 4096x1000 forced 'Unaccelerated' (area: 4096000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 4096x2048 forced 'Unaccelerated' (area: 8388608)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 4096x4096 forced 'Unaccelerated' (area: 16777216)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 4096x8192 forced 'Unaccelerated' (area: 33554432)
 PASS Context was lost
 Testing 4096x16384 forced 'Unaccelerated' (area: 67108864)
@@ -514,13 +522,13 @@ Testing 4096x32769 forced 'Unaccelerated' (area: 134221824)
 PASS Context was lost
 Testing 8192x1 forced 'Unaccelerated' (area: 8192)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 8192x1000 forced 'Unaccelerated' (area: 8192000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 8192x2048 forced 'Unaccelerated' (area: 16777216)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 8192x4096 forced 'Unaccelerated' (area: 33554432)
 PASS Context was lost
 Testing 8192x8192 forced 'Unaccelerated' (area: 67108864)
@@ -533,10 +541,10 @@ Testing 8192x32769 forced 'Unaccelerated' (area: 268443648)
 PASS Context was lost
 Testing 16384x1 forced 'Unaccelerated' (area: 16384)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 16384x1000 forced 'Unaccelerated' (area: 16384000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 16384x2048 forced 'Unaccelerated' (area: 33554432)
 PASS Context was lost
 Testing 16384x4096 forced 'Unaccelerated' (area: 67108864)
@@ -551,7 +559,7 @@ Testing 16384x32769 forced 'Unaccelerated' (area: 536887296)
 PASS Context was lost
 Testing 32768x1 forced 'Unaccelerated' (area: 32768)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 32768x1000 forced 'Unaccelerated' (area: 32768000)
 PASS Context was lost
 Testing 32768x2048 forced 'Unaccelerated' (area: 67108864)
@@ -568,7 +576,7 @@ Testing 32768x32769 forced 'Unaccelerated' (area: 1073774592)
 PASS Context was lost
 Testing 32769x1 forced 'Unaccelerated' (area: 32769)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 32769x1000 forced 'Unaccelerated' (area: 32769000)
 PASS Context was lost
 Testing 32769x2048 forced 'Unaccelerated' (area: 67110912)

--- a/LayoutTests/platform/mac-wk1/fast/canvas/image-buffer-backend-variants-expected.txt
+++ b/LayoutTests/platform/mac-wk1/fast/canvas/image-buffer-backend-variants-expected.txt
@@ -223,160 +223,160 @@ Testing 100x0 (area: 0)
 PASS Context was lost
 Testing 1x1 forced 'Accelerated' (area: 1)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 1x1000 forced 'Accelerated' (area: 1000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 1x2048 forced 'Accelerated' (area: 2048)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 1x4096 forced 'Accelerated' (area: 4096)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 1x8192 forced 'Accelerated' (area: 8192)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 1x16384 forced 'Accelerated' (area: 16384)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 1x32768 forced 'Accelerated' (area: 32768)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 1x32769 forced 'Accelerated' (area: 32769)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 1000x1 forced 'Accelerated' (area: 1000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 1000x1000 forced 'Accelerated' (area: 1000000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 1000x2048 forced 'Accelerated' (area: 2048000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 1000x4096 forced 'Accelerated' (area: 4096000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 1000x8192 forced 'Accelerated' (area: 8192000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 1000x16384 forced 'Accelerated' (area: 16384000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 1000x32768 forced 'Accelerated' (area: 32768000)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 1000x32769 forced 'Accelerated' (area: 32769000)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 2048x1 forced 'Accelerated' (area: 2048)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 2048x1000 forced 'Accelerated' (area: 2048000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 2048x2048 forced 'Accelerated' (area: 4194304)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 2048x4096 forced 'Accelerated' (area: 8388608)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 2048x8192 forced 'Accelerated' (area: 16777216)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 2048x16384 forced 'Accelerated' (area: 33554432)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 2048x32768 forced 'Accelerated' (area: 67108864)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 2048x32769 forced 'Accelerated' (area: 67110912)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 4096x1 forced 'Accelerated' (area: 4096)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 4096x1000 forced 'Accelerated' (area: 4096000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 4096x2048 forced 'Accelerated' (area: 8388608)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 4096x4096 forced 'Accelerated' (area: 16777216)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 4096x8192 forced 'Accelerated' (area: 33554432)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 4096x16384 forced 'Accelerated' (area: 67108864)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 4096x32768 forced 'Accelerated' (area: 134217728)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 4096x32769 forced 'Accelerated' (area: 134221824)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 8192x1 forced 'Accelerated' (area: 8192)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 8192x1000 forced 'Accelerated' (area: 8192000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 8192x2048 forced 'Accelerated' (area: 16777216)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 8192x4096 forced 'Accelerated' (area: 33554432)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 8192x8192 forced 'Accelerated' (area: 67108864)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 8192x16384 forced 'Accelerated' (area: 134217728)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 8192x32768 forced 'Accelerated' (area: 268435456)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 8192x32769 forced 'Accelerated' (area: 268443648)
 PASS Context was lost
 Testing 16384x1 forced 'Accelerated' (area: 16384)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 16384x1000 forced 'Accelerated' (area: 16384000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 16384x2048 forced 'Accelerated' (area: 33554432)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 16384x4096 forced 'Accelerated' (area: 67108864)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 16384x8192 forced 'Accelerated' (area: 134217728)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 16384x16384 forced 'Accelerated' (area: 268435456)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Effective renderingMode: Accelerated
 Testing 16384x32768 forced 'Accelerated' (area: 536870912)
 PASS Context was lost
 Testing 16384x32769 forced 'Accelerated' (area: 536887296)
 PASS Context was lost
 Testing 32768x1 forced 'Accelerated' (area: 32768)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 32768x1000 forced 'Accelerated' (area: 32768000)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 32768x2048 forced 'Accelerated' (area: 67108864)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 32768x4096 forced 'Accelerated' (area: 134217728)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 32768x8192 forced 'Accelerated' (area: 268435456)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 32768x16384 forced 'Accelerated' (area: 536870912)
 PASS Context was lost
 Testing 32768x32768 forced 'Accelerated' (area: 1073741824)
@@ -385,16 +385,16 @@ Testing 32768x32769 forced 'Accelerated' (area: 1073774592)
 PASS Context was lost
 Testing 32769x1 forced 'Accelerated' (area: 32769)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 32769x1000 forced 'Accelerated' (area: 32769000)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 32769x2048 forced 'Accelerated' (area: 67110912)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 32769x4096 forced 'Accelerated' (area: 134221824)
 PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Effective renderingMode: Unaccelerated
 Testing 32769x8192 forced 'Accelerated' (area: 268443648)
 PASS Context was lost
 Testing 32769x16384 forced 'Accelerated' (area: 536887296)
@@ -411,160 +411,160 @@ Testing 100x0 forced 'Accelerated' (area: 0)
 PASS Context was lost
 Testing 1x1 forced 'Unaccelerated' (area: 1)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1x1000 forced 'Unaccelerated' (area: 1000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1x2048 forced 'Unaccelerated' (area: 2048)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1x4096 forced 'Unaccelerated' (area: 4096)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1x8192 forced 'Unaccelerated' (area: 8192)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1x16384 forced 'Unaccelerated' (area: 16384)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1x32768 forced 'Unaccelerated' (area: 32768)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1x32769 forced 'Unaccelerated' (area: 32769)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1000x1 forced 'Unaccelerated' (area: 1000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1000x1000 forced 'Unaccelerated' (area: 1000000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1000x2048 forced 'Unaccelerated' (area: 2048000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1000x4096 forced 'Unaccelerated' (area: 4096000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1000x8192 forced 'Unaccelerated' (area: 8192000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1000x16384 forced 'Unaccelerated' (area: 16384000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1000x32768 forced 'Unaccelerated' (area: 32768000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 1000x32769 forced 'Unaccelerated' (area: 32769000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 2048x1 forced 'Unaccelerated' (area: 2048)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 2048x1000 forced 'Unaccelerated' (area: 2048000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 2048x2048 forced 'Unaccelerated' (area: 4194304)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 2048x4096 forced 'Unaccelerated' (area: 8388608)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 2048x8192 forced 'Unaccelerated' (area: 16777216)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 2048x16384 forced 'Unaccelerated' (area: 33554432)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 2048x32768 forced 'Unaccelerated' (area: 67108864)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 2048x32769 forced 'Unaccelerated' (area: 67110912)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 4096x1 forced 'Unaccelerated' (area: 4096)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 4096x1000 forced 'Unaccelerated' (area: 4096000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 4096x2048 forced 'Unaccelerated' (area: 8388608)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 4096x4096 forced 'Unaccelerated' (area: 16777216)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 4096x8192 forced 'Unaccelerated' (area: 33554432)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 4096x16384 forced 'Unaccelerated' (area: 67108864)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 4096x32768 forced 'Unaccelerated' (area: 134217728)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 4096x32769 forced 'Unaccelerated' (area: 134221824)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 8192x1 forced 'Unaccelerated' (area: 8192)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 8192x1000 forced 'Unaccelerated' (area: 8192000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 8192x2048 forced 'Unaccelerated' (area: 16777216)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 8192x4096 forced 'Unaccelerated' (area: 33554432)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 8192x8192 forced 'Unaccelerated' (area: 67108864)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 8192x16384 forced 'Unaccelerated' (area: 134217728)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 8192x32768 forced 'Unaccelerated' (area: 268435456)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 8192x32769 forced 'Unaccelerated' (area: 268443648)
 PASS Context was lost
 Testing 16384x1 forced 'Unaccelerated' (area: 16384)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 16384x1000 forced 'Unaccelerated' (area: 16384000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 16384x2048 forced 'Unaccelerated' (area: 33554432)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 16384x4096 forced 'Unaccelerated' (area: 67108864)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 16384x8192 forced 'Unaccelerated' (area: 134217728)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 16384x16384 forced 'Unaccelerated' (area: 268435456)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 16384x32768 forced 'Unaccelerated' (area: 536870912)
 PASS Context was lost
 Testing 16384x32769 forced 'Unaccelerated' (area: 536887296)
 PASS Context was lost
 Testing 32768x1 forced 'Unaccelerated' (area: 32768)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 32768x1000 forced 'Unaccelerated' (area: 32768000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 32768x2048 forced 'Unaccelerated' (area: 67108864)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 32768x4096 forced 'Unaccelerated' (area: 134217728)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 32768x8192 forced 'Unaccelerated' (area: 268435456)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 32768x16384 forced 'Unaccelerated' (area: 536870912)
 PASS Context was lost
 Testing 32768x32768 forced 'Unaccelerated' (area: 1073741824)
@@ -573,16 +573,16 @@ Testing 32768x32769 forced 'Unaccelerated' (area: 1073774592)
 PASS Context was lost
 Testing 32769x1 forced 'Unaccelerated' (area: 32769)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 32769x1000 forced 'Unaccelerated' (area: 32769000)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 32769x2048 forced 'Unaccelerated' (area: 67110912)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 32769x4096 forced 'Unaccelerated' (area: 134221824)
 PASS imageData.data is red
-PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Effective renderingMode: Unaccelerated
 Testing 32769x8192 forced 'Unaccelerated' (area: 268443648)
 PASS Context was lost
 Testing 32769x16384 forced 'Unaccelerated' (area: 536887296)

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -254,11 +254,10 @@ static RefPtr<ImageBuffer> allocateImageBufferInternal(const FloatSize& logicalS
             imageBuffer = ImageBuffer::create<ImageBufferShareableMappedIOSurfaceBitmapBackend, ImageBufferType>(logicalSize, resolutionScale, colorSpace, pixelFormat, purpose, creationContext, imageBufferIdentifier);
         if (!imageBuffer)
             imageBuffer = ImageBuffer::create<ImageBufferShareableMappedIOSurfaceBackend, ImageBufferType>(logicalSize, resolutionScale, colorSpace, pixelFormat, purpose, creationContext, imageBufferIdentifier);
-    } else
-        imageBuffer = ImageBuffer::create<ImageBufferShareableBitmapBackend, ImageBufferType>(logicalSize, resolutionScale, colorSpace, pixelFormat, purpose, creationContext, imageBufferIdentifier);
-#else
-    imageBuffer = ImageBuffer::create<ImageBufferShareableBitmapBackend, ImageBufferType>(logicalSize, resolutionScale, colorSpace, pixelFormat, purpose, creationContext, imageBufferIdentifier);
+    }
 #endif
+    if (!imageBuffer)
+        imageBuffer = ImageBuffer::create<ImageBufferShareableBitmapBackend, ImageBufferType>(logicalSize, resolutionScale, colorSpace, pixelFormat, purpose, creationContext, imageBufferIdentifier);
 
     return imageBuffer;
 }


### PR DESCRIPTION
#### 074ad42e866f713abc448fa3a42c2f84c5ee07e0
<pre>
REGRESSION (268251@main): 2D contexts fail after GPUP IOSurface limits have been exceeded
<a href="https://bugs.webkit.org/show_bug.cgi?id=267262">https://bugs.webkit.org/show_bug.cgi?id=267262</a>
<a href="https://rdar.apple.com/120695232">rdar://120695232</a>

Reviewed by Matt Woodrow.

IOSurfaces fail to allocate when GPUP has too many of them. The commit
268251@main removed the fallback for RemoteImageBuffer allocations,
where Accelerated buffers would fall back to normal Unaccelerated
buffers. Instead, the idea was to treat exceeding IOSurface limits as
OOM situation. This would be done to prepare being able to create the
specific Backend instance at RemoteImageBufferProxy instantiation time.

This would break existing content that would leak thousands of 2d
contexts. The content could still work with the fallback in place.

Reimplement the fallback to Unaccelerated.

* LayoutTests/fast/canvas/2d.context.many.small-expected.html: Added.
* LayoutTests/fast/canvas/2d.context.many.small.html: Added.
* LayoutTests/fast/canvas/image-buffer-backend-variants-expected.txt:
* LayoutTests/fast/canvas/image-buffer-backend-variants.html:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::allocateImageBufferInternal):
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp:
(WebKit::RemoteImageBufferProxy::didCreateBackend):

Canonical link: <a href="https://commits.webkit.org/272892@main">https://commits.webkit.org/272892@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb237f701a95ed7ac5051ab043af701bb0a322be

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33363 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12134 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35272 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35989 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30324 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14482 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9278 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29459 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33837 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10228 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29786 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8923 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9061 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29768 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37319 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30292 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30116 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35172 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9175 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7120 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33038 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10924 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/29440 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7748 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9757 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9898 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->