### PR TITLE
Add a VideoTrackGenerator skeleton

### DIFF
--- a/LayoutTests/imported/w3c/resources/import-expectations.json
+++ b/LayoutTests/imported/w3c/resources/import-expectations.json
@@ -232,7 +232,7 @@
     "web-platform-tests/mediacapture-fromelement": "import",
     "web-platform-tests/mediacapture-handle": "skip",
     "web-platform-tests/mediacapture-image": "skip",
-    "web-platform-tests/mediacapture-insertable-streams": "skip",
+    "web-platform-tests/mediacapture-insertable-streams": "import",
     "web-platform-tests/mediacapture-record": "import",
     "web-platform-tests/mediacapture-region": "skip",
     "web-platform-tests/mediacapture-streams": "import",

--- a/LayoutTests/imported/w3c/web-platform-tests/interfaces/mediacapture-transform.idl
+++ b/LayoutTests/imported/w3c/web-platform-tests/interfaces/mediacapture-transform.idl
@@ -1,0 +1,23 @@
+// GENERATED CONTENT - DO NOT EDIT
+// Content was automatically extracted by Reffy into webref
+// (https://github.com/w3c/webref)
+// Source: MediaStreamTrack Insertable Media Processing using Streams (https://w3c.github.io/mediacapture-transform/)
+
+[Exposed=DedicatedWorker]
+interface MediaStreamTrackProcessor {
+    constructor(MediaStreamTrackProcessorInit init);
+    attribute ReadableStream readable;
+};
+
+dictionary MediaStreamTrackProcessorInit {
+  required MediaStreamTrack track;
+  [EnforceRange] unsigned short maxBufferSize;
+};
+
+[Exposed=DedicatedWorker]
+interface VideoTrackGenerator {
+  constructor();
+  readonly attribute WritableStream writable;
+  attribute boolean muted;
+  readonly attribute MediaStreamTrack track;
+};

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackGenerator-audio.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackGenerator-audio.https-expected.txt
@@ -1,0 +1,17 @@
+When prompted, use the accept button to give permission to use your audio and video devices.
+
+Description
+
+This test checks that generating audio MediaStreamTracks works as expected.
+
+
+FAIL Tests that creating a Audio MediaStreamTrackGenerator works as expected promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: MediaStreamTrackGenerator"
+FAIL Creating Generator with an invalid kind throws assert_throws_js: function "() => { new MediaStreamTrackGenerator({ kind: "invalid kind" }) }" threw object "ReferenceError: Can't find variable: MediaStreamTrackGenerator" ("ReferenceError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Creating Generator with a missing kind throws assert_throws_js: function "() => { new MediaStreamTrackGenerator() }" threw object "ReferenceError: Can't find variable: MediaStreamTrackGenerator" ("ReferenceError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Mismatched data and generator kind throws on write. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: MediaStreamTrackGenerator"
+FAIL Tests that audio actually flows to a connected audio element promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: MediaStreamTrackGenerator"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackGenerator-audio.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackGenerator-audio.https.html
@@ -1,0 +1,97 @@
+<!doctype html>
+<html>
+
+<head>
+  <title>MediaStreamTrackGenerator</title>
+  <link rel="help" href="https://w3c.github.io/mediacapture-insertable-streams">
+</head>
+
+<body>
+  <p class="instructions">When prompted, use the accept button to give permission to use your audio and video devices.</p>
+  <h1 class="instructions">Description</h1>
+  <p class="instructions">This test checks that generating audio MediaStreamTracks works as expected.</p>
+  <audio id="audioElement" autoplay=true></audio>
+  <script src=/resources/testharness.js></script>
+  <script src=/resources/testharnessreport.js></script>
+  <script src=/resources/testdriver.js></script>
+  <script src=/resources/testdriver-vendor.js></script>
+  <script src='../mediacapture-streams/permission-helper.js'></script>
+  <script>
+
+    function makeAudioData(timestamp) {
+      const sampleRate = 30000;
+
+      let frames = sampleRate / 10;
+      let channels = 1;
+
+      // Generate a simple sin wave, so we have something.
+      let data = new Float32Array(frames*channels);
+      const hz = 100; // sound frequency
+      for (let i = 0; i < data.length; i++) {
+        const t = (i / sampleRate) * hz * (Math.PI * 2);
+        data[i] = Math.sin(t);
+      }
+
+      return new AudioData({
+        timestamp: timestamp,
+        numberOfFrames: frames,
+        numberOfChannels: channels,
+        sampleRate: sampleRate,
+        data: data,
+        format: "f32",
+      });
+    }
+
+    promise_test(async t => {
+      const generator = new MediaStreamTrackGenerator("audio");
+
+      const writer = generator.writable.getWriter();
+      await writer.write(makeAudioData(1));
+
+      assert_equals(generator.kind, "audio");
+      assert_equals(generator.readyState, "live");
+
+      t.add_cleanup(() => generator.stop());
+    }, "Tests that creating a Audio MediaStreamTrackGenerator works as expected");
+
+    promise_test(async t => {
+      assert_throws_js(TypeError, () => { new MediaStreamTrackGenerator({ kind: "invalid kind" }) });
+    }, "Creating Generator with an invalid kind throws");
+
+    promise_test(async t => {
+      await setMediaPermission();
+      const capturedStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      assert_equals(capturedStream.getAudioTracks().length, 1);
+      const upstreamTrack = capturedStream.getAudioTracks()[0];
+      t.add_cleanup(() => upstreamTrack.stop());
+
+      assert_throws_js(TypeError, () => { new MediaStreamTrackGenerator() });
+    }, "Creating Generator with a missing kind throws");
+
+    promise_test(async t => {
+      const generator = new MediaStreamTrackGenerator({ kind: "video" });
+      t.add_cleanup(() => generator.stop());
+
+      const writer = generator.writable.getWriter();
+      const data = makeAudioData(1);
+
+      writer.write(data).then(t.step_func(() => assert_unreached("Write should reject")), t.step_func(f => assert_true(f instanceof TypeError, "write rejects with a TypeError")));
+    }, "Mismatched data and generator kind throws on write.");
+
+    promise_test(async t => {
+      const generator = new MediaStreamTrackGenerator("audio");
+      t.add_cleanup(() => generator.stop());
+
+      const audioElement = document.getElementById("audioElement");
+      audioElement.srcObject = new MediaStream([generator]);
+      await audioElement.play();
+
+      const writer = generator.writable.getWriter();
+      await writer.write(makeAudioData(1));
+
+      // Wait for audio playout to actually happen.
+      await t.step_wait(() => audioElement.currentTime > 0, "audioElement played out generated track");
+    }, "Tests that audio actually flows to a connected audio element");
+  </script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackGenerator-in-service-worker.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackGenerator-in-service-worker.https-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL A service worker is able to initialize a MediaStreamTrackGenerator without crashing promise_test: Unhandled rejection with value: "Failed with error ReferenceError: Can't find variable: MediaStreamTrackGenerator"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackGenerator-in-service-worker.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackGenerator-in-service-worker.https.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<title>Test initialize MediaStreamTrackGenerator in a service worker</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src='/service-workers/service-worker/resources/test-helpers.sub.js'></script>
+<script>
+'use strict';
+
+promise_test(async t => {
+    const registration = await navigator.serviceWorker.register('service-worker.js');
+    await wait_for_state(t, registration.installing, 'activated');
+    const result = new Promise((resolve, reject) => {
+        navigator.serviceWorker.addEventListener('message', (e) => {
+            if (e.data.result === 'Failure') {
+                reject('Failed with error ' + e.data.error);
+            } else {
+                resolve();
+            }
+        });
+    });
+    registration.active.postMessage('hello world');
+    return result;
+}, 'A service worker is able to initialize a MediaStreamTrackGenerator without crashing');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackGenerator-in-shared-worker.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackGenerator-in-shared-worker.https-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL A shared worker is able to initialize a MediaStreamTrackGenerator without crashing promise_test: Unhandled rejection with value: "Failed with error ReferenceError: Can't find variable: MediaStreamTrackGenerator"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackGenerator-in-shared-worker.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackGenerator-in-shared-worker.https.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<title>Test initialize MediaStreamTrackGenerator in a shared worker</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+'use strict';
+
+promise_test(async t => {
+    const worker = new SharedWorker('shared-worker.js');
+    const result = new Promise((resolve, reject) => {
+        worker.port.onmessage = (e) => {
+            if (e.data.result === 'Failure') {
+                reject('Failed with error ' + e.data.error);
+            } else {
+                resolve();
+            }
+        };
+    });
+    worker.port.postMessage('Hello world');
+    return result;
+}, 'A shared worker is able to initialize a MediaStreamTrackGenerator without crashing');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackGenerator-in-worker.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackGenerator-in-worker.https-expected.txt
@@ -1,0 +1,5 @@
+
+FAIL A worker is able to initialize a MediaStreamTrackGenerator without crashing promise_test: Unhandled rejection with value: "Failed with error ReferenceError: Can't find variable: MediaStreamTrackGenerator"
+FAIL A worker is able to enable a MediaStreamTrackGenerator without crashing promise_test: Unhandled rejection with value: "Failed with error ReferenceError: Can't find variable: MediaStreamTrackGenerator"
+FAIL A worker is able to disable a MediaStreamTrackGenerator without crashing promise_test: Unhandled rejection with value: "Failed with error ReferenceError: Can't find variable: MediaStreamTrackGenerator"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackGenerator-in-worker.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackGenerator-in-worker.https.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<title>Test creation of MediaStreamTrackGenerator in a worker</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+'use strict';
+
+function initWorker(){
+  const worker = new Worker('dedicated-worker.js');
+  const result = new Promise((resolve, reject) => {
+    worker.onmessage = (e) => {
+      if (e.data.result === 'Failure') {
+        reject('Failed with error ' + e.data.error);
+      } else {
+        resolve();
+      }
+    };
+  });
+  return [worker,result];
+}
+
+promise_test(async t => {
+  const [worker,result] = initWorker();
+  worker.postMessage({msg: 'Hello there'});
+  return result;
+}, 'A worker is able to initialize a MediaStreamTrackGenerator without crashing');
+
+promise_test(async t => {
+  const [worker,result] = initWorker();
+  worker.postMessage({enable: true});
+  return result;
+}, 'A worker is able to enable a MediaStreamTrackGenerator without crashing');
+
+promise_test(async t => {
+  const [worker,result] = initWorker();
+  worker.postMessage({enable: false});
+  return result;
+}, 'A worker is able to disable a MediaStreamTrackGenerator without crashing');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackGenerator-pipes-data-in-worker.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackGenerator-pipes-data-in-worker.https-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL A worker is able to pipe data through a MediaStreamTrackGenerator without crashing promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: MediaStreamTrackProcessor"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackGenerator-pipes-data-in-worker.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackGenerator-pipes-data-in-worker.https.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<title>Test piping data through MediaStreamTrackGenerator in a worker</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script id="workerCode" type="javascript/worker">
+self.onmessage = (e) => {
+  try {
+    const generator = new MediaStreamTrackGenerator({kind: 'video'});
+    e.data.readable.pipeTo(generator.writable);
+    self.postMessage({result: 'Success'});
+  } catch (e) {
+    self.postMessage({result: 'Failure', error: e});
+  }
+}
+</script>
+<script>
+'use strict';
+
+promise_test(async t => {
+    const workerBlob = new Blob([document.querySelector('#workerCode').textContent],
+        { type: "text/javascript" });
+    const workerUrl = window.URL.createObjectURL(workerBlob);
+    const worker = new Worker(workerUrl);
+    window.URL.revokeObjectURL(workerUrl);
+    const result = new Promise((resolve, reject) => {
+        worker.onmessage = (e) => {
+            if (e.data.result === 'Failure') {
+                reject('Failed with error ' + e.data.error);
+            } else {
+                resolve();
+            }
+        };
+    });
+    const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+    const track = stream.getVideoTracks()[0];
+    const processor = new MediaStreamTrackProcessor({ track: track });
+    worker.postMessage({ readable: processor.readable },
+        [processor.readable]);
+    return result;
+}, 'A worker is able to pipe data through a MediaStreamTrackGenerator without crashing');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackGenerator-video.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackGenerator-video.https-expected.txt
@@ -1,0 +1,15 @@
+When prompted, use the accept button to give permission to use your audio and video devices.
+
+Description
+
+This test checks that generating video MediaStreamTracks works as expected.
+
+
+FAIL Tests that MediaStreamTrackGenerator forwards frames to sink promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: MediaStreamTrackProcessor"
+FAIL Tests that frames are actually rendered correctly in a stream used for a video element. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: MediaStreamTrackGenerator"
+FAIL Tests that frames are actually rendered correctly in a stream sent over a peer connection. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: MediaStreamTrackGenerator"
+FAIL Tests that frames are sent correctly with RTCRtpEncodingParameters.scaleResolutionDownBy. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: MediaStreamTrackGenerator"
+FAIL Tests that creating a Video MediaStreamTrackGenerator works as expected promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: MediaStreamTrackGenerator"
+FAIL Tests that VideoFrames are destroyed on write. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: MediaStreamTrackGenerator"
+FAIL Mismatched frame and generator kind throws on write. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: MediaStreamTrackGenerator"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackGenerator-video.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackGenerator-video.https.html
@@ -1,0 +1,285 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MediaStream Insertable Streams - Video</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/webrtc/RTCPeerConnection-helper.js"></script>
+</head>
+<body>
+  <p class="instructions">When prompted, use the accept button to give permission to use your audio and video devices.</p>
+  <h1 class="instructions">Description</h1>
+  <p class="instructions">This test checks that generating video MediaStreamTracks works as expected.</p>
+  <script>
+
+    const pixelColour = [50, 100, 150, 255];
+    const height = 240;
+    const width = 320;
+    function makeVideoFrame(timestamp) {
+      const canvas = new OffscreenCanvas(width, height);
+
+      const ctx = canvas.getContext('2d', {alpha: false});
+      ctx.fillStyle = `rgba(${pixelColour.join()})`;
+      ctx.fillRect(0, 0, width, height);
+
+      return new VideoFrame(canvas, {timestamp, alpha: 'discard'});
+    }
+
+    async function getVideoFrame() {
+      const stream = await getNoiseStream({video: true});
+      const input_track = stream.getTracks()[0];
+      const processor = new MediaStreamTrackProcessor(input_track);
+      const reader = processor.readable.getReader();
+      const result = await reader.read();
+      input_track.stop();
+      return result.value;
+    }
+
+    function assertPixel(t, bytes, expected, epsilon = 5) {
+      for (let i = 0; i < bytes.length; i++) {
+        t.step(() => {
+          assert_less_than(Math.abs(bytes[i] - expected[i]),  epsilon, "Mismatched pixel");
+        });
+      }
+    }
+
+    async function initiateSingleTrackCall(t, track, output) {
+      const caller = new RTCPeerConnection();
+      t.add_cleanup(() => caller.close());
+      const callee = new RTCPeerConnection();
+      t.add_cleanup(() => callee.close());
+      caller.addTrack(track);
+      t.add_cleanup(() => track.stop());
+
+      exchangeIceCandidates(caller, callee);
+      // Wait for the first track.
+      const e = await exchangeOfferAndListenToOntrack(t, caller, callee);
+      output.srcObject = new MediaStream([e.track]);
+      // Exchange answer.
+      await exchangeAnswer(caller, callee);
+      await waitForConnectionStateChange(callee, ['connected']);
+    }
+
+    promise_test(async t => {
+      const videoFrame = await getVideoFrame();
+      const originalWidth = videoFrame.displayWidth;
+      const originalHeight = videoFrame.displayHeight;
+      const originalTimestamp = videoFrame.timestamp;
+      const generator = new MediaStreamTrackGenerator({kind: 'video'});
+      t.add_cleanup(() => generator.stop());
+
+      // Use a MediaStreamTrackProcessor as a sink for |generator| to verify
+      // that |processor| actually forwards the frames written to its writable
+      // field.
+      const processor = new MediaStreamTrackProcessor(generator);
+      const reader = processor.readable.getReader();
+      const readerPromise = new Promise(async resolve => {
+        const result = await reader.read();
+        assert_equals(result.value.displayWidth, originalWidth);
+        assert_equals(result.value.displayHeight, originalHeight);
+        assert_equals(result.value.timestamp, originalTimestamp);
+        resolve();
+      });
+
+      generator.writable.getWriter().write(videoFrame);
+
+      return readerPromise;
+    }, 'Tests that MediaStreamTrackGenerator forwards frames to sink');
+
+    promise_test(async t => {
+      const videoFrame = makeVideoFrame(1);
+      const originalWidth = videoFrame.displayWidth;
+      const originalHeight = videoFrame.displayHeight;
+      const generator = new MediaStreamTrackGenerator({ kind: 'video' });
+      t.add_cleanup(() => generator.stop());
+
+      const video = document.createElement("video");
+      video.autoplay = true;
+      video.width = 320;
+      video.height = 240;
+      video.srcObject = new MediaStream([generator]);
+      video.play();
+
+      // Wait for the video element to be connected to the generator and
+      // generate the frame.
+      video.onloadstart = () => generator.writable.getWriter().write(videoFrame);
+
+      return new Promise((resolve)=> {
+        video.ontimeupdate = t.step_func(() => {
+          const canvas = document.createElement("canvas");
+          canvas.width = originalWidth;
+          canvas.height = originalHeight;
+          const context = canvas.getContext('2d');
+          context.drawImage(video, 0, 0);
+          // Pick a pixel in the centre of the video and check that it has the colour of the frame provided.
+          const pixel = context.getImageData(videoFrame.displayWidth/2, videoFrame.displayHeight/2, 1, 1);
+          assertPixel(t, pixel.data, pixelColour);
+          resolve();
+        });
+      });
+    }, 'Tests that frames are actually rendered correctly in a stream used for a video element.');
+
+    promise_test(async t => {
+      const generator = new MediaStreamTrackGenerator({kind: 'video'});
+      t.add_cleanup(() => generator.stop());
+
+      // Write frames for the duration of the test.
+      const writer = generator.writable.getWriter();
+      let timestamp = 0;
+      const intervalId = setInterval(
+          t.step_func(async () => {
+            if (generator.readyState === 'live') {
+              timestamp++;
+              await writer.write(makeVideoFrame(timestamp));
+            }
+          }),
+          40);
+      t.add_cleanup(() => clearInterval(intervalId));
+
+      const video = document.createElement('video');
+      video.autoplay = true;
+      video.width = width;
+      video.height = height;
+      video.muted = true;
+
+      await initiateSingleTrackCall(t, generator, video);
+
+      return new Promise(resolve => {
+        video.ontimeupdate = t.step_func(() => {
+          const canvas = document.createElement('canvas');
+          canvas.width = width;
+          canvas.height = height;
+          const context = canvas.getContext('2d');
+          context.drawImage(video, 0, 0);
+          // Pick a pixel in the centre of the video and check that it has the
+          // colour of the frame provided.
+          const pixel = context.getImageData(width / 2, height / 2, 1, 1);
+          // Encoding/decoding can add noise, so increase the threshhold to 8.
+          assertPixel(t, pixel.data, pixelColour, 8);
+          resolve();
+        });
+      });
+    }, 'Tests that frames are actually rendered correctly in a stream sent over a peer connection.');
+
+    promise_test(async t => {
+      const generator = new MediaStreamTrackGenerator({kind: 'video'});
+      t.add_cleanup(() => generator.stop());
+
+      const inputCanvas = new OffscreenCanvas(width, height);
+
+      const inputContext = inputCanvas.getContext('2d', {alpha: false});
+      // draw four quadrants
+      const colorUL = [255, 0, 0, 255];
+      inputContext.fillStyle = `rgba(${colorUL.join()})`;
+      inputContext.fillRect(0, 0, width / 2, height / 2);
+      const colorUR = [255, 255, 0, 255];
+      inputContext.fillStyle = `rgba(${colorUR.join()})`;
+      inputContext.fillRect(width / 2, 0, width / 2, height / 2);
+      const colorLL = [0, 255, 0, 255];
+      inputContext.fillStyle = `rgba(${colorLL.join()})`;
+      inputContext.fillRect(0, height / 2, width / 2, height / 2);
+      const colorLR = [0, 255, 255, 255];
+      inputContext.fillStyle = `rgba(${colorLR.join()})`;
+      inputContext.fillRect(width / 2, height / 2, width / 2, height / 2);
+
+      // Write frames for the duration of the test.
+      const writer = generator.writable.getWriter();
+      let timestamp = 0;
+      const intervalId = setInterval(
+          t.step_func(async () => {
+            if (generator.readyState === 'live') {
+              timestamp++;
+              await writer.write(new VideoFrame(
+                  inputCanvas, {timestamp: timestamp, alpha: 'discard'}));
+            }
+          }),
+          40);
+      t.add_cleanup(() => clearInterval(intervalId));
+
+      const caller = new RTCPeerConnection();
+      t.add_cleanup(() => caller.close());
+      const callee = new RTCPeerConnection();
+      t.add_cleanup(() => callee.close());
+      const sender = caller.addTrack(generator);
+
+      exchangeIceCandidates(caller, callee);
+      // Wait for the first track.
+      const e = await exchangeOfferAndListenToOntrack(t, caller, callee);
+
+      // Exchange answer.
+      await exchangeAnswer(caller, callee);
+      await waitForConnectionStateChange(callee, ['connected']);
+      const params = sender.getParameters();
+      params.encodings.forEach(e => e.scaleResolutionDownBy = 2);
+      sender.setParameters(params);
+
+      const processor = new MediaStreamTrackProcessor(e.track);
+      const reader = processor.readable.getReader();
+
+      // The first frame may not have had scaleResolutionDownBy applied
+      const numTries = 5;
+      for (let i = 1; i <= numTries; i++) {
+        const {value: outputFrame} = await reader.read();
+        if (outputFrame.displayWidth !== width / 2) {
+          assert_less_than(i, numTries, `First ${numTries} frames were the wrong size.`);
+          outputFrame.close();
+          continue;
+        }
+
+        assert_equals(outputFrame.displayWidth, width / 2);
+        assert_equals(outputFrame.displayHeight, height / 2);
+
+        const outputCanvas = new OffscreenCanvas(width / 2, height / 2);
+        const outputContext = outputCanvas.getContext('2d', {alpha: false});
+        outputContext.drawImage(outputFrame, 0, 0);
+        outputFrame.close();
+        // Check the four quadrants
+        const pixelUL = outputContext.getImageData(width / 8, height / 8, 1, 1);
+        assertPixel(t, pixelUL.data, colorUL);
+        const pixelUR =
+            outputContext.getImageData(width * 3 / 8, height / 8, 1, 1);
+        assertPixel(t, pixelUR.data, colorUR);
+        const pixelLL =
+            outputContext.getImageData(width / 8, height * 3 / 8, 1, 1);
+        assertPixel(t, pixelLL.data, colorLL);
+        const pixelLR =
+            outputContext.getImageData(width * 3 / 8, height * 3 / 8, 1, 1);
+        assertPixel(t, pixelLR.data, colorLR);
+        break;
+      }
+    }, 'Tests that frames are sent correctly with RTCRtpEncodingParameters.scaleResolutionDownBy.');
+
+    promise_test(async t => {
+      const generator = new MediaStreamTrackGenerator("video");
+      t.add_cleanup(() => generator.stop());
+
+      const writer = generator.writable.getWriter();
+      const frame = makeVideoFrame(1);
+      await writer.write(frame);
+
+      assert_equals(generator.kind, "video");
+      assert_equals(generator.readyState, "live");
+    }, "Tests that creating a Video MediaStreamTrackGenerator works as expected");
+
+    promise_test(async t => {
+      const generator = new MediaStreamTrackGenerator("video");
+      t.add_cleanup(() => generator.stop());
+
+      const writer = generator.writable.getWriter();
+      const frame = makeVideoFrame(1);
+      await writer.write(frame);
+
+      assert_throws_dom("InvalidStateError", () => frame.clone(), "VideoFrame wasn't destroyed on write.");
+    }, "Tests that VideoFrames are destroyed on write.");
+
+    promise_test(async t => {
+      const generator = new MediaStreamTrackGenerator("audio");
+      t.add_cleanup(() => generator.stop());
+
+      const writer = generator.writable.getWriter();
+      const frame = makeVideoFrame(1);
+      assert_throws_js(TypeError, writer.write(frame));
+    }, "Mismatched frame and generator kind throws on write.");
+  </script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-audio.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-audio.https-expected.txt
@@ -1,0 +1,10 @@
+When prompted, use the accept button to give permission to use your audio and video devices.
+
+Description
+
+This test checks that MediaStreamTrackProcessor works as expected on audio MediaStreamTracks.
+
+
+FAIL Tests that the reader of an audio MediaStreamTrackProcessor produces AudioData objects and is closed on track stop promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: MediaStreamTrackProcessor"
+FAIL Tests that the reader of an audio MediaStreamTrackProcessor produces AudioData objects and is closed on track stop while running on a worker promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: MediaStreamTrackProcessor"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-audio.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-audio.https.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html>
+<head>
+  <title>MediaStreamTrackProcessor</title>
+  <link rel="help" href="https://w3c.github.io/mediacapture-insertable-streams">
+</head>
+<body>
+<p class="instructions">When prompted, use the accept button to give permission to use your audio and video devices.</p>
+<h1 class="instructions">Description</h1>
+<p class="instructions">This test checks that MediaStreamTrackProcessor works as expected on audio MediaStreamTracks.</p>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/resources/testdriver.js></script>
+<script src=/resources/testdriver-vendor.js></script>
+<script src='../mediacapture-streams/permission-helper.js'></script>
+<script>
+promise_test(async t => {
+  await setMediaPermission("granted", ["microphone"]);
+  const stream = await navigator.mediaDevices.getUserMedia({audio: true});
+  const track = stream.getTracks()[0];
+  const processor = new MediaStreamTrackProcessor({track: track});
+  const reader = processor.readable.getReader();
+  const readResult = await reader.read();
+  assert_false(readResult.done)
+  assert_true(readResult.value instanceof AudioData);
+  readResult.value.close();
+  track.stop();
+  return reader.closed;
+}, "Tests that the reader of an audio MediaStreamTrackProcessor produces AudioData objects and is closed on track stop");
+
+promise_test(async t => {
+  const stream = await navigator.mediaDevices.getUserMedia({audio: true});
+  const track = stream.getTracks()[0];
+  const processor = new MediaStreamTrackProcessor({track: track});
+  const worker = new Worker('MediaStreamTrackProcessor-worker.js');
+  const promise = new Promise(resolve => {
+    worker.onmessage = t.step_func(msg => {
+      if (msg.data instanceof AudioData) {
+        msg.data.close();
+        track.stop();
+      } else if (msg.data == 'closed') {
+        resolve();
+      } else {
+        assert_unreached();
+      }
+    })
+  });
+  worker.postMessage({readable: processor.readable},
+                     [processor.readable]);
+  return promise;
+}, "Tests that the reader of an audio MediaStreamTrackProcessor produces AudioData objects and is closed on track stop while running on a worker");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-backpressure.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-backpressure.https-expected.txt
@@ -1,0 +1,7 @@
+Description
+
+This test checks that MediaStreamTrackProcessor handles backpressure from a WHATWG stream pipeline.
+
+
+FAIL Tests that backpressure forces MediaStreamTrackProcess to skip frames promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: MediaStreamTrackGenerator"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-backpressure.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-backpressure.https.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<html>
+<head>
+  <title>MediaStreamTrackProcessor backpressure</title>
+  <link rel="help" href="https://w3c.github.io/mediacapture-insertable-streams">
+</head>
+<body>
+  <h1 class="instructions">Description</h1>
+<p class="instructions">This test checks that MediaStreamTrackProcessor handles backpressure from a WHATWG stream pipeline.</p>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/resources/testdriver.js></script>
+<script src=/resources/testdriver-vendor.js></script>
+<script>
+
+  const height = 240;
+  const width = 320;
+
+  const inputCanvas = new OffscreenCanvas(width, height);
+  const inputCtx = inputCanvas.getContext('2d', {alpha: false});
+  inputCtx.fillStyle = 'black';
+  inputCtx.fillRect(0, 0, width, height);
+
+  const frameDuration = 40;
+
+  function makeUniformVideoFrame(timestamp) {
+    return new VideoFrame(inputCanvas, {timestamp, alpha: 'discard'});
+  }
+
+  promise_test(async t => {
+    // TODO: use  "new VideoTrackGenerator"
+    const generator = new MediaStreamTrackGenerator({kind: 'video'});
+    t.add_cleanup(() => generator.stop());
+
+    // Write frames for the duration of the test.
+    const writer = generator.writable.getWriter();
+    let timestamp = 0;
+    const intervalId = setInterval(
+      t.step_func(async () => {
+        if (generator.readyState === 'live') {
+          timestamp++;
+          await writer.write(makeUniformVideoFrame(timestamp));
+        }
+      }),
+      frameDuration);
+    t.add_cleanup(() => clearInterval(intervalId));
+    t.step_timeout(function() {
+      clearInterval(intervalId);
+      generator.stop();
+    }, 2000);
+    const processor = new MediaStreamTrackProcessor({track: generator});
+    let ts = 1;
+    await processor.readable.pipeTo(new WritableStream({
+      async write(frame) {
+        if (ts === 1) {
+          assert_equals(frame.timestamp, ts, "Timestamp mismatch");
+        } else {
+          assert_greater_than_equal(frame.timestamp, ts, "Backpressure should have resulted in skipping at least 3 frames");
+        }
+        frame.close();
+        ts+=3;
+        // Wait the equivalent of 3 frames
+        return new Promise((res) => t.step_timeout(res, 3*frameDuration));
+      }
+    }));
+  }, "Tests that backpressure forces MediaStreamTrackProcess to skip frames");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-video.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-video.https-expected.txt
@@ -1,0 +1,11 @@
+When prompted, use the accept button to give permission to use your audio and video devices.
+
+Description
+
+This test checks that MediaStreamTrackProcessor works as expected on video MediaStreamTracks.
+
+
+FAIL Tests that the reader of a video MediaStreamTrackProcessor produces video frames and is closed on track stop promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: MediaStreamTrackProcessor"
+FAIL Tests that the reader of a video MediaStreamTrackProcessor produces VideoFrame objects and is closed on track stop while running on a worker promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: MediaStreamTrackProcessor"
+FAIL Tests that multiple read requests are eventually settled promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: MediaStreamTrackGenerator"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-video.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-video.https.html
@@ -1,0 +1,97 @@
+<!doctype html>
+<html>
+<head>
+  <title>MediaStreamTrackProcessor</title>
+  <link rel="help" href="https://w3c.github.io/mediacapture-insertable-streams">
+</head>
+<body>
+<p class="instructions">When prompted, use the accept button to give permission to use your audio and video devices.</p>
+<h1 class="instructions">Description</h1>
+<p class="instructions">This test checks that MediaStreamTrackProcessor works as expected on video MediaStreamTracks.</p>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/resources/testdriver.js></script>
+<script src=/resources/testdriver-vendor.js></script>
+<script src='../mediacapture-streams/permission-helper.js'></script>
+<script>
+promise_test(async t => {
+  await setMediaPermission("granted", ["camera"]);
+  const stream = await navigator.mediaDevices.getUserMedia({video: true});
+  const track = stream.getTracks()[0];
+  const processor = new MediaStreamTrackProcessor({track: track});
+  const reader = processor.readable.getReader();
+  const readResult = await reader.read();
+  assert_false(readResult.done)
+  assert_true(readResult.value instanceof VideoFrame);
+  readResult.value.close();
+  track.stop();
+  return reader.closed;
+}, "Tests that the reader of a video MediaStreamTrackProcessor produces video frames and is closed on track stop");
+
+promise_test(async t => {
+  const stream = await navigator.mediaDevices.getUserMedia({video: true});
+  const track = stream.getTracks()[0];
+  const processor = new MediaStreamTrackProcessor({track: track});
+  const worker = new Worker('MediaStreamTrackProcessor-worker.js');
+  const promise = new Promise(resolve => {
+    worker.onmessage = t.step_func(msg => {
+      if (msg.data instanceof VideoFrame) {
+        msg.data.close();
+        track.stop();
+      } else if (msg.data == 'closed') {
+        resolve();
+      } else {
+        assert_unreached();
+      }
+    })
+  });
+  worker.postMessage({readable: processor.readable},
+                     [processor.readable]);
+  return promise;
+}, "Tests that the reader of a video MediaStreamTrackProcessor produces VideoFrame objects and is closed on track stop while running on a worker");
+
+function makeVideoFrame(timestamp) {
+  const canvas = new OffscreenCanvas(100, 100);
+  const ctx = canvas.getContext('2d');
+  return new VideoFrame(canvas, {timestamp});
+}
+
+promise_test(async t => {
+  // The generator will be used as the source for the processor to
+  // produce frames in a controlled manner.
+  const generator = new MediaStreamTrackGenerator('video');
+  t.add_cleanup(() => generator.stop());
+  // Use a larger maxBufferSize than the default to ensure no frames
+  // will be dropped.
+  const processor = new MediaStreamTrackProcessor({track: generator, maxBufferSize:10});
+  const reader = processor.readable.getReader();
+  const writer = generator.writable.getWriter();
+
+  let numReads = 0;
+  let resolve = null;
+  const promise = new Promise(r => resolve = r);
+
+  const numOperations = 4;
+  // Issue reads without waiting for the frames to arrive.
+  for (let i = 0; i < numOperations; i++) {
+    reader.read().then(dv=> {
+      dv.value.close();
+      if (++numReads == numOperations)
+        resolve();
+    });
+  }
+
+  // Write video frames in different tasks to "slowly" settle the pending read
+  // requests.
+  for (let i = 0; i<numOperations; i++) {
+     await writer.write(makeVideoFrame(i));
+     await new Promise(r=>setTimeout(r,0));
+  }
+
+  return promise;
+
+}, "Tests that multiple read requests are eventually settled");
+
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-worker.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-worker.js
@@ -1,0 +1,17 @@
+onmessage = async msg => {
+  const reader = msg.data.readable.getReader();
+  let readResult = await reader.read();
+  postMessage(readResult.value);
+  readResult.value.close();
+  // Continue reading until the stream is done due to a track.stop()
+  while (true) {
+    readResult = await reader.read();
+    if (readResult.done) {
+      break;
+    } else {
+      readResult.value.close();
+    }
+  }
+  await reader.closed;
+  postMessage('closed');
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/VideoTrackGenerator.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/VideoTrackGenerator.https-expected.txt
@@ -1,0 +1,16 @@
+If prompted, use the accept button to give permission to use your audio and video devices.
+
+Description
+
+This test checks that generating video MediaStreamTracks from VideoTrackGenerator works as expected.
+
+
+FAIL Tests that VideoTrackGenerator forwards frames to sink promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: MediaStreamTrackProcessor"
+FAIL Tests that frames are actually rendered correctly in a stream used for a video element. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: VideoTrackGenerator"
+FAIL Tests that frames are actually rendered correctly in a stream sent over a peer connection. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: VideoTrackGenerator"
+FAIL Tests that frames are sent correctly with RTCRtpEncodingParameters.scaleResolutionDownBy. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: VideoTrackGenerator"
+FAIL Tests that creating a VideoTrackGenerator works as expected promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: VideoTrackGenerator"
+FAIL Tests that VideoFrames are destroyed on write. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: VideoTrackGenerator"
+FAIL Mismatched frame and generator kind throws on write. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: VideoTrackGenerator"
+FAIL Tests that VideoTrackGenerator forwards frames only when unmuted promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: VideoTrackGenerator"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/VideoTrackGenerator.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/VideoTrackGenerator.https.html
@@ -1,0 +1,327 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MediaStream Insertable Streams - VideoTrackGenerator</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../webrtc/RTCPeerConnection-helper.js"></script>
+</head>
+<body>
+  <p class="instructions">If prompted, use the accept button to give permission to use your audio and video devices.</p>
+  <h1 class="instructions">Description</h1>
+  <p class="instructions">This test checks that generating video MediaStreamTracks from VideoTrackGenerator works as expected.</p>
+  <script>
+
+    const pixelColour = [50, 100, 150, 255];
+    const height = 240;
+    const width = 320;
+    function makeVideoFrame(timestamp) {
+      const canvas = new OffscreenCanvas(width, height);
+
+      const ctx = canvas.getContext('2d', {alpha: false});
+      ctx.fillStyle = `rgba(${pixelColour.join()})`;
+      ctx.fillRect(0, 0, width, height);
+
+      return new VideoFrame(canvas, {timestamp, alpha: 'discard'});
+    }
+
+    async function getVideoFrame() {
+      const stream = await getNoiseStream({video: true});
+      const input_track = stream.getTracks()[0];
+      const processor = new MediaStreamTrackProcessor(input_track);
+      const reader = processor.readable.getReader();
+      const result = await reader.read();
+      input_track.stop();
+      return result.value;
+    }
+
+    function assertPixel(t, bytes, expected, epsilon = 5) {
+      for (let i = 0; i < bytes.length; i++) {
+        t.step(() => {
+          assert_less_than(Math.abs(bytes[i] - expected[i]),  epsilon, "Mismatched pixel");
+        });
+      }
+    }
+
+    async function initiateSingleTrackCall(t, track, output) {
+      const caller = new RTCPeerConnection();
+      t.add_cleanup(() => caller.close());
+      const callee = new RTCPeerConnection();
+      t.add_cleanup(() => callee.close());
+      caller.addTrack(track);
+      t.add_cleanup(() => track.stop());
+
+      exchangeIceCandidates(caller, callee);
+      // Wait for the first track.
+      const e = await exchangeOfferAndListenToOntrack(t, caller, callee);
+      output.srcObject = new MediaStream([e.track]);
+      // Exchange answer.
+      await exchangeAnswer(caller, callee);
+      await waitForConnectionStateChange(callee, ['connected']);
+    }
+
+    promise_test(async t => {
+      const videoFrame = await getVideoFrame();
+      const originalWidth = videoFrame.displayWidth;
+      const originalHeight = videoFrame.displayHeight;
+      const originalTimestamp = videoFrame.timestamp;
+      const generator = new VideoTrackGenerator();
+      t.add_cleanup(() => generator.track.stop());
+
+      // Use a MediaStreamTrackProcessor as a sink for |generator| to verify
+      // that |processor| actually forwards the frames written to its writable
+      // field.
+      const processor = new MediaStreamTrackProcessor(generator);
+      const reader = processor.readable.getReader();
+      const readerPromise = new Promise(async resolve => {
+        const result = await reader.read();
+        assert_equals(result.value.displayWidth, originalWidth);
+        assert_equals(result.value.displayHeight, originalHeight);
+        assert_equals(result.value.timestamp, originalTimestamp);
+        resolve();
+      });
+
+      generator.writable.getWriter().write(videoFrame);
+      return readerPromise;
+    }, 'Tests that VideoTrackGenerator forwards frames to sink');
+
+    promise_test(async t => {
+      const videoFrame = makeVideoFrame(1);
+      const originalWidth = videoFrame.displayWidth;
+      const originalHeight = videoFrame.displayHeight;
+      const generator = new VideoTrackGenerator();
+      t.add_cleanup(() => generator.track.stop());
+
+      const video = document.createElement("video");
+      video.autoplay = true;
+      video.width = 320;
+      video.height = 240;
+      video.srcObject = new MediaStream([generator.track]);
+      video.play();
+
+      // Wait for the video element to be connected to the generator and
+      // generate the frame.
+      video.onloadstart = () => generator.writable.getWriter().write(videoFrame);
+
+      return new Promise((resolve)=> {
+        video.ontimeupdate = t.step_func(() => {
+          const canvas = document.createElement("canvas");
+          canvas.width = originalWidth;
+          canvas.height = originalHeight;
+          const context = canvas.getContext('2d');
+          context.drawImage(video, 0, 0);
+          // Pick a pixel in the centre of the video and check that it has the colour of the frame provided.
+          const pixel = context.getImageData(videoFrame.displayWidth/2, videoFrame.displayHeight/2, 1, 1);
+          assertPixel(t, pixel.data, pixelColour);
+          resolve();
+        });
+      });
+    }, 'Tests that frames are actually rendered correctly in a stream used for a video element.');
+
+    promise_test(async t => {
+      const generator = new VideoTrackGenerator();
+      t.add_cleanup(() => generator.track.stop());
+
+      // Write frames for the duration of the test.
+      const writer = generator.writable.getWriter();
+      let timestamp = 0;
+      const intervalId = setInterval(
+          t.step_func(async () => {
+            if (generator.track.readyState === 'live') {
+              timestamp++;
+              await writer.write(makeVideoFrame(timestamp));
+            }
+          }),
+          40);
+      t.add_cleanup(() => clearInterval(intervalId));
+
+      const video = document.createElement('video');
+      video.autoplay = true;
+      video.width = width;
+      video.height = height;
+      video.muted = true;
+
+      await initiateSingleTrackCall(t, generator.track, video);
+
+      return new Promise(resolve => {
+        video.ontimeupdate = t.step_func(() => {
+          const canvas = document.createElement('canvas');
+          canvas.width = width;
+          canvas.height = height;
+          const context = canvas.getContext('2d');
+          context.drawImage(video, 0, 0);
+          // Pick a pixel in the centre of the video and check that it has the
+          // colour of the frame provided.
+          const pixel = context.getImageData(width / 2, height / 2, 1, 1);
+          // Encoding/decoding can add noise, so increase the threshhold to 8.
+          assertPixel(t, pixel.data, pixelColour, 8);
+          resolve();
+        });
+      });
+    }, 'Tests that frames are actually rendered correctly in a stream sent over a peer connection.');
+
+
+    promise_test(async t => {
+      const generator = new VideoTrackGenerator();
+      t.add_cleanup(() => generator.track.stop());
+
+      const inputCanvas = new OffscreenCanvas(width, height);
+
+      const inputContext = inputCanvas.getContext('2d', {alpha: false});
+      // draw four quadrants
+      const colorUL = [255, 0, 0, 255];
+      inputContext.fillStyle = `rgba(${colorUL.join()})`;
+      inputContext.fillRect(0, 0, width / 2, height / 2);
+      const colorUR = [255, 255, 0, 255];
+      inputContext.fillStyle = `rgba(${colorUR.join()})`;
+      inputContext.fillRect(width / 2, 0, width / 2, height / 2);
+      const colorLL = [0, 255, 0, 255];
+      inputContext.fillStyle = `rgba(${colorLL.join()})`;
+      inputContext.fillRect(0, height / 2, width / 2, height / 2);
+      const colorLR = [0, 255, 255, 255];
+      inputContext.fillStyle = `rgba(${colorLR.join()})`;
+      inputContext.fillRect(width / 2, height / 2, width / 2, height / 2);
+
+      // Write frames for the duration of the test.
+      const writer = generator.writable.getWriter();
+      let timestamp = 0;
+      const intervalId = setInterval(
+          t.step_func(async () => {
+            if (generator.track.readyState === 'live') {
+              timestamp++;
+              await writer.write(new VideoFrame(
+                  inputCanvas, {timestamp: timestamp, alpha: 'discard'}));
+            }
+          }),
+          40);
+      t.add_cleanup(() => clearInterval(intervalId));
+
+      const caller = new RTCPeerConnection();
+      t.add_cleanup(() => caller.close());
+      const callee = new RTCPeerConnection();
+      t.add_cleanup(() => callee.close());
+      const sender = caller.addTrack(generator.track);
+
+      exchangeIceCandidates(caller, callee);
+      // Wait for the first track.
+      const e = await exchangeOfferAndListenToOntrack(t, caller, callee);
+
+      // Exchange answer.
+      await exchangeAnswer(caller, callee);
+      await waitForConnectionStateChange(callee, ['connected']);
+      const params = sender.getParameters();
+      params.encodings.forEach(e => e.scaleResolutionDownBy = 2);
+      sender.setParameters(params);
+
+      const processor = new MediaStreamTrackProcessor(e.track);
+      const reader = processor.readable.getReader();
+
+      // The first frame may not have had scaleResolutionDownBy applied
+      const numTries = 5;
+      for (let i = 1; i <= numTries; i++) {
+        const {value: outputFrame} = await reader.read();
+        if (outputFrame.displayWidth !== width / 2) {
+          assert_less_than(i, numTries, `First ${numTries} frames were the wrong size.`);
+          outputFrame.close();
+          continue;
+        }
+
+        assert_equals(outputFrame.displayWidth, width / 2);
+        assert_equals(outputFrame.displayHeight, height / 2);
+
+        const outputCanvas = new OffscreenCanvas(width / 2, height / 2);
+        const outputContext = outputCanvas.getContext('2d', {alpha: false});
+        outputContext.drawImage(outputFrame, 0, 0);
+        outputFrame.close();
+        // Check the four quadrants
+        const pixelUL = outputContext.getImageData(width / 8, height / 8, 1, 1);
+        assertPixel(t, pixelUL.data, colorUL);
+        const pixelUR =
+            outputContext.getImageData(width * 3 / 8, height / 8, 1, 1);
+        assertPixel(t, pixelUR.data, colorUR);
+        const pixelLL =
+            outputContext.getImageData(width / 8, height * 3 / 8, 1, 1);
+        assertPixel(t, pixelLL.data, colorLL);
+        const pixelLR =
+            outputContext.getImageData(width * 3 / 8, height * 3 / 8, 1, 1);
+        assertPixel(t, pixelLR.data, colorLR);
+        break;
+      }
+    }, 'Tests that frames are sent correctly with RTCRtpEncodingParameters.scaleResolutionDownBy.');
+
+    promise_test(async t => {
+      const generator = new VideoTrackGenerator();
+      t.add_cleanup(() => generator.track.stop());
+
+      const writer = generator.writable.getWriter();
+      const frame = makeVideoFrame(1);
+      await writer.write(frame);
+
+      assert_equals(generator.track.kind, "video");
+      assert_equals(generator.track.readyState, "live");
+    }, "Tests that creating a VideoTrackGenerator works as expected");
+
+    promise_test(async t => {
+      const generator = new VideoTrackGenerator();
+      t.add_cleanup(() => generator.track.stop());
+
+      const writer = generator.writable.getWriter();
+      const frame = makeVideoFrame(1);
+      await writer.write(frame);
+
+      assert_throws_dom("InvalidStateError", () => frame.clone(), "VideoFrame wasn't destroyed on write.");
+    }, "Tests that VideoFrames are destroyed on write.");
+
+    promise_test(async t => {
+      const generator = new VideoTrackGenerator();
+      t.add_cleanup(() => generator.track.stop());
+
+      const writer = generator.writable.getWriter();
+      const frame = makeVideoFrame(1);
+      assert_throws_js(TypeError, writer.write(frame));
+    }, "Mismatched frame and generator kind throws on write.");
+
+  promise_test(async t => {
+      const generator = new VideoTrackGenerator();
+    t.add_cleanup(() => generator.track.stop());
+
+    // Use a MediaStreamTrackProcessor as a sink for |generator| to verify
+    // that |processor| actually forwards the frames written to its writable
+    // field.
+    const processor = new MediaStreamTrackProcessor(generator.track);
+    const reader = processor.readable.getReader();
+    const videoFrame = makeVideoFrame(1);
+
+    const writer = generator.writable.getWriter();
+    const videoFrame1 = makeVideoFrame(1);
+    writer.write(videoFrame1);
+    const result1 = await reader.read();
+    assert_equals(result1.value.timestamp, 1);
+    generator.muted = true;
+
+    // This frame is expected to be discarded.
+    const videoFrame2 = makeVideoFrame(2);
+    writer.write(videoFrame2);
+    generator.muted = false;
+
+    const videoFrame3 = makeVideoFrame(3);
+    writer.write(videoFrame3);
+    const result3 = await reader.read();
+    assert_equals(result3.value.timestamp, 3);
+
+    // Set up a read ahead of time, then mute, enqueue and unmute.
+    const promise5 = reader.read();
+    generator.muted = true;
+    writer.write(makeVideoFrame(4)); // Expected to be discarded.
+    generator.muted = false;
+    writer.write(makeVideoFrame(5));
+    const result5 = await promise5;
+    assert_equals(result5.value.timestamp, 5);
+  }, 'Tests that VideoTrackGenerator forwards frames only when unmuted');
+
+  // Note - tests for mute/unmute events will be added once
+  // https://github.com/w3c/mediacapture-transform/issues/81 is resolved
+
+  </script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/dedicated-worker.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/dedicated-worker.js
@@ -1,0 +1,11 @@
+self.onmessage = (e) => {
+  try {
+    const mstg = new MediaStreamTrackGenerator({kind: 'video'});
+    if ('enable' in e.data) {
+      mstg.enabled = e.data.enable;
+    }
+    self.postMessage({result: 'Success'});
+  } catch (e) {
+    self.postMessage({result: 'Failure', error: e});
+  }
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/idlharness.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/idlharness.any.js
@@ -1,0 +1,13 @@
+// META: global=dedicatedworker
+// META: script=/resources/WebIDLParser.js
+// META: script=/resources/idlharness.js
+
+idl_test(
+  ['mediacapture-transform'],
+  ['dom', 'html'],
+  idl_array => {
+    idl_array.add_objects({
+      VideoTrackGenerator: ['new VideoTrackGenerator()'],
+    });
+  }
+);

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/idlharness.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/idlharness.any.worker-expected.txt
@@ -1,0 +1,25 @@
+
+PASS idl_test setup
+PASS idl_test validation
+FAIL MediaStreamTrackProcessor interface: existence and properties of interface object assert_own_property: self does not have own property "MediaStreamTrackProcessor" expected property "MediaStreamTrackProcessor" missing
+FAIL MediaStreamTrackProcessor interface object length assert_own_property: self does not have own property "MediaStreamTrackProcessor" expected property "MediaStreamTrackProcessor" missing
+FAIL MediaStreamTrackProcessor interface object name assert_own_property: self does not have own property "MediaStreamTrackProcessor" expected property "MediaStreamTrackProcessor" missing
+FAIL MediaStreamTrackProcessor interface: existence and properties of interface prototype object assert_own_property: self does not have own property "MediaStreamTrackProcessor" expected property "MediaStreamTrackProcessor" missing
+FAIL MediaStreamTrackProcessor interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "MediaStreamTrackProcessor" expected property "MediaStreamTrackProcessor" missing
+FAIL MediaStreamTrackProcessor interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "MediaStreamTrackProcessor" expected property "MediaStreamTrackProcessor" missing
+FAIL MediaStreamTrackProcessor interface: attribute readable assert_own_property: self does not have own property "MediaStreamTrackProcessor" expected property "MediaStreamTrackProcessor" missing
+PASS VideoTrackGenerator interface: existence and properties of interface object
+PASS VideoTrackGenerator interface object length
+PASS VideoTrackGenerator interface object name
+PASS VideoTrackGenerator interface: existence and properties of interface prototype object
+PASS VideoTrackGenerator interface: existence and properties of interface prototype object's "constructor" property
+PASS VideoTrackGenerator interface: existence and properties of interface prototype object's @@unscopables property
+FAIL VideoTrackGenerator interface: attribute writable assert_true: The prototype object must have a property "writable" expected true got false
+PASS VideoTrackGenerator interface: attribute muted
+FAIL VideoTrackGenerator interface: attribute track assert_true: The prototype object must have a property "track" expected true got false
+PASS VideoTrackGenerator must be primary interface of new VideoTrackGenerator()
+PASS Stringification of new VideoTrackGenerator()
+FAIL VideoTrackGenerator interface: new VideoTrackGenerator() must inherit property "writable" with the proper type assert_inherits: property "writable" not found in prototype chain
+PASS VideoTrackGenerator interface: new VideoTrackGenerator() must inherit property "muted" with the proper type
+FAIL VideoTrackGenerator interface: new VideoTrackGenerator() must inherit property "track" with the proper type assert_inherits: property "track" not found in prototype chain
+

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/idlharness.any.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/idlharness.any.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/service-worker.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/service-worker.js
@@ -1,0 +1,8 @@
+self.addEventListener('message', (event) => {
+  try {
+    const mstg = new MediaStreamTrackGenerator({ kind: 'video' });
+    event.source.postMessage({ result: 'Success' });
+  } catch (e) {
+    event.source.postMessage({ result: 'Failure', error: e });
+  };
+});

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/shared-worker.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/shared-worker.js
@@ -1,0 +1,11 @@
+onconnect = (e) => {
+    const port = e.ports[0];
+    port.onmessage = (e) => {
+      try {
+        const generator = new MediaStreamTrackGenerator({kind: 'video'});
+        port.postMessage({result: 'Success'});
+      } catch (e) {
+        port.postMessage({result: 'Failure', error: e});
+      }
+    }
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/w3c-import.log
@@ -1,0 +1,30 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackGenerator-audio.https.html
+/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackGenerator-in-service-worker.https.html
+/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackGenerator-in-shared-worker.https.html
+/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackGenerator-in-worker.https.html
+/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackGenerator-pipes-data-in-worker.https.html
+/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackGenerator-video.https.html
+/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-audio.https.html
+/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-backpressure.https.html
+/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-video.https.html
+/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-worker.js
+/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/VideoTrackGenerator.https.html
+/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/dedicated-worker.js
+/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/service-worker.js
+/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/shared-worker.js

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -65,6 +65,7 @@ fast/mediastream
 imported/w3c/web-platform-tests/feature-policy/reporting/camera-reporting.https.html [ Skip ]
 imported/w3c/web-platform-tests/feature-policy/reporting/microphone-reporting.https.html [ Skip ]
 imported/w3c/web-platform-tests/mediacapture-streams
+imported/w3c/web-platform-tests/mediacapture-insertable-streams
 http/tests/media/media-stream
 http/tests/ssl/media-stream
 inspector/page/overrideSetting-MockCaptureDevicesEnabled.html [ Skip ]

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -4491,6 +4491,21 @@ MediaStreamEnabled:
     WebCore:
       default: true
 
+MediaStreamTrackProcessingEnabled:
+  type: bool
+  status: testable
+  category: media
+  humanReadableName: "MediaStreamTrack Processing"
+  humanReadableDescription: "Enable MediaStreamTrack Processing"
+  condition: ENABLE(MEDIA_STREAM)
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 MediaUserGestureInheritsFromDocument:
   type: bool
   status: embedder

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -529,6 +529,7 @@ set(WebCore_NON_SVG_IDL_FILES
     Modules/mediastream/RTCTrackEvent.idl
     Modules/mediastream/RTCTransformEvent.idl
     Modules/mediastream/RedEyeReduction.idl
+    Modules/mediastream/VideoTrackGenerator.idl
 
     Modules/model-element/HTMLModelElement.idl
     Modules/model-element/HTMLModelElementCamera.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -657,6 +657,7 @@ $(PROJECT_DIR)/Modules/mediastream/RTCStatsReport.idl
 $(PROJECT_DIR)/Modules/mediastream/RTCTrackEvent.idl
 $(PROJECT_DIR)/Modules/mediastream/RTCTransformEvent.idl
 $(PROJECT_DIR)/Modules/mediastream/RedEyeReduction.idl
+$(PROJECT_DIR)/Modules/mediastream/VideoTrackGenerator.idl
 $(PROJECT_DIR)/Modules/model-element/HTMLModelElement.idl
 $(PROJECT_DIR)/Modules/model-element/HTMLModelElementCamera.idl
 $(PROJECT_DIR)/Modules/modern-media-controls/controls/activity-indicator.css

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -2996,6 +2996,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSVideoTrack.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSVideoTrack.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSVideoTrackConfiguration.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSVideoTrackConfiguration.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSVideoTrackGenerator.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSVideoTrackGenerator.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSVideoTrackList.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSVideoTrackList.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSVideoTrackMediaSource.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -525,6 +525,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/mediastream/RTCStatsReport.idl \
     $(WebCore)/Modules/mediastream/RTCTrackEvent.idl \
     $(WebCore)/Modules/mediastream/RTCTransformEvent.idl \
+    $(WebCore)/Modules/mediastream/VideoTrackGenerator.idl \
     $(WebCore)/Modules/model-element/HTMLModelElement.idl \
     $(WebCore)/Modules/model-element/HTMLModelElementCamera.idl \
     $(WebCore)/Modules/notifications/Notification.idl \

--- a/Source/WebCore/Modules/mediastream/VideoTrackGenerator.cpp
+++ b/Source/WebCore/Modules/mediastream/VideoTrackGenerator.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "VideoTrackGenerator.h"
+
+#if ENABLE(MEDIA_STREAM)
+
+#include "MediaStreamTrack.h"
+#include "WritableStream.h"
+
+namespace WebCore {
+
+WTF_MAKE_ISO_ALLOCATED_IMPL(VideoTrackGenerator);
+
+VideoTrackGenerator::VideoTrackGenerator(ScriptExecutionContext&)
+{
+}
+
+VideoTrackGenerator::~VideoTrackGenerator()
+{
+}
+
+void VideoTrackGenerator::setMuted(bool muted)
+{
+    m_muted = muted;
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(MEDIA_STREAM)

--- a/Source/WebCore/Modules/mediastream/VideoTrackGenerator.h
+++ b/Source/WebCore/Modules/mediastream/VideoTrackGenerator.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(MEDIA_STREAM)
+
+#include <wtf/RefCounted.h>
+
+namespace WebCore {
+
+class MediaStreamTrack;
+class ScriptExecutionContext;
+class WritableStream;
+
+class VideoTrackGenerator : public RefCounted<VideoTrackGenerator> {
+    WTF_MAKE_ISO_ALLOCATED(VideoTrackGenerator);
+public:
+    static Ref<VideoTrackGenerator> create(ScriptExecutionContext& context) { return adoptRef(*new VideoTrackGenerator(context)); }
+    ~VideoTrackGenerator();
+
+    void setMuted(bool);
+    bool muted() const { return m_muted; }
+
+private:
+    explicit VideoTrackGenerator(ScriptExecutionContext&);
+
+    bool m_muted { false };
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(MEDIA_STREAM)

--- a/Source/WebCore/Modules/mediastream/VideoTrackGenerator.idl
+++ b/Source/WebCore/Modules/mediastream/VideoTrackGenerator.idl
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    Conditional=MEDIA_STREAM,
+    PrivateIdentifier,
+    PublicIdentifier,
+    EnabledBySetting=MediaStreamTrackProcessingEnabled,
+    Exposed=DedicatedWorker
+] interface VideoTrackGenerator {
+    [CallWith=CurrentScriptExecutionContext] constructor();
+
+    // readonly attribute WritableStream writable;
+    attribute boolean muted;
+    // readonly attribute MediaStreamTrack track;
+};

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -275,6 +275,7 @@ Modules/mediastream/SFrameUtils.cpp
 Modules/mediastream/STUNMessageParsing.cpp
 Modules/mediastream/UserMediaController.cpp
 Modules/mediastream/UserMediaRequest.cpp
+Modules/mediastream/VideoTrackGenerator.cpp
 Modules/model-element/HTMLModelElement.cpp
 Modules/model-element/ModelPlayer.cpp
 Modules/model-element/ModelPlayerClient.cpp
@@ -4414,6 +4415,7 @@ JSVideoPixelFormat.cpp
 JSVideoPlaybackQuality.cpp
 JSVideoTrack.cpp
 JSVideoTrackConfiguration.cpp
+JSVideoTrackGenerator.cpp
 JSVideoTrackList.cpp
 JSVideoTransferCharacteristics.cpp
 JSViewTimeline.cpp

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -507,6 +507,7 @@ namespace WebCore {
     macro(XRViewerPose) \
     macro(XRViewport) \
     macro(XRWebGLLayer) \
+    macro(VideoTrackGenerator) \
     macro(abortAlgorithm) \
     macro(abortSteps) \
     macro(addAbortAlgorithmToSignal) \


### PR DESCRIPTION
#### 47a504ad8797a7c3b0d660a8aa7b9590a3aa0c9a
<pre>
Add a VideoTrackGenerator skeleton
<a href="https://bugs.webkit.org/show_bug.cgi?id=267267">https://bugs.webkit.org/show_bug.cgi?id=267267</a>
<a href="https://rdar.apple.com/120708226">rdar://120708226</a>

Reviewed by Eric Carlson.

We introduce a skeleton of VideoTrackGenerator.
We do not yet expose readable and track as this will be done in a follow-up.

We import mediacapture-insertable-streams tests even though they are testing API in window context.
This allows to cover IDL tests with newly added mediacapture-insertable-streams/idlharness.any.worker.html.

* LayoutTests/imported/w3c/resources/import-expectations.json:
* LayoutTests/imported/w3c/web-platform-tests/interfaces/mediacapture-transform.idl: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackGenerator-audio.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackGenerator-audio.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackGenerator-in-service-worker.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackGenerator-in-service-worker.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackGenerator-in-shared-worker.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackGenerator-in-shared-worker.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackGenerator-in-worker.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackGenerator-in-worker.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackGenerator-pipes-data-in-worker.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackGenerator-pipes-data-in-worker.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackGenerator-video.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackGenerator-video.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-audio.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-audio.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-backpressure.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-backpressure.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-video.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-video.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-worker.js: Added.
(onmessage.async msg):
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/VideoTrackGenerator.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/VideoTrackGenerator.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/dedicated-worker.js: Added.
(self.onmessage):
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/idlharness.any.js: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/idlharness.any.worker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/idlharness.any.worker.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/service-worker.js: Added.
(event.catch):
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/shared-worker.js: Added.
(onconnect):
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/w3c-import.log: Added.
* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Modules/mediastream/VideoTrackGenerator.cpp: Added.
(WebCore::VideoTrackGenerator::VideoTrackGenerator):
(WebCore::VideoTrackGenerator::~VideoTrackGenerator):
(WebCore::VideoTrackGenerator::setMuted):
* Source/WebCore/Modules/mediastream/VideoTrackGenerator.h: Added.
(WebCore::VideoTrackGenerator::create):
(WebCore::VideoTrackGenerator::muted const):
* Source/WebCore/Modules/mediastream/VideoTrackGenerator.idl: Added.
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:

Canonical link: <a href="https://commits.webkit.org/272827@main">https://commits.webkit.org/272827@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/06c2ca3ba24d60ec643b57ad546f26248b1b4422

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33190 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11964 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35104 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35827 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29968 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34161 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14311 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9133 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29366 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33665 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10091 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29652 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8793 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8946 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29627 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37159 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/28392 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30159 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30009 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35056 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/33193 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9077 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7012 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32925 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10797 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/29285 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/39660 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7700 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9662 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8341 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9745 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->