### PR TITLE
Prepare for MotionMark 1.3 in testing infrastructure

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/data/patches/signposts/MotionMark1.3.patch
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/patches/signposts/MotionMark1.3.patch
@@ -17,10 +17,10 @@ index 1aa630356cff167ec370961d7256920a21d6c508..ef393bcdebc03d2aad9c52c3caef5ad0
              suiteResults[test.name] = testData;
              self._suitesResults[suite.name] = suiteResults;
 diff --git a/tests/resources/main.js b/tests/resources/main.js
-index c6c669e0eb1f5e1fa2dc6ac60ca0a7532d5d690f..81b121ef765d546fce7c02ac91d2c053a9de7ad3 100644
+index 212470bfb1b93e25db7966a2192b3ab84a1ace84..b90324994aa9be4e02de269e356d190c19f11292 100644
 --- a/tests/resources/main.js
 +++ b/tests/resources/main.js
-@@ -851,6 +851,8 @@ Benchmark = Utilities.createClass(
+@@ -889,6 +889,8 @@ Benchmark = Utilities.createClass(
          this._frameCount = 0;
          this._warmupFrameCount = options["warmup-frame-count"];
          this._firstFrameMinimumLength = options["first-frame-minimum-length"];
@@ -29,7 +29,7 @@ index c6c669e0eb1f5e1fa2dc6ac60ca0a7532d5d690f..81b121ef765d546fce7c02ac91d2c053
  
          this._stage = stage;
          this._stage.initialize(this, options);
-@@ -908,6 +910,7 @@ Benchmark = Utilities.createClass(
+@@ -946,6 +948,7 @@ Benchmark = Utilities.createClass(
              this._finishPromise = new SimplePromise;
              this._previousTimestamp = undefined;
              this._didWarmUp = false;
@@ -37,7 +37,7 @@ index c6c669e0eb1f5e1fa2dc6ac60ca0a7532d5d690f..81b121ef765d546fce7c02ac91d2c053
              this._stage.tune(this._controller.initialComplexity - this._stage.complexity());
              this._animateLoop();
              return this._finishPromise;
-@@ -938,6 +941,7 @@ Benchmark = Utilities.createClass(
+@@ -976,6 +979,7 @@ Benchmark = Utilities.createClass(
                  this._benchmarkStartTimestamp = timestamp;
              } else if (timestamp - this._previousTimestamp >= this._warmupLength && this._frameCount >= this._warmupFrameCount) {
                  this._didWarmUp = true;

--- a/Tools/Scripts/webkitpy/benchmark_runner/data/patches/webdriver/MotionMark1.3.patch
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/patches/webdriver/MotionMark1.3.patch
@@ -1,8 +1,8 @@
 diff --git a/resources/runner/motionmark.js b/resources/runner/motionmark.js
-index 65e8c54..1643e70 100644
+index a2ea11401414e03ea07ea94be8761f0542da515a..6fa67427e96eb7a9b5a6e208d75dd747d47e5b97 100644
 --- a/resources/runner/motionmark.js
 +++ b/resources/runner/motionmark.js
-@@ -393,6 +393,48 @@ window.benchmarkRunnerClient = {
+@@ -420,6 +420,48 @@ window.benchmarkRunnerClient = {
      didFinishLastIteration: function()
      {
          benchmarkController.showResults();
@@ -50,13 +50,13 @@ index 65e8c54..1643e70 100644
 +        window.webdriver_results = results;
      }
  };
-
-@@ -436,7 +491,7 @@ window.sectionsManager =
- window.benchmarkController = {
-     initialize: function()
-     {
--        benchmarkController.addOrientationListenerIfNecessary();
-+        setTimeout(benchmarkController.startBenchmark.bind(benchmarkController), 3000);
+ 
+@@ -521,6 +563,8 @@ window.benchmarkController = {
+ 
+         this._startButton.textContent = Strings.text.runBenchmark;
+         this._startButton.disabled = false;
++
++        setTimeout(benchmarkController.startBenchmark.bind(benchmarkController), 2000);
      },
-
-     determineCanvasSize: function() {
+ 
+     determineCanvasSize: function()

--- a/Tools/Scripts/webkitpy/benchmark_runner/data/patches/webserver/MotionMark1.3.patch
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/patches/webserver/MotionMark1.3.patch
@@ -1,5 +1,5 @@
 diff --git a/resources/debug-runner/debug-runner.js b/resources/debug-runner/debug-runner.js
-index 46d62ddc837d0a59f675aa592ef31186f3f6a0f3..afb5b5b331783e9f7e6d613bbba04780e5a639b0 100644
+index 8f7a3c10e907cfeead784f3b768633322fd9e603..78d2f300d0e61c60f07290273ae5a513faf11eef 100644
 --- a/resources/debug-runner/debug-runner.js
 +++ b/resources/debug-runner/debug-runner.js
 @@ -509,6 +509,37 @@ window.suitesManager = {
@@ -40,7 +40,7 @@ index 46d62ddc837d0a59f675aa592ef31186f3f6a0f3..afb5b5b331783e9f7e6d613bbba04780
      updateLocalStorageFromJSON: function(results)
      {
          for (var suiteName in results[Strings.json.results.tests]) {
-@@ -663,16 +694,12 @@ Utilities.extendObject(window.benchmarkController, {
+@@ -679,16 +710,12 @@ Utilities.extendObject(window.benchmarkController, {
  
      startBenchmarkImmediatelyIfEncoded: function()
      {
@@ -60,10 +60,10 @@ index 46d62ddc837d0a59f675aa592ef31186f3f6a0f3..afb5b5b331783e9f7e6d613bbba04780
          return true;
      },
 diff --git a/resources/runner/motionmark.js b/resources/runner/motionmark.js
-index f29cfbb1a0ac6ede74db300424d779f543a78274..36ddee639735d4c678734dfdec1707762a4744c6 100644
+index a2ea11401414e03ea07ea94be8761f0542da515a..5f7f4f1d791c2392edf1df61f4d45665e4d63ced 100644
 --- a/resources/runner/motionmark.js
 +++ b/resources/runner/motionmark.js
-@@ -417,6 +417,62 @@ window.benchmarkRunnerClient = {
+@@ -420,6 +420,62 @@ window.benchmarkRunnerClient = {
      didFinishLastIteration: function()
      {
          benchmarkController.showResults();
@@ -126,7 +126,7 @@ index f29cfbb1a0ac6ede74db300424d779f543a78274..36ddee639735d4c678734dfdec170776
      }
  };
  
-@@ -744,5 +800,11 @@ window.benchmarkController = {
+@@ -751,5 +807,11 @@ window.benchmarkController = {
      }
  };
  

--- a/Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark.plan
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark.plan
@@ -1,1 +1,1 @@
-motionmark1.3-tentative.plan
+motionmark1.3.plan

--- a/Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.3.plan
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.3.plan
@@ -1,10 +1,10 @@
 {
     "timeout": 1800,
     "count": 3,
-    "github_source": "https://github.com/webkit/MotionMark/tree/655c569c743dc3092102cf5c759b1d446105a74b/MotionMark",
-    "webserver_benchmark_patch": "data/patches/webserver/MotionMark1.3-tentative.patch",
-    "webdriver_benchmark_patch": "data/patches/webdriver/MotionMark1.3-tentative.patch",
-    "signpost_patch": "data/patches/signposts/MotionMark1.3-tentative.patch",
+    "github_source": "https://github.com/webkit/MotionMark/tree/c52acd4c645780fd77cdbbd572750a5abfee1f7d/MotionMark",
+    "webserver_benchmark_patch": "data/patches/webserver/MotionMark1.3.patch",
+    "webdriver_benchmark_patch": "data/patches/webdriver/MotionMark1.3.patch",
+    "signpost_patch": "data/patches/signposts/MotionMark1.3.patch",
     "entry_point": "index.html",
     "subtest_entry_point": "developer.html",
     "config": {
@@ -106,7 +106,7 @@
         ]
     },
     "github_subtree": {
-        "url": "https://api.github.com/repos/WebKit/MotionMark/git/trees/2dee014260f48fae17d68754479ab6dc3e688271",
+        "url": "https://api.github.com/repos/WebKit/MotionMark/git/trees/2ccd8c3022e9e8c350a54947a0734bc3af8a43c4",
         "tree": [
             {"path": "about.html", "mode": "100644", "type": "blob"},
             {"path": "developer.html", "mode": "100644", "type": "blob"},


### PR DESCRIPTION
#### a762e46e5f2fce85f55d14f4fee7e82f6868b885
<pre>
Prepare for MotionMark 1.3 in testing infrastructure
<a href="https://bugs.webkit.org/show_bug.cgi?id=267308">https://bugs.webkit.org/show_bug.cgi?id=267308</a>
<a href="https://rdar.apple.com/120756294">rdar://120756294</a>

Reviewed by Dewei Zhu.

Add patch and plan files for MotionMark 1.3 (<a href="https://github.com/WebKit/MotionMark/releases/tag/release%2FMotionMark1.3)">https://github.com/WebKit/MotionMark/releases/tag/release%2FMotionMark1.3)</a>

* Tools/Scripts/webkitpy/benchmark_runner/data/patches/signposts/MotionMark1.3.patch: Renamed from Tools/Scripts/webkitpy/benchmark_runner/data/patches/signposts/MotionMark1.3-tentative.patch.
* Tools/Scripts/webkitpy/benchmark_runner/data/patches/webdriver/MotionMark1.3.patch: Renamed from Tools/Scripts/webkitpy/benchmark_runner/data/patches/webdriver/MotionMark1.3-tentative.patch.
* Tools/Scripts/webkitpy/benchmark_runner/data/patches/webserver/MotionMark1.3.patch: Renamed from Tools/Scripts/webkitpy/benchmark_runner/data/patches/webserver/MotionMark1.3-tentative.patch.
* Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark.plan:
* Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.3.plan: Renamed from Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.3-tentative.plan.

Canonical link: <a href="https://commits.webkit.org/272838@main">https://commits.webkit.org/272838@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/193d589b580c069f5cc5c0831524485fcf4a4fed

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33307 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12078 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35216 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35936 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/30291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34279 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14422 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9235 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/29429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33781 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10183 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29739 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/8883 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/33581 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/9018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/29718 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37266 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30247 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/30078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/35128 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/9139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/7088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32995 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10877 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7713 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/9721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9848 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->