### PR TITLE
[Nicosia] Holepunch broken when media controls are enabled

### DIFF
--- a/ManualTests/wpe/video-player-holepunch-external.html
+++ b/ManualTests/wpe/video-player-holepunch-external.html
@@ -46,11 +46,22 @@
       }, 5000);
 
       setTimeout(function() {
+        v.controls = true;
+        log.innerHTML = "Showing media controls on the second video. They should be visible over the transparent rectangle";
+      }, 8000);
+
+      setTimeout(function() {
+        v.controls = false;
         s.type = "video/mp4";
         v.load();
         v.play();
         log.innerHTML = "Playing third video. The video (or a transparent rectangle if GStreamer holepunch is enabled) should be visible";
       }, 10000);
+
+      setTimeout(function() {
+        v.controls = true;
+        log.innerHTML = "Showing media controls on the third video. They should be visible over video or the transparent rectangle";
+      }, 13000);
     </script>
   </body>
 </html>

--- a/ManualTests/wpe/video-player-holepunch-gstreamer.html
+++ b/ManualTests/wpe/video-player-holepunch-gstreamer.html
@@ -23,11 +23,18 @@
       If everything is working fine, there should be a transparent rectangle of 400x400 just
       below this.
     </p>
+    <p>
+      After 5s the controls should be shown over the transparent rectangle.
+    </p>
     <video id="video"></video>
     <script type="text/javascript">
       var v = document.getElementById("video");
       v.src = "../../LayoutTests/media/content/long-test.mp4";
       v.play();
+
+      setTimeout(function() {
+        v.controls = true;
+      }, 5000);
     </script>
   </body>
 </html>

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -175,6 +175,9 @@ MediaPlayerPrivateGStreamer::MediaPlayerPrivateGStreamer(MediaPlayer* player)
             if (webKitDMABufVideoSinkIsEnabled() && webKitDMABufVideoSinkProbePlatform())
                 return adoptRef(*new TextureMapperPlatformLayerProxyDMABuf);
 #endif
+#if USE(GSTREAMER_HOLEPUNCH)
+            return adoptRef(*new TextureMapperPlatformLayerProxyGL(true));
+#endif
             return adoptRef(*new TextureMapperPlatformLayerProxyGL);
         }());
 #endif
@@ -3242,9 +3245,6 @@ PlatformLayer* MediaPlayerPrivateGStreamer::platformLayer() const
 #if USE(NICOSIA)
 void MediaPlayerPrivateGStreamer::swapBuffersIfNeeded()
 {
-#if USE(GSTREAMER_HOLEPUNCH)
-    pushNextHolePunchBuffer();
-#endif
 }
 #else
 RefPtr<TextureMapperPlatformLayerProxy> MediaPlayerPrivateGStreamer::proxy() const

--- a/Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunch.cpp
+++ b/Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunch.cpp
@@ -36,7 +36,7 @@ MediaPlayerPrivateHolePunch::MediaPlayerPrivateHolePunch(MediaPlayer* player)
     , m_readyTimer(RunLoop::main(), this, &MediaPlayerPrivateHolePunch::notifyReadyState)
     , m_networkState(MediaPlayer::NetworkState::Empty)
 #if USE(NICOSIA)
-    , m_nicosiaLayer(Nicosia::ContentLayer::create(*this))
+    , m_nicosiaLayer(Nicosia::ContentLayer::create(*this, adoptRef(*new WebCore::TextureMapperPlatformLayerProxyGL(true))))
 #else
     , m_platformLayerProxy(adoptRef(new TextureMapperPlatformLayerProxyGL))
 #endif
@@ -93,7 +93,9 @@ void MediaPlayerPrivateHolePunch::pushNextHolePunchBuffer()
 
 void MediaPlayerPrivateHolePunch::swapBuffersIfNeeded()
 {
+#if !USE(NICOSIA)
     pushNextHolePunchBuffer();
+#endif
 }
 
 #if !USE(NICOSIA)

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyGL.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyGL.cpp
@@ -42,7 +42,10 @@ static const Seconds releaseUnusedBuffersTimerInterval = { 500_ms };
 
 namespace WebCore {
 
-TextureMapperPlatformLayerProxyGL::TextureMapperPlatformLayerProxyGL() = default;
+TextureMapperPlatformLayerProxyGL::TextureMapperPlatformLayerProxyGL(bool disableBufferInvalidation)
+    : m_disableBufferInvalidation(disableBufferInvalidation)
+{
+}
 
 TextureMapperPlatformLayerProxyGL::~TextureMapperPlatformLayerProxyGL()
 {
@@ -101,10 +104,12 @@ void TextureMapperPlatformLayerProxyGL::invalidate()
             m_targetLayer = nullptr;
         }
 
-        m_currentBuffer = nullptr;
-        m_pendingBuffer = nullptr;
-        m_releaseUnusedBuffersTimer = nullptr;
-        m_usedBuffers.clear();
+        if (!m_disableBufferInvalidation) {
+            m_currentBuffer = nullptr;
+            m_pendingBuffer = nullptr;
+            m_releaseUnusedBuffersTimer = nullptr;
+            m_usedBuffers.clear();
+        }
 
         // Clear the timer and dispatch the update function manually now.
         m_compositorThreadUpdateTimer = nullptr;

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyGL.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyGL.h
@@ -44,7 +44,7 @@ namespace WebCore {
 class TextureMapperPlatformLayerProxyGL final : public TextureMapperPlatformLayerProxy {
     WTF_MAKE_FAST_ALLOCATED();
 public:
-    TextureMapperPlatformLayerProxyGL();
+    TextureMapperPlatformLayerProxyGL(bool disableBufferInvalidation = false);
     virtual ~TextureMapperPlatformLayerProxyGL();
 
     bool isGLBased() const override { return true; }
@@ -67,6 +67,7 @@ private:
 
     std::unique_ptr<TextureMapperPlatformLayerBuffer> m_currentBuffer;
     std::unique_ptr<TextureMapperPlatformLayerBuffer> m_pendingBuffer;
+    bool m_disableBufferInvalidation;
 
     Lock m_wasBufferDroppedLock;
     Condition m_wasBufferDroppedCondition;


### PR DESCRIPTION
#### ed3ac4ca860410fa6d225f8c597e0bd75a2e095a
<pre>
[Nicosia] Holepunch broken when media controls are enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=267322">https://bugs.webkit.org/show_bug.cgi?id=267322</a>

Reviewed by Miguel Gomez.

Enabling the media controls creates the shadow root, which destroys the
RenderVideo, RenderLayer, RenderLayerBacking and CoordinatedGraphicsLayer.
Then the RenderVideo is created again, a new CoordinatedGraphicsLayer is
created, then CoordinatedGraphicsLayer::setContentsToPlatformLayer is called
with the PlatformLayer of the MediaPlayerPrivate.
CoordinatedGraphicsLayer::updatePlatformLayer is called, so the
MediaPlayerPrivate pushes a new buffer (pushNextHolePunchBuffer).
But later when the old layer is removed in CoordinatedGraphicsScene,
TextureMapperPlatformLayerProxyGL::invalidate deletes the buffer.

So we disable the buffer invalidation in TextureMapperPlatformLayerProxyGL for
the holepunch cases.
Pushing new buffers in swapBuffersIfNeeded is no longer needed.

* ManualTests/wpe/video-player-holepunch-external.html: Show the controls
* ManualTests/wpe/video-player-holepunch-gstreamer.html: Ditto
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::MediaPlayerPrivateGStreamer):
(WebCore::MediaPlayerPrivateGStreamer::swapBuffersIfNeeded):
* Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunch.cpp:
(WebCore::MediaPlayerPrivateHolePunch::MediaPlayerPrivateHolePunch):
(WebCore::MediaPlayerPrivateHolePunch::swapBuffersIfNeeded):
* Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyGL.cpp:
(WebCore::TextureMapperPlatformLayerProxyGL::TextureMapperPlatformLayerProxyGL):
(WebCore::TextureMapperPlatformLayerProxyGL::invalidate):
* Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyGL.h:

Canonical link: <a href="https://commits.webkit.org/272907@main">https://commits.webkit.org/272907@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4bd8dd1292f55c6e79eb3d94ce9cb65f43d424f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33350 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12121 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35259 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35976 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30315 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34322 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14468 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9265 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29448 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33824 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10217 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29770 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8911 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9041 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29752 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37306 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30281 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30100 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35160 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9163 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7108 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33026 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10911 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7763 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9745 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9886 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->