### PR TITLE
browser.scripting.executeScript doesn't handle all valid argument types

### DIFF
--- a/Source/WebKit/Shared/Extensions/WebExtensionDynamicScripts.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionDynamicScripts.serialization.in
@@ -27,7 +27,7 @@ headers: "WebExtensionScriptInjectionParameters.h" "WebExtensionScriptInjectionR
 struct WebKit::WebExtensionScriptInjectionParameters {
     std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier;
 
-    std::optional<Vector<String>> arguments;
+    std::optional<Ref<API::Data>> arguments;
     std::optional<Vector<String>> files;
     std::optional<Vector<WebKit::WebExtensionFrameIdentifier>> frameIDs;
 

--- a/Source/WebKit/Shared/Extensions/WebExtensionScriptInjectionParameters.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionScriptInjectionParameters.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
+#include "APIData.h"
 #include <wtf/Forward.h>
 
 namespace WebKit {
@@ -34,7 +35,7 @@ namespace WebKit {
 struct WebExtensionScriptInjectionParameters {
     std::optional<WebExtensionTabIdentifier> tabIdentifier;
 
-    std::optional<Vector<String>> arguments;
+    std::optional<Ref<API::Data>> arguments;
     std::optional<Vector<String>> files;
     std::optional<Vector<WebExtensionFrameIdentifier>> frameIDs;
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
@@ -31,6 +31,8 @@
 #import "WebExtensionDynamicScripts.h"
 
 #if ENABLE(WK_WEB_EXTENSIONS)
+#import "APIData.h"
+#import "CocoaHelpers.h"
 #import "WKContentWorld.h"
 #import "WKFrameInfoPrivate.h"
 #import "WKWebViewInternal.h"
@@ -121,7 +123,7 @@ void executeScript(std::optional<SourcePairs> scriptPairs, WKWebView *webView, A
 
             if (parameters.function) {
                 NSString *javaScript = [NSString stringWithFormat:@"return (%@)(...arguments)", (NSString *)parameters.function.value()];
-                NSArray *arguments = parameters.arguments ? createNSArray(parameters.arguments.value()).get() : @[ ];
+                NSArray *arguments = parameters.arguments ? parseJSON(parameters.arguments.value(), JSONOptions::FragmentsAllowed) : @[ ];
 
                 [webView _callAsyncJavaScript:javaScript arguments:@{ @"arguments": arguments } inFrame:frameInfo inContentWorld:world completionHandler:makeBlockPtr([injectionResults, aggregator, frameInfo](id resultOfExecution, NSError *error) mutable {
                     injectionResults->results.append(toInjectionResultParameters(resultOfExecution, frameInfo, error.localizedDescription));

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIScripting.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIScripting.h
@@ -68,7 +68,7 @@ private:
 
     void parseCSSInjectionOptions(NSDictionary *, WebExtensionScriptInjectionParameters&);
     void parseTargetInjectionOptions(NSDictionary *, WebExtensionScriptInjectionParameters&, NSString **outExceptionString);
-    void parseScriptInjectionOptions(NSDictionary *, WebExtensionScriptInjectionParameters&);
+    void parseScriptInjectionOptions(NSDictionary *, WebExtensionScriptInjectionParameters&, NSString **outExceptionString);
     static void parseRegisteredContentScripts(NSArray *, FirstTimeRegistration, Vector<WebExtensionRegisteredScriptParameters>&);
 
 #endif

--- a/Source/WebKit/WebProcess/Extensions/Bindings/Cocoa/JSWebExtensionWrapperCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/Cocoa/JSWebExtensionWrapperCocoa.mm
@@ -157,7 +157,7 @@ id WebExtensionCallbackHandler::call(id argumentOne, id argumentTwo, id argument
     });
 }
 
-id toNSObject(JSContextRef context, JSValueRef valueRef, Class requiredClass)
+id toNSObject(JSContextRef context, JSValueRef valueRef, Class containingObjectsOfClass)
 {
     ASSERT(context);
 
@@ -166,22 +166,32 @@ id toNSObject(JSContextRef context, JSValueRef valueRef, Class requiredClass)
 
     JSValue *value = [JSValue valueWithJSValueRef:valueRef inContext:[JSContext contextWithJSGlobalContextRef:JSContextGetGlobalContext(context)]];
 
-    // Return the JSValue instead of calling toObject for some objects,
-    // since that would convert it to an empty NSDictionary and be useless.
-    if (value.isObject && !value._isDictionary && !value.isArray && !value.isDate && !value.isNull)
+    if (value.isArray) {
+        NSUInteger length = [value[@"length"] toUInt32];
+        NSMutableArray *mutableArray = [NSMutableArray arrayWithCapacity:length];
+
+        for (NSUInteger i = 0; i < length; ++i) {
+            JSValue *itemValue = [value valueAtIndex:i];
+            if (id convertedItem = toNSObject(context, itemValue.JSValueRef))
+                [mutableArray addObject:convertedItem];
+        }
+
+        NSArray *resultArray = [mutableArray copy];
+        if (!containingObjectsOfClass || containingObjectsOfClass == NSObject.class)
+            return resultArray;
+
+        return filterObjects(resultArray, ^bool(id, id value) {
+            return [value isKindOfClass:containingObjectsOfClass];
+        });
+    }
+
+    if (value._isDictionary)
+        return toNSDictionary(context, valueRef);
+
+    if (value.isObject && !value.isDate && !value.isNull)
         return value;
 
-    id result = [value toObject];
-    NSArray *resultArray = dynamic_objc_cast<NSArray>(result);
-    if (!requiredClass || !resultArray)
-        return result;
-
-    if (requiredClass == NSObject.class)
-        return resultArray;
-
-    return filterObjects(resultArray, ^bool (id, id value) {
-        return [value isKindOfClass:requiredClass];
-    });
+    return [value toObject];
 }
 
 NSString *toNSString(JSContextRef context, JSValueRef value, NullStringPolicy nullStringPolicy)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIScripting.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIScripting.mm
@@ -60,6 +60,9 @@ TEST(WKWebExtensionAPIScripting, Errors)
         @"browser.test.assertThrows(() => browser.scripting.executeScript({'target': { 'tabId': 0 }, args: ['args'], func: () => 'function', arguments: ['arguments']}), /it cannot specify both 'args' and 'arguments'. Please use 'args'./i)",
         @"browser.test.assertThrows(() => browser.scripting.executeScript({'target': { 'tabId': 0 }, args: ['args'], files: ['path/to/file']}), /it must specify both 'func' and 'args'./i)",
 
+        @"browser.test.assertThrows(() => browser.scripting.executeScript({'target': { 'tabId': 0 }, args: 0, func: () => 'function' }), /'args' is expected to be an array, but a number was provided./i)",
+        @"browser.test.assertThrows(() => browser.scripting.executeScript({'target': { 'tabId': 0 }, func: () => 'function', args: [ () => 'arguments' ] }), /it is not JSON-serializable./i)",
+
         @"const notAFunction = null",
         @"browser.test.assertThrows(() => browser.scripting.executeScript({'target': { 'tabId': 0 }, func: 'not a function' }), /is expected to be a value, but a string was provided./i)",
 
@@ -147,6 +150,9 @@ TEST(WKWebExtensionAPIScripting, ExecuteScript)
         @"  browser.test.assertDeepEq(results[0], expectedResultWithFileExecution)",
 
         @"  results = await browser.scripting.executeScript( { target: { tabId: tabId, frameIds: [ 0 ] }, func: changeBackgroundColor, args: ['pink'] })",
+        @"  browser.test.assertDeepEq(results[0], expectedResultWithFunctionExecution)",
+
+        @"  results = await browser.scripting.executeScript({target: {tabId: tabId}, func: (bool, number, string, dict, array) => { browser.test.log('supported argument types') }, args: [true, 10, 'string', { }, [ ]]})",
         @"  browser.test.assertDeepEq(results[0], expectedResultWithFunctionExecution)",
 
         @"  await browser.scripting.executeScript( { target: { tabId: tabId, allFrames: true }, func: changeBackgroundColor, args: ['blue'] })",


### PR DESCRIPTION
#### 38171256d2490d68d09297e3aa7afe34d1ae75d4
<pre>
browser.scripting.executeScript doesn&apos;t handle all valid argument types
<a href="https://bugs.webkit.org/show_bug.cgi?id=267289">https://bugs.webkit.org/show_bug.cgi?id=267289</a>
<a href="https://rdar.apple.com/120727491">rdar://120727491</a>

Reviewed by Timothy Hatcher.

We are incorrectly assuming all argument types passed into the &apos;args&apos; (or &apos;arguments&apos;) property for
a calling to scripting.executeScript() will be a type String. However, that is incorrect since the
property types can be all JSON serializable values.

To fix this, we should check to see if the arguments passed are a valid JSON serializable objects
and then encode the data before passing it off to the UI Process.

* Source/WebKit/Shared/Extensions/WebExtensionDynamicScripts.serialization.in:
* Source/WebKit/Shared/Extensions/WebExtensionScriptInjectionParameters.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm:
(WebKit::WebExtensionDynamicScripts::executeScript):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIScriptingCocoa.mm:
(WebKit::WebExtensionAPIScripting::executeScript):
(WebKit::WebExtensionAPIScripting::validateScript):
We shouldn&apos;t be using NSObject anymore for expected value types since everything would return true.
Instead, verify that the top-level is an array and use isValidJSONObject to validate the contents.

(WebKit::WebExtensionAPIScripting::parseScriptInjectionOptions):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIScripting.h:

* Source/WebKit/WebProcess/Extensions/Bindings/Cocoa/JSWebExtensionWrapperCocoa.mm:
(WebKit::toNSObject):
Update method to iterate through the array and convert each element to a JSValue. Similar to what
we do in toNSDictionary(). Without this, element types like functions would be converted to an empty
NSDictionary and not a JSValue.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIScripting.mm:
(TestWebKitAPI::TEST):
Add new test to check that functions passed as arguments throw an error.
Add new tests that verify supported argument types.

Canonical link: <a href="https://commits.webkit.org/272836@main">https://commits.webkit.org/272836@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee8493cfdbc9b05d1aa71ace0336df4777c12f75

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33250 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12026 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35164 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35887 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/30269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34221 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14373 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9199 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29402 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33725 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10145 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29699 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8841 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8990 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29676 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37218 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30210 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30052 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35099 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/9116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7064 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32961 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10846 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/9699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4273 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9802 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->