### PR TITLE
DOMTokenList should take more advantage of AtomString

### DIFF
--- a/Source/WebCore/html/DOMTokenList.h
+++ b/Source/WebCore/html/DOMTokenList.h
@@ -60,11 +60,11 @@ public:
     WEBCORE_EXPORT const AtomString& value() const;
 
 private:
-    void updateTokensFromAttributeValue(StringView);
+    void updateTokensFromAttributeValue(const AtomString&);
     void updateAssociatedAttributeFromTokens();
 
-    WEBCORE_EXPORT Vector<AtomString>& tokens();
-    const Vector<AtomString>& tokens() const { return const_cast<DOMTokenList&>(*this).tokens(); }
+    WEBCORE_EXPORT Vector<AtomString, 1>& tokens();
+    const Vector<AtomString, 1>& tokens() const { return const_cast<DOMTokenList&>(*this).tokens(); }
 
     static ExceptionOr<void> validateToken(StringView);
     static ExceptionOr<void> validateTokens(const AtomString* tokens, size_t length);
@@ -75,7 +75,7 @@ private:
     const WebCore::QualifiedName& m_attributeName;
     bool m_inUpdateAssociatedAttributeFromTokens { false };
     bool m_tokensNeedUpdating { true };
-    Vector<AtomString> m_tokens;
+    Vector<AtomString, 1> m_tokens;
     IsSupportedTokenFunction m_isSupportedToken;
 };
 


### PR DESCRIPTION
#### 21f7c39a0c3e3d47409eb8b225c037df243c1dcd
<pre>
DOMTokenList should take more advantage of AtomString
<a href="https://bugs.webkit.org/show_bug.cgi?id=267313">https://bugs.webkit.org/show_bug.cgi?id=267313</a>

Reviewed by Yusuke Suzuki.

Take advantage of the fact updateTokensFromAttributeValue and updateAssociatedAttributeFromTokens
can both receive AtomString as arguments.

* Source/WebCore/html/DOMTokenList.cpp:
(WebCore::replaceInOrderedSet):
(WebCore::DOMTokenList::updateTokensFromAttributeValue):
(WebCore::DOMTokenList::updateAssociatedAttributeFromTokens):
(WebCore::DOMTokenList::tokens):
* Source/WebCore/html/DOMTokenList.h:
(WebCore::DOMTokenList::tokens const):

Canonical link: <a href="https://commits.webkit.org/272857@main">https://commits.webkit.org/272857@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d64d2f83fd03b52219d2f568b3443181c9c09842

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33342 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12113 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35251 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35968 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30307 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34314 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14457 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9257 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29441 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33816 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10206 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29762 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8904 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9031 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29744 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37298 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30270 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30093 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35153 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9155 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7100 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33018 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10903 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9737 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4286 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9878 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->