### PR TITLE
[Win] REGRESSION(272822@main): StreamClientConnection.h(216,20): error: call to implicitly-deleted copy constructor of 'StreamClientConnection::SendSyncResult<PrepareForDisplay>'

### DIFF
--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -6184,7 +6184,7 @@ void Internals::whenServiceWorkerIsTerminated(ServiceWorker& worker, DOMPromiseD
     });
 }
 
-NO_RETURN_DUE_TO_CRASH void Internals::terminateWebContentProcess()
+void Internals::terminateWebContentProcess()
 {
     exit(0);
 }

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1016,7 +1016,7 @@ public:
     void hasServiceWorkerRegistration(const String& clientURL, HasRegistrationPromise&&);
     void terminateServiceWorker(ServiceWorker&, DOMPromiseDeferred<void>&&);
     void whenServiceWorkerIsTerminated(ServiceWorker&, DOMPromiseDeferred<void>&&);
-    void terminateWebContentProcess();
+    NO_RETURN_DUE_TO_CRASH void terminateWebContentProcess();
 
 #if ENABLE(APPLE_PAY)
     MockPaymentCoordinator& mockPaymentCoordinator(Document&);

--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -169,6 +169,15 @@ template<typename T> struct ConnectionSendSyncResult {
     bool succeeded() const { return value.has_value(); }
     Error error() const { return value.has_value() ? Error::NoError : value.error(); }
 
+    // FIXME: Remove this when we start using c++23 and std::expected.
+#if OS(WINDOWS) // Expected isn't move-constuctible
+    ConnectionSendSyncResult(ConnectionSendSyncResult&& other)
+        : value(makeUnexpected(Error::NoError))
+    {
+        value.swap(other.value);
+    }
+#endif
+
     typename T::ReplyArguments& reply()
     {
         return value.value();


### PR DESCRIPTION
#### 3505bb0973f997dc1e1ae8cde963887e29d6b8cd
<pre>
[Win] REGRESSION(272822@main): StreamClientConnection.h(216,20): error: call to implicitly-deleted copy constructor of &apos;StreamClientConnection::SendSyncResult&lt;PrepareForDisplay&gt;&apos;
<a href="https://bugs.webkit.org/show_bug.cgi?id=267294">https://bugs.webkit.org/show_bug.cgi?id=267294</a>
<a href="https://rdar.apple.com/120756511">rdar://120756511</a>

Reviewed by Alex Christensen.

Fujii suggested this fix, and I initially thought I could do better by modifying WTF::Expected,
but after looking at it for a few hours, I&apos;m not sure why MSVC doesn&apos;t see the move constructor.
Soon we&apos;ll have std::expected and this will hopefully not be an issue.

Also move a NO_RETURN_DUE_TO_CRASH macro to make MSVC happy.

* Source/WTF/wtf/Expected.h:
(std::experimental::fundamentals_v3::__expected_detail::constexpr_base::constexpr_base):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::terminateWebContentProcess):
* Source/WebCore/testing/Internals.h:

Canonical link: <a href="https://commits.webkit.org/272842@main">https://commits.webkit.org/272842@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36a8a238dd2320519104ab34441b33891248c540

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33314 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12086 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35225 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35942 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/30293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34286 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14430 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9240 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/29431 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33788 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10189 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29746 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8887 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/9022 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29725 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37272 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30252 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30082 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/35133 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/9141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/7092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33000 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10883 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/9723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4276 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9855 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->