### PR TITLE
`text-indent` does not affect the selected file label for file inputs

### DIFF
--- a/LayoutTests/fast/forms/file/file-input-text-indent-expected.html
+++ b/LayoutTests/fast/forms/file/file-input-text-indent-expected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div style="margin: 20px;">
+<input type="file" style="margin-inline-start: 20px;">
+<br>
+<input type="file" style="margin-inline-start: -20px;">
+<br>
+<div style="writing-mode: vertical-rl; margin-top: 20px">
+<input type="file" style="margin-inline-start: 20px;">
+<br>
+<input type="file" style="margin-inline-start: -20px;">
+</div>
+</body>
+</html>

--- a/LayoutTests/fast/forms/file/file-input-text-indent.html
+++ b/LayoutTests/fast/forms/file/file-input-text-indent.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div style="margin: 20px;">
+<input type="file" style="text-indent: 20px;">
+<br>
+<input type="file" style="text-indent: -20px;">
+<br>
+<div style="writing-mode: vertical-rl; margin-top: 20px">
+<input type="file" style="text-indent: 20px;">
+<br>
+<input type="file" style="text-indent: -20px;">
+</div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderFileUploadControl.cpp
+++ b/Source/WebCore/rendering/RenderFileUploadControl.cpp
@@ -162,6 +162,11 @@ void RenderFileUploadControl::paintControl(PaintInfo& paintInfo, const LayoutPoi
 #endif
         // Determine where the filename should be placed
         LayoutUnit contentLogicalLeft = logicalPaintOffset.x() + logicalLeftOffsetForContent();
+        if (style().isLeftToRightDirection())
+            contentLogicalLeft += textIndentOffset();
+        else
+            contentLogicalLeft -= textIndentOffset();
+
         HTMLInputElement* button = uploadButton();
         if (!button)
             return;


### PR DESCRIPTION
#### 9ea2d325ad2d8b885ccb5835763a0773fd2e00ff
<pre>
`text-indent` does not affect the selected file label for file inputs
<a href="https://bugs.webkit.org/show_bug.cgi?id=253463">https://bugs.webkit.org/show_bug.cgi?id=253463</a>
<a href="https://rdar.apple.com/105223868">rdar://105223868</a>

Reviewed by Alan Baradlay.

Sites, such as daum.net, use `text-indent` with a large negative value to hide
the contents (button and selected file label) of file inputs.

However, since the selected file label is not implemented as it&apos;s own element,
and is simply custom painted text inside the input element, it does not follow
`text-indent`. This results in the button being moved, but not the text.
Consequently, the text remains in the same position regardless of `text-indent`.

In the longer term, this issue should be fixed by making the selected file label
a real element in the file input&apos;s shadow subtree. However, as that is a larger
architectural change, the issue is addressed by honoring `text-indent` when
performing the custom text painting.

* LayoutTests/fast/forms/file/file-input-text-indent-expected.html: Added.
* LayoutTests/fast/forms/file/file-input-text-indent.html: Added.
* Source/WebCore/rendering/RenderFileUploadControl.cpp:
(WebCore::RenderFileUploadControl::paintControl):

Note that even after this fix, there is still an interoperability issue with
file inputs in WebKit. Specifically, file inputs in WebKit do not specify
`overflow: hidden`, while others engines do. This means that the button and
selected file label can be painted outside of the element&apos;s box when using
`text-indent`. However, while new to the label, this issue already exists for
the button. This interoperability issue should be addressed separately, as
it does not directly affect the known compatibility scenario. Additionally it
is non-trivial to fix, as `overflow: hidden` would clip the button element
inside file inputs in their default configuration. The issue is tracked in
webkit.org/b/267299.

Canonical link: <a href="https://commits.webkit.org/272837@main">https://commits.webkit.org/272837@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/255afa5f0a93187bd371bd25667d59b52e05d3b7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33255 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12031 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35169 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35892 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/30273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34226 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14378 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9203 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29407 "Found 1 new test failure: media/media-source/media-source-abort-resets-parser.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33730 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10152 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29705 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8849 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8996 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29682 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37223 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30217 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30060 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35104 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/9120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7069 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32967 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10850 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/29348 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7714 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/9703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9807 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->