### PR TITLE
Use CheckedRef inside render tree's FlexItem

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-inline-multiline.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-inline-multiline.html
@@ -27,10 +27,10 @@ item {
 </head>
 <body>
 <flexbox>
-<item></item>
-<item></item>
-<item></item>
-<item></item>
+<item id="1"></item>
+<item id="2"></item>
+<item id="3"></item>
+<item id="4"></item>
 </flexbox>
 </body>
 </html>

--- a/Source/WebCore/rendering/FlexibleBoxAlgorithm.cpp
+++ b/Source/WebCore/rendering/FlexibleBoxAlgorithm.cpp
@@ -70,9 +70,9 @@ void FlexLayoutAlgorithm::removeMarginEndFromFlexSizes(FlexItem& flexItem, Layou
 {
     LayoutUnit margin;
     if (m_flexbox.isHorizontalFlow())
-        margin = flexItem.box.marginEnd(&m_flexbox.style());
+        margin = flexItem.box->marginEnd(&m_flexbox.style());
     else
-        margin = flexItem.box.marginAfter(&m_flexbox.style());
+        margin = flexItem.box->marginAfter(&m_flexbox.style());
     sumFlexBaseSize -= margin;
     sumHypotheticalMainSize -= margin;
 } 
@@ -89,14 +89,14 @@ bool FlexLayoutAlgorithm::computeNextFlexLine(size_t& nextIndex, Vector<FlexItem
         m_flexbox.trimMainAxisMarginStart(m_allItems[nextIndex]);
     for (; nextIndex < m_allItems.size(); ++nextIndex) {
         const auto& flexItem = m_allItems[nextIndex];
-        ASSERT(!flexItem.box.isOutOfFlowPositioned());
+        ASSERT(!flexItem.box->isOutOfFlowPositioned());
         if (isMultiline() && (sumHypotheticalMainSize + flexItem.hypotheticalMainAxisMarginBoxSize() > m_lineBreakLength && !canFitItemWithTrimmedMarginEnd(flexItem, sumHypotheticalMainSize)) && !lineItems.isEmpty())
             break;
         lineItems.append(flexItem);
         sumFlexBaseSize += flexItem.flexBaseMarginBoxSize() + m_gapBetweenItems;
-        totalFlexGrow += flexItem.box.style().flexGrow();
-        totalFlexShrink += flexItem.box.style().flexShrink();
-        totalWeightedFlexShrink += flexItem.box.style().flexShrink() * flexItem.flexBaseContentSize;
+        totalFlexGrow += flexItem.box->style().flexGrow();
+        totalFlexShrink += flexItem.box->style().flexShrink();
+        totalWeightedFlexShrink += flexItem.box->style().flexShrink() * flexItem.flexBaseContentSize;
         sumHypotheticalMainSize += flexItem.hypotheticalMainAxisMarginBoxSize() + m_gapBetweenItems;
     }
 

--- a/Source/WebCore/rendering/FlexibleBoxAlgorithm.h
+++ b/Source/WebCore/rendering/FlexibleBoxAlgorithm.h
@@ -60,7 +60,7 @@ public:
 
     LayoutUnit constrainSizeByMinMax(const LayoutUnit) const;
 
-    RenderBox& box;
+    CheckedRef<RenderBox> box;
     LayoutUnit flexBaseContentSize;
     const LayoutUnit mainAxisBorderAndPadding;
     mutable LayoutUnit mainAxisMargin;


### PR DESCRIPTION
#### 9abc579db90c65162c39830cd913b943f0f8c0cf
<pre>
Use CheckedRef inside render tree&apos;s FlexItem
<a href="https://bugs.webkit.org/show_bug.cgi?id=267301">https://bugs.webkit.org/show_bug.cgi?id=267301</a>
<a href="https://rdar.apple.com/120751074">rdar://120751074</a>

Reviewed by Alan Baradlay.

* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-inline-multiline.html:
* Source/WebCore/rendering/FlexibleBoxAlgorithm.cpp:
(WebCore::FlexLayoutAlgorithm::removeMarginEndFromFlexSizes const):
(WebCore::FlexLayoutAlgorithm::computeNextFlexLine):
* Source/WebCore/rendering/FlexibleBoxAlgorithm.h:
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::trimMainAxisMarginStart):
(WebCore::RenderFlexibleBox::trimMainAxisMarginEnd):
(WebCore::RenderFlexibleBox::layoutFlexItems):
(WebCore::RenderFlexibleBox::autoMarginOffsetInMainAxis):
(WebCore::RenderFlexibleBox::freezeViolations):
(WebCore::RenderFlexibleBox::freezeInflexibleItems):
(WebCore::RenderFlexibleBox::resolveFlexibleLengths):
(WebCore::RenderFlexibleBox::layoutAndPlaceChildren):
(WebCore::RenderFlexibleBox::layoutColumnReverse):
(WebCore::RenderFlexibleBox::alignChildren):
(WebCore::RenderFlexibleBox::flipForRightToLeftColumn):

Canonical link: <a href="https://commits.webkit.org/272884@main">https://commits.webkit.org/272884@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3faa3c7b5d8c68f2412b9c6a8720a895e1b97e4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33426 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12197 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35340 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36052 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30371 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34398 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14548 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9391 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29499 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33899 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10290 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29834 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8981 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9104 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29824 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37381 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30357 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30172 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35227 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9229 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7206 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33096 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10982 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/29496 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7742 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9815 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9955 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->