### PR TITLE
Make event handler house keeping in moveNodeToNewDocument more efficient

### DIFF
--- a/Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm
+++ b/Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm
@@ -122,14 +122,14 @@ AccessibilityObjectInclusion AccessibilityObject::accessibilityPlatformIncludesO
 bool AccessibilityObject::hasTouchEventListener() const
 {
     // Check whether this->node or any of its ancestors has any of the touch-related event listeners.
-    auto touchEventNames = eventNames().touchRelatedEventNames();
+    auto& eventNames = WebCore::eventNames();
     // If the node is in a shadowRoot, going up the node parent tree will stop and
     // not check the entire chain of ancestors. Thus, use the parentInComposedTree instead.
     for (auto* node = this->node(); node; node = node->parentInComposedTree()) {
-        for (auto eventName : touchEventNames) {
-            if (node->hasEventListeners(eventName))
-                return true;
-        }
+        if (node->containsMatchingEventListener([&](const AtomString& name, auto&) {
+            return eventNames.typeInfoForEvent(name).isInCategory(EventCategory::TouchRelated);
+        }))
+            return true;
     }
     return false;
 }

--- a/Source/WebCore/dom/EventListenerMap.h
+++ b/Source/WebCore/dom/EventListenerMap.h
@@ -67,11 +67,21 @@ public:
     const EventListenerVector* find(const AtomString& eventType) const { return const_cast<EventListenerMap*>(this)->find(eventType); }
     Vector<AtomString> eventTypes() const;
 
-    template <typename CallbackType>
-    void enumerateEventListenerTypes(CallbackType callback)
+    template<typename CallbackType>
+    void enumerateEventListenerTypes(CallbackType callback) const
     {
         for (auto& entry : m_entries)
             callback(entry.first, entry.second.size());
+    }
+
+    template<typename CallbackType>
+    bool containsMatchingEventListener(CallbackType callback) const
+    {
+        for (auto& entry : m_entries) {
+            if (callback(entry.first, m_entries))
+                return true;
+        }
+        return false;
     }
 
     void removeFirstEventListenerCreatedFromMarkup(const AtomString& eventType);

--- a/Source/WebCore/dom/EventTarget.h
+++ b/Source/WebCore/dom/EventTarget.h
@@ -150,6 +150,21 @@ public:
         return nullptr;
     }
 
+    template<typename CallbackType>
+    void enumerateEventListenerTypes(CallbackType callback) const
+    {
+        if (auto* data = eventTargetData())
+            data->eventListenerMap.enumerateEventListenerTypes(callback);
+    }
+
+    template<typename CallbackType>
+    bool containsMatchingEventListener(CallbackType callback) const
+    {
+        if (auto* data = eventTargetData())
+            return data->eventListenerMap.containsMatchingEventListener(callback);
+        return false;
+    }
+
     bool hasEventTargetData() const { return hasEventTargetFlag(EventTargetFlag::HasEventTargetData); }
     bool isNode() const { return hasEventTargetFlag(EventTargetFlag::IsNode); }
 

--- a/Source/WebCore/dom/make-event-names.py
+++ b/Source/WebCore/dom/make-event-names.py
@@ -150,15 +150,9 @@ public:''')
     static std::unique_ptr<EventNames> create(Args&&... args)
     {
         return std::unique_ptr<EventNames>(new EventNames(std::forward<Args>(args)...));
-    }''')
-
-        for category in sorted(category_map.keys()):
-            name_count = len(category_map[category])
-            writeln(f'    inline std::array<const AtomString, {name_count}> {lowercase_first_letter(category)}EventNames() const;')
-
-        writeln('')
-        writeln(f'    inline std::array<const AtomString, {len(event_names_input)}> allEventNames() const;')
-
+    }
+''')
+        writeln(f'    std::array<const AtomString, {len(event_names_input)}> allEventNames() const;')
         writeln('''
 private:
     EventNames();
@@ -176,41 +170,9 @@ inline const EventNames& eventNames()
 inline EventTypeInfo EventNames::typeInfoForEvent(const AtomString& eventType) const
 {
     return m_typeInfoMap.inlineGet(eventType);
-}''')
+}
 
-        for category in sorted(category_map.keys()):
-            names = category_map[category]
-            name_count = len(category_map[category])
-            writeln('')
-            writeln(f'inline std::array<const AtomString, {name_count}> EventNames::{lowercase_first_letter(category)}EventNames() const')
-            writeln('{')
-            writeln('    return { {')
-            for name in names:
-                conditional = event_names_input[name].get('conditional', None)
-                if conditional:
-                    writeln(f'#if {conditional}')
-                writeln(f'        {name}Event,')
-                if conditional:
-                    writeln(f'#endif')
-            writeln('    } };')
-            writeln('}')
-
-        writeln('')
-
-        writeln(f'inline std::array<const AtomString, {len(event_names_input)}> EventNames::allEventNames() const')
-        writeln('{')
-        writeln('    return { {')
-        for name in sorted(event_names_input.keys()):
-            conditional = event_names_input[name].get('conditional', None)
-            if conditional:
-                writeln(f'#if {conditional}')
-            writeln(f'        {name}Event,')
-            if conditional:
-                writeln(f'#endif')
-        writeln('    } };')
-        writeln('}')
-        writeln('')
-        writeln('} // namespace WebCore')
+} // namespace WebCore''')
 
     with open('EventNames.cpp', 'w') as output_file:
         def writeln(text):
@@ -272,7 +234,20 @@ EventNames::EventNames()''')
             if conditional:
                 writeln('#endif')
         writeln('    })')
-        writeln('''{ }
+        writeln('{ }')
+        writeln('')
+        writeln(f'std::array<const AtomString, {len(event_names_input)}> EventNames::allEventNames() const')
+        writeln('{')
+        writeln('    return { {')
+        for name in sorted(event_names_input.keys()):
+            conditional = event_names_input[name].get('conditional', None)
+            if conditional:
+                writeln(f'#if {conditional}')
+            writeln(f'        {name}Event,')
+            if conditional:
+                writeln(f'#endif')
+        writeln('''    } };
+}
 
 } // namespace WebCore''')
 


### PR DESCRIPTION
#### d2548129f1780abac960e3a93eaa547ba11073b6
<pre>
Make event handler house keeping in moveNodeToNewDocument more efficient
<a href="https://bugs.webkit.org/show_bug.cgi?id=267264">https://bugs.webkit.org/show_bug.cgi?id=267264</a>

Reviewed by Chris Dumez.

Prior to this PR, the code to update the number of wheel, touch, and gesture events in
Node::moveNodeToNewDocument were inefficient because it traversed EventListenerMap for
each distinct wheel, touch, and gesture event type. This is O(kn) where k is the total
number of event types, and n is the total number of event listeners on a given Node.

This PR reimplements the same house keeping in O(n): It enumerates types of event
listeners added on &quot;this&quot; event target and their count, and uses this information to
count the total number of wheel, touch, and gesture events in a single iteration over
EventListenerMap.

* Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm:
(WebCore::AccessibilityObject::hasTouchEventListener const):
* Source/WebCore/dom/EventListenerMap.h:
(WebCore::EventListenerMap::containsMatchingEventListener):
* Source/WebCore/dom/EventTarget.h:
(WebCore::EventTarget::enumerateEventListenerTypes):
(WebCore::EventTarget::containsMatchingEventListener):
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::moveNodeToNewDocument):
* Source/WebCore/dom/make-event-names.py:

Canonical link: <a href="https://commits.webkit.org/272834@main">https://commits.webkit.org/272834@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3cd91e76cfbd4854fbdd93d920811aefcd14164

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33233 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12009 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35147 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35870 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/30256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34204 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14354 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9181 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29394 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33708 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10130 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29685 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8830 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8977 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29660 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37201 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30197 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30040 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35087 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/9102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7056 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32947 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10831 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/9685 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4272 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9785 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->