### PR TITLE
[git-webkit] Don't mark all merge-back clones as Escapes

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/clone.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/clone.py
@@ -203,7 +203,7 @@ class Clone(Command):
                 return False
             return value
 
-        category = pick_attr('category', 'categories', 'Escape / Regression in the Build' if merge_back else None)
+        category = pick_attr('category', 'categories', None)
         event = pick_attr('event', 'events')
         tentpole = pick_attr('tentpole', 'tentpoles')
 

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/clone_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/clone_unittest.py
@@ -141,12 +141,14 @@ class TestClone(testing.PathTestCase):
         )
 
     def test_merge_back(self):
+        issues = [issue.copy() for issue in bmocks.ISSUES]
+        issues[0]['category'] = 'Tentpole Feature Work'
+
         with mocks.local.Git(self.path), mocks.local.Svn(), Environment(RADAR_USERNAME='tcontributor'), bmocks.Radar(
-            issues=bmocks.ISSUES,
+            issues=issues,
             projects=bmocks.PROJECTS,
             milestones=bmocks.MILESTONES,
         ), MockTerminal.input('1'), OutputCapture() as captured, patch('webkitbugspy.Tracker._trackers', [radar.Tracker()]):
-
             self.assertEqual(0, program.main(
                 args=('clone', 'rdar://1', '--reason', 'Cloning for an October branch', '--milestone', 'October', '--merge-back'),
                 path=self.path,
@@ -155,7 +157,7 @@ class TestClone(testing.PathTestCase):
             raw_issue = tracker.client.radar_for_id(4)
 
             self.assertEqual(raw_issue.milestone.name, 'October')
-            self.assertEqual(raw_issue.category.name, 'Escape / Regression in the Build')
+            self.assertEqual(raw_issue.category.name, 'Tentpole Feature Work')
             self.assertIsNone(raw_issue.event)
             self.assertIsNone(raw_issue.tentpole)
 


### PR DESCRIPTION
#### 53a2f8c87cc589846e262a7889fc4af9a032123f
<pre>
[git-webkit] Don&apos;t mark all merge-back clones as Escapes
<a href="https://bugs.webkit.org/show_bug.cgi?id=267306">https://bugs.webkit.org/show_bug.cgi?id=267306</a>
<a href="https://rdar.apple.com/120754443">rdar://120754443</a>

Reviewed by Ryan Haddad.

Use category of original issue when cloning merge-back radars.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/clone.py:
(Clone.main): Use category of original issue during merge-back.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/clone_unittest.py:
(TestClone.test_merge_back):

Canonical link: <a href="https://commits.webkit.org/272839@main">https://commits.webkit.org/272839@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ccdb79d1f26617e9add5f044d70f751ffd6c6983

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33287 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12061 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35199 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35921 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/30284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34258 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14406 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9226 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/29425 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33761 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10170 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29725 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8879 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/33560 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/9011 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29705 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37251 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30234 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30073 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35119 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/9132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/7084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32986 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/33171 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10867 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/9714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4274 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9833 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->