### PR TITLE
SVG element is not displayed if it is inside a <switch> element and it has an SVGFilter resource

### DIFF
--- a/LayoutTests/svg/filters/filter-target-switch-element-expected.svg
+++ b/LayoutTests/svg/filters/filter-target-switch-element-expected.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <filter id="drop-shadow" width="140%" height="140%">
+        <feDropShadow dx="20" dy="20" stdDeviation="0" flood-color="black" />
+    </filter>
+    <g style="filter:url(#drop-shadow)">
+        <rect x="20" y="20" fill="green" width="100" height="100" />
+    </g>
+</svg>

--- a/LayoutTests/svg/filters/filter-target-switch-element.svg
+++ b/LayoutTests/svg/filters/filter-target-switch-element.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <filter id="drop-shadow" width="140%" height="140%">
+        <feDropShadow dx="20" dy="20" stdDeviation="0" flood-color="black" />
+    </filter>
+    <switch style="filter:url(#drop-shadow)">
+        <rect x="20" y="20" fill="green" width="100" height="100" />
+    </switch>
+</svg>

--- a/Source/WebCore/rendering/svg/SVGResources.cpp
+++ b/Source/WebCore/rendering/svg/SVGResources.cpp
@@ -77,6 +77,7 @@ static const MemoryCompactLookupOnlyRobinHoodHashSet<AtomString>& clipperFilterM
         &SVGNames::polylineTag,
         &SVGNames::rectTag,
         &SVGNames::svgTag,
+        &SVGNames::switchTag,
         &SVGNames::textTag,
         &SVGNames::useTag,
 
@@ -98,7 +99,7 @@ static const MemoryCompactLookupOnlyRobinHoodHashSet<AtomString>& clipperFilterM
         &SVGNames::foreignObjectTag,
 
         // Elements that we ignore, as it doesn't make any sense.
-        // defs, pattern, switch (FIXME: Mail SVG WG about these)
+        // defs, pattern (FIXME: Mail SVG WG about these)
         // symbol (is converted to a svg element, when referenced by use, we can safely ignore it.)
     };
     static NeverDestroyed set = tagSet(tags);


### PR DESCRIPTION
#### df6e4e277baa1038e1240ac467b6cc645e8e56e6
<pre>
SVG element is not displayed if it is inside a &lt;switch&gt; element and it has an SVGFilter resource
<a href="https://bugs.webkit.org/show_bug.cgi?id=267192">https://bugs.webkit.org/show_bug.cgi?id=267192</a>
<a href="https://rdar.apple.com/120732837">rdar://120732837</a>

Reviewed by Simon Fraser.

Allow SVGFilter as a resource to the &lt;switch&gt; element. The &lt;switch&gt; element is a
container element which is similar to &lt;a&gt;, &lt;g&gt; and &lt;use&gt; elements. They all create
LegacyRenderSVGTransformableContainer as their renderers.

* LayoutTests/svg/filters/filter-target-switch-element-expected.svg: Added.
* LayoutTests/svg/filters/filter-target-switch-element.svg: Added.
* Source/WebCore/rendering/svg/SVGResources.cpp:
(WebCore::clipperFilterMaskerTags):

Canonical link: <a href="https://commits.webkit.org/272831@main">https://commits.webkit.org/272831@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b4d02b29e160ee47a0eed30ac9c10f506fb2988

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33227 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12002 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35141 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35864 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/30252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34198 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14348 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9175 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29387 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33702 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10125 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29678 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8818 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8973 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29653 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37195 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30192 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30033 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35080 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/9098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7045 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32940 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10827 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7707 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/9681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9779 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->