### PR TITLE
[Books] Returning from Lock Screen shows a flash of missing content

### DIFF
--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
@@ -112,6 +112,7 @@ public:
     bool performDelegatedLayerDisplay();
 
     void paintContents();
+    virtual void prepareToDisplay() = 0;
     virtual void createContextAndPaintContents() = 0;
 
     virtual Vector<std::unique_ptr<WebCore::ThreadSafeImageBufferFlusher>> createFlushers() = 0;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm
@@ -78,8 +78,6 @@ void RemoteLayerBackingStoreCollection::prepareBackingStoresForDisplay(RemoteLay
             if (!remoteBackingStore->hasFrontBuffer() || !remoteBackingStore->supportsPartialRepaint())
                 remoteBackingStore->setNeedsDisplay();
 
-            remoteBackingStore->clearBackingStore();
-
             prepareBuffersData.append({
                 bufferSet,
                 remoteBackingStore->dirtyRegion(),
@@ -89,8 +87,9 @@ void RemoteLayerBackingStoreCollection::prepareBackingStoresForDisplay(RemoteLay
             });
 
             backingStoreList.append(*remoteBackingStore);
-        } else
-            downcast<RemoteLayerWithInProcessRenderingBackingStore>(backingStore).prepareToDisplay();
+        }
+
+        backingStore.prepareToDisplay();
     }
 
     if (prepareBuffersData.size()) {

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.h
@@ -35,7 +35,7 @@ public:
 
     bool isRemoteLayerWithInProcessRenderingBackingStore() const final { return true; }
 
-    void prepareToDisplay();
+    void prepareToDisplay() final;
     void createContextAndPaintContents() final;
     Vector<std::unique_ptr<WebCore::ThreadSafeImageBufferFlusher>> createFlushers() final;
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.h
@@ -38,6 +38,7 @@ public:
 
     bool isRemoteLayerWithRemoteRenderingBackingStore() const final { return true; }
 
+    void prepareToDisplay() final;
     void clearBackingStore() final;
     void createContextAndPaintContents() final;
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm
@@ -62,6 +62,11 @@ bool RemoteLayerWithRemoteRenderingBackingStore::frontBufferMayBeVolatile() cons
     return m_bufferSet->requestedVolatility().contains(BufferInSetType::Front);
 }
 
+void RemoteLayerWithRemoteRenderingBackingStore::prepareToDisplay()
+{
+    m_contentsBufferHandle = std::nullopt;
+}
+
 void RemoteLayerWithRemoteRenderingBackingStore::clearBackingStore()
 {
     m_contentsBufferHandle = std::nullopt;


### PR DESCRIPTION
#### 39ec746c46ceb11d77d4f0f65be943905484289c
<pre>
[Books] Returning from Lock Screen shows a flash of missing content
<a href="https://bugs.webkit.org/show_bug.cgi?id=267300">https://bugs.webkit.org/show_bug.cgi?id=267300</a>
&lt;<a href="https://rdar.apple.com/119957147">rdar://119957147</a>&gt;

Reviewed by Simon Fraser.

If we&apos;ve included an ImageBufferSet with an empty dirty region in the prepare for display
set, then we always need to return a valid buffer handle.

This happens when we think the front buffer is volatile (as happens when the screen is locked),
and we want to confirm that the contents are still there. If they are, no drawing is needed,
but we still need to update the buffer handle.

* Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp:
(WebKit::RemoteImageBufferSet::ensureBufferForDisplay):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm:
(WebKit::RemoteLayerBackingStoreCollection::prepareBackingStoresForDisplay):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm:
(WebKit::RemoteLayerWithRemoteRenderingBackingStore::prepareToDisplay):

Canonical link: <a href="https://commits.webkit.org/272932@main">https://commits.webkit.org/272932@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4467c8c4f9791eef07b1f926138910560db1a6c8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33464 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12235 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35382 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36089 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30399 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14678 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9381 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29520 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33939 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10370 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29864 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9012 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9165 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37413 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30437 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30204 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35255 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9257 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7197 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33128 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11012 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7779 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9842 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9989 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->