### PR TITLE
[iOS] With media capability grants enabled, unable to activate camera or mic on bing.com

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -4231,10 +4231,10 @@ MediaCapabilityGrantsEnabled:
       default: false
     WebKit:
       "PLATFORM(IOS_FAMILY_SIMULATOR)": false
-      default: false
+      default: true
     WebCore:
       "PLATFORM(IOS_FAMILY_SIMULATOR)": false
-      default: false
+      default: true
 
 MediaCaptionFormatTypesAllowedInLockdownMode:
   type: String

--- a/Source/WebKit/Platform/cocoa/MediaCapability.h
+++ b/Source/WebKit/Platform/cocoa/MediaCapability.h
@@ -28,20 +28,25 @@
 #if ENABLE(EXTENSION_CAPABILITIES)
 
 #include "ExtensionCapability.h"
-#include <WebCore/RegistrableDomain.h>
 #include <wtf/Forward.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/URL.h>
 #include <wtf/WeakPtr.h>
+
+namespace WebCore {
+class RegistrableDomain;
+}
 
 namespace WebKit {
 
 class ExtensionCapabilityGrant;
 
-using WebCore::RegistrableDomain;
-
 class MediaCapability final : public ExtensionCapability, public CanMakeWeakPtr<MediaCapability> {
+    WTF_MAKE_NONCOPYABLE(MediaCapability);
 public:
-    explicit MediaCapability(RegistrableDomain);
-    explicit MediaCapability(const URL&);
+    explicit MediaCapability(URL);
+    MediaCapability(MediaCapability&&) = default;
+    MediaCapability& operator=(MediaCapability&&) = default;
 
     enum class State : uint8_t {
         Inactive,
@@ -52,8 +57,10 @@ public:
 
     State state() const { return m_state; }
     void setState(State state) { m_state = state; }
+    bool isActivatingOrActive() const;
 
-    const RegistrableDomain& registrableDomain() const { return m_registrableDomain; }
+    const URL& url() const { return m_url; }
+    WebCore::RegistrableDomain registrableDomain() const;
 
     // ExtensionCapability
     String environmentIdentifier() const final;
@@ -61,7 +68,7 @@ public:
 
 private:
     State m_state { State::Inactive };
-    RegistrableDomain m_registrableDomain;
+    URL m_url;
     RetainPtr<_SECapability> m_platformCapability;
 };
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -12655,8 +12655,8 @@ void WebPageProxy::gpuProcessDidFinishLaunching()
     pageClient().gpuProcessDidFinishLaunching();
 #if ENABLE(EXTENSION_CAPABILITIES)
     if (auto& mediaCapability = this->mediaCapability()) {
-        WEBPAGEPROXY_RELEASE_LOG(ProcessCapabilities, "gpuProcessDidFinishLaunching: [envID=%{public}s] granting media capability", mediaCapability->environmentIdentifier().utf8().data());
-        protectedProcess()->protectedProcessPool()->extensionCapabilityGranter().grant(*mediaCapability);
+        WEBPAGEPROXY_RELEASE_LOG(ProcessCapabilities, "gpuProcessDidFinishLaunching[envID=%{public}s]: updating media capability", mediaCapability->environmentIdentifier().utf8().data());
+        updateMediaCapability();
     }
 #endif
 }

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -1046,8 +1046,8 @@ void WebProcessPool::processDidFinishLaunching(WebProcessProxy& process)
 #if ENABLE(EXTENSION_CAPABILITIES)
     for (auto& page : process.pages()) {
         if (auto& mediaCapability = page->mediaCapability()) {
-            WEBPROCESSPOOL_RELEASE_LOG(ProcessCapabilities, "processDidFinishLaunching: granting media capability (envID=%{public}s)", mediaCapability->environmentIdentifier().utf8().data());
-            extensionCapabilityGranter().grant(*mediaCapability);
+            WEBPROCESSPOOL_RELEASE_LOG(ProcessCapabilities, "processDidFinishLaunching[envID=%{public}s]: updating media capability", mediaCapability->environmentIdentifier().utf8().data());
+            page->updateMediaCapability();
         }
     }
 #endif


### PR DESCRIPTION
#### 35716bf5f66cdd27a4b72d9c7a3ef8317c77a932
<pre>
[iOS] With media capability grants enabled, unable to activate camera or mic on bing.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=267296">https://bugs.webkit.org/show_bug.cgi?id=267296</a>
<a href="https://rdar.apple.com/120510826">rdar://120510826</a>

Reviewed by Jer Noble and Per Arne Vollan.

Prior to this change, WebKit would create a media capability each time the main frame navigates to a
new registrable domain and grant it to the page&apos;s WebContent and GPU processes. Later, when the page
began playback or capture, WebKit would activate the capability. Granting and activating in this
order exposed a bug in iOS where other parts of the system would not detect the activated
capability, leading to failures to activate the camera and microphone (among other issues).

To work around this bug, this change reverses the order of operations. WebKit now creates a new
capability per top frame navigation and defers granting it until it is activated.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
Re-activated the media capabilities feature by default.

* Source/WebKit/Platform/cocoa/MediaCapability.h:
* Source/WebKit/Platform/cocoa/MediaCapability.mm:
(WebKit::createPlatformCapability):
(WebKit::MediaCapability::MediaCapability):
(WebKit::MediaCapability::isActivatingOrActive const):
(WebKit::MediaCapability::registrableDomain const):
(WebKit::MediaCapability::environmentIdentifier const):
Changed to hold a URL and vend a RegistrableDomain on demand. This was necessary because we now must
re-create and re-grant the capability per top frame navigation, so it&apos;s insufficient to compare an
existing media capability to the page&apos;s current URL by registrable domain. Drive-by fix: made the
class non-copyable.

* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::setMediaCapability):
(WebKit::WebPageProxy::updateMediaCapability):
(WebKit::WebPageProxy::shouldDeactivateMediaCapability const):
Changed the logic to re-create media capabilities per top frame navigation and defer granting them
to the WebContent and GPU processes until they are activated.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::gpuProcessDidFinishLaunching):
Because the process will finish launching before playback or capture is active, it&apos;s not safe to
grant the capability immediately. Instead, called updateMediaCapability, which will only grant the
capability if activated.

* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::processDidFinishLaunching):
Ditto.

Canonical link: <a href="https://commits.webkit.org/272833@main">https://commits.webkit.org/272833@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/13f434d4bfbaec544e6c7c2b466b5a84b7363525

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33260 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12036 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35175 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35898 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/30274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14383 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9208 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/29412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33735 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10159 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29708 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8855 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/9003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29685 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37228 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/28442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30224 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/30061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/35103 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/33262 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/9122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/7073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32966 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10854 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/39729 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7706 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/9704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8354 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9812 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->