### PR TITLE
Reduce use of downcast<>() in rendering code

### DIFF
--- a/Source/WebCore/rendering/RenderProgress.cpp
+++ b/Source/WebCore/rendering/RenderProgress.cpp
@@ -112,8 +112,8 @@ HTMLProgressElement* RenderProgress::progressElement() const
     if (!element())
         return nullptr;
 
-    if (is<HTMLProgressElement>(*element()))
-        return downcast<HTMLProgressElement>(element());
+    if (auto* progressElement = dynamicDowncast<HTMLProgressElement>(*element()))
+        return progressElement;
 
     ASSERT(element()->shadowHost());
     return downcast<HTMLProgressElement>(element()->shadowHost());

--- a/Source/WebCore/rendering/RenderQuote.cpp
+++ b/Source/WebCore/rendering/RenderQuote.cpp
@@ -437,17 +437,6 @@ static inline StringImpl* apostropheString()
     return apostropheString;
 }
 
-static RenderTextFragment* quoteTextRenderer(RenderObject* lastChild)
-{
-    if (!lastChild)
-        return nullptr;
-
-    if (!is<RenderTextFragment>(lastChild))
-        return nullptr;
-
-    return downcast<RenderTextFragment>(lastChild);
-}
-
 void RenderQuote::updateTextRenderer(RenderTreeBuilder& builder)
 {
     ASSERT_WITH_SECURITY_IMPLICATION(document().inRenderTreeUpdate());
@@ -455,7 +444,7 @@ void RenderQuote::updateTextRenderer(RenderTreeBuilder& builder)
     if (m_text == text)
         return;
     m_text = text;
-    if (auto* renderText = quoteTextRenderer(lastChild())) {
+    if (auto* renderText = dynamicDowncast<RenderTextFragment>(lastChild())) {
         renderText->setContentString(m_text);
         renderText->dirtyLineBoxes(false);
         return;

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -424,8 +424,8 @@ void RenderReplaced::computeAspectRatioInformationForRenderBox(RenderBox* conten
         // Handle zoom & vertical writing modes here, as the embedded document doesn't know about them.
         intrinsicSize.scale(style().effectiveZoom());
 
-        if (is<RenderImage>(*this))
-            intrinsicSize.scale(downcast<RenderImage>(*this).imageDevicePixelRatio());
+        if (auto* image = dynamicDowncast<RenderImage>(*this))
+            intrinsicSize.scale(image->imageDevicePixelRatio());
 
         // Update our intrinsic size to match what the content renderer has computed, so that when we
         // constrain the size below, the correct intrinsic size will be obtained for comparison against

--- a/Source/WebCore/rendering/RenderRubyBase.cpp
+++ b/Source/WebCore/rendering/RenderRubyBase.cpp
@@ -98,14 +98,14 @@ void RenderRubyBase::cachePriorCharactersIfNeeded(const CachedLineBreakIteratorF
 
 bool RenderRubyBase::isEmptyOrHasInFlowContent() const
 {
-    auto* firstChild = this->firstChild();
-    if (!firstChild || !is<RenderElement>(*firstChild))
+    auto* firstChild = dynamicDowncast<RenderElement>(this->firstChild());
+    if (!firstChild)
         return true;
 
     if (firstChild->isOutOfFlowPositioned())
         return false;
 
-    for (auto& child : childrenOfType<RenderObject>(*downcast<RenderElement>(firstChild))) {
+    for (auto& child : childrenOfType<RenderObject>(*firstChild)) {
         if (!child.isOutOfFlowPositioned())
             return true;
     }

--- a/Source/WebCore/rendering/RenderSelectionGeometry.cpp
+++ b/Source/WebCore/rendering/RenderSelectionGeometry.cpp
@@ -46,8 +46,8 @@ RenderSelectionGeometry::RenderSelectionGeometry(RenderObject& renderer, bool cl
     : RenderSelectionGeometryBase(renderer)
 {
     if (renderer.canUpdateSelectionOnRootLineBoxes()) {
-        if (is<RenderText>(renderer))
-            m_rect = downcast<RenderText>(renderer).collectSelectionGeometriesForLineBoxes(m_repaintContainer, clipToVisibleContent, m_collectedSelectionQuads);
+        if (CheckedPtr textRenderer = dynamicDowncast<RenderText>(renderer))
+            m_rect = textRenderer->collectSelectionGeometriesForLineBoxes(m_repaintContainer, clipToVisibleContent, m_collectedSelectionQuads);
         else
             m_rect = renderer.selectionRectForRepaint(m_repaintContainer, clipToVisibleContent);
     }

--- a/Source/WebCore/rendering/RenderTableCell.cpp
+++ b/Source/WebCore/rendering/RenderTableCell.cpp
@@ -111,11 +111,12 @@ void RenderTableCell::willBeRemovedFromTree(IsInternalMove isInternalMove)
 unsigned RenderTableCell::parseColSpanFromDOM() const
 {
     ASSERT(element());
-    if (is<HTMLTableCellElement>(*element()))
-        return std::min<unsigned>(downcast<HTMLTableCellElement>(*element()).colSpan(), maxColumnIndex);
+    if (auto* cell = dynamicDowncast<HTMLTableCellElement>(*element()))
+        return std::min<unsigned>(cell->colSpan(), maxColumnIndex);
 #if ENABLE(MATHML)
-    if (element()->hasTagName(MathMLNames::mtdTag))
-        return std::min<unsigned>(downcast<MathMLElement>(*element()).colSpan(), maxColumnIndex);
+    auto* mathMLElement = dynamicDowncast<MathMLElement>(*element());
+    if (mathMLElement && mathMLElement->hasTagName(MathMLNames::mtdTag))
+        return std::min<unsigned>(mathMLElement->colSpan(), maxColumnIndex);
 #endif
     return 1;
 }
@@ -123,11 +124,12 @@ unsigned RenderTableCell::parseColSpanFromDOM() const
 unsigned RenderTableCell::parseRowSpanFromDOM() const
 {
     ASSERT(element());
-    if (is<HTMLTableCellElement>(*element()))
-        return std::min<unsigned>(downcast<HTMLTableCellElement>(*element()).rowSpan(), maxRowIndex);
+    if (auto* cell = dynamicDowncast<HTMLTableCellElement>(*element()))
+        return std::min<unsigned>(cell->rowSpan(), maxRowIndex);
 #if ENABLE(MATHML)
-    if (element()->hasTagName(MathMLNames::mtdTag))
-        return std::min<unsigned>(downcast<MathMLElement>(*element()).rowSpan(), maxRowIndex);
+    auto* mathMLElement = dynamicDowncast<MathMLElement>(*element());
+    if (mathMLElement && mathMLElement->hasTagName(MathMLNames::mtdTag))
+        return std::min<unsigned>(mathMLElement->rowSpan(), maxRowIndex);
 #endif
     return 1;
 }

--- a/Source/WebCore/rendering/RenderTableCol.cpp
+++ b/Source/WebCore/rendering/RenderTableCol.cpp
@@ -176,13 +176,13 @@ RenderTable* RenderTableCol::table() const
 
 RenderTableCol* RenderTableCol::enclosingColumnGroup() const
 {
-    if (!is<RenderTableCol>(*parent()))
+    auto* parentColumnGroup = dynamicDowncast<RenderTableCol>(*parent());
+    if (!parentColumnGroup)
         return nullptr;
 
-    RenderTableCol& parentColumnGroup = downcast<RenderTableCol>(*parent());
-    ASSERT(parentColumnGroup.isTableColumnGroup());
+    ASSERT(parentColumnGroup->isTableColumnGroup());
     ASSERT(isTableColumn());
-    return &parentColumnGroup;
+    return parentColumnGroup;
 }
 
 RenderTableCol* RenderTableCol::nextColumn() const
@@ -198,9 +198,12 @@ RenderTableCol* RenderTableCol::nextColumn() const
     if (!next && is<RenderTableCol>(*parent()))
         next = parent()->nextSibling();
 
-    for (; next && !is<RenderTableCol>(*next); next = next->nextSibling()) { }
+    for (; next; next = next->nextSibling()) {
+        if (auto* column = dynamicDowncast<RenderTableCol>(*next))
+            return column;
+    }
 
-    return downcast<RenderTableCol>(next);
+    return nullptr;
 }
 
 const BorderValue& RenderTableCol::borderAdjoiningCellStartBorder() const

--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -506,11 +506,12 @@ void RenderTableSection::relayoutCellIfFlexed(RenderTableCell& cell, int rowInde
     bool flexAllChildren = cell.style().logicalHeight().isFixed() || (!table()->style().logicalHeight().isAuto() && rowHeight != cell.logicalHeight());
     
     for (auto& renderer : childrenOfType<RenderBox>(cell)) {
-        if (renderer.style().logicalHeight().isPercentOrCalculated()
-            && (flexAllChildren || shouldFlexCellChild(cell, renderer))
-            && (!is<RenderTable>(renderer) || downcast<RenderTable>(renderer).hasSections())) {
-            cellChildrenFlex = true;
-            break;
+        if (renderer.style().logicalHeight().isPercentOrCalculated() && (flexAllChildren || shouldFlexCellChild(cell, renderer))) {
+            auto* renderTable = dynamicDowncast<RenderTable>(renderer);
+            if (!renderTable || renderTable->hasSections()) {
+                cellChildrenFlex = true;
+                break;
+            }
         }
     }
 

--- a/Source/WebCore/rendering/RenderTextControlMultiLine.cpp
+++ b/Source/WebCore/rendering/RenderTextControlMultiLine.cpp
@@ -105,12 +105,11 @@ void RenderTextControlMultiLine::layoutExcludedChildren(bool relayoutChildren)
     RenderElement* placeholderRenderer = placeholder ? placeholder->renderer() : 0;
     if (!placeholderRenderer)
         return;
-    if (is<RenderBox>(placeholderRenderer)) {
-        auto& placeholderBox = downcast<RenderBox>(*placeholderRenderer);
-        placeholderBox.mutableStyle().setLogicalWidth(Length(contentLogicalWidth() - placeholderBox.borderAndPaddingLogicalWidth(), LengthType::Fixed));
-        placeholderBox.layoutIfNeeded();
-        placeholderBox.setX(borderLeft() + paddingLeft());
-        placeholderBox.setY(borderTop() + paddingTop());
+    if (CheckedPtr placeholderBox = dynamicDowncast<RenderBox>(placeholderRenderer)) {
+        placeholderBox->mutableStyle().setLogicalWidth(Length(contentLogicalWidth() - placeholderBox->borderAndPaddingLogicalWidth(), LengthType::Fixed));
+        placeholderBox->layoutIfNeeded();
+        placeholderBox->setX(borderLeft() + paddingLeft());
+        placeholderBox->setY(borderTop() + paddingTop());
     }
 }
     

--- a/Source/WebCore/rendering/RenderTextControlSingleLine.h
+++ b/Source/WebCore/rendering/RenderTextControlSingleLine.h
@@ -91,9 +91,8 @@ private:
     bool hasLineIfEmpty() const override { return true; }
     bool canBeProgramaticallyScrolled() const override
     {
-        auto* shadowHost = element()->shadowHost();
-        if (is<HTMLInputElement>(shadowHost))
-            return !downcast<HTMLInputElement>(*shadowHost).hasAutoFillStrongPasswordButton();
+        if (auto* shadowHost = dynamicDowncast<HTMLInputElement>(element()->shadowHost()))
+            return !shadowHost->hasAutoFillStrongPasswordButton();
         return true;
     }
 };

--- a/Source/WebCore/rendering/RenderTextFragment.h
+++ b/Source/WebCore/rendering/RenderTextFragment.h
@@ -73,5 +73,9 @@ private:
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::RenderTextFragment)
     static bool isType(const WebCore::RenderText& renderer) { return renderer.isRenderTextFragment(); }
-    static bool isType(const WebCore::RenderObject& renderer) { return is<WebCore::RenderText>(renderer) && isType(downcast<WebCore::RenderText>(renderer)); }
+    static bool isType(const WebCore::RenderObject& renderer)
+    {
+        auto* text = dynamicDowncast<WebCore::RenderText>(renderer);
+        return text && isType(*text);
+    }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -451,7 +451,6 @@ static void updateProgressBarPartForRenderer(ProgressBarPart& progressBarPart, c
 
 static void updateSliderTrackPartForRenderer(SliderTrackPart& sliderTrackPart, const RenderObject& renderer)
 {
-    ASSERT(is<HTMLInputElement>(renderer.node()));
     auto& input = downcast<HTMLInputElement>(*renderer.node());
     ASSERT(input.isRangeControl());
 
@@ -617,13 +616,11 @@ RefPtr<ControlPart> RenderTheme::createControlPart(const RenderObject& renderer)
 void RenderTheme::updateControlPartForRenderer(ControlPart& part, const RenderObject& renderer) const
 {
     if (auto* meterPart = dynamicDowncast<MeterPart>(part)) {
-        ASSERT(is<RenderMeter>(renderer));
         updateMeterPartForRenderer(*meterPart, downcast<RenderMeter>(renderer));
         return;
     }
 
     if (auto* progressBarPart = dynamicDowncast<ProgressBarPart>(part)) {
-        ASSERT(is<RenderProgress>(renderer));
         updateProgressBarPartForRenderer(*progressBarPart, downcast<RenderProgress>(renderer));
         return;
     }

--- a/Source/WebCore/rendering/RenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/RenderTreeAsText.cpp
@@ -142,17 +142,17 @@ static String getTagName(Node* n)
 
 static bool isEmptyOrUnstyledAppleStyleSpan(const Node* node)
 {
-    if (!is<HTMLSpanElement>(node))
+    auto* element = dynamicDowncast<HTMLSpanElement>(node);
+    if (!element)
         return false;
 
-    const HTMLElement& element = downcast<HTMLSpanElement>(*node);
-    if (element.getAttribute(classAttr) != "Apple-style-span"_s)
+    if (element->getAttribute(classAttr) != "Apple-style-span"_s)
         return false;
 
     if (!node->hasChildNodes())
         return true;
 
-    const StyleProperties* inlineStyleDecl = element.inlineStyle();
+    const StyleProperties* inlineStyleDecl = element->inlineStyle();
     return (!inlineStyleDecl || inlineStyleDecl->isEmpty());
 }
 
@@ -188,10 +188,10 @@ static inline bool isRenderInlineEmpty(const RenderInline& inlineRenderer)
         if (child.isFloatingOrOutOfFlowPositioned())
             continue;
         auto isChildEmpty = false;
-        if (is<RenderInline>(child))
-            isChildEmpty = isRenderInlineEmpty(downcast<RenderInline>(child));
-        else if (is<RenderText>(child))
-            isChildEmpty = !downcast<RenderText>(child).linesBoundingBox().height();
+        if (auto* renderInline = dynamicDowncast<RenderInline>(child))
+            isChildEmpty = isRenderInlineEmpty(*renderInline);
+        else if (auto* text = dynamicDowncast<RenderText>(child))
+            isChildEmpty = !text->linesBoundingBox().height();
         if (!isChildEmpty)
             return false;
     }
@@ -207,10 +207,10 @@ static inline bool hasNonEmptySibling(const RenderInline& inlineRenderer)
     for (auto& sibling : childrenOfType<RenderObject>(*parent)) {
         if (&sibling == &inlineRenderer || sibling.isFloatingOrOutOfFlowPositioned())
             continue;
-        if (!is<RenderInline>(sibling))
+        auto* siblingRendererInline = dynamicDowncast<RenderInline>(sibling);
+        if (!siblingRendererInline)
             return true;
-        auto& siblingRendererInline = downcast<RenderInline>(sibling);
-        if (siblingRendererInline.mayAffectLayout() || !isRenderInlineEmpty(siblingRendererInline))
+        if (siblingRendererInline->mayAffectLayout() || !isRenderInlineEmpty(*siblingRendererInline))
             return true;
     }
     return false;
@@ -258,12 +258,11 @@ void RenderTreeAsText::writeRenderObject(TextStream& ts, const RenderObject& o, 
 
     bool enableSubpixelPrecisionForTextDump = shouldEnableSubpixelPrecisionForTextDump(o.document());
     LayoutRect r;
-    if (is<RenderText>(o)) {
+    if (auto* text = dynamicDowncast<RenderText>(o)) {
         // FIXME: Would be better to dump the bounding box x and y rather than the first run's x and y, but that would involve updating
         // many test results.
-        const RenderText& text = downcast<RenderText>(o);
-        r = IntRect(text.firstRunLocation(), text.linesBoundingBox().size());
-        if (!InlineIterator::firstTextBoxFor(text))
+        r = IntRect(text->firstRunLocation(), text->linesBoundingBox().size());
+        if (!InlineIterator::firstTextBoxFor(*text))
             adjustForTableCells = false;
     } else if (o.isBR()) {
         const RenderLineBreak& br = downcast<RenderLineBreak>(o);
@@ -271,37 +270,35 @@ void RenderTreeAsText::writeRenderObject(TextStream& ts, const RenderObject& o, 
         r = IntRect(linesBox.x(), linesBox.y(), linesBox.width(), linesBox.height());
         if (!br.inlineBoxWrapper() && !InlineIterator::boxFor(br))
             adjustForTableCells = false;
-    } else if (is<RenderInline>(o)) {
-        const RenderInline& inlineFlow = downcast<RenderInline>(o);
+    } else if (auto* inlineFlow = dynamicDowncast<RenderInline>(o)) {
         // FIXME: Would be better not to just dump 0, 0 as the x and y here.
-        auto width = inlineFlow.linesBoundingBox().width();
+        auto width = inlineFlow->linesBoundingBox().width();
         auto inlineHeight = [&] {
             // Let's match legacy line layout's RenderInline behavior and report 0 height when the inline box is "empty".
             // FIXME: Remove and rebaseline when LFC inline boxes are enabled (see webkit.org/b/220722) 
-            auto height = inlineFlow.linesBoundingBox().height();
+            auto height = inlineFlow->linesBoundingBox().height();
             if (width)
                 return height;
-            if (is<RenderQuote>(inlineFlow) || is<RenderRubyAsInline>(inlineFlow))
+            if (is<RenderQuote>(*inlineFlow) || is<RenderRubyAsInline>(*inlineFlow))
                 return height;
-            if (inlineFlow.marginStart() || inlineFlow.marginEnd())
+            if (inlineFlow->marginStart() || inlineFlow->marginEnd())
                 return height;
             // This is mostly pre/post continuation content. Also see webkit.org/b/220735
-            if (hasNonEmptySibling(inlineFlow))
+            if (hasNonEmptySibling(*inlineFlow))
                 return height;
-            if (isRenderInlineEmpty(inlineFlow))
+            if (isRenderInlineEmpty(*inlineFlow))
                 return 0;
             return height;
         };
         r = IntRect(0, 0, width, inlineHeight());
         adjustForTableCells = false;
-    } else if (is<RenderTableCell>(o)) {
+    } else if (auto* cell = dynamicDowncast<RenderTableCell>(o)) {
         // FIXME: Deliberately dump the "inner" box of table cells, since that is what current results reflect.  We'd like
         // to clean up the results to dump both the outer box and the intrinsic padding so that both bits of information are
         // captured by the results.
-        const RenderTableCell& cell = downcast<RenderTableCell>(o);
-        r = LayoutRect(cell.x(), cell.y() + cell.intrinsicPaddingBefore(), cell.width(), cell.height() - cell.intrinsicPaddingBefore() - cell.intrinsicPaddingAfter());
-    } else if (is<RenderBox>(o))
-        r = downcast<RenderBox>(o).frameRect();
+        r = LayoutRect(cell->x(), cell->y() + cell->intrinsicPaddingBefore(), cell->width(), cell->height() - cell->intrinsicPaddingBefore() - cell->intrinsicPaddingAfter());
+    } else if (auto* box = dynamicDowncast<RenderBox>(o))
+        r = box->frameRect();
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
     else if (auto* svgModelObject = dynamicDowncast<RenderSVGModelObject>(o)) {
         r = svgModelObject->frameRectEquivalent();
@@ -321,11 +318,11 @@ void RenderTreeAsText::writeRenderObject(TextStream& ts, const RenderObject& o, 
         ts << " " << enclosingIntRect(r);
 
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
-    if (is<RenderSVGModelObject>(o)) {
-        writeSVGPaintingFeatures(ts, downcast<RenderSVGModelObject>(o), behavior);
+    if (auto* svgModelObject = dynamicDowncast<RenderSVGModelObject>(o)) {
+        writeSVGPaintingFeatures(ts, *svgModelObject, behavior);
 
-        if (is<RenderSVGShape>(o))
-            writeSVGGraphicsElement(ts, downcast<RenderSVGShape>(o).graphicsElement());
+        if (auto* svgShape = dynamicDowncast<RenderSVGShape>(*svgModelObject))
+            writeSVGGraphicsElement(ts, svgShape->graphicsElement());
 
         writeDebugInfo(ts, o, behavior);
         return;
@@ -333,8 +330,8 @@ void RenderTreeAsText::writeRenderObject(TextStream& ts, const RenderObject& o, 
 #endif
 
     if (!is<RenderText>(o)) {
-        if (is<RenderFileUploadControl>(o))
-            ts << " " << quoteAndEscapeNonPrintables(downcast<RenderFileUploadControl>(o).fileTextValue());
+        if (auto* control = dynamicDowncast<RenderFileUploadControl>(o))
+            ts << " " << quoteAndEscapeNonPrintables(control->fileTextValue());
 
         if (o.parent()) {
             Color color = o.style().visitedDependentColor(CSSPropertyColor);
@@ -361,17 +358,17 @@ void RenderTreeAsText::writeRenderObject(TextStream& ts, const RenderObject& o, 
                 ts << " [textStrokeWidth=" << o.style().textStrokeWidth() << "]";
         }
 
-        if (!is<RenderBoxModelObject>(o) || is<RenderLineBreak>(o))
+        auto* box = dynamicDowncast<RenderBoxModelObject>(o);
+        if (!box || is<RenderLineBreak>(*box))
             return;
 
-        const RenderBoxModelObject& box = downcast<RenderBoxModelObject>(o);
-        LayoutUnit borderTop = box.borderTop();
-        LayoutUnit borderRight = box.borderRight();
-        LayoutUnit borderBottom = box.borderBottom();
-        LayoutUnit borderLeft = box.borderLeft();
+        LayoutUnit borderTop = box->borderTop();
+        LayoutUnit borderRight = box->borderRight();
+        LayoutUnit borderBottom = box->borderBottom();
+        LayoutUnit borderLeft = box->borderLeft();
         bool overridden = o.style().borderImage().overridesBorderWidths();
-        if (box.isFieldset()) {
-            const auto& block = downcast<RenderBlock>(box);
+        if (box->isFieldset()) {
+            const auto& block = downcast<RenderBlock>(*box);
             if (o.style().blockFlowDirection() == BlockFlowDirection::TopToBottom)
                 borderTop -= block.intrinsicBorderForFieldset();
             else if (o.style().blockFlowDirection() == BlockFlowDirection::BottomToTop)
@@ -419,30 +416,28 @@ void RenderTreeAsText::writeRenderObject(TextStream& ts, const RenderObject& o, 
 
 #if ENABLE(MATHML)
         // We want to show any layout padding, both CSS padding and intrinsic padding, so we can't just check o.style().hasPadding().
-        if (o.isRenderMathMLBlock() && (box.paddingTop() || box.paddingRight() || box.paddingBottom() || box.paddingLeft())) {
+        if (o.isRenderMathMLBlock() && (box->paddingTop() || box->paddingRight() || box->paddingBottom() || box->paddingLeft())) {
             ts << " [";
-            LayoutUnit cssTop = box.computedCSSPaddingTop();
-            LayoutUnit cssRight = box.computedCSSPaddingRight();
-            LayoutUnit cssBottom = box.computedCSSPaddingBottom();
-            LayoutUnit cssLeft = box.computedCSSPaddingLeft();
-            if (box.paddingTop() != cssTop || box.paddingRight() != cssRight || box.paddingBottom() != cssBottom || box.paddingLeft() != cssLeft) {
+            LayoutUnit cssTop = box->computedCSSPaddingTop();
+            LayoutUnit cssRight = box->computedCSSPaddingRight();
+            LayoutUnit cssBottom = box->computedCSSPaddingBottom();
+            LayoutUnit cssLeft = box->computedCSSPaddingLeft();
+            if (box->paddingTop() != cssTop || box->paddingRight() != cssRight || box->paddingBottom() != cssBottom || box->paddingLeft() != cssLeft) {
                 ts << "intrinsic ";
                 if (cssTop || cssRight || cssBottom || cssLeft)
                     ts << "+ CSS ";
             }
-            ts << "padding: " << roundToInt(box.paddingTop()) << " " << roundToInt(box.paddingRight()) << " " << roundToInt(box.paddingBottom()) << " " << roundToInt(box.paddingLeft()) << "]";
+            ts << "padding: " << roundToInt(box->paddingTop()) << " " << roundToInt(box->paddingRight()) << " " << roundToInt(box->paddingBottom()) << " " << roundToInt(box->paddingLeft()) << "]";
         }
 #endif
     }
 
-    if (is<RenderTableCell>(o)) {
-        const RenderTableCell& c = downcast<RenderTableCell>(o);
-        ts << " [r=" << c.rowIndex() << " c=" << c.col() << " rs=" << c.rowSpan() << " cs=" << c.colSpan() << "]";
-    }
+    if (auto* cell = dynamicDowncast<RenderTableCell>(o))
+        ts << " [r=" << cell->rowIndex() << " c=" << cell->col() << " rs=" << cell->rowSpan() << " cs=" << cell->colSpan() << "]";
 
-    if (is<RenderDetailsMarker>(o)) {
+    if (auto* detailsMarker = dynamicDowncast<RenderDetailsMarker>(o)) {
         ts << ": ";
-        switch (downcast<RenderDetailsMarker>(o).orientation()) {
+        switch (detailsMarker->orientation()) {
         case RenderDetailsMarker::Left:
             ts << "left";
             break;
@@ -458,8 +453,8 @@ void RenderTreeAsText::writeRenderObject(TextStream& ts, const RenderObject& o, 
         }
     }
 
-    if (is<RenderListMarker>(o)) {
-        String text = downcast<RenderListMarker>(o).textWithoutSuffix().toString();
+    if (auto* listMarker = dynamicDowncast<RenderListMarker>(o)) {
+        String text = listMarker->textWithoutSuffix().toString();
         if (!text.isEmpty()) {
             if (text.length() != 1)
                 text = quoteAndEscapeNonPrintables(text);
@@ -540,23 +535,22 @@ void writeDebugInfo(TextStream& ts, const RenderObject& object, OptionSet<Render
     }
 
     if (behavior.contains(RenderAsTextFlag::ShowOverflow)) {
-        if (is<RenderBox>(object)) {
-            const auto& box = downcast<RenderBox>(object);
-            if (box.hasRenderOverflow()) {
-                LayoutRect layoutOverflow = box.layoutOverflowRect();
+        if (auto* box = dynamicDowncast<RenderBox>(object)) {
+            if (box->hasRenderOverflow()) {
+                LayoutRect layoutOverflow = box->layoutOverflowRect();
                 ts << " (layout overflow " << layoutOverflow.x().toInt() << "," << layoutOverflow.y().toInt() << " " << layoutOverflow.width().toInt() << "x" << layoutOverflow.height().toInt() << ")";
 
-                if (box.hasVisualOverflow()) {
-                    LayoutRect visualOverflow = box.visualOverflowRect();
+                if (box->hasVisualOverflow()) {
+                    LayoutRect visualOverflow = box->visualOverflowRect();
                     ts << " (visual overflow " << visualOverflow.x().toInt() << "," << visualOverflow.y().toInt() << " " << visualOverflow.width().toInt() << "x" << visualOverflow.height().toInt() << ")";
                 }
             }
         }
 
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
-        if (is<RenderSVGModelObject>(object)) {
-            if (const auto& renderSVGModelObject = downcast<RenderSVGModelObject>(object); renderSVGModelObject.hasVisualOverflow()) {
-                auto visualOverflow = renderSVGModelObject.visualOverflowRectEquivalent();
+        if (auto* renderSVGModelObject = dynamicDowncast<RenderSVGModelObject>(object)) {
+            if (renderSVGModelObject->hasVisualOverflow()) {
+                auto visualOverflow = renderSVGModelObject->visualOverflowRectEquivalent();
                 ts << " (visual overflow " << visualOverflow.x() << "," << visualOverflow.y() << " " << visualOverflow.width() << "x" << visualOverflow.height() << ")";
             }
         }
@@ -574,8 +568,8 @@ void write(TextStream& ts, const RenderObject& o, OptionSet<RenderAsTextFlag> be
         // FIXME: Use non-logical width. webkit.org/b/206809.
         int logicalWidth = ceilf(rect.x() + (textRun.isHorizontal() ? rect.width() : rect.height())) - x;
         // FIXME: Table cell adjustment is temporary until results can be updated.
-        if (is<RenderTableCell>(*o.containingBlock()))
-            y -= floorToInt(downcast<RenderTableCell>(*o.containingBlock()).intrinsicPaddingBefore());
+        if (auto* tableCell = dynamicDowncast<RenderTableCell>(*o.containingBlock()))
+            y -= floorToInt(tableCell->intrinsicPaddingBefore());
 
         ts << "text run at (" << x << "," << y << ") width " << logicalWidth;
         if (!textRun.isLeftToRightDirection())
@@ -588,36 +582,36 @@ void write(TextStream& ts, const RenderObject& o, OptionSet<RenderAsTextFlag> be
     };
 
 
-    if (is<LegacyRenderSVGShape>(o)) {
-        write(ts, downcast<LegacyRenderSVGShape>(o), behavior);
+    if (auto* svgShape = dynamicDowncast<LegacyRenderSVGShape>(o)) {
+        write(ts, *svgShape, behavior);
         return;
     }
-    if (is<RenderSVGGradientStop>(o)) {
-        writeSVGGradientStop(ts, downcast<RenderSVGGradientStop>(o), behavior);
+    if (auto* svgGradientStop = dynamicDowncast<RenderSVGGradientStop>(o)) {
+        writeSVGGradientStop(ts, *svgGradientStop, behavior);
         return;
     }
-    if (is<LegacyRenderSVGResourceContainer>(o)) {
-        writeSVGResourceContainer(ts, downcast<LegacyRenderSVGResourceContainer>(o), behavior);
+    if (auto* svgResourceContainer = dynamicDowncast<LegacyRenderSVGResourceContainer>(o)) {
+        writeSVGResourceContainer(ts, *svgResourceContainer, behavior);
         return;
     }
-    if (is<LegacyRenderSVGContainer>(o)) {
-        writeSVGContainer(ts, downcast<LegacyRenderSVGContainer>(o), behavior);
+    if (auto* svgContainer = dynamicDowncast<LegacyRenderSVGContainer>(o)) {
+        writeSVGContainer(ts, *svgContainer, behavior);
         return;
     }
-    if (is<LegacyRenderSVGRoot>(o)) {
-        write(ts, downcast<LegacyRenderSVGRoot>(o), behavior);
+    if (auto* svgRoot = dynamicDowncast<LegacyRenderSVGRoot>(o)) {
+        write(ts, *svgRoot, behavior);
         return;
     }
-    if (is<RenderSVGText>(o)) {
-        writeSVGText(ts, downcast<RenderSVGText>(o), behavior);
+    if (auto* text = dynamicDowncast<RenderSVGText>(o)) {
+        writeSVGText(ts, *text, behavior);
         return;
     }
-    if (is<RenderSVGInlineText>(o)) {
-        writeSVGInlineText(ts, downcast<RenderSVGInlineText>(o), behavior);
+    if (auto* inlineText = dynamicDowncast<RenderSVGInlineText>(o)) {
+        writeSVGInlineText(ts, *inlineText, behavior);
         return;
     }
-    if (is<LegacyRenderSVGImage>(o)) {
-        writeSVGImage(ts, downcast<LegacyRenderSVGImage>(o), behavior);
+    if (auto* svgImage = dynamicDowncast<LegacyRenderSVGImage>(o)) {
+        writeSVGImage(ts, *svgImage, behavior);
         return;
     }
 
@@ -628,11 +622,10 @@ void write(TextStream& ts, const RenderObject& o, OptionSet<RenderAsTextFlag> be
 
     TextStream::IndentScope indentScope(ts);
 
-    if (is<RenderText>(o)) {
-        auto& text = downcast<RenderText>(o);
-        for (auto& run : InlineIterator::textBoxesFor(text)) {
+    if (auto* text = dynamicDowncast<RenderText>(o)) {
+        for (auto& run : InlineIterator::textBoxesFor(*text)) {
             ts << indent;
-            writeTextRun(text, run);
+            writeTextRun(*text, run);
         }
     } else {
         for (auto& child : childrenOfType<RenderObject>(downcast<RenderElement>(o))) {
@@ -642,9 +635,8 @@ void write(TextStream& ts, const RenderObject& o, OptionSet<RenderAsTextFlag> be
         }
     }
 
-    if (is<RenderWidget>(o)) {
-        Widget* widget = downcast<RenderWidget>(o).widget();
-        if (widget) {
+    if (auto* renderWidget = dynamicDowncast<RenderWidget>(o)) {
+        if (auto* widget = renderWidget->widget()) {
             if (auto* frameView = dynamicDowncast<FrameView>(widget))
                 frameView->writeRenderTreeAsText(ts, behavior);
         }
@@ -1001,14 +993,13 @@ String counterValueForElement(Element* element)
 String markerTextForListItem(Element* element)
 {
     // Make sure the element is not freed during the layout.
-    RefPtr<Element> elementRef(element);
+    RefPtr protectedElement { element };
     element->document().updateLayout();
 
-    RenderElement* renderer = element->renderer();
-    if (!is<RenderListItem>(renderer))
+    auto* renderer = dynamicDowncast<RenderListItem>(element->renderer());
+    if (!renderer)
         return String();
-
-    return downcast<RenderListItem>(*renderer).markerTextWithoutSuffix().toString();
+    return renderer->markerTextWithoutSuffix().toString();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -343,9 +343,8 @@ RenderElement* RenderView::rendererForRootBackground() const
     auto* firstChild = this->firstChild();
     if (!firstChild)
         return nullptr;
-    ASSERT(is<RenderElement>(*firstChild));
-    auto& documentRenderer = downcast<RenderElement>(*firstChild);
 
+    auto& documentRenderer = downcast<RenderElement>(*firstChild);
     if (documentRenderer.hasBackground())
         return &documentRenderer;
 

--- a/Source/WebCore/rendering/RenderWidget.cpp
+++ b/Source/WebCore/rendering/RenderWidget.cpp
@@ -248,10 +248,11 @@ void RenderWidget::paintContents(PaintInfo& paintInfo, const LayoutPoint& paintO
     LayoutRect paintRect = paintInfo.rect;
 
     OptionSet<PaintBehavior> oldBehavior = PaintBehavior::Normal;
-    if (is<LocalFrameView>(*m_widget) && (paintInfo.paintBehavior & PaintBehavior::DefaultAsynchronousImageDecode)) {
-        LocalFrameView& frameView = downcast<LocalFrameView>(*m_widget);
-        oldBehavior = frameView.paintBehavior();
-        frameView.setPaintBehavior(oldBehavior | PaintBehavior::DefaultAsynchronousImageDecode);
+    if (paintInfo.paintBehavior & PaintBehavior::DefaultAsynchronousImageDecode) {
+        if (RefPtr frameView = dynamicDowncast<LocalFrameView>(m_widget)) {
+            oldBehavior = frameView->paintBehavior();
+            frameView->setPaintBehavior(oldBehavior | PaintBehavior::DefaultAsynchronousImageDecode);
+        }
     }
 
     IntPoint widgetLocation = m_widget->frameRect().location();
@@ -278,15 +279,14 @@ void RenderWidget::paintContents(PaintInfo& paintInfo, const LayoutPoint& paintO
     if (!widgetPaintOffset.isZero())
         paintInfo.context().translate(-widgetPaintOffset);
 
-    if (is<LocalFrameView>(*m_widget)) {
-        LocalFrameView& frameView = downcast<LocalFrameView>(*m_widget);
-        bool runOverlapTests = !frameView.useSlowRepaintsIfNotOverlapped();
+    if (RefPtr frameView = dynamicDowncast<LocalFrameView>(m_widget)) {
+        bool runOverlapTests = !frameView->useSlowRepaintsIfNotOverlapped();
         if (paintInfo.overlapTestRequests && runOverlapTests) {
             ASSERT(!paintInfo.overlapTestRequests->contains(this) || (paintInfo.overlapTestRequests->get(this) == m_widget->frameRect()));
             paintInfo.overlapTestRequests->set(this, m_widget->frameRect());
         }
         if (paintInfo.paintBehavior & PaintBehavior::DefaultAsynchronousImageDecode)
-            frameView.setPaintBehavior(oldBehavior);
+            frameView->setPaintBehavior(oldBehavior);
     }
 }
 
@@ -314,7 +314,8 @@ void RenderWidget::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
     // FIXME: Shouldn't check if the frame view needs layout during event region painting. This is a workaround
     // for the fact that non-composited frames depend on their enclosing compositing layer to perform an event
     // region update on their behalf. See <https://webkit.org/b/210311> for more details.
-    bool needsEventRegionContentPaint = paintInfo.phase == PaintPhase::EventRegion && is<LocalFrameView>(m_widget) && !downcast<LocalFrameView>(*m_widget).needsLayout();
+    auto* frameView = dynamicDowncast<LocalFrameView>(m_widget.get());
+    bool needsEventRegionContentPaint = paintInfo.phase == PaintPhase::EventRegion && frameView && !frameView->needsLayout();
     if (paintInfo.phase != PaintPhase::Foreground && !needsEventRegionContentPaint)
         return;
 
@@ -371,14 +372,13 @@ RenderWidget::ChildWidgetState RenderWidget::updateWidgetPosition()
 
     // if the frame size got changed, or if view needs layout (possibly indicating
     // content size is wrong) we have to do a layout to set the right widget size.
-    if (is<LocalFrameView>(*m_widget)) {
-        LocalFrameView& frameView = downcast<LocalFrameView>(*m_widget);
+    if (RefPtr frameView = dynamicDowncast<LocalFrameView>(*m_widget)) {
         // Check the frame's page to make sure that the frame isn't in the process of being destroyed.
-        Ref localFrame = frameView.frame();
-        if ((widgetSizeChanged || frameView.needsLayout())
+        Ref localFrame = frameView->frame();
+        if ((widgetSizeChanged || frameView->needsLayout())
             && localFrame->page()
             && localFrame->document())
-            frameView.layoutContext().layout();
+            frameView->layoutContext().layout();
     }
     return ChildWidgetState::Valid;
 }
@@ -405,17 +405,15 @@ RenderWidget* RenderWidget::find(const Widget& widget)
 bool RenderWidget::nodeAtPoint(const HitTestRequest& request, HitTestResult& result, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction action)
 {
     auto shouldHitTestChildFrameContent = request.allowsChildFrameContent() || (request.allowsVisibleChildFrameContent() && visibleToHitTesting(request));
-    auto hasRenderView = is<LocalFrameView>(widget()) && downcast<LocalFrameView>(*widget()).renderView();
-    if (shouldHitTestChildFrameContent && hasRenderView) {
-        LocalFrameView& childFrameView = downcast<LocalFrameView>(*widget());
-
+    auto* childFrameView = dynamicDowncast<LocalFrameView>(widget());
+    if (shouldHitTestChildFrameContent && childFrameView && childFrameView->renderView()) {
         LayoutPoint adjustedLocation = accumulatedOffset + location();
-        LayoutPoint contentOffset = LayoutPoint(borderLeft() + paddingLeft(), borderTop() + paddingTop()) - toIntSize(childFrameView.scrollPosition());
+        LayoutPoint contentOffset = LayoutPoint(borderLeft() + paddingLeft(), borderTop() + paddingTop()) - toIntSize(childFrameView->scrollPosition());
         HitTestLocation newHitTestLocation(locationInContainer, -adjustedLocation - contentOffset);
         HitTestRequest newHitTestRequest(request.type() | HitTestRequest::Type::ChildFrameHitTest);
         HitTestResult childFrameResult(newHitTestLocation);
 
-        auto* document = childFrameView.frame().document();
+        auto* document = childFrameView->frame().document();
         if (!document)
             return false;
         bool isInsideChildFrame = document->hitTest(newHitTestRequest, newHitTestLocation, childFrameResult);
@@ -471,9 +469,10 @@ bool RenderWidget::needsPreferredWidthsRecalculation() const
 
 RenderBox* RenderWidget::embeddedContentBox() const
 {
-    if (!is<RenderEmbeddedObject>(this) || !is<LocalFrameView>(widget()))
+    if (!is<RenderEmbeddedObject>(this))
         return nullptr;
-    return downcast<LocalFrameView>(*widget()).embeddedContentBox();
+    auto* frameView = dynamicDowncast<LocalFrameView>(widget());
+    return frameView ? frameView->embeddedContentBox() : nullptr;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/TextAutoSizing.cpp
+++ b/Source/WebCore/rendering/TextAutoSizing.cpp
@@ -136,12 +136,11 @@ auto TextAutoSizingValue::adjustTextNodeSizes() -> StillHasNodes
             parentRenderer = parentRenderer->parent();
 
         // If we have a list we should resize ListMarkers separately.
-        if (is<RenderListMarker>(*parentRenderer->firstChild())) {
-            auto& listMarkerRenderer = downcast<RenderListMarker>(*parentRenderer->firstChild());
-            auto style = cloneRenderStyleWithState(listMarkerRenderer.style());
+        if (auto* listMarkerRenderer = dynamicDowncast<RenderListMarker>(*parentRenderer->firstChild())) {
+            auto style = cloneRenderStyleWithState(listMarkerRenderer->style());
             style.setFontDescription(FontCascadeDescription { fontDescription });
             style.fontCascade().update(&node->document().fontSelector());
-            listMarkerRenderer.setStyle(WTFMove(style));
+            listMarkerRenderer->setStyle(WTFMove(style));
         }
 
         // Resize the line height of the parent.
@@ -170,10 +169,10 @@ auto TextAutoSizingValue::adjustTextNodeSizes() -> StillHasNodes
     }
 
     for (auto& node : m_autoSizedNodes) {
-        auto& textRenderer = *node->renderer();
-        if (!is<RenderTextFragment>(textRenderer))
+        auto* textRenderer = dynamicDowncast<RenderTextFragment>(*node->renderer());
+        if (!textRenderer)
             continue;
-        auto* block = downcast<RenderTextFragment>(textRenderer).blockForAccompanyingFirstLetter();
+        auto* block = textRenderer->blockForAccompanyingFirstLetter();
         if (!block)
             continue;
 

--- a/Source/WebCore/rendering/TextDecorationPainter.cpp
+++ b/Source/WebCore/rendering/TextDecorationPainter.cpp
@@ -349,8 +349,8 @@ static void collectStylesForRenderer(TextDecorationPainter::Styles& result, cons
 
     auto styleForRenderer = [&] (const RenderObject& renderer) -> const RenderStyle& {
         if (pseudoId != PseudoId::None && renderer.style().hasPseudoStyle(pseudoId)) {
-            if (is<RenderText>(renderer))
-                return *downcast<RenderText>(renderer).getCachedPseudoStyle(pseudoId);
+            if (auto textRenderer = dynamicDowncast<RenderText>(renderer))
+                return *textRenderer->getCachedPseudoStyle(pseudoId);
             return *downcast<RenderElement>(renderer).getCachedPseudoStyle(pseudoId);
         }
         return firstLineStyle ? renderer.firstLineStyle() : renderer.style();
@@ -365,8 +365,11 @@ static void collectStylesForRenderer(TextDecorationPainter::Styles& result, cons
             return;
 
         current = current->parent();
-        if (current && current->isAnonymousBlock() && downcast<RenderBlock>(*current).continuation())
-            current = downcast<RenderBlock>(*current).continuation();
+        if (current && current->isAnonymousBlock()) {
+            auto& currentBlock = downcast<RenderBlock>(*current);
+            if (auto* continuation = currentBlock.continuation())
+                current = continuation;
+        }
 
         if (remainingDecorations.isEmpty())
             break;


### PR DESCRIPTION
#### c3228161cb7c2728db4b2e648037649df2ebca2f
<pre>
Reduce use of downcast&lt;&gt;() in rendering code
<a href="https://bugs.webkit.org/show_bug.cgi?id=267310">https://bugs.webkit.org/show_bug.cgi?id=267310</a>

Reviewed by Darin Adler.

Reduce use of downcast&lt;&gt;() in rendering code. Prefer dynamicDowncast&lt;&gt;().

* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::setFragmentedFlowStateIncludingDescendants):
(WebCore::RenderObject::resetFragmentedFlowStateOnRemoval):
(WebCore::RenderObject::clearNeedsLayout):
(WebCore::scheduleRelayoutForSubtree):
(WebCore::RenderObject::checkBlockPositionedObjectsNeedLayout):
(WebCore::RenderObject::containingBlock const):
(WebCore::RenderObject::addAbsoluteRectForLayer):
(WebCore::RenderObject::paintingRootRect):
(WebCore::canRelyOnAncestorLayerFullRepaint):
(WebCore::RenderObject::propagateRepaintToParentWithOutlineAutoIfNeeded const):
(WebCore::RenderObject::showLineTreeForThis const):
(WebCore::enclosingFragmentedFlowFromRenderer):
(WebCore::RenderObject::outputRegionsInformation const):
(WebCore::RenderObject::outputRenderObject const):
(WebCore::RenderObject::outputRenderSubTreeAndMark const):
(WebCore::RenderObject::mapLocalToContainer const):
(WebCore::RenderObject::pushMappingToContainer const):
(WebCore::RenderObject::mapAbsoluteToLocalPoint const):
(WebCore::RenderObject::offsetFromContainer const):
(WebCore::containerForElement):
(WebCore::RenderObject::destroy):
(WebCore::RenderObject::absoluteTextRects):
(WebCore::borderAndTextRects):
* Source/WebCore/rendering/RenderProgress.cpp:
(WebCore::RenderProgress::progressElement const):
* Source/WebCore/rendering/RenderQuote.cpp:
(WebCore::RenderQuote::updateTextRenderer):
(WebCore::quoteTextRenderer): Deleted.
* Source/WebCore/rendering/RenderReplaced.cpp:
(WebCore::RenderReplaced::computeAspectRatioInformationForRenderBox const):
* Source/WebCore/rendering/RenderRubyBase.cpp:
(WebCore::RenderRubyBase::isEmptyOrHasInFlowContent const):
* Source/WebCore/rendering/RenderSelectionGeometry.cpp:
(WebCore::RenderSelectionGeometry::RenderSelectionGeometry):
* Source/WebCore/rendering/RenderTable.cpp:
(WebCore::RenderTable::layout):
(WebCore::RenderTable::firstColumn const):
(WebCore::RenderTable::recalcSections const):
(WebCore::RenderTable::sectionAbove const):
(WebCore::RenderTable::sectionBelow const):
(WebCore::RenderTable::bottomSection const):
(WebCore::RenderTable::nodeAtPoint):
* Source/WebCore/rendering/RenderTableCell.cpp:
(WebCore::RenderTableCell::parseColSpanFromDOM const):
(WebCore::RenderTableCell::parseRowSpanFromDOM const):
* Source/WebCore/rendering/RenderTableCol.cpp:
(WebCore::RenderTableCol::enclosingColumnGroup const):
(WebCore::RenderTableCol::nextColumn const):
* Source/WebCore/rendering/RenderTableSection.cpp:
(WebCore::RenderTableSection::relayoutCellIfFlexed):
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::selectionRectForTextBox):
(WebCore::boundariesForTextBox):
(WebCore::combineTextWidth):
(WebCore::isInlineFlowOrEmptyText):
(WebCore::RenderText::previousCharacter const):
(WebCore::RenderText::emphasisMarkExistsAndIsAbove):
* Source/WebCore/rendering/RenderTextControlMultiLine.cpp:
(WebCore::RenderTextControlMultiLine::layoutExcludedChildren):
* Source/WebCore/rendering/RenderTextControlSingleLine.h:
* Source/WebCore/rendering/RenderTextFragment.h:
(isType):
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::updateSliderTrackPartForRenderer):
(WebCore::RenderTheme::updateControlPartForRenderer const):
* Source/WebCore/rendering/RenderThemeIOS.mm:
(WebCore::RenderThemeIOS::paintMenuListButtonDecorations):
* Source/WebCore/rendering/RenderTreeAsText.cpp:
(WebCore::isEmptyOrUnstyledAppleStyleSpan):
(WebCore::isRenderInlineEmpty):
(WebCore::hasNonEmptySibling):
(WebCore::RenderTreeAsText::writeRenderObject):
(WebCore::writeDebugInfo):
(WebCore::write):
(WebCore::markerTextForListItem):
* Source/WebCore/rendering/RenderView.cpp:
(WebCore::RenderView::rendererForRootBackground const):
* Source/WebCore/rendering/RenderWidget.cpp:
(WebCore::RenderWidget::paintContents):
(WebCore::RenderWidget::paint):
(WebCore::RenderWidget::updateWidgetPosition):
(WebCore::RenderWidget::nodeAtPoint):
(WebCore::RenderWidget::embeddedContentBox const):
* Source/WebCore/rendering/TextAutoSizing.cpp:
(WebCore::TextAutoSizingValue::adjustTextNodeSizes):
* Source/WebCore/rendering/TextDecorationPainter.cpp:
(WebCore::collectStylesForRenderer):

Canonical link: <a href="https://commits.webkit.org/272954@main">https://commits.webkit.org/272954@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ec478a5faacd84edc41b7296e08c2a6ee2e65f9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33716 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12489 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35648 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36331 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/30569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34764 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14861 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9642 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29646 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34193 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10529 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30056 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9186 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/9283 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30069 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37654 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30597 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30390 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35411 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/9423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/7369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33298 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11203 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/10006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4341 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10209 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->